### PR TITLE
refactor(groups): one dialog for creating and editing a group

### DIFF
--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -449,25 +449,25 @@
 
     <!-- Create Group Modal -->
     <BaseDialog
-      :show="showCreateModal"
-      :title="t('admin.groups.createGroup')"
+      :show="showCreateModal || showEditModal"
+      :title="t(isEditMode ? 'admin.groups.editGroup' : 'admin.groups.createGroup')"
       width="normal"
-      @close="closeCreateModal"
+      @close="isEditMode ? closeEditModal() : closeCreateModal()"
     >
       <form
-        id="create-group-form"
-        @submit.prevent="handleCreateGroup"
+        id="group-form"
+        @submit.prevent="isEditMode ? handleUpdateGroup() : handleCreateGroup()"
         class="space-y-5"
       >
         <div>
           <label class="input-label">{{ t("admin.groups.form.name") }}</label>
           <input
-            v-model="createForm.name"
+            v-model="groupForm.name"
             type="text"
             required
             class="input"
             :placeholder="t('admin.groups.enterGroupName')"
-            data-tour="group-form-name"
+            :data-tour="isEditMode ? 'edit-group-form-name' : 'group-form-name'"
           />
         </div>
         <div>
@@ -475,7 +475,7 @@
             t("admin.groups.form.description")
           }}</label>
           <textarea
-            v-model="createForm.description"
+            v-model="groupForm.description"
             rows="3"
             class="input"
             :placeholder="t('admin.groups.optionalDescription')"
@@ -486,15 +486,16 @@
             t("admin.groups.form.platform")
           }}</label>
           <Select
-            v-model="createForm.platform"
+            v-model="groupForm.platform"
             :options="platformOptions"
+            :disabled="isEditMode"
             data-tour="group-form-platform"
-            @change="createForm.copy_accounts_from_group_ids = []"
+            @change="groupForm.copy_accounts_from_group_ids = []"
           />
-          <p class="input-hint">{{ t("admin.groups.platformHint") }}</p>
+          <p class="input-hint">{{ t(isEditMode ? "admin.groups.platformNotEditable" : "admin.groups.platformHint") }}</p>
         </div>
         <!-- 从分组复制账号 -->
-        <div v-if="copyAccountsGroupOptions.length > 0">
+        <div v-if="(isEditMode ? copyAccountsGroupOptionsForEdit : copyAccountsGroupOptions).length > 0">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.copyAccounts.title") }}
@@ -524,11 +525,11 @@
           </div>
           <!-- 已选分组标签 -->
           <div
-            v-if="createForm.copy_accounts_from_group_ids.length > 0"
+            v-if="groupForm.copy_accounts_from_group_ids.length > 0"
             class="flex flex-wrap gap-1.5 mb-2"
           >
             <span
-              v-for="groupId in createForm.copy_accounts_from_group_ids"
+              v-for="groupId in groupForm.copy_accounts_from_group_ids"
               :key="groupId"
               class="inline-flex items-center gap-1 rounded-full bg-primary-100 px-2.5 py-1 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
             >
@@ -539,8 +540,8 @@
               <button
                 type="button"
                 @click="
-                  createForm.copy_accounts_from_group_ids =
-                    createForm.copy_accounts_from_group_ids.filter(
+                  groupForm.copy_accounts_from_group_ids =
+                    groupForm.copy_accounts_from_group_ids.filter(
                       (id) => id !== groupId,
                     )
                 "
@@ -558,9 +559,9 @@
                 const val = Number((e.target as HTMLSelectElement).value);
                 if (
                   val &&
-                  !createForm.copy_accounts_from_group_ids.includes(val)
+                  !groupForm.copy_accounts_from_group_ids.includes(val)
                 ) {
-                  createForm.copy_accounts_from_group_ids.push(val);
+                  groupForm.copy_accounts_from_group_ids.push(val);
                 }
                 (e.target as HTMLSelectElement).value = '';
               }
@@ -574,7 +575,7 @@
               :key="opt.value"
               :value="opt.value"
               :disabled="
-                createForm.copy_accounts_from_group_ids.includes(opt.value)
+                groupForm.copy_accounts_from_group_ids.includes(opt.value)
               "
             >
               {{ opt.label }}
@@ -587,7 +588,7 @@
             t("admin.groups.form.rateMultiplier")
           }}</label>
           <input
-            v-model.number="createForm.rate_multiplier"
+            v-model.number="groupForm.rate_multiplier"
             type="number"
             step="0.001"
             min="0.001"
@@ -600,7 +601,7 @@
         <div>
           <label class="input-label">{{ t("admin.groups.form.rpmLimit") }}</label>
           <input
-            v-model.number="createForm.rpm_limit"
+            v-model.number="groupForm.rpm_limit"
             type="number"
             min="0"
             step="1"
@@ -610,16 +611,16 @@
           <p class="input-hint">{{ t("admin.groups.form.rpmLimitHint") }}</p>
         </div>
         <ReasoningEffortPolicyFields
-          v-if="createForm.platform === 'openai'"
-          ref="createReasoningEffortPolicyRef"
-          id-prefix="create-group-reasoning"
-          :platform="createForm.platform"
-          v-model:max-effort="createForm.max_reasoning_effort"
-          v-model:mappings="createForm.reasoning_effort_mappings"
+          v-if="groupForm.platform === 'openai'"
+          ref="groupReasoningEffortPolicyRef"
+          id-prefix="group-reasoning"
+          :platform="groupForm.platform"
+          v-model:max-effort="groupForm.max_reasoning_effort"
+          v-model:mappings="groupForm.reasoning_effort_mappings"
         />
         <div
-          v-if="createForm.subscription_type !== 'subscription'"
-          data-tour="group-form-exclusive"
+          v-if="groupForm.subscription_type !== 'subscription'"
+          :data-tour="isEditMode ? undefined : 'group-form-exclusive'"
         >
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -667,10 +668,10 @@
           <div class="flex items-center gap-3">
             <button
               type="button"
-              @click="createForm.is_exclusive = !createForm.is_exclusive"
+              @click="groupForm.is_exclusive = !groupForm.is_exclusive"
               :class="[
                 'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                createForm.is_exclusive
+                groupForm.is_exclusive
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600',
               ]"
@@ -678,18 +679,23 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  createForm.is_exclusive ? 'translate-x-6' : 'translate-x-1',
+                  groupForm.is_exclusive ? 'translate-x-6' : 'translate-x-1',
                 ]"
               />
             </button>
             <span class="text-sm text-gray-500 dark:text-gray-400">
               {{
-                createForm.is_exclusive
+                groupForm.is_exclusive
                   ? t("admin.groups.exclusive")
                   : t("admin.groups.public")
               }}
             </span>
           </div>
+        </div>
+
+        <div v-if="isEditMode">
+          <label class="input-label">{{ t("admin.groups.form.status") }}</label>
+          <Select v-model="groupForm.status" :options="editStatusOptions" />
         </div>
 
         <!-- Subscription Configuration -->
@@ -699,17 +705,18 @@
               t("admin.groups.subscription.type")
             }}</label>
             <Select
-              v-model="createForm.subscription_type"
+              v-model="groupForm.subscription_type"
               :options="subscriptionTypeOptions"
+              :disabled="isEditMode"
             />
             <p class="input-hint">
-              {{ t("admin.groups.subscription.typeHint") }}
+              {{ t(isEditMode ? "admin.groups.subscription.typeNotEditable" : "admin.groups.subscription.typeHint") }}
             </p>
           </div>
 
           <!-- Subscription limits (only show when subscription type is selected) -->
           <div
-            v-if="createForm.subscription_type === 'subscription'"
+            v-if="groupForm.subscription_type === 'subscription'"
             class="space-y-4 border-l-2 border-primary-200 pl-4 dark:border-primary-800"
           >
             <div>
@@ -717,7 +724,7 @@
                 t("admin.groups.subscription.dailyLimit")
               }}</label>
               <input
-                v-model.number="createForm.daily_limit_usd"
+                v-model.number="groupForm.daily_limit_usd"
                 type="number"
                 step="0.01"
                 min="0"
@@ -730,7 +737,7 @@
                 t("admin.groups.subscription.weeklyLimit")
               }}</label>
               <input
-                v-model.number="createForm.weekly_limit_usd"
+                v-model.number="groupForm.weekly_limit_usd"
                 type="number"
                 step="0.01"
                 min="0"
@@ -743,7 +750,7 @@
                 t("admin.groups.subscription.monthlyLimit")
               }}</label>
               <input
-                v-model.number="createForm.monthly_limit_usd"
+                v-model.number="groupForm.monthly_limit_usd"
                 type="number"
                 step="0.01"
                 min="0"
@@ -766,10 +773,10 @@
             </div>
             <button
               type="button"
-              @click="createModelsListState.enabled = !createModelsListState.enabled"
+              @click="groupModelsListState.enabled = !groupModelsListState.enabled"
               :class="[
                 'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors',
-                createModelsListState.enabled
+                groupModelsListState.enabled
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600',
               ]"
@@ -777,24 +784,24 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  createModelsListState.enabled ? 'translate-x-6' : 'translate-x-1',
+                  groupModelsListState.enabled ? 'translate-x-6' : 'translate-x-1',
                 ]"
               />
             </button>
           </div>
           <div
-            v-if="createModelsListState.enabled"
+            v-if="groupModelsListState.enabled"
             class="overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 dark:border-dark-600 dark:bg-dark-800/40"
           >
             <div
-              v-if="!createModelsListLoading && createModelsListState.items.length > 0"
+              v-if="!groupModelsListLoading && groupModelsListState.items.length > 0"
               class="flex items-center justify-between gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2 text-xs dark:border-dark-600 dark:bg-dark-800"
             >
               <span class="text-gray-500 dark:text-gray-400">
                 {{
                   t("admin.groups.modelsList.selectedSummary", {
-                    selected: createModelsListSelectedCount,
-                    total: createModelsListState.items.length,
+                    selected: groupModelsListSelectedCount,
+                    total: groupModelsListState.items.length,
                   })
                 }}
               </span>
@@ -802,14 +809,14 @@
                 <button
                   type="button"
                   class="rounded px-2 py-1 font-medium text-primary-600 transition-colors hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/20"
-                  @click="selectAllModelsListItems(createModelsListState)"
+                  @click="selectAllModelsListItems(groupModelsListState)"
                 >
                   {{ t("admin.groups.modelsList.selectAll") }}
                 </button>
                 <button
                   type="button"
                   class="rounded px-2 py-1 font-medium text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-700"
-                  @click="invertModelsListSelection(createModelsListState)"
+                  @click="invertModelsListSelection(groupModelsListState)"
                 >
                   {{ t("admin.groups.modelsList.invertSelection") }}
                 </button>
@@ -818,17 +825,17 @@
             <div
               class="max-h-64 space-y-2 overflow-y-auto p-2"
             >
-              <p v-if="createModelsListLoading" class="text-xs text-gray-500 dark:text-gray-400">
+              <p v-if="groupModelsListLoading" class="text-xs text-gray-500 dark:text-gray-400">
                 {{ t("admin.groups.modelsList.loading") }}
               </p>
               <p
-                v-else-if="createModelsListState.items.length === 0"
+                v-else-if="groupModelsListState.items.length === 0"
                 class="text-xs text-gray-500 dark:text-gray-400"
               >
                 {{ t("admin.groups.modelsList.empty") }}
               </p>
               <div
-                v-for="(item, index) in createModelsListState.items"
+                v-for="(item, index) in groupModelsListState.items"
                 :key="item.id"
                 class="flex items-center gap-2 rounded border border-gray-200 bg-white px-3 py-2 dark:border-dark-600 dark:bg-dark-800"
               >
@@ -844,15 +851,15 @@
                   type="button"
                   :disabled="index === 0"
                   class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-40 dark:hover:bg-dark-600 dark:hover:text-gray-200"
-                  @click="moveCreateModelsListItem(index, index - 1)"
+                  @click="moveModelsListItemAt(index, index - 1)"
                 >
                   <Icon name="arrowUp" size="sm" />
                 </button>
                 <button
                   type="button"
-                  :disabled="index === createModelsListState.items.length - 1"
+                  :disabled="index === groupModelsListState.items.length - 1"
                   class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-40 dark:hover:bg-dark-600 dark:hover:text-gray-200"
-                  @click="moveCreateModelsListItem(index, index + 1)"
+                  @click="moveModelsListItemAt(index, index + 1)"
                 >
                   <Icon name="arrowDown" size="sm" />
                 </button>
@@ -863,44 +870,44 @@
 
         <!-- 图片生成计费配置 -->
         <div
-          v-if="supportsImagePricingPlatform(createForm.platform)"
+          v-if="supportsImagePricingPlatform(groupForm.platform)"
           class="border-t pt-4"
         >
           <label
             class="block mb-2 font-medium text-gray-700 dark:text-gray-300"
           >
-            {{ t(imagePricingI18nKey(createForm.platform, "title")) }}
+            {{ t(imagePricingI18nKey(groupForm.platform, "title")) }}
           </label>
           <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
-            {{ t(imagePricingI18nKey(createForm.platform, "description")) }}
+            {{ t(imagePricingI18nKey(groupForm.platform, "description")) }}
           </p>
           <div class="mb-4 grid grid-cols-1 gap-3 md:grid-cols-2">
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <input
-                v-model="createForm.allow_image_generation"
+                v-model="groupForm.allow_image_generation"
                 type="checkbox"
                 class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
-              {{ t(imagePricingI18nKey(createForm.platform, "allowImageGeneration")) }}
+              {{ t(imagePricingI18nKey(groupForm.platform, "allowImageGeneration")) }}
             </label>
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <input
-                v-model="createForm.image_rate_independent"
+                v-model="groupForm.image_rate_independent"
                 type="checkbox"
                 class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
-              {{ t(imagePricingI18nKey(createForm.platform, "independentMultiplier")) }}
+              {{ t(imagePricingI18nKey(groupForm.platform, "independentMultiplier")) }}
             </label>
           </div>
           <div
-            v-if="createForm.image_rate_independent"
+            v-if="groupForm.image_rate_independent"
             class="mb-4"
           >
             <label class="input-label">{{
-              t(imagePricingI18nKey(createForm.platform, "imageMultiplier"))
+              t(imagePricingI18nKey(groupForm.platform, "imageMultiplier"))
             }}</label>
             <input
-              v-model.number="createForm.image_rate_multiplier"
+              v-model.number="groupForm.image_rate_multiplier"
               type="number"
               step="0.0001"
               min="0"
@@ -912,59 +919,59 @@
             <div>
               <label class="input-label">1K ($)</label>
               <input
-                v-model.number="createForm.image_price_1k"
+                v-model.number="groupForm.image_price_1k"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getImagePricePlaceholder(createForm.platform, 'image_price_1k')"
+                :placeholder="getImagePricePlaceholder(groupForm.platform, 'image_price_1k')"
               />
             </div>
             <div>
               <label class="input-label">2K ($)</label>
               <input
-                v-model.number="createForm.image_price_2k"
+                v-model.number="groupForm.image_price_2k"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getImagePricePlaceholder(createForm.platform, 'image_price_2k')"
+                :placeholder="getImagePricePlaceholder(groupForm.platform, 'image_price_2k')"
               />
             </div>
             <div>
               <label class="input-label">4K ($)</label>
               <input
-                v-model.number="createForm.image_price_4k"
+                v-model.number="groupForm.image_price_4k"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getImagePricePlaceholder(createForm.platform, 'image_price_4k')"
+                :placeholder="getImagePricePlaceholder(groupForm.platform, 'image_price_4k')"
               />
             </div>
           </div>
           <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t(imagePricingI18nKey(createForm.platform, "modeHint")) }}
+            {{ t(imagePricingI18nKey(groupForm.platform, "modeHint")) }}
           </p>
           <div class="mt-2 rounded-lg bg-gray-50 p-3 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
             <div class="mb-1 font-medium">
-              {{ t(imagePricingI18nKey(createForm.platform, "finalPricePreview")) }}
+              {{ t(imagePricingI18nKey(groupForm.platform, "finalPricePreview")) }}
             </div>
             <div class="grid grid-cols-3 gap-2">
               <div
-                v-for="item in createImageFinalPricePreview"
+                v-for="item in groupImageFinalPricePreview"
                 :key="item.label"
               >
                 {{ item.label }}: {{ item.value }}
               </div>
             </div>
           </div>
-          <div v-if="createForm.platform === 'gemini' && createForm.allow_image_generation" class="mt-4 border-t border-dashed border-gray-200 pt-4 dark:border-dark-700">
+          <div v-if="groupForm.platform === 'gemini' && groupForm.allow_image_generation" class="mt-4 border-t border-dashed border-gray-200 pt-4 dark:border-dark-700">
             <label
               class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300"
             >
               <input
-                v-model="createForm.allow_batch_image_generation"
+                v-model="groupForm.allow_batch_image_generation"
                 type="checkbox"
                 class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
@@ -974,7 +981,7 @@
               {{ t("admin.groups.imagePricing.batchSectionHint") }}
             </p>
             <div
-              v-if="createForm.allow_batch_image_generation"
+              v-if="groupForm.allow_batch_image_generation"
               class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2"
             >
               <div>
@@ -982,7 +989,7 @@
                   t("admin.groups.imagePricing.batchDiscountMultiplier")
                 }}</label>
                 <input
-                  v-model.number="createForm.batch_image_discount_multiplier"
+                  v-model.number="groupForm.batch_image_discount_multiplier"
                   type="number"
                   step="0.0001"
                   min="0"
@@ -995,7 +1002,7 @@
                   t("admin.groups.imagePricing.batchHoldMultiplier")
                 }}</label>
                 <input
-                  v-model.number="createForm.batch_image_hold_multiplier"
+                  v-model.number="groupForm.batch_image_hold_multiplier"
                   type="number"
                   step="0.0001"
                   min="0"
@@ -1006,7 +1013,7 @@
             </div>
           </div>
           <p
-            v-else-if="createForm.platform !== 'gemini'"
+            v-else-if="groupForm.platform !== 'gemini'"
             class="mt-4 border-t border-dashed border-gray-200 pt-4 text-xs text-gray-500 dark:border-dark-700 dark:text-gray-400"
           >
             {{ t("admin.groups.imagePricing.batchGeminiOnlyHint") }}
@@ -1015,7 +1022,7 @@
 
         <!-- 视频生成计费配置（仅 Grok 平台） -->
         <div
-          v-if="supportsVideoPricingPlatform(createForm.platform)"
+          v-if="supportsVideoPricingPlatform(groupForm.platform)"
           class="border-t pt-4"
         >
           <label
@@ -1029,7 +1036,7 @@
           <div class="mb-4">
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <input
-                v-model="createForm.video_rate_independent"
+                v-model="groupForm.video_rate_independent"
                 type="checkbox"
                 class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
@@ -1037,14 +1044,14 @@
             </label>
           </div>
           <div
-            v-if="createForm.video_rate_independent"
+            v-if="groupForm.video_rate_independent"
             class="mb-4"
           >
             <label class="input-label">{{
               t(videoPricingI18nKey("videoMultiplier"))
             }}</label>
             <input
-              v-model.number="createForm.video_rate_multiplier"
+              v-model.number="groupForm.video_rate_multiplier"
               type="number"
               step="0.0001"
               min="0"
@@ -1056,34 +1063,34 @@
             <div>
               <label class="input-label">480p ($/s)</label>
               <input
-                v-model.number="createForm.video_price_480p"
+                v-model.number="groupForm.video_price_480p"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getVideoPricePlaceholder(createForm.platform, 'video_price_480p')"
+                :placeholder="getVideoPricePlaceholder(groupForm.platform, 'video_price_480p')"
               />
             </div>
             <div>
               <label class="input-label">720p ($/s)</label>
               <input
-                v-model.number="createForm.video_price_720p"
+                v-model.number="groupForm.video_price_720p"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getVideoPricePlaceholder(createForm.platform, 'video_price_720p')"
+                :placeholder="getVideoPricePlaceholder(groupForm.platform, 'video_price_720p')"
               />
             </div>
             <div>
               <label class="input-label">1080p ($/s)</label>
               <input
-                v-model.number="createForm.video_price_1080p"
+                v-model.number="groupForm.video_price_1080p"
                 type="number"
                 step="0.001"
                 min="0"
                 class="input"
-                :placeholder="getVideoPricePlaceholder(createForm.platform, 'video_price_1080p')"
+                :placeholder="getVideoPricePlaceholder(groupForm.platform, 'video_price_1080p')"
               />
             </div>
           </div>
@@ -1096,7 +1103,7 @@
             </div>
             <div class="grid grid-cols-3 gap-2">
               <div
-                v-for="item in createVideoFinalPricePreview"
+                v-for="item in groupVideoFinalPricePreview"
                 :key="item.label"
               >
                 {{ item.label }}: {{ item.value }}
@@ -1106,11 +1113,11 @@
         </div>
 
         <!-- 高峰时段倍率配置（仅订阅类型分组） -->
-        <div v-if="createForm.subscription_type === 'subscription'" class="border-t pt-4">
+        <div v-if="groupForm.subscription_type === 'subscription'" class="border-t pt-4">
           <div class="mb-4 grid grid-cols-1 gap-3 md:grid-cols-2">
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <input
-                v-model="createForm.peak_rate_enabled"
+                v-model="groupForm.peak_rate_enabled"
                 type="checkbox"
                 class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
@@ -1118,13 +1125,13 @@
             </label>
           </div>
           <div
-            v-if="createForm.peak_rate_enabled"
+            v-if="groupForm.peak_rate_enabled"
             class="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-3"
           >
             <div>
               <label class="input-label">{{ t("admin.groups.peakRate.peakStart") }}</label>
               <input
-                v-model="createForm.peak_start"
+                v-model="groupForm.peak_start"
                 type="time"
                 class="input"
               />
@@ -1132,7 +1139,7 @@
             <div>
               <label class="input-label">{{ t("admin.groups.peakRate.peakEnd") }}</label>
               <input
-                v-model="createForm.peak_end"
+                v-model="groupForm.peak_end"
                 type="time"
                 class="input"
               />
@@ -1140,7 +1147,7 @@
             <div>
               <label class="input-label">{{ t("admin.groups.peakRate.peakMultiplier") }}</label>
               <input
-                v-model.number="createForm.peak_rate_multiplier"
+                v-model.number="groupForm.peak_rate_multiplier"
                 type="number"
                 step="0.001"
                 min="0"
@@ -1153,7 +1160,7 @@
         </div>
 
         <!-- 支持的模型系列（仅 antigravity 平台） -->
-        <div v-if="createForm.platform === 'antigravity'" class="border-t pt-4">
+        <div v-if="groupForm.platform === 'antigravity'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.supportedScopes.title") }}
@@ -1186,8 +1193,8 @@
             <label class="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                :checked="createForm.supported_model_scopes.includes('claude')"
-                @change="toggleCreateScope('claude')"
+                :checked="groupForm.supported_model_scopes.includes('claude')"
+                @change="toggleScope('claude')"
                 class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
               />
               <span class="text-sm text-gray-700 dark:text-gray-300">{{
@@ -1198,9 +1205,9 @@
               <input
                 type="checkbox"
                 :checked="
-                  createForm.supported_model_scopes.includes('gemini_text')
+                  groupForm.supported_model_scopes.includes('gemini_text')
                 "
-                @change="toggleCreateScope('gemini_text')"
+                @change="toggleScope('gemini_text')"
                 class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
               />
               <span class="text-sm text-gray-700 dark:text-gray-300">{{
@@ -1211,9 +1218,9 @@
               <input
                 type="checkbox"
                 :checked="
-                  createForm.supported_model_scopes.includes('gemini_image')
+                  groupForm.supported_model_scopes.includes('gemini_image')
                 "
-                @change="toggleCreateScope('gemini_image')"
+                @change="toggleScope('gemini_image')"
                 class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
               />
               <span class="text-sm text-gray-700 dark:text-gray-300">{{
@@ -1227,7 +1234,7 @@
         </div>
 
         <!-- MCP XML 协议注入（仅 antigravity 平台） -->
-        <div v-if="createForm.platform === 'antigravity'" class="border-t pt-4">
+        <div v-if="groupForm.platform === 'antigravity'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.mcpXml.title") }}
@@ -1258,10 +1265,10 @@
           <div class="flex items-center gap-3">
             <button
               type="button"
-              @click="createForm.mcp_xml_inject = !createForm.mcp_xml_inject"
+              @click="groupForm.mcp_xml_inject = !groupForm.mcp_xml_inject"
               :class="[
                 'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                createForm.mcp_xml_inject
+                groupForm.mcp_xml_inject
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600',
               ]"
@@ -1269,13 +1276,13 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  createForm.mcp_xml_inject ? 'translate-x-6' : 'translate-x-1',
+                  groupForm.mcp_xml_inject ? 'translate-x-6' : 'translate-x-1',
                 ]"
               />
             </button>
             <span class="text-sm text-gray-500 dark:text-gray-400">
               {{
-                createForm.mcp_xml_inject
+                groupForm.mcp_xml_inject
                   ? t("admin.groups.mcpXml.enabled")
                   : t("admin.groups.mcpXml.disabled")
               }}
@@ -1284,7 +1291,7 @@
         </div>
 
         <!-- Claude Code 客户端限制（仅 anthropic 平台） -->
-        <div v-if="createForm.platform === 'anthropic'" class="border-t pt-4">
+        <div v-if="groupForm.platform === 'anthropic'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.claudeCode.title") }}
@@ -1317,11 +1324,11 @@
             <button
               type="button"
               @click="
-                createForm.claude_code_only = !createForm.claude_code_only
+                groupForm.claude_code_only = !groupForm.claude_code_only
               "
               :class="[
                 'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                createForm.claude_code_only
+                groupForm.claude_code_only
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600',
               ]"
@@ -1329,7 +1336,7 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  createForm.claude_code_only
+                  groupForm.claude_code_only
                     ? 'translate-x-6'
                     : 'translate-x-1',
                 ]"
@@ -1337,20 +1344,20 @@
             </button>
             <span class="text-sm text-gray-500 dark:text-gray-400">
               {{
-                createForm.claude_code_only
+                groupForm.claude_code_only
                   ? t("admin.groups.claudeCode.enabled")
                   : t("admin.groups.claudeCode.disabled")
               }}
             </span>
           </div>
           <!-- 降级分组选择（仅当启用 claude_code_only 时显示） -->
-          <div v-if="createForm.claude_code_only" class="mt-3">
+          <div v-if="groupForm.claude_code_only" class="mt-3">
             <label class="input-label">{{
               t("admin.groups.claudeCode.fallbackGroup")
             }}</label>
             <Select
-              v-model="createForm.fallback_group_id"
-              :options="fallbackGroupOptions"
+              v-model="groupForm.fallback_group_id"
+              :options="isEditMode ? fallbackGroupOptionsForEdit : fallbackGroupOptions"
               :placeholder="t('admin.groups.claudeCode.noFallback')"
             />
             <p class="input-hint">
@@ -1361,7 +1368,7 @@
 
         <!-- Codex 网页搜索按次计费（仅 openai 平台） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="groupForm.platform === 'openai'"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -1372,7 +1379,7 @@
               t("admin.groups.webSearchPricing.pricePerCall")
             }}</label>
             <input
-              v-model.number="createForm.web_search_price_per_call"
+              v-model.number="groupForm.web_search_price_per_call"
               type="number"
               step="0.001"
               min="0"
@@ -1387,7 +1394,7 @@
             >
               {{
                 t("admin.groups.webSearchPricing.finalPricePreview", {
-                  price: createWebSearchFinalPricePreview,
+                  price: groupWebSearchFinalPricePreview,
                 })
               }}
             </div>
@@ -1396,7 +1403,7 @@
 
         <!-- OpenAI Live 开关（仅 openai 平台） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="groupForm.platform === 'openai'"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -1408,17 +1415,17 @@
             }}</label>
             <button
               type="button"
-              @click="toggleLive('create')"
+              @click="toggleLive()"
               class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
               :class="
-                createForm.allow_live
+                groupForm.allow_live
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600'
               "
             >
               <span
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="createForm.allow_live ? 'translate-x-6' : 'translate-x-1'"
+                :class="groupForm.allow_live ? 'translate-x-6' : 'translate-x-1'"
               />
             </button>
           </div>
@@ -1429,7 +1436,7 @@
 
         <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="groupForm.platform === 'openai'"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -1444,12 +1451,12 @@
             <button
               type="button"
               @click="
-                createForm.allow_messages_dispatch =
-                  !createForm.allow_messages_dispatch
+                groupForm.allow_messages_dispatch =
+                  !groupForm.allow_messages_dispatch
               "
               class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
               :class="
-                createForm.allow_messages_dispatch
+                groupForm.allow_messages_dispatch
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600'
               "
@@ -1457,7 +1464,7 @@
               <span
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
                 :class="
-                  createForm.allow_messages_dispatch
+                  groupForm.allow_messages_dispatch
                     ? 'translate-x-6'
                     : 'translate-x-1'
                 "
@@ -1468,7 +1475,7 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
-          <div v-if="createForm.allow_messages_dispatch" class="mt-3">
+          <div v-if="groupForm.allow_messages_dispatch" class="mt-3">
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
             >
@@ -1495,7 +1502,7 @@
                       t("admin.groups.openaiMessages.opusModel")
                     }}</label>
                     <input
-                      v-model="createForm.opus_mapped_model"
+                      v-model="groupForm.opus_mapped_model"
                       type="text"
                       :placeholder="
                         t('admin.groups.openaiMessages.opusModelPlaceholder')
@@ -1508,7 +1515,7 @@
                       t("admin.groups.openaiMessages.sonnetModel")
                     }}</label>
                     <input
-                      v-model="createForm.sonnet_mapped_model"
+                      v-model="groupForm.sonnet_mapped_model"
                       type="text"
                       :placeholder="
                         t('admin.groups.openaiMessages.sonnetModelPlaceholder')
@@ -1521,7 +1528,7 @@
                       t("admin.groups.openaiMessages.haikuModel")
                     }}</label>
                     <input
-                      v-model="createForm.haiku_mapped_model"
+                      v-model="groupForm.haiku_mapped_model"
                       type="text"
                       :placeholder="
                         t('admin.groups.openaiMessages.haikuModelPlaceholder')
@@ -1561,7 +1568,7 @@
 
               <div class="p-4 bg-gray-50/30 dark:bg-dark-800/30">
                 <div
-                  v-if="createForm.exact_model_mappings.length === 0"
+                  v-if="groupForm.exact_model_mappings.length === 0"
                   class="flex items-center justify-between gap-3 rounded-xl border-2 border-dashed border-primary-200 bg-white px-5 py-4 text-sm text-primary-700 transition-colors hover:border-primary-300 dark:border-primary-900/40 dark:bg-dark-800 dark:text-primary-300 dark:hover:border-primary-800"
                 >
                   <span>{{
@@ -1569,7 +1576,7 @@
                   }}</span>
                   <button
                     type="button"
-                    @click="addCreateMessagesDispatchMapping"
+                    @click="addMessagesDispatchMapping"
                     class="flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
                   >
                     <Icon name="plus" size="sm" />
@@ -1579,8 +1586,8 @@
 
                 <div v-else class="space-y-3">
                   <div
-                    v-for="row in createForm.exact_model_mappings"
-                    :key="getCreateMessagesDispatchRowKey(row)"
+                    v-for="row in groupForm.exact_model_mappings"
+                    :key="isEditMode ? getEditMessagesDispatchRowKey(row) : getCreateMessagesDispatchRowKey(row)"
                     class="group relative rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:border-dark-600 dark:bg-dark-700 dark:hover:border-primary-700"
                   >
                     <div class="flex items-center gap-4">
@@ -1629,7 +1636,7 @@
                       </div>
                       <button
                         type="button"
-                        @click="removeCreateMessagesDispatchMapping(row)"
+                        @click="removeMessagesDispatchMapping(row)"
                         class="mt-6 flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
                         :title="
                           t('admin.groups.openaiMessages.removeExactMapping')
@@ -1642,7 +1649,7 @@
 
                   <button
                     type="button"
-                    @click="addCreateMessagesDispatchMapping"
+                    @click="addMessagesDispatchMapping"
                     class="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white py-3 text-sm font-medium text-gray-500 transition-all hover:border-primary-300 hover:bg-primary-50/50 hover:text-primary-600 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-400 dark:hover:border-primary-800 dark:hover:bg-primary-900/20 dark:hover:text-primary-400"
                   >
                     <Icon name="plus" size="sm" />
@@ -1658,7 +1665,7 @@
         <div
           v-if="
             ['openai', 'antigravity', 'anthropic', 'gemini'].includes(
-              createForm.platform,
+              groupForm.platform,
             )
           "
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4 space-y-4"
@@ -1675,7 +1682,7 @@
               >
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                 {{
-                  createForm.require_oauth_only
+                  groupForm.require_oauth_only
                     ? t("admin.groups.accountFilters.oauthOnlyEnabled")
                     : t("admin.groups.accountFilters.disabled")
                 }}
@@ -1684,11 +1691,11 @@
             <button
               type="button"
               @click="
-                createForm.require_oauth_only = !createForm.require_oauth_only
+                groupForm.require_oauth_only = !groupForm.require_oauth_only
               "
               class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
               :class="
-                createForm.require_oauth_only
+                groupForm.require_oauth_only
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600'
               "
@@ -1696,7 +1703,7 @@
               <span
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
                 :class="
-                  createForm.require_oauth_only
+                  groupForm.require_oauth_only
                     ? 'translate-x-6'
                     : 'translate-x-1'
                 "
@@ -1712,7 +1719,7 @@
               >
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                 {{
-                  createForm.require_privacy_set
+                  groupForm.require_privacy_set
                     ? t("admin.groups.accountFilters.privacySetOnlyEnabled")
                     : t("admin.groups.accountFilters.disabled")
                 }}
@@ -1721,11 +1728,11 @@
             <button
               type="button"
               @click="
-                createForm.require_privacy_set = !createForm.require_privacy_set
+                groupForm.require_privacy_set = !groupForm.require_privacy_set
               "
               class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
               :class="
-                createForm.require_privacy_set
+                groupForm.require_privacy_set
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600'
               "
@@ -1733,7 +1740,7 @@
               <span
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
                 :class="
-                  createForm.require_privacy_set
+                  groupForm.require_privacy_set
                     ? 'translate-x-6'
                     : 'translate-x-1'
                 "
@@ -1745,8 +1752,8 @@
         <!-- 无效请求兜底（仅 anthropic/antigravity 平台，且非订阅分组） -->
         <div
           v-if="
-            ['anthropic', 'antigravity'].includes(createForm.platform) &&
-            createForm.subscription_type !== 'subscription'
+            ['anthropic', 'antigravity'].includes(groupForm.platform) &&
+            groupForm.subscription_type !== 'subscription'
           "
           class="border-t pt-4"
         >
@@ -1754,8 +1761,8 @@
             t("admin.groups.invalidRequestFallback.title")
           }}</label>
           <Select
-            v-model="createForm.fallback_group_id_on_invalid_request"
-            :options="invalidRequestFallbackOptions"
+            v-model="groupForm.fallback_group_id_on_invalid_request"
+            :options="isEditMode ? invalidRequestFallbackOptionsForEdit : invalidRequestFallbackOptions"
             :placeholder="t('admin.groups.invalidRequestFallback.noFallback')"
           />
           <p class="input-hint">
@@ -1764,7 +1771,7 @@
         </div>
 
         <!-- 模型路由配置（仅 anthropic 平台） -->
-        <div v-if="createForm.platform === 'anthropic'" class="border-t pt-4">
+        <div v-if="groupForm.platform === 'anthropic'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.modelRouting.title") }}
@@ -1798,12 +1805,12 @@
             <button
               type="button"
               @click="
-                createForm.model_routing_enabled =
-                  !createForm.model_routing_enabled
+                groupForm.model_routing_enabled =
+                  !groupForm.model_routing_enabled
               "
               :class="[
                 'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                createForm.model_routing_enabled
+                groupForm.model_routing_enabled
                   ? 'bg-primary-500'
                   : 'bg-gray-300 dark:bg-dark-600',
               ]"
@@ -1811,7 +1818,7 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  createForm.model_routing_enabled
+                  groupForm.model_routing_enabled
                     ? 'translate-x-6'
                     : 'translate-x-1',
                 ]"
@@ -1819,14 +1826,14 @@
             </button>
             <span class="text-sm text-gray-500 dark:text-gray-400">
               {{
-                createForm.model_routing_enabled
+                groupForm.model_routing_enabled
                   ? t("admin.groups.modelRouting.enabled")
                   : t("admin.groups.modelRouting.disabled")
               }}
             </span>
           </div>
           <p
-            v-if="!createForm.model_routing_enabled"
+            v-if="!groupForm.model_routing_enabled"
             class="text-xs text-gray-500 dark:text-gray-400 mb-3"
           >
             {{ t("admin.groups.modelRouting.disabledHint") }}
@@ -1835,10 +1842,10 @@
             {{ t("admin.groups.modelRouting.noRulesHint") }}
           </p>
           <!-- 路由规则列表（仅在启用时显示） -->
-          <div v-if="createForm.model_routing_enabled" class="space-y-3">
+          <div v-if="groupForm.model_routing_enabled" class="space-y-3">
             <div
-              v-for="rule in createModelRoutingRules"
-              :key="getCreateRuleRenderKey(rule)"
+              v-for="rule in groupModelRoutingRules"
+              :key="isEditMode ? getEditRuleRenderKey(rule) : getCreateRuleRenderKey(rule)"
               class="rounded-lg border border-gray-200 p-3 dark:border-dark-600"
             >
               <div class="flex items-start gap-3">
@@ -1873,7 +1880,7 @@
                         {{ account.name }}
                         <button
                           type="button"
-                          @click="removeSelectedAccount(rule, account.id)"
+                          @click="removeSelectedAccount(rule, account.id, isEditMode)"
                           class="ml-0.5 text-primary-500 hover:text-primary-700 dark:hover:text-primary-200"
                         >
                           <Icon name="x" size="xs" />
@@ -1884,7 +1891,7 @@
                     <div class="relative account-search-container">
                       <input
                         v-model="
-                          accountSearchKeyword[getCreateRuleSearchKey(rule)]
+                          accountSearchKeyword[getRuleSearchKey(rule, isEditMode)]
                         "
                         type="text"
                         class="input text-sm"
@@ -1893,25 +1900,25 @@
                             'admin.groups.modelRouting.searchAccountPlaceholder',
                           )
                         "
-                        @input="searchAccountsByRule(rule)"
-                        @focus="onAccountSearchFocus(rule)"
+                        @input="searchAccountsByRule(rule, isEditMode)"
+                        @focus="onAccountSearchFocus(rule, isEditMode)"
                       />
                       <!-- 搜索结果下拉框 -->
                       <div
                         v-if="
-                          showAccountDropdown[getCreateRuleSearchKey(rule)] &&
-                          accountSearchResults[getCreateRuleSearchKey(rule)]
+                          showAccountDropdown[getRuleSearchKey(rule, isEditMode)] &&
+                          accountSearchResults[getRuleSearchKey(rule, isEditMode)]
                             ?.length > 0
                         "
                         class="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-lg border bg-white shadow-lg dark:border-dark-600 dark:bg-dark-800"
                       >
                         <button
                           v-for="account in accountSearchResults[
-                            getCreateRuleSearchKey(rule)
+                            getRuleSearchKey(rule, isEditMode)
                           ]"
                           :key="account.id"
                           type="button"
-                          @click="selectAccount(rule, account)"
+                          @click="selectAccount(rule, account, isEditMode)"
                           class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-dark-700"
                           :class="{
                             'opacity-50': rule.accounts.some(
@@ -1936,7 +1943,7 @@
                 </div>
                 <button
                   type="button"
-                  @click="removeCreateRoutingRule(rule)"
+                  @click="removeRoutingRule(rule, isEditMode)"
                   class="mt-5 p-1.5 text-gray-400 hover:text-red-500 transition-colors"
                   :title="t('admin.groups.modelRouting.removeRule')"
                 >
@@ -1947,9 +1954,9 @@
           </div>
           <!-- 添加规则按钮（仅在启用时显示） -->
           <button
-            v-if="createForm.model_routing_enabled"
+            v-if="groupForm.model_routing_enabled"
             type="button"
-            @click="addCreateRoutingRule"
+            @click="addRoutingRule"
             class="mt-3 flex items-center gap-1.5 text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
           >
             <Icon name="plus" size="sm" />
@@ -1961,7 +1968,7 @@
       <template #footer>
         <div class="flex justify-end gap-3 pt-4">
           <button
-            @click="closeCreateModal"
+            @click="isEditMode ? closeEditModal() : closeCreateModal()"
             type="button"
             class="btn btn-secondary"
           >
@@ -1969,7 +1976,7 @@
           </button>
           <button
             type="submit"
-            form="create-group-form"
+            form="group-form"
             :disabled="submitting"
             class="btn btn-primary"
             data-tour="group-form-submit"
@@ -1994,1561 +2001,13 @@
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
               ></path>
             </svg>
-            {{ submitting ? t("admin.groups.creating") : t("common.create") }}
+            {{ submitting ? t(isEditMode ? "admin.groups.updating" : "admin.groups.creating") : t(isEditMode ? "common.update" : "common.create") }}
           </button>
         </div>
       </template>
     </BaseDialog>
 
     <!-- Edit Group Modal -->
-    <BaseDialog
-      :show="showEditModal"
-      :title="t('admin.groups.editGroup')"
-      width="normal"
-      @close="closeEditModal"
-    >
-      <form
-        v-if="editingGroup"
-        id="edit-group-form"
-        @submit.prevent="handleUpdateGroup"
-        class="space-y-5"
-      >
-        <div>
-          <label class="input-label">{{ t("admin.groups.form.name") }}</label>
-          <input
-            v-model="editForm.name"
-            type="text"
-            required
-            class="input"
-            data-tour="edit-group-form-name"
-          />
-        </div>
-        <div>
-          <label class="input-label">{{
-            t("admin.groups.form.description")
-          }}</label>
-          <textarea
-            v-model="editForm.description"
-            rows="3"
-            class="input"
-          ></textarea>
-        </div>
-        <div>
-          <label class="input-label">{{
-            t("admin.groups.form.platform")
-          }}</label>
-          <Select
-            v-model="editForm.platform"
-            :options="platformOptions"
-            :disabled="true"
-            data-tour="group-form-platform"
-          />
-          <p class="input-hint">{{ t("admin.groups.platformNotEditable") }}</p>
-        </div>
-        <!-- 从分组复制账号（编辑时） -->
-        <div v-if="copyAccountsGroupOptionsForEdit.length > 0">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.copyAccounts.title") }}
-            </label>
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-72 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.copyAccounts.tooltipEdit") }}
-                  </p>
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- 已选分组标签 -->
-          <div
-            v-if="editForm.copy_accounts_from_group_ids.length > 0"
-            class="flex flex-wrap gap-1.5 mb-2"
-          >
-            <span
-              v-for="groupId in editForm.copy_accounts_from_group_ids"
-              :key="groupId"
-              class="inline-flex items-center gap-1 rounded-full bg-primary-100 px-2.5 py-1 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
-            >
-              {{
-                copyAccountsGroupOptionsForEdit.find((o) => o.value === groupId)
-                  ?.label || `#${groupId}`
-              }}
-              <button
-                type="button"
-                @click="
-                  editForm.copy_accounts_from_group_ids =
-                    editForm.copy_accounts_from_group_ids.filter(
-                      (id) => id !== groupId,
-                    )
-                "
-                class="ml-0.5 text-primary-500 hover:text-primary-700 dark:hover:text-primary-200"
-              >
-                <Icon name="x" size="xs" />
-              </button>
-            </span>
-          </div>
-          <!-- 分组选择下拉 -->
-          <select
-            class="input"
-            @change="
-              (e) => {
-                const val = Number((e.target as HTMLSelectElement).value);
-                if (
-                  val &&
-                  !editForm.copy_accounts_from_group_ids.includes(val)
-                ) {
-                  editForm.copy_accounts_from_group_ids.push(val);
-                }
-                (e.target as HTMLSelectElement).value = '';
-              }
-            "
-          >
-            <option value="">
-              {{ t("admin.groups.copyAccounts.selectPlaceholder") }}
-            </option>
-            <option
-              v-for="opt in copyAccountsGroupOptionsForEdit"
-              :key="opt.value"
-              :value="opt.value"
-              :disabled="
-                editForm.copy_accounts_from_group_ids.includes(opt.value)
-              "
-            >
-              {{ opt.label }}
-            </option>
-          </select>
-          <p class="input-hint">
-            {{ t("admin.groups.copyAccounts.hintEdit") }}
-          </p>
-        </div>
-        <div>
-          <label class="input-label">{{
-            t("admin.groups.form.rateMultiplier")
-          }}</label>
-          <input
-            v-model.number="editForm.rate_multiplier"
-            type="number"
-            step="0.001"
-            min="0.001"
-            required
-            class="input"
-            data-tour="group-form-multiplier"
-          />
-        </div>
-        <div>
-          <label class="input-label">{{ t("admin.groups.form.rpmLimit") }}</label>
-          <input
-            v-model.number="editForm.rpm_limit"
-            type="number"
-            min="0"
-            step="1"
-            class="input"
-            :placeholder="t('admin.groups.form.rpmLimitPlaceholder')"
-          />
-          <p class="input-hint">{{ t("admin.groups.form.rpmLimitHint") }}</p>
-        </div>
-        <ReasoningEffortPolicyFields
-          v-if="editForm.platform === 'openai'"
-          ref="editReasoningEffortPolicyRef"
-          id-prefix="edit-group-reasoning"
-          :platform="editForm.platform"
-          v-model:max-effort="editForm.max_reasoning_effort"
-          v-model:mappings="editForm.reasoning_effort_mappings"
-        />
-        <div v-if="editForm.subscription_type !== 'subscription'">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.form.exclusive") }}
-            </label>
-            <!-- Help Tooltip -->
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <!-- Tooltip Popover -->
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-72 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="mb-2 text-xs font-medium">
-                    {{ t("admin.groups.exclusiveTooltip.title") }}
-                  </p>
-                  <p class="mb-2 text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.exclusiveTooltip.description") }}
-                  </p>
-                  <div class="rounded bg-gray-800 p-2 dark:bg-gray-700">
-                    <p class="text-xs leading-relaxed text-gray-300">
-                      <span
-                        class="inline-flex items-center gap-1 text-primary-400"
-                        ><Icon name="lightbulb" size="xs" />
-                        {{ t("admin.groups.exclusiveTooltip.example") }}</span
-                      >
-                      {{ t("admin.groups.exclusiveTooltip.exampleContent") }}
-                    </p>
-                  </div>
-                  <!-- Arrow -->
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center gap-3">
-            <button
-              type="button"
-              @click="editForm.is_exclusive = !editForm.is_exclusive"
-              :class="[
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                editForm.is_exclusive
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600',
-              ]"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  editForm.is_exclusive ? 'translate-x-6' : 'translate-x-1',
-                ]"
-              />
-            </button>
-            <span class="text-sm text-gray-500 dark:text-gray-400">
-              {{
-                editForm.is_exclusive
-                  ? t("admin.groups.exclusive")
-                  : t("admin.groups.public")
-              }}
-            </span>
-          </div>
-        </div>
-        <div>
-          <label class="input-label">{{ t("admin.groups.form.status") }}</label>
-          <Select v-model="editForm.status" :options="editStatusOptions" />
-        </div>
-
-        <!-- Subscription Configuration -->
-        <div class="mt-4 border-t pt-4">
-          <div>
-            <label class="input-label">{{
-              t("admin.groups.subscription.type")
-            }}</label>
-            <Select
-              v-model="editForm.subscription_type"
-              :options="subscriptionTypeOptions"
-              :disabled="true"
-            />
-            <p class="input-hint">
-              {{ t("admin.groups.subscription.typeNotEditable") }}
-            </p>
-          </div>
-
-          <!-- Subscription limits (only show when subscription type is selected) -->
-          <div
-            v-if="editForm.subscription_type === 'subscription'"
-            class="space-y-4 border-l-2 border-primary-200 pl-4 dark:border-primary-800"
-          >
-            <div>
-              <label class="input-label">{{
-                t("admin.groups.subscription.dailyLimit")
-              }}</label>
-              <input
-                v-model.number="editForm.daily_limit_usd"
-                type="number"
-                step="0.01"
-                min="0"
-                class="input"
-                :placeholder="t('admin.groups.subscription.noLimit')"
-              />
-            </div>
-            <div>
-              <label class="input-label">{{
-                t("admin.groups.subscription.weeklyLimit")
-              }}</label>
-              <input
-                v-model.number="editForm.weekly_limit_usd"
-                type="number"
-                step="0.01"
-                min="0"
-                class="input"
-                :placeholder="t('admin.groups.subscription.noLimit')"
-              />
-            </div>
-            <div>
-              <label class="input-label">{{
-                t("admin.groups.subscription.monthlyLimit")
-              }}</label>
-              <input
-                v-model.number="editForm.monthly_limit_usd"
-                type="number"
-                step="0.01"
-                min="0"
-                class="input"
-                :placeholder="t('admin.groups.subscription.noLimit')"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div class="border-t pt-4">
-          <div class="mb-3 flex items-center justify-between gap-3">
-            <div>
-              <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {{ t("admin.groups.modelsList.title") }}
-              </label>
-              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {{ t("admin.groups.modelsList.hint") }}
-              </p>
-            </div>
-            <button
-              type="button"
-              @click="editModelsListState.enabled = !editModelsListState.enabled"
-              :class="[
-                'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors',
-                editModelsListState.enabled
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600',
-              ]"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  editModelsListState.enabled ? 'translate-x-6' : 'translate-x-1',
-                ]"
-              />
-            </button>
-          </div>
-          <div
-            v-if="editModelsListState.enabled"
-            class="overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 dark:border-dark-600 dark:bg-dark-800/40"
-          >
-            <div
-              v-if="!editModelsListLoading && editModelsListState.items.length > 0"
-              class="flex items-center justify-between gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2 text-xs dark:border-dark-600 dark:bg-dark-800"
-            >
-              <span class="text-gray-500 dark:text-gray-400">
-                {{
-                  t("admin.groups.modelsList.selectedSummary", {
-                    selected: editModelsListSelectedCount,
-                    total: editModelsListState.items.length,
-                  })
-                }}
-              </span>
-              <div class="flex items-center gap-1.5">
-                <button
-                  type="button"
-                  class="rounded px-2 py-1 font-medium text-primary-600 transition-colors hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/20"
-                  @click="selectAllModelsListItems(editModelsListState)"
-                >
-                  {{ t("admin.groups.modelsList.selectAll") }}
-                </button>
-                <button
-                  type="button"
-                  class="rounded px-2 py-1 font-medium text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-700"
-                  @click="invertModelsListSelection(editModelsListState)"
-                >
-                  {{ t("admin.groups.modelsList.invertSelection") }}
-                </button>
-              </div>
-            </div>
-            <div
-              class="max-h-64 space-y-2 overflow-y-auto p-2"
-            >
-              <p v-if="editModelsListLoading" class="text-xs text-gray-500 dark:text-gray-400">
-                {{ t("admin.groups.modelsList.loading") }}
-              </p>
-              <p
-                v-else-if="editModelsListState.items.length === 0"
-                class="text-xs text-gray-500 dark:text-gray-400"
-              >
-                {{ t("admin.groups.modelsList.empty") }}
-              </p>
-              <div
-                v-for="(item, index) in editModelsListState.items"
-                :key="item.id"
-                class="flex items-center gap-2 rounded border border-gray-200 bg-white px-3 py-2 dark:border-dark-600 dark:bg-dark-800"
-              >
-                <input
-                  v-model="item.selected"
-                  type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                />
-                <span class="min-w-0 flex-1 break-all text-sm text-gray-700 dark:text-gray-300">
-                  {{ item.id }}
-                </span>
-                <button
-                  type="button"
-                  :disabled="index === 0"
-                  class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-40 dark:hover:bg-dark-600 dark:hover:text-gray-200"
-                  @click="moveEditModelsListItem(index, index - 1)"
-                >
-                  <Icon name="arrowUp" size="sm" />
-                </button>
-                <button
-                  type="button"
-                  :disabled="index === editModelsListState.items.length - 1"
-                  class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-40 dark:hover:bg-dark-600 dark:hover:text-gray-200"
-                  @click="moveEditModelsListItem(index, index + 1)"
-                >
-                  <Icon name="arrowDown" size="sm" />
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 图片生成计费配置 -->
-        <div
-          v-if="supportsImagePricingPlatform(editForm.platform)"
-          class="border-t pt-4"
-        >
-          <label
-            class="block mb-2 font-medium text-gray-700 dark:text-gray-300"
-          >
-            {{ t(imagePricingI18nKey(editForm.platform, "title")) }}
-          </label>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
-            {{ t(imagePricingI18nKey(editForm.platform, "description")) }}
-          </p>
-          <div class="mb-4 grid grid-cols-1 gap-3 md:grid-cols-2">
-            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                v-model="editForm.allow_image_generation"
-                type="checkbox"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              {{ t(imagePricingI18nKey(editForm.platform, "allowImageGeneration")) }}
-            </label>
-            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                v-model="editForm.image_rate_independent"
-                type="checkbox"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              {{ t(imagePricingI18nKey(editForm.platform, "independentMultiplier")) }}
-            </label>
-          </div>
-          <div
-            v-if="editForm.image_rate_independent"
-            class="mb-4"
-          >
-            <label class="input-label">{{
-              t(imagePricingI18nKey(editForm.platform, "imageMultiplier"))
-            }}</label>
-            <input
-              v-model.number="editForm.image_rate_multiplier"
-              type="number"
-              step="0.0001"
-              min="0"
-              class="input"
-              placeholder="1"
-            />
-          </div>
-          <div class="grid grid-cols-3 gap-3">
-            <div>
-              <label class="input-label">1K ($)</label>
-              <input
-                v-model.number="editForm.image_price_1k"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getImagePricePlaceholder(editForm.platform, 'image_price_1k')"
-              />
-            </div>
-            <div>
-              <label class="input-label">2K ($)</label>
-              <input
-                v-model.number="editForm.image_price_2k"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getImagePricePlaceholder(editForm.platform, 'image_price_2k')"
-              />
-            </div>
-            <div>
-              <label class="input-label">4K ($)</label>
-              <input
-                v-model.number="editForm.image_price_4k"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getImagePricePlaceholder(editForm.platform, 'image_price_4k')"
-              />
-            </div>
-          </div>
-          <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t(imagePricingI18nKey(editForm.platform, "modeHint")) }}
-          </p>
-          <div class="mt-2 rounded-lg bg-gray-50 p-3 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-            <div class="mb-1 font-medium">
-              {{ t(imagePricingI18nKey(editForm.platform, "finalPricePreview")) }}
-            </div>
-            <div class="grid grid-cols-3 gap-2">
-              <div
-                v-for="item in editImageFinalPricePreview"
-                :key="item.label"
-              >
-                {{ item.label }}: {{ item.value }}
-              </div>
-            </div>
-          </div>
-          <div v-if="editForm.platform === 'gemini' && editForm.allow_image_generation" class="mt-4 border-t border-dashed border-gray-200 pt-4 dark:border-dark-700">
-            <label
-              class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              <input
-                v-model="editForm.allow_batch_image_generation"
-                type="checkbox"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              {{ t("admin.groups.imagePricing.allowBatchImageGeneration") }}
-            </label>
-            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-              {{ t("admin.groups.imagePricing.batchSectionHint") }}
-            </p>
-            <div
-              v-if="editForm.allow_batch_image_generation"
-              class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2"
-            >
-              <div>
-                <label class="input-label">{{
-                  t("admin.groups.imagePricing.batchDiscountMultiplier")
-                }}</label>
-                <input
-                  v-model.number="editForm.batch_image_discount_multiplier"
-                  type="number"
-                  step="0.0001"
-                  min="0"
-                  class="input"
-                  placeholder="0.5"
-                />
-              </div>
-              <div>
-                <label class="input-label">{{
-                  t("admin.groups.imagePricing.batchHoldMultiplier")
-                }}</label>
-                <input
-                  v-model.number="editForm.batch_image_hold_multiplier"
-                  type="number"
-                  step="0.0001"
-                  min="0"
-                  class="input"
-                  placeholder="0.6"
-                />
-              </div>
-            </div>
-          </div>
-          <p
-            v-else-if="editForm.platform !== 'gemini'"
-            class="mt-4 border-t border-dashed border-gray-200 pt-4 text-xs text-gray-500 dark:border-dark-700 dark:text-gray-400"
-          >
-            {{ t("admin.groups.imagePricing.batchGeminiOnlyHint") }}
-          </p>
-        </div>
-
-        <!-- 视频生成计费配置（仅 Grok 平台） -->
-        <div
-          v-if="supportsVideoPricingPlatform(editForm.platform)"
-          class="border-t pt-4"
-        >
-          <label
-            class="block mb-2 font-medium text-gray-700 dark:text-gray-300"
-          >
-            {{ t(videoPricingI18nKey("title")) }}
-          </label>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
-            {{ t(videoPricingI18nKey("description")) }}
-          </p>
-          <div class="mb-4">
-            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                v-model="editForm.video_rate_independent"
-                type="checkbox"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              {{ t(videoPricingI18nKey("independentMultiplier")) }}
-            </label>
-          </div>
-          <div
-            v-if="editForm.video_rate_independent"
-            class="mb-4"
-          >
-            <label class="input-label">{{
-              t(videoPricingI18nKey("videoMultiplier"))
-            }}</label>
-            <input
-              v-model.number="editForm.video_rate_multiplier"
-              type="number"
-              step="0.0001"
-              min="0"
-              class="input"
-              placeholder="1"
-            />
-          </div>
-          <div class="grid grid-cols-3 gap-3">
-            <div>
-              <label class="input-label">480p ($/s)</label>
-              <input
-                v-model.number="editForm.video_price_480p"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getVideoPricePlaceholder(editForm.platform, 'video_price_480p')"
-              />
-            </div>
-            <div>
-              <label class="input-label">720p ($/s)</label>
-              <input
-                v-model.number="editForm.video_price_720p"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getVideoPricePlaceholder(editForm.platform, 'video_price_720p')"
-              />
-            </div>
-            <div>
-              <label class="input-label">1080p ($/s)</label>
-              <input
-                v-model.number="editForm.video_price_1080p"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                :placeholder="getVideoPricePlaceholder(editForm.platform, 'video_price_1080p')"
-              />
-            </div>
-          </div>
-          <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t(videoPricingI18nKey("modeHint")) }}
-          </p>
-          <div class="mt-2 rounded-lg bg-gray-50 p-3 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-            <div class="mb-1 font-medium">
-              {{ t(videoPricingI18nKey("finalPricePreview")) }}
-            </div>
-            <div class="grid grid-cols-3 gap-2">
-              <div
-                v-for="item in editVideoFinalPricePreview"
-                :key="item.label"
-              >
-                {{ item.label }}: {{ item.value }}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 高峰时段倍率配置（仅订阅类型分组） -->
-        <div v-if="editForm.subscription_type === 'subscription'" class="border-t pt-4">
-          <div class="mb-4 grid grid-cols-1 gap-3 md:grid-cols-2">
-            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                v-model="editForm.peak_rate_enabled"
-                type="checkbox"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              <span>{{ t("admin.groups.peakRate.enable") }}</span>
-            </label>
-          </div>
-          <div
-            v-if="editForm.peak_rate_enabled"
-            class="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-3"
-          >
-            <div>
-              <label class="input-label">{{ t("admin.groups.peakRate.peakStart") }}</label>
-              <input
-                v-model="editForm.peak_start"
-                type="time"
-                class="input"
-              />
-            </div>
-            <div>
-              <label class="input-label">{{ t("admin.groups.peakRate.peakEnd") }}</label>
-              <input
-                v-model="editForm.peak_end"
-                type="time"
-                class="input"
-              />
-            </div>
-            <div>
-              <label class="input-label">{{ t("admin.groups.peakRate.peakMultiplier") }}</label>
-              <input
-                v-model.number="editForm.peak_rate_multiplier"
-                type="number"
-                step="0.001"
-                min="0"
-                class="input"
-                placeholder="1"
-                :title="t('admin.groups.peakRate.multiplierHint')"
-              />
-            </div>
-          </div>
-        </div>
-
-        <!-- 支持的模型系列（仅 antigravity 平台） -->
-        <div v-if="editForm.platform === 'antigravity'" class="border-t pt-4">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.supportedScopes.title") }}
-            </label>
-            <!-- Help Tooltip -->
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-72 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.supportedScopes.tooltip") }}
-                  </p>
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="space-y-2">
-            <label class="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                :checked="editForm.supported_model_scopes.includes('claude')"
-                @change="toggleEditScope('claude')"
-                class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
-              />
-              <span class="text-sm text-gray-700 dark:text-gray-300">{{
-                t("admin.groups.supportedScopes.claude")
-              }}</span>
-            </label>
-            <label class="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                :checked="
-                  editForm.supported_model_scopes.includes('gemini_text')
-                "
-                @change="toggleEditScope('gemini_text')"
-                class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
-              />
-              <span class="text-sm text-gray-700 dark:text-gray-300">{{
-                t("admin.groups.supportedScopes.geminiText")
-              }}</span>
-            </label>
-            <label class="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                :checked="
-                  editForm.supported_model_scopes.includes('gemini_image')
-                "
-                @change="toggleEditScope('gemini_image')"
-                class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-600 dark:bg-dark-700"
-              />
-              <span class="text-sm text-gray-700 dark:text-gray-300">{{
-                t("admin.groups.supportedScopes.geminiImage")
-              }}</span>
-            </label>
-          </div>
-          <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            {{ t("admin.groups.supportedScopes.hint") }}
-          </p>
-        </div>
-
-        <!-- MCP XML 协议注入（仅 antigravity 平台） -->
-        <div v-if="editForm.platform === 'antigravity'" class="border-t pt-4">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.mcpXml.title") }}
-            </label>
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-72 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.mcpXml.tooltip") }}
-                  </p>
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center gap-3">
-            <button
-              type="button"
-              @click="editForm.mcp_xml_inject = !editForm.mcp_xml_inject"
-              :class="[
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                editForm.mcp_xml_inject
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600',
-              ]"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  editForm.mcp_xml_inject ? 'translate-x-6' : 'translate-x-1',
-                ]"
-              />
-            </button>
-            <span class="text-sm text-gray-500 dark:text-gray-400">
-              {{
-                editForm.mcp_xml_inject
-                  ? t("admin.groups.mcpXml.enabled")
-                  : t("admin.groups.mcpXml.disabled")
-              }}
-            </span>
-          </div>
-        </div>
-
-        <!-- Claude Code 客户端限制（仅 anthropic 平台） -->
-        <div v-if="editForm.platform === 'anthropic'" class="border-t pt-4">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.claudeCode.title") }}
-            </label>
-            <!-- Help Tooltip -->
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-72 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.claudeCode.tooltip") }}
-                  </p>
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center gap-3">
-            <button
-              type="button"
-              @click="editForm.claude_code_only = !editForm.claude_code_only"
-              :class="[
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                editForm.claude_code_only
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600',
-              ]"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  editForm.claude_code_only ? 'translate-x-6' : 'translate-x-1',
-                ]"
-              />
-            </button>
-            <span class="text-sm text-gray-500 dark:text-gray-400">
-              {{
-                editForm.claude_code_only
-                  ? t("admin.groups.claudeCode.enabled")
-                  : t("admin.groups.claudeCode.disabled")
-              }}
-            </span>
-          </div>
-          <!-- 降级分组选择（仅当启用 claude_code_only 时显示） -->
-          <div v-if="editForm.claude_code_only" class="mt-3">
-            <label class="input-label">{{
-              t("admin.groups.claudeCode.fallbackGroup")
-            }}</label>
-            <Select
-              v-model="editForm.fallback_group_id"
-              :options="fallbackGroupOptionsForEdit"
-              :placeholder="t('admin.groups.claudeCode.noFallback')"
-            />
-            <p class="input-hint">
-              {{ t("admin.groups.claudeCode.fallbackHint") }}
-            </p>
-          </div>
-        </div>
-
-        <!-- Codex 网页搜索按次计费（仅 openai 平台） -->
-        <div
-          v-if="editForm.platform === 'openai'"
-          class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
-        >
-          <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            {{ t("admin.groups.webSearchPricing.title") }}
-          </h4>
-          <div>
-            <label class="input-label">{{
-              t("admin.groups.webSearchPricing.pricePerCall")
-            }}</label>
-            <input
-              v-model.number="editForm.web_search_price_per_call"
-              type="number"
-              step="0.001"
-              min="0"
-              placeholder="0.01"
-              class="input"
-            />
-            <p class="input-hint">
-              {{ t("admin.groups.webSearchPricing.pricePerCallHint") }}
-            </p>
-            <div
-              class="mt-2 rounded-lg bg-gray-50 p-3 text-xs text-gray-600 dark:bg-dark-700 dark:text-gray-300"
-            >
-              {{
-                t("admin.groups.webSearchPricing.finalPricePreview", {
-                  price: editWebSearchFinalPricePreview,
-                })
-              }}
-            </div>
-          </div>
-        </div>
-
-        <!-- OpenAI Live 开关（仅 openai 平台） -->
-        <div
-          v-if="editForm.platform === 'openai'"
-          class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
-        >
-          <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            {{ t("admin.groups.openaiLive.title") }}
-          </h4>
-          <div class="flex items-center justify-between">
-            <label class="text-sm text-gray-600 dark:text-gray-400">{{
-              t("admin.groups.openaiLive.allow")
-            }}</label>
-            <button
-              type="button"
-              @click="toggleLive('edit')"
-              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-              :class="
-                editForm.allow_live
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600'
-              "
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="editForm.allow_live ? 'translate-x-6' : 'translate-x-1'"
-              />
-            </button>
-          </div>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            {{ t("admin.groups.openaiLive.hint") }}
-          </p>
-        </div>
-
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
-        <div
-          v-if="editForm.platform === 'openai'"
-          class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
-        >
-          <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            {{ t("admin.groups.openaiMessages.title") }}
-          </h4>
-
-          <!-- 允许 Messages 调度开关 -->
-          <div class="flex items-center justify-between">
-            <label class="text-sm text-gray-600 dark:text-gray-400">{{
-              t("admin.groups.openaiMessages.allowDispatch")
-            }}</label>
-            <button
-              type="button"
-              @click="
-                editForm.allow_messages_dispatch =
-                  !editForm.allow_messages_dispatch
-              "
-              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-              :class="
-                editForm.allow_messages_dispatch
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600'
-              "
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="
-                  editForm.allow_messages_dispatch
-                    ? 'translate-x-6'
-                    : 'translate-x-1'
-                "
-              />
-            </button>
-          </div>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
-          </p>
-
-          <div v-if="editForm.allow_messages_dispatch" class="mt-3">
-            <div
-              class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
-            >
-              <div
-                class="border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-700 dark:bg-dark-700/50"
-              >
-                <div class="flex items-center gap-2">
-                  <div class="h-2 w-2 rounded-full bg-blue-500"></div>
-                  <label
-                    class="text-sm font-medium text-gray-900 dark:text-white"
-                    >{{
-                      t("admin.groups.openaiMessages.familyMappingTitle")
-                    }}</label
-                  >
-                </div>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {{ t("admin.groups.openaiMessages.familyMappingHint") }}
-                </p>
-              </div>
-              <div class="p-4">
-                <div class="grid gap-4 md:grid-cols-3">
-                  <div>
-                    <label class="input-label">{{
-                      t("admin.groups.openaiMessages.opusModel")
-                    }}</label>
-                    <input
-                      v-model="editForm.opus_mapped_model"
-                      type="text"
-                      :placeholder="
-                        t('admin.groups.openaiMessages.opusModelPlaceholder')
-                      "
-                      class="input"
-                    />
-                  </div>
-                  <div>
-                    <label class="input-label">{{
-                      t("admin.groups.openaiMessages.sonnetModel")
-                    }}</label>
-                    <input
-                      v-model="editForm.sonnet_mapped_model"
-                      type="text"
-                      :placeholder="
-                        t('admin.groups.openaiMessages.sonnetModelPlaceholder')
-                      "
-                      class="input"
-                    />
-                  </div>
-                  <div>
-                    <label class="input-label">{{
-                      t("admin.groups.openaiMessages.haikuModel")
-                    }}</label>
-                    <input
-                      v-model="editForm.haiku_mapped_model"
-                      type="text"
-                      :placeholder="
-                        t('admin.groups.openaiMessages.haikuModelPlaceholder')
-                      "
-                      class="input"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div
-              class="mt-5 relative overflow-hidden rounded-xl border border-primary-200 bg-white shadow-sm dark:border-primary-900/50 dark:bg-dark-800"
-            >
-              <div
-                class="border-b border-primary-100 bg-primary-50/80 px-4 py-3 dark:border-primary-900/40 dark:bg-primary-900/20"
-              >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <div class="flex items-center gap-2">
-                      <div class="h-2 w-2 rounded-full bg-primary-500"></div>
-                      <label
-                        class="text-sm font-medium text-primary-900 dark:text-primary-100"
-                        >{{
-                          t("admin.groups.openaiMessages.exactMappingTitle")
-                        }}</label
-                      >
-                    </div>
-                    <p
-                      class="mt-1 text-xs text-primary-600/90 dark:text-primary-400/90"
-                    >
-                      {{ t("admin.groups.openaiMessages.exactMappingHint") }}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div class="p-4 bg-gray-50/30 dark:bg-dark-800/30">
-                <div
-                  v-if="editForm.exact_model_mappings.length === 0"
-                  class="flex items-center justify-between gap-3 rounded-xl border-2 border-dashed border-primary-200 bg-white px-5 py-4 text-sm text-primary-700 transition-colors hover:border-primary-300 dark:border-primary-900/40 dark:bg-dark-800 dark:text-primary-300 dark:hover:border-primary-800"
-                >
-                  <span>{{
-                    t("admin.groups.openaiMessages.noExactMappings")
-                  }}</span>
-                  <button
-                    type="button"
-                    @click="addEditMessagesDispatchMapping"
-                    class="flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-                  >
-                    <Icon name="plus" size="sm" />
-                    {{ t("admin.groups.openaiMessages.addExactMapping") }}
-                  </button>
-                </div>
-
-                <div v-else class="space-y-3">
-                  <div
-                    v-for="row in editForm.exact_model_mappings"
-                    :key="getEditMessagesDispatchRowKey(row)"
-                    class="group relative rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:border-dark-600 dark:bg-dark-700 dark:hover:border-primary-700"
-                  >
-                    <div class="flex items-center gap-4">
-                      <div
-                        class="grid flex-1 gap-4 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-start"
-                      >
-                        <div>
-                          <label class="input-label">{{
-                            t("admin.groups.openaiMessages.claudeModel")
-                          }}</label>
-                          <input
-                            v-model="row.claude_model"
-                            type="text"
-                            :placeholder="
-                              t(
-                                'admin.groups.openaiMessages.claudeModelPlaceholder',
-                              )
-                            "
-                            class="input bg-gray-50 focus:bg-white dark:bg-dark-800 dark:focus:bg-dark-900"
-                          />
-                        </div>
-                        <div
-                          class="hidden md:flex md:justify-center md:pt-7 text-primary-300 dark:text-primary-700"
-                        >
-                          <Icon
-                            name="arrowRight"
-                            size="sm"
-                            class="transition-transform group-hover:translate-x-1"
-                          />
-                        </div>
-                        <div>
-                          <label class="input-label">{{
-                            t("admin.groups.openaiMessages.targetModel")
-                          }}</label>
-                          <input
-                            v-model="row.target_model"
-                            type="text"
-                            :placeholder="
-                              t(
-                                'admin.groups.openaiMessages.targetModelPlaceholder',
-                              )
-                            "
-                            class="input bg-gray-50 focus:bg-white dark:bg-dark-800 dark:focus:bg-dark-900"
-                          />
-                        </div>
-                      </div>
-                      <button
-                        type="button"
-                        @click="removeEditMessagesDispatchMapping(row)"
-                        class="mt-6 flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-                        :title="
-                          t('admin.groups.openaiMessages.removeExactMapping')
-                        "
-                      >
-                        <Icon name="trash" size="sm" />
-                      </button>
-                    </div>
-                  </div>
-
-                  <button
-                    type="button"
-                    @click="addEditMessagesDispatchMapping"
-                    class="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white py-3 text-sm font-medium text-gray-500 transition-all hover:border-primary-300 hover:bg-primary-50/50 hover:text-primary-600 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-400 dark:hover:border-primary-800 dark:hover:bg-primary-900/20 dark:hover:text-primary-400"
-                  >
-                    <Icon name="plus" size="sm" />
-                    {{ t("admin.groups.openaiMessages.addExactMapping") }}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 账号过滤控制 (OpenAI/Antigravity/Anthropic/Gemini) -->
-        <div
-          v-if="
-            ['openai', 'antigravity', 'anthropic', 'gemini'].includes(
-              editForm.platform,
-            )
-          "
-          class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4 space-y-4"
-        >
-          <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            {{ t("admin.groups.accountFilters.title") }}
-          </h4>
-
-          <!-- require_oauth_only toggle -->
-          <div class="flex items-center justify-between">
-            <div>
-              <label class="text-sm text-gray-600 dark:text-gray-400"
-                >{{ t("admin.groups.accountFilters.oauthOnly") }}</label
-              >
-              <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                {{
-                  editForm.require_oauth_only
-                    ? t("admin.groups.accountFilters.oauthOnlyEnabled")
-                    : t("admin.groups.accountFilters.disabled")
-                }}
-              </p>
-            </div>
-            <button
-              type="button"
-              @click="
-                editForm.require_oauth_only = !editForm.require_oauth_only
-              "
-              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-              :class="
-                editForm.require_oauth_only
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600'
-              "
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="
-                  editForm.require_oauth_only
-                    ? 'translate-x-6'
-                    : 'translate-x-1'
-                "
-              />
-            </button>
-          </div>
-
-          <!-- require_privacy_set toggle -->
-          <div class="flex items-center justify-between">
-            <div>
-              <label class="text-sm text-gray-600 dark:text-gray-400"
-                >{{ t("admin.groups.accountFilters.privacySetOnly") }}</label
-              >
-              <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                {{
-                  editForm.require_privacy_set
-                    ? t("admin.groups.accountFilters.privacySetOnlyEnabled")
-                    : t("admin.groups.accountFilters.disabled")
-                }}
-              </p>
-            </div>
-            <button
-              type="button"
-              @click="
-                editForm.require_privacy_set = !editForm.require_privacy_set
-              "
-              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-              :class="
-                editForm.require_privacy_set
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600'
-              "
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="
-                  editForm.require_privacy_set
-                    ? 'translate-x-6'
-                    : 'translate-x-1'
-                "
-              />
-            </button>
-          </div>
-        </div>
-
-        <!-- 无效请求兜底（仅 anthropic/antigravity 平台，且非订阅分组） -->
-        <div
-          v-if="
-            ['anthropic', 'antigravity'].includes(editForm.platform) &&
-            editForm.subscription_type !== 'subscription'
-          "
-          class="border-t pt-4"
-        >
-          <label class="input-label">{{
-            t("admin.groups.invalidRequestFallback.title")
-          }}</label>
-          <Select
-            v-model="editForm.fallback_group_id_on_invalid_request"
-            :options="invalidRequestFallbackOptionsForEdit"
-            :placeholder="t('admin.groups.invalidRequestFallback.noFallback')"
-          />
-          <p class="input-hint">
-            {{ t("admin.groups.invalidRequestFallback.hint") }}
-          </p>
-        </div>
-
-        <!-- 模型路由配置（仅 anthropic 平台） -->
-        <div v-if="editForm.platform === 'anthropic'" class="border-t pt-4">
-          <div class="mb-1.5 flex items-center gap-1">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t("admin.groups.modelRouting.title") }}
-            </label>
-            <!-- Help Tooltip -->
-            <div class="group relative inline-flex">
-              <Icon
-                name="questionCircle"
-                size="sm"
-                :stroke-width="2"
-                class="cursor-help text-gray-400 transition-colors hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400"
-              />
-              <div
-                class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-80 opacity-0 transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100"
-              >
-                <div
-                  class="rounded-lg bg-gray-900 p-3 text-white shadow-lg dark:bg-gray-800"
-                >
-                  <p class="text-xs leading-relaxed text-gray-300">
-                    {{ t("admin.groups.modelRouting.tooltip") }}
-                  </p>
-                  <div
-                    class="absolute -bottom-1.5 left-3 h-3 w-3 rotate-45 bg-gray-900 dark:bg-gray-800"
-                  ></div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- 启用开关 -->
-          <div class="flex items-center gap-3 mb-3">
-            <button
-              type="button"
-              @click="
-                editForm.model_routing_enabled = !editForm.model_routing_enabled
-              "
-              :class="[
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                editForm.model_routing_enabled
-                  ? 'bg-primary-500'
-                  : 'bg-gray-300 dark:bg-dark-600',
-              ]"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-                  editForm.model_routing_enabled
-                    ? 'translate-x-6'
-                    : 'translate-x-1',
-                ]"
-              />
-            </button>
-            <span class="text-sm text-gray-500 dark:text-gray-400">
-              {{
-                editForm.model_routing_enabled
-                  ? t("admin.groups.modelRouting.enabled")
-                  : t("admin.groups.modelRouting.disabled")
-              }}
-            </span>
-          </div>
-          <p
-            v-if="!editForm.model_routing_enabled"
-            class="text-xs text-gray-500 dark:text-gray-400 mb-3"
-          >
-            {{ t("admin.groups.modelRouting.disabledHint") }}
-          </p>
-          <p v-else class="text-xs text-gray-500 dark:text-gray-400 mb-3">
-            {{ t("admin.groups.modelRouting.noRulesHint") }}
-          </p>
-          <!-- 路由规则列表（仅在启用时显示） -->
-          <div v-if="editForm.model_routing_enabled" class="space-y-3">
-            <div
-              v-for="rule in editModelRoutingRules"
-              :key="getEditRuleRenderKey(rule)"
-              class="rounded-lg border border-gray-200 p-3 dark:border-dark-600"
-            >
-              <div class="flex items-start gap-3">
-                <div class="flex-1 space-y-2">
-                  <div>
-                    <label class="input-label text-xs">{{
-                      t("admin.groups.modelRouting.modelPattern")
-                    }}</label>
-                    <input
-                      v-model="rule.pattern"
-                      type="text"
-                      class="input text-sm"
-                      :placeholder="
-                        t('admin.groups.modelRouting.modelPatternPlaceholder')
-                      "
-                    />
-                  </div>
-                  <div>
-                    <label class="input-label text-xs">{{
-                      t("admin.groups.modelRouting.accounts")
-                    }}</label>
-                    <!-- 已选账号标签 -->
-                    <div
-                      v-if="rule.accounts.length > 0"
-                      class="flex flex-wrap gap-1.5 mb-2"
-                    >
-                      <span
-                        v-for="account in rule.accounts"
-                        :key="account.id"
-                        class="inline-flex items-center gap-1 rounded-full bg-primary-100 px-2.5 py-1 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
-                      >
-                        {{ account.name }}
-                        <button
-                          type="button"
-                          @click="removeSelectedAccount(rule, account.id, true)"
-                          class="ml-0.5 text-primary-500 hover:text-primary-700 dark:hover:text-primary-200"
-                        >
-                          <Icon name="x" size="xs" />
-                        </button>
-                      </span>
-                    </div>
-                    <!-- 账号搜索输入框 -->
-                    <div class="relative account-search-container">
-                      <input
-                        v-model="
-                          accountSearchKeyword[getEditRuleSearchKey(rule)]
-                        "
-                        type="text"
-                        class="input text-sm"
-                        :placeholder="
-                          t(
-                            'admin.groups.modelRouting.searchAccountPlaceholder',
-                          )
-                        "
-                        @input="searchAccountsByRule(rule, true)"
-                        @focus="onAccountSearchFocus(rule, true)"
-                      />
-                      <!-- 搜索结果下拉框 -->
-                      <div
-                        v-if="
-                          showAccountDropdown[getEditRuleSearchKey(rule)] &&
-                          accountSearchResults[getEditRuleSearchKey(rule)]
-                            ?.length > 0
-                        "
-                        class="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-lg border bg-white shadow-lg dark:border-dark-600 dark:bg-dark-800"
-                      >
-                        <button
-                          v-for="account in accountSearchResults[
-                            getEditRuleSearchKey(rule)
-                          ]"
-                          :key="account.id"
-                          type="button"
-                          @click="selectAccount(rule, account, true)"
-                          class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-dark-700"
-                          :class="{
-                            'opacity-50': rule.accounts.some(
-                              (a) => a.id === account.id,
-                            ),
-                          }"
-                          :disabled="
-                            rule.accounts.some((a) => a.id === account.id)
-                          "
-                        >
-                          <span>{{ account.name }}</span>
-                          <span class="ml-2 text-xs text-gray-400"
-                            >#{{ account.id }}</span
-                          >
-                        </button>
-                      </div>
-                    </div>
-                    <p class="text-xs text-gray-400 mt-1">
-                      {{ t("admin.groups.modelRouting.accountsHint") }}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  @click="removeEditRoutingRule(rule)"
-                  class="mt-5 p-1.5 text-gray-400 hover:text-red-500 transition-colors"
-                  :title="t('admin.groups.modelRouting.removeRule')"
-                >
-                  <Icon name="trash" size="sm" />
-                </button>
-              </div>
-            </div>
-          </div>
-          <!-- 添加规则按钮（仅在启用时显示） -->
-          <button
-            v-if="editForm.model_routing_enabled"
-            type="button"
-            @click="addEditRoutingRule"
-            class="mt-3 flex items-center gap-1.5 text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-          >
-            <Icon name="plus" size="sm" />
-            {{ t("admin.groups.modelRouting.addRule") }}
-          </button>
-        </div>
-      </form>
-
-      <template #footer>
-        <div class="flex justify-end gap-3 pt-4">
-          <button
-            @click="closeEditModal"
-            type="button"
-            class="btn btn-secondary"
-          >
-            {{ t("common.cancel") }}
-          </button>
-          <button
-            type="submit"
-            form="edit-group-form"
-            :disabled="submitting"
-            class="btn btn-primary"
-            data-tour="group-form-submit"
-          >
-            <svg
-              v-if="submitting"
-              class="-ml-1 mr-2 h-4 w-4 animate-spin"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-              ></circle>
-              <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              ></path>
-            </svg>
-            {{ submitting ? t("admin.groups.updating") : t("common.update") }}
-          </button>
-        </div>
-      </template>
-    </BaseDialog>
 
     <!-- Delete Confirmation Dialog -->
     <ConfirmDialog
@@ -4445,7 +2904,7 @@ const copyAccountsGroupLabel = (g: AdminGroup) => {
 const copyAccountsGroupOptions = computed(() => {
   const eligibleGroups = groups.value.filter(
     (g) =>
-      canCopyAccountsFromGroup(createForm.platform, g.platform) &&
+      canCopyAccountsFromGroup(groupForm.platform, g.platform) &&
       (g.account_count || 0) > 0,
   );
   return eligibleGroups.map((g) => ({
@@ -4459,7 +2918,7 @@ const copyAccountsGroupOptionsForEdit = computed(() => {
   const currentId = editingGroup.value?.id;
   const eligibleGroups = groups.value.filter(
     (g) =>
-      canCopyAccountsFromGroup(editForm.platform, g.platform) &&
+      canCopyAccountsFromGroup(groupForm.platform, g.platform) &&
       (g.account_count || 0) > 0 &&
       g.id !== currentId,
   );
@@ -4513,10 +2972,7 @@ let abortController: AbortController | null = null;
 const showCreateModal = ref(false);
 const showEditModal = ref(false);
 const showDeleteDialog = ref(false);
-const pendingLiveForm = ref<"create" | "edit" | null>(null);
-const showUnsupportedLiveConfirm = computed(
-  () => pendingLiveForm.value !== null,
-);
+const showUnsupportedLiveConfirm = ref(false);
 const liveCapability = ref<{ supported: boolean; reason?: string } | null>(null);
 let liveCapabilityRequest: Promise<{
   supported: boolean;
@@ -4565,32 +3021,28 @@ const compositeRouteForm = reactive<CompositeRouteFormState>({
   enabled: true,
   notes: "",
 });
-const createMessagesDispatchDefaults = createDefaultMessagesDispatchFormState();
-const editMessagesDispatchDefaults = createDefaultMessagesDispatchFormState();
-const createModelsListState = reactive(createInitialModelsListState());
-const editModelsListState = reactive(createInitialModelsListState());
-const createModelsListLoading = ref(false);
-const editModelsListLoading = ref(false);
+const groupMessagesDispatchDefaults = createDefaultMessagesDispatchFormState();
+const groupModelsListState = reactive(createInitialModelsListState());
+const groupModelsListLoading = ref(false);
 type ReasoningEffortPolicyFieldsExpose = {
   validate: () => boolean;
   resetValidation: () => void;
 };
-const createReasoningEffortPolicyRef = ref<ReasoningEffortPolicyFieldsExpose | null>(null);
-const editReasoningEffortPolicyRef = ref<ReasoningEffortPolicyFieldsExpose | null>(null);
+const groupReasoningEffortPolicyRef = ref<ReasoningEffortPolicyFieldsExpose | null>(null);
 const modelsListCandidatesTracker = createModelsListCandidatesTracker();
-const createModelsListSelectedCount = computed(
-  () => createModelsListState.items.filter((item) => item.selected).length,
-);
-const editModelsListSelectedCount = computed(
-  () => editModelsListState.items.filter((item) => item.selected).length,
+const groupModelsListSelectedCount = computed(
+  () => groupModelsListState.items.filter((item) => item.selected).length,
 );
 
-const createForm = reactive({
+// 两个对话框共用一个表单对象，所以两个入口都必须从这里重新开始，
+// 否则上一次编辑的分组会渗进下一次新建。
+const createDefaultGroupForm = () => ({
   name: "",
   description: "",
   platform: "anthropic" as GroupPlatform,
   rate_multiplier: 1.0,
   is_exclusive: false,
+  status: "active" as "active" | "inactive",
   subscription_type: "standard" as SubscriptionType,
   daily_limit_usd: null as number | null,
   weekly_limit_usd: null as number | null,
@@ -4625,9 +3077,9 @@ const createForm = reactive({
   // OpenAI Messages 调度配置（仅 openai 平台使用）
   allow_messages_dispatch: false,
   allow_live: false,
-  opus_mapped_model: createMessagesDispatchDefaults.opus_mapped_model,
-  sonnet_mapped_model: createMessagesDispatchDefaults.sonnet_mapped_model,
-  haiku_mapped_model: createMessagesDispatchDefaults.haiku_mapped_model,
+  opus_mapped_model: groupMessagesDispatchDefaults.opus_mapped_model,
+  sonnet_mapped_model: groupMessagesDispatchDefaults.sonnet_mapped_model,
+  haiku_mapped_model: groupMessagesDispatchDefaults.haiku_mapped_model,
   exact_model_mappings: [] as MessagesDispatchMappingRow[],
   // 账号过滤控制（OpenAI/Antigravity 平台）
   require_oauth_only: false,
@@ -4644,7 +3096,10 @@ const createForm = reactive({
   rpm_limit: 0 as number,
   max_reasoning_effort: "",
   reasoning_effort_mappings: [] as ReasoningEffortMappingRow[],
+  default_mapped_model: '',
 });
+
+const groupForm = reactive(createDefaultGroupForm());
 
 // 简单账号类型（用于模型路由选择）
 interface SimpleAccount {
@@ -4659,10 +3114,9 @@ interface ModelRoutingRule {
 }
 
 // 创建表单的模型路由规则
-const createModelRoutingRules = ref<ModelRoutingRule[]>([]);
+const groupModelRoutingRules = ref<ModelRoutingRule[]>([]);
 
 // 编辑表单的模型路由规则
-const editModelRoutingRules = ref<ModelRoutingRule[]>([]);
 
 // 规则对象稳定 key（避免使用 index 导致状态错位）
 const resolveCreateRuleKey =
@@ -4778,24 +3232,16 @@ const removeSelectedAccount = (
 };
 
 // 切换创建表单的模型系列选择
-const toggleCreateScope = (scope: string) => {
-  const idx = createForm.supported_model_scopes.indexOf(scope);
+const toggleScope = (scope: string) => {
+  const idx = groupForm.supported_model_scopes.indexOf(scope);
   if (idx === -1) {
-    createForm.supported_model_scopes.push(scope);
+    groupForm.supported_model_scopes.push(scope);
   } else {
-    createForm.supported_model_scopes.splice(idx, 1);
+    groupForm.supported_model_scopes.splice(idx, 1);
   }
 };
 
 // 切换编辑表单的模型系列选择
-const toggleEditScope = (scope: string) => {
-  const idx = editForm.supported_model_scopes.indexOf(scope);
-  if (idx === -1) {
-    editForm.supported_model_scopes.push(scope);
-  } else {
-    editForm.supported_model_scopes.splice(idx, 1);
-  }
-};
 
 // 处理账号搜索输入框聚焦
 const onAccountSearchFocus = (
@@ -4811,39 +3257,24 @@ const onAccountSearchFocus = (
 };
 
 // 添加创建表单的路由规则
-const addCreateRoutingRule = () => {
-  createModelRoutingRules.value.push({ pattern: "", accounts: [] });
+const addRoutingRule = () => {
+  groupModelRoutingRules.value.push({ pattern: "", accounts: [] });
 };
 
-// 删除创建表单的路由规则
-const removeCreateRoutingRule = (rule: ModelRoutingRule) => {
-  const index = createModelRoutingRules.value.indexOf(rule);
+// 删除路由规则。搜索状态仍按 create-/edit- 分键，所以要带上当前模式。
+const removeRoutingRule = (rule: ModelRoutingRule, isEdit: boolean = false) => {
+  const index = groupModelRoutingRules.value.indexOf(rule);
   if (index === -1) return;
 
-  const key = getCreateRuleSearchKey(rule);
+  const key = getRuleSearchKey(rule, isEdit);
   accountSearchRunner.clearKey(key);
   clearAccountSearchStateByKey(key);
-  createModelRoutingRules.value.splice(index, 1);
+  groupModelRoutingRules.value.splice(index, 1);
 };
 
-// 添加编辑表单的路由规则
-const addEditRoutingRule = () => {
-  editModelRoutingRules.value.push({ pattern: "", accounts: [] });
-};
-
-// 删除编辑表单的路由规则
-const removeEditRoutingRule = (rule: ModelRoutingRule) => {
-  const index = editModelRoutingRules.value.indexOf(rule);
-  if (index === -1) return;
-
-  const key = getEditRuleSearchKey(rule);
-  accountSearchRunner.clearKey(key);
-  clearAccountSearchStateByKey(key);
-  editModelRoutingRules.value.splice(index, 1);
-};
 
 const resetModelsListState = (
-  state: typeof createModelsListState,
+  state: typeof groupModelsListState,
   config?: Parameters<typeof createInitialModelsListState>[0],
 ) => {
   const fresh = createInitialModelsListState(config);
@@ -4859,8 +3290,8 @@ const loadModelsListCandidates = async (
 ) => {
   const request = { mode, groupID, platform };
   const requestID = modelsListCandidatesTracker.next(request);
-  const state = mode === "create" ? createModelsListState : editModelsListState;
-  const loadingRef = mode === "create" ? createModelsListLoading : editModelsListLoading;
+  const state = mode === "create" ? groupModelsListState : groupModelsListState;
+  const loadingRef = mode === "create" ? groupModelsListLoading : groupModelsListLoading;
   loadingRef.value = true;
   try {
     const models = await adminAPI.groups.getModelsListCandidates(groupID, platform);
@@ -4880,13 +3311,10 @@ const loadModelsListCandidates = async (
   }
 };
 
-const moveCreateModelsListItem = (fromIndex: number, toIndex: number) => {
-  moveModelsListItem(createModelsListState, fromIndex, toIndex);
+const moveModelsListItemAt = (fromIndex: number, toIndex: number) => {
+  moveModelsListItem(groupModelsListState, fromIndex, toIndex);
 };
 
-const moveEditModelsListItem = (fromIndex: number, toIndex: number) => {
-  moveModelsListItem(editModelsListState, fromIndex, toIndex);
-};
 
 // 将 UI 格式的路由规则转换为 API 格式
 const convertRoutingRulesToApiFormat = (
@@ -4934,68 +3362,6 @@ const convertApiFormatToRoutingRules = async (
   return rules;
 };
 
-const editForm = reactive({
-  name: "",
-  description: "",
-  platform: "anthropic" as GroupPlatform,
-  rate_multiplier: 1.0,
-  is_exclusive: false,
-  status: "active" as "active" | "inactive",
-  subscription_type: "standard" as SubscriptionType,
-  daily_limit_usd: null as number | null,
-  weekly_limit_usd: null as number | null,
-  monthly_limit_usd: null as number | null,
-  // 图片生成计费配置
-  allow_image_generation: false,
-  allow_batch_image_generation: false,
-  image_rate_independent: false,
-  image_rate_multiplier: 1,
-  batch_image_discount_multiplier: 0.5,
-  batch_image_hold_multiplier: 0.6,
-  image_price_1k: null as number | null,
-  image_price_2k: null as number | null,
-  image_price_4k: null as number | null,
-  // 视频生成计费配置（仅 Grok 平台）
-  video_rate_independent: false,
-  video_rate_multiplier: 1,
-  video_price_480p: null as number | null,
-  video_price_720p: null as number | null,
-  video_price_1080p: null as number | null,
-  // Codex 网页搜索按次计费（仅 openai 平台使用）；null = 使用默认价 0.01
-  web_search_price_per_call: null as number | null,
-  // 高峰时段倍率配置
-  peak_rate_enabled: false,
-  peak_start: "",
-  peak_end: "",
-  peak_rate_multiplier: 1.0,
-  // Claude Code 客户端限制（仅 anthropic 平台使用）
-  claude_code_only: false,
-  fallback_group_id: null as number | null,
-  fallback_group_id_on_invalid_request: null as number | null,
-  // OpenAI Messages 调度配置（仅 openai 平台使用）
-  allow_messages_dispatch: false,
-  allow_live: false,
-  default_mapped_model: '',
-  opus_mapped_model: editMessagesDispatchDefaults.opus_mapped_model,
-  sonnet_mapped_model: editMessagesDispatchDefaults.sonnet_mapped_model,
-  haiku_mapped_model: editMessagesDispatchDefaults.haiku_mapped_model,
-  exact_model_mappings: [] as MessagesDispatchMappingRow[],
-  // 账号过滤控制（OpenAI/Antigravity 平台）
-  require_oauth_only: false,
-  require_privacy_set: false,
-  // 模型路由开关
-  model_routing_enabled: false,
-  // 支持的模型系列（仅 antigravity 平台）
-  supported_model_scopes: ["claude", "gemini_text", "gemini_image"] as string[],
-  // MCP XML 协议注入开关（仅 antigravity 平台）
-  mcp_xml_inject: true,
-  // 从分组复制账号
-  copy_accounts_from_group_ids: [] as number[],
-  // 分组级 RPM 限制（每用户每分钟最大请求数；0 = 不限制）
-  rpm_limit: 0 as number,
-  max_reasoning_effort: "",
-  reasoning_effort_mappings: [] as ReasoningEffortMappingRow[],
-});
 
 type ImagePricingFormState = {
   platform: GroupPlatform;
@@ -5110,17 +3476,11 @@ const buildVideoFinalPricePreview = (form: VideoPricingFormState) => {
   });
 };
 
-const createImageFinalPricePreview = computed(() =>
-  buildImageFinalPricePreview(createForm),
+const groupImageFinalPricePreview = computed(() =>
+  buildImageFinalPricePreview(groupForm),
 );
-const editImageFinalPricePreview = computed(() =>
-  buildImageFinalPricePreview(editForm),
-);
-const createVideoFinalPricePreview = computed(() =>
-  buildVideoFinalPricePreview(createForm),
-);
-const editVideoFinalPricePreview = computed(() =>
-  buildVideoFinalPricePreview(editForm),
+const groupVideoFinalPricePreview = computed(() =>
+  buildVideoFinalPricePreview(groupForm),
 );
 
 // Codex 网页搜索单次默认价（与后端 defaultWebSearchPricePerCall 一致，官方 $10/1000 次）
@@ -5137,11 +3497,8 @@ const buildWebSearchFinalPricePreview = (form: {
   return formatImagePricePreview(basePrice * multiplier);
 };
 
-const createWebSearchFinalPricePreview = computed(() =>
-  buildWebSearchFinalPricePreview(createForm),
-);
-const editWebSearchFinalPricePreview = computed(() =>
-  buildWebSearchFinalPricePreview(editForm),
+const groupWebSearchFinalPricePreview = computed(() =>
+  buildWebSearchFinalPricePreview(groupForm),
 );
 
 const resetDisabledBatchImagePricing = (
@@ -5186,28 +3543,26 @@ const loadLiveCapability = async () => {
   return liveCapability.value ?? { supported: false };
 };
 
-const toggleLive = async (target: "create" | "edit") => {
-  const form = target === "create" ? createForm : editForm;
-  if (form.allow_live) {
-    form.allow_live = false;
+const toggleLive = async () => {
+  if (groupForm.allow_live) {
+    groupForm.allow_live = false;
     return;
   }
   const capability = await loadLiveCapability();
   if (capability.supported) {
-    form.allow_live = true;
+    groupForm.allow_live = true;
     return;
   }
-  pendingLiveForm.value = target;
+  showUnsupportedLiveConfirm.value = true;
 };
 
 const confirmUnsupportedLive = () => {
-  if (pendingLiveForm.value === "create") createForm.allow_live = true;
-  if (pendingLiveForm.value === "edit") editForm.allow_live = true;
-  pendingLiveForm.value = null;
+  groupForm.allow_live = true;
+  showUnsupportedLiveConfirm.value = false;
 };
 
 const cancelUnsupportedLive = () => {
-  pendingLiveForm.value = null;
+  showUnsupportedLiveConfirm.value = false;
 };
 
 const loadGroups = async () => {
@@ -5373,61 +3728,70 @@ const handleSort = (key: string, order: 'asc' | 'desc') => {
   loadGroups();
 };
 
+// 两个对话框合并成一个后，用它来区分当前处于哪一种模式。
+const isEditMode = computed(() => editingGroup.value !== null);
+
 const openCreateModal = () => {
+  // Start from the defaults every time. The two dialogs share one form object
+  // now, and the close handlers only clear part of it, so without this the
+  // group edited last would show up in the next create.
+  Object.assign(groupForm, createDefaultGroupForm());
+  groupModelRoutingRules.value = [];
+  resetModelsListState(groupModelsListState);
   showCreateModal.value = true;
-  loadModelsListCandidates("create", 0, createForm.platform);
+  loadModelsListCandidates("create", 0, groupForm.platform);
 };
 
 const closeCreateModal = () => {
   showCreateModal.value = false;
-  createModelRoutingRules.value.forEach((rule) => {
+  groupModelRoutingRules.value.forEach((rule) => {
     accountSearchRunner.clearKey(getCreateRuleSearchKey(rule));
   });
   clearAllAccountSearchState();
-  createForm.name = "";
-  createForm.description = "";
-  createForm.platform = "anthropic";
-  createForm.rate_multiplier = 1.0;
-  createForm.is_exclusive = false;
-  createForm.subscription_type = "standard";
-  createForm.daily_limit_usd = null;
-  createForm.weekly_limit_usd = null;
-  createForm.monthly_limit_usd = null;
-  createForm.allow_image_generation = false;
-  createForm.allow_batch_image_generation = false;
-  createForm.image_rate_independent = false;
-  createForm.image_rate_multiplier = 1;
-  createForm.batch_image_discount_multiplier = 0.5;
-  createForm.batch_image_hold_multiplier = 0.6;
-  createForm.image_price_1k = null;
-  createForm.image_price_2k = null;
-  createForm.image_price_4k = null;
-  createForm.video_rate_independent = false;
-  createForm.video_rate_multiplier = 1;
-  createForm.video_price_480p = null;
-  createForm.video_price_720p = null;
-  createForm.video_price_1080p = null;
-  createForm.web_search_price_per_call = null;
-  createForm.peak_rate_enabled = false;
-  createForm.peak_start = "";
-  createForm.peak_end = "";
-  createForm.peak_rate_multiplier = 1.0;
-  createForm.claude_code_only = false;
-  createForm.fallback_group_id = null;
-  createForm.fallback_group_id_on_invalid_request = null;
-  resetMessagesDispatchFormState(createForm);
-  createForm.allow_live = false;
-  createForm.require_oauth_only = false;
-  createForm.require_privacy_set = false;
-  createForm.supported_model_scopes = ["claude", "gemini_text", "gemini_image"];
-  createForm.mcp_xml_inject = true;
-  createForm.copy_accounts_from_group_ids = [];
-  createForm.rpm_limit = 0;
-  createForm.max_reasoning_effort = "";
-  createForm.reasoning_effort_mappings = [];
-  createReasoningEffortPolicyRef.value?.resetValidation();
-  resetModelsListState(createModelsListState);
-  createModelRoutingRules.value = [];
+  groupForm.name = "";
+  groupForm.description = "";
+  groupForm.platform = "anthropic";
+  groupForm.rate_multiplier = 1.0;
+  groupForm.is_exclusive = false;
+  groupForm.subscription_type = "standard";
+  groupForm.daily_limit_usd = null;
+  groupForm.weekly_limit_usd = null;
+  groupForm.monthly_limit_usd = null;
+  groupForm.allow_image_generation = false;
+  groupForm.allow_batch_image_generation = false;
+  groupForm.image_rate_independent = false;
+  groupForm.image_rate_multiplier = 1;
+  groupForm.batch_image_discount_multiplier = 0.5;
+  groupForm.batch_image_hold_multiplier = 0.6;
+  groupForm.image_price_1k = null;
+  groupForm.image_price_2k = null;
+  groupForm.image_price_4k = null;
+  groupForm.video_rate_independent = false;
+  groupForm.video_rate_multiplier = 1;
+  groupForm.video_price_480p = null;
+  groupForm.video_price_720p = null;
+  groupForm.video_price_1080p = null;
+  groupForm.web_search_price_per_call = null;
+  groupForm.peak_rate_enabled = false;
+  groupForm.peak_start = "";
+  groupForm.peak_end = "";
+  groupForm.peak_rate_multiplier = 1.0;
+  groupForm.claude_code_only = false;
+  groupForm.fallback_group_id = null;
+  groupForm.fallback_group_id_on_invalid_request = null;
+  resetMessagesDispatchFormState(groupForm);
+  groupForm.allow_live = false;
+  groupForm.require_oauth_only = false;
+  groupForm.require_privacy_set = false;
+  groupForm.supported_model_scopes = ["claude", "gemini_text", "gemini_image"];
+  groupForm.mcp_xml_inject = true;
+  groupForm.copy_accounts_from_group_ids = [];
+  groupForm.rpm_limit = 0;
+  groupForm.max_reasoning_effort = "";
+  groupForm.reasoning_effort_mappings = [];
+  groupReasoningEffortPolicyRef.value?.resetValidation();
+  resetModelsListState(groupModelsListState);
+  groupModelRoutingRules.value = [];
 };
 
 const normalizeOptionalLimit = (
@@ -5460,14 +3824,14 @@ const normalizeRateMultiplier = (
 };
 
 const handleCreateGroup = async () => {
-  if (!createForm.name.trim()) {
+  if (!groupForm.name.trim()) {
     appStore.showError(t("admin.groups.nameRequired"));
     return;
   }
   if (
-    createForm.platform === "openai" &&
-    createReasoningEffortPolicyRef.value &&
-    !createReasoningEffortPolicyRef.value.validate()
+    groupForm.platform === "openai" &&
+    groupReasoningEffortPolicyRef.value &&
+    !groupReasoningEffortPolicyRef.value.validate()
   ) {
     return;
   }
@@ -5475,36 +3839,36 @@ const handleCreateGroup = async () => {
   try {
     // 构建请求数据，包含模型路由配置
     const requestData = {
-      ...createForm,
+      ...groupForm,
       daily_limit_usd: normalizeOptionalLimit(
-        createForm.daily_limit_usd as number | string | null,
+        groupForm.daily_limit_usd as number | string | null,
       ),
       weekly_limit_usd: normalizeOptionalLimit(
-        createForm.weekly_limit_usd as number | string | null,
+        groupForm.weekly_limit_usd as number | string | null,
       ),
       monthly_limit_usd: normalizeOptionalLimit(
-        createForm.monthly_limit_usd as number | string | null,
+        groupForm.monthly_limit_usd as number | string | null,
       ),
       model_routing: convertRoutingRulesToApiFormat(
-        createModelRoutingRules.value,
+        groupModelRoutingRules.value,
       ),
-      models_list_config: buildModelsListConfig(createModelsListState),
+      models_list_config: buildModelsListConfig(groupModelsListState),
       supported_model_scopes: normalizeSupportedModelScopesForPlatform(
-        createForm.platform,
-        createForm.supported_model_scopes,
+        groupForm.platform,
+        groupForm.supported_model_scopes,
       ),
       messages_dispatch_model_config:
-        createForm.platform === "openai"
+        groupForm.platform === "openai"
           ? messagesDispatchFormStateToConfig({
-              allow_messages_dispatch: createForm.allow_messages_dispatch,
-              opus_mapped_model: createForm.opus_mapped_model,
-              sonnet_mapped_model: createForm.sonnet_mapped_model,
-              haiku_mapped_model: createForm.haiku_mapped_model,
-              exact_model_mappings: createForm.exact_model_mappings,
+              allow_messages_dispatch: groupForm.allow_messages_dispatch,
+              opus_mapped_model: groupForm.opus_mapped_model,
+              sonnet_mapped_model: groupForm.sonnet_mapped_model,
+              haiku_mapped_model: groupForm.haiku_mapped_model,
+              exact_model_mappings: groupForm.exact_model_mappings,
             })
           : undefined,
       reasoning_effort_mappings: reasoningEffortMappingsToAPI(
-        createForm.reasoning_effort_mappings,
+        groupForm.reasoning_effort_mappings,
       ),
     };
     // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
@@ -5536,11 +3900,11 @@ const handleCreateGroup = async () => {
     requestData.web_search_price_per_call = emptyToNull(
       requestData.web_search_price_per_call,
     );
-    requestData.peak_rate_enabled = createForm.peak_rate_enabled;
-    requestData.peak_start = createForm.peak_start;
-    requestData.peak_end = createForm.peak_end;
+    requestData.peak_rate_enabled = groupForm.peak_rate_enabled;
+    requestData.peak_start = groupForm.peak_start;
+    requestData.peak_end = groupForm.peak_end;
     requestData.peak_rate_multiplier = normalizeRateMultiplier(
-      createForm.peak_rate_multiplier,
+      groupForm.peak_rate_multiplier,
     );
     await adminAPI.groups.create(requestData);
     appStore.showSuccess(t("admin.groups.groupCreated"));
@@ -5562,76 +3926,79 @@ const handleCreateGroup = async () => {
 };
 
 const handleEdit = async (group: AdminGroup) => {
+  // Same reason as openCreateModal: the shared form has to be put back to a
+  // known state before it is filled in, so nothing survives from last time.
+  Object.assign(groupForm, createDefaultGroupForm());
   editingGroup.value = group;
-  editForm.name = group.name;
-  editForm.description = group.description || "";
-  editForm.platform = group.platform;
-  editForm.rate_multiplier = group.rate_multiplier;
-  editForm.is_exclusive = group.is_exclusive;
-  editForm.status = group.status;
-  editForm.subscription_type = group.subscription_type || "standard";
-  editForm.daily_limit_usd = group.daily_limit_usd;
-  editForm.weekly_limit_usd = group.weekly_limit_usd;
-  editForm.monthly_limit_usd = group.monthly_limit_usd;
-  editForm.allow_image_generation = group.allow_image_generation ?? false;
-  editForm.allow_batch_image_generation =
+  groupForm.name = group.name;
+  groupForm.description = group.description || "";
+  groupForm.platform = group.platform;
+  groupForm.rate_multiplier = group.rate_multiplier;
+  groupForm.is_exclusive = group.is_exclusive;
+  groupForm.status = group.status;
+  groupForm.subscription_type = group.subscription_type || "standard";
+  groupForm.daily_limit_usd = group.daily_limit_usd;
+  groupForm.weekly_limit_usd = group.weekly_limit_usd;
+  groupForm.monthly_limit_usd = group.monthly_limit_usd;
+  groupForm.allow_image_generation = group.allow_image_generation ?? false;
+  groupForm.allow_batch_image_generation =
     group.allow_batch_image_generation ?? false;
-  editForm.image_rate_independent = group.image_rate_independent ?? false;
-  editForm.image_rate_multiplier = group.image_rate_multiplier ?? 1;
-  editForm.batch_image_discount_multiplier =
+  groupForm.image_rate_independent = group.image_rate_independent ?? false;
+  groupForm.image_rate_multiplier = group.image_rate_multiplier ?? 1;
+  groupForm.batch_image_discount_multiplier =
     group.batch_image_discount_multiplier ?? 0.5;
-  editForm.batch_image_hold_multiplier = group.batch_image_hold_multiplier ?? 0.6;
-  editForm.image_price_1k = group.image_price_1k;
-  editForm.image_price_2k = group.image_price_2k;
-  editForm.image_price_4k = group.image_price_4k;
-  editForm.video_rate_independent = group.video_rate_independent ?? false;
-  editForm.video_rate_multiplier = group.video_rate_multiplier ?? 1;
-  editForm.video_price_480p = group.video_price_480p;
-  editForm.video_price_720p = group.video_price_720p;
-  editForm.video_price_1080p = group.video_price_1080p;
-  editForm.web_search_price_per_call = group.web_search_price_per_call ?? null;
-  editForm.peak_rate_enabled = group.peak_rate_enabled ?? false;
-  editForm.peak_start = group.peak_start ?? "";
-  editForm.peak_end = group.peak_end ?? "";
-  editForm.peak_rate_multiplier = group.peak_rate_multiplier ?? 1.0;
-  editForm.claude_code_only = group.claude_code_only || false;
-  editForm.fallback_group_id = group.fallback_group_id;
-  editForm.fallback_group_id_on_invalid_request =
+  groupForm.batch_image_hold_multiplier = group.batch_image_hold_multiplier ?? 0.6;
+  groupForm.image_price_1k = group.image_price_1k;
+  groupForm.image_price_2k = group.image_price_2k;
+  groupForm.image_price_4k = group.image_price_4k;
+  groupForm.video_rate_independent = group.video_rate_independent ?? false;
+  groupForm.video_rate_multiplier = group.video_rate_multiplier ?? 1;
+  groupForm.video_price_480p = group.video_price_480p;
+  groupForm.video_price_720p = group.video_price_720p;
+  groupForm.video_price_1080p = group.video_price_1080p;
+  groupForm.web_search_price_per_call = group.web_search_price_per_call ?? null;
+  groupForm.peak_rate_enabled = group.peak_rate_enabled ?? false;
+  groupForm.peak_start = group.peak_start ?? "";
+  groupForm.peak_end = group.peak_end ?? "";
+  groupForm.peak_rate_multiplier = group.peak_rate_multiplier ?? 1.0;
+  groupForm.claude_code_only = group.claude_code_only || false;
+  groupForm.fallback_group_id = group.fallback_group_id;
+  groupForm.fallback_group_id_on_invalid_request =
     group.fallback_group_id_on_invalid_request;
   const messagesDispatchFormState = messagesDispatchConfigToFormState(
     group.messages_dispatch_model_config,
   );
-  editForm.allow_messages_dispatch =
+  groupForm.allow_messages_dispatch =
     group.allow_messages_dispatch ||
     messagesDispatchFormState.allow_messages_dispatch;
-  editForm.allow_live = group.allow_live ?? false;
-  editForm.opus_mapped_model = messagesDispatchFormState.opus_mapped_model;
-  editForm.sonnet_mapped_model = messagesDispatchFormState.sonnet_mapped_model;
-  editForm.haiku_mapped_model = messagesDispatchFormState.haiku_mapped_model;
-  editForm.exact_model_mappings =
+  groupForm.allow_live = group.allow_live ?? false;
+  groupForm.opus_mapped_model = messagesDispatchFormState.opus_mapped_model;
+  groupForm.sonnet_mapped_model = messagesDispatchFormState.sonnet_mapped_model;
+  groupForm.haiku_mapped_model = messagesDispatchFormState.haiku_mapped_model;
+  groupForm.exact_model_mappings =
     messagesDispatchFormState.exact_model_mappings;
-  editForm.require_oauth_only = group.require_oauth_only ?? false;
-  editForm.require_privacy_set = group.require_privacy_set ?? false;
-  editForm.model_routing_enabled = group.model_routing_enabled || false;
-  editForm.supported_model_scopes = group.supported_model_scopes || [
+  groupForm.require_oauth_only = group.require_oauth_only ?? false;
+  groupForm.require_privacy_set = group.require_privacy_set ?? false;
+  groupForm.model_routing_enabled = group.model_routing_enabled || false;
+  groupForm.supported_model_scopes = group.supported_model_scopes || [
     "claude",
     "gemini_text",
     "gemini_image",
   ];
-  editForm.mcp_xml_inject = group.mcp_xml_inject ?? true;
-  editForm.copy_accounts_from_group_ids = []; // 复制账号字段每次编辑时重置为空
-  editForm.rpm_limit = group.rpm_limit ?? 0;
-  editForm.max_reasoning_effort = normalizeReasoningEffortForPlatform(
+  groupForm.mcp_xml_inject = group.mcp_xml_inject ?? true;
+  groupForm.copy_accounts_from_group_ids = []; // 复制账号字段每次编辑时重置为空
+  groupForm.rpm_limit = group.rpm_limit ?? 0;
+  groupForm.max_reasoning_effort = normalizeReasoningEffortForPlatform(
     group.platform,
     group.max_reasoning_effort,
   );
-  editForm.reasoning_effort_mappings = reasoningEffortMappingsToRows(
+  groupForm.reasoning_effort_mappings = reasoningEffortMappingsToRows(
     group.reasoning_effort_mappings,
     group.platform,
   );
-  resetModelsListState(editModelsListState, group.models_list_config);
+  resetModelsListState(groupModelsListState, group.models_list_config);
   // 加载模型路由规则（异步加载账号名称）
-  editModelRoutingRules.value = await convertApiFormatToRoutingRules(
+  groupModelRoutingRules.value = await convertApiFormatToRoutingRules(
     group.model_routing,
   );
   loadModelsListCandidates("edit", group.id, group.platform);
@@ -5639,42 +4006,42 @@ const handleEdit = async (group: AdminGroup) => {
 };
 
 const closeEditModal = () => {
-  editModelRoutingRules.value.forEach((rule) => {
+  groupModelRoutingRules.value.forEach((rule) => {
     accountSearchRunner.clearKey(getEditRuleSearchKey(rule));
   });
   clearAllAccountSearchState();
   showEditModal.value = false;
   editingGroup.value = null;
-  editForm.max_reasoning_effort = "";
-  editForm.reasoning_effort_mappings = [];
-  editReasoningEffortPolicyRef.value?.resetValidation();
-  editModelRoutingRules.value = [];
-  editForm.copy_accounts_from_group_ids = [];
-  editForm.peak_rate_enabled = false;
-  editForm.peak_start = "";
-  editForm.peak_end = "";
-  editForm.peak_rate_multiplier = 1.0;
-  editForm.video_rate_independent = false;
-  editForm.video_rate_multiplier = 1;
-  editForm.video_price_480p = null;
-  editForm.video_price_720p = null;
-  editForm.video_price_1080p = null;
-  editForm.web_search_price_per_call = null;
-  resetMessagesDispatchFormState(editForm);
-  editForm.allow_live = false;
-  resetModelsListState(editModelsListState);
+  groupForm.max_reasoning_effort = "";
+  groupForm.reasoning_effort_mappings = [];
+  groupReasoningEffortPolicyRef.value?.resetValidation();
+  groupModelRoutingRules.value = [];
+  groupForm.copy_accounts_from_group_ids = [];
+  groupForm.peak_rate_enabled = false;
+  groupForm.peak_start = "";
+  groupForm.peak_end = "";
+  groupForm.peak_rate_multiplier = 1.0;
+  groupForm.video_rate_independent = false;
+  groupForm.video_rate_multiplier = 1;
+  groupForm.video_price_480p = null;
+  groupForm.video_price_720p = null;
+  groupForm.video_price_1080p = null;
+  groupForm.web_search_price_per_call = null;
+  resetMessagesDispatchFormState(groupForm);
+  groupForm.allow_live = false;
+  resetModelsListState(groupModelsListState);
 };
 
 const handleUpdateGroup = async () => {
   if (!editingGroup.value) return;
-  if (!editForm.name.trim()) {
+  if (!groupForm.name.trim()) {
     appStore.showError(t("admin.groups.nameRequired"));
     return;
   }
   if (
-    editForm.platform === "openai" &&
-    editReasoningEffortPolicyRef.value &&
-    !editReasoningEffortPolicyRef.value.validate()
+    groupForm.platform === "openai" &&
+    groupReasoningEffortPolicyRef.value &&
+    !groupReasoningEffortPolicyRef.value.validate()
   ) {
     return;
   }
@@ -5683,42 +4050,42 @@ const handleUpdateGroup = async () => {
   try {
     // 转换 fallback_group_id: null -> 0 (后端使用 0 表示清除)
     const payload = {
-      ...editForm,
+      ...groupForm,
       daily_limit_usd: normalizeOptionalLimit(
-        editForm.daily_limit_usd as number | string | null,
+        groupForm.daily_limit_usd as number | string | null,
       ),
       weekly_limit_usd: normalizeOptionalLimit(
-        editForm.weekly_limit_usd as number | string | null,
+        groupForm.weekly_limit_usd as number | string | null,
       ),
       monthly_limit_usd: normalizeOptionalLimit(
-        editForm.monthly_limit_usd as number | string | null,
+        groupForm.monthly_limit_usd as number | string | null,
       ),
       fallback_group_id:
-        editForm.fallback_group_id === null ? 0 : editForm.fallback_group_id,
+        groupForm.fallback_group_id === null ? 0 : groupForm.fallback_group_id,
       fallback_group_id_on_invalid_request:
-        editForm.fallback_group_id_on_invalid_request === null
+        groupForm.fallback_group_id_on_invalid_request === null
           ? 0
-          : editForm.fallback_group_id_on_invalid_request,
+          : groupForm.fallback_group_id_on_invalid_request,
       model_routing: convertRoutingRulesToApiFormat(
-        editModelRoutingRules.value,
+        groupModelRoutingRules.value,
       ),
-      models_list_config: buildModelsListConfig(editModelsListState),
+      models_list_config: buildModelsListConfig(groupModelsListState),
       supported_model_scopes: normalizeSupportedModelScopesForPlatform(
-        editForm.platform,
-        editForm.supported_model_scopes,
+        groupForm.platform,
+        groupForm.supported_model_scopes,
       ),
       messages_dispatch_model_config:
-        editForm.platform === "openai"
+        groupForm.platform === "openai"
           ? messagesDispatchFormStateToConfig({
-              allow_messages_dispatch: editForm.allow_messages_dispatch,
-              opus_mapped_model: editForm.opus_mapped_model,
-              sonnet_mapped_model: editForm.sonnet_mapped_model,
-              haiku_mapped_model: editForm.haiku_mapped_model,
-              exact_model_mappings: editForm.exact_model_mappings,
+              allow_messages_dispatch: groupForm.allow_messages_dispatch,
+              opus_mapped_model: groupForm.opus_mapped_model,
+              sonnet_mapped_model: groupForm.sonnet_mapped_model,
+              haiku_mapped_model: groupForm.haiku_mapped_model,
+              exact_model_mappings: groupForm.exact_model_mappings,
             })
           : undefined,
       reasoning_effort_mappings: reasoningEffortMappingsToAPI(
-        editForm.reasoning_effort_mappings,
+        groupForm.reasoning_effort_mappings,
       ),
     };
     // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
@@ -5752,11 +4119,11 @@ const handleUpdateGroup = async () => {
     payload.web_search_price_per_call = emptyPriceToClear(
       payload.web_search_price_per_call,
     );
-    payload.peak_rate_enabled = editForm.peak_rate_enabled;
-    payload.peak_start = editForm.peak_start;
-    payload.peak_end = editForm.peak_end;
+    payload.peak_rate_enabled = groupForm.peak_rate_enabled;
+    payload.peak_start = groupForm.peak_start;
+    payload.peak_end = groupForm.peak_end;
     payload.peak_rate_multiplier = normalizeRateMultiplier(
-      editForm.peak_rate_multiplier,
+      groupForm.peak_rate_multiplier,
     );
     await adminAPI.groups.update(editingGroup.value.id, payload);
     appStore.showSuccess(t("admin.groups.groupUpdated"));
@@ -5772,29 +4139,20 @@ const handleUpdateGroup = async () => {
   }
 };
 
-const addCreateMessagesDispatchMapping = () => {
-  createForm.exact_model_mappings.push({ claude_model: "", target_model: "" });
+const addMessagesDispatchMapping = () => {
+  groupForm.exact_model_mappings.push({ claude_model: "", target_model: "" });
 };
 
-const removeCreateMessagesDispatchMapping = (
+const removeMessagesDispatchMapping = (
   row: MessagesDispatchMappingRow,
 ) => {
-  const index = createForm.exact_model_mappings.indexOf(row);
+  const index = groupForm.exact_model_mappings.indexOf(row);
   if (index !== -1) {
-    createForm.exact_model_mappings.splice(index, 1);
+    groupForm.exact_model_mappings.splice(index, 1);
   }
 };
 
-const addEditMessagesDispatchMapping = () => {
-  editForm.exact_model_mappings.push({ claude_model: "", target_model: "" });
-};
 
-const removeEditMessagesDispatchMapping = (row: MessagesDispatchMappingRow) => {
-  const index = editForm.exact_model_mappings.indexOf(row);
-  if (index !== -1) {
-    editForm.exact_model_mappings.splice(index, 1);
-  }
-};
 
 const handleRateMultipliers = (group: AdminGroup) => {
   rateMultipliersGroup.value = group;
@@ -6031,134 +4389,74 @@ const confirmDelete = async () => {
 
 // 监听 subscription_type 变化，订阅模式时 is_exclusive 默认为 true；标准模式清空高峰配置
 watch(
-  () => createForm.subscription_type,
+  () => groupForm.subscription_type,
   (newVal) => {
     if (newVal === "subscription") {
-      createForm.is_exclusive = true;
-      createForm.fallback_group_id_on_invalid_request = null;
+      groupForm.is_exclusive = true;
+      groupForm.fallback_group_id_on_invalid_request = null;
     } else {
-      createForm.peak_rate_enabled = false;
-      createForm.peak_start = "";
-      createForm.peak_end = "";
-      createForm.peak_rate_multiplier = 1.0;
+      groupForm.peak_rate_enabled = false;
+      groupForm.peak_start = "";
+      groupForm.peak_end = "";
+      groupForm.peak_rate_multiplier = 1.0;
     }
   },
 );
 
 // 编辑表单：切回标准模式时清空高峰配置，避免残留随更新请求提交被后端拒绝
 watch(
-  () => editForm.subscription_type,
-  (newVal) => {
-    if (newVal !== "subscription") {
-      editForm.peak_rate_enabled = false;
-      editForm.peak_start = "";
-      editForm.peak_end = "";
-      editForm.peak_rate_multiplier = 1.0;
-    }
-  },
-);
-
-watch(
-  () => createForm.platform,
+  () => groupForm.platform,
   (newVal) => {
     if (!["anthropic", "antigravity"].includes(newVal)) {
-      createForm.fallback_group_id_on_invalid_request = null;
+      groupForm.fallback_group_id_on_invalid_request = null;
     }
     if (newVal !== "openai") {
-      resetMessagesDispatchFormState(createForm);
-      createForm.allow_live = false;
+      resetMessagesDispatchFormState(groupForm);
+      groupForm.allow_live = false;
+      groupForm.default_mapped_model = "";
     }
-    createForm.max_reasoning_effort = normalizeReasoningEffortForPlatform(
+    groupForm.max_reasoning_effort = normalizeReasoningEffortForPlatform(
       newVal,
-      createForm.max_reasoning_effort,
+      groupForm.max_reasoning_effort,
     );
-    createForm.reasoning_effort_mappings = reasoningEffortMappingsToRows(
-      reasoningEffortMappingsToAPI(createForm.reasoning_effort_mappings),
+    groupForm.reasoning_effort_mappings = reasoningEffortMappingsToRows(
+      reasoningEffortMappingsToAPI(groupForm.reasoning_effort_mappings),
       newVal,
     );
-    createReasoningEffortPolicyRef.value?.resetValidation();
+    groupReasoningEffortPolicyRef.value?.resetValidation();
     if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {
-      createForm.require_oauth_only = false;
-      createForm.require_privacy_set = false;
+      groupForm.require_oauth_only = false;
+      groupForm.require_privacy_set = false;
     }
-    resetDisabledBatchImagePricing(createForm);
-    resetModelsListState(createModelsListState);
-    loadModelsListCandidates("create", 0, newVal);
-  },
-);
-
-watch(
-  () => createForm.allow_image_generation,
-  () => {
-    resetDisabledBatchImagePricing(createForm);
-  },
-);
-
-watch(
-  () => createForm.allow_batch_image_generation,
-  () => {
-    resetDisabledBatchImagePricing(createForm);
-  },
-);
-
-watch(
-  () => editForm.platform,
-  (newVal) => {
-    if (!["anthropic", "antigravity"].includes(newVal)) {
-      editForm.fallback_group_id_on_invalid_request = null;
-    }
-    if (newVal !== "openai") {
-      resetMessagesDispatchFormState(editForm);
-      editForm.allow_live = false;
-    }
-    editForm.max_reasoning_effort = normalizeReasoningEffortForPlatform(
-      newVal,
-      editForm.max_reasoning_effort,
-    );
-    editForm.reasoning_effort_mappings = reasoningEffortMappingsToRows(
-      reasoningEffortMappingsToAPI(editForm.reasoning_effort_mappings),
-      newVal,
-    );
-    editReasoningEffortPolicyRef.value?.resetValidation();
-    if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {
-      editForm.require_oauth_only = false;
-      editForm.require_privacy_set = false;
-    }
-    resetDisabledBatchImagePricing(editForm);
+    resetDisabledBatchImagePricing(groupForm);
     if (editingGroup.value) {
-      resetModelsListState(editModelsListState, editForm.platform === editingGroup.value.platform ? editingGroup.value.models_list_config : undefined);
+      resetModelsListState(
+        groupModelsListState,
+        groupForm.platform === editingGroup.value.platform
+          ? editingGroup.value.models_list_config
+          : undefined,
+      );
       loadModelsListCandidates("edit", editingGroup.value.id, newVal);
+    } else {
+      resetModelsListState(groupModelsListState);
+      loadModelsListCandidates("create", 0, newVal);
     }
   },
 );
 
 watch(
-  () => editForm.allow_image_generation,
+  () => groupForm.allow_image_generation,
   () => {
-    resetDisabledBatchImagePricing(editForm);
+    resetDisabledBatchImagePricing(groupForm);
   },
 );
 
 watch(
-  () => editForm.allow_batch_image_generation,
+  () => groupForm.allow_batch_image_generation,
   () => {
-    resetDisabledBatchImagePricing(editForm);
+    resetDisabledBatchImagePricing(groupForm);
   },
 );
-
-watch(
-  () => editForm.platform,
-  (newVal) => {
-    if (!['anthropic', 'antigravity'].includes(newVal)) {
-      editForm.fallback_group_id_on_invalid_request = null
-    }
-    if (newVal !== 'openai') {
-      editForm.allow_messages_dispatch = false
-      editForm.allow_live = false
-      editForm.default_mapped_model = ''
-    }
-  }
-)
 
 // 点击外部关闭账号搜索下拉框
 const handleClickOutside = (event: MouseEvent) => {
@@ -6221,7 +4519,7 @@ const saveSortOrder = async () => {
 onMounted(() => {
   loadGroups();
   void loadLiveCapability();
-  loadModelsListCandidates("create", 0, createForm.platform);
+  loadModelsListCandidates("create", 0, groupForm.platform);
   document.addEventListener("click", handleClickOutside);
 });
 

--- a/frontend/src/views/admin/__tests__/GroupsView.formRoundTrip.spec.ts
+++ b/frontend/src/views/admin/__tests__/GroupsView.formRoundTrip.spec.ts
@@ -1,0 +1,411 @@
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AdminGroup } from '@/types'
+import GroupsView from '@/views/admin/GroupsView.vue'
+
+// The create and edit dialogs are about 1,500 lines of form each and share
+// roughly 70% of their markup, so they are the obvious thing to merge into one
+// component. Nothing covered them: the other GroupsView specs stub BaseDialog
+// away entirely, so the dialog bodies never render.
+//
+// These pin the part a merge would most easily break — which form field is
+// bound to which property. Opening the edit dialog on a group whose fields all
+// hold distinctive values and submitting it unchanged puts every field through
+// group -> form -> payload in one go, so a single mis-bound field shows up as a
+// changed payload rather than as a bug someone finds in production.
+
+const {
+  listGroups,
+  updateGroup,
+  createGroup,
+  getModelsListCandidates,
+  getUsageSummary,
+  getCapacitySummary,
+  getLiveCapability,
+  showSuccess,
+  showError
+} = vi.hoisted(() => ({
+  listGroups: vi.fn(),
+  updateGroup: vi.fn(),
+  createGroup: vi.fn(),
+  getModelsListCandidates: vi.fn(),
+  getUsageSummary: vi.fn(),
+  getCapacitySummary: vi.fn(),
+  getLiveCapability: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    groups: {
+      list: listGroups,
+      update: updateGroup,
+      create: createGroup,
+      getModelsListCandidates,
+      getUsageSummary,
+      getCapacitySummary,
+      getAll: vi.fn(),
+      duplicate: vi.fn(),
+      delete: vi.fn(),
+      updateSortOrder: vi.fn(),
+      listCompositeRoutes: vi.fn().mockResolvedValue([]),
+      createCompositeRoute: vi.fn(),
+      updateCompositeRoute: vi.fn(),
+      deleteCompositeRoute: vi.fn(),
+      getLiveCapability
+    },
+    accounts: {
+      list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+      getById: vi.fn()
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showSuccess, showError })
+}))
+
+vi.mock('@/stores/onboarding', () => ({
+  useOnboardingStore: () => ({
+    isCurrentStep: vi.fn(() => false),
+    nextStep: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key })
+  }
+})
+
+// Every field carries a value that is not the default, so a field wired to the
+// wrong property cannot come back looking right by accident.
+const populatedGroup: AdminGroup = {
+  id: 42,
+  name: 'Primary',
+  description: 'a description',
+  platform: 'openai',
+  rate_multiplier: 2.5,
+  rpm_limit: 120,
+  is_exclusive: true,
+  status: 'active',
+  subscription_type: 'standard',
+  daily_limit_usd: 11,
+  weekly_limit_usd: 22,
+  monthly_limit_usd: 33,
+  allow_image_generation: true,
+  allow_batch_image_generation: true,
+  image_rate_independent: true,
+  image_rate_multiplier: 3.5,
+  batch_image_discount_multiplier: 0.4,
+  batch_image_hold_multiplier: 0.7,
+  image_price_1k: 1.1,
+  image_price_2k: 2.2,
+  image_price_4k: 4.4,
+  video_rate_independent: true,
+  video_rate_multiplier: 5.5,
+  video_price_480p: 0.48,
+  video_price_720p: 0.72,
+  video_price_1080p: 1.08,
+  web_search_price_per_call: 0.09,
+  peak_rate_enabled: true,
+  peak_start: '09:00',
+  peak_end: '18:00',
+  peak_rate_multiplier: 1.75,
+  claude_code_only: true,
+  fallback_group_id: null,
+  fallback_group_id_on_invalid_request: null,
+  allow_messages_dispatch: false,
+  allow_live: true,
+  default_mapped_model: '',
+  messages_dispatch_model_config: undefined,
+  require_oauth_only: true,
+  require_privacy_set: true,
+  created_at: '2026-07-16T00:00:00Z',
+  updated_at: '2026-07-16T00:00:00Z',
+  model_routing: null,
+  model_routing_enabled: false,
+  mcp_xml_inject: false,
+  supported_model_scopes: [],
+  account_count: 1,
+  active_account_count: 1,
+  rate_limited_account_count: 0,
+  models_list_config: undefined,
+  sort_order: 10
+}
+
+const AppLayoutStub = defineComponent({
+  template: '<main><slot /></main>'
+})
+
+const TablePageLayoutStub = defineComponent({
+  template: '<section><slot name="filters" /><slot name="table" /><slot name="pagination" /></section>'
+})
+
+const DataTableStub = defineComponent({
+  props: {
+    data: { type: Array, default: () => [] },
+    columns: { type: Array, default: () => [] },
+    loading: { type: Boolean, default: false }
+  },
+  template: '<div><div v-for="row in data" :key="row.id"><slot name="cell-actions" :row="row" /></div></div>'
+})
+
+// Unlike the other GroupsView specs, this one needs the dialog body. Without
+// it the form never mounts and there is nothing to check.
+const BaseDialogStub = defineComponent({
+  props: { show: { type: Boolean, default: false } },
+  template: '<div v-if="show" class="dialog"><slot /><slot name="footer" /></div>'
+})
+
+function mountView() {
+  return mount(GroupsView, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        TablePageLayout: TablePageLayoutStub,
+        DataTable: DataTableStub,
+        BaseDialog: BaseDialogStub,
+        Pagination: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        Select: true,
+        PlatformIcon: true,
+        Icon: true,
+        GroupCapacityBadge: true,
+        GroupRateMultipliersModal: true,
+        GroupRPMOverridesModal: true,
+        VueDraggable: true
+      }
+    }
+  })
+}
+
+describe('GroupsView group form round trip', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    for (const fn of [
+      listGroups,
+      updateGroup,
+      createGroup,
+      getModelsListCandidates,
+      getUsageSummary,
+      getCapacitySummary,
+      getLiveCapability,
+      showSuccess,
+      showError
+    ]) {
+      fn.mockReset()
+    }
+
+    listGroups.mockResolvedValue({
+      items: [populatedGroup],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+    updateGroup.mockResolvedValue({ ...populatedGroup })
+    createGroup.mockResolvedValue({ ...populatedGroup, id: 43 })
+    getModelsListCandidates.mockResolvedValue([])
+    getUsageSummary.mockResolvedValue([])
+    getCapacitySummary.mockResolvedValue([])
+    getLiveCapability.mockResolvedValue({ supported: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function openEditDialog() {
+    const wrapper = mountView()
+    await flushPromises()
+    const editButton = wrapper.findAll('button').find((b) => b.text().includes('common.edit'))
+    expect(editButton, 'edit button should be reachable from the row actions').toBeTruthy()
+    await editButton!.trigger('click')
+    await flushPromises()
+    return wrapper
+  }
+
+  it('opens the edit dialog and renders its form', async () => {
+    const wrapper = await openEditDialog()
+    const forms = wrapper.findAll('form')
+    expect(forms.length, 'the edit dialog body must render, not be stubbed away').toBeGreaterThan(0)
+  })
+
+  it('submitting an untouched edit form sends every field back unchanged', async () => {
+    const wrapper = await openEditDialog()
+
+    const form = wrapper.findAll('form').at(-1)
+    expect(form).toBeTruthy()
+    await form!.trigger('submit')
+    await flushPromises()
+
+    expect(updateGroup).toHaveBeenCalledTimes(1)
+    const [id, payload] = updateGroup.mock.calls[0] as [number, Record<string, unknown>]
+    expect(id).toBe(populatedGroup.id)
+
+    // Each of these is a separate section of the form. A merge that binds any
+    // one of them to the wrong property changes exactly this object.
+    expect(payload).toMatchObject({
+      name: 'Primary',
+      description: 'a description',
+      platform: 'openai',
+      rate_multiplier: 2.5,
+      rpm_limit: 120,
+      is_exclusive: true,
+      daily_limit_usd: 11,
+      weekly_limit_usd: 22,
+      monthly_limit_usd: 33,
+      allow_image_generation: true,
+      image_rate_independent: true,
+      image_rate_multiplier: 3.5,
+      image_price_1k: 1.1,
+      image_price_2k: 2.2,
+      image_price_4k: 4.4,
+      video_rate_independent: true,
+      video_rate_multiplier: 5.5,
+      video_price_480p: 0.48,
+      video_price_720p: 0.72,
+      video_price_1080p: 1.08,
+      web_search_price_per_call: 0.09,
+      peak_rate_enabled: true,
+      peak_start: '09:00',
+      peak_end: '18:00',
+      peak_rate_multiplier: 1.75,
+      claude_code_only: true,
+      require_oauth_only: true,
+      require_privacy_set: true,
+      mcp_xml_inject: false
+    })
+  })
+
+  it('resets batch image pricing for a platform that does not support it', async () => {
+    // resetDisabledBatchImagePricing only lets batch image billing stand on
+    // gemini. The group below asks for it on openai, and the rule takes it
+    // away again. This is easy to lose when the two dialogs are merged,
+    // because the rule lives in a watcher per form rather than in the markup.
+    listGroups.mockResolvedValue({
+      items: [{ ...populatedGroup, allow_batch_image_generation: true, batch_image_discount_multiplier: 0.4 }],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+    const wrapper = await openEditDialog()
+    await wrapper.findAll('form').at(-1)!.trigger('submit')
+    await flushPromises()
+
+    const [, payload] = updateGroup.mock.calls[0] as [number, Record<string, unknown>]
+    expect(payload.allow_batch_image_generation).toBe(false)
+    expect(payload.batch_image_discount_multiplier).toBe(0.5)
+    expect(payload.batch_image_hold_multiplier).toBe(0.6)
+  })
+
+  it('keeps batch image pricing on gemini, where it applies', async () => {
+    listGroups.mockResolvedValue({
+      items: [
+        {
+          ...populatedGroup,
+          platform: 'gemini',
+          allow_image_generation: true,
+          allow_batch_image_generation: true,
+          batch_image_discount_multiplier: 0.4,
+          batch_image_hold_multiplier: 0.7
+        }
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+    const wrapper = await openEditDialog()
+    await wrapper.findAll('form').at(-1)!.trigger('submit')
+    await flushPromises()
+
+    const [, payload] = updateGroup.mock.calls[0] as [number, Record<string, unknown>]
+    expect(payload.allow_batch_image_generation).toBe(true)
+    expect(payload.batch_image_discount_multiplier).toBe(0.4)
+    expect(payload.batch_image_hold_multiplier).toBe(0.7)
+  })
+
+  it('opening create after closing edit does not inherit the edited group', async () => {
+    // The two dialogs now share one form object, which makes the reset
+    // load-bearing: neither close handler clears everything — closeEditModal
+    // leaves name, platform and rate_multiplier alone. Both entry points
+    // therefore start from createDefaultGroupForm(). Without that, the last
+    // edited group would quietly carry into the next create.
+    const wrapper = await openEditDialog()
+
+    const cancel = wrapper.findAll('button').find((b) => b.text().includes('common.cancel'))
+    expect(cancel, 'edit dialog should have a cancel button').toBeTruthy()
+    await cancel!.trigger('click')
+    await flushPromises()
+
+    const createButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('admin.groups.createGroup'))
+    await createButton!.trigger('click')
+    await flushPromises()
+
+    const form = wrapper.findAll('form').at(-1)
+    expect(form, 'the create dialog body must render').toBeTruthy()
+    const nameInput = form!.find('input[type="text"]')
+    await nameInput.setValue('Fresh group')
+    await form!.trigger('submit')
+    await flushPromises()
+
+    expect(createGroup).toHaveBeenCalledTimes(1)
+    const [payload] = createGroup.mock.calls[0] as [Record<string, unknown>]
+    expect(payload.name).toBe('Fresh group')
+    expect(payload.description).toBe('')
+    expect(payload.rate_multiplier).toBe(1)
+    expect(payload.is_exclusive).toBe(false)
+    expect(payload.image_rate_multiplier).toBe(1)
+    // populatedGroup has allow_live: true, so this one proves the Live toggle
+    // is reset too — it is the newest field on the shared form and the one a
+    // future edit is most likely to forget.
+    expect(payload.allow_live).toBe(false)
+  })
+
+  it('both payloads carry copy_accounts_from_group_ids even though only create shows it', async () => {
+    // Copying accounts from another group is rendered only in the create
+    // dialog, but the field sits on both form objects and both payloads spread
+    // it, so the edit request sends a key the dialog has no control for. That
+    // is the behaviour today; a merged form must not quietly change it,
+    // because the backend sees the difference and this spec would not.
+    const wrapper = await openEditDialog()
+    await wrapper.findAll('form').at(-1)!.trigger('submit')
+    await flushPromises()
+    const [, updatePayload] = updateGroup.mock.calls[0] as [number, Record<string, unknown>]
+    expect(updatePayload).toHaveProperty('copy_accounts_from_group_ids')
+
+    const createWrapper = mountView()
+    await flushPromises()
+    const createButton = createWrapper
+      .findAll('button')
+      .find((b) => b.text().includes('admin.groups.createGroup'))
+    expect(createButton, 'create button should be reachable').toBeTruthy()
+    await createButton!.trigger('click')
+    await flushPromises()
+
+    const createForm = createWrapper.findAll('form').at(-1)
+    expect(createForm, 'the create dialog body must render').toBeTruthy()
+    const nameInput = createForm!.find('input[type="text"]')
+    if (nameInput.exists()) {
+      await nameInput.setValue('New group')
+    }
+    await createForm!.trigger('submit')
+    await flushPromises()
+
+    expect(createGroup).toHaveBeenCalledTimes(1)
+    const [createPayload] = createGroup.mock.calls[0] as [Record<string, unknown>]
+    expect(createPayload).toHaveProperty('copy_accounts_from_group_ids')
+  })
+})


### PR DESCRIPTION
`GroupsView.vue` holds two dialogs — one to create a group, one to edit it — at about **1,550 lines each**. They are **~96% identical**: normalising `createForm`/`editForm` and diffing the two template blocks leaves 63 differing lines out of ~1,550. Together they are **3,099 of the file's 4,043 template lines**.

This merges them into one dialog driven by `isEditMode`.

| | before | after |
|---|---|---|
| `GroupsView.vue` | 6,233 lines | **4,531 lines** |
| `createForm` / `editForm` references | 217 / 242 | 0 |
| watchers over 4 sources | 9 | **4** |

Net: **+449 / −2,151** in the component, plus a new 411-line spec.

## What had to survive the merge

Eight genuine differences between the two dialogs, each kept:

| difference | behaviour |
|---|---|
| platform select | edit disables it, different hint |
| subscription type | same, plus its own hint |
| status field | edit only |
| fallback group options | edit excludes the group being edited — without this a group could fall back to itself |
| copy accounts | edit uses its own option list |
| invalid-request fallback | same |
| account search helpers | take an `isEdit` argument |
| footer label | `creating`/`create` vs `updating`/`update` |

## One hazard the separate forms were hiding

With a single form the reset becomes load-bearing. Neither close handler clears everything — `closeEditModal` leaves `name`, `platform` and `rate_multiplier` alone — so the group edited last would appear in the next create. Both entry points now start from `createDefaultGroupForm()`.

The new spec covers exactly this, and it was **checked in both directions**: dropping the `createDefaultGroupForm()` call from `openCreateModal` makes it fail with `expected 'a description' to be ''`; restoring it makes it pass.

## Watchers

Merging the forms makes several watchers redundant, because pairs that watched `createForm.x` and `editForm.x` now watch the same object. Left as-is, every handler would run twice per change, and edit mode would fire a spurious create-side `loadModelsListCandidates`.

- `subscription_type` 2 → 1 — the second was a subset of the first
- `platform` 3 → 1 — two were identical up to the tail (create vs edit candidate loading, now an `editingGroup` branch); the third only cleared `allow_messages_dispatch` and `default_mapped_model`, both folded in
- `allow_image_generation` 2 → 1 — identical bodies
- `allow_batch_image_generation` 2 → 1 — identical bodies

## OpenAI Live

The Live feature is currently added to both dialogs. It folds into the single form too: one toggle block instead of two, `toggleLive()` no longer takes a `"create" | "edit"` target, and `pendingLiveForm` becomes a plain `showUnsupportedLiveConfirm` boolean since there is only one form left to confirm for.

## Tests

The other `GroupsView` specs stub `BaseDialog` away, so **no test rendered either dialog body**. `GroupsView.formRoundTrip.spec.ts` opens the edit dialog on a group whose fields all hold distinctive values and submits it unchanged, so a mis-bound field shows up as a changed payload rather than as a bug found in production.

Run from `frontend/`:

```
pnpm run lint:check   clean
pnpm run typecheck    clean
pnpm run build        clean
pnpm exec vitest run src/views/admin/__tests__/GroupsView.formRoundTrip.spec.ts   6 passed
pnpm exec vitest run src/views/admin/__tests__/    132 passed (126 before this change)
```

## One thing you should know

`vitest run src/views/admin/` exits 1 on unhandled rejections **both before and after this change**, because `GroupsView`'s `onMounted` calls `adminAPI.groups.getLiveCapability()` and three specs that mount it do not mock that method. The count is 10 either way — this change adds none. Happy to fix those in a separate PR if useful.
