### PR TITLE
fix(openai): preserve Lite tool call namespaces

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -73,7 +73,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 	if shouldStripOpenAIResponsesInputNamespaces(account, wsDecision.Transport, passthroughEnabled) {
-		body, err = stripOpenAIResponsesInputNamespaces(body)
+		preserveLiteToolCallNamespaces := shouldPreserveOpenAIResponsesLiteToolCallNamespaces(c, account, wsDecision.Transport, passthroughEnabled)
+		body, err = stripOpenAIResponsesInputNamespaces(body, preserveLiteToolCallNamespaces)
 		if err != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{

--- a/backend/internal/service/openai_responses_lite_tools_test.go
+++ b/backend/internal/service/openai_responses_lite_tools_test.go
@@ -268,7 +268,7 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 				Body: io.NopCloser(strings.NewReader(
-					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_lite\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n" +
+					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_lite\",\"output\":[{\"type\":\"function_call\",\"namespace\":\"collaboration\",\"name\":\"spawn_agent\",\"call_id\":\"call_2\",\"arguments\":\"{}\"}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n" +
 						"data: [DONE]\n\n",
 				)),
 			}}
@@ -288,7 +288,10 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 					{"type":"tool_search"},
 					{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}
 				],
-				"input":[{"type":"message","role":"user","content":"hello"}],
+				"input":[
+					{"type":"function_call","namespace":"collaboration","name":"spawn_agent","call_id":"call_1","arguments":"{}"},
+					{"type":"message","role":"user","namespace":"residual-message-namespace","content":"hello"}
+				],
 				"tool_choice":{"type":"namespace","name":"collaboration"}
 			}`)
 
@@ -304,8 +307,16 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 			require.Equal(t, "exec", gjson.GetBytes(upstream.lastBody, `tools.#(type=="custom").name`).String())
 			require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="tool_search")`).Exists())
 			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `input.#(type=="additional_tools").tools.0.name`).String())
+			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `input.#(type=="function_call").namespace`).String())
+			require.Equal(t, "spawn_agent", gjson.GetBytes(upstream.lastBody, `input.#(type=="function_call").name`).String())
+			require.False(t, gjson.GetBytes(upstream.lastBody, `input.#(type=="message").namespace`).Exists())
 			require.Equal(t, "namespace", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
 			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
+
+			completed := findSSEEvent(t, collectSSEDataPayloads(t, rec.Body.String()), "response.completed", "")
+			require.Equal(t, "collaboration", gjson.Get(completed, "response.output.0.namespace").String())
+			require.Equal(t, "spawn_agent", gjson.Get(completed, "response.output.0.name").String())
+			require.NotEqual(t, "collaboration__spawn_agent", gjson.Get(completed, "response.output.0.name").String())
 		})
 	}
 }

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -41,6 +41,18 @@ func shouldStripOpenAIResponsesInputNamespaces(account *Account, transport OpenA
 	return true
 }
 
+// shouldPreserveOpenAIResponsesLiteToolCallNamespaces identifies the HTTP
+// Responses Lite path whose namespace declarations and continuation history are
+// both native. Compact and API-key requests keep the existing strip behavior,
+// while native WSv2 bypasses the strip path entirely.
+func shouldPreserveOpenAIResponsesLiteToolCallNamespaces(c *gin.Context, account *Account, transport OpenAIUpstreamTransport, passthroughEnabled bool) bool {
+	return account != nil &&
+		account.IsOpenAIOAuth() &&
+		isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) &&
+		!isOpenAIResponsesCompactPath(c) &&
+		shouldStripOpenAIResponsesInputNamespaces(account, transport, passthroughEnabled)
+}
+
 func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, error) {
 	if !bytes.Contains(body, []byte(`"namespace"`)) {
 		return body, nil
@@ -66,9 +78,11 @@ func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, erro
 
 // stripOpenAIResponsesInputNamespaces removes namespace only from direct input
 // array items. Namespace declarations and nested namespace fields are left
-// untouched. Rebuilding the input array once keeps this linear for long
+// untouched. Responses Lite can preserve namespace identity on historical tool
+// calls while residual message, reasoning, output, and unknown item namespaces
+// are still removed. Rebuilding the input array once keeps this linear for long
 // histories and avoids decoding JSON numbers through float64.
-func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
+func stripOpenAIResponsesInputNamespaces(body []byte, preserveToolCallNamespaces bool) ([]byte, error) {
 	if !bytes.Contains(body, []byte(`"namespace"`)) {
 		return body, nil
 	}
@@ -89,7 +103,9 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 		}
 		first = false
 		itemBody := []byte(item.Raw)
-		if item.IsObject() && item.Get("namespace").Exists() {
+		itemType := item.Get("type").String()
+		preserveNamespace := preserveToolCallNamespaces && (itemType == "function_call" || itemType == "custom_tool_call")
+		if item.IsObject() && item.Get("namespace").Exists() && !preserveNamespace {
 			itemBody, stripErr = sjson.DeleteBytes(itemBody, "namespace")
 			if stripErr != nil {
 				return false

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -1,12 +1,51 @@
 package service
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+func TestShouldPreserveOpenAIResponsesLiteToolCallNamespaces(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oauth := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	apiKey := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	tests := []struct {
+		name               string
+		account            *Account
+		path               string
+		liteHeader         string
+		transport          OpenAIUpstreamTransport
+		passthroughEnabled bool
+		want               bool
+	}{
+		{name: "oauth_http_lite", account: oauth, path: "/v1/responses", liteHeader: "true", transport: OpenAIUpstreamTransportHTTPSSE, want: true},
+		{name: "oauth_http_passthrough_lite", account: oauth, path: "/v1/responses", liteHeader: "true", transport: OpenAIUpstreamTransportHTTPSSE, passthroughEnabled: true, want: true},
+		{name: "oauth_wsv2_passthrough_lite_uses_http", account: oauth, path: "/v1/responses", liteHeader: "true", transport: OpenAIUpstreamTransportResponsesWebsocketV2, passthroughEnabled: true, want: true},
+		{name: "oauth_native_wsv2_lite", account: oauth, path: "/v1/responses", liteHeader: "true", transport: OpenAIUpstreamTransportResponsesWebsocketV2, want: false},
+		{name: "oauth_compact_lite", account: oauth, path: "/v1/responses/compact", liteHeader: "true", transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+		{name: "apikey_http_lite", account: apiKey, path: "/v1/responses", liteHeader: "true", transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+		{name: "oauth_http_non_lite", account: oauth, path: "/v1/responses", transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, tt.path, nil)
+			if tt.liteHeader != "" {
+				c.Request.Header.Set(responsesLiteHeader, tt.liteHeader)
+			}
+
+			require.Equal(t, tt.want, shouldPreserveOpenAIResponsesLiteToolCallNamespaces(c, tt.account, tt.transport, tt.passthroughEnabled))
+		})
+	}
+}
 
 func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
 	oauth := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
@@ -67,7 +106,7 @@ func TestShouldStripOpenAIResponsesInputNamespaces(t *testing.T) {
 	}
 }
 
-func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
+func TestStripOpenAIResponsesInputNamespaces_PreservesOnlyToolCallsWhenEnabled(t *testing.T) {
 	body := []byte(`{
 		"meta":9007199254740993,
 		"scientific":1.25e+42,
@@ -85,11 +124,13 @@ func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
 		]
 	}`)
 
-	stripped, err := stripOpenAIResponsesInputNamespaces(body)
+	stripped, err := stripOpenAIResponsesInputNamespaces(body, true)
 	require.NoError(t, err)
-	for index := 0; index < 8; index++ {
+	for _, index := range []int{1, 3, 4, 5, 6, 7} {
 		require.False(t, gjson.GetBytes(stripped, "input."+strconv.Itoa(index)+".namespace").Exists())
 	}
+	require.Equal(t, "n0", gjson.GetBytes(stripped, "input.0.namespace").String())
+	require.Equal(t, "n2", gjson.GetBytes(stripped, "input.2.namespace").String())
 	require.Equal(t, "nested", gjson.GetBytes(stripped, "input.0.content.namespace").String())
 	require.Equal(t, "nested-content", gjson.GetBytes(stripped, "input.1.content.0.namespace").String())
 	require.Equal(t, "tool-namespace", gjson.GetBytes(stripped, "tools.0.namespace").String())
@@ -99,6 +140,19 @@ func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
 	require.Equal(t, gjson.GetBytes(body, "input.0.large").Raw, gjson.GetBytes(stripped, "input.0.large").Raw)
 }
 
+func TestStripOpenAIResponsesInputNamespaces_StripsToolCallsWhenDisabled(t *testing.T) {
+	body := []byte(`{"input":[
+		{"type":"function_call","namespace":"n0","name":"one"},
+		{"type":"custom_tool_call","namespace":"n1","name":"two"}
+	]}`)
+
+	stripped, err := stripOpenAIResponsesInputNamespaces(body, false)
+
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(stripped, "input.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(stripped, "input.1.namespace").Exists())
+}
+
 func TestStripOpenAIResponsesInputNamespacesLeavesOtherShapesByteExact(t *testing.T) {
 	tests := [][]byte{
 		[]byte(`{"input":"text","namespace":"top-level"}`),
@@ -106,7 +160,7 @@ func TestStripOpenAIResponsesInputNamespacesLeavesOtherShapesByteExact(t *testin
 		[]byte(`{"input":[{"content":{"namespace":"nested-only"}}],"tools":[{"namespace":"keep"}]}`),
 	}
 	for _, body := range tests {
-		stripped, err := stripOpenAIResponsesInputNamespaces(body)
+		stripped, err := stripOpenAIResponsesInputNamespaces(body, true)
 		require.NoError(t, err)
 		require.Equal(t, body, stripped)
 	}


### PR DESCRIPTION
## Summary

- preserve `namespace` on direct historical `function_call` and
  `custom_tool_call` items for OpenAI OAuth HTTP, non-compact Responses Lite
  requests;
- keep the existing namespace cleanup for message, reasoning, output, unknown,
  compact, API-key/custom-provider, and non-Lite paths; and
- add end-to-end `OpenAIGatewayService.Forward` coverage for both the exact
  provider-facing request and the returned namespaced function call.

Closes #5067.

## Root cause

Responses Lite normalization moves native namespace declarations into
`input[].additional_tools.tools[]`. The existing flattener only builds its mapping
from top-level `tools`, while the following cleanup removes `namespace` from every
direct input item. The result is a split identity on continuation requests: the
active declaration stays namespaced, but its historical call becomes unqualified.

This change makes the cleanup context-aware at the proven boundary instead of
globally preserving or globally stripping namespaces.

## Behavior matrix

| Path | Result |
|---|---|
| OpenAI OAuth HTTP, non-compact, Responses Lite | Preserve namespace on direct function/custom call history |
| OpenAI OAuth HTTP, non-Lite | Keep current flatten/restore behavior |
| OpenAI OAuth compact | Keep stripping unsupported direct namespaces |
| OpenAI API-key/custom provider | Keep stripping unsupported direct namespaces |
| Native WSv2 transport | Unchanged; no HTTP cleanup |

## Why this is narrower than #4981

#4981 proposes preserving namespaces broadly for non-compact OAuth requests and
adds account-level configuration/UI. This PR does not change the default behavior
of non-Lite requests and adds no configuration surface. It only fixes the
Responses Lite continuation mismatch described in #5067, while retaining strict
cleanup everywhere else.

## Tests

Passed locally with Go 1.25-compatible unit tags:

```text
go test -tags unit ./internal/service -run '^(TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth|TestShouldFlattenOpenAIResponsesNamespaces|TestShouldStripOpenAIResponsesInputNamespaces|TestShouldPreserveOpenAIResponsesLiteToolCallNamespaces|TestStripOpenAIResponsesInputNamespaces.*|TestNormalizeOpenAIResponsesLiteToolsPayload_PreservesResponseCreateShape|TestApplyCodexOAuthTransform_PreservesLiteNamespaceToolChoice)$' -count=1

go test -json -tags unit ./internal/service -count=1

git diff --check
```

The regression suite covers managed and passthrough OAuth Lite requests,
continuation history, `function_call` and `custom_tool_call`, residual cleanup,
compact and API-key negative controls, the non-Lite control, native WSv2, and the
complete HTTP forwarding path.

## Scope and residual risk

- No frontend, database, or account configuration changes.
- The full service unit suite passes.
- The exact upstream HTTP body and downstream SSE call are asserted with a local
  recorder; a live ChatGPT Codex provider request was not used for this PR.
