### PR TITLE
feat(security-audit): 提示词审计支持 Guard 失败放行和模型范围

### DIFF
--- a/backend/internal/securityaudit/coordinator.go
+++ b/backend/internal/securityaudit/coordinator.go
@@ -114,9 +114,15 @@ func prioritize(legacy *LegacyDecision, prompt *PromptDecision) Decision {
 		return Decision{Kind: DecisionBlock, HTTPStatus: http.StatusForbidden, ErrorCode: ErrorCodeBlocked,
 			ClientMessage: "提示词安全审计拒绝了该请求，请调整输入后重试", Legacy: legacy, Prompt: prompt}
 	case DecisionInvalid:
+		if prompt.AllowNextStage {
+			return allowDecision(legacy, prompt)
+		}
 		return Decision{Kind: DecisionInvalid, HTTPStatus: http.StatusServiceUnavailable, ErrorCode: ErrorCodeInvalidResponse,
 			ClientMessage: "提示词安全审计暂时不可用，请稍后重试", Legacy: legacy, Prompt: prompt}
 	case DecisionUnavailable:
+		if prompt.AllowNextStage {
+			return allowDecision(legacy, prompt)
+		}
 		return Decision{Kind: DecisionUnavailable, HTTPStatus: http.StatusServiceUnavailable, ErrorCode: ErrorCodeUnavailable,
 			ClientMessage: "提示词安全审计暂时不可用，请稍后重试", Legacy: legacy, Prompt: prompt}
 	case DecisionFlag:

--- a/backend/internal/securityaudit/coordinator_test.go
+++ b/backend/internal/securityaudit/coordinator_test.go
@@ -83,6 +83,22 @@ func TestCoordinatorDoesNotMutateRequestBody(t *testing.T) {
 	require.Equal(t, original, body)
 }
 
+func TestCoordinatorAllowsConfiguredGuardFailureWithoutBypassingLegacyBlock(t *testing.T) {
+	failure := &PromptDecision{Kind: DecisionUnavailable, ErrorCode: ErrorCodeUnavailable, AllowNextStage: true}
+
+	allowed := NewCoordinator(&fakeLegacyEngine{decision: &LegacyDecision{Allowed: true}},
+		&fakePromptEngine{mode: ModeBlocking, decision: failure}).Check(context.Background(), Request{})
+	require.Equal(t, DecisionAllow, allowed.Kind)
+	require.True(t, allowed.AllowNextStage)
+	require.Same(t, failure, allowed.Prompt)
+
+	blocked := NewCoordinator(&fakeLegacyEngine{decision: &LegacyDecision{Blocked: true, StatusCode: http.StatusForbidden, ErrorCode: "legacy_block"}},
+		&fakePromptEngine{mode: ModeBlocking, decision: failure}).Check(context.Background(), Request{})
+	require.Equal(t, DecisionBlock, blocked.Kind)
+	require.False(t, blocked.AllowNextStage)
+	require.Equal(t, "legacy_block", blocked.ErrorCode)
+}
+
 func TestCoordinatorBlockingPriorityCoversBothEngineDecisionMatrix(t *testing.T) {
 	legacyCases := []struct {
 		name     string

--- a/backend/internal/securityaudit/prompt_config.go
+++ b/backend/internal/securityaudit/prompt_config.go
@@ -129,6 +129,7 @@ type ActiveConfig struct {
 	AllGroups              bool
 	GroupIDs               []int64
 	ModelFilter            PromptAuditModelFilter
+	modelFilterSet         map[string]struct{}
 	Endpoints              []ActiveEndpoint
 	ConfigVersion          int64
 	UpdatedAt              time.Time
@@ -284,6 +285,9 @@ func normalizeStorageConfig(cfg *storageConfig) {
 
 func validateStorageConfig(cfg storageConfig) error {
 	cfg.ModelFilter = normalizeModelFilter(cfg.ModelFilter)
+	if err := validateModelFilter(cfg.ModelFilter); err != nil {
+		return err
+	}
 	if cfg.BlockingEnabled && !cfg.Enabled {
 		return infraerrors.BadRequest(ErrorCodeRequiresEnabled, "开启同步阻止前必须先启用提示词审计")
 	}
@@ -298,9 +302,6 @@ func validateStorageConfig(cfg storageConfig) error {
 	}
 	if !cfg.AllGroups && len(cfg.GroupIDs) == 0 {
 		return infraerrors.BadRequest("prompt_audit_groups_required", "指定分组模式至少需要选择一个分组")
-	}
-	if cfg.ModelFilter.Type != ModelFilterAll && len(cfg.ModelFilter.Models) == 0 {
-		return infraerrors.BadRequest("prompt_audit_models_required", "指定或排除模型时至少需要配置一个模型")
 	}
 	if len(cfg.Scanners) == 0 {
 		return infraerrors.BadRequest("prompt_audit_scanners_required", "至少需要启用一个风险分类")
@@ -366,8 +367,8 @@ func validateUpdateConfigRequest(req UpdateConfigRequest) error {
 		}
 	}
 	filter := normalizeModelFilter(req.ModelFilter)
-	if filter.Type != ModelFilterAll && len(filter.Models) == 0 {
-		return infraerrors.BadRequest("prompt_audit_models_required", "指定或排除模型时至少需要配置一个模型")
+	if err := validateModelFilter(filter); err != nil {
+		return err
 	}
 	for _, endpoint := range req.Endpoints {
 		if endpoint.TimeoutMS < MinTimeoutMS || endpoint.TimeoutMS > MaxTimeoutMS {
@@ -402,15 +403,28 @@ func (cfg ActiveConfig) IncludesGroup(groupID *int64) bool {
 }
 
 func (cfg ActiveConfig) IncludesModel(model string) bool {
-	filter := normalizeModelFilter(cfg.ModelFilter)
-	switch filter.Type {
-	case ModelFilterInclude:
-		return modelFilterContains(filter.Models, model)
-	case ModelFilterExclude:
-		return !modelFilterContains(filter.Models, model)
-	default:
+	switch cfg.ModelFilter.Type {
+	case "", ModelFilterAll:
 		return true
+	case ModelFilterInclude:
+		return cfg.modelFilterIncludes(model)
+	case ModelFilterExclude:
+		return !cfg.modelFilterIncludes(model)
+	default:
+		return false
 	}
+}
+
+func (cfg ActiveConfig) modelFilterIncludes(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return false
+	}
+	if cfg.modelFilterSet != nil {
+		_, ok := cfg.modelFilterSet[model]
+		return ok
+	}
+	return modelFilterContains(cfg.ModelFilter.Models, model)
 }
 
 func (cfg ActiveConfig) EnabledEndpoints() []ActiveEndpoint {
@@ -471,12 +485,13 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 }
 
 func ActiveFromStorage(cfg storageConfig, riskControlEnabled bool, encryptor SecretEncryptor) (ActiveConfig, error) {
+	modelFilter := cloneModelFilter(cfg.ModelFilter)
 	active := ActiveConfig{
 		RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled,
 		BlockingLatestTurnOnly: cfg.BlockingLatestTurnOnly, ContinueOnGuardFailure: cfg.ContinueOnGuardFailure,
 		StorePassEvents: cfg.StorePassEvents, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: append([]string(nil), cfg.Scanners...), AllGroups: cfg.AllGroups,
-		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ModelFilter: cloneModelFilter(cfg.ModelFilter), ConfigVersion: cfg.ConfigVersion,
+		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ModelFilter: modelFilter, modelFilterSet: modelFilterSet(modelFilter.Models), ConfigVersion: cfg.ConfigVersion,
 		UpdatedAt: cfg.UpdatedAt, UpdatedBy: cfg.UpdatedBy, ChangeSummary: cfg.ChangeSummary,
 		Endpoints: make([]ActiveEndpoint, 0, len(cfg.Endpoints)),
 	}
@@ -563,14 +578,36 @@ func cloneModelFilter(filter PromptAuditModelFilter) PromptAuditModelFilter {
 }
 
 func normalizeModelFilterType(value string) string {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case ModelFilterInclude:
-		return ModelFilterInclude
-	case ModelFilterExclude:
-		return ModelFilterExclude
-	default:
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
 		return ModelFilterAll
 	}
+	return value
+}
+
+func validateModelFilter(filter PromptAuditModelFilter) error {
+	switch filter.Type {
+	case ModelFilterAll:
+		return nil
+	case ModelFilterInclude, ModelFilterExclude:
+		if len(filter.Models) == 0 {
+			return infraerrors.BadRequest("prompt_audit_models_required", "指定或排除模型时至少需要配置一个模型")
+		}
+		return nil
+	default:
+		return infraerrors.BadRequest("prompt_audit_invalid_model_filter", "提示词审计模型范围无效")
+	}
+}
+
+func modelFilterSet(models []string) map[string]struct{} {
+	if len(models) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		result[strings.ToLower(model)] = struct{}{}
+	}
+	return result
 }
 
 func canonicalModelNames(values []string) []string {

--- a/backend/internal/securityaudit/prompt_config.go
+++ b/backend/internal/securityaudit/prompt_config.go
@@ -24,7 +24,15 @@ const (
 	DefaultInputLimit    = 4000
 	MinInputLimit        = 128
 	MaxInputLimit        = 100000
+	MaxModelFilterModels = 1000
+	MaxModelFilterRunes  = 200
 	DefaultPayloadTTL    = 30 * time.Minute
+)
+
+const (
+	ModelFilterAll     = "all"
+	ModelFilterInclude = "include"
+	ModelFilterExclude = "exclude"
 )
 
 type SecretEncryptor interface {
@@ -63,22 +71,31 @@ type StorageEndpoint struct {
 	Enabled         bool   `json:"enabled"`
 }
 
+// PromptAuditModelFilter controls which requested models enter prompt audit.
+// Model IDs use exact, case-insensitive matching to match content moderation.
+type PromptAuditModelFilter struct {
+	Type   string   `json:"type"`
+	Models []string `json:"models"`
+}
+
 type storageConfig struct {
-	Enabled                bool              `json:"enabled"`
-	BlockingEnabled        bool              `json:"blocking_enabled"`
-	BlockingLatestTurnOnly bool              `json:"blocking_latest_turn_only"`
-	StorePassEvents        bool              `json:"store_pass_events"`
-	Strategy               string            `json:"strategy"`
-	WorkerCount            int               `json:"worker_count"`
-	QueueCapacity          int               `json:"queue_capacity"`
-	Scanners               []string          `json:"scanners"`
-	AllGroups              bool              `json:"all_groups"`
-	GroupIDs               []int64           `json:"group_ids"`
-	Endpoints              []StorageEndpoint `json:"endpoints"`
-	ConfigVersion          int64             `json:"config_version"`
-	UpdatedAt              time.Time         `json:"updated_at"`
-	UpdatedBy              int64             `json:"updated_by"`
-	ChangeSummary          string            `json:"change_summary"`
+	Enabled                bool                   `json:"enabled"`
+	BlockingEnabled        bool                   `json:"blocking_enabled"`
+	BlockingLatestTurnOnly bool                   `json:"blocking_latest_turn_only"`
+	ContinueOnGuardFailure bool                   `json:"continue_on_guard_failure"`
+	StorePassEvents        bool                   `json:"store_pass_events"`
+	Strategy               string                 `json:"strategy"`
+	WorkerCount            int                    `json:"worker_count"`
+	QueueCapacity          int                    `json:"queue_capacity"`
+	Scanners               []string               `json:"scanners"`
+	AllGroups              bool                   `json:"all_groups"`
+	GroupIDs               []int64                `json:"group_ids"`
+	ModelFilter            PromptAuditModelFilter `json:"model_filter"`
+	Endpoints              []StorageEndpoint      `json:"endpoints"`
+	ConfigVersion          int64                  `json:"config_version"`
+	UpdatedAt              time.Time              `json:"updated_at"`
+	UpdatedBy              int64                  `json:"updated_by"`
+	ChangeSummary          string                 `json:"change_summary"`
 }
 
 type ActiveEndpoint struct {
@@ -103,6 +120,7 @@ type ActiveConfig struct {
 	Enabled                bool
 	BlockingEnabled        bool
 	BlockingLatestTurnOnly bool
+	ContinueOnGuardFailure bool
 	StorePassEvents        bool
 	Strategy               string
 	WorkerCount            int
@@ -110,6 +128,7 @@ type ActiveConfig struct {
 	Scanners               []string
 	AllGroups              bool
 	GroupIDs               []int64
+	ModelFilter            PromptAuditModelFilter
 	Endpoints              []ActiveEndpoint
 	ConfigVersion          int64
 	UpdatedAt              time.Time
@@ -131,22 +150,24 @@ type PublicEndpoint struct {
 }
 
 type PublicConfig struct {
-	Enabled                bool             `json:"enabled"`
-	BlockingEnabled        bool             `json:"blocking_enabled"`
-	BlockingLatestTurnOnly bool             `json:"blocking_latest_turn_only"`
-	StorePassEvents        bool             `json:"store_pass_events"`
-	EffectiveMode          Mode             `json:"effective_mode"`
-	Strategy               string           `json:"strategy"`
-	WorkerCount            int              `json:"worker_count"`
-	QueueCapacity          int              `json:"queue_capacity"`
-	Scanners               []string         `json:"scanners"`
-	AllGroups              bool             `json:"all_groups"`
-	GroupIDs               []int64          `json:"group_ids"`
-	Endpoints              []PublicEndpoint `json:"endpoints"`
-	ConfigVersion          int64            `json:"config_version"`
-	UpdatedAt              time.Time        `json:"updated_at"`
-	UpdatedBy              int64            `json:"updated_by"`
-	ChangeSummary          string           `json:"change_summary"`
+	Enabled                bool                   `json:"enabled"`
+	BlockingEnabled        bool                   `json:"blocking_enabled"`
+	BlockingLatestTurnOnly bool                   `json:"blocking_latest_turn_only"`
+	ContinueOnGuardFailure bool                   `json:"continue_on_guard_failure"`
+	StorePassEvents        bool                   `json:"store_pass_events"`
+	EffectiveMode          Mode                   `json:"effective_mode"`
+	Strategy               string                 `json:"strategy"`
+	WorkerCount            int                    `json:"worker_count"`
+	QueueCapacity          int                    `json:"queue_capacity"`
+	Scanners               []string               `json:"scanners"`
+	AllGroups              bool                   `json:"all_groups"`
+	GroupIDs               []int64                `json:"group_ids"`
+	ModelFilter            PromptAuditModelFilter `json:"model_filter"`
+	Endpoints              []PublicEndpoint       `json:"endpoints"`
+	ConfigVersion          int64                  `json:"config_version"`
+	UpdatedAt              time.Time              `json:"updated_at"`
+	UpdatedBy              int64                  `json:"updated_by"`
+	ChangeSummary          string                 `json:"change_summary"`
 }
 
 type UpdateEndpoint struct {
@@ -163,18 +184,20 @@ type UpdateEndpoint struct {
 }
 
 type UpdateConfigRequest struct {
-	ExpectedConfigVersion  int64            `json:"expected_config_version" binding:"required"`
-	Enabled                bool             `json:"enabled"`
-	BlockingEnabled        bool             `json:"blocking_enabled"`
-	BlockingLatestTurnOnly bool             `json:"blocking_latest_turn_only"`
-	StorePassEvents        bool             `json:"store_pass_events"`
-	Strategy               string           `json:"strategy"`
-	WorkerCount            int              `json:"worker_count"`
-	QueueCapacity          int              `json:"queue_capacity"`
-	Scanners               []string         `json:"scanners"`
-	AllGroups              bool             `json:"all_groups"`
-	GroupIDs               []int64          `json:"group_ids"`
-	Endpoints              []UpdateEndpoint `json:"endpoints"`
+	ExpectedConfigVersion  int64                  `json:"expected_config_version" binding:"required"`
+	Enabled                bool                   `json:"enabled"`
+	BlockingEnabled        bool                   `json:"blocking_enabled"`
+	BlockingLatestTurnOnly bool                   `json:"blocking_latest_turn_only"`
+	ContinueOnGuardFailure bool                   `json:"continue_on_guard_failure"`
+	StorePassEvents        bool                   `json:"store_pass_events"`
+	Strategy               string                 `json:"strategy"`
+	WorkerCount            int                    `json:"worker_count"`
+	QueueCapacity          int                    `json:"queue_capacity"`
+	Scanners               []string               `json:"scanners"`
+	AllGroups              bool                   `json:"all_groups"`
+	GroupIDs               []int64                `json:"group_ids"`
+	ModelFilter            PromptAuditModelFilter `json:"model_filter"`
+	Endpoints              []UpdateEndpoint       `json:"endpoints"`
 }
 
 func DefaultStorageConfig() storageConfig {
@@ -189,6 +212,7 @@ func DefaultStorageConfig() storageConfig {
 		Scanners:               append([]string(nil), AllScannerIDs...),
 		AllGroups:              true,
 		GroupIDs:               []int64{},
+		ModelFilter:            PromptAuditModelFilter{Type: ModelFilterAll, Models: []string{}},
 		Endpoints:              []StorageEndpoint{},
 		ConfigVersion:          1,
 	}
@@ -230,6 +254,10 @@ func normalizeStorageConfig(cfg *storageConfig) {
 	}
 	cfg.Scanners = canonicalScannerIDs(cfg.Scanners)
 	cfg.GroupIDs = canonicalInt64s(cfg.GroupIDs)
+	cfg.ModelFilter = normalizeModelFilter(cfg.ModelFilter)
+	if !cfg.BlockingEnabled {
+		cfg.ContinueOnGuardFailure = false
+	}
 	// Preserve an invalid blocking-without-audit combination so validation can
 	// reject it instead of silently changing administrator intent.
 	for i := range cfg.Endpoints {
@@ -255,6 +283,7 @@ func normalizeStorageConfig(cfg *storageConfig) {
 }
 
 func validateStorageConfig(cfg storageConfig) error {
+	cfg.ModelFilter = normalizeModelFilter(cfg.ModelFilter)
 	if cfg.BlockingEnabled && !cfg.Enabled {
 		return infraerrors.BadRequest(ErrorCodeRequiresEnabled, "开启同步阻止前必须先启用提示词审计")
 	}
@@ -269,6 +298,9 @@ func validateStorageConfig(cfg storageConfig) error {
 	}
 	if !cfg.AllGroups && len(cfg.GroupIDs) == 0 {
 		return infraerrors.BadRequest("prompt_audit_groups_required", "指定分组模式至少需要选择一个分组")
+	}
+	if cfg.ModelFilter.Type != ModelFilterAll && len(cfg.ModelFilter.Models) == 0 {
+		return infraerrors.BadRequest("prompt_audit_models_required", "指定或排除模型时至少需要配置一个模型")
 	}
 	if len(cfg.Scanners) == 0 {
 		return infraerrors.BadRequest("prompt_audit_scanners_required", "至少需要启用一个风险分类")
@@ -333,6 +365,10 @@ func validateUpdateConfigRequest(req UpdateConfigRequest) error {
 			}
 		}
 	}
+	filter := normalizeModelFilter(req.ModelFilter)
+	if filter.Type != ModelFilterAll && len(filter.Models) == 0 {
+		return infraerrors.BadRequest("prompt_audit_models_required", "指定或排除模型时至少需要配置一个模型")
+	}
 	for _, endpoint := range req.Endpoints {
 		if endpoint.TimeoutMS < MinTimeoutMS || endpoint.TimeoutMS > MaxTimeoutMS {
 			return infraerrors.BadRequest("prompt_audit_invalid_timeout", "审计节点超时超出允许范围")
@@ -365,6 +401,18 @@ func (cfg ActiveConfig) IncludesGroup(groupID *int64) bool {
 	return i < len(cfg.GroupIDs) && cfg.GroupIDs[i] == *groupID
 }
 
+func (cfg ActiveConfig) IncludesModel(model string) bool {
+	filter := normalizeModelFilter(cfg.ModelFilter)
+	switch filter.Type {
+	case ModelFilterInclude:
+		return modelFilterContains(filter.Models, model)
+	case ModelFilterExclude:
+		return !modelFilterContains(filter.Models, model)
+	default:
+		return true
+	}
+}
+
 func (cfg ActiveConfig) EnabledEndpoints() []ActiveEndpoint {
 	result := make([]ActiveEndpoint, 0, len(cfg.Endpoints))
 	for _, ep := range cfg.Endpoints {
@@ -394,6 +442,7 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 	}
 	scanners := append([]string{}, cfg.Scanners...)
 	groupIDs := append([]int64{}, cfg.GroupIDs...)
+	modelFilter := cloneModelFilter(cfg.ModelFilter)
 	endpoints := make([]PublicEndpoint, 0, len(cfg.Endpoints))
 	for _, ep := range cfg.Endpoints {
 		hasToken := strings.TrimSpace(ep.TokenCiphertext) != ""
@@ -412,10 +461,11 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 	}
 	active := ActiveConfig{RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled}
 	return PublicConfig{
-		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, BlockingLatestTurnOnly: cfg.BlockingLatestTurnOnly, StorePassEvents: cfg.StorePassEvents,
+		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, BlockingLatestTurnOnly: cfg.BlockingLatestTurnOnly,
+		ContinueOnGuardFailure: cfg.ContinueOnGuardFailure, StorePassEvents: cfg.StorePassEvents,
 		EffectiveMode: active.EffectiveMode(), Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: scanners, AllGroups: cfg.AllGroups,
-		GroupIDs: groupIDs, Endpoints: endpoints, ConfigVersion: cfg.ConfigVersion,
+		GroupIDs: groupIDs, ModelFilter: modelFilter, Endpoints: endpoints, ConfigVersion: cfg.ConfigVersion,
 		UpdatedAt: cfg.UpdatedAt, UpdatedBy: cfg.UpdatedBy, ChangeSummary: cfg.ChangeSummary,
 	}
 }
@@ -423,10 +473,10 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 func ActiveFromStorage(cfg storageConfig, riskControlEnabled bool, encryptor SecretEncryptor) (ActiveConfig, error) {
 	active := ActiveConfig{
 		RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled,
-		BlockingLatestTurnOnly: cfg.BlockingLatestTurnOnly,
-		StorePassEvents:        cfg.StorePassEvents, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
+		BlockingLatestTurnOnly: cfg.BlockingLatestTurnOnly, ContinueOnGuardFailure: cfg.ContinueOnGuardFailure,
+		StorePassEvents: cfg.StorePassEvents, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: append([]string(nil), cfg.Scanners...), AllGroups: cfg.AllGroups,
-		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ConfigVersion: cfg.ConfigVersion,
+		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ModelFilter: cloneModelFilter(cfg.ModelFilter), ConfigVersion: cfg.ConfigVersion,
 		UpdatedAt: cfg.UpdatedAt, UpdatedBy: cfg.UpdatedBy, ChangeSummary: cfg.ChangeSummary,
 		Endpoints: make([]ActiveEndpoint, 0, len(cfg.Endpoints)),
 	}
@@ -463,13 +513,16 @@ func changeSummary(cfg storageConfig) string {
 		Enabled                bool   `json:"enabled"`
 		BlockingEnabled        bool   `json:"blocking_enabled"`
 		BlockingLatestTurnOnly bool   `json:"blocking_latest_turn_only"`
+		ContinueOnGuardFailure bool   `json:"continue_on_guard_failure"`
 		StorePassEvents        bool   `json:"store_pass_events"`
 		EndpointCount          int    `json:"endpoint_count"`
 		ScannerCount           int    `json:"scanner_count"`
 		AllGroups              bool   `json:"all_groups"`
 		GroupCount             int    `json:"group_count"`
+		ModelFilterType        string `json:"model_filter_type"`
+		ModelCount             int    `json:"model_count"`
 		GroupHash              string `json:"group_hash"`
-	}{cfg.Enabled, cfg.BlockingEnabled, cfg.BlockingLatestTurnOnly, cfg.StorePassEvents, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), ""}
+	}{cfg.Enabled, cfg.BlockingEnabled, cfg.BlockingLatestTurnOnly, cfg.ContinueOnGuardFailure, cfg.StorePassEvents, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), cfg.ModelFilter.Type, len(cfg.ModelFilter.Models), ""}
 	rawGroups, _ := json.Marshal(cfg.GroupIDs)
 	digest := sha256.Sum256(rawGroups)
 	summary.GroupHash = hex.EncodeToString(digest[:])
@@ -492,6 +545,70 @@ func canonicalInt64s(values []int64) []int64 {
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
 	return result
+}
+
+func normalizeModelFilter(filter PromptAuditModelFilter) PromptAuditModelFilter {
+	filter.Type = normalizeModelFilterType(filter.Type)
+	filter.Models = canonicalModelNames(filter.Models)
+	if filter.Type == ModelFilterAll {
+		filter.Models = []string{}
+	}
+	return filter
+}
+
+func cloneModelFilter(filter PromptAuditModelFilter) PromptAuditModelFilter {
+	filter = normalizeModelFilter(filter)
+	filter.Models = append([]string(nil), filter.Models...)
+	return filter
+}
+
+func normalizeModelFilterType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case ModelFilterInclude:
+		return ModelFilterInclude
+	case ModelFilterExclude:
+		return ModelFilterExclude
+	default:
+		return ModelFilterAll
+	}
+}
+
+func canonicalModelNames(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		runes := []rune(value)
+		if len(runes) > MaxModelFilterRunes {
+			value = string(runes[:MaxModelFilterRunes])
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+		if len(result) == MaxModelFilterModels {
+			break
+		}
+	}
+	return result
+}
+
+func modelFilterContains(models []string, model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return false
+	}
+	for _, candidate := range models {
+		if strings.ToLower(strings.TrimSpace(candidate)) == model {
+			return true
+		}
+	}
+	return false
 }
 
 func canonicalScannerIDs(values []string) []string {

--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -510,6 +510,7 @@ func cloneActiveConfig(cfg ActiveConfig) ActiveConfig {
 	cfg.Scanners = append([]string(nil), cfg.Scanners...)
 	cfg.GroupIDs = append([]int64(nil), cfg.GroupIDs...)
 	cfg.ModelFilter = cloneModelFilter(cfg.ModelFilter)
+	cfg.modelFilterSet = modelFilterSet(cfg.ModelFilter.Models)
 	cfg.Endpoints = append([]ActiveEndpoint(nil), cfg.Endpoints...)
 	return cfg
 }

--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -335,10 +335,11 @@ func (m *ConfigManager) buildNextStorage(current storageConfig, req UpdateConfig
 		currentByID[endpoint.ID] = endpoint
 	}
 	next := storageConfig{
-		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, BlockingLatestTurnOnly: req.BlockingLatestTurnOnly, StorePassEvents: req.StorePassEvents,
+		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, BlockingLatestTurnOnly: req.BlockingLatestTurnOnly,
+		ContinueOnGuardFailure: req.ContinueOnGuardFailure, StorePassEvents: req.StorePassEvents,
 		Strategy: strings.TrimSpace(req.Strategy), WorkerCount: req.WorkerCount,
 		QueueCapacity: req.QueueCapacity, Scanners: append([]string(nil), req.Scanners...),
-		AllGroups: req.AllGroups, GroupIDs: append([]int64(nil), req.GroupIDs...),
+		AllGroups: req.AllGroups, GroupIDs: append([]int64(nil), req.GroupIDs...), ModelFilter: cloneModelFilter(req.ModelFilter),
 		ConfigVersion: current.ConfigVersion, UpdatedBy: actorID,
 		Endpoints: make([]StorageEndpoint, 0, len(req.Endpoints)),
 	}
@@ -500,6 +501,7 @@ func (m *ConfigManager) clearLoadError() {
 func cloneStorageConfig(cfg storageConfig) storageConfig {
 	cfg.Scanners = append([]string(nil), cfg.Scanners...)
 	cfg.GroupIDs = append([]int64(nil), cfg.GroupIDs...)
+	cfg.ModelFilter = cloneModelFilter(cfg.ModelFilter)
 	cfg.Endpoints = append([]StorageEndpoint(nil), cfg.Endpoints...)
 	return cfg
 }
@@ -507,6 +509,7 @@ func cloneStorageConfig(cfg storageConfig) storageConfig {
 func cloneActiveConfig(cfg ActiveConfig) ActiveConfig {
 	cfg.Scanners = append([]string(nil), cfg.Scanners...)
 	cfg.GroupIDs = append([]int64(nil), cfg.GroupIDs...)
+	cfg.ModelFilter = cloneModelFilter(cfg.ModelFilter)
 	cfg.Endpoints = append([]ActiveEndpoint(nil), cfg.Endpoints...)
 	return cfg
 }

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -440,6 +440,17 @@ func TestPromptAuditModelFilterMatchesContentModerationSemantics(t *testing.T) {
 	err := validateUpdateConfigRequest(UpdateConfigRequest{Strategy: "priority", WorkerCount: 1, QueueCapacity: 1,
 		Scanners: []string{"pii"}, AllGroups: true, ModelFilter: PromptAuditModelFilter{Type: ModelFilterInclude}})
 	require.Equal(t, "prompt_audit_models_required", infraerrors.Reason(err))
+
+	_, err = ParseStorageConfig(`{"model_filter":{"type":"includee","models":["gpt-5"]}}`)
+	require.Equal(t, "prompt_audit_invalid_model_filter", infraerrors.Reason(err))
+
+	storage := DefaultStorageConfig()
+	storage.ModelFilter = PromptAuditModelFilter{Type: ModelFilterInclude, Models: []string{"GPT-5", "claude-sonnet"}}
+	active, err := ActiveFromStorage(storage, true, prefixEncryptor{})
+	require.NoError(t, err)
+	require.Len(t, active.modelFilterSet, 2)
+	require.True(t, active.IncludesModel("gpt-5"))
+	require.False(t, active.IncludesModel("gpt-4"))
 }
 
 func TestContinueOnGuardFailureIsOnlyPersistedForBlockingMode(t *testing.T) {
@@ -471,6 +482,9 @@ func TestUpdateConfigStrictBoundsAndKnownValues(t *testing.T) {
 		{name: "unknown scanner", mutate: func(req *UpdateConfigRequest) { req.Scanners = []string{"made_up"} }, reason: "prompt_audit_invalid_scanner"},
 		{name: "group required", mutate: func(req *UpdateConfigRequest) { req.AllGroups = false; req.GroupIDs = nil }, reason: "prompt_audit_groups_required"},
 		{name: "group positive", mutate: func(req *UpdateConfigRequest) { req.AllGroups = false; req.GroupIDs = []int64{0} }, reason: "prompt_audit_invalid_group"},
+		{name: "invalid model filter", mutate: func(req *UpdateConfigRequest) {
+			req.ModelFilter = PromptAuditModelFilter{Type: "includee", Models: []string{"gpt-5"}}
+		}, reason: "prompt_audit_invalid_model_filter"},
 		{name: "timeout low", mutate: func(req *UpdateConfigRequest) { req.Endpoints[0].TimeoutMS = MinTimeoutMS - 1 }, reason: "prompt_audit_invalid_timeout"},
 		{name: "timeout high", mutate: func(req *UpdateConfigRequest) { req.Endpoints[0].TimeoutMS = MaxTimeoutMS + 1 }, reason: "prompt_audit_invalid_timeout"},
 		{name: "input low", mutate: func(req *UpdateConfigRequest) { req.Endpoints[0].InputLimit = MinInputLimit - 1 }, reason: "prompt_audit_invalid_input_limit"},

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -37,10 +37,13 @@ func TestDefaultConfigIsOff(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ModeOff, active.EffectiveMode())
 	require.Equal(t, AllScannerIDs, storage.Scanners)
+	require.False(t, storage.ContinueOnGuardFailure)
+	require.Equal(t, PromptAuditModelFilter{Type: ModelFilterAll, Models: []string{}}, storage.ModelFilter)
 	publicJSON, err := json.Marshal(PublicFromStorage(storage, true, nil))
 	require.NoError(t, err)
 	require.Contains(t, string(publicJSON), `"group_ids":[]`)
 	require.Contains(t, string(publicJSON), `"endpoints":[]`)
+	require.Contains(t, string(publicJSON), `"continue_on_guard_failure":false`)
 }
 
 func TestBlockingLatestTurnOnlyConfigRoundTrip(t *testing.T) {
@@ -417,6 +420,38 @@ func TestParseLegacyConfigDefaultsMissingFieldsWithoutEnablingBlocking(t *testin
 	require.Equal(t, DefaultQueueCapacity, storage.QueueCapacity)
 	require.Equal(t, AllScannerIDs, storage.Scanners)
 	require.True(t, storage.AllGroups)
+	require.False(t, storage.ContinueOnGuardFailure)
+	require.Equal(t, PromptAuditModelFilter{Type: ModelFilterAll, Models: []string{}}, storage.ModelFilter)
+}
+
+func TestPromptAuditModelFilterMatchesContentModerationSemantics(t *testing.T) {
+	config := ActiveConfig{ModelFilter: PromptAuditModelFilter{Type: ModelFilterAll}}
+	require.True(t, config.IncludesModel("gpt-5"))
+
+	config.ModelFilter = PromptAuditModelFilter{Type: ModelFilterInclude, Models: []string{" GPT-5 ", "gpt-5", "claude-sonnet"}}
+	require.True(t, config.IncludesModel("gpt-5"))
+	require.True(t, config.IncludesModel("CLAUDE-SONNET"))
+	require.False(t, config.IncludesModel("gpt-4"))
+
+	config.ModelFilter = PromptAuditModelFilter{Type: ModelFilterExclude, Models: []string{"gpt-5"}}
+	require.False(t, config.IncludesModel("GPT-5"))
+	require.True(t, config.IncludesModel("gpt-4"))
+
+	err := validateUpdateConfigRequest(UpdateConfigRequest{Strategy: "priority", WorkerCount: 1, QueueCapacity: 1,
+		Scanners: []string{"pii"}, AllGroups: true, ModelFilter: PromptAuditModelFilter{Type: ModelFilterInclude}})
+	require.Equal(t, "prompt_audit_models_required", infraerrors.Reason(err))
+}
+
+func TestContinueOnGuardFailureIsOnlyPersistedForBlockingMode(t *testing.T) {
+	config := DefaultStorageConfig()
+	config.ContinueOnGuardFailure = true
+	normalizeStorageConfig(&config)
+	require.False(t, config.ContinueOnGuardFailure)
+
+	config.BlockingEnabled = true
+	config.ContinueOnGuardFailure = true
+	normalizeStorageConfig(&config)
+	require.True(t, config.ContinueOnGuardFailure)
 }
 
 func TestUpdateConfigStrictBoundsAndKnownValues(t *testing.T) {

--- a/backend/internal/securityaudit/prompt_enqueue.go
+++ b/backend/internal/securityaudit/prompt_enqueue.go
@@ -35,6 +35,10 @@ func (e *Enqueuer) Enqueue(ctx context.Context, req Request) error {
 		LogInfo(EventEnqueueSkipped, mergeLogFields(baseFields, map[string]any{"status": "skipped", "error_code": "group_out_of_scope"}))
 		return nil
 	}
+	if !cfg.IncludesModel(req.Model) {
+		LogInfo(EventEnqueueSkipped, mergeLogFields(baseFields, map[string]any{"status": "skipped", "error_code": "model_out_of_scope"}))
+		return nil
+	}
 	if len(cfg.EnabledEndpoints()) == 0 {
 		e.recordDropped()
 		LogWarn(EventEnqueueDropped, mergeLogFields(baseFields, map[string]any{"status": "dropped", "error_code": "no_enabled_endpoint"}))

--- a/backend/internal/securityaudit/prompt_handler.go
+++ b/backend/internal/securityaudit/prompt_handler.go
@@ -229,9 +229,11 @@ func configAuditFields(request UpdateConfigRequest, saved *PublicConfig) map[str
 	return map[string]any{
 		"enabled": request.Enabled, "blocking_enabled": request.BlockingEnabled,
 		"blocking_latest_turn_only": request.BlockingLatestTurnOnly,
+		"continue_on_guard_failure": request.ContinueOnGuardFailure,
 		"config_version":            version, "endpoint_count": len(request.Endpoints),
 		"scanner_count": len(request.Scanners), "all_groups": request.AllGroups,
-		"group_count": len(request.GroupIDs),
+		"group_count": len(request.GroupIDs), "model_filter_type": request.ModelFilter.Type,
+		"model_count": len(request.ModelFilter.Models),
 	}
 }
 

--- a/backend/internal/securityaudit/prompt_service.go
+++ b/backend/internal/securityaudit/prompt_service.go
@@ -153,7 +153,7 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 		}
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}
-	if cfg.EffectiveMode() != ModeBlocking || !cfg.IncludesGroup(req.GroupID) {
+	if cfg.EffectiveMode() != ModeBlocking || !cfg.IncludesGroup(req.GroupID) || !cfg.IncludesModel(req.Model) {
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}
 	snapshot, err := ExtractBlockingPromptSnapshot(req, cfg.BlockingLatestTurnOnly)
@@ -163,7 +163,18 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 	if err != nil {
 		return nil, &GuardError{Code: ErrorCodeInvalidResponse, Cause: err}
 	}
-	return s.evaluator.Evaluate(ctx, cfg, snapshot)
+	decision, err := s.evaluator.Evaluate(ctx, cfg, snapshot)
+	if err == nil || !cfg.ContinueOnGuardFailure {
+		return decision, err
+	}
+	var guardErr *GuardError
+	if !errors.As(err, &guardErr) {
+		return decision, err
+	}
+	// Preserve the Guard diagnostic while allowing configured fail-open traffic.
+	failure := unavailablePromptDecision(guardErr.Code)
+	failure.AllowNextStage = true
+	return failure, nil
 }
 
 func (s *PromptService) GetConfig() (PublicConfig, error) { return s.config.Public() }

--- a/backend/internal/securityaudit/prompt_service_test.go
+++ b/backend/internal/securityaudit/prompt_service_test.go
@@ -3,6 +3,7 @@ package securityaudit
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +11,40 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPromptServiceAppliesModelScopeAndGuardFailurePolicy(t *testing.T) {
+	endpoint := ActiveEndpoint{ID: "guard-1", Name: "Guard", Protocol: "openai_compatible", BaseURL: "http://127.0.0.1:8080", Model: DefaultGuardModel, TimeoutMS: 1000, InputLimit: 1000, Enabled: true}
+	config := ActiveConfig{RiskControlEnabled: true, Enabled: true, BlockingEnabled: true,
+		AllGroups: true, ModelFilter: PromptAuditModelFilter{Type: ModelFilterInclude, Models: []string{"gpt-5"}}, Endpoints: []ActiveEndpoint{endpoint}}
+	failureCode := ErrorCodeUnavailable
+	scanner := PromptScannerFunc(func(context.Context, ActiveEndpoint, string, []string) (*NormalizedResult, error) {
+		return nil, &GuardError{Code: failureCode, Cause: errors.New("guard failure")}
+	})
+	service := &PromptService{config: &fakeConfigStore{active: true, cfg: config}, evaluator: NewGuardEvaluator(scanner, nil, nil)}
+	request := Request{Model: "gpt-4", Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"user","content":"hello"}]}`)}
+
+	decision, err := service.Evaluate(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, DecisionAllow, decision.Kind)
+
+	request.Model = "GPT-5"
+	decision, err = service.Evaluate(context.Background(), request)
+	require.Error(t, err)
+	require.Nil(t, decision)
+
+	config.ContinueOnGuardFailure = true
+	service.config = &fakeConfigStore{active: true, cfg: config}
+	decision, err = service.Evaluate(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, DecisionUnavailable, decision.Kind)
+	require.True(t, decision.AllowNextStage)
+
+	failureCode = ErrorCodeInvalidResponse
+	decision, err = service.Evaluate(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, DecisionInvalid, decision.Kind)
+	require.True(t, decision.AllowNextStage)
+}
 
 type staticSettingRepository struct {
 	values map[string]string

--- a/backend/internal/securityaudit/prompt_worker_test.go
+++ b/backend/internal/securityaudit/prompt_worker_test.go
@@ -302,6 +302,15 @@ func TestEnqueuerSkipsOffOutOfScopeAndNoText(t *testing.T) {
 			cfg.GroupIDs = []int64{9}
 			return cfg
 		}(), req: asyncRequest()},
+		{name: "model out of scope", cfg: func() ActiveConfig {
+			cfg := asyncConfig()
+			cfg.ModelFilter = PromptAuditModelFilter{Type: ModelFilterInclude, Models: []string{"gpt-5"}}
+			return cfg
+		}(), req: func() Request {
+			req := asyncRequest()
+			req.Model = "gpt-4"
+			return req
+		}()},
 		{name: "no user text", cfg: asyncConfig(), req: Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"function","content":"not audited"}]}`)}},
 	}
 	for _, tt := range tests {

--- a/frontend/src/features/prompt-audit/PromptAuditView.vue
+++ b/frontend/src/features/prompt-audit/PromptAuditView.vue
@@ -96,6 +96,7 @@
           <SaveToggle :label="t('admin.promptAudit.saveBar.enabled')" :model-value="draft.enabled" data-test="enabled-toggle" @update:model-value="setEnabled" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.blocking')" :model-value="draft.blocking_enabled" :disabled="!draft.enabled" data-test="blocking-toggle" @update:model-value="setBlocking" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.blockingLatestTurnOnly')" :model-value="draft.blocking_latest_turn_only" :disabled="!draft.enabled || !draft.blocking_enabled" data-test="blocking-latest-turn-only-toggle" @update:model-value="replaceDraft({ ...draft!, blocking_latest_turn_only: $event })" />
+          <SaveToggle :label="t('admin.promptAudit.saveBar.continueOnGuardFailure')" :model-value="draft.continue_on_guard_failure" :disabled="!draft.enabled || !draft.blocking_enabled" data-test="continue-on-guard-failure-toggle" @update:model-value="replaceDraft({ ...draft!, continue_on_guard_failure: $event })" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.storePass')" :model-value="draft.store_pass_events" data-test="store-pass-toggle" @update:model-value="replaceDraft({ ...draft!, store_pass_events: $event })" />
         </div>
         <div class="flex items-center gap-3">
@@ -296,12 +297,12 @@ function updateEndpoints(value: PromptAuditEndpointDraft[]) {
 }
 function setEnabled(value: boolean) {
   if (!draft.value) return
-  replaceDraft({ ...draft.value, enabled: value, blocking_enabled: value ? draft.value.blocking_enabled : false })
+  replaceDraft({ ...draft.value, enabled: value, blocking_enabled: value ? draft.value.blocking_enabled : false, blocking_latest_turn_only: value ? draft.value.blocking_latest_turn_only : false, continue_on_guard_failure: value ? draft.value.continue_on_guard_failure : false })
 }
 function setBlocking(value: boolean) {
   if (!draft.value || !draft.value.enabled) return
   if (value && !draft.value.blocking_enabled) { showBlockingConfirmation.value = true; return }
-  replaceDraft({ ...draft.value, blocking_enabled: value })
+  replaceDraft({ ...draft.value, blocking_enabled: value, blocking_latest_turn_only: value ? draft.value.blocking_latest_turn_only : false, continue_on_guard_failure: value ? draft.value.continue_on_guard_failure : false })
 }
 function confirmBlocking() {
   showBlockingConfirmation.value = false

--- a/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
@@ -19,8 +19,8 @@ vi.mock('vue-i18n', async () => {
 })
 
 const baseConfig = (): PromptAuditConfig => ({
-  enabled: true, blocking_enabled: false, blocking_latest_turn_only: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
-  worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: true, group_ids: [],
+  enabled: true, blocking_enabled: false, blocking_latest_turn_only: false, continue_on_guard_failure: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+  worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: true, group_ids: [], model_filter: { type: 'all', models: [] },
   endpoints: [{ id: 'guard-1', name: 'Guard One', protocol: 'openai_compatible', base_url: 'http://127.0.0.1:8000', model: 'guard-model', timeout_ms: 3000, input_limit: 4000, enabled: true, has_token: true, token_status: 'configured' }],
   config_version: 7, updated_at: '2026-07-16T00:00:00Z', updated_by: 1, change_summary: '{}',
 })
@@ -133,6 +133,21 @@ describe('PromptAuditView', () => {
     expect(wrapper.get('[data-test="blocking-toggle"]').attributes('aria-checked')).toBe('false')
     expect(wrapper.get('[data-test="blocking-toggle"]').attributes()).toHaveProperty('disabled')
     expect(wrapper.get('[data-test="blocking-latest-turn-only-toggle"]').attributes()).toHaveProperty('disabled')
+    expect(wrapper.get('[data-test="continue-on-guard-failure-toggle"]').attributes()).toHaveProperty('disabled')
+  })
+
+  it('only enables Guard failure continuation during synchronous blocking and saves it', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.get('[data-test="tab-config"]').trigger('click')
+    expect(wrapper.get('[data-test="continue-on-guard-failure-toggle"]').attributes()).toHaveProperty('disabled')
+    await wrapper.get('[data-test="blocking-toggle"]').trigger('click')
+    await wrapper.get('[data-test="confirm-action"]').trigger('click')
+    await wrapper.get('[data-test="continue-on-guard-failure-toggle"]').trigger('click')
+    expect(wrapper.get('[data-test="continue-on-guard-failure-toggle"]').attributes('aria-checked')).toBe('true')
+    await wrapper.get('[data-test="save-config"]').trigger('click')
+    await flushPromises()
+    expect(mocks.updateConfig).toHaveBeenCalledWith(expect.objectContaining({ blocking_enabled: true, continue_on_guard_failure: true }))
   })
 
   it('clears plaintext token state after a successful save', async () => {
@@ -178,7 +193,7 @@ describe('PromptAuditView', () => {
     await flushPromises()
     await wrapper.get('[data-test="tab-config"]').trigger('click')
     const switches = wrapper.findAll('[role="switch"]')
-    expect(switches).toHaveLength(4)
+    expect(switches).toHaveLength(5)
     expect(switches.every((item) => Boolean(item.attributes('aria-label')))).toBe(true)
     expect(wrapper.html()).toContain('fixed inset-x-0 bottom-0')
     expect(wrapper.html()).toContain('flex-wrap')

--- a/frontend/src/features/prompt-audit/__tests__/components.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/components.spec.ts
@@ -67,12 +67,13 @@ describe('Prompt Audit components', () => {
 
   it('supports group search, stale configured groups, nine scanners, and bounded worker inputs', async () => {
     const draft: PromptAuditDraft = {
-      enabled: true, blocking_enabled: false, blocking_latest_turn_only: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
-      worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: false, group_ids: [1, 99],
+      enabled: true, blocking_enabled: false, blocking_latest_turn_only: false, continue_on_guard_failure: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+      worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: false, group_ids: [1, 99], model_filter: { type: 'all', models: [] },
       endpoints: [endpoint()], config_version: 1, updated_at: '', updated_by: 0, change_summary: '',
     }
     const wrapper = mount(PolicyPanel, {
       props: { draft, groups: [{ id: 1, name: 'Alpha', platform: 'openai', status: 'active' }, { id: 2, name: 'Beta', platform: 'claude', status: 'inactive' }] },
+      global: { stubs: { ModelWhitelistSelector: true } },
     })
     expect(wrapper.text()).toContain('99')
     expect(wrapper.findAll('input[type="checkbox"]').filter((input) => SCANNER_CATALOG.some((scanner) => input.attributes('aria-label') === `admin.promptAudit.scanners.${scanner.id}`))).toHaveLength(9)
@@ -82,6 +83,24 @@ describe('Prompt Audit components', () => {
     await wrapper.get('[aria-label="admin.promptAudit.policy.workerCount"]').setValue('6')
     const emitted = wrapper.emitted('update:draft')?.at(-1)?.[0] as PromptAuditDraft
     expect(emitted.worker_count).toBe(6)
+  })
+
+  it('switches the model scope and clears its list for all models', async () => {
+    const draft: PromptAuditDraft = {
+      enabled: true, blocking_enabled: false, blocking_latest_turn_only: false, continue_on_guard_failure: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+      worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: true, group_ids: [], model_filter: { type: 'include', models: ['gpt-test'] },
+      endpoints: [endpoint()], config_version: 1, updated_at: '', updated_by: 0, change_summary: '',
+    }
+    const wrapper = mount(PolicyPanel, {
+      props: { draft, groups: [] },
+      global: { stubs: { ModelWhitelistSelector: true } },
+    })
+    expect(wrapper.find('model-whitelist-selector-stub').exists()).toBe(true)
+    const allModels = wrapper.findAll('button').find((button) => button.text().includes('admin.promptAudit.policy.modelFilterAll'))
+    expect(allModels).toBeTruthy()
+    await allModels!.trigger('click')
+    const emitted = wrapper.emitted('update:draft')?.at(-1)?.[0] as PromptAuditDraft
+    expect(emitted.model_filter).toEqual({ type: 'all', models: [] })
   })
 
   it('keeps identity fields separate, supports selection, and opens filter deletion from the toolbar', async () => {

--- a/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
@@ -14,6 +14,7 @@ const config = (): PromptAuditConfig => ({
   enabled: true,
   blocking_enabled: false,
   blocking_latest_turn_only: false,
+  continue_on_guard_failure: false,
   store_pass_events: false,
   effective_mode: 'async_audit',
   strategy: 'priority',
@@ -22,6 +23,7 @@ const config = (): PromptAuditConfig => ({
   scanners: SCANNER_CATALOG.map((item) => item.id),
   all_groups: true,
   group_ids: [],
+  model_filter: { type: 'all', models: [] },
   endpoints: [{
     id: 'guard-1', name: 'Guard One', protocol: 'openai_compatible', base_url: 'http://127.0.0.1:8000',
     model: 'sileader/qwen3guard:0.6b', timeout_ms: 3000, input_limit: 4000, enabled: true,
@@ -35,8 +37,8 @@ const config = (): PromptAuditConfig => ({
 
 describe('Prompt Audit view model', () => {
   it('normalizes legacy null collections from the public config', () => {
-    const legacy = { ...config(), group_ids: null, scanners: null, endpoints: null } as unknown as PromptAuditConfig
-    expect(configToDraft(legacy)).toMatchObject({ group_ids: [], scanners: [], endpoints: [] })
+    const legacy = { ...config(), group_ids: null, scanners: null, endpoints: null, continue_on_guard_failure: undefined, model_filter: undefined } as unknown as PromptAuditConfig
+    expect(configToDraft(legacy)).toMatchObject({ group_ids: [], scanners: [], endpoints: [], continue_on_guard_failure: false, model_filter: { type: 'all', models: [] } })
   })
 
   it('models all nine official input scanners', () => {
@@ -69,6 +71,17 @@ describe('Prompt Audit view model', () => {
     expect(draftFingerprint(changed)).toBe(draftFingerprint(original))
     changed.queue_capacity += 1
     expect(draftFingerprint(changed)).not.toBe(draftFingerprint(original))
+  })
+
+  it('normalizes model scope and only sends Guard failure continuation for synchronous blocking', () => {
+    const draft = configToDraft({ ...config(), continue_on_guard_failure: true, model_filter: { type: 'include', models: [' gpt-test ', 'GPT-TEST', '', 'claude-test'] } })
+    expect(draft.model_filter).toEqual({ type: 'include', models: ['gpt-test', 'claude-test'] })
+    expect(buildUpdateRequest(draft)).toMatchObject({ continue_on_guard_failure: false, model_filter: { type: 'include', models: ['gpt-test', 'claude-test'] } })
+
+    draft.blocking_enabled = true
+    expect(buildUpdateRequest(draft).continue_on_guard_failure).toBe(true)
+    draft.model_filter = { type: 'all', models: ['ignored'] }
+    expect(buildUpdateRequest(draft).model_filter).toEqual({ type: 'all', models: [] })
   })
 
   it('requires a valid explicit range and sends canonical ISO timestamps for filter deletion', () => {

--- a/frontend/src/features/prompt-audit/components/PolicyPanel.vue
+++ b/frontend/src/features/prompt-audit/components/PolicyPanel.vue
@@ -43,6 +43,32 @@
         </div>
 
         <fieldset class="mt-5 border-t border-gray-100 pt-5 dark:border-dark-800">
+          <legend class="text-sm font-medium text-gray-900 dark:text-white">{{ t('admin.promptAudit.policy.modelFilter') }}</legend>
+          <p class="mt-1 text-sm text-gray-500 dark:text-dark-400">{{ t('admin.promptAudit.policy.modelFilterHint') }}</p>
+          <div class="mt-3 grid gap-2 sm:grid-cols-3">
+            <button
+              v-for="option in modelFilterOptions"
+              :key="option.value"
+              type="button"
+              class="rounded-lg border p-3 text-left transition-colors"
+              :class="draft.model_filter.type === option.value
+                ? 'border-primary-300 bg-primary-50 text-primary-900 shadow-sm dark:border-primary-700 dark:bg-primary-900/20 dark:text-primary-100'
+                : 'border-gray-100 hover:bg-gray-50 dark:border-dark-700 dark:hover:bg-dark-700/60'"
+              :aria-pressed="draft.model_filter.type === option.value"
+              @click="setModelFilterType(option.value)"
+            >
+              <span class="block text-sm font-semibold">{{ option.label }}</span>
+              <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-dark-400">{{ option.description }}</span>
+            </button>
+          </div>
+          <div v-if="draft.model_filter.type !== 'all'" class="mt-4 space-y-2">
+            <label class="block text-sm text-gray-700 dark:text-dark-200">{{ t('admin.promptAudit.policy.modelFilterModels') }}</label>
+            <ModelWhitelistSelector :model-value="draft.model_filter.models" @update:model-value="setModelFilterModels" />
+            <p class="text-xs text-gray-500 dark:text-dark-400">{{ t('admin.promptAudit.policy.modelFilterModelCount', { count: draft.model_filter.models.length }) }}</p>
+          </div>
+        </fieldset>
+
+        <fieldset class="mt-5 border-t border-gray-100 pt-5 dark:border-dark-800">
           <legend class="text-sm font-medium text-gray-900 dark:text-white">{{ t('admin.promptAudit.policy.scanners') }}</legend>
           <div class="mt-3 grid gap-2 sm:grid-cols-2">
             <label v-for="scanner in SCANNER_CATALOG" :key="scanner.id" class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:text-dark-200 dark:hover:bg-dark-800">
@@ -74,8 +100,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.vue'
 import type { PromptAuditDraft, PromptAuditGroup } from '../types'
-import { cloneData, SCANNER_CATALOG } from '../viewModel'
+import { cloneData, normalizeModelFilter, SCANNER_CATALOG } from '../viewModel'
 
 const props = defineProps<{ draft: PromptAuditDraft; groups: PromptAuditGroup[] }>()
 const emit = defineEmits<{ (event: 'update:draft', value: PromptAuditDraft): void }>()
@@ -89,6 +116,11 @@ const filteredGroups = computed(() => {
 })
 const knownGroupIds = computed(() => new Set(props.groups.map((group) => group.id)))
 const missingGroupIds = computed(() => props.draft.group_ids.filter((id) => !knownGroupIds.value.has(id)))
+const modelFilterOptions = computed(() => [
+  { value: 'all' as const, label: t('admin.promptAudit.policy.modelFilterAll'), description: t('admin.promptAudit.policy.modelFilterAllDesc') },
+  { value: 'include' as const, label: t('admin.promptAudit.policy.modelFilterInclude'), description: t('admin.promptAudit.policy.modelFilterIncludeDesc') },
+  { value: 'exclude' as const, label: t('admin.promptAudit.policy.modelFilterExclude'), description: t('admin.promptAudit.policy.modelFilterExcludeDesc') },
+])
 
 function patch(value: Partial<PromptAuditDraft>) {
   emit('update:draft', { ...cloneData(props.draft), ...value })
@@ -104,6 +136,12 @@ function toggleScanner(id: string) {
   if (selected.has(id)) selected.delete(id)
   else selected.add(id)
   patch({ scanners: SCANNER_CATALOG.map((item) => item.id).filter((item) => selected.has(item)) })
+}
+function setModelFilterType(type: 'all' | 'include' | 'exclude') {
+  patch({ model_filter: type === 'all' ? { type, models: [] } : { type, models: [...props.draft.model_filter.models] } })
+}
+function setModelFilterModels(models: string[]) {
+  patch({ model_filter: normalizeModelFilter({ type: props.draft.model_filter.type, models }) })
 }
 function scannerLabel(id: string): string {
   return t(`admin.promptAudit.scanners.${id}`)

--- a/frontend/src/features/prompt-audit/types.ts
+++ b/frontend/src/features/prompt-audit/types.ts
@@ -1,6 +1,12 @@
 export type PromptAuditMode = 'off' | 'async_audit' | 'blocking'
 export type PromptDecision = 'pass' | 'flag' | 'critical'
 export type PromptRiskLevel = 'low' | 'medium' | 'high' | 'critical'
+export type PromptAuditModelFilterType = 'all' | 'include' | 'exclude'
+
+export interface PromptAuditModelFilter {
+  type: PromptAuditModelFilterType
+  models: string[]
+}
 
 export interface PromptAuditEndpoint {
   id: string
@@ -24,6 +30,7 @@ export interface PromptAuditConfig {
   enabled: boolean
   blocking_enabled: boolean
   blocking_latest_turn_only: boolean
+  continue_on_guard_failure: boolean
   store_pass_events: boolean
   effective_mode: PromptAuditMode
   strategy: 'priority'
@@ -32,6 +39,7 @@ export interface PromptAuditConfig {
   scanners: string[]
   all_groups: boolean
   group_ids: number[]
+  model_filter: PromptAuditModelFilter
   endpoints: PromptAuditEndpoint[]
   config_version: number
   updated_at: string
@@ -48,6 +56,7 @@ export interface PromptAuditUpdateRequest {
   enabled: boolean
   blocking_enabled: boolean
   blocking_latest_turn_only: boolean
+  continue_on_guard_failure: boolean
   store_pass_events: boolean
   strategy: 'priority'
   worker_count: number
@@ -55,6 +64,7 @@ export interface PromptAuditUpdateRequest {
   scanners: string[]
   all_groups: boolean
   group_ids: number[]
+  model_filter: PromptAuditModelFilter
   endpoints: Array<{
     id: string
     name: string

--- a/frontend/src/features/prompt-audit/viewModel.ts
+++ b/frontend/src/features/prompt-audit/viewModel.ts
@@ -2,6 +2,8 @@ import type {
   PromptAuditConfig,
   PromptAuditDraft,
   PromptAuditEndpointDraft,
+  PromptAuditModelFilter,
+  PromptAuditModelFilterType,
   PromptAuditUpdateRequest,
   PromptEventFilters,
 } from './types'
@@ -30,8 +32,11 @@ export function cloneData<T>(value: T): T {
 export function configToDraft(config: PromptAuditConfig): PromptAuditDraft {
   return {
     ...cloneData(config),
+    blocking_latest_turn_only: config.blocking_latest_turn_only === true,
+    continue_on_guard_failure: config.continue_on_guard_failure === true,
     group_ids: [...(config.group_ids ?? [])],
     scanners: [...(config.scanners ?? [])],
+    model_filter: normalizeModelFilter(config.model_filter),
     endpoints: (config.endpoints ?? []).map((endpoint) => ({
       ...endpoint,
       token: '',
@@ -63,6 +68,7 @@ export function buildUpdateRequest(draft: PromptAuditDraft): PromptAuditUpdateRe
     enabled: draft.enabled,
     blocking_enabled: draft.enabled && draft.blocking_enabled,
     blocking_latest_turn_only: draft.blocking_latest_turn_only,
+    continue_on_guard_failure: draft.enabled && draft.blocking_enabled && draft.continue_on_guard_failure,
     store_pass_events: draft.store_pass_events,
     strategy: 'priority',
     worker_count: Number(draft.worker_count),
@@ -70,6 +76,7 @@ export function buildUpdateRequest(draft: PromptAuditDraft): PromptAuditUpdateRe
     scanners: [...draft.scanners],
     all_groups: draft.all_groups,
     group_ids: draft.all_groups ? [] : [...draft.group_ids].sort((a, b) => a - b),
+    model_filter: normalizeModelFilter(draft.model_filter),
     endpoints: draft.endpoints.map((endpoint) => ({
       id: endpoint.id.trim(),
       name: endpoint.name.trim(),
@@ -83,6 +90,23 @@ export function buildUpdateRequest(draft: PromptAuditDraft): PromptAuditUpdateRe
       enabled: endpoint.enabled,
     })),
   }
+}
+
+export function normalizeModelFilter(value: unknown): PromptAuditModelFilter {
+  if (!value || typeof value !== 'object') return { type: 'all', models: [] }
+  const raw = value as Partial<PromptAuditModelFilter>
+  const type: PromptAuditModelFilterType = raw.type === 'include' || raw.type === 'exclude' || raw.type === 'all' ? raw.type : 'all'
+  if (type === 'all') return { type, models: [] }
+
+  const seen = new Set<string>()
+  const models: string[] = []
+  for (const item of Array.isArray(raw.models) ? raw.models : []) {
+    const model = String(item ?? '').trim()
+    if (!model || seen.has(model.toLowerCase())) continue
+    seen.add(model.toLowerCase())
+    models.push(model)
+  }
+  return { type, models }
 }
 
 export function draftFingerprint(draft: PromptAuditDraft | null): string {

--- a/frontend/src/i18n/locales/en/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/en/admin/promptAudit.ts
@@ -53,9 +53,12 @@ export default {
     policy: {
       title: 'Audit policy', description: 'Configure group scope, nine input-risk categories, workers, and queue bounds.', scope: 'Scope', allGroups: 'All groups', selectedGroups: 'Selected groups',
       searchGroups: 'Search groups', noGroups: 'No matching groups', missingGroups: 'Configured IDs for groups that no longer exist', selectedCount: '{count} groups selected',
+      modelFilter: 'Model scope', modelFilterHint: 'Use the client-requested model name to decide whether Prompt Audit runs.', modelFilterAll: 'All models', modelFilterAllDesc: 'Requests for every model enter Prompt Audit.',
+      modelFilterInclude: 'Only specified models', modelFilterIncludeDesc: 'Only models in the list enter Prompt Audit.', modelFilterExclude: 'Exclude specified models', modelFilterExcludeDesc: 'Models in the list skip Prompt Audit; all others are audited.',
+      modelFilterModels: 'Model list', modelFilterModelCount: '{count} models configured',
       scanners: 'Qwen3Guard input-risk categories', workerCount: 'Worker count', queueCapacity: 'Persistent queue capacity', strategy: 'Node strategy', strategyHint: 'Try nodes in configuration order and fail over when allowed.',
     },
-    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', blockingLatestTurnOnly: 'Only latest input and prior output', storePass: 'Store safe events', dirty: 'Unsaved changes', synced: 'Configuration synced' },
+    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', blockingLatestTurnOnly: 'Only latest input and prior output', continueOnGuardFailure: 'Continue request when Guard times out or fails', storePass: 'Store safe events', dirty: 'Unsaved changes', synced: 'Configuration synced' },
     blockingConfirm: {
       title: 'Enable synchronous blocking?',
       message: 'Applicable requests wait for Guard before account selection, billing, or upstream access. Block, unavailable Guard, and invalid responses all prevent upstream access.',

--- a/frontend/src/i18n/locales/zh/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/zh/admin/promptAudit.ts
@@ -53,9 +53,12 @@ export default {
     policy: {
       title: '审计策略', description: '配置适用分组、九类输入风险、Worker 与队列边界。', scope: '适用范围', allGroups: '全部分组', selectedGroups: '指定分组',
       searchGroups: '搜索分组', noGroups: '没有匹配分组', missingGroups: '配置中包含已删除的分组 ID', selectedCount: '已选择 {count} 个分组',
+      modelFilter: '模型范围', modelFilterHint: '按客户端请求的模型名决定是否执行提示词审计。', modelFilterAll: '所有模型', modelFilterAllDesc: '所有模型请求都会进入提示词审计。',
+      modelFilterInclude: '仅指定模型', modelFilterIncludeDesc: '只有列表中的模型会执行提示词审计。', modelFilterExclude: '排除指定模型', modelFilterExcludeDesc: '列表中的模型跳过提示词审计，其余模型执行审计。',
+      modelFilterModels: '模型列表', modelFilterModelCount: '已配置 {count} 个模型',
       scanners: 'Qwen3Guard 输入风险分类', workerCount: 'Worker 数量', queueCapacity: '持久队列容量', strategy: '节点策略', strategyHint: '按配置顺序优先尝试，必要时故障切换。',
     },
-    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', blockingLatestTurnOnly: '仅审最新输入和上一轮输出', storePass: '保存安全事件', dirty: '有未保存的更改', synced: '配置已同步' },
+    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', blockingLatestTurnOnly: '仅审最新输入和上一轮输出', continueOnGuardFailure: 'Guard 超时/失败时继续请求', storePass: '保存安全事件', dirty: '有未保存的更改', synced: '配置已同步' },
     blockingConfirm: {
       title: '开启同步阻止？',
       message: '适用请求会在账号选择、计费和访问上游之前等待 Guard。命中 Block、Guard 不可用或响应非法时，请求都不会访问上游。',


### PR DESCRIPTION
## Summary
- add a synchronous Guard failure continuation switch, disabled by default
- add all/include/exclude model scope for prompt audit
- apply group and model scope to blocking evaluation and async enqueue

背景：
1 当审计节点审核失败/超时时，可以配置放行请求，默认为不放行，避免因审计节点故障导致服务故障
2 某些模型不需要审核，比如codex-auto-review，误判率高