### PR TITLE
fix(risk-control): record latest user input for cyber policy hits

### DIFF
--- a/backend/internal/handler/content_moderation_helper.go
+++ b/backend/internal/handler/content_moderation_helper.go
@@ -38,7 +38,7 @@ func clientRequestedUsageFields(c *gin.Context, mapping service.ChannelMappingRe
 	return mapping.ToUsageFields(clientRequestedModel(c, fallbackModel), upstreamModel)
 }
 
-func runContentModeration(c *gin.Context, reqLog *zap.Logger, svc *service.ContentModerationService, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol string, model string, body []byte) *service.ContentModerationDecision {
+func runContentModeration(c *gin.Context, reqLog *zap.Logger, svc *service.ContentModerationService, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol string, model string, body []byte, memo *service.ContentModerationInputMemo) *service.ContentModerationDecision {
 	if svc == nil || c == nil || c.Request == nil {
 		return nil
 	}
@@ -58,7 +58,7 @@ func runContentModeration(c *gin.Context, reqLog *zap.Logger, svc *service.Conte
 			zap.Int("body_bytes", len(body)),
 		)
 	}
-	decision, err := svc.Check(c.Request.Context(), input)
+	decision, err := svc.CheckWithInputMemo(c.Request.Context(), input, memo)
 	if err != nil {
 		if reqLog != nil {
 			reqLog.Warn("content_moderation.check_failed", zap.Error(err))

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -100,7 +100,8 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 	setOpsRequestContext(c, reqModel, reqStream)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 
-	if decision := h.checkSecurityAudit(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIChat, reqModel, body); decision != nil && !decision.AllowNextStage {
+	decision, cyberPolicyInput := h.checkSecurityAuditStageWithInputCapture(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIChat, reqModel, body, "http")
+	if decision != nil && !decision.AllowNextStage {
 		h.openAISecurityAuditError(c, decision)
 		return
 	}
@@ -232,7 +233,8 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyChat = service.CyberSessionBlockKey(apiKey.ID, c, body)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyChat, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
+		inputExcerpt := cyberPolicyInputExcerptIfMarked(c, cyberPolicyInput, service.ContentModerationProtocolOpenAIChat, body)
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyChat, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body), inputExcerpt)
 
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)

--- a/backend/internal/handler/openai_gateway_cyber_test.go
+++ b/backend/internal/handler/openai_gateway_cyber_test.go
@@ -24,11 +24,44 @@ func TestRecordCyberPolicyIfMarked_NoMark(t *testing.T) {
 	c := newTestGinContext()
 	h := &OpenAIGatewayHandler{}
 
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "", "")
 
 	// Flag must NOT be set when there was no mark.
 	require.False(t, c.GetBool(cyberPolicyRecordedKey),
 		"cyberPolicyRecordedKey must remain false when no cyber mark is present")
+}
+
+func TestCyberPolicyInputExcerptIfMarkedFallsBackOnlyOnHit(t *testing.T) {
+	c := newTestGinContext()
+	body := []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"actual user prompt"}]},{"type":"function_call_output","call_id":"call_1","output":"done"}]}`)
+
+	require.Empty(t, cyberPolicyInputExcerptIfMarked(c, securityAuditInputCapture{}, service.ContentModerationProtocolOpenAIResponses, body))
+
+	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "blocked"})
+	require.Equal(t, "actual user prompt", cyberPolicyInputExcerptIfMarked(c, securityAuditInputCapture{}, service.ContentModerationProtocolOpenAIResponses, body))
+	require.Equal(t, "already extracted", cyberPolicyInputExcerptIfMarked(c, securityAuditInputCapture{excerpt: "already extracted"}, service.ContentModerationProtocolOpenAIResponses, []byte(`invalid`)))
+
+	c.Set(cyberPolicyRecordedKey, true)
+	require.Empty(t, cyberPolicyInputExcerptIfMarked(c, securityAuditInputCapture{}, service.ContentModerationProtocolOpenAIResponses, body))
+}
+
+func TestOpenAIWSTurnInputSnapshotMatchesTurnAndCyberMark(t *testing.T) {
+	c := newTestGinContext()
+	body := []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"ws prompt"}]}]}`)
+	snapshot := newOpenAIWSTurnInputSnapshot(2, securityAuditInputCapture{}, body)
+
+	require.Empty(t, snapshot.inputExcerptIfMarked(c, 2), "unmatched requests must not trigger fallback extraction")
+	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "blocked"})
+	require.Empty(t, snapshot.inputExcerptIfMarked(c, 1), "a cyber mark from another turn must not use this payload")
+	require.Equal(t, "ws prompt", snapshot.inputExcerptIfMarked(c, 2))
+
+	resolved := newOpenAIWSTurnInputSnapshot(3, securityAuditInputCapture{excerpt: "memo prompt"}, body)
+	require.Nil(t, resolved.payload)
+	require.Equal(t, "memo prompt", resolved.inputExcerptIfMarked(c, 3))
+
+	resolvedEmpty := newOpenAIWSTurnInputSnapshot(4, securityAuditInputCapture{}, body)
+	require.NotNil(t, resolvedEmpty.payload)
+	require.Equal(t, "ws prompt", resolvedEmpty.inputExcerptIfMarked(c, 4))
 }
 
 // TestRecordCyberPolicyIfMarked_WithMark verifies that:
@@ -47,14 +80,14 @@ func TestRecordCyberPolicyIfMarked_WithMark(t *testing.T) {
 
 	// First call: should set the flag.
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "", "")
 	})
 	require.True(t, c.GetBool(cyberPolicyRecordedKey),
 		"cyberPolicyRecordedKey must be true after first call with a mark")
 
 	// Second call: flag already set — must be a no-op (idempotent).
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", "")
 	})
 	// Flag should still be true (not toggled or cleared).
 	require.True(t, c.GetBool(cyberPolicyRecordedKey),
@@ -75,7 +108,7 @@ func TestRecordCyberPolicyIfMarked_ForwardSuccessSkipsUsageLog(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false /* forwardErrored=false */, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false /* forwardErrored=false */, "", service.ChannelUsageFields{}, "", "")
 	})
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 }
@@ -88,7 +121,7 @@ func TestClearCyberPolicyTurnState(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "turn1", UpstreamStatus: 200})
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", "")
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 
 	clearCyberPolicyTurnState(c)
@@ -97,7 +130,7 @@ func TestClearCyberPolicyTurnState(t *testing.T) {
 
 	// turn2: a fresh cyber hit must be recordable again.
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "turn2", UpstreamStatus: 200})
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", "")
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 	require.Equal(t, "turn2", service.GetOpsCyberPolicy(c).Message)
 }
@@ -147,7 +180,7 @@ func TestRecordCyberPolicyIfMarked_BlockKeyPlumbed(t *testing.T) {
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "x", UpstreamStatus: 400})
 	h := &OpenAIGatewayHandler{}
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "deadbeef", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "deadbeef", service.ChannelUsageFields{}, "", "")
 	})
 }
 

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -49,6 +49,32 @@ type openAIWSTurnChannelMappingSnapshot struct {
 	mapping service.ChannelMappingResult
 }
 
+type openAIWSTurnInputSnapshot struct {
+	turn    int
+	excerpt string
+	payload []byte
+}
+
+func newOpenAIWSTurnInputSnapshot(turn int, capture securityAuditInputCapture, payload []byte) *openAIWSTurnInputSnapshot {
+	snapshot := &openAIWSTurnInputSnapshot{turn: turn, excerpt: capture.excerpt}
+	if strings.TrimSpace(capture.excerpt) == "" {
+		// The forwarder keeps the client frame alive through AfterTurn. Retain only
+		// the slice header so cyber fallback does not allocate a payload copy.
+		snapshot.payload = payload
+	}
+	return snapshot
+}
+
+func (snapshot *openAIWSTurnInputSnapshot) inputExcerptIfMarked(c *gin.Context, turn int) string {
+	if snapshot == nil || snapshot.turn != turn || c == nil || c.GetBool(cyberPolicyRecordedKey) || service.GetOpsCyberPolicy(c) == nil {
+		return ""
+	}
+	if strings.TrimSpace(snapshot.excerpt) != "" {
+		return snapshot.excerpt
+	}
+	return service.ExtractLatestUserContentModerationInput(service.ContentModerationProtocolOpenAIResponses, snapshot.payload).ExcerptText()
+}
+
 var errOpenAIWSUnsupportedModelSwitch = errors.New("selected account does not support websocket model switch")
 
 func newOpenAIWSUnsupportedModelSwitchError(model string) error {
@@ -349,7 +375,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	setOpsRequestContext(c, reqModel, reqStream)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 
-	if decision := h.checkSecurityAudit(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, reqModel, body); decision != nil && !decision.AllowNextStage {
+	decision, cyberPolicyInput := h.checkSecurityAuditStageWithInputCapture(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, reqModel, body, "http")
+	if decision != nil && !decision.AllowNextStage {
 		h.openAISecurityAuditError(c, decision)
 		return
 	}
@@ -543,7 +570,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyHTTP = service.CyberSessionBlockKey(apiKey.ID, c, sessionHashBody)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyHTTP, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
+		inputExcerpt := cyberPolicyInputExcerptIfMarked(c, cyberPolicyInput, service.ContentModerationProtocolOpenAIResponses, body)
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyHTTP, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body), inputExcerpt)
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
 		responseLatencyMs := forwardDurationMs
@@ -941,7 +969,8 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 	setOpsRequestContext(c, reqModel, reqStream)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 
-	if decision := h.checkSecurityAudit(c, reqLog, apiKey, subject, service.ContentModerationProtocolAnthropicMessages, reqModel, body); decision != nil && !decision.AllowNextStage {
+	decision, cyberPolicyInput := h.checkSecurityAuditStageWithInputCapture(c, reqLog, apiKey, subject, service.ContentModerationProtocolAnthropicMessages, reqModel, body, "http")
+	if decision != nil && !decision.AllowNextStage {
 		h.anthropicSecurityAuditError(c, decision)
 		return
 	}
@@ -1082,7 +1111,8 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyMsg = service.CyberSessionBlockKey(apiKey.ID, c, body)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyMsg, clientRequestedUsageFields(c, channelMappingMsg, reqModel, ""), service.HashUsageRequestPayload(body))
+		inputExcerpt := cyberPolicyInputExcerptIfMarked(c, cyberPolicyInput, service.ContentModerationProtocolAnthropicMessages, body)
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyMsg, clientRequestedUsageFields(c, channelMappingMsg, reqModel, ""), service.HashUsageRequestPayload(body), inputExcerpt)
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
 		responseLatencyMs := forwardDurationMs
@@ -1575,7 +1605,8 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	setOpsRequestContext(c, reqModel, true)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeWSV2))
 
-	if decision := h.checkSecurityAuditStage(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, reqModel, firstMessage, "first_turn"); decision != nil && !decision.AllowNextStage {
+	decision, firstTurnInput := h.checkSecurityAuditStageWithInputCapture(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, reqModel, firstMessage, "first_turn")
+	if decision != nil && !decision.AllowNextStage {
 		writeSecurityAuditWSError(ctx, wsConn, decision)
 		closeOpenAIClientWS(wsConn, securityAuditWSCloseStatus(decision), securityAuditWSCloseReason(decision))
 		return
@@ -1824,6 +1855,8 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		// turn-tagged slot preserves the exact mapping used for the in-flight request.
 		var turnChannelMapping atomic.Pointer[openAIWSTurnChannelMappingSnapshot]
 		turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{turn: 1, mapping: channelMappingWS})
+		var turnInput atomic.Pointer[openAIWSTurnInputSnapshot]
+		turnInput.Store(newOpenAIWSTurnInputSnapshot(1, firstTurnInput, firstMessage))
 		hooks := &service.OpenAIWSIngressHooks{
 			InitialRequestModel:     reqModel,
 			MaxReasoningEffort:      maxReasoningEffort,
@@ -1842,7 +1875,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				if model == "" {
 					model = reqModel
 				}
-				if decision := h.checkSecurityAuditStage(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, model, payload, "subsequent_turn"); decision != nil && !decision.AllowNextStage {
+				decision, inputCapture := h.checkSecurityAuditStageWithInputCapture(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, model, payload, "subsequent_turn")
+				turnInput.Store(newOpenAIWSTurnInputSnapshot(turn, inputCapture, payload))
+				if decision != nil && !decision.AllowNextStage {
 					writeSecurityAuditWSError(ctx, wsConn, decision)
 					return service.NewOpenAIWSClientCloseError(securityAuditWSCloseStatus(decision), securityAuditWSCloseReason(decision), nil)
 				}
@@ -1904,6 +1939,11 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				// CyberBlocked 必须在 submit 前同步预捕获（task 闭包由 worker 池异步执行，
 				// 届时 defer 已清除标记）。
 				defer clearCyberPolicyTurnState(c)
+				inputExcerpt := ""
+				if snapshot := turnInput.Load(); snapshot != nil && snapshot.turn == turn {
+					defer func() { turnInput.CompareAndSwap(snapshot, nil) }()
+					inputExcerpt = snapshot.inputExcerptIfMarked(c, turn)
+				}
 				releaseTurnSlots()
 				turnRequestedModel := reqModel
 				turnUpstreamModel := ""
@@ -1925,7 +1965,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					turnUpstreamModel = turnRequestedModel
 				}
 				turnUsageFields := turnMapping.ToUsageFields(turnRequestedModel, turnUpstreamModel)
-				h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, turnRequestedModel, turnErr != nil, cyberBlockKey, turnUsageFields, requestPayloadHash)
+				h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, turnRequestedModel, turnErr != nil, cyberBlockKey, turnUsageFields, requestPayloadHash, inputExcerpt)
 				if service.GetOpsCyberPolicy(c) != nil {
 					cyberBlockedThisConn = true
 				}
@@ -2931,7 +2971,14 @@ func (h *OpenAIGatewayHandler) enqueueCyberSessionBlockedOpsEntry(c *gin.Context
 // 并在 forward 返回错误时写一条 tokens=0 用量行。标记由 gateway 服务层在透传 cyber 后设置；
 // 当前请求已发给用户，本方法只做事后记录，不影响响应。forwardErrored 为 true 时才写用量行，
 // 避免与正常 RecordUsage(forward 成功路径)重复。每请求至多记录一次。
-func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey *service.APIKey, account *service.Account, subscription *service.UserSubscription, model string, forwardErrored bool, cyberBlockKey string, channelFields service.ChannelUsageFields, requestPayloadHash string) {
+func cyberPolicyInputExcerptIfMarked(c *gin.Context, capture securityAuditInputCapture, protocol string, body []byte) string {
+	if c == nil || c.GetBool(cyberPolicyRecordedKey) || service.GetOpsCyberPolicy(c) == nil {
+		return ""
+	}
+	return capture.resolve(protocol, body)
+}
+
+func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey *service.APIKey, account *service.Account, subscription *service.UserSubscription, model string, forwardErrored bool, cyberBlockKey string, channelFields service.ChannelUsageFields, requestPayloadHash string, inputExcerpt string) {
 	mark := service.GetOpsCyberPolicy(c)
 	if mark == nil {
 		return
@@ -3027,6 +3074,7 @@ func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey 
 				GroupName:       groupName,
 				Endpoint:        inboundEndpoint,
 				Model:           model,
+				InputExcerpt:    inputExcerpt,
 				UpstreamMessage: mark.Message,
 				UpstreamBody:    mark.Body,
 				UpstreamStatus:  mark.UpstreamStatus,

--- a/backend/internal/handler/security_audit_helper.go
+++ b/backend/internal/handler/security_audit_helper.go
@@ -13,6 +13,19 @@ import (
 
 const securityAuditCompletedContextKey = "sub2api.security_audit.completed"
 
+type securityAuditInputCapture struct {
+	// Empty means cyber recording may fall back to the current request body,
+	// regardless of whether ordinary moderation ran and produced no excerpt.
+	excerpt string
+}
+
+func (capture securityAuditInputCapture) resolve(protocol string, body []byte) string {
+	if strings.TrimSpace(capture.excerpt) != "" {
+		return capture.excerpt
+	}
+	return service.ExtractLatestUserContentModerationInput(protocol, body).ExcerptText()
+}
+
 // cachesSecurityAuditCompletion reports whether a successful audit may be
 // reused for the rest of the gin request. WebSocket turns share one Context
 // across many response.create frames and must be audited independently.
@@ -39,14 +52,21 @@ func (h *OpenAIGatewayHandler) checkSecurityAudit(c *gin.Context, reqLog *zap.Lo
 	return runSecurityAudit(c, reqLog, h.securityAuditCoordinator, h.contentModerationService, apiKey, subject, protocol, model, body, "http")
 }
 
-func (h *OpenAIGatewayHandler) checkSecurityAuditStage(c *gin.Context, reqLog *zap.Logger, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol, model string, body []byte, stage string) *securityaudit.Decision {
+func (h *OpenAIGatewayHandler) checkSecurityAuditStageWithInputCapture(c *gin.Context, reqLog *zap.Logger, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol, model string, body []byte, stage string) (*securityaudit.Decision, securityAuditInputCapture) {
 	if h == nil {
-		return nil
+		return nil, securityAuditInputCapture{}
 	}
-	return runSecurityAudit(c, reqLog, h.securityAuditCoordinator, h.contentModerationService, apiKey, subject, protocol, model, body, stage)
+	memo := service.NewContentModerationInputMemo(protocol, body)
+	decision := runSecurityAuditWithInputMemo(c, reqLog, h.securityAuditCoordinator, h.contentModerationService, apiKey, subject, protocol, model, body, stage, memo)
+	_, excerpt := memo.Capture()
+	return decision, securityAuditInputCapture{excerpt: excerpt}
 }
 
 func runSecurityAudit(c *gin.Context, reqLog *zap.Logger, coordinator *securityaudit.Coordinator, legacy *service.ContentModerationService, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol, model string, body []byte, stage string) *securityaudit.Decision {
+	return runSecurityAuditWithInputMemo(c, reqLog, coordinator, legacy, apiKey, subject, protocol, model, body, stage, nil)
+}
+
+func runSecurityAuditWithInputMemo(c *gin.Context, reqLog *zap.Logger, coordinator *securityaudit.Coordinator, legacy *service.ContentModerationService, apiKey *service.APIKey, subject middleware2.AuthSubject, protocol, model string, body []byte, stage string, memo *service.ContentModerationInputMemo) *securityaudit.Decision {
 	if c == nil || c.Request == nil {
 		return nil
 	}
@@ -57,7 +77,7 @@ func runSecurityAudit(c *gin.Context, reqLog *zap.Logger, coordinator *securitya
 		}
 	}
 	if coordinator == nil {
-		legacyDecision := runContentModeration(c, reqLog, legacy, apiKey, subject, protocol, model, body)
+		legacyDecision := runContentModeration(c, reqLog, legacy, apiKey, subject, protocol, model, body, memo)
 		if legacyDecision == nil {
 			return nil
 		}
@@ -84,7 +104,7 @@ func runSecurityAudit(c *gin.Context, reqLog *zap.Logger, coordinator *securitya
 			zap.String("protocol", request.Protocol), zap.String("model", request.Model), zap.String("stage", request.Stage),
 			zap.Int("body_bytes", len(body)))
 	}
-	decision := coordinator.Check(c.Request.Context(), request)
+	decision := coordinator.CheckWithLegacyInputMemo(c.Request.Context(), request, memo)
 	if decision.AllowNextStage && cacheCompletion {
 		c.Set(securityAuditCompletedContextKey, true)
 	}

--- a/backend/internal/securityaudit/coordinator.go
+++ b/backend/internal/securityaudit/coordinator.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"sync"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 type LegacyEngine interface {
-	Check(ctx context.Context, req Request) (*LegacyDecision, error)
+	Check(ctx context.Context, req Request, memo *service.ContentModerationInputMemo) (*LegacyDecision, error)
 }
 
 type PromptEngine interface {
@@ -27,6 +29,12 @@ func NewCoordinator(legacy LegacyEngine, prompt PromptEngine) *Coordinator {
 }
 
 func (c *Coordinator) Check(ctx context.Context, req Request) Decision {
+	return c.CheckWithLegacyInputMemo(ctx, req, nil)
+}
+
+// CheckWithLegacyInputMemo shares request input extraction with the legacy
+// moderation engine. Prompt audit never receives or retains the memo.
+func (c *Coordinator) CheckWithLegacyInputMemo(ctx context.Context, req Request, memo *service.ContentModerationInputMemo) Decision {
 	if c == nil {
 		return allowDecision(nil, nil)
 	}
@@ -39,24 +47,24 @@ func (c *Coordinator) Check(ctx context.Context, req Request) Decision {
 		// Enqueue is deliberately best-effort. The implementation owns a bounded
 		// context and copies request memory before it can outlive the Handler.
 		_ = c.prompt.Enqueue(ctx, req.Clone())
-		legacy, _ := c.checkLegacy(ctx, req)
+		legacy, _ := c.checkLegacy(ctx, req, memo)
 		return prioritize(legacy, nil)
 	case ModeBlocking:
-		return c.checkBlocking(ctx, req)
+		return c.checkBlocking(ctx, req, memo)
 	default:
-		legacy, _ := c.checkLegacy(ctx, req)
+		legacy, _ := c.checkLegacy(ctx, req, memo)
 		return prioritize(legacy, nil)
 	}
 }
 
-func (c *Coordinator) checkBlocking(ctx context.Context, req Request) Decision {
+func (c *Coordinator) checkBlocking(ctx context.Context, req Request, memo *service.ContentModerationInputMemo) Decision {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	var legacy *LegacyDecision
 	var prompt *PromptDecision
 	go func() {
 		defer wg.Done()
-		legacy, _ = c.checkLegacy(ctx, req)
+		legacy, _ = c.checkLegacy(ctx, req, memo)
 	}()
 	go func() {
 		defer wg.Done()
@@ -84,11 +92,11 @@ func (c *Coordinator) checkBlocking(ctx context.Context, req Request) Decision {
 	return prioritize(legacy, prompt)
 }
 
-func (c *Coordinator) checkLegacy(ctx context.Context, req Request) (*LegacyDecision, error) {
+func (c *Coordinator) checkLegacy(ctx context.Context, req Request, memo *service.ContentModerationInputMemo) (*LegacyDecision, error) {
 	if c.legacy == nil {
 		return nil, nil
 	}
-	return c.legacy.Check(ctx, req)
+	return c.legacy.Check(ctx, req, memo)
 }
 
 func prioritize(legacy *LegacyDecision, prompt *PromptDecision) Decision {

--- a/backend/internal/securityaudit/coordinator_legacy.go
+++ b/backend/internal/securityaudit/coordinator_legacy.go
@@ -14,16 +14,16 @@ func NewLegacyModerationAdapter(svc *service.ContentModerationService) LegacyEng
 	return &LegacyModerationAdapter{service: svc}
 }
 
-func (a *LegacyModerationAdapter) Check(ctx context.Context, req Request) (*LegacyDecision, error) {
+func (a *LegacyModerationAdapter) Check(ctx context.Context, req Request, memo *service.ContentModerationInputMemo) (*LegacyDecision, error) {
 	if a == nil || a.service == nil {
 		return nil, nil
 	}
-	decision, err := a.service.Check(ctx, service.ContentModerationCheckInput{
+	decision, err := a.service.CheckWithInputMemo(ctx, service.ContentModerationCheckInput{
 		RequestID: req.RequestID, UserID: req.UserID, UserEmail: req.UserEmail,
 		APIKeyID: req.APIKeyID, APIKeyName: req.APIKeyName, GroupID: cloneInt64Ptr(req.GroupID),
 		GroupName: req.GroupName, Endpoint: req.Endpoint, Provider: req.Provider,
 		Model: req.Model, Protocol: req.Protocol, Body: req.Body,
-	})
+	}, memo)
 	if err != nil || decision == nil {
 		return nil, err
 	}

--- a/backend/internal/securityaudit/coordinator_test.go
+++ b/backend/internal/securityaudit/coordinator_test.go
@@ -8,17 +8,22 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeLegacyEngine struct {
-	decision *LegacyDecision
-	err      error
-	calls    atomic.Int64
+	decision    *LegacyDecision
+	err         error
+	resolveMemo bool
+	calls       atomic.Int64
 }
 
-func (f *fakeLegacyEngine) Check(context.Context, Request) (*LegacyDecision, error) {
+func (f *fakeLegacyEngine) Check(_ context.Context, _ Request, memo *service.ContentModerationInputMemo) (*LegacyDecision, error) {
 	f.calls.Add(1)
+	if f.resolveMemo {
+		memo.Resolve()
+	}
 	return f.decision, f.err
 }
 
@@ -81,6 +86,24 @@ func TestCoordinatorDoesNotMutateRequestBody(t *testing.T) {
 	decision := NewCoordinator(&fakeLegacyEngine{}, prompt).Check(context.Background(), Request{Body: body})
 	require.True(t, decision.AllowNextStage)
 	require.Equal(t, original, body)
+}
+
+func TestCoordinatorSharesLegacyInputMemoInEveryPromptMode(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"shared prompt"}]}`)
+	for _, mode := range []Mode{ModeOff, ModeAsync, ModeBlocking} {
+		t.Run(string(mode), func(t *testing.T) {
+			memo := service.NewContentModerationInputMemo(service.ContentModerationProtocolOpenAIChat, body)
+			legacy := &fakeLegacyEngine{resolveMemo: true}
+			prompt := &fakePromptEngine{mode: mode, decision: &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}}
+
+			NewCoordinator(legacy, prompt).CheckWithLegacyInputMemo(context.Background(), Request{Body: body}, memo)
+
+			resolved, excerpt := memo.Capture()
+			require.True(t, resolved)
+			require.Equal(t, "shared prompt", excerpt)
+			require.Equal(t, int64(1), legacy.calls.Load())
+		})
+	}
 }
 
 func TestCoordinatorBlockingPriorityCoversBothEngineDecisionMatrix(t *testing.T) {

--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -782,6 +782,17 @@ func (s *ContentModerationService) TestAPIKeys(ctx context.Context, input TestCo
 }
 
 func (s *ContentModerationService) Check(ctx context.Context, input ContentModerationCheckInput) (*ContentModerationDecision, error) {
+	return s.check(ctx, input, nil)
+}
+
+// CheckWithInputMemo lets a request-scoped caller share the existing input
+// extraction without attaching the memo to ContentModerationCheckInput, which
+// may be copied into asynchronous moderation tasks.
+func (s *ContentModerationService) CheckWithInputMemo(ctx context.Context, input ContentModerationCheckInput, memo *ContentModerationInputMemo) (*ContentModerationDecision, error) {
+	return s.check(ctx, input, memo)
+}
+
+func (s *ContentModerationService) check(ctx context.Context, input ContentModerationCheckInput, memo *ContentModerationInputMemo) (*ContentModerationDecision, error) {
 	allow := &ContentModerationDecision{Allowed: true, Action: ContentModerationActionAllow}
 	if s == nil || s.settingRepo == nil || s.repo == nil {
 		slog.Info("content_moderation.skip_unavailable",
@@ -879,7 +890,12 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 			"configured_models", cfg.ModelFilter.Models)
 		return allow, nil
 	}
-	content := ExtractContentModerationInput(input.Protocol, input.Body)
+	var content ContentModerationInput
+	if memo != nil {
+		content = memo.Resolve()
+	} else {
+		content = ExtractContentModerationInput(input.Protocol, input.Body)
+	}
 	if content.IsEmpty() {
 		slog.Info("content_moderation.skip_empty_input",
 			"user_id", input.UserID,
@@ -2871,6 +2887,7 @@ type CyberPolicyRecordInput struct {
 	GroupName       string
 	Endpoint        string
 	Model           string
+	InputExcerpt    string
 	UpstreamMessage string
 	UpstreamBody    string
 	UpstreamStatus  int
@@ -2925,6 +2942,7 @@ func (s *ContentModerationService) RecordCyberPolicyEvent(ctx context.Context, i
 		Flagged:         true,
 		HighestCategory: "cyber_policy",
 		HighestScore:    1.0,
+		InputExcerpt:    trimRunes(redactContentModerationSecrets(in.InputExcerpt), maxModerationExcerptRunes),
 		Error:           trimRunes(redactContentModerationSecrets(errBody), maxModerationExcerptRunes*4),
 		CreatedAt:       time.Now(),
 	}

--- a/backend/internal/service/content_moderation_cyber_test.go
+++ b/backend/internal/service/content_moderation_cyber_test.go
@@ -154,6 +154,50 @@ func TestRecordCyberPolicyEvent_WritesLogWhenEnabled(t *testing.T) {
 		"Error should mention flagged or cyber_policy")
 }
 
+func TestRecordCyberPolicyEventSanitizesInputExcerptSeparatelyFromUpstreamError(t *testing.T) {
+	repo := &contentModerationTestRepo{}
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{SettingKeyRiskControlEnabled: "true"}},
+		repo, nil, nil, nil, nil, nil,
+	)
+	longPrompt := "sk-proj-1234567890abcdef " + strings.Repeat("用", maxModerationExcerptRunes+20)
+
+	svc.RecordCyberPolicyEvent(context.Background(), CyberPolicyRecordInput{
+		InputExcerpt:    longPrompt,
+		UpstreamMessage: "upstream cyber response",
+	})
+
+	logs := repo.snapshotLogs()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0].InputExcerpt, "[已脱敏]")
+	require.NotContains(t, logs[0].InputExcerpt, "sk-proj-1234567890abcdef")
+	require.LessOrEqual(t, len([]rune(logs[0].InputExcerpt)), maxModerationExcerptRunes)
+	require.Equal(t, "upstream cyber response", logs[0].Error, "existing upstream error remains a separate field")
+}
+
+func TestRecordCyberPolicyEventPersistsLatestUserFromToolLoop(t *testing.T) {
+	repo := &contentModerationTestRepo{}
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{SettingKeyRiskControlEnabled: "true"}},
+		repo, nil, nil, nil, nil, nil,
+	)
+	body := []byte(`{"input":[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"sk-proj-1234567890abcdef actual prompt"}]},
+		{"type":"function_call_output","call_id":"call_1","output":"done"}
+	]}`)
+	excerpt := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body).ExcerptText()
+
+	svc.RecordCyberPolicyEvent(context.Background(), CyberPolicyRecordInput{
+		InputExcerpt:    excerpt,
+		UpstreamMessage: "upstream cyber response",
+	})
+
+	logs := repo.snapshotLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, "[已脱敏] actual prompt", logs[0].InputExcerpt)
+	require.Equal(t, "upstream cyber response", logs[0].Error)
+}
+
 // TestRecordCyberPolicyEvent_CreateLogBeforeEmail verifies F7: the moderation
 // log is persisted BEFORE email delivery, and EmailSent is patched afterwards —
 // SMTP hangs can no longer swallow the audit record.

--- a/backend/internal/service/content_moderation_input.go
+++ b/backend/internal/service/content_moderation_input.go
@@ -5,9 +5,44 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"github.com/tidwall/gjson"
 )
+
+// ContentModerationInputMemo shares one extraction across the synchronous
+// legacy moderation check and its caller. It must not outlive that check.
+type ContentModerationInputMemo struct {
+	once     sync.Once
+	protocol string
+	body     []byte
+	input    ContentModerationInput
+	resolved bool
+}
+
+func NewContentModerationInputMemo(protocol string, body []byte) *ContentModerationInputMemo {
+	return &ContentModerationInputMemo{protocol: protocol, body: body}
+}
+
+func (m *ContentModerationInputMemo) Resolve() ContentModerationInput {
+	if m == nil {
+		return ContentModerationInput{}
+	}
+	m.once.Do(func() {
+		m.input = ExtractContentModerationInput(m.protocol, m.body)
+		m.resolved = true
+		m.body = nil
+	})
+	return m.input
+}
+
+// Capture reports whether Resolve ran without triggering extraction itself.
+func (m *ContentModerationInputMemo) Capture() (bool, string) {
+	if m == nil || !m.resolved {
+		return false, ""
+	}
+	return true, m.input.ExcerptText()
+}
 
 func ExtractContentModerationText(protocol string, body []byte) string {
 	return ExtractContentModerationInput(protocol, body).Text
@@ -44,6 +79,41 @@ func ExtractContentModerationInput(protocol string, body []byte) ContentModerati
 	return out
 }
 
+// ExtractLatestUserContentModerationInput finds the nearest user-authored
+// content in the current request, even when tool or assistant items follow it.
+// Empty, tool-only, and system-reminder user items may cause it to select an
+// earlier user item. It is intended for post-response audit context only.
+func ExtractLatestUserContentModerationInput(protocol string, body []byte) ContentModerationInput {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return ContentModerationInput{}
+	}
+	var parts []string
+	var images []string
+	switch protocol {
+	case ContentModerationProtocolAnthropicMessages:
+		collectLatestAnthropicUserMessage(gjson.GetBytes(body, "messages"), &parts, &images)
+	case ContentModerationProtocolOpenAIChat:
+		collectLatestRoleMessage(gjson.GetBytes(body, "messages"), "user", &parts, &images)
+	case ContentModerationProtocolOpenAIResponses:
+		collectLatestResponsesUserInput(gjson.GetBytes(body, "input"), &parts, &images)
+	case ContentModerationProtocolGemini:
+		collectLatestGeminiUserContent(gjson.GetBytes(body, "contents"), &parts, &images)
+	case ContentModerationProtocolOpenAIImages:
+		addModerationText(&parts, gjson.GetBytes(body, "prompt").String())
+		collectContentValue(gjson.GetBytes(body, "images"), &parts, &images)
+	default:
+		collectLatestResponsesUserInput(gjson.GetBytes(body, "input"), &parts, &images)
+		collectLatestRoleMessage(gjson.GetBytes(body, "messages"), "user", &parts, &images)
+		collectLatestGeminiUserContent(gjson.GetBytes(body, "contents"), &parts, &images)
+	}
+	out := ContentModerationInput{
+		Text:   normalizeContentModerationText(strings.Join(parts, "\n")),
+		Images: normalizeModerationImages(images),
+	}
+	out.Normalize()
+	return out
+}
+
 func collectLastRoleMessage(messages gjson.Result, role string, parts *[]string, images *[]string) {
 	if !messages.IsArray() {
 		return
@@ -66,6 +136,28 @@ func collectLastRoleMessage(messages gjson.Result, role string, parts *[]string,
 	*images = append(*images, candidateImages...)
 }
 
+func collectLatestRoleMessage(messages gjson.Result, role string, parts *[]string, images *[]string) {
+	if !messages.IsArray() {
+		return
+	}
+	array := messages.Array()
+	for i := len(array) - 1; i >= 0; i-- {
+		item := array[i]
+		if strings.ToLower(strings.TrimSpace(item.Get("role").String())) != role {
+			continue
+		}
+		var candidate []string
+		var candidateImages []string
+		collectContentValue(item.Get("content"), &candidate, &candidateImages)
+		if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+			continue
+		}
+		*parts = append(*parts, candidate...)
+		*images = append(*images, candidateImages...)
+		return
+	}
+}
+
 func collectLastAnthropicUserMessage(messages gjson.Result, parts *[]string, images *[]string) {
 	if !messages.IsArray() {
 		return
@@ -86,6 +178,28 @@ func collectLastAnthropicUserMessage(messages gjson.Result, parts *[]string, ima
 	}
 	*parts = append(*parts, candidate...)
 	*images = append(*images, candidateImages...)
+}
+
+func collectLatestAnthropicUserMessage(messages gjson.Result, parts *[]string, images *[]string) {
+	if !messages.IsArray() {
+		return
+	}
+	array := messages.Array()
+	for i := len(array) - 1; i >= 0; i-- {
+		item := array[i]
+		if strings.ToLower(strings.TrimSpace(item.Get("role").String())) != "user" {
+			continue
+		}
+		var candidate []string
+		var candidateImages []string
+		collectAnthropicUserContentValue(item.Get("content"), &candidate, &candidateImages)
+		if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+			continue
+		}
+		*parts = append(*parts, candidate...)
+		*images = append(*images, candidateImages...)
+		return
+	}
 }
 
 func collectAnthropicUserContentValue(value gjson.Result, parts *[]string, images *[]string) {
@@ -150,6 +264,48 @@ func collectLastResponsesInput(input gjson.Result, parts *[]string, images *[]st
 	}
 }
 
+func collectLatestResponsesUserInput(input gjson.Result, parts *[]string, images *[]string) {
+	switch {
+	case !input.Exists():
+		return
+	case input.Type == gjson.String:
+		addModerationText(parts, input.String())
+	case input.IsArray():
+		array := input.Array()
+		for i := len(array) - 1; i >= 0; i-- {
+			item := array[i]
+			if isResponsesNonUserItemType(item) {
+				continue
+			}
+			if !isResponsesUserTextItem(item) {
+				continue
+			}
+			collectContentValue(item.Get("content"), parts, images)
+			if item.Get("type").String() == "input_text" || item.Get("text").Exists() {
+				collectContentValue(item, parts, images)
+			}
+			return
+		}
+	case input.IsObject():
+		if !isResponsesNonUserItemType(input) && isResponsesUserTextItem(input) {
+			collectContentValue(input.Get("content"), parts, images)
+			if input.Get("type").String() == "input_text" || input.Get("text").Exists() {
+				collectContentValue(input, parts, images)
+			}
+		}
+	}
+}
+
+func isResponsesNonUserItemType(item gjson.Result) bool {
+	switch strings.ToLower(strings.TrimSpace(item.Get("type").String())) {
+	case "function_call", "function_call_output", "computer_call", "computer_call_output",
+		"web_search_call", "file_search_call", "reasoning", "item_reference":
+		return true
+	default:
+		return false
+	}
+}
+
 func isResponsesUserTextItem(item gjson.Result) bool {
 	role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
 	if role == "user" {
@@ -198,6 +354,35 @@ func collectLastGeminiContent(contents gjson.Result, parts *[]string, images *[]
 	}
 	*parts = append(*parts, candidate...)
 	*images = append(*images, candidateImages...)
+}
+
+func collectLatestGeminiUserContent(contents gjson.Result, parts *[]string, images *[]string) {
+	if !contents.IsArray() {
+		return
+	}
+	array := contents.Array()
+	for i := len(array) - 1; i >= 0; i-- {
+		item := array[i]
+		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+		if role != "" && role != "user" {
+			continue
+		}
+		var candidate []string
+		var candidateImages []string
+		if arr := item.Get("parts"); arr.IsArray() {
+			arr.ForEach(func(_, part gjson.Result) bool {
+				addModerationText(&candidate, part.Get("text").String())
+				addGeminiModerationImage(&candidateImages, part)
+				return true
+			})
+		}
+		if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+			continue
+		}
+		*parts = append(*parts, candidate...)
+		*images = append(*images, candidateImages...)
+		return
+	}
 }
 
 func collectContentValue(value gjson.Result, parts *[]string, images *[]string) {

--- a/backend/internal/service/content_moderation_input_test.go
+++ b/backend/internal/service/content_moderation_input_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestContentModerationInputMemoCaptureLifecycle(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"latest prompt"}]}`)
+	memo := NewContentModerationInputMemo(ContentModerationProtocolOpenAIChat, body)
+
+	resolved, excerpt := memo.Capture()
+	require.False(t, resolved)
+	require.Empty(t, excerpt)
+
+	input := memo.Resolve()
+	require.Equal(t, "latest prompt", input.Text)
+	body[0] = '['
+
+	resolved, excerpt = memo.Capture()
+	require.True(t, resolved)
+	require.Equal(t, "latest prompt", excerpt)
+	require.Equal(t, input, memo.Resolve(), "Resolve must be idempotent after releasing the body reference")
+}
+
+func TestContentModerationInputMemoCapturesResolvedEmptyInput(t *testing.T) {
+	memo := NewContentModerationInputMemo(ContentModerationProtocolOpenAIResponses, []byte(`{"input":[]}`))
+	require.True(t, memo.Resolve().IsEmpty())
+
+	resolved, excerpt := memo.Capture()
+	require.True(t, resolved)
+	require.Empty(t, excerpt)
+}
+
 // 当数组末尾不是用户消息时（典型场景：Agent 工具循环结束于 tool/assistant），
 // 应直接跳过审计——不再回溯查找历史中的某条用户消息。
 
@@ -176,4 +203,144 @@ func TestExtractContentModerationInput_ResponsesLastIsAssistantSkipped(t *testin
 
 	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesAgentToolLoop(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run the tests"}]},
+			{"type":"function_call","call_id":"call_1","name":"run_tests","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_1","output":"all passed"}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "run the tests", input.Text)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesAssistantEnding(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"latest user prompt"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"assistant answer"}]}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "latest user prompt", input.Text)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesFinalUserUnchanged(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"latest"}]}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "latest", input.Text)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesWithoutUser(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"system instructions"}]},
+			{"type":"function_call_output","call_id":"call_1","output":"all passed"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"assistant answer"}]}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesExplicitlySkipsToolText(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"actual user prompt"}]},
+			{"type":"function_call_output","call_id":"call_1","content":[{"type":"input_text","text":"tool output must not be recorded"}]}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "actual user prompt", input.Text)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesToolObjectWithoutUser(t *testing.T) {
+	body := []byte(`{
+		"input":{"type":"function_call_output","call_id":"call_1","content":[{"type":"input_text","text":"tool output must not be recorded"}]}
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractLatestUserContentModerationInput_ResponsesImageOnlyUserStopsSearch(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"older user prompt"}]},
+			{"type":"message","role":"user","content":[{"type":"input_image","image_url":"https://example.com/latest.png"}]}
+		]
+	}`)
+
+	input := ExtractLatestUserContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text, "an image-only latest user item must not fall back to older text")
+	require.Equal(t, []string{"https://example.com/latest.png"}, input.Images)
+}
+
+func TestExtractLatestUserContentModerationInput_OtherToolLoops(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		body     string
+		expected string
+	}{
+		{
+			name:     "openai chat",
+			protocol: ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[
+				{"role":"user","content":"list my orders"},
+				{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"orders","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"call_1","content":"[]"}
+			]}`,
+			expected: "list my orders",
+		},
+		{
+			name:     "anthropic messages",
+			protocol: ContentModerationProtocolAnthropicMessages,
+			body: `{"messages":[
+				{"role":"user","content":"check the weather"},
+				{"role":"assistant","content":[{"type":"tool_use","id":"tool_1","name":"weather","input":{}}]},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":"sunny"}]}
+			]}`,
+			expected: "check the weather",
+		},
+		{
+			name:     "gemini",
+			protocol: ContentModerationProtocolGemini,
+			body: `{"contents":[
+				{"role":"user","parts":[{"text":"check the weather"}]},
+				{"role":"model","parts":[{"functionCall":{"name":"weather","args":{}}}]},
+				{"role":"user","parts":[{"functionResponse":{"name":"weather","response":{"temp":25}}}]}
+			]}`,
+			expected: "check the weather",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := ExtractLatestUserContentModerationInput(tt.protocol, []byte(tt.body))
+			require.Equal(t, tt.expected, input.Text)
+		})
+	}
 }

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -419,6 +419,29 @@ func TestBuildContentModerationLog_RedactsInputExcerpt(t *testing.T) {
 	require.Contains(t, log.InputExcerpt, "[已脱敏]")
 }
 
+func TestContentModerationCheckWithInputMemoLeavesDisabledAuditUnresolved(t *testing.T) {
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{
+			SettingKeyRiskControlEnabled:      "true",
+			SettingKeyContentModerationConfig: `{"enabled":false}`,
+		}},
+		&contentModerationTestRepo{}, nil, nil, nil, nil, nil,
+	)
+	body := []byte(`{"messages":[{"role":"user","content":"cyber still needs this"}]}`)
+	memo := NewContentModerationInputMemo(ContentModerationProtocolOpenAIChat, body)
+
+	decision, err := svc.CheckWithInputMemo(context.Background(), ContentModerationCheckInput{
+		Protocol: ContentModerationProtocolOpenAIChat,
+		Body:     body,
+	}, memo)
+
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	resolved, excerpt := memo.Capture()
+	require.False(t, resolved)
+	require.Empty(t, excerpt)
+}
+
 func TestRedactContentModerationSecrets_LongHexAndTokens(t *testing.T) {
 	input := "你哈市多大事cf5bbdc4cd508f3aaf0d2070d529d4a4ac29099f8ecc357f696df28e1df91554 token=abc123456789xyz Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturepart https://example.com/private/path?token=abc123"
 


### PR DESCRIPTION
## Summary

- Record the latest user-authored input in the moderation log when an upstream request is rejected by `cyber_policy`.
- Reuse the existing content-moderation input extraction when it already ran, avoiding duplicate parsing.
- Fall back to scanning the current request body only after a cyber policy hit when no reusable input was captured.
- Keep ordinary content-moderation behavior unchanged.

## Protocol handling

- OpenAI Responses: skip trailing reasoning, assistant, function call, and function call output items.
- OpenAI Chat Completions: select the latest non-empty user message even when assistant or tool messages follow it.
- Anthropic Messages: skip tool-result-only user blocks and select the latest actual user content.
- Gemini: skip function-response-only content and select the latest actual user content.
- Preserve image-only user input without incorrectly falling back to an earlier text message.

The extracted value is sanitized and length-limited before it is persisted as
`ContentModerationLog.InputExcerpt`.

## Cyber policy behavior

Cyber policy detection remains independent of whether ordinary content moderation
is enabled. When ordinary moderation already extracted the request input, the
cyber policy recording path reuses that result. Otherwise, extraction happens
only after an upstream cyber policy hit.

The upstream cyber policy message and response body remain unchanged and continue
to be stored separately for diagnostics.

## Resource impact

- No additional request-body copy is introduced.
- Requests without a cyber policy hit do not perform fallback extraction.
- When ordinary moderation runs, its existing extraction result is reused.
- WebSocket handling retains only the current turn's existing payload reference
  until that turn completes.

## Tests

- [x] `go test ./internal/service ./internal/securityaudit ./internal/handler -count=1`
- [x] `golangci-lint run ./internal/handler/... ./internal/service/... ./internal/securityaudit/...`
- [x] `go build -buildvcs=false ./...`
- [x] `git diff --check`

Added coverage for Responses, Chat Completions, Anthropic, Gemini, tool loops,
image-only inputs, disabled ordinary moderation, WebSocket turns, sanitization,
and persistence to the moderation log.
