### PR TITLE
fix(openai): preserve official Codex Responses semantics

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/securityaudit"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -105,6 +106,18 @@ func resolveOpenAIMessagesDispatchMappedModel(apiKey *service.APIKey, requestedM
 }
 
 type openAIModelBodyReplaceFunc func([]byte, string) []byte
+
+type openAIResponsesAttemptForwardFunc func(context.Context, *gin.Context, *service.Account, []byte) (*service.OpenAIForwardResult, error)
+
+func applyOpenAIResponsesReasoningPolicy(body []byte, group *service.Group) []byte {
+	if group == nil || group.Platform != service.PlatformOpenAI {
+		return body
+	}
+	if cappedBody, changed := service.ApplyOpenAIReasoningEffortPolicy(body, group.MaxReasoningEffort, group.ReasoningEffortMappings); changed {
+		return cappedBody
+	}
+	return body
+}
 
 func openAIModelMappedBody(body []byte, mapped bool, mappedModel string, replace openAIModelBodyReplaceFunc) []byte {
 	if !mapped || replace == nil {
@@ -312,11 +325,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by this OpenAI-compatible endpoint for composite groups")
 		return
 	}
-	if apiKey.Group != nil && apiKey.Group.Platform == service.PlatformOpenAI {
-		if cappedBody, changed := service.ApplyOpenAIReasoningEffortPolicy(body, apiKey.Group.MaxReasoningEffort, apiKey.Group.ReasoningEffortMappings); changed {
-			body = cappedBody
-		}
-	}
+	body = applyOpenAIResponsesReasoningPolicy(body, apiKey.Group)
 
 	reqStream, ok := parseOpenAICompatibleStream(body)
 	if !ok {
@@ -325,27 +334,32 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
 	previousResponseID := strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String())
+	previousResponseIDKind := ""
+	deferOfficialCompatibilityValidation := openai.IsCodexOfficialClientByHeaders(
+		c.GetHeader("User-Agent"), c.GetHeader("originator"),
+	)
 	if previousResponseID != "" {
-		previousResponseIDKind := service.ClassifyOpenAIPreviousResponseIDKind(previousResponseID)
+		previousResponseIDKind = service.ClassifyOpenAIPreviousResponseIDKind(previousResponseID)
 		reqLog = reqLog.With(
 			zap.Bool("has_previous_response_id", true),
 			zap.String("previous_response_id_kind", previousResponseIDKind),
 			zap.Int("previous_response_id_len", len(previousResponseID)),
 		)
-		if previousResponseIDKind == service.OpenAIPreviousResponseIDKindMessageID {
+		if !deferOfficialCompatibilityValidation {
+			if previousResponseIDKind == service.OpenAIPreviousResponseIDKindMessageID {
+				reqLog.Warn("openai.request_validation_failed",
+					zap.String("reason", "previous_response_id_looks_like_message_id"),
+				)
+				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*), not a message id")
+				return
+			}
 			reqLog.Warn("openai.request_validation_failed",
-				zap.String("reason", "previous_response_id_looks_like_message_id"),
+				zap.String("reason", "previous_response_id_requires_wsv2"),
 			)
-			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*), not a message id")
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id is only supported on Responses WebSocket v2")
 			return
 		}
-		reqLog.Warn("openai.request_validation_failed",
-			zap.String("reason", "previous_response_id_requires_wsv2"),
-		)
-		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id is only supported on Responses WebSocket v2")
-		return
 	}
-
 	setOpsRequestContext(c, reqModel, reqStream)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 
@@ -380,7 +394,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	seedOpenAIForwardImageIntentHint(c, channelMapping.Mapped, imageIntent)
 
 	// 提前校验 function_call_output 是否具备可关联上下文，避免上游 400。
-	if !h.validateFunctionCallOutputRequest(c, body, reqLog) {
+	if !deferOfficialCompatibilityValidation && !h.validateFunctionCallOutputRequest(c, body, reqLog) {
 		return
 	}
 
@@ -431,7 +445,6 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	var lastFailoverErr *service.UpstreamFailoverError
 	var oauth429FailoverState service.OpenAIOAuth429FailoverState
 	var passthroughFailoverState openAIPassthroughFailoverState
-
 	// 生图意图的 /v1/responses 请求必须调度到确实支持 Responses API 的账号，否则
 	// 会在 forward 阶段被静默降级为无法生图的 Chat Completions 直转（#4417）。
 	// 仅对 OpenAI 平台生效：Grok 生图走独立的 forwardGrokResponses 路径，不应被过滤。
@@ -448,20 +461,46 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		// Select account supporting the requested model
 		reqLog.Debug("openai.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
-		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
-			c.Request.Context(),
-			apiKey.GroupID,
-			previousResponseID,
-			sessionHash,
-			reqModel,
-			failedAccountIDs,
-			service.OpenAIUpstreamTransportAny,
-			requiredCapability,
-			requireCompact,
-			false,
-			!imageIntent,
-			requestPlatform,
-		)
+		var selection *service.AccountSelectionResult
+		var scheduleDecision service.OpenAIAccountScheduleDecision
+		var err error
+		if deferOfficialCompatibilityValidation && previousResponseID != "" {
+			selection, scheduleDecision, err = h.gatewayService.SelectOfficialCodexTransparentHTTPAccountByPreviousResponseID(
+				c.Request.Context(),
+				apiKey.GroupID,
+				previousResponseID,
+				reqModel,
+				failedAccountIDs,
+				requiredCapability,
+				requireCompact,
+			)
+			if err == nil && (selection == nil || selection.Account == nil) {
+				if lastFailoverErr != nil {
+					h.handleFailoverExhausted(c, lastFailoverErr, streamStarted)
+					return
+				}
+				reqLog.Warn("openai.previous_response_affinity_miss",
+					zap.String("previous_response_id_kind", previousResponseIDKind),
+				)
+				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id is not bound to an available transparent OAuth account")
+				return
+			}
+		} else {
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+				c.Request.Context(),
+				apiKey.GroupID,
+				previousResponseID,
+				sessionHash,
+				reqModel,
+				failedAccountIDs,
+				service.OpenAIUpstreamTransportAny,
+				requiredCapability,
+				requireCompact,
+				false,
+				!imageIntent,
+				requestPlatform,
+			)
+		}
 		if err != nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai.account_select_aborted_client_disconnected", zap.Error(err))
@@ -512,6 +551,14 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			zap.Float64("load_skew", scheduleDecision.LoadSkew),
 		)
 		account := selection.Account
+		if deferOfficialCompatibilityValidation && !h.validateOpenAIResponsesAttemptCompatibility(
+			c, account, body, previousResponseID, previousResponseIDKind, reqLog,
+		) {
+			if selection.Acquired && selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			return
+		}
 		sessionHash = ensureOpenAIPoolModeSessionHash(sessionHash, account)
 		reqLog.Debug("openai.account_selected", zap.Int64("account_id", account.ID), zap.String("account_name", account.Name))
 		setOpsSelectedAccount(c, account.ID, account.Platform)
@@ -527,17 +574,15 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		// 用扣除 compact 心跳字节的口径快照：心跳注释不构成语义响应，
 		// 不能因心跳字节变化而放弃 failover 换号（#3887）。
 		writerSizeBeforeForward := service.OpenAICompactKeepaliveAdjustedWrittenSize(c)
-		// 跨 passthrough 边界的 failover：从 Kiro 等透传账号切到 Bedrock 等非透传账号前，
-		// 从不可变的 canonical forwardBody 派生本次尝试 body 并整块剔除上游私有的加密
-		// reasoning item（含耦合的 id/summary），避免非透传上游 400 拒绝 Kiro reasoning 形态。
-		attemptBody := h.deriveOpenAIForwardAttemptBody(reqLog, forwardBody, account, &passthroughFailoverState)
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
 			}()
-			return h.gatewayService.Forward(c.Request.Context(), c, account, attemptBody)
+			return h.forwardOpenAIResponsesAttempt(
+				c.Request.Context(), c, account, forwardBody, reqLog, &passthroughFailoverState, h.gatewayService.Forward,
+			)
 		}()
 		cyberBlockKeyHTTP := ""
 		if service.GetOpsCyberPolicy(c) != nil {
@@ -554,7 +599,17 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if err == nil && result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
-		if err != nil {
+		forwardFailedWithUsage := err != nil && result != nil && errors.Is(err, service.ErrOfficialCodexTransparentStreamFailed)
+		if forwardFailedWithUsage {
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), false, nil)
+			reqLog.Warn("openai.forward_failed_with_usage",
+				zap.Int64("account_id", account.ID),
+				zap.Bool("fallback_error_response_written", false),
+				zap.Int("input_tokens", result.Usage.InputTokens),
+				zap.Int("output_tokens", result.Usage.OutputTokens),
+				zap.Error(err),
+			)
+		} else if err != nil {
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),
@@ -664,7 +719,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
 			}
-			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
+			if !forwardFailedWithUsage {
+				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
+			}
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), nil)
 		}
@@ -1328,6 +1385,52 @@ func (h *OpenAIGatewayHandler) validateFunctionCallOutputRequest(c *gin.Context,
 	)
 	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "function_call_output requires item_reference ids matching each call_id on HTTP requests; continuation via previous_response_id is only supported on Responses WebSocket v2")
 	return false
+}
+
+func (h *OpenAIGatewayHandler) forwardOpenAIResponsesAttempt(
+	ctx context.Context,
+	c *gin.Context,
+	account *service.Account,
+	forwardBody []byte,
+	reqLog *zap.Logger,
+	passthroughFailoverState *openAIPassthroughFailoverState,
+	forward openAIResponsesAttemptForwardFunc,
+) (*service.OpenAIForwardResult, error) {
+	if forward == nil {
+		return nil, errors.New("OpenAI Responses forward function is nil")
+	}
+	// Derive each attempt from the canonical policy- and mapping-adjusted body so
+	// failover-specific compatibility changes never discard mandatory transforms.
+	attemptBody := h.deriveOpenAIForwardAttemptBody(reqLog, forwardBody, account, passthroughFailoverState)
+	return forward(ctx, c, account, attemptBody)
+}
+
+func (h *OpenAIGatewayHandler) validateOpenAIResponsesAttemptCompatibility(
+	c *gin.Context,
+	account *service.Account,
+	body []byte,
+	previousResponseID string,
+	previousResponseIDKind string,
+	reqLog *zap.Logger,
+) bool {
+	if service.ShouldUseOfficialCodexResponsesTransparentPassthrough(c, account) {
+		return true
+	}
+	if previousResponseID != "" {
+		if previousResponseIDKind == service.OpenAIPreviousResponseIDKindMessageID {
+			reqLog.Warn("openai.request_validation_failed",
+				zap.String("reason", "previous_response_id_looks_like_message_id"),
+			)
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*), not a message id")
+			return false
+		}
+		reqLog.Warn("openai.request_validation_failed",
+			zap.String("reason", "previous_response_id_requires_wsv2"),
+		)
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id is only supported on Responses WebSocket v2")
+		return false
+	}
+	return h.validateFunctionCallOutputRequest(c, body, reqLog)
 }
 
 func (h *OpenAIGatewayHandler) acquireResponsesUserSlot(
@@ -2503,16 +2606,7 @@ func shouldLogOpenAIForwardFailureAsWarn(c *gin.Context, wroteFallback bool) boo
 }
 
 // openAIForwardErrorAlreadyCommunicated reports whether Forward returned an
-// error after it had already written the upstream terminal error response to
-// the client.
-//
-// This matters for Responses streams: upstream may return HTTP 200 with a
-// non-retryable `response.failed` event (for example a policy/safety rejection).
-// The service layer forwards that terminal event verbatim, then returns an
-// error so the caller can log/account for the failed upstream response. The
-// handler must not append its generic fallback `response.failed`, otherwise
-// strict clients may see the useful upstream message replaced by "Upstream
-// request failed" or receive duplicate terminal events.
+// error after it had already written a complete terminal error response.
 func openAIForwardErrorAlreadyCommunicated(c *gin.Context, writerSizeBeforeForward int, err error) bool {
 	if err == nil || c == nil || c.Writer == nil {
 		return false
@@ -2531,7 +2625,9 @@ func openAIForwardErrorAlreadyCommunicated(c *gin.Context, writerSizeBeforeForwa
 	if service.GetOpsCyberPolicy(c) != nil {
 		return true
 	}
-
+	if errors.Is(err, service.ErrOfficialCodexTransparentStreamFailed) {
+		return true
+	}
 	msg := strings.TrimSpace(err.Error())
 	for _, prefix := range []string{
 		"upstream response failed:",

--- a/backend/internal/handler/openai_transparent_passthrough_test.go
+++ b/backend/internal/handler/openai_transparent_passthrough_test.go
@@ -123,9 +123,10 @@ func (u *openAITransparentMixedAccountUpstream) Do(req *http.Request, _ string, 
 	}
 	u.bodies = append(u.bodies, requestBody)
 	responseID := "resp_api_key_first"
-	if accountID == 70 {
+	switch accountID {
+	case 70:
 		responseID = "resp_oauth_issuer"
-	} else if accountID == 71 {
+	case 71:
 		responseID = "resp_oauth_other"
 	}
 	body := fmt.Sprintf(`{"id":%q,"object":"response","model":"gpt-5.6-sol","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`, responseID)

--- a/backend/internal/handler/openai_transparent_passthrough_test.go
+++ b/backend/internal/handler/openai_transparent_passthrough_test.go
@@ -1,0 +1,420 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+func newOfficialCodexTransparentPassthroughContext() *gin.Context {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+	return c
+}
+
+func newOfficialCodexTransparentPassthroughAccount() *service.Account {
+	return &service.Account{
+		ID:          70,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Credentials: map[string]any{"access_token": "test-token"},
+		Extra:       map[string]any{"openai_passthrough": true},
+	}
+}
+
+func TestValidateOpenAIResponsesAttemptCompatibility(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &OpenAIGatewayHandler{}
+	invalidContinuation := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call_output","call_id":"call_1","output":"{}"}]}`)
+
+	t.Run("official transparent passthrough defers continuation validation", func(t *testing.T) {
+		c := newOfficialCodexTransparentPassthroughContext()
+		ok := h.validateOpenAIResponsesAttemptCompatibility(
+			c,
+			newOfficialCodexTransparentPassthroughAccount(),
+			invalidContinuation,
+			"msg_not_a_response_id",
+			service.OpenAIPreviousResponseIDKindMessageID,
+			zap.NewNop(),
+		)
+		require.True(t, ok)
+		require.False(t, c.Writer.Written())
+	})
+
+	t.Run("non passthrough keeps previous response validation", func(t *testing.T) {
+		c := newOfficialCodexTransparentPassthroughContext()
+		account := newOfficialCodexTransparentPassthroughAccount()
+		account.Extra = nil
+		ok := h.validateOpenAIResponsesAttemptCompatibility(
+			c,
+			account,
+			invalidContinuation,
+			"msg_not_a_response_id",
+			service.OpenAIPreviousResponseIDKindMessageID,
+			zap.NewNop(),
+		)
+		require.False(t, ok)
+		require.Equal(t, http.StatusBadRequest, c.Writer.Status())
+	})
+}
+
+type openAITransparentMixedAccountRepo struct {
+	service.AccountRepository
+	accounts []service.Account
+}
+
+func (r *openAITransparentMixedAccountRepo) ListSchedulableByPlatform(_ context.Context, platform string) ([]service.Account, error) {
+	accounts := make([]service.Account, 0, len(r.accounts))
+	for _, account := range r.accounts {
+		if account.Platform == platform && account.IsSchedulable() {
+			accounts = append(accounts, account)
+		}
+	}
+	return accounts, nil
+}
+
+func (r *openAITransparentMixedAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, _ int64, platform string) ([]service.Account, error) {
+	return r.ListSchedulableByPlatform(ctx, platform)
+}
+
+func (r *openAITransparentMixedAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Context, platform string) ([]service.Account, error) {
+	return r.ListSchedulableByPlatform(ctx, platform)
+}
+
+func (r *openAITransparentMixedAccountRepo) GetByID(_ context.Context, id int64) (*service.Account, error) {
+	for _, account := range r.accounts {
+		if account.ID == id {
+			copy := account
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+type openAITransparentMixedAccountUpstream struct {
+	service.HTTPUpstream
+	accountIDs   []int64
+	bodies       [][]byte
+	responseBody string
+	contentType  string
+}
+
+func (u *openAITransparentMixedAccountUpstream) Do(req *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
+	u.accountIDs = append(u.accountIDs, accountID)
+	requestBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	u.bodies = append(u.bodies, requestBody)
+	responseID := "resp_api_key_first"
+	if accountID == 70 {
+		responseID = "resp_oauth_issuer"
+	} else if accountID == 71 {
+		responseID = "resp_oauth_other"
+	}
+	body := fmt.Sprintf(`{"id":%q,"object":"response","model":"gpt-5.6-sol","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`, responseID)
+	if u.responseBody != "" {
+		body = u.responseBody
+	}
+	contentType := u.contentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{contentType}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestOpenAIResponsesContinuationPreservesIssuerAffinityAndReleasesAcquiredSlot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(4204)
+	issuerAccount := *newOfficialCodexTransparentPassthroughAccount()
+	issuerAccount.Name = "oauth-issuer"
+	issuerAccount.Status = service.StatusActive
+	issuerAccount.Schedulable = true
+	issuerAccount.Priority = 1
+	issuerAccount.Concurrency = 1
+	issuerAccount.Credentials["base_url"] = "https://api.example.test"
+	otherAccount := issuerAccount
+	otherAccount.ID = 71
+	otherAccount.Name = "oauth-other"
+	otherAccount.Priority = 2
+	otherAccount.Credentials = map[string]any{"access_token": "other-token", "base_url": "https://api.example.test"}
+	otherAccount.Extra = map[string]any{"openai_passthrough": true}
+
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.MaxAccountSwitches = 2
+	repo := &openAITransparentMixedAccountRepo{accounts: []service.Account{issuerAccount, otherAccount}}
+	upstream := &openAITransparentMixedAccountUpstream{}
+	cache := &concurrencyCacheMock{
+		acquireAccountSlotFn: func(context.Context, int64, int, string) (bool, error) { return true, nil },
+	}
+	concurrency := service.NewConcurrencyService(cache)
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		repo, nil, nil, nil, nil, nil, nil, cfg, nil, concurrency,
+		service.NewBillingService(cfg, nil), nil, billingCache, upstream,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway,
+		concurrency,
+		billingCache,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg),
+		nil, nil, nil, nil, cfg,
+	)
+
+	request := func(body string) *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+		c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+			ID: 1804, GroupID: &groupID,
+			User:  &service.User{ID: 1704, Status: service.StatusActive},
+			Group: &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+		})
+		c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1704, Concurrency: 0})
+		h.Responses(c)
+		return recorder
+	}
+
+	first := request(`{"model":"gpt-5.6-sol","input":"hello","stream":false}`)
+	require.Equal(t, http.StatusOK, first.Code)
+	require.Equal(t, "resp_oauth_issuer", gjson.GetBytes(first.Body.Bytes(), "id").String())
+	repo.accounts[0].Priority = 2
+	repo.accounts[1].Priority = 1
+
+	probeSelection, probeDecision, err := gateway.SelectOfficialCodexTransparentHTTPAccountByPreviousResponseID(
+		context.Background(), &groupID, "resp_oauth_issuer", "gpt-5.6-sol", nil,
+		service.OpenAIEndpointCapabilityResponses, false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, probeSelection)
+	require.True(t, probeDecision.StickyPreviousHit)
+	require.Equal(t, issuerAccount.ID, probeDecision.SelectedAccountID)
+	require.Equal(t, issuerAccount.ID, probeSelection.Account.ID)
+	if probeSelection.ReleaseFunc != nil {
+		probeSelection.ReleaseFunc()
+	}
+
+	continuation := `{"model":"gpt-5.6-sol","previous_response_id":"resp_oauth_issuer","input":[{"type":"function_call_output","call_id":"call_1","output":"{}"}],"stream":false}`
+	releasesBeforeContinuation := atomic.LoadInt32(&cache.releaseAccountCalled)
+	second := request(continuation)
+
+	require.Equal(t, http.StatusOK, second.Code)
+	require.Equal(t, []int64{70, 70}, upstream.accountIDs)
+	require.Equal(t, "resp_oauth_issuer", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
+	require.Equal(t, releasesBeforeContinuation+1, atomic.LoadInt32(&cache.releaseAccountCalled), "selected continuation account slot must be released exactly once")
+
+	miss := request(`{"model":"gpt-5.6-sol","previous_response_id":"resp_unknown","input":"continue","stream":false}`)
+	require.Equal(t, http.StatusBadRequest, miss.Code)
+	require.Equal(t, "previous_response_id is not bound to an available transparent OAuth account", gjson.GetBytes(miss.Body.Bytes(), "error.message").String())
+	require.Equal(t, []int64{70, 70}, upstream.accountIDs, "affinity miss must not migrate to the newly preferred account")
+}
+
+func TestOpenAIResponsesMandatoryTransformsReachUpstreamThroughHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(4205)
+	group := &service.Group{
+		ID:                 groupID,
+		Platform:           service.PlatformOpenAI,
+		Status:             service.StatusActive,
+		MaxReasoningEffort: "medium",
+	}
+	account := *newOfficialCodexTransparentPassthroughAccount()
+	account.Name = "mapped-oauth"
+	account.Status = service.StatusActive
+	account.Schedulable = true
+	account.Priority = 1
+	account.Credentials["base_url"] = "https://api.example.test"
+	repo := &openAITransparentMixedAccountRepo{accounts: []service.Account{account}}
+	upstream := &openAITransparentMixedAccountUpstream{}
+	channelService := service.NewChannelService(
+		&openAIWSUsageHandlerChannelRepoStub{
+			channels: []service.Channel{{
+				ID:       8805,
+				Name:     "transparent-handler-mapping",
+				Status:   service.StatusActive,
+				GroupIDs: []int64{groupID},
+				ModelMapping: map[string]map[string]string{
+					service.PlatformOpenAI: {"alias": "gpt-5.6-sol"},
+				},
+			}},
+			groupPlatforms: map[int64]string{groupID: service.PlatformOpenAI},
+		},
+		nil, nil, nil,
+	)
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		repo, nil, nil, nil, nil, nil, nil, cfg, nil, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, upstream,
+		&service.DeferredService{}, nil, nil, nil, channelService, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway, service.NewConcurrencyService(nil), billingCache,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg),
+		nil, nil, nil, nil, cfg,
+	)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(`{"model":"alias","reasoning":{"effort":"high"},"input":"test","stream":false}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1805, GroupID: &groupID,
+		User:  &service.User{ID: 1705, Status: service.StatusActive},
+		Group: group,
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1705, Concurrency: 0})
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Len(t, upstream.bodies, 1)
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.bodies[0], "model").String())
+	require.Equal(t, "medium", gjson.GetBytes(upstream.bodies[0], "reasoning.effort").String())
+}
+
+func TestOpenAIResponsesTransparentFailureSanitizesClientAndRecordsUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(4206)
+	account := *newOfficialCodexTransparentPassthroughAccount()
+	account.Name = "failed-oauth"
+	account.Status = service.StatusActive
+	account.Schedulable = true
+	account.Priority = 1
+	account.Credentials["base_url"] = "https://api.example.test"
+	repo := &openAITransparentMixedAccountRepo{accounts: []service.Account{account}}
+	upstream := &openAITransparentMixedAccountUpstream{
+		contentType: "text/event-stream",
+		responseBody: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed\",\"error\":{\"message\":\"sensitive upstream failure\"},\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}}\n\n" +
+			"data: [DONE]\n\n",
+	}
+	usageRepo := &openAIWSUsageHandlerUsageLogRepoStub{created: make(chan *service.UsageLog, 1)}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		repo, usageRepo, nil, nil, nil, nil, nil, cfg, nil, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, upstream,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway, service.NewConcurrencyService(nil), billingCache,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg),
+		nil, nil, nil, nil, cfg,
+	)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"test","stream":true}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1806, GroupID: &groupID,
+		User:  &service.User{ID: 1706, Status: service.StatusActive},
+		Group: &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1706, Concurrency: 0})
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), `"type":"response.failed"`))
+	require.Contains(t, recorder.Body.String(), "Upstream request failed")
+	require.NotContains(t, recorder.Body.String(), "sensitive upstream failure")
+	require.NotContains(t, recorder.Body.String(), "[DONE]")
+	select {
+	case usageLog := <-usageRepo.created:
+		require.Equal(t, 2, usageLog.InputTokens)
+		require.Equal(t, 1, usageLog.OutputTokens)
+		require.True(t, usageLog.Stream)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for failed transparent stream usage record")
+	}
+}
+
+func TestOpenAIResponsesTransparentFailureWithEmptyUsageDoesNotRecordZeroUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(4207)
+	account := *newOfficialCodexTransparentPassthroughAccount()
+	account.Name = "failed-without-usage-oauth"
+	account.Status = service.StatusActive
+	account.Schedulable = true
+	account.Priority = 1
+	account.Credentials["base_url"] = "https://api.example.test"
+	repo := &openAITransparentMixedAccountRepo{accounts: []service.Account{account}}
+	upstream := &openAITransparentMixedAccountUpstream{
+		contentType: "text/event-stream",
+		responseBody: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed_empty_usage\",\"error\":{\"message\":\"sensitive upstream failure\"},\"usage\":{}}}\n\n" +
+			"data: [DONE]\n\n",
+	}
+	usageRepo := &openAIWSUsageHandlerUsageLogRepoStub{created: make(chan *service.UsageLog, 1)}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		repo, usageRepo, nil, nil, nil, nil, nil, cfg, nil, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, upstream,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway, service.NewConcurrencyService(nil), billingCache,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg),
+		nil, nil, nil, nil, cfg,
+	)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(`{"model":"gpt-5.6-sol","input":"test","stream":true}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1807, GroupID: &groupID,
+		User:  &service.User{ID: 1707, Status: service.StatusActive},
+		Group: &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1707, Concurrency: 0})
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), `"type":"response.failed"`))
+	require.Contains(t, recorder.Body.String(), "Upstream request failed")
+	require.NotContains(t, recorder.Body.String(), "sensitive upstream failure")
+	require.NotContains(t, recorder.Body.String(), "[DONE]")
+	select {
+	case usageLog := <-usageRepo.created:
+		t.Fatalf("unexpected zero-usage record: %+v", usageLog)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -38,31 +38,35 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
 	}
 
-	normalizedBody, normalized, err := normalizeOpenAICodexCompactReasoningEffortForAccount(c, account, body)
-	if err != nil {
-		return nil, err
-	}
-	if normalized {
-		body = normalizedBody
-	}
-	if account.IsOpenAIOAuth() && isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
-		liteBody, changed, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
-		if liteErr != nil {
-			setOpsUpstreamError(c, http.StatusBadRequest, liteErr.Error(), "")
-			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{
-				"type": "invalid_request_error", "message": liteErr.Error(), "param": "tools",
-			}})
-			return nil, liteErr
+	transparentPassthrough := shouldUseOfficialCodexResponsesTransparentPassthrough(c, account)
+	if !transparentPassthrough {
+		normalizedBody, normalized, err := normalizeOpenAICodexCompactReasoningEffortForAccount(c, account, body)
+		if err != nil {
+			return nil, err
 		}
-		if changed {
-			body = liteBody
+		if normalized {
+			body = normalizedBody
+		}
+		if account.IsOpenAIOAuth() && isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
+			liteBody, changed, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
+			if liteErr != nil {
+				setOpsUpstreamError(c, http.StatusBadRequest, liteErr.Error(), "")
+				c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{
+					"type": "invalid_request_error", "message": liteErr.Error(), "param": "tools",
+				}})
+				return nil, liteErr
+			}
+			if changed {
+				body = liteBody
+			}
 		}
 	}
 	wsDecision := s.getOpenAIWSProtocolResolver().Resolve(account)
 	// 仅允许 WS 入站请求走 WS 上游，避免出现 HTTP -> WS 协议混用。
 	wsDecision = resolveOpenAIWSDecisionByClientTransport(wsDecision, GetOpenAIClientTransport(c))
 	passthroughEnabled := account.IsOpenAIPassthroughEnabled()
-	if shouldFlattenOpenAIResponsesNamespaces(account, wsDecision.Transport, passthroughEnabled) {
+	if !transparentPassthrough && shouldFlattenOpenAIResponsesNamespaces(account, wsDecision.Transport, passthroughEnabled) {
+		var err error
 		body, err = flattenOpenAIResponsesNamespaces(c, body)
 		if err != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
@@ -72,7 +76,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			return nil, err
 		}
 	}
-	if shouldStripOpenAIResponsesInputNamespaces(account, wsDecision.Transport, passthroughEnabled) {
+	if !transparentPassthrough && shouldStripOpenAIResponsesInputNamespaces(account, wsDecision.Transport, passthroughEnabled) {
+		var err error
 		body, err = stripOpenAIResponsesInputNamespaces(body)
 		if err != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
@@ -147,7 +152,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	}
 	if passthroughEnabled {
 		attemptImageIntentInvalidated := false
-		if isCodexCLI && codexImageGenerationExplicitToolPolicy == codexImageGenerationExplicitToolPolicyStrip {
+		if !transparentPassthrough && isCodexCLI && codexImageGenerationExplicitToolPolicy == codexImageGenerationExplicitToolPolicyStrip {
 			strippedBody, changed, stripErr := stripOpenAIImageGenerationToolsFromRawPayload(body)
 			if stripErr != nil {
 				return nil, stripErr

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -17,12 +18,37 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
+
+var (
+	ErrOfficialCodexTransparentStreamFailed    = errors.New("official Codex transparent stream failed")
+	ErrOfficialCodexTransparentStreamIntegrity = errors.New("official Codex transparent stream integrity failure")
+)
+
+const openAITransparentSSEReaderBufferSize = 32 * 1024
+
+func shouldPreserveOfficialCodexResponsesPayload(c *gin.Context, account *Account) bool {
+	if c == nil || account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth || account.IsOpenAIAgentIdentity() {
+		return false
+	}
+	return openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator"))
+}
+
+func shouldUseOfficialCodexResponsesTransparentPassthrough(c *gin.Context, account *Account) bool {
+	return shouldPreserveOfficialCodexResponsesPayload(c, account) &&
+		account.IsOpenAIPassthroughEnabled() &&
+		!isOpenAIResponsesCompactPath(c)
+}
+
+func ShouldUseOfficialCodexResponsesTransparentPassthrough(c *gin.Context, account *Account) bool {
+	return shouldUseOfficialCodexResponsesTransparentPassthrough(c, account)
+}
 
 func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	ctx context.Context,
@@ -36,8 +62,9 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	reqStream bool,
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
+	transparentPassthrough := shouldUseOfficialCodexResponsesTransparentPassthrough(c, account)
 	upstreamPassthroughModel := ""
-	if isOpenAIResponsesCompactPath(c) {
+	if !transparentPassthrough && isOpenAIResponsesCompactPath(c) {
 		compactMappedModel := resolveOpenAICompactForwardModel(account, reqModel)
 		if compactMappedModel != "" && compactMappedModel != reqModel {
 			nextBody, setErr := sjson.SetBytes(body, "model", compactMappedModel)
@@ -50,7 +77,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		}
 	}
 
-	if account != nil && account.Type == AccountTypeOAuth {
+	if account != nil && account.Type == AccountTypeOAuth && !transparentPassthrough {
 		if rejectReason := detectOpenAIPassthroughInstructionsRejectReason(reqModel, body); rejectReason != "" {
 			rejectMsg := "OpenAI codex passthrough requires a non-empty instructions field"
 			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
@@ -74,12 +101,14 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		reqStream = gjson.GetBytes(body, "stream").Bool()
 	}
 
-	sanitizedBody, sanitized, err := sanitizeEmptyBase64InputImagesInOpenAIBody(body)
-	if err != nil {
-		return nil, err
-	}
-	if sanitized {
-		body = sanitizedBody
+	if !transparentPassthrough {
+		sanitizedBody, sanitized, err := sanitizeEmptyBase64InputImagesInOpenAIBody(body)
+		if err != nil {
+			return nil, err
+		}
+		if sanitized {
+			body = sanitizedBody
+		}
 	}
 
 	// Apply OpenAI fast policy to the passthrough body (filter/block by service_tier).
@@ -204,7 +233,6 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		if resp.StatusCode < 400 {
 			break
 		}
-
 		// Peek only to identify an invalid task. Restore the body so the existing
 		// passthrough error handling sees the same response after recovery fails.
 		probeBody := s.readUpstreamErrorBody(resp)
@@ -236,10 +264,15 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	responseID := ""
 	imageCount := 0
 	var imageOutputSizes []string
+	var responseErr error
 	if reqStream {
 		result, err := s.handleStreamingResponsePassthrough(ctx, resp, c, account, startTime, reqModel, upstreamPassthroughModel)
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrOfficialCodexTransparentStreamFailed) && !errors.Is(err, ErrOfficialCodexTransparentStreamIntegrity) {
 			return nil, err
+		}
+		responseErr = err
+		if result == nil {
+			return nil, responseErr
 		}
 		usage = result.usage
 		firstTokenMs = result.firstTokenMs
@@ -247,7 +280,13 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	} else {
-		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		var result *openaiNonStreamingResultPassthrough
+		var err error
+		if transparentPassthrough {
+			result, err = s.handleNonStreamingResponseTransparentPassthrough(resp, c)
+		} else {
+			result, err = s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +295,9 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	}
-	s.bindHTTPResponseAccount(ctx, c, account, responseID)
+	if responseErr == nil {
+		s.bindHTTPResponseAccount(ctx, c, account, responseID)
+	}
 
 	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
 	if !account.IsShadow() {
@@ -265,6 +306,9 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		}
 	}
 
+	if errors.Is(responseErr, ErrOfficialCodexTransparentStreamFailed) && usage == nil {
+		return nil, responseErr
+	}
 	if usage == nil {
 		usage = &OpenAIUsage{}
 	}
@@ -289,7 +333,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		forwardResult.ImageOutputSizes = imageOutputSizes
 		forwardResult.BillingModel = imageBillingModel
 	}
-	return forwardResult, nil
+	return forwardResult, responseErr
 }
 
 func logOpenAIPassthroughInstructionsRejected(
@@ -754,6 +798,127 @@ func openAIStreamDataStartsClientOutput(data, eventType string) bool {
 	return !openAIStreamEventIsPreamble(eventType)
 }
 
+func sanitizeOpenAITransparentFailedPayload(payload []byte) ([]byte, bool) {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) || strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "response.failed" {
+		return payload, false
+	}
+
+	usagePath := ""
+	usageRaw := ""
+	if value := gjson.GetBytes(payload, "response.usage"); value.Exists() && value.IsObject() {
+		usagePath = "response.usage"
+		usageRaw = value.Raw
+	} else if value := gjson.GetBytes(payload, "usage"); value.Exists() && value.IsObject() {
+		usagePath = "usage"
+		usageRaw = value.Raw
+	}
+
+	updated, _ := sanitizeOpenAIResponseFailedEventForClient(payload, "response.failed", true)
+	errorPath := "error"
+	if gjson.GetBytes(updated, "response").Exists() {
+		errorPath = "response.error"
+	}
+	next, err := sjson.SetBytes(updated, errorPath, map[string]any{
+		"type":    "upstream_error",
+		"code":    "upstream_error",
+		"message": "Upstream request failed",
+	})
+	if err != nil {
+		return payload, false
+	}
+	updated = next
+	if usagePath != "" {
+		updated, err = sjson.SetRawBytes(updated, usagePath, []byte(usageRaw))
+		if err != nil {
+			return payload, false
+		}
+	}
+	return updated, true
+}
+
+func replaceOpenAISSEDataPayload(event, payload []byte) []byte {
+	if len(event) == 0 {
+		return event
+	}
+	separator := []byte("\n")
+	lines := bytes.Split(event, separator)
+	replaced := false
+	out := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		trimmed := bytes.TrimSuffix(line, []byte("\r"))
+		if bytes.HasPrefix(trimmed, []byte("data:")) {
+			if replaced {
+				continue
+			}
+			replacement := append([]byte("data: "), payload...)
+			if len(line) != len(trimmed) {
+				replacement = append(replacement, '\r')
+			}
+			out = append(out, replacement)
+			replaced = true
+			continue
+		}
+		out = append(out, line)
+	}
+	if !replaced {
+		return event
+	}
+	return bytes.Join(out, separator)
+}
+
+func openAITransparentOversizedEventType(prefix []byte) string {
+	explicitType := ""
+	for len(prefix) > 0 {
+		line := prefix
+		if newline := bytes.IndexByte(prefix, '\n'); newline >= 0 {
+			line = prefix[:newline]
+			prefix = prefix[newline+1:]
+		} else {
+			prefix = nil
+		}
+		line = bytes.TrimSpace(line)
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			explicitType = strings.TrimSpace(string(bytes.TrimPrefix(line, []byte("event:"))))
+		case bytes.HasPrefix(line, []byte("data:")):
+			decoder := json.NewDecoder(bytes.NewReader(bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))))
+			token, err := decoder.Token()
+			if err != nil || token != json.Delim('{') {
+				continue
+			}
+			for decoder.More() {
+				keyToken, keyErr := decoder.Token()
+				if keyErr != nil {
+					break
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					break
+				}
+				if key == "type" {
+					valueToken, valueErr := decoder.Token()
+					if valueErr == nil {
+						if eventType, ok := valueToken.(string); ok {
+							return strings.TrimSpace(eventType)
+						}
+					}
+					break
+				}
+				var discarded json.RawMessage
+				if decodeErr := decoder.Decode(&discarded); decodeErr != nil {
+					break
+				}
+			}
+		}
+	}
+	return explicitType
+}
+
+func openAITransparentOversizedEventIsObservableNonterminal(eventType string) bool {
+	eventType = strings.TrimSpace(eventType)
+	return strings.HasPrefix(eventType, "response.") && !isOpenAIWSTerminalEvent(eventType)
+}
+
 func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
 	if isOpenAIContextWindowError(message, payload) {
 		return http.StatusBadRequest
@@ -968,6 +1133,9 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	originalModel string,
 	mappedModel string,
 ) (*openaiStreamingResultPassthrough, error) {
+	if shouldUseOfficialCodexResponsesTransparentPassthrough(c, account) {
+		return s.handleStreamingResponseTransparentPassthrough(ctx, resp, c, account, startTime)
+	}
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
 	// SSE headers
@@ -1223,6 +1391,228 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	return resultWithUsage(), nil
 }
 
+func (s *OpenAIGatewayService) handleStreamingResponseTransparentPassthrough(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	startTime time.Time,
+) (*openaiStreamingResultPassthrough, error) {
+	writeOpenAITransparentResponseHeaders(c.Writer.Header(), resp.Header)
+	c.Writer.WriteHeader(resp.StatusCode)
+
+	w := c.Writer
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, errors.New("streaming not supported")
+	}
+	flusher.Flush()
+
+	var usage *OpenAIUsage
+	imageCounter := newOpenAIImageOutputCounter()
+	var firstTokenMs *int
+	responseID := ""
+	sawTerminalEvent := false
+	sawFailedEvent := false
+	failedMessage := ""
+	clientDisconnected := false
+	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
+	maxObservedEventSize := defaultMaxLineSize
+	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+		maxObservedEventSize = s.cfg.Gateway.MaxLineSize
+	}
+	eventBuffer := make([]byte, 0, min(4096, maxObservedEventSize))
+	eventOverflow := false
+	eventOverflowForwarded := false
+	integrityFailure := ""
+	downstreamTerminated := false
+
+	forwardEvent := func(event []byte) {
+		if clientDisconnected || len(event) == 0 {
+			return
+		}
+		if _, writeErr := w.Write(event); writeErr != nil {
+			clientDisconnected = true
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] client disconnected during transparent stream, continuing to drain usage: account=%d", account.ID)
+			return
+		}
+		flusher.Flush()
+	}
+	observeEvent := func(event []byte) ([]byte, bool) {
+		if integrityFailure != "" {
+			return event, false
+		}
+		forward := true
+		observedEvent := event
+		if openAITransparentSSEEventContainsDone(event) && !sawTerminalEvent {
+			integrityFailure = "SSE [DONE] arrived before a trustworthy terminal event"
+			return observedEvent, false
+		}
+		forEachOpenAISSEDataPayload(string(event), func(dataBytes []byte) {
+			if downstreamTerminated {
+				forward = false
+				return
+			}
+			trimmedData := strings.TrimSpace(string(dataBytes))
+			if !gjson.ValidBytes(dataBytes) {
+				integrityFailure = "malformed SSE data event"
+				forward = false
+				return
+			}
+			eventType := strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+			parsedUsage, usageParsed := extractTrustworthyOpenAITransparentUsageFromJSONBytes(dataBytes)
+			if usageParsed {
+				parsedUsageCopy := parsedUsage
+				usage = &parsedUsageCopy
+			}
+			imageCounter.AddSSEData(dataBytes)
+			if responseID == "" {
+				responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
+			}
+			if firstTokenMs == nil && openAIStreamDataStartsClientOutput(trimmedData, eventType) {
+				ms := int(time.Since(startTime).Milliseconds())
+				firstTokenMs = &ms
+			}
+			if !openAIStreamEventIsTerminal(trimmedData) {
+				return
+			}
+			if eventType == "response.failed" {
+				sawTerminalEvent = true
+				sawFailedEvent = true
+				downstreamTerminated = true
+				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
+				s.recordOpenAIStreamUpstreamError(c, account, true, upstreamRequestID, "http_error", dataBytes, failedMessage)
+				if hit, code, msg := detectOpenAICyberPolicy(dataBytes); hit {
+					inputTokens := 0
+					outputTokens := 0
+					if usage != nil {
+						inputTokens = usage.InputTokens
+						outputTokens = usage.OutputTokens
+					}
+					MarkOpsCyberPolicy(c, CyberPolicyMark{
+						Code:           code,
+						Message:        msg,
+						Body:           truncateString(string(dataBytes), 4096),
+						UpstreamStatus: http.StatusOK,
+						UpstreamInTok:  inputTokens,
+						UpstreamOutTok: outputTokens,
+					})
+				}
+				if sanitizedPayload, sanitized := sanitizeOpenAITransparentFailedPayload(dataBytes); sanitized {
+					observedEvent = replaceOpenAISSEDataPayload(event, sanitizedPayload)
+				} else {
+					integrityFailure = "response.failed event could not be sanitized"
+					forward = false
+				}
+				return
+			}
+			if (eventType == "response.completed" || eventType == "response.done") && !usageParsed {
+				integrityFailure = "terminal event did not contain trustworthy usage"
+				forward = false
+				return
+			}
+			sawTerminalEvent = true
+		})
+		return observedEvent, forward && integrityFailure == ""
+	}
+	finishEvent := func() {
+		if eventOverflow {
+			// Oversized ordinary events were already streamed while their local
+			// observation was discarded. Terminal or unclassifiable events are
+			// suppressed and leave integrityFailure set.
+		} else if !downstreamTerminated && len(eventBuffer) > 0 {
+			if observedEvent, shouldForward := observeEvent(eventBuffer); shouldForward {
+				forwardEvent(observedEvent)
+			}
+		}
+		eventBuffer = eventBuffer[:0]
+		eventOverflow = false
+		eventOverflowForwarded = false
+	}
+	resultWithUsage := func() *openaiStreamingResultPassthrough {
+		return &openaiStreamingResultPassthrough{
+			usage:            usage,
+			firstTokenMs:     firstTokenMs,
+			responseID:       responseID,
+			imageCount:       imageCounter.Count(),
+			imageOutputSizes: imageCounter.Sizes(),
+		}
+	}
+
+	reader := bufio.NewReaderSize(resp.Body, openAITransparentSSEReaderBufferSize)
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		if len(fragment) > 0 && !downstreamTerminated {
+			switch {
+			case eventOverflow:
+				if eventOverflowForwarded {
+					forwardEvent(fragment)
+				}
+			case len(eventBuffer)+len(fragment) > maxObservedEventSize:
+				observationPrefix := append([]byte(nil), eventBuffer...)
+				remaining := maxObservedEventSize - len(observationPrefix)
+				if remaining > len(fragment) {
+					remaining = len(fragment)
+				}
+				if remaining > 0 {
+					observationPrefix = append(observationPrefix, fragment[:remaining]...)
+				}
+				eventType := openAITransparentOversizedEventType(observationPrefix)
+				eventOverflow = true
+				if openAITransparentOversizedEventIsObservableNonterminal(eventType) {
+					eventOverflowForwarded = true
+					if firstTokenMs == nil && openAIStreamDataStartsClientOutput("observed", eventType) {
+						ms := int(time.Since(startTime).Milliseconds())
+						firstTokenMs = &ms
+					}
+					forwardEvent(eventBuffer)
+					forwardEvent(fragment)
+				} else if integrityFailure == "" {
+					integrityFailure = "SSE event exceeded bounded observation limit with terminal or unknown type"
+				}
+				eventBuffer = eventBuffer[:0]
+			default:
+				eventBuffer = append(eventBuffer, fragment...)
+			}
+		}
+		if bytes.Equal(fragment, []byte("\n")) || bytes.Equal(fragment, []byte("\r\n")) {
+			finishEvent()
+		}
+		if errors.Is(readErr, bufio.ErrBufferFull) {
+			continue
+		}
+		if readErr == nil {
+			continue
+		}
+		if errors.Is(readErr, io.EOF) {
+			if len(eventBuffer) > 0 || eventOverflow {
+				finishEvent()
+			}
+			break
+		}
+		s.recordOpenAIProxyStreamDisconnect(account, readErr, upstreamRequestID)
+		return resultWithUsage(), fmt.Errorf("transparent stream read error: %w", readErr)
+	}
+	if integrityFailure != "" {
+		s.recordOpenAIProxyStreamDisconnect(account, errors.New(integrityFailure), upstreamRequestID)
+		return resultWithUsage(), fmt.Errorf("%w: %s", ErrOfficialCodexTransparentStreamIntegrity, integrityFailure)
+	}
+	if !sawTerminalEvent {
+		logger.FromContext(ctx).With(
+			zap.String("component", "service.openai_gateway"),
+			zap.Int64("account_id", account.ID),
+			zap.String("upstream_request_id", upstreamRequestID),
+		).Info("OpenAI passthrough 上游流在未收到 [DONE] 时结束，疑似断流")
+		s.recordOpenAIProxyStreamDisconnect(account, errors.New("stream ended before terminal event"), upstreamRequestID)
+		return resultWithUsage(), fmt.Errorf("%w: missing terminal event", ErrOfficialCodexTransparentStreamIntegrity)
+	}
+	if sawFailedEvent {
+		return resultWithUsage(), ErrOfficialCodexTransparentStreamFailed
+	}
+	s.clearOpenAIProxyStreamDisconnect(account)
+	return resultWithUsage(), nil
+}
+
 func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
@@ -1279,6 +1669,138 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 		imageCount:       countOpenAIResponseImageOutputsFromJSONBytes(body),
 		imageOutputSizes: collectOpenAIResponseImageOutputSizesFromJSONBytes(body),
 	}, nil
+}
+
+func (s *OpenAIGatewayService) handleNonStreamingResponseTransparentPassthrough(
+	resp *http.Response,
+	c *gin.Context,
+) (*openaiNonStreamingResultPassthrough, error) {
+	observationLimit := resolveUpstreamResponseReadLimit(s.cfg)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, observationLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read official Codex upstream response: %w", err)
+	}
+	if int64(len(body)) > observationLimit {
+		reason := "response exceeded bounded observation limit"
+		setOpsUpstreamError(c, http.StatusBadGateway, reason, "")
+		return nil, fmt.Errorf("official Codex nonstream response rejected before commit: %s", reason)
+	}
+	usage := &OpenAIUsage{}
+	usageParsed := false
+	responseID := ""
+	imageCount := 0
+	var imageOutputSizes []string
+	if isEventStreamResponse(resp.Header) || bodyHasSSEFraming(body) {
+		if finalResponse, ok := extractCodexFinalResponse(string(body)); ok {
+			if parsedUsage, parsed := extractTrustworthyOpenAITransparentUsageFromJSONBytes(finalResponse); parsed {
+				*usage = parsedUsage
+				usageParsed = true
+			}
+			responseID = extractOpenAIResponseIDFromJSONBytes(finalResponse)
+		}
+		imageCount = countOpenAIImageOutputsFromSSEBody(string(body))
+		imageOutputSizes = collectOpenAIImageOutputSizesFromSSEBody(string(body))
+	} else if parsedUsage, ok := extractTrustworthyOpenAITransparentUsageFromJSONBytes(body); ok {
+		usage = &parsedUsage
+		usageParsed = true
+		responseID = extractOpenAIResponseIDFromJSONBytes(body)
+		imageCount = countOpenAIResponseImageOutputsFromJSONBytes(body)
+		imageOutputSizes = collectOpenAIResponseImageOutputSizesFromJSONBytes(body)
+	}
+	if !usageParsed {
+		reason := "response did not contain trustworthy usage"
+		setOpsUpstreamError(c, http.StatusBadGateway, reason, "")
+		return nil, fmt.Errorf("official Codex nonstream response rejected before commit: %s", reason)
+	}
+
+	writeOpenAITransparentResponseHeaders(c.Writer.Header(), resp.Header)
+	MarkResponseCommitted(c)
+	c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+	return &openaiNonStreamingResultPassthrough{
+		OpenAIUsage:      usage,
+		usage:            usage,
+		responseID:       responseID,
+		imageCount:       imageCount,
+		imageOutputSizes: imageOutputSizes,
+	}, nil
+}
+
+func extractTrustworthyOpenAITransparentUsageFromJSONBytes(body []byte) (OpenAIUsage, bool) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return OpenAIUsage{}, false
+	}
+
+	for _, candidate := range []struct {
+		usagePath    string
+		imageGenPath string
+	}{
+		{usagePath: "usage", imageGenPath: "tool_usage.image_gen"},
+		{usagePath: "response.usage", imageGenPath: "response.tool_usage.image_gen"},
+	} {
+		usageValue := gjson.GetBytes(body, candidate.usagePath)
+		if !openAITransparentUsageHasRecognizedTokenCount(usageValue) {
+			continue
+		}
+		usage, ok := openAIUsageFromGJSON(usageValue)
+		if !ok {
+			continue
+		}
+		mergeHostedImageGenToolUsage(gjson.GetBytes(body, candidate.imageGenPath), &usage)
+		return usage, true
+	}
+
+	return OpenAIUsage{}, false
+}
+
+func openAITransparentSSEEventContainsDone(event []byte) bool {
+	for _, line := range strings.Split(string(event), "\n") {
+		data, ok := extractOpenAISSEDataLine(strings.TrimRight(line, "\r\n"))
+		if ok && strings.TrimSpace(data) == "[DONE]" {
+			return true
+		}
+	}
+	return false
+}
+
+func openAITransparentUsageHasRecognizedTokenCount(usage gjson.Result) bool {
+	if !usage.Exists() || !usage.IsObject() {
+		return false
+	}
+
+	for _, path := range []string{
+		"input_tokens",
+		"prompt_tokens",
+		"output_tokens",
+		"completion_tokens",
+		"cache_read_input_tokens",
+		"cache_read_tokens",
+		"cached_tokens",
+		"cache_write_tokens",
+		"cache_creation_input_tokens",
+		"cache_write_input_tokens",
+		"cache_creation_tokens",
+		"input_tokens_details.cached_tokens",
+		"prompt_tokens_details.cached_tokens",
+		"input_tokens_details.cache_write_tokens",
+		"prompt_tokens_details.cache_write_tokens",
+		"input_tokens_details.cache_creation_tokens",
+		"prompt_tokens_details.cache_creation_tokens",
+		"input_tokens_details.image_tokens",
+		"prompt_tokens_details.image_tokens",
+		"output_tokens_details.image_tokens",
+		"completion_tokens_details.image_tokens",
+	} {
+		value := usage.Get(path)
+		if value.Type != gjson.Number {
+			continue
+		}
+		tokenCount := value.Float()
+		if !math.IsNaN(tokenCount) && !math.IsInf(tokenCount, 0) && tokenCount >= 0 && math.Trunc(tokenCount) == tokenCount {
+			return true
+		}
+	}
+
+	return false
 }
 
 // handlePassthroughSSEToJSON converts an SSE response body into a JSON
@@ -1397,6 +1919,39 @@ func writeOpenAIPassthroughResponseHeaders(dst http.Header, src http.Header, fil
 		dst.Del(key)
 		for _, v := range vals {
 			dst.Add(key, v)
+		}
+	}
+}
+
+func writeOpenAITransparentResponseHeaders(dst http.Header, src http.Header) {
+	if dst == nil || src == nil {
+		return
+	}
+	connectionHeaders := make(map[string]struct{})
+	for key, values := range src {
+		if !strings.EqualFold(key, "Connection") {
+			continue
+		}
+		for _, value := range values {
+			for _, token := range strings.Split(value, ",") {
+				if token = strings.ToLower(strings.TrimSpace(token)); token != "" {
+					connectionHeaders[token] = struct{}{}
+				}
+			}
+		}
+	}
+	for key, values := range src {
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+		switch lowerKey {
+		case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade", "set-cookie":
+			continue
+		}
+		if _, isConnectionHeader := connectionHeaders[lowerKey]; isConnectionHeader {
+			continue
+		}
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
 		}
 	}
 }

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -344,7 +344,7 @@ func captureStructuredLog(t *testing.T) (*inMemoryLogSink, func()) {
 	}
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormalized(t *testing.T) {
+func TestOpenAIGatewayService_OfficialCodexOAuthPassthrough_StreamKeepsToolNameAndRawBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -364,6 +364,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 
 	upstreamSSE := strings.Join([]string{
 		`data: {"type":"response.output_item.added","item":{"type":"tool_call","tool_calls":[{"function":{"name":"apply_patch"}}]}}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_tool","usage":{"input_tokens":2,"output_tokens":1}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -404,13 +406,11 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
 
-	// 1) 透传 OAuth 请求体与旧链路关键行为保持一致：store=false + stream=true。
-	require.Equal(t, false, gjson.GetBytes(upstream.lastBody, "store").Bool())
-	require.Equal(t, true, gjson.GetBytes(upstream.lastBody, "stream").Bool())
-	require.Equal(t, "local-test-instructions", strings.TrimSpace(gjson.GetBytes(upstream.lastBody, "instructions").String()))
-	// 其余关键字段保持原值。
-	require.Equal(t, "gpt-5.2", gjson.GetBytes(upstream.lastBody, "model").String())
-	require.Equal(t, "hi", gjson.GetBytes(upstream.lastBody, "input.0.text").String())
+	// Official Codex owns the Responses payload contract. Only mandatory local
+	// policy/model mapping may alter the body; this fixture activates neither.
+	require.Equal(t, originalBody, upstream.lastBody)
+	require.True(t, gjson.GetBytes(upstream.lastBody, "store").Bool())
+	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
 
 	// 2) only auth is replaced; inbound auth/cookie are not forwarded
 	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("Authorization"))
@@ -433,7 +433,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 	require.NotContains(t, body, "\"name\":\"edit\"")
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse(t *testing.T) {
+func TestOpenAIGatewayService_OfficialCodexOAuthPassthrough_PreservesNamespaceRequestAndStreamResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -457,11 +457,11 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 	}`)
 
 	upstreamSSE := strings.Join([]string{
-		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":""}}`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"spawn_agent","namespace":"collaboration","arguments":""}}`,
 		"",
-		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":"{}"}}`,
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"spawn_agent","namespace":"collaboration","arguments":"{}"}}`,
 		"",
-		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"spawn_agent","namespace":"collaboration","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -482,23 +482,18 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	require.Len(t, gjson.GetBytes(upstream.lastBody, "tools").Array(), 2)
-	require.Equal(t, "plain", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
-	require.Equal(t, "function", gjson.GetBytes(upstream.lastBody, "tools.1.type").String())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.1.name").String())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "tools.1.tools").Exists())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice.namespace").Exists())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.namespace").Exists())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "input.1.namespace").Exists())
+	require.Equal(t, originalBody, upstream.lastBody)
+	require.Equal(t, "namespace", gjson.GetBytes(upstream.lastBody, "tools.1.type").String())
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tools.1.name").String())
+	require.Equal(t, "spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.1.tools.0.name").String())
+	require.Equal(t, "spawn_agent", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tool_choice.namespace").String())
+	require.Equal(t, "spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "input.0.namespace").String())
+	require.Equal(t, "residual", gjson.GetBytes(upstream.lastBody, "input.1.namespace").String())
 	require.Equal(t, "nested", gjson.GetBytes(upstream.lastBody, "input.1.content.0.namespace").String())
 	require.Len(t, upstream.bodies, 1)
-
-	downstream := rec.Body.String()
-	require.NotContains(t, downstream, "collaboration__spawn_agent")
-	require.Contains(t, downstream, `"name":"spawn_agent"`)
-	require.Contains(t, downstream, `"namespace":"collaboration"`)
+	require.Equal(t, upstreamSSE, rec.Body.String())
 }
 
 func TestOpenAIGatewayService_NativeOAuth_NamespaceRequestAndStreamResponse(t *testing.T) {
@@ -596,7 +591,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceNonStreamingResponse(t *
 	require.Contains(t, rec.Body.String(), `"namespace":"collaboration"`)
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_NamespaceCollisionReturnsBadRequest(t *testing.T) {
+func TestOpenAIGatewayService_OfficialCodexOAuthPassthrough_ForwardsNamespaceCollision(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -609,7 +604,12 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceCollisionReturnsBadReque
 			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}
 		],"input":"hi"
 	}`)
-	upstream := &httpUpstreamRecorder{}
+	upstreamError := `{"error":{"type":"invalid_request_error","message":"upstream collision policy"}}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamError)),
+	}}
 	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
 	account := &Account{
 		ID: 123, Name: "acc", Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 1,
@@ -620,11 +620,15 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceCollisionReturnsBadReque
 	result, err := svc.Forward(context.Background(), c, account, body)
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Nil(t, upstream.lastReq)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, body, upstream.lastBody)
+	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tools.1.name").String())
+	require.Equal(t, "spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.1.tools.0.name").String())
 	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
-	require.Equal(t, "tools", gjson.Get(rec.Body.String(), "error.param").String())
-	require.Contains(t, gjson.Get(rec.Body.String(), "error.message").String(), "conflicts with a top-level tool")
+	require.Equal(t, "upstream_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, "Upstream request failed", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.NotContains(t, rec.Body.String(), "upstream collision policy")
 }
 
 func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreaming(t *testing.T) {
@@ -727,7 +731,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_UpstreamRequestIgnoresClientCance
 	require.NoError(t, upstream.lastReq.Context().Err())
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedBeforeUpstream(t *testing.T) {
+func TestOpenAIGatewayService_NonOfficialOAuthPassthrough_CodexMissingInstructionsRejectedBeforeUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logSink, restore := captureStructuredLog(t)
 	defer restore()
@@ -735,7 +739,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedB
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses?trace=1", bytes.NewReader(nil))
-	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.98.0 (Windows 10.0.19045; x86_64) unknown")
+	c.Request.Header.Set("User-Agent", "curl/8.0")
 	c.Request.Header.Set("Content-Type", "application/json")
 	c.Request.Header.Set("OpenAI-Beta", "responses=experimental")
 
@@ -776,7 +780,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedB
 	require.Nil(t, upstream.lastReq)
 
 	require.True(t, logSink.ContainsMessage("OpenAI passthrough 本地拦截：Codex 请求缺少有效 instructions"))
-	require.True(t, logSink.ContainsFieldValue("request_user_agent", "codex_cli_rs/0.98.0 (Windows 10.0.19045; x86_64) unknown"))
+	require.True(t, logSink.ContainsFieldValue("request_user_agent", "curl/8.0"))
 	require.True(t, logSink.ContainsFieldValue("reject_reason", "instructions_missing"))
 }
 
@@ -1439,6 +1443,10 @@ func TestOpenAIGatewayService_OpenAIPassthrough_RetryableStatusesTriggerFailover
 				require.False(t, errors.As(err, &failoverErr))
 				require.True(t, c.Writer.Written(), "非 failover 的 passthrough http 错误应直接写回客户端")
 				require.Equal(t, tc.statusCode, rec.Code)
+				if tc.accountType == AccountTypeOAuth {
+					require.Equal(t, "upstream_error", gjson.Get(rec.Body.String(), "error.type").String())
+					require.NotContains(t, rec.Body.String(), gjson.Get(tc.body, "error.message").String())
+				}
 			}
 
 			v, ok := c.Get(OpsUpstreamErrorsKey)
@@ -1725,7 +1733,10 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexTuiIdentityPreservedAndPaire
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
-		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_tui\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n" +
+				"data: [DONE]\n\n",
+		)),
 	}
 	upstream := &httpUpstreamRecorder{resp: resp}
 
@@ -1821,7 +1832,10 @@ func TestOpenAIGatewayService_CodexCLIOnly_AllowOfficialClientFamilies(t *testin
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
-				Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+				Body: io.NopCloser(strings.NewReader(
+					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_official_family\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n" +
+						"data: [DONE]\n\n",
+				)),
 			}
 			upstream := &httpUpstreamRecorder{resp: resp}
 
@@ -1862,6 +1876,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamingSetsFirstTokenMs(t *test
 
 	upstreamSSE := strings.Join([]string{
 		`data: {"type":"response.output_text.delta","delta":"h"}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_first_token","usage":{"input_tokens":1,"output_tokens":1}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -1909,8 +1925,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamClientDisconnectStillCollec
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
-	// 首次写入成功，后续写入失败，模拟客户端中途断开。
-	c.Writer = &failingGinWriter{ResponseWriter: c.Writer, failAfter: 1}
+	// 首次 body 写入即失败，验证透明路径不会因此停止读取上游 usage。
+	c.Writer = &failingGinWriter{ResponseWriter: c.Writer, failAfter: 0}
 
 	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
 
@@ -2026,7 +2042,10 @@ func TestOpenAIGatewayService_OAuthPassthrough_WarnOnTimeoutHeadersForStream(t *
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid-timeout"}},
-		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_timeout_header\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n" +
+				"data: [DONE]\n\n",
+		)),
 	}
 	upstream := &httpUpstreamRecorder{resp: resp}
 	svc := &OpenAIGatewayService{
@@ -2088,7 +2107,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_InfoWhenStreamEndsWithoutDone(t *
 	}
 
 	_, err := svc.Forward(context.Background(), c, account, originalBody)
-	require.EqualError(t, err, "stream usage incomplete: missing terminal event")
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamIntegrity)
+	require.EqualError(t, err, "official Codex transparent stream integrity failure: missing terminal event")
 	require.True(t, logSink.ContainsMessage("上游流在未收到 [DONE] 时结束，疑似断流"))
 	require.True(t, logSink.ContainsMessageAtLevel("上游流在未收到 [DONE] 时结束，疑似断流", "info"))
 	require.True(t, logSink.ContainsFieldValue("upstream_request_id", "rid-truncate"))

--- a/backend/internal/service/openai_responses_lite_tools_test.go
+++ b/backend/internal/service/openai_responses_lite_tools_test.go
@@ -250,15 +250,28 @@ func TestApplyCodexOAuthTransform_PreservesLiteNamespaceToolChoice(t *testing.T)
 	require.Equal(t, map[string]any{"type": "namespace", "name": "collaboration"}, reqBody["tool_choice"])
 }
 
-func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *testing.T) {
+func TestOpenAIGatewayServiceForward_HandlesResponsesLiteToolsForOAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	for _, passthrough := range []bool{false, true} {
-		name := "managed"
-		if passthrough {
-			name = "passthrough"
-		}
-		t.Run(name, func(t *testing.T) {
+	tests := []struct {
+		name                     string
+		passthrough              bool
+		reasoningContext         string
+		preserveNamespaceInTools bool
+	}{
+		{
+			name:             "managed normalization",
+			reasoningContext: "all_turns",
+		},
+		{
+			name:                     "official passthrough preservation",
+			passthrough:              true,
+			reasoningContext:         "current_turn",
+			preserveNamespaceInTools: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(rec)
 			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
@@ -277,7 +290,7 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 				ID: 501, Name: "responses-lite", Platform: PlatformOpenAI, Type: AccountTypeOAuth,
 				Concurrency: 1, Status: StatusActive, Schedulable: true, RateMultiplier: f64p(1),
 				Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-account"},
-				Extra:       map[string]any{"openai_passthrough": passthrough},
+				Extra:       map[string]any{"openai_passthrough": tt.passthrough},
 			}
 			body := []byte(`{
 				"model":"gpt-5.6-terra","stream":true,"instructions":"test",
@@ -298,12 +311,18 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 			require.NotNil(t, result)
 			require.Equal(t, "true", upstream.lastReq.Header.Get(responsesLiteHeader))
 			require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
-			require.Equal(t, "all_turns", gjson.GetBytes(upstream.lastBody, "reasoning.context").String())
-			require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="namespace")`).Exists())
+			require.Equal(t, tt.reasoningContext, gjson.GetBytes(upstream.lastBody, "reasoning.context").String())
+			if tt.preserveNamespaceInTools {
+				require.JSONEq(t, string(body), string(upstream.lastBody))
+				require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `tools.#(type=="namespace").name`).String())
+				require.False(t, gjson.GetBytes(upstream.lastBody, `input.#(type=="additional_tools")`).Exists())
+			} else {
+				require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="namespace")`).Exists())
+				require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `input.#(type=="additional_tools").tools.0.name`).String())
+			}
 			require.Equal(t, "shell", gjson.GetBytes(upstream.lastBody, `tools.#(type=="function").name`).String())
 			require.Equal(t, "exec", gjson.GetBytes(upstream.lastBody, `tools.#(type=="custom").name`).String())
 			require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="tool_search")`).Exists())
-			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `input.#(type=="additional_tools").tools.0.name`).String())
 			require.Equal(t, "namespace", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
 			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
 		})

--- a/backend/internal/service/openai_transparent_passthrough_test.go
+++ b/backend/internal/service/openai_transparent_passthrough_test.go
@@ -1,0 +1,602 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type transparentTrackingReadCloser struct {
+	reader      io.Reader
+	bytesRead   int
+	maxReadSize int
+}
+
+func (r *transparentTrackingReadCloser) Read(p []byte) (int, error) {
+	if len(p) > r.maxReadSize {
+		r.maxReadSize = len(p)
+	}
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
+}
+
+func (r *transparentTrackingReadCloser) Close() error { return nil }
+
+func newOpenAITransparentPassthroughTestAccount() *Account {
+	return &Account{
+		ID:             125,
+		Name:           "openai-transparent",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "test-token", "chatgpt_account_id": "test-account"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+}
+
+func newOpenAITransparentPassthroughTestContext(path, userAgent string) (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", userAgent)
+	return c, recorder
+}
+
+func TestShouldUseOfficialCodexResponsesTransparentPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := newOpenAITransparentPassthroughTestAccount()
+
+	c, _ := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	require.True(t, shouldUseOfficialCodexResponsesTransparentPassthrough(c, account))
+
+	c, _ = newOpenAITransparentPassthroughTestContext("/v1/responses/compact", "codex_cli_rs/0.145.0")
+	require.False(t, shouldUseOfficialCodexResponsesTransparentPassthrough(c, account))
+
+	c, _ = newOpenAITransparentPassthroughTestContext("/v1/responses", "curl/8.0")
+	require.False(t, shouldUseOfficialCodexResponsesTransparentPassthrough(c, account))
+
+	c, _ = newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	account.Extra = nil
+	require.False(t, shouldUseOfficialCodexResponsesTransparentPassthrough(c, account))
+
+	account = newOpenAITransparentPassthroughTestAccount()
+	account.Credentials[openAIAuthModeCredentialKey] = OpenAIAuthModeAgentIdentity
+	require.False(t, shouldUseOfficialCodexResponsesTransparentPassthrough(c, account))
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughPreservesRequestAndSSE(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{
+  "model":"gpt-5.6-sol",
+  "stream":true,
+  "store":false,
+  "tools":[{"type":"function","namespace":"collaboration","name":"list_agents","parameters":{"type":"object"}}],
+  "tool_choice":{"type":"function","namespace":"collaboration","name":"list_agents"},
+  "input":[{"type":"function_call","call_id":"call_1","namespace":"collaboration","name":"list_agents","arguments":"{}"},{"type":"function_call_output","call_id":"call_1","output":"[]"}]
+}`)
+	upstreamBody := "event: response.output_item.added\r\n" +
+		"data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"namespace\":\"collaboration\",\"name\":\"list_agents\",\"call_id\":\"call_2\",\"arguments\":\"{}\"}}\r\n\r\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}}\r\n\r\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream; charset=utf-8"},
+			"Connection":   []string{"close, X-Hop"},
+			"Set-Cookie":   []string{"upstream-secret=1"},
+			"X-Hop":        []string{"must-not-be-forwarded"},
+			"X-Upstream":   []string{"preserved"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+	require.Equal(t, requestBody, upstream.lastBody)
+	require.Equal(t, upstreamBody, recorder.Body.String())
+	require.Equal(t, "preserved", recorder.Header().Get("X-Upstream"))
+	require.Empty(t, recorder.Header().Get("Connection"))
+	require.Empty(t, recorder.Header().Get("Set-Cookie"))
+	require.Empty(t, recorder.Header().Get("X-Hop"))
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughDefaultConfigUsesFixedReaderBuffer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	upstreamBody := &transparentTrackingReadCloser{reader: strings.NewReader(
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_small\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n" +
+			"data: [DONE]\n\n",
+	)}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       upstreamBody,
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, openAITransparentSSEReaderBufferSize, upstreamBody.maxReadSize)
+	require.Less(t, upstreamBody.maxReadSize, defaultMaxLineSize)
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughAppliesFastPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"service_tier":"default","input":"test"}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop"}}`)),
+	}}
+	settings := &OpenAIFastPolicySettings{Rules: []OpenAIFastPolicyRule{{
+		ServiceTier: OpenAIFastTierAny,
+		Action:      OpenAIFastPolicyActionForcePriority,
+		Scope:       BetaPolicyScopeAll,
+	}}}
+	svc := newOpenAIGatewayServiceWithSettings(t, settings)
+	svc.httpUpstream = upstream
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "priority", gjson.GetBytes(upstream.lastBody, "service_tier").String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughRejectsOversizedTerminalBeforeDone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`)
+	outputEvent := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"
+	oversizedTerminal := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_large\",\"usage\":{\"input_tokens\":2,\"output_tokens\":1},\"padding\":\"" + strings.Repeat("x", 512) + "\"}}\n\n"
+	upstreamBody := outputEvent + oversizedTerminal + "data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{MaxLineSize: 256}},
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamIntegrity)
+	require.NotNil(t, result)
+	require.Zero(t, result.Usage.InputTokens)
+	require.Zero(t, result.Usage.OutputTokens)
+	require.Equal(t, outputEvent, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughRecoversAfterOversizedDelta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`)
+	oversizedDelta := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"" + strings.Repeat("x", 512) + "\"}\n\n"
+	completed := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_after_large_delta\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}}\n\n"
+	upstreamBody := oversizedDelta + completed + "data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{MaxLineSize: 128}},
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 7, result.Usage.InputTokens)
+	require.Equal(t, 3, result.Usage.OutputTokens)
+	require.Equal(t, "resp_after_large_delta", result.ResponseID)
+	require.Equal(t, upstreamBody, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughDoneRequiresTrustedTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	completed := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_done_order\",\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}}\n\n"
+	done := "data: [DONE]\n\n"
+
+	for _, tt := range []struct {
+		name       string
+		upstream   string
+		wantBody   string
+		wantErr    error
+		wantInput  int
+		wantOutput int
+	}{
+		{name: "done only", upstream: done, wantErr: ErrOfficialCodexTransparentStreamIntegrity},
+		{name: "done before terminal", upstream: done + completed, wantErr: ErrOfficialCodexTransparentStreamIntegrity},
+		{name: "completed before done", upstream: completed + done, wantBody: completed + done, wantInput: 2, wantOutput: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(tt.upstream)),
+			}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+			result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.NotNil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, tt.wantInput, result.Usage.InputTokens)
+				require.Equal(t, tt.wantOutput, result.Usage.OutputTokens)
+			}
+			require.Equal(t, tt.wantBody, recorder.Body.String())
+		})
+	}
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughSanitizesAndBoundsHTTPErrorBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"test"}`)
+
+	for _, tt := range []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "within fixed limit", body: `{"error":{"message":"sensitive upstream detail"}}`, wantStatus: http.StatusBadRequest, wantBody: `{"error":{"message":"Upstream request failed","type":"upstream_error"}}`},
+		{name: "oversized body", body: strings.Repeat("x", int(openAIUpstreamErrorBodyReadLimit*2)), wantStatus: http.StatusBadRequest, wantBody: `{"error":{"message":"Upstream request failed","type":"upstream_error"}}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+			upstreamBody := &transparentTrackingReadCloser{reader: strings.NewReader(tt.body)}
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header: http.Header{
+					"Content-Type":      []string{"application/json"},
+					"X-Upstream-Secret": []string{"must-not-be-forwarded"},
+				},
+				Body: upstreamBody,
+			}}
+			svc := &OpenAIGatewayService{
+				cfg:          &config.Config{},
+				httpUpstream: upstream,
+			}
+
+			result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.Equal(t, tt.wantStatus, recorder.Code)
+			require.Equal(t, tt.wantBody, recorder.Body.String())
+			require.Empty(t, recorder.Header().Get("X-Upstream-Secret"))
+			require.LessOrEqual(t, upstreamBody.bytesRead, int(openAIUpstreamErrorBodyReadLimit))
+		})
+	}
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughPreservesNonStreamingBytes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"test"}`)
+	upstreamBody := "event: response.created\r\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_raw\"}}\r\n\r\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_raw\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\r\n\r\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Stream)
+	require.Equal(t, upstreamBody, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughFailsSettlementClosedWhenNonStreamingUsageIsUnobservable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"test"}`)
+	upstreamBody := `{"id":"resp_large","output":[{"type":"message","content":"` + strings.Repeat("x", 128) + `"}],"usage":{"input_tokens":4,"output_tokens":2}}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{UpstreamResponseReadMaxBytes: 64}},
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.EqualError(t, err, "official Codex nonstream response rejected before commit: response exceeded bounded observation limit")
+	require.Nil(t, result)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughRejectsUsageLessNonstreamBeforeCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"test"}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_missing_usage","output":[]}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.EqualError(t, err, "official Codex nonstream response rejected before commit: response did not contain trustworthy usage")
+	require.Nil(t, result)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughRejectsEmptyNonstreamUsageBeforeCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"test"}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_empty_usage","output":[],"usage":{}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.EqualError(t, err, "official Codex nonstream response rejected before commit: response did not contain trustworthy usage")
+	require.Nil(t, result)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughRejectsCompletedWithEmptyUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	upstreamBody := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_empty_usage\",\"usage\":{}}}\n\n" +
+		"data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamIntegrity)
+	require.NotNil(t, result)
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughAcceptsExplicitZeroUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	upstreamBody := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_zero_usage\",\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n" +
+		"data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Zero(t, result.Usage.InputTokens)
+	require.Zero(t, result.Usage.OutputTokens)
+	require.Equal(t, upstreamBody, recorder.Body.String())
+}
+
+func TestOpenAITransparentUsageHasRecognizedNonNegativeIntegerTokenCount(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		usage string
+		want  bool
+	}{
+		{name: "empty usage", usage: `{}`, want: false},
+		{name: "explicit zero", usage: `{"input_tokens":0}`, want: true},
+		{name: "positive integer", usage: `{"output_tokens":12}`, want: true},
+		{name: "negative integer", usage: `{"input_tokens":-1}`, want: false},
+		{name: "negative fraction", usage: `{"input_tokens":-0.5}`, want: false},
+		{name: "positive fraction", usage: `{"input_tokens":0.5}`, want: false},
+		{name: "integer exponent", usage: `{"input_tokens":1e3}`, want: true},
+		{name: "fraction exponent", usage: `{"input_tokens":1e-1}`, want: false},
+		{name: "overflowing exponent", usage: `{"input_tokens":1e999}`, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, openAITransparentUsageHasRecognizedTokenCount(gjson.Parse(tt.usage)))
+		})
+	}
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughSanitizesFailedSSEAndSuppressesDone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`)
+	upstreamBody := "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed\",\"error\":{\"message\":\"upstream failed\"},\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}}\r\n\r\n" +
+		"data: [DONE]\r\n\r\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamFailed)
+	require.NotNil(t, result)
+	require.Equal(t, 2, result.Usage.InputTokens)
+	require.Equal(t, 1, result.Usage.OutputTokens)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), "response.failed"))
+	require.Contains(t, recorder.Body.String(), "Upstream request failed")
+	require.NotContains(t, recorder.Body.String(), "upstream failed")
+	require.NotContains(t, recorder.Body.String(), "[DONE]")
+	require.Contains(t, recorder.Body.String(), `"input_tokens":2`)
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughFailedWithoutUsageDoesNotReturnZeroUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	upstreamBody := "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed_no_usage\",\"error\":{\"message\":\"upstream failed\"}}}\n\n" +
+		"data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamFailed)
+	require.Nil(t, result)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), "response.failed"))
+	require.Contains(t, recorder.Body.String(), "Upstream request failed")
+	require.NotContains(t, recorder.Body.String(), "upstream failed")
+	require.NotContains(t, recorder.Body.String(), "[DONE]")
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughFailedWithEmptyUsageDoesNotReturnZeroUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+	upstreamBody := "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed_empty_usage\",\"error\":{\"message\":\"upstream failed\"},\"usage\":{}}}\n\n" +
+		"data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`))
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamFailed)
+	require.Nil(t, result)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), "response.failed"))
+	require.Contains(t, recorder.Body.String(), "Upstream request failed")
+	require.NotContains(t, recorder.Body.String(), "upstream failed")
+	require.NotContains(t, recorder.Body.String(), "[DONE]")
+}
+
+func TestOpenAIGatewayService_OfficialCodexPassthroughClientDisconnectDoesNotWaiveMissingTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.145.0")
+	writer := &passthroughFlushTestWriter{ResponseWriter: c.Writer, recorder: recorder, failAfterWrites: 0}
+	c.Writer = writer
+	requestBody := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":"test"}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader("data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n")),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+	require.ErrorIs(t, err, ErrOfficialCodexTransparentStreamIntegrity)
+	require.NotNil(t, result)
+	require.Equal(t, 1, writer.failedWrites)
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOpenAIGatewayService_NonTransparentPassthroughKeepsLegacyNormalizationAndValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("API key strips input namespaces", func(t *testing.T) {
+		c, _ := newOpenAITransparentPassthroughTestContext("/v1/responses", "codex_cli_rs/0.145.0")
+		requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":[{"type":"function_call","call_id":"call_1","namespace":"collaboration","name":"list_agents","arguments":"{}"}]}`)
+		upstream := &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_api_key","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		}}
+		account := newOpenAITransparentPassthroughTestAccount()
+		account.Type = AccountTypeAPIKey
+		account.Credentials = map[string]any{"api_key": "test-key", "base_url": "https://api.example.test"}
+		account.Extra[openai_compat.ExtraKeyResponsesMode] = string(openai_compat.ResponsesSupportModeAuto)
+		account.Extra[openai_compat.ExtraKeyResponsesSupported] = true
+		svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+		result, err := svc.Forward(context.Background(), c, account, requestBody)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "list_agents", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
+		require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.namespace").Exists())
+	})
+
+	t.Run("compact rejects namespace collisions", func(t *testing.T) {
+		c, recorder := newOpenAITransparentPassthroughTestContext("/v1/responses/compact", "codex_cli_rs/0.145.0")
+		requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"tools":[{"type":"function","name":"collaboration__list_agents","parameters":{"type":"object"}},{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"list_agents","parameters":{"type":"object"}}]}],"input":"test"}`)
+		upstream := &httpUpstreamRecorder{}
+		svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+		result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Nil(t, upstream.lastReq)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		require.Equal(t, "tools", gjson.Get(recorder.Body.String(), "error.param").String())
+		require.Contains(t, gjson.Get(recorder.Body.String(), "error.message").String(), "conflicts with a top-level tool")
+	})
+
+	t.Run("nonofficial OAuth normalizes body", func(t *testing.T) {
+		c, _ := newOpenAITransparentPassthroughTestContext("/v1/responses", "curl/8.0")
+		requestBody := []byte(`{"model":"gpt-5.6-sol","stream":false,"store":true,"instructions":"test","input":"test"}`)
+		upstreamSSE := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_nonofficial\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\ndata: [DONE]\n\n"
+		upstream := &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+		}}
+		svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+		result, err := svc.Forward(context.Background(), c, newOpenAITransparentPassthroughTestAccount(), requestBody)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
+		require.False(t, gjson.GetBytes(upstream.lastBody, "store").Bool())
+	})
+}

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -387,6 +387,39 @@ func (s *OpenAIGatewayService) SelectAccountByPreviousResponseID(
 	return s.selectAccountByPreviousResponseIDForCapability(ctx, groupID, previousResponseID, requestedModel, excludedIDs, "", requireCompact)
 }
 
+// SelectOfficialCodexTransparentHTTPAccountByPreviousResponseID resolves an
+// HTTP Responses continuation to the OAuth passthrough account that issued the
+// previous response. A miss is intentionally returned to the caller instead of
+// falling back to normal scheduling, because response chains are account-local.
+func (s *OpenAIGatewayService) SelectOfficialCodexTransparentHTTPAccountByPreviousResponseID(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+	selection, err := s.selectAccountByPreviousResponseIDForCapabilityMode(
+		ctx,
+		groupID,
+		previousResponseID,
+		requestedModel,
+		excludedIDs,
+		requiredCapability,
+		requireCompact,
+		true,
+	)
+	decision := OpenAIAccountScheduleDecision{}
+	if selection != nil && selection.Account != nil {
+		decision.Layer = openAIAccountScheduleLayerPreviousResponse
+		decision.StickyPreviousHit = true
+		decision.SelectedAccountID = selection.Account.ID
+		decision.SelectedAccountType = selection.Account.Type
+	}
+	return selection, decision, err
+}
+
 func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 	ctx context.Context,
 	groupID *int64,
@@ -396,10 +429,41 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 	requiredCapability OpenAIEndpointCapability,
 	requireCompact bool,
 ) (*AccountSelectionResult, error) {
+	return s.selectAccountByPreviousResponseIDForCapabilityMode(
+		ctx,
+		groupID,
+		previousResponseID,
+		requestedModel,
+		excludedIDs,
+		requiredCapability,
+		requireCompact,
+		false,
+	)
+}
+
+func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapabilityMode(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+	allowTransparentHTTP bool,
+) (*AccountSelectionResult, error) {
 	if s == nil {
 		return nil, nil
 	}
-	accountID, account, responseID, store := s.resolveAccountByPreviousResponseIDForCapability(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
+	accountID, account, responseID, store := s.resolveAccountByPreviousResponseIDForCapability(
+		ctx,
+		groupID,
+		previousResponseID,
+		requestedModel,
+		excludedIDs,
+		requiredCapability,
+		requireCompact,
+		allowTransparentHTTP,
+	)
 	if accountID <= 0 || account == nil || store == nil {
 		return nil, nil
 	}
@@ -443,8 +507,16 @@ func (s *OpenAIGatewayService) ResolveAccountIDByPreviousResponseIDForScheduler(
 	requiredCapability OpenAIEndpointCapability,
 	requireCompact bool,
 ) int64 {
-	accountID, _, _, _ := s.resolveAccountByPreviousResponseIDForCapability(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
+	accountID, _, _, _ := s.resolveAccountByPreviousResponseIDForCapability(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact, false)
 	return accountID
+}
+
+func isOfficialCodexTransparentHTTPAffinityAccount(account *Account) bool {
+	return account != nil &&
+		account.Platform == PlatformOpenAI &&
+		account.Type == AccountTypeOAuth &&
+		!account.IsOpenAIAgentIdentity() &&
+		account.IsOpenAIPassthroughEnabled()
 }
 
 func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
@@ -455,6 +527,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	excludedIDs map[int64]struct{},
 	requiredCapability OpenAIEndpointCapability,
 	requireCompact bool,
+	allowTransparentHTTP bool,
 ) (int64, *Account, string, OpenAIWSStateStore) {
 	if s == nil {
 		return 0, nil, "", nil
@@ -483,9 +556,14 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
 	}
-	// 非 WSv2 场景（如 force_http/全局关闭）不应使用 previous_response_id 粘连，
-	// 以保持“回滚到 HTTP”后的历史行为一致性。
-	if s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
+	transport := s.getOpenAIWSProtocolResolver().Resolve(account).Transport
+	if allowTransparentHTTP && !isOfficialCodexTransparentHTTPAffinityAccount(account) {
+		return 0, nil, "", nil
+	}
+	// Keep the historical WS-only behavior for every existing caller. The sole
+	// exception is the explicit official-Codex transparent HTTP continuation
+	// path above, which must remain on its issuing OAuth passthrough account.
+	if transport != OpenAIUpstreamTransportResponsesWebsocketV2 && !allowTransparentHTTP {
 		return 0, nil, "", nil
 	}
 	if shouldClearStickySession(account, requestedModel) || !account.IsOpenAI() || !account.IsSchedulable() {


### PR DESCRIPTION
## Problem

Official Codex OAuth `/v1/responses` traffic could lose tool namespace and identity or diverge from direct OpenAI behavior across flat/custom and wrapper declarations, `tool_choice`, historical tool calls, SSE events, and terminal handling.

## Root cause

The compatibility path rewrote noncompact official OAuth requests and streams like legacy or API-key traffic. Continuation routing also did not consistently bind `previous_response_id` to the issuing account, while response readers could trust incomplete or unbounded terminal state.

## Changes

- Apply mandatory policy and model routing transforms, then relay official OAuth noncompact Responses payloads without compatibility rewrites.
- Preserve flat and wrapper tool declarations, `tool_choice`, historical call identity, and SSE bytes.
- Enforce issuer-account affinity for `previous_response_id` and fail closed on missing or mismatched bindings.
- Bound upstream HTTP error bodies and require observable terminal usage before settlement.
- Add regressions for request, history, SSE, failover, affinity, disconnect, oversized event, and nonstream integrity paths.

## Compatibility

Compact, API-key, Agent Identity, and nonofficial paths keep their existing normalization. Fresh requests retain `429` and `529` account failover, while continuations do not migrate between accounts.

## Tests

- Focused transparent relay service and handler tests
- Complete `internal/service` default and embed suites, excluding the known unrelated Windows timing test
- Complete `internal/handler` and `internal/pkg/apicompat` default and embed suites
- `go vet` for handler, service, and apicompat in default and embed modes
- Embed server build and frontend type-check/build

## Related work

Related changes #4981, #4979, #4888, and #5068 cover portions of namespace preservation, history handling, or Lite routing. This PR covers the remaining official OAuth noncompact path end to end: flat and wrapper declarations, choice and history identity, SSE restoration, continuation affinity, and transparent response integrity.
