### PR TITLE
fix(gateway): 脱敏上游错误追踪 ID 并统一公共池错误响应格式

### DIFF
--- a/backend/internal/handler/concurrency_error_response.go
+++ b/backend/internal/handler/concurrency_error_response.go
@@ -21,6 +21,9 @@ func concurrencyErrorResponse(err error, slotType string) (int, string, string) 
 		if concurrencyErr.SlotType != "" {
 			slotType = concurrencyErr.SlotType
 		}
+		if slotType == "account" {
+			return http.StatusTooManyRequests, "rate_limit_error", publicServiceUnavailableMessage
+		}
 		return http.StatusTooManyRequests, "rate_limit_error",
 			fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType)
 	}
@@ -29,5 +32,5 @@ func concurrencyErrorResponse(err error, slotType string) (int, string, string) 
 		return statusClientClosedRequest, "api_error", "context canceled"
 	}
 
-	return http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable, please retry later"
+	return http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage
 }

--- a/backend/internal/handler/concurrency_error_response_test.go
+++ b/backend/internal/handler/concurrency_error_response_test.go
@@ -24,7 +24,7 @@ func TestConcurrencyErrorResponse(t *testing.T) {
 			slotType:    "user",
 			wantStatus:  http.StatusTooManyRequests,
 			wantType:    "rate_limit_error",
-			wantMessage: "Concurrency limit exceeded for account, please retry later",
+			wantMessage: publicServiceUnavailableMessage,
 		},
 		{
 			name:        "client cancellation is not classified as concurrency limit",

--- a/backend/internal/handler/gateway_error_contract.go
+++ b/backend/internal/handler/gateway_error_contract.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+const publicServiceUnavailableMessage = "Service temporarily unavailable, please retry later"
+
+// matchGatewayErrorPassthrough keeps every public gateway protocol on the same
+// configured upstream-error contract while preserving full diagnostics in ops logs.
+func matchGatewayErrorPassthrough(
+	c *gin.Context,
+	svc *service.ErrorPassthroughService,
+	platform string,
+	statusCode int,
+	responseBody []byte,
+) (int, string, bool) {
+	if svc == nil {
+		return 0, "", false
+	}
+
+	rule := svc.MatchRule(platform, statusCode, responseBody)
+	if rule == nil {
+		return 0, "", false
+	}
+
+	responseCode := statusCode
+	if !rule.PassthroughCode && rule.ResponseCode != nil {
+		responseCode = *rule.ResponseCode
+	}
+
+	message := strings.TrimSpace(service.ExtractClientSafeUpstreamErrorMessage(responseBody))
+	if !rule.PassthroughBody && rule.CustomMessage != nil {
+		message = strings.TrimSpace(*rule.CustomMessage)
+	}
+	if message == "" {
+		message = publicServiceUnavailableMessage
+	}
+
+	if rule.SkipMonitoring && c != nil {
+		c.Set(service.OpsSkipPassthroughKey, true)
+	}
+
+	return responseCode, message, true
+}

--- a/backend/internal/handler/gateway_error_contract_test.go
+++ b/backend/internal/handler/gateway_error_contract_test.go
@@ -1,0 +1,145 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type staticErrorPassthroughRepo struct {
+	rules []*model.ErrorPassthroughRule
+}
+
+func (r *staticErrorPassthroughRepo) List(context.Context) ([]*model.ErrorPassthroughRule, error) {
+	return r.rules, nil
+}
+
+func (r *staticErrorPassthroughRepo) GetByID(_ context.Context, id int64) (*model.ErrorPassthroughRule, error) {
+	for _, rule := range r.rules {
+		if rule.ID == id {
+			return rule, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *staticErrorPassthroughRepo) Create(_ context.Context, rule *model.ErrorPassthroughRule) (*model.ErrorPassthroughRule, error) {
+	return rule, nil
+}
+
+func (r *staticErrorPassthroughRepo) Update(_ context.Context, rule *model.ErrorPassthroughRule) (*model.ErrorPassthroughRule, error) {
+	return rule, nil
+}
+
+func (r *staticErrorPassthroughRepo) Delete(context.Context, int64) error {
+	return nil
+}
+
+func new429ErrorPassthroughService() *service.ErrorPassthroughService {
+	responseCode := http.StatusTooManyRequests
+	message := "号池算力紧张，请稍后再试"
+	return service.NewErrorPassthroughService(&staticErrorPassthroughRepo{
+		rules: []*model.ErrorPassthroughRule{
+			{
+				ID:              3,
+				Name:            "429",
+				Enabled:         true,
+				Priority:        -1,
+				ErrorCodes:      []int{http.StatusTooManyRequests},
+				Keywords:        []string{"rate_limit"},
+				MatchMode:       model.MatchModeAny,
+				PassthroughCode: false,
+				ResponseCode:    &responseCode,
+				PassthroughBody: false,
+				CustomMessage:   &message,
+			},
+		},
+	}, nil)
+}
+
+func TestGatewayCompatibleFailoverExhaustionUsesConfigured429Message(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{errorPassthroughService: new429ErrorPassthroughService()}
+	failoverErr := &service.UpstreamFailoverError{
+		StatusCode: http.StatusTooManyRequests,
+		ResponseBody: []byte(`{
+			"error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded"}
+		}`),
+		ResponseHeaders: http.Header{"Retry-After": []string{"45"}},
+	}
+
+	t.Run("chat completions", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+
+		h.handleCCFailoverExhausted(c, failoverErr, service.PlatformAnthropic, false)
+
+		require.Equal(t, http.StatusTooManyRequests, recorder.Code)
+		require.Equal(t, "45", recorder.Header().Get("Retry-After"))
+		require.JSONEq(t, `{"error":{"type":"upstream_error","message":"号池算力紧张，请稍后再试"}}`, recorder.Body.String())
+	})
+
+	t.Run("responses", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+
+		h.handleResponsesFailoverExhausted(c, failoverErr, service.PlatformAnthropic, false)
+
+		require.Equal(t, http.StatusTooManyRequests, recorder.Code)
+		require.Equal(t, "45", recorder.Header().Get("Retry-After"))
+		require.JSONEq(t, `{"error":{"code":"upstream_error","message":"号池算力紧张，请稍后再试"}}`, recorder.Body.String())
+	})
+
+	t.Run("gemini model discovery", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+
+		h.writeGeminiAIStudioResponse(c, &service.UpstreamHTTPResult{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       failoverErr.ResponseBody,
+		})
+
+		require.Equal(t, http.StatusTooManyRequests, recorder.Code)
+		require.JSONEq(t, `{"error":{"code":429,"message":"号池算力紧张，请稍后再试","status":"RESOURCE_EXHAUSTED"}}`, recorder.Body.String())
+	})
+}
+
+func TestMatchGatewayErrorPassthroughSupportsCodeOnlyEmptyBody(t *testing.T) {
+	responseCode := 524
+	message := "服务器繁忙，请稍后再试"
+	svc := service.NewErrorPassthroughService(&staticErrorPassthroughRepo{
+		rules: []*model.ErrorPassthroughRule{
+			{
+				ID:              5,
+				Name:            "524",
+				Enabled:         true,
+				ErrorCodes:      []int{524},
+				MatchMode:       model.MatchModeAny,
+				PassthroughCode: false,
+				ResponseCode:    &responseCode,
+				PassthroughBody: false,
+				CustomMessage:   &message,
+				SkipMonitoring:  true,
+			},
+		},
+	}, nil)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	status, gotMessage, matched := matchGatewayErrorPassthrough(c, svc, service.PlatformAnthropic, 524, nil)
+
+	require.True(t, matched)
+	require.Equal(t, 524, status)
+	require.Equal(t, message, gotMessage)
+	skipMonitoring, exists := c.Get(service.OpsSkipPassthroughKey)
+	require.True(t, exists)
+	require.Equal(t, true, skipMonitoring)
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -326,11 +326,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Bool("model_not_found", cls.ModelNotFound),
 						zap.Error(err),
 					)
-					message := cls.Message
-					if !cls.ModelNotFound {
-						message = "No available accounts: " + err.Error()
-					}
-					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -380,7 +376,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage, streamStarted)
 					return
 				}
 				accountWaitCounted := false
@@ -616,11 +612,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Bool("model_not_found", cls.ModelNotFound),
 						zap.Error(err),
 					)
-					message := cls.Message
-					if !cls.ModelNotFound {
-						message = "No available accounts: " + err.Error()
-					}
-					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -680,7 +672,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage, streamStarted)
 					return
 				}
 				accountWaitCounted := false
@@ -1713,32 +1705,15 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 	responseBody := failoverErr.ResponseBody
 	if service.IsOpenAISilentRefusalErrorBody(responseBody) {
 		service.SetOpsUpstreamError(c, statusCode, service.OpenAISilentRefusalClientMessage(), "")
-		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage(), streamStarted)
+		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage, streamStarted)
 		return
 	}
 
-	// 先检查透传规则
-	if h.errorPassthroughService != nil && len(responseBody) > 0 {
-		if rule := h.errorPassthroughService.MatchRule(platform, statusCode, responseBody); rule != nil {
-			// 确定响应状态码
-			respCode := statusCode
-			if !rule.PassthroughCode && rule.ResponseCode != nil {
-				respCode = *rule.ResponseCode
-			}
-
-			// 确定响应消息
-			msg := service.ExtractClientSafeUpstreamErrorMessage(responseBody)
-			if !rule.PassthroughBody && rule.CustomMessage != nil {
-				msg = *rule.CustomMessage
-			}
-
-			if rule.SkipMonitoring {
-				c.Set(service.OpsSkipPassthroughKey, true)
-			}
-
-			h.handleStreamingAwareError(c, respCode, "upstream_error", msg, streamStarted)
-			return
-		}
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, platform, statusCode, responseBody,
+	); matched {
+		h.handleStreamingAwareError(c, responseCode, "upstream_error", message, streamStarted)
+		return
 	}
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1727,7 +1727,7 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 			}
 
 			// 确定响应消息
-			msg := service.ExtractUpstreamErrorMessage(responseBody)
+			msg := service.ExtractClientSafeUpstreamErrorMessage(responseBody)
 			if !rule.PassthroughBody && rule.CustomMessage != nil {
 				msg = *rule.CustomMessage
 			}

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -175,11 +175,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
-				if !cls.ModelNotFound {
-					message = "No available accounts: " + err.Error()
-				}
-				h.chatCompletionsErrorResponse(c, cls.Status, cls.ErrType, message)
+				h.chatCompletionsErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -191,9 +187,9 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				return
 			default:
 				if fs.LastFailoverErr != nil {
-					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, groupPlatform, streamStarted)
 				} else {
-					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", publicServiceUnavailableMessage)
 				}
 				return
 			}
@@ -206,7 +202,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage)
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
@@ -243,7 +239,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		setActualUpstreamEndpoint(c, "")
 		if account.Platform == service.PlatformGemini {
 			if h.geminiCompatService == nil {
-				h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", "Gemini compatibility service is not configured")
+				h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage)
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
@@ -252,7 +248,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			result, err = h.geminiCompatService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody)
 		} else if shouldUseAntigravityCompat(account) {
 			if h.antigravityGatewayService == nil {
-				h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", "Antigravity compatibility service is not configured")
+				h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage)
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
@@ -272,7 +268,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				if c.Writer.Size() != writerSizeBeforeForward {
-					h.handleCCFailoverExhausted(c, failoverErr, true)
+					h.handleCCFailoverExhausted(c, failoverErr, account.Platform, true)
 					return
 				}
 				action := fs.HandleFailoverError(c.Request.Context(), h.gatewayService, account.ID, account.Platform, account.GetPoolModeRetryCount(), failoverErr)
@@ -280,7 +276,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				case FailoverContinue:
 					continue
 				case FailoverExhausted:
-					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, account.Platform, streamStarted)
 					return
 				case FailoverCanceled:
 					failoverClientGone(c)
@@ -348,26 +344,38 @@ func (h *GatewayHandler) chatCompletionsErrorResponse(c *gin.Context, status int
 }
 
 // handleCCFailoverExhausted writes a failover-exhausted error in CC format.
-func (h *GatewayHandler) handleCCFailoverExhausted(c *gin.Context, lastErr *service.UpstreamFailoverError, streamStarted bool) {
+func (h *GatewayHandler) handleCCFailoverExhausted(c *gin.Context, lastErr *service.UpstreamFailoverError, platform string, streamStarted bool) {
 	if streamStarted {
 		return
 	}
-	if lastErr != nil {
-		copyFailoverRetryAfter(c, lastErr.ResponseHeaders)
+	if lastErr == nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", publicServiceUnavailableMessage)
+		return
 	}
-	if lastErr != nil && lastErr.IsCredentialFailure() {
+	copyFailoverRetryAfter(c, lastErr.ResponseHeaders)
+	if lastErr.IsCredentialFailure() {
 		status, message := credentialFailoverClientResponse(lastErr)
 		h.chatCompletionsErrorResponse(c, status, "server_error", message)
 		return
 	}
 	statusCode := http.StatusBadGateway
-	if lastErr != nil && lastErr.StatusCode > 0 {
+	if lastErr.StatusCode > 0 {
 		statusCode = lastErr.StatusCode
 	}
-	if lastErr != nil && service.IsOpenAISilentRefusalErrorBody(lastErr.ResponseBody) {
+	if service.IsOpenAISilentRefusalErrorBody(lastErr.ResponseBody) {
 		service.SetOpsUpstreamError(c, statusCode, service.OpenAISilentRefusalClientMessage(), "")
-		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage())
+		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage)
 		return
 	}
-	h.chatCompletionsErrorResponse(c, statusCode, "server_error", "All available accounts exhausted")
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, platform, statusCode, lastErr.ResponseBody,
+	); matched {
+		h.chatCompletionsErrorResponse(c, responseCode, "upstream_error", message)
+		return
+	}
+
+	upstreamMessage := service.ExtractUpstreamErrorMessage(lastErr.ResponseBody)
+	service.SetOpsUpstreamError(c, statusCode, upstreamMessage, "")
+	status, errType, message := h.mapUpstreamError(statusCode)
+	h.chatCompletionsErrorResponse(c, status, errType, message)
 }

--- a/backend/internal/handler/gateway_handler_error_fallback_test.go
+++ b/backend/internal/handler/gateway_handler_error_fallback_test.go
@@ -135,16 +135,20 @@ func TestGatewayForwardErrorAlreadyCommunicated(t *testing.T) {
 		require.False(t, reported)
 	})
 
-	// apikey 场景核心回归：复刻 GatewayService.handleErrorResponse 的 case 400 ——
-	// 原样透传上游 JSON body 后返回 err。此时错误已经完整告知客户端，
-	// handler 不得再追加 data:{"type":"error"} 帧，否则响应被污染成「JSON + 一行 data:」。
-	t.Run("upstream 400 json passthrough via c.Data", func(t *testing.T) {
+	// apikey 场景核心回归：GatewayService.handleErrorResponse 的 case 400 会写入
+	// 标准化、脱敏后的 JSON 再返回 err。handler 不得追加第二个 SSE error 帧。
+	t.Run("upstream 400 normalized json response", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodPost, EndpointMessages, nil)
 		before := c.Writer.Size()
-		upstreamBody := []byte(`{"type":"error","error":{"type":"upstream_error","message":"Your Claude Code version (2.1.39) is below the minimum required version (2.1.81). Please update: npm update -g @anthropic-ai/claude-code"}}`)
-		c.Data(http.StatusBadRequest, "application/json", upstreamBody)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "upstream_error",
+				"message": "Your Claude Code version (2.1.39) is below the minimum required version (2.1.81). Please update: npm update -g @anthropic-ai/claude-code",
+			},
+		})
 
 		reported := gatewayForwardErrorAlreadyCommunicated(c, before, errors.New("upstream error: 400 message=version too low"))
 

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -157,6 +157,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		APIKeyID:  apiKey.ID,
 	}
 	sessionHash := h.gatewayService.GenerateSessionHash(parsedReq)
+	groupPlatform := effectiveAPIKeyPlatform(c, apiKey)
 
 	// 3. Account selection + failover loop
 	fs := NewFailoverState(h.maxAccountSwitches, false)
@@ -168,15 +169,11 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(requestCtx, apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
-				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, effectiveAPIKeyPlatform(c, apiKey))
+				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, groupPlatform)
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
-				if !cls.ModelNotFound {
-					message = "No available accounts: " + err.Error()
-				}
-				h.responsesErrorResponse(c, cls.Status, cls.ErrType, message)
+				h.responsesErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(requestCtx)
@@ -188,9 +185,9 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				return
 			default:
 				if fs.LastFailoverErr != nil {
-					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, groupPlatform, streamStarted)
 				} else {
-					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", publicServiceUnavailableMessage)
 				}
 				return
 			}
@@ -203,7 +200,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage)
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
@@ -232,7 +229,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		setActualUpstreamEndpoint(c, "")
 		if shouldUseAntigravityCompat(account) {
 			if h.antigravityGatewayService == nil {
-				h.responsesErrorResponse(c, http.StatusBadGateway, "upstream_error", "Antigravity compatibility service is not configured")
+				h.responsesErrorResponse(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage)
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
@@ -253,7 +250,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 			if errors.As(err, &failoverErr) {
 				// Can't failover if streaming content already sent
 				if c.Writer.Size() != writerSizeBeforeForward {
-					h.handleResponsesFailoverExhausted(c, failoverErr, true)
+					h.handleResponsesFailoverExhausted(c, failoverErr, account.Platform, true)
 					return
 				}
 				action := fs.HandleFailoverError(requestCtx, h.gatewayService, account.ID, account.Platform, account.GetPoolModeRetryCount(), failoverErr)
@@ -261,7 +258,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				case FailoverContinue:
 					continue
 				case FailoverExhausted:
-					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, account.Platform, streamStarted)
 					return
 				case FailoverCanceled:
 					failoverClientGone(c)
@@ -329,26 +326,38 @@ func (h *GatewayHandler) responsesErrorResponse(c *gin.Context, status int, code
 }
 
 // handleResponsesFailoverExhausted writes a failover-exhausted error in Responses format.
-func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastErr *service.UpstreamFailoverError, streamStarted bool) {
+func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastErr *service.UpstreamFailoverError, platform string, streamStarted bool) {
 	if streamStarted {
 		return // Can't write error after stream started
 	}
-	if lastErr != nil {
-		copyFailoverRetryAfter(c, lastErr.ResponseHeaders)
+	if lastErr == nil {
+		h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", publicServiceUnavailableMessage)
+		return
 	}
-	if lastErr != nil && lastErr.IsCredentialFailure() {
+	copyFailoverRetryAfter(c, lastErr.ResponseHeaders)
+	if lastErr.IsCredentialFailure() {
 		status, message := credentialFailoverClientResponse(lastErr)
 		h.responsesErrorResponse(c, status, "server_error", message)
 		return
 	}
 	statusCode := http.StatusBadGateway
-	if lastErr != nil && lastErr.StatusCode > 0 {
+	if lastErr.StatusCode > 0 {
 		statusCode = lastErr.StatusCode
 	}
-	if lastErr != nil && service.IsOpenAISilentRefusalErrorBody(lastErr.ResponseBody) {
+	if service.IsOpenAISilentRefusalErrorBody(lastErr.ResponseBody) {
 		service.SetOpsUpstreamError(c, statusCode, service.OpenAISilentRefusalClientMessage(), "")
-		h.responsesErrorResponse(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage())
+		h.responsesErrorResponse(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage)
 		return
 	}
-	h.responsesErrorResponse(c, statusCode, "server_error", "All available accounts exhausted")
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, platform, statusCode, lastErr.ResponseBody,
+	); matched {
+		h.responsesErrorResponse(c, responseCode, "upstream_error", message)
+		return
+	}
+
+	upstreamMessage := service.ExtractUpstreamErrorMessage(lastErr.ResponseBody)
+	service.SetOpsUpstreamError(c, statusCode, upstreamMessage, "")
+	status, errType, message := h.mapUpstreamError(statusCode)
+	h.responsesErrorResponse(c, status, errType, message)
 }

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -62,20 +62,21 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 			return
 		}
 		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-		googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
+		googleError(c, http.StatusServiceUnavailable, publicServiceUnavailableMessage)
 		return
 	}
 
 	res, err := h.geminiCompatService.ForwardAIStudioGET(c.Request.Context(), account, "/v1beta/models")
 	if err != nil {
-		googleError(c, http.StatusBadGateway, err.Error())
+		service.SetOpsUpstreamError(c, http.StatusBadGateway, err.Error(), "")
+		googleError(c, http.StatusBadGateway, publicServiceUnavailableMessage)
 		return
 	}
 	if shouldFallbackGeminiModels(res) {
 		c.JSON(http.StatusOK, gemini.FallbackModelsList())
 		return
 	}
-	writeUpstreamResponse(c, res)
+	h.writeGeminiAIStudioResponse(c, res)
 }
 
 // GeminiV1BetaGetModel proxies:
@@ -118,18 +119,32 @@ func (h *GatewayHandler) GeminiV1BetaGetModel(c *gin.Context) {
 			return
 		}
 		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-		googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
+		googleError(c, http.StatusServiceUnavailable, publicServiceUnavailableMessage)
 		return
 	}
 
 	res, err := h.geminiCompatService.ForwardAIStudioGET(c.Request.Context(), account, "/v1beta/models/"+modelName)
 	if err != nil {
-		googleError(c, http.StatusBadGateway, err.Error())
+		service.SetOpsUpstreamError(c, http.StatusBadGateway, err.Error(), "")
+		googleError(c, http.StatusBadGateway, publicServiceUnavailableMessage)
 		return
 	}
 	if shouldFallbackGeminiModel(modelName, res) {
 		c.JSON(http.StatusOK, gemini.FallbackModel(modelName))
 		return
+	}
+	h.writeGeminiAIStudioResponse(c, res)
+}
+
+func (h *GatewayHandler) writeGeminiAIStudioResponse(c *gin.Context, res *service.UpstreamHTTPResult) {
+	if res != nil && res.StatusCode >= http.StatusBadRequest {
+		if responseCode, message, matched := matchGatewayErrorPassthrough(
+			c, h.errorPassthroughService, service.PlatformGemini, res.StatusCode, res.Body,
+		); matched {
+			service.SetOpsUpstreamError(c, res.StatusCode, service.ExtractUpstreamErrorMessage(res.Body), "")
+			googleError(c, responseCode, message)
+			return
+		}
 	}
 	writeUpstreamResponse(c, res)
 }
@@ -360,11 +375,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
-				if !cls.ModelNotFound {
-					message = "No available Gemini accounts: " + err.Error()
-				}
-				googleError(c, cls.Status, message)
+				googleError(c, cls.Status, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -413,7 +424,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts")
+				googleError(c, http.StatusServiceUnavailable, publicServiceUnavailableMessage)
 				return
 			}
 			accountWaitCounted := false
@@ -447,7 +458,8 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			)
 			if err != nil {
 				reqLog.Warn("gemini.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
-				googleError(c, http.StatusTooManyRequests, err.Error())
+				status, _, message := concurrencyErrorResponse(err, "account")
+				googleError(c, status, message)
 				return
 			}
 			if accountWaitCounted {
@@ -599,28 +611,11 @@ func (h *GatewayHandler) handleGeminiFailoverExhausted(c *gin.Context, failoverE
 	statusCode := failoverErr.StatusCode
 	responseBody := failoverErr.ResponseBody
 
-	// 先检查透传规则
-	if h.errorPassthroughService != nil && len(responseBody) > 0 {
-		if rule := h.errorPassthroughService.MatchRule(service.PlatformGemini, statusCode, responseBody); rule != nil {
-			// 确定响应状态码
-			respCode := statusCode
-			if !rule.PassthroughCode && rule.ResponseCode != nil {
-				respCode = *rule.ResponseCode
-			}
-
-			// 确定响应消息
-			msg := service.ExtractUpstreamErrorMessage(responseBody)
-			if !rule.PassthroughBody && rule.CustomMessage != nil {
-				msg = *rule.CustomMessage
-			}
-
-			if rule.SkipMonitoring {
-				c.Set(service.OpsSkipPassthroughKey, true)
-			}
-
-			googleError(c, respCode, msg)
-			return
-		}
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, service.PlatformGemini, statusCode, responseBody,
+	); matched {
+		googleError(c, responseCode, message)
+		return
 	}
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误

--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -221,7 +221,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 			if endpoint.IsGenerationRequest() && errors.Is(err, service.ErrNoAvailableAccounts) &&
 				(len(failedAccountIDs) == 0 || (mediaEligibilityRejected && lastFailoverErr == nil)) {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.errorResponse(c, http.StatusServiceUnavailable, "grok_media_no_eligible_account", "No eligible Grok media accounts")
+				h.errorResponse(c, http.StatusServiceUnavailable, "service_unavailable", publicServiceUnavailableMessage)
 				return
 			}
 			if len(failedAccountIDs) == 0 {
@@ -242,7 +242,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 		if selection == nil || selection.Account == nil {
 			if endpoint.IsGenerationRequest() {
 				markOpsRoutingCapacityLimited(c)
-				h.errorResponse(c, http.StatusServiceUnavailable, "grok_media_no_eligible_account", "No eligible Grok media accounts")
+				h.errorResponse(c, http.StatusServiceUnavailable, "service_unavailable", publicServiceUnavailableMessage)
 				return
 			}
 			cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, requestModel, routingModel, service.PlatformGrok)
@@ -283,7 +283,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 				)
 				if switchCount >= maxAccountSwitches {
 					markOpsRoutingCapacityLimited(c)
-					h.errorResponse(c, http.StatusServiceUnavailable, "grok_media_no_eligible_account", "No eligible Grok media accounts")
+					h.errorResponse(c, http.StatusServiceUnavailable, "service_unavailable", publicServiceUnavailableMessage)
 					return
 				}
 				switchCount++

--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -67,7 +67,7 @@ func classifyNoAccountError(
 	fallback := noAccountErrorClassification{
 		Status:  http.StatusServiceUnavailable,
 		ErrType: "api_error",
-		Message: "Service temporarily unavailable",
+		Message: publicServiceUnavailableMessage,
 	}
 
 	routingModel = strings.TrimSpace(routingModel)
@@ -84,7 +84,7 @@ func classifyNoAccountError(
 		return noAccountErrorClassification{
 			Status:        http.StatusNotFound,
 			ErrType:       "model_not_found",
-			Message:       fmt.Sprintf("Model %q is not supported by any configured account in this group", displayModel),
+			Message:       fmt.Sprintf("Model %q is not supported in this group", displayModel),
 			ModelNotFound: true,
 		}
 	}

--- a/backend/internal/handler/no_account_error_test.go
+++ b/backend/internal/handler/no_account_error_test.go
@@ -58,6 +58,8 @@ func TestClassifyNoAccountError_NilDiagnoser_Falls503(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, cls.Status)
 	require.Equal(t, "api_error", cls.ErrType)
+	require.Equal(t, publicServiceUnavailableMessage, cls.Message)
+	require.NotContains(t, cls.Message, "account")
 	require.False(t, cls.ModelNotFound)
 }
 
@@ -107,6 +109,7 @@ func TestClassifyNoAccountError_ModelNotSupported_Returns404(t *testing.T) {
 	require.Equal(t, "model_not_found", cls.ErrType)
 	require.True(t, cls.ModelNotFound)
 	require.Contains(t, cls.Message, "gpt-5.1-codex-mini", "message must surface the requested model")
+	require.NotContains(t, cls.Message, "account")
 
 	require.Len(t, fd.calls, 1)
 	require.Equal(t, "gpt-5.1-codex-mini", fd.calls[0].Model)

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -47,10 +47,13 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 				return
 			}
 			if lastUpstreamErr != nil {
-				h.errorResponse(c, infraerrors.Code(lastUpstreamErr), "upstream_error", infraerrors.Message(lastUpstreamErr))
+				status := infraerrors.Code(lastUpstreamErr)
+				service.SetOpsUpstreamError(c, status, infraerrors.Message(lastUpstreamErr), "")
+				h.errorResponse(c, status, "upstream_error", publicServiceUnavailableMessage)
 				return
 			}
-			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
+			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", publicServiceUnavailableMessage)
 			return
 		}
 		// 让 ops 错误日志携带实际选中的上游账号，便于定位失效账号（#4544）。
@@ -67,7 +70,9 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 				lastUpstreamErr = err
 				continue
 			}
-			h.errorResponse(c, infraerrors.Code(err), "upstream_error", infraerrors.Message(err))
+			status := infraerrors.Code(err)
+			service.SetOpsUpstreamError(c, status, infraerrors.Message(err), "")
+			h.errorResponse(c, status, "upstream_error", publicServiceUnavailableMessage)
 			return
 		}
 		if c.Request.Context().Err() != nil {

--- a/backend/internal/handler/openai_codex_models_handler_test.go
+++ b/backend/internal/handler/openai_codex_models_handler_test.go
@@ -211,7 +211,7 @@ func TestCodexModelsDoesNotFailOverFromUpstreamConfigurationError(t *testing.T) 
 	}
 }
 
-func TestCodexModelsReturnsLastUpstreamErrorWhenAccountsAreExhausted(t *testing.T) {
+func TestCodexModelsReturnsNeutralErrorWhenAccountsAreExhausted(t *testing.T) {
 	handler, upstream, groupID := newCodexModelsFailoverTestHandler(http.StatusServiceUnavailable)
 	upstream.statuses = map[int64]int{
 		1: http.StatusServiceUnavailable,
@@ -225,8 +225,8 @@ func TestCodexModelsReturnsLastUpstreamErrorWhenAccountsAreExhausted(t *testing.
 	if recorder.Code != http.StatusBadGateway {
 		t.Fatalf("status: got %d, want %d; body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
 	}
-	if body := recorder.Body.String(); !strings.Contains(body, "upstream error 504") {
-		t.Fatalf("body does not preserve the last upstream error: %s", body)
+	if body := recorder.Body.String(); !strings.Contains(body, publicServiceUnavailableMessage) || strings.Contains(strings.ToLower(body), "account") || strings.Contains(body, "upstream error") {
+		t.Fatalf("body exposes internal routing details: %s", body)
 	}
 }
 

--- a/backend/internal/handler/openai_codex_models_handler_test.go
+++ b/backend/internal/handler/openai_codex_models_handler_test.go
@@ -246,8 +246,8 @@ func TestCodexModelsHonorsAccountSwitchLimit(t *testing.T) {
 	if recorder.Code != http.StatusBadGateway {
 		t.Fatalf("status: got %d, want %d; body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
 	}
-	if body := recorder.Body.String(); !strings.Contains(body, "upstream error 504") {
-		t.Fatalf("body does not preserve the limit-ending upstream error: %s", body)
+	if body := recorder.Body.String(); !strings.Contains(body, publicServiceUnavailableMessage) {
+		t.Fatalf("body does not contain expected neutral message: %s", body)
 	}
 }
 

--- a/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
+++ b/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
@@ -434,7 +434,7 @@ func TestResponsesCredentialFailoverLoop(t *testing.T) {
 		router.ServeHTTP(recorder, req)
 
 		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-		require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+		require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
 		require.Empty(t, repo.errorIDs())
 		require.Empty(t, upstream.accountHits())
 		require.Equal(t, 1, repo.selectorCalls())
@@ -534,7 +534,7 @@ func TestResponsesCredentialFailoverLoop(t *testing.T) {
 				router.ServeHTTP(recorder, req)
 
 				require.Equal(t, http.StatusServiceUnavailable, recorder.Code, recorder.Body.String())
-				require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+				require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
 				require.Empty(t, upstream.accountHits())
 				require.Equal(t, 1, repo.selectorCalls())
 			})
@@ -551,7 +551,7 @@ func TestResponsesCredentialFailoverLoop(t *testing.T) {
 		router.ServeHTTP(recorder, req)
 
 		require.Equal(t, http.StatusServiceUnavailable, recorder.Code, recorder.Body.String())
-		require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+		require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
 		require.Equal(t, 1, repo.selectorCalls())
 		require.Empty(t, upstream.accountHits())
 		require.Empty(t, repo.errorIDs())
@@ -734,7 +734,7 @@ func TestGrokOAuthCredentialFailoverAcrossHTTPHandlers(t *testing.T) {
 			router.ServeHTTP(recorder, req)
 
 			require.Equal(t, http.StatusServiceUnavailable, recorder.Code, recorder.Body.String())
-			require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+			require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
 			require.NotContains(t, recorder.Body.String(), "revoked-refresh")
 			require.NotContains(t, recorder.Body.String(), "healthy-refresh")
 			require.Equal(t, []int64{801, 802}, repo.errorIDs())
@@ -809,7 +809,7 @@ func TestResponsesWebSocketCredentialFailoverLoop(t *testing.T) {
 		cancel()
 		var closeErr coderws.CloseError
 		require.ErrorAs(t, err, &closeErr)
-		require.Contains(t, closeErr.Reason, service.GrokCredentialUnavailableClientMessage)
+		require.Contains(t, closeErr.Reason, publicServiceUnavailableMessage)
 		require.Equal(t, 1, repo.selectorCalls())
 		require.Empty(t, upstream.accountHits())
 	})

--- a/backend/internal/handler/openai_gateway_credential_failover_test.go
+++ b/backend/internal/handler/openai_gateway_credential_failover_test.go
@@ -34,15 +34,17 @@ func TestGatewayChatCredentialStopDoesNotSelectAnotherAccountAndReturnsSafe503(t
 
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
-	(&GatewayHandler{}).handleCCFailoverExhausted(c, state.LastFailoverErr, false)
+	(&GatewayHandler{}).handleCCFailoverExhausted(c, state.LastFailoverErr, service.PlatformGrok, false)
 
 	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-	require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+	require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
+	require.NotContains(t, recorder.Body.String(), "Grok")
+	require.NotContains(t, recorder.Body.String(), "OAuth")
 	require.NotContains(t, recorder.Body.String(), "invalid_client")
 	require.NotContains(t, recorder.Body.String(), "client_secret")
 }
 
-func TestGatewayChatAntigravityCredentialFailureReturnsActionableMessage(t *testing.T) {
+func TestGatewayChatAntigravityCredentialFailureReturnsNeutralMessage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -56,10 +58,12 @@ func TestGatewayChatAntigravityCredentialFailureReturnsActionableMessage(t *test
 		ClientStatusCode:  http.StatusBadGateway,
 		ClientMessage:     service.AntigravityCredentialRejectedClientMessage,
 		ResponseBody:      []byte(`{"error":{"message":"Invalid bearer token","refresh_token":"must-not-leak"}}`),
-	}, false)
+	}, service.PlatformAntigravity, false)
 
 	require.Equal(t, http.StatusBadGateway, recorder.Code)
-	require.Contains(t, recorder.Body.String(), service.AntigravityCredentialRejectedClientMessage)
+	require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
+	require.NotContains(t, recorder.Body.String(), "Antigravity")
+	require.NotContains(t, recorder.Body.String(), "OAuth")
 	require.NotContains(t, strings.ToLower(recorder.Body.String()), "bearer")
 	require.NotContains(t, strings.ToLower(recorder.Body.String()), "refresh_token")
 }
@@ -72,7 +76,7 @@ func TestGatewayChatInferenceExhaustionRestoresRetryAfter(t *testing.T) {
 	(&GatewayHandler{}).handleCCFailoverExhausted(c, &service.UpstreamFailoverError{
 		StatusCode:      http.StatusTooManyRequests,
 		ResponseHeaders: http.Header{"Retry-After": []string{"45"}},
-	}, false)
+	}, service.PlatformAnthropic, false)
 
 	require.Equal(t, http.StatusTooManyRequests, recorder.Code)
 	require.Equal(t, "45", recorder.Header().Get("Retry-After"))
@@ -94,7 +98,9 @@ func TestCredentialFailoverExhaustionReturnsFixedSafe503(t *testing.T) {
 	}, false)
 
 	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-	require.Contains(t, recorder.Body.String(), service.GrokCredentialUnavailableClientMessage)
+	require.Contains(t, recorder.Body.String(), publicServiceUnavailableMessage)
+	require.NotContains(t, recorder.Body.String(), "Grok")
+	require.NotContains(t, recorder.Body.String(), "OAuth")
 	require.NotContains(t, strings.ToLower(recorder.Body.String()), "invalid_grant")
 	require.NotContains(t, strings.ToLower(recorder.Body.String()), "refresh_token")
 	require.NotContains(t, recorder.Body.String(), "must-not-leak")

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -474,7 +474,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				if errors.Is(err, service.ErrNoAvailableCompactAccounts) {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "compact_not_supported", "No available accounts support /responses/compact", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "compact_not_supported", "Responses compact is temporarily unavailable for this model", streamStarted)
 					return
 				}
 				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, requestPlatform)
@@ -1359,7 +1359,7 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 ) (func(), bool) {
 	if selection == nil || selection.Account == nil {
 		markOpsRoutingCapacityLimited(c)
-		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", *streamStarted)
+		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage, *streamStarted)
 		return nil, false
 	}
 
@@ -1370,7 +1370,7 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	}
 	if selection.WaitPlan == nil {
 		markOpsRoutingCapacityLimited(c)
-		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", *streamStarted)
+		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", publicServiceUnavailableMessage, *streamStarted)
 		return nil, false
 	}
 
@@ -1679,7 +1679,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		}
 		releaseAccountSlot()
 		if !failoverErr.ShouldRetryNextAccount() {
-			closeOpenAIWSFailoverExhausted(wsConn, failoverErr)
+			h.closeOpenAIWSFailoverExhausted(c, wsConn, failoverErr, requestPlatform)
 			return false
 		}
 		if ctx.Err() != nil {
@@ -1689,12 +1689,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		failedAccountIDs[account.ID] = struct{}{}
 		lastFailoverErr = failoverErr
 		if switchCount >= maxAccountSwitches {
-			closeOpenAIWSFailoverExhausted(wsConn, failoverErr)
+			h.closeOpenAIWSFailoverExhausted(c, wsConn, failoverErr, requestPlatform)
 			return false
 		}
 		switchCount++
 		if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
-			closeOpenAIWSFailoverExhausted(wsConn, failoverErr)
+			h.closeOpenAIWSFailoverExhausted(c, wsConn, failoverErr, requestPlatform)
 			return false
 		}
 		reqLog.Warn("openai.websocket_upstream_failover_switching",
@@ -1742,17 +1742,17 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if lastFailoverErr != nil {
-				closeOpenAIWSFailoverExhausted(wsConn, lastFailoverErr)
+				h.closeOpenAIWSFailoverExhausted(c, wsConn, lastFailoverErr, requestPlatform)
 			} else {
-				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "no available account")
+				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 			}
 			return
 		}
 		if selection == nil || selection.Account == nil {
 			if lastFailoverErr != nil {
-				closeOpenAIWSFailoverExhausted(wsConn, lastFailoverErr)
+				h.closeOpenAIWSFailoverExhausted(c, wsConn, lastFailoverErr, requestPlatform)
 			} else {
-				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "no available account")
+				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 			}
 			return
 		}
@@ -1765,7 +1765,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		accountReleaseFunc := selection.ReleaseFunc
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
-				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "account is busy, please retry later")
+				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 				return
 			}
 			fastReleaseFunc, fastAcquired, err := h.concurrencyHelper.TryAcquireAccountSlot(
@@ -1775,11 +1775,11 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			)
 			if err != nil {
 				reqLog.Warn("openai.websocket_account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
-				closeOpenAIClientWS(wsConn, coderws.StatusInternalError, "failed to acquire account concurrency slot")
+				closeOpenAIClientWS(wsConn, coderws.StatusInternalError, publicServiceUnavailableMessage)
 				return
 			}
 			if !fastAcquired {
-				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "account is busy, please retry later")
+				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 				return
 			}
 			accountReleaseFunc = fastReleaseFunc
@@ -1887,13 +1887,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					if userReleaseFunc != nil {
 						userReleaseFunc()
 					}
-					return service.NewOpenAIWSClientCloseError(coderws.StatusInternalError, "failed to acquire account concurrency slot", err)
+					return service.NewOpenAIWSClientCloseError(coderws.StatusInternalError, publicServiceUnavailableMessage, err)
 				}
 				if !accountAcquired {
 					if userReleaseFunc != nil {
 						userReleaseFunc()
 					}
-					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is busy, please retry later", nil)
+					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, publicServiceUnavailableMessage, nil)
 				}
 				currentUserRelease = wrapReleaseOnDone(ctx, userReleaseFunc)
 				currentAccountRelease = wrapReleaseOnDone(ctx, accountReleaseFunc)
@@ -2287,32 +2287,15 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 	responseBody := failoverErr.ResponseBody
 	if service.IsOpenAISilentRefusalErrorBody(responseBody) {
 		service.SetOpsUpstreamError(c, statusCode, service.OpenAISilentRefusalClientMessage(), "")
-		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage(), streamStarted)
+		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", publicServiceUnavailableMessage, streamStarted)
 		return
 	}
 
-	// 先检查透传规则
-	if h.errorPassthroughService != nil && len(responseBody) > 0 {
-		if rule := h.errorPassthroughService.MatchRule("openai", statusCode, responseBody); rule != nil {
-			// 确定响应状态码
-			respCode := statusCode
-			if !rule.PassthroughCode && rule.ResponseCode != nil {
-				respCode = *rule.ResponseCode
-			}
-
-			// 确定响应消息
-			msg := service.ExtractUpstreamErrorMessage(responseBody)
-			if !rule.PassthroughBody && rule.CustomMessage != nil {
-				msg = *rule.CustomMessage
-			}
-
-			if rule.SkipMonitoring {
-				c.Set(service.OpsSkipPassthroughKey, true)
-			}
-
-			h.handleStreamingAwareError(c, respCode, "upstream_error", msg, streamStarted)
-			return
-		}
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, service.PlatformOpenAI, statusCode, responseBody,
+	); matched {
+		h.handleStreamingAwareError(c, responseCode, "upstream_error", message, streamStarted)
+		return
 	}
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误
@@ -2326,9 +2309,9 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 
 func credentialFailoverClientResponse(failoverErr *service.UpstreamFailoverError) (int, string) {
 	if failoverErr != nil && failoverErr.Reason == service.AntigravityCredentialRejectedReason {
-		return http.StatusBadGateway, service.AntigravityCredentialRejectedClientMessage
+		return http.StatusBadGateway, publicServiceUnavailableMessage
 	}
-	return http.StatusServiceUnavailable, service.GrokCredentialUnavailableClientMessage
+	return http.StatusServiceUnavailable, publicServiceUnavailableMessage
 }
 
 func copyFailoverRetryAfter(c *gin.Context, headers http.Header) {
@@ -2645,24 +2628,46 @@ func closeOpenAIClientWS(conn *coderws.Conn, status coderws.StatusCode, reason s
 	_ = conn.CloseNow()
 }
 
-func closeOpenAIWSFailoverExhausted(conn *coderws.Conn, failoverErr *service.UpstreamFailoverError) {
+func (h *OpenAIGatewayHandler) closeOpenAIWSFailoverExhausted(
+	c *gin.Context,
+	conn *coderws.Conn,
+	failoverErr *service.UpstreamFailoverError,
+	platform string,
+) {
 	if failoverErr == nil {
-		closeOpenAIClientWS(conn, coderws.StatusInternalError, "upstream websocket proxy failed")
+		closeOpenAIClientWS(conn, coderws.StatusInternalError, publicServiceUnavailableMessage)
 		return
 	}
 	if failoverErr.Stage == service.GatewayFailureStageAccountAuth {
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, service.GrokCredentialUnavailableClientMessage)
+		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
+		return
+	}
+	if responseCode, message, matched := matchGatewayErrorPassthrough(
+		c, h.errorPassthroughService, platform, failoverErr.StatusCode, failoverErr.ResponseBody,
+	); matched {
+		closeOpenAIClientWS(conn, openAIWSCloseStatusForHTTP(responseCode), message)
 		return
 	}
 	switch failoverErr.StatusCode {
 	case http.StatusTooManyRequests:
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, "upstream rate limit exceeded, please retry later")
+		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 	case 529, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, "upstream service temporarily unavailable")
+		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, publicServiceUnavailableMessage)
 	case http.StatusUnauthorized, http.StatusForbidden:
-		closeOpenAIClientWS(conn, coderws.StatusPolicyViolation, "upstream websocket authentication failed")
+		closeOpenAIClientWS(conn, coderws.StatusPolicyViolation, publicServiceUnavailableMessage)
 	default:
-		closeOpenAIClientWS(conn, coderws.StatusInternalError, "upstream websocket proxy failed")
+		closeOpenAIClientWS(conn, coderws.StatusInternalError, publicServiceUnavailableMessage)
+	}
+}
+
+func openAIWSCloseStatusForHTTP(status int) coderws.StatusCode {
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return coderws.StatusPolicyViolation
+	case status == http.StatusTooManyRequests || status >= http.StatusInternalServerError:
+		return coderws.StatusTryAgainLater
+	default:
+		return coderws.StatusInternalError
 	}
 }
 

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2128,7 +2128,7 @@ func (h *OpenAIGatewayHandler) ensureResponsesDependencies(c *gin.Context, reqLo
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error": gin.H{
 				"type":    "api_error",
-				"message": "Service temporarily unavailable",
+				"message": publicServiceUnavailableMessage,
 			},
 		})
 	}

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -572,7 +572,7 @@ func TestOpenAIEnsureResponsesDependencies(t *testing.T) {
 		errorObj, exists := parsed["error"].(map[string]any)
 		require.True(t, exists)
 		assert.Equal(t, "api_error", errorObj["type"])
-		assert.Equal(t, "Service temporarily unavailable", errorObj["message"])
+		assert.Equal(t, publicServiceUnavailableMessage, errorObj["message"])
 	})
 
 	t.Run("already_written_response_not_overridden", func(t *testing.T) {
@@ -785,7 +785,7 @@ func TestOpenAIResponses_MissingDependencies_ReturnsServiceUnavailable(t *testin
 	errorObj, ok := parsed["error"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "api_error", errorObj["type"])
-	assert.Equal(t, "Service temporarily unavailable", errorObj["message"])
+	assert.Equal(t, publicServiceUnavailableMessage, errorObj["message"])
 }
 
 func TestOpenAIResponses_SetsClientTransportHTTP(t *testing.T) {

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -180,11 +180,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
-				if !cls.ModelNotFound {
-					message = "No available compatible accounts"
-				}
-				h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+				h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -199,11 +195,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			if !cls.ModelNotFound {
 				markOpsRoutingCapacityLimited(c)
 			}
-			message := cls.Message
-			if !cls.ModelNotFound {
-				message = "No available compatible accounts"
-			}
-			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 			return
 		}
 

--- a/backend/internal/service/antigravity_gateway_compat.go
+++ b/backend/internal/service/antigravity_gateway_compat.go
@@ -141,11 +141,12 @@ func (s *AntigravityGatewayService) validateAntigravityCompatAccount(c *gin.Cont
 	if account != nil && account.Platform == PlatformAntigravity && account.Type == AccountTypeOAuth {
 		return nil
 	}
+	setOpsUpstreamError(c, http.StatusBadRequest, "native OAuth account required for antigravity compatibility mode", "")
 	return s.writeAntigravityCompatError(
 		c,
 		http.StatusBadRequest,
 		"invalid_request_error",
-		"native OAuth account required for antigravity compatibility mode",
+		"Service temporarily unavailable, please retry later",
 	)
 }
 

--- a/backend/internal/service/antigravity_gateway_compat_test.go
+++ b/backend/internal/service/antigravity_gateway_compat_test.go
@@ -217,7 +217,9 @@ func TestAntigravityCompatRejectsUnsupportedAccountType(t *testing.T) {
 			require.Error(t, err)
 			require.Nil(t, result)
 			require.Equal(t, http.StatusBadRequest, recorder.Code)
-			require.Contains(t, recorder.Body.String(), "native OAuth account required for antigravity compatibility mode")
+			require.Contains(t, recorder.Body.String(), "Service temporarily unavailable, please retry later")
+			require.NotContains(t, recorder.Body.String(), "OAuth")
+			require.NotContains(t, recorder.Body.String(), "account")
 		})
 	}
 }

--- a/backend/internal/service/error_passthrough_runtime.go
+++ b/backend/internal/service/error_passthrough_runtime.go
@@ -56,7 +56,7 @@ func applyErrorPassthroughRule(
 		status = *rule.ResponseCode
 	}
 
-	errMsg = ExtractUpstreamErrorMessage(responseBody)
+	errMsg = ExtractClientSafeUpstreamErrorMessage(responseBody)
 	if !rule.PassthroughBody && rule.CustomMessage != nil {
 		errMsg = *rule.CustomMessage
 	}

--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestApplyErrorPassthroughRule_NoBoundService(t *testing.T) {
@@ -61,6 +62,31 @@ func TestGatewayHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "upstream_error", errField["type"])
 	assert.Equal(t, "Upstream request failed", errField["message"])
+}
+
+func TestGatewayHandleErrorResponse_NoRule400NormalizesClientMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	rawMessage := "messages.3.content.0.text must not be empty (request id: provider-123456)"
+	respBody := []byte(`{"error":{"message":"` + rawMessage + `"}}`)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+		Header:     http.Header{},
+	}
+	account := &Account{ID: 11, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	_, err := (&GatewayService{}).handleErrorResponse(context.Background(), resp, c, account)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "messages.3.content.0.text must not be empty", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.NotContains(t, rec.Body.String(), "provider-123456")
+
+	opsMessage, ok := c.Get(OpsUpstreamErrorMessageKey)
+	require.True(t, ok)
+	require.Equal(t, rawMessage, opsMessage)
 }
 
 func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
@@ -167,6 +193,57 @@ func TestGatewayHandleErrorResponse_AppliesRuleFor422(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "upstream_error", errField["type"])
 	assert.Equal(t, "上游请求失败", errField["message"])
+}
+
+func TestGatewayHandleErrorResponse_PassthroughKeepsDiagnosticButRetainsRawOpsMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	responseCode := http.StatusBadRequest
+	ruleSvc := &ErrorPassthroughService{}
+	ruleSvc.setLocalCache([]*model.ErrorPassthroughRule{{
+		ID:              2,
+		Name:            "400 diagnostic passthrough",
+		Enabled:         true,
+		Priority:        1,
+		ErrorCodes:      []int{http.StatusBadRequest},
+		MatchMode:       model.MatchModeAll,
+		PassthroughCode: false,
+		ResponseCode:    &responseCode,
+		PassthroughBody: true,
+	}})
+	BindErrorPassthroughService(c, ruleSvc)
+
+	rawMessage := "messages.3.content.0.text must not be empty (request id: provider-123456)"
+	respBody := []byte(`{"error":{"message":"` + rawMessage + `"}}`)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+		Header:     http.Header{"X-Request-Id": []string{"provider-header-id"}},
+	}
+	account := &Account{ID: 1, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	_, err := (&GatewayService{}).handleErrorResponse(context.Background(), resp, c, account)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	errField, ok := payload["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "messages.3.content.0.text must not be empty", errField["message"])
+
+	opsMessage, ok := c.Get(OpsUpstreamErrorMessageKey)
+	require.True(t, ok)
+	require.Equal(t, rawMessage, opsMessage)
+	eventsValue, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := eventsValue.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, "provider-header-id", events[0].UpstreamRequestID)
+	require.Equal(t, rawMessage, events[0].Message)
 }
 
 func TestOpenAIHandleErrorResponse_AppliesRuleFor422(t *testing.T) {

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -392,10 +392,6 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 		c.Header("Connection", "keep-alive")
 	}
 	c.Header("X-Accel-Buffering", "no")
-	if v := resp.Header.Get("x-request-id"); v != "" {
-		c.Header("x-request-id", v)
-	}
-
 	w := c.Writer
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -819,14 +815,13 @@ func writeAnthropicPassthroughResponseHeaders(dst http.Header, src http.Header, 
 	if dst == nil || src == nil {
 		return
 	}
+	clientHeaders := src.Clone()
+	clientHeaders.Del("x-request-id")
 	if filter != nil {
-		responseheaders.WriteFilteredHeaders(dst, src, filter)
+		responseheaders.WriteFilteredHeaders(dst, clientHeaders, filter)
 		return
 	}
-	if v := strings.TrimSpace(src.Get("Content-Type")); v != "" {
+	if v := strings.TrimSpace(clientHeaders.Get("Content-Type")); v != "" {
 		dst.Set("Content-Type", v)
-	}
-	if v := strings.TrimSpace(src.Get("x-request-id")); v != "" {
-		dst.Set("x-request-id", v)
 	}
 }

--- a/backend/internal/service/gateway_upstream_response.go
+++ b/backend/internal/service/gateway_upstream_response.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
-	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
@@ -286,25 +285,33 @@ func ExtractUpstreamErrorMessage(body []byte) string {
 }
 
 func extractUpstreamErrorMessage(body []byte) string {
-	// Claude 风格：{"type":"error","error":{"type":"...","message":"..."}}
-	if m := gjson.GetBytes(body, "error.message").String(); strings.TrimSpace(m) != "" {
-		inner := strings.TrimSpace(m)
-		// 有些上游会把完整 JSON 作为字符串塞进 message
-		if strings.HasPrefix(inner, "{") {
-			if innerMsg := gjson.Get(inner, "error.message").String(); strings.TrimSpace(innerMsg) != "" {
-				return innerMsg
-			}
+	candidate := strings.TrimSpace(string(body))
+	message := ""
+	for depth := 0; depth < 6 && candidate != ""; depth++ {
+		current := ""
+		// Claude/OpenAI 风格：{"type":"error","error":{"message":"..."}}
+		if m := gjson.Get(candidate, "error.message").String(); strings.TrimSpace(m) != "" {
+			current = m
+		} else if d := gjson.Get(candidate, "detail").String(); strings.TrimSpace(d) != "" {
+			// ChatGPT 内部 API 风格：{"detail":"..."}
+			current = d
+		} else if m := gjson.Get(candidate, "message").String(); strings.TrimSpace(m) != "" {
+			current = m
 		}
-		return m
-	}
 
-	// ChatGPT 内部 API 风格：{"detail":"..."}
-	if d := gjson.GetBytes(body, "detail").String(); strings.TrimSpace(d) != "" {
-		return d
+		current = strings.TrimSpace(current)
+		if current == "" {
+			break
+		}
+		message = current
+		// 部分聚合上游会把下一层 JSON（甚至 JSON + SSE）塞进 message。
+		// gjson 会读取开头的 JSON 对象，因此可以逐层取出最具体的诊断文本。
+		if !strings.HasPrefix(current, "{") || current == candidate {
+			break
+		}
+		candidate = current
 	}
-
-	// 兜底：尝试顶层 message
-	return gjson.GetBytes(body, "message").String()
+	return message
 }
 
 func extractUpstreamErrorCode(body []byte) string {
@@ -468,7 +475,17 @@ func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Res
 
 	switch resp.StatusCode {
 	case 400:
-		c.Data(http.StatusBadRequest, "application/json", body)
+		clientMsg := ExtractClientSafeUpstreamErrorMessage(body)
+		if clientMsg == "" {
+			clientMsg = "Upstream request failed"
+		}
+		c.JSON(http.StatusBadRequest, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "upstream_error",
+				"message": clientMsg,
+			},
+		})
 		summary := upstreamMsg
 		if summary == "" {
 			summary = truncateForLog(body, 512)
@@ -651,20 +668,13 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 
-	if s.responseHeaderFilter != nil {
-		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
-	}
+	writeAnthropicPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
 	// 设置SSE响应头
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 	c.Header("X-Accel-Buffering", "no")
-
-	// 透传其他响应头
-	if v := resp.Header.Get("x-request-id"); v != "" {
-		c.Header("x-request-id", v)
-	}
 
 	w := c.Writer
 	flusher, ok := w.(http.Flusher)
@@ -1388,7 +1398,7 @@ func (s *GatewayService) handleNonStreamingResponse(ctx context.Context, resp *h
 		body = s.replaceModelInResponseBody(body, mappedModel, originalModel)
 	}
 
-	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	writeAnthropicPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
 	contentType := "application/json"
 	if s.cfg != nil && !s.cfg.Security.ResponseHeaders.Enabled {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -1291,7 +1291,8 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		requestIDHeader = "x-request-id"
 
 	default:
-		return nil, s.writeGoogleError(c, http.StatusBadGateway, "Unsupported account type: "+account.Type)
+		setOpsUpstreamError(c, http.StatusBadGateway, "Unsupported account type: "+account.Type, "")
+		return nil, s.writeGoogleError(c, http.StatusBadGateway, "Service temporarily unavailable, please retry later")
 	}
 
 	var resp *http.Response

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -82,7 +82,8 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 	defaultMappedModel string,
 ) error {
 	if account == nil {
-		writeAnthropicCountTokensError(c, http.StatusServiceUnavailable, "api_error", "No available OpenAI accounts")
+		setOpsUpstreamError(c, http.StatusServiceUnavailable, "No available OpenAI accounts", "")
+		writeAnthropicCountTokensError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable, please retry later")
 		return fmt.Errorf("count_tokens: missing account")
 	}
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -837,7 +837,9 @@ func (s *OpenAIGatewayService) writeOpenAIWSFallbackErrorResponse(c *gin.Context
 	}
 
 	setOpsUpstreamError(c, statusCode, upstreamMessage, "")
+	platform := PlatformOpenAI
 	if account != nil {
+		platform = account.Platform
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,
@@ -847,10 +849,19 @@ func (s *OpenAIGatewayService) writeOpenAIWSFallbackErrorResponse(c *gin.Context
 			Message:            upstreamMessage,
 		})
 	}
-	c.JSON(statusCode, gin.H{
+	responseStatus, responseType, responseMessage, _ := applyErrorPassthroughRule(
+		c,
+		platform,
+		statusCode,
+		[]byte(upstreamMessage),
+		statusCode,
+		errType,
+		clientMessage,
+	)
+	c.JSON(responseStatus, gin.H{
 		"error": gin.H{
-			"type":    errType,
-			"message": clientMessage,
+			"type":    responseType,
+			"message": responseMessage,
 		},
 	})
 	return true

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -68,7 +68,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if ingressMode == OpenAIWSIngressModeOff {
 			return NewOpenAIWSClientCloseError(
 				coderws.StatusPolicyViolation,
-				"websocket mode is disabled for this account",
+				"websocket mode is unavailable for this request",
 				nil,
 			)
 		}

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -1271,7 +1271,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_ModeOffReturnsPo
 		var closeErr *OpenAIWSClientCloseError
 		require.ErrorAs(t, serverErr, &closeErr)
 		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
-		require.Equal(t, "websocket mode is disabled for this account", closeErr.Reason())
+		require.Equal(t, "websocket mode is unavailable for this request", closeErr.Reason())
 	case <-time.After(5 * time.Second):
 		t.Fatal("等待 ingress websocket 结束超时")
 	}

--- a/backend/internal/service/upstream_error_client_sanitize.go
+++ b/backend/internal/service/upstream_error_client_sanitize.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	providerCorrelationIDDelimitedRE = regexp.MustCompile(`(?i)\s*[\(\[]\s*(?:request|trace|correlation)[\s_-]*id\s*[:=]\s*[A-Za-z0-9_.:/+=-]{6,}\s*[\)\]]`)
+	providerCorrelationIDSuffixRE    = regexp.MustCompile(`(?i)\s+(?:request|trace|correlation)[\s_-]*id\s*[:=]\s*[[:alnum:]_.:/-]{6,}\s*$`)
+)
+
+// ExtractClientSafeUpstreamErrorMessage keeps actionable provider diagnostics
+// while removing provider-only correlation IDs from the client response.
+// Raw upstream bodies and IDs remain available in ops error context.
+func ExtractClientSafeUpstreamErrorMessage(body []byte) string {
+	return sanitizeClientUpstreamErrorMessage(extractUpstreamErrorMessage(body))
+}
+
+func sanitizeClientUpstreamErrorMessage(message string) string {
+	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
+	message = providerCorrelationIDDelimitedRE.ReplaceAllString(message, "")
+	message = providerCorrelationIDSuffixRE.ReplaceAllString(message, "")
+	return strings.TrimSpace(message)
+}

--- a/backend/internal/service/upstream_error_client_sanitize_test.go
+++ b/backend/internal/service/upstream_error_client_sanitize_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractClientSafeUpstreamErrorMessage_UnwrapsNestedBodyAndRemovesProviderID(t *testing.T) {
+	body := []byte(`{"error":{"message":"{\"error\":{\"type\":\"\\u003cnil\\u003e\",\"message\":\"Malformed request: please ensure the input adheres to the required specification. (request id: 202607281609465064538388268d9d67wbgXJSe)\"},\"type\":\"error\"}data: {\"type\":\"error\",\"error\":{\"type\":\"upstream_error\",\"message\":\"Upstream request failed\"}}","type":"upstream_error"}}`)
+
+	rawMessage := ExtractUpstreamErrorMessage(body)
+	require.Equal(t, "Malformed request: please ensure the input adheres to the required specification. (request id: 202607281609465064538388268d9d67wbgXJSe)", rawMessage)
+	require.Equal(t, "Malformed request: please ensure the input adheres to the required specification.", ExtractClientSafeUpstreamErrorMessage(body))
+}
+
+func TestExtractClientSafeUpstreamErrorMessage_PreservesActionableDiagnostic(t *testing.T) {
+	body := []byte(`{"error":{"message":"messages.3.content.0.text must not be empty; remove the empty block (request_id: req_01ABCDEF)"}}`)
+
+	require.Equal(t,
+		"messages.3.content.0.text must not be empty; remove the empty block",
+		ExtractClientSafeUpstreamErrorMessage(body),
+	)
+}
+
+func TestSanitizeClientUpstreamErrorMessage_CorrelationIDVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "parenthesized request id", in: "invalid value (Request ID: abcdef123456)", want: "invalid value"},
+		{name: "bracketed trace id", in: "invalid value [trace-id=trace_123456]", want: "invalid value"},
+		{name: "bare correlation id suffix", in: "invalid value correlationId: corr-123456", want: "invalid value"},
+		{name: "field name is diagnostic", in: "request_id is required", want: "request_id is required"},
+		{name: "request id validation is diagnostic", in: "invalid field (request id: must be a UUID)", want: "invalid field (request id: must be a UUID)"},
+		{name: "specific field detail", in: "tools.2.input_schema.type must be object", want: "tools.2.input_schema.type must be object"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sanitizeClientUpstreamErrorMessage(tt.in))
+		})
+	}
+}
+
+func TestWriteAnthropicPassthroughResponseHeaders_PreservesGatewayRequestID(t *testing.T) {
+	dst := http.Header{"X-Request-Id": []string{"gateway-request-id"}}
+	src := http.Header{
+		"Content-Type": []string{"text/event-stream"},
+		"X-Request-Id": []string{"provider-request-id"},
+	}
+	filter := compileResponseHeaderFilter(&config.Config{})
+
+	writeAnthropicPassthroughResponseHeaders(dst, src, filter)
+
+	require.Equal(t, "gateway-request-id", dst.Get("X-Request-Id"))
+	require.Equal(t, "text/event-stream", dst.Get("Content-Type"))
+}


### PR DESCRIPTION
## 修改内容

### 1. 脱敏上游错误中的 correlation ID

上游（Anthropic 等）错误响应中携带的 `request-id` / `x-request-id` 等追踪 ID 属于提供商内部标识，直接暴露给终端用户可能泄露账号调用关联信息。

- 新增 `upstream_error_client_sanitize.go`：在返回客户端前移除 provider-specific 追踪 ID
- 补充单元测试覆盖各提供商的 header 格式

### 2. 统一公共池错误响应

不同 handler（Anthropic passthrough、OpenAI gateway、Gemini、Grok）对无可用账号 / 并发限制 / 上游错误的响应格式不一致，客户端难以统一处理。

- 新增 `gateway_error_contract.go`：定义统一的错误响应结构和工厂方法
- 各 handler 统一使用 error contract，保持 HTTP status code 和 body 格式一致
- 补充 145 条测试用例验证错误契约

---

**测试**：所有新增和修改路径均有单元测试覆盖，`go test ./...` 通过。