### PR TITLE
fix(openai): apply passthrough rules to response.failed events

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1465,6 +1465,11 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	if !h.ensureResponsesDependencies(c, reqLog) {
 		return
 	}
+	// WebSocket requests bypass the regular Responses handler, so bind the
+	// passthrough service here as well for in-band response.failed events.
+	if h.errorPassthroughService != nil {
+		service.BindErrorPassthroughService(c, h.errorPassthroughService)
+	}
 	reqLog.Info("openai.websocket_ingress_started")
 	clientIP := ip.GetClientIP(c)
 	userAgent := strings.TrimSpace(c.GetHeader("User-Agent"))

--- a/backend/internal/service/openai_compact_stream_bridge_test.go
+++ b/backend/internal/service/openai_compact_stream_bridge_test.go
@@ -318,7 +318,7 @@ func TestHandlePassthroughSSEToJSON_CompactRawOutputItemDoneRepairsEmptyTerminal
 		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -512,7 +512,7 @@ func TestHandleNonStreamingResponsePassthrough_CompactClientStreamBridgesToSSE(t
 		}`)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -247,7 +247,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	} else {
-		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, account, reqModel, upstreamPassthroughModel)
 		if err != nil {
 			return nil, err
 		}
@@ -856,6 +856,72 @@ func applyOpenAIStreamFailedErrorPassthroughRule(
 	)
 }
 
+// applyOpenAIStreamFailedEventPassthroughRule applies a matched rule to an
+// in-band response.failed event. The wire status may already be committed, so
+// the returned status is the logical stream-error status while a custom message
+// is written back into the original Responses payload.
+func applyOpenAIStreamFailedEventPassthroughRule(
+	c *gin.Context,
+	account *Account,
+	payload []byte,
+	failedMessage string,
+) (updatedPayload []byte, status int, errType string, errMsg string, matched bool) {
+	failedMessage = strings.TrimSpace(failedMessage)
+	if failedMessage == "" {
+		failedMessage = "Upstream response failed"
+	}
+	status = openAIStreamFailedEventSemanticStatus(payload, failedMessage)
+	errType = "upstream_error"
+	errMsg = failedMessage
+	updatedPayload = payload
+
+	platform := PlatformOpenAI
+	if account != nil && strings.TrimSpace(account.Platform) != "" {
+		platform = strings.TrimSpace(account.Platform)
+	}
+	ruleStatus, ruleErrType, ruleErrMsg, ruleMatched := applyOpenAIStreamFailedErrorPassthroughRule(
+		c,
+		platform,
+		payload,
+		failedMessage,
+	)
+	if !ruleMatched {
+		return updatedPayload, status, errType, errMsg, false
+	}
+	status = ruleStatus
+	errType = ruleErrType
+	if strings.TrimSpace(ruleErrMsg) != "" {
+		errMsg = ruleErrMsg
+	}
+	if strings.TrimSpace(errMsg) == "" || errMsg == extractOpenAISSEErrorMessage(payload) {
+		return updatedPayload, status, errType, errMsg, true
+	}
+
+	paths := make([]string, 0, 2)
+	if gjson.GetBytes(payload, "response.error").IsObject() {
+		paths = append(paths, "response.error.message")
+	}
+	if gjson.GetBytes(payload, "error").IsObject() {
+		paths = append(paths, "error.message")
+	}
+	if len(paths) == 0 {
+		if gjson.GetBytes(payload, "response").IsObject() {
+			paths = append(paths, "response.error.message")
+		} else {
+			paths = append(paths, "error.message")
+		}
+	}
+
+	for _, path := range paths {
+		next, err := sjson.SetBytes(updatedPayload, path, errMsg)
+		if err != nil {
+			return payload, status, errType, errMsg, true
+		}
+		updatedPayload = next
+	}
+	return updatedPayload, status, errType, errMsg, true
+}
+
 func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool {
 	if isOpenAIContextWindowError(message, payload) {
 		return false
@@ -1113,6 +1179,18 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 							s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage)
 					}
 				}
+				if openAIStreamClientOutputStarted(c, clientOutputStarted) {
+					updatedData, status, errType, errMsg, _ := applyOpenAIStreamFailedEventPassthroughRule(
+						c, account, dataBytes, failedMessage,
+					)
+					failedMessage = errMsg
+					if !bytes.Equal(updatedData, dataBytes) {
+						dataBytes = updatedData
+						trimmedData = strings.TrimSpace(string(updatedData))
+						line = "data: " + string(updatedData)
+					}
+					MarkOpsStreamError(c, errType, failedMessage, status)
+				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
 			}
@@ -1227,6 +1305,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 ) (*openaiNonStreamingResultPassthrough, error) {
@@ -1240,7 +1319,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	// stream=false was requested. Without this conversion the client would
 	// receive raw SSE text or a terminal event with empty output.
 	if isEventStreamResponse(resp.Header) {
-		return s.handlePassthroughSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handlePassthroughSSEToJSON(resp, c, body, account, originalModel, mappedModel)
 	}
 
 	usage := &OpenAIUsage{}
@@ -1285,7 +1364,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 // response for the passthrough path. It mirrors handleSSEToJSON while
 // preserving passthrough payloads, except compact-only model remapping may
 // rewrite model fields back to the original requested model.
-func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel string, mappedModel string) (*openaiNonStreamingResultPassthrough, error) {
+func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, body []byte, account *Account, originalModel string, mappedModel string) (*openaiNonStreamingResultPassthrough, error) {
 	bodyText := string(body)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
@@ -1322,7 +1401,8 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			upstreamStatus := resolveOpenAIResponseFailedUpstreamStatus(resp, terminalPayload)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, account, upstreamStatus, terminalPayload, msg)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != "" && mappedModel != "" && originalModel != mappedModel {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -453,6 +453,18 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 						return
 					}
 				}
+				if openAIStreamClientOutputStarted(c, clientOutputStarted) {
+					updatedData, status, errType, errMsg, _ := applyOpenAIStreamFailedEventPassthroughRule(
+						c, account, dataBytes, failedMessage,
+					)
+					failedMessage = errMsg
+					if !bytes.Equal(updatedData, dataBytes) {
+						dataBytes = updatedData
+						data = string(updatedData)
+						line = "data: " + data
+					}
+					MarkOpsStreamError(c, errType, failedMessage, status)
+				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
 			}
@@ -1115,7 +1127,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	// Some OpenAI-compatible upstreams (including other sub2api instances)
 	// may return SSE even when stream=false was requested.
 	if isEventStreamResponse(resp.Header) {
-		return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handleSSEToJSON(resp, c, body, account, originalModel, mappedModel)
 	}
 	// bodyLooksLikeSSE is a line-level heuristic: real SSE framing requires
 	// "data:"/"event:" field names at the very start of a physical line. A
@@ -1131,7 +1143,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	// positives on JSON responses that coincidentally contain "data:" or
 	// "event:" in their text content.
 	if account.Type == AccountTypeOAuth && bodyLooksLikeSSE {
-		return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handleSSEToJSON(resp, c, body, account, originalModel, mappedModel)
 	}
 	if account != nil && account.IsGrok() && isOpenAIResponsesCompactPath(c) {
 		body, err = convertGrokResponseToOpenAICompact(body)
@@ -1143,7 +1155,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	usageValue, usageOK := extractOpenAIUsageFromJSONBytes(body)
 	if !usageOK {
 		if bodyLooksLikeSSE {
-			return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+			return s.handleSSEToJSON(resp, c, body, account, originalModel, mappedModel)
 		}
 		return nil, fmt.Errorf("parse response: invalid json response")
 	}
@@ -1204,7 +1216,7 @@ func bodyHasSSEFraming(body []byte) bool {
 	return false
 }
 
-func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
+func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, body []byte, account *Account, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
 	bodyText := string(body)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
@@ -1246,7 +1258,8 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			upstreamStatus := resolveOpenAIResponseFailedUpstreamStatus(resp, terminalPayload)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, account, upstreamStatus, terminalPayload, msg)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != mappedModel {
@@ -1361,26 +1374,98 @@ func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string
 	return updated, !bytes.Equal(updated, payload)
 }
 
-func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string) error {
+func resolveOpenAIResponseFailedUpstreamStatus(resp *http.Response, payload []byte) int {
+	for _, path := range []string{
+		"response.status_code",
+		"response.error.status_code",
+		"error.status_code",
+		"status_code",
+		"response.error.code",
+		"error.code",
+		"code",
+	} {
+		if status, ok := parseOpenAIHTTPStatusValue(gjson.GetBytes(payload, path)); ok {
+			return status
+		}
+	}
+	if resp != nil && resp.StatusCode >= http.StatusBadRequest {
+		return resp.StatusCode
+	}
+	return openAIStreamFailedEventSemanticStatus(payload, extractOpenAISSEErrorMessage(payload))
+}
+
+func parseOpenAIHTTPStatusValue(value gjson.Result) (int, bool) {
+	if !value.Exists() {
+		return 0, false
+	}
+	raw := strings.TrimSpace(value.String())
+	if raw == "" {
+		raw = strings.TrimSpace(value.Raw)
+	}
+	status, err := strconv.Atoi(raw)
+	if err != nil || status < http.StatusBadRequest || status > 599 {
+		return 0, false
+	}
+	return status, true
+}
+
+func openAINonStreamingProtocolErrorBody(message string) []byte {
+	body, err := json.Marshal(gin.H{"error": gin.H{"message": message}})
+	if err != nil {
+		return []byte(`{"error":{"message":"Upstream request failed"}}`)
+	}
+	return body
+}
+
+func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, account *Account, upstreamStatus int, responseBody []byte, message string) error {
 	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
 	if message == "" {
 		message = "Upstream returned an invalid non-streaming response"
 	}
-	setOpsUpstreamError(c, http.StatusBadGateway, message, "")
+	if upstreamStatus < http.StatusBadRequest || upstreamStatus > 599 {
+		upstreamStatus = http.StatusBadGateway
+	}
+	if len(bytes.TrimSpace(responseBody)) == 0 {
+		responseBody = openAINonStreamingProtocolErrorBody(message)
+	}
+	platform := PlatformOpenAI
+	if account != nil && strings.TrimSpace(account.Platform) != "" {
+		platform = account.Platform
+	}
+	ruleBody := openAIStreamFailedEventPassthroughBody(responseBody, message)
+	statusCode, errType, errMsg, matched := applyErrorPassthroughRule(
+		c,
+		platform,
+		upstreamStatus,
+		ruleBody,
+		http.StatusBadGateway,
+		"upstream_error",
+		message,
+	)
+	if strings.TrimSpace(errMsg) == "" {
+		errMsg = message
+	}
+	setOpsUpstreamError(c, upstreamStatus, message, "")
 	// body-signal compact 心跳可能已把响应头提交为 200，此时只能以
 	// response.failed 终止事件回传错误，不能再写 JSON+状态码。
 	if openAICompactClientWantsStream(c) && StopOpenAICompactSSEKeepaliveCommitted(c) {
-		writeOpenAICompactSSEFailureMessage(c, http.StatusBadGateway, "upstream_error", message)
+		writeOpenAICompactSSEFailureMessage(c, statusCode, errType, errMsg)
 		return fmt.Errorf("non-streaming openai protocol error: %s", message)
 	}
-	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	MarkResponseCommitted(c)
+	if resp != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
-	c.JSON(http.StatusBadGateway, gin.H{
+	c.JSON(statusCode, gin.H{
 		"error": gin.H{
-			"type":    "upstream_error",
-			"message": message,
+			"type":    errType,
+			"message": errMsg,
 		},
 	})
+	if matched {
+		return fmt.Errorf("non-streaming openai protocol error: upstream status %d (passthrough rule matched) message=%s", upstreamStatus, message)
+	}
 	return fmt.Errorf("non-streaming openai protocol error: %s", message)
 }
 

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -3133,7 +3133,7 @@ func TestHandleSSEToJSON_CompletedEventReturnsJSON(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, body, &Account{Platform: PlatformOpenAI}, "gpt-4o", "gpt-4o")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 7, usage.InputTokens)
@@ -3226,7 +3226,7 @@ func TestHandleSSEToJSON_ReconstructsImageGenerationOutputItemDone(t *testing.T)
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-5.4", "gpt-5.4")
+	usage, err := svc.handleSSEToJSON(resp, c, body, &Account{Platform: PlatformOpenAI}, "gpt-5.4", "gpt-5.4")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 4, usage.ImageOutputTokens)
@@ -3253,7 +3253,7 @@ func TestHandleSSEToJSON_NoFinalResponseKeepsSSEBody(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, body, &Account{Platform: PlatformOpenAI}, "gpt-4o", "gpt-4o")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 0, usage.InputTokens)
@@ -3277,7 +3277,7 @@ func TestHandleSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, body, &Account{Platform: PlatformOpenAI}, "gpt-4o", "gpt-4o")
 	require.Nil(t, usage)
 	require.Error(t, err)
 	require.Equal(t, http.StatusBadGateway, rec.Code)

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -587,7 +587,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceNonStreamingResponse(t *
 	setOpenAIResponsesNamespaceNames(c, names)
 
 	result, err := (&OpenAIGatewayService{cfg: &config.Config{}}).handleNonStreamingResponsePassthrough(
-		context.Background(), resp, c, "gpt-5.5", "",
+		context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/backend/internal/service/openai_response_failed_passthrough_test.go
+++ b/backend/internal/service/openai_response_failed_passthrough_test.go
@@ -1,0 +1,240 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	responseFailedUpstreamMessage = "Our servers are currently overloaded. Please try again later."
+	responseFailedCustomMessage   = "service temporarily busy"
+	responseFailedCustomStatus    = 521
+)
+
+func newResponseFailedKeywordPassthroughRule() *model.ErrorPassthroughRule {
+	responseCode := responseFailedCustomStatus
+	customMessage := responseFailedCustomMessage
+	return &model.ErrorPassthroughRule{
+		ID:              991,
+		Name:            "response-failed-keyword",
+		Enabled:         true,
+		Priority:        1,
+		ErrorCodes:      []int{http.StatusTeapot},
+		Keywords:        []string{"our servers are currently overloaded"},
+		MatchMode:       model.MatchModeAny,
+		Platforms:       []string{PlatformOpenAI},
+		PassthroughCode: false,
+		ResponseCode:    &responseCode,
+		PassthroughBody: false,
+		CustomMessage:   &customMessage,
+		SkipMonitoring:  true,
+	}
+}
+
+func newResponseFailedKeywordPassthroughService() *ErrorPassthroughService {
+	ruleSvc := &ErrorPassthroughService{}
+	ruleSvc.setLocalCache([]*model.ErrorPassthroughRule{newResponseFailedKeywordPassthroughRule()})
+	return ruleSvc
+}
+
+func bindResponseFailedKeywordPassthroughRule(c *gin.Context) {
+	BindErrorPassthroughService(c, newResponseFailedKeywordPassthroughService())
+}
+
+func TestHandleSSEToJSONResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	bindResponseFailedKeywordPassthroughRule(c)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	body := []byte(strings.Join([]string{
+		`data: {"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`,
+		`data: [DONE]`,
+	}, "\n"))
+
+	usage, err := svc.handleSSEToJSON(resp, c, body, &Account{ID: 1, Platform: PlatformOpenAI}, "gpt-test", "gpt-test")
+	require.Nil(t, usage)
+	require.Error(t, err)
+	require.Equal(t, responseFailedCustomStatus, rec.Code)
+	require.Equal(t, responseFailedCustomMessage, gjson.Get(rec.Body.String(), "error.message").String())
+	require.Contains(t, err.Error(), "passthrough rule matched")
+}
+
+func TestHandlePassthroughSSEToJSONResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	bindResponseFailedKeywordPassthroughRule(c)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	body := []byte(strings.Join([]string{
+		`data: {"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`,
+		`data: [DONE]`,
+	}, "\n"))
+
+	usage, err := svc.handlePassthroughSSEToJSON(resp, c, body, &Account{ID: 2, Platform: PlatformOpenAI}, "gpt-test", "gpt-test")
+	require.Nil(t, usage)
+	require.Error(t, err)
+	require.Equal(t, responseFailedCustomStatus, rec.Code)
+	require.Equal(t, responseFailedCustomMessage, gjson.Get(rec.Body.String(), "error.message").String())
+}
+
+func TestApplyOpenAIStreamFailedEventPassthroughRuleMatchesKeyword(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	bindResponseFailedKeywordPassthroughRule(c)
+
+	payload := []byte(`{"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`)
+	updated, status, errType, errMsg, matched := applyOpenAIStreamFailedEventPassthroughRule(
+		c,
+		&Account{ID: 3, Platform: PlatformOpenAI},
+		payload,
+		responseFailedUpstreamMessage,
+	)
+
+	require.True(t, matched, "the configured status is intentionally different, so the keyword must match")
+	require.Equal(t, responseFailedCustomStatus, status)
+	require.Equal(t, "upstream_error", errType)
+	require.Equal(t, responseFailedCustomMessage, errMsg)
+	require.Equal(t, responseFailedCustomMessage, gjson.GetBytes(updated, "response.error.message").String())
+	require.Equal(t, "server_is_overloaded", gjson.GetBytes(updated, "response.error.code").String())
+	skipMonitoring, exists := c.Get(OpsSkipPassthroughKey)
+	require.True(t, exists)
+	require.Equal(t, true, skipMonitoring)
+}
+
+func TestApplyOpenAIStreamFailedEventPassthroughRulePreservesConfiguredBodyAndCode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ruleSvc := &ErrorPassthroughService{}
+	ruleSvc.setLocalCache([]*model.ErrorPassthroughRule{{
+		ID:              992,
+		Name:            "overloaded-passthrough",
+		Enabled:         true,
+		ErrorCodes:      []int{http.StatusBadGateway, http.StatusServiceUnavailable},
+		Keywords:        []string{"upstream response failed", "our servers are currently overloaded"},
+		MatchMode:       model.MatchModeAny,
+		Platforms:       []string{PlatformOpenAI},
+		PassthroughCode: true,
+		PassthroughBody: true,
+	}})
+	BindErrorPassthroughService(c, ruleSvc)
+	payload := []byte(`{"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`)
+
+	updated, status, errType, errMsg, matched := applyOpenAIStreamFailedEventPassthroughRule(
+		c,
+		&Account{ID: 5, Platform: PlatformOpenAI},
+		payload,
+		responseFailedUpstreamMessage,
+	)
+
+	require.True(t, matched)
+	require.Equal(t, http.StatusServiceUnavailable, status)
+	require.Equal(t, "upstream_error", errType)
+	require.Equal(t, responseFailedUpstreamMessage, errMsg)
+	require.Equal(t, payload, updated)
+}
+
+func TestApplyOpenAIStreamFailedEventPassthroughRuleLeavesUnmatchedPayloadUntouched(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	payload := []byte(`{"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`)
+
+	updated, status, errType, errMsg, matched := applyOpenAIStreamFailedEventPassthroughRule(
+		c,
+		&Account{ID: 6, Platform: PlatformOpenAI},
+		payload,
+		responseFailedUpstreamMessage,
+	)
+
+	require.False(t, matched)
+	require.Equal(t, http.StatusServiceUnavailable, status)
+	require.Equal(t, "upstream_error", errType)
+	require.Equal(t, responseFailedUpstreamMessage, errMsg)
+	require.Equal(t, payload, updated)
+}
+
+func TestOpenAIStreamingResponseFailedAfterOutputHonorsKeywordPassthroughRule(t *testing.T) {
+	for _, passthrough := range []bool{false, true} {
+		name := "normalized"
+		if passthrough {
+			name = "passthrough"
+		}
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			cfg := &config.Config{
+				Gateway: config.GatewayConfig{
+					StreamDataIntervalTimeout: 0,
+					StreamKeepaliveInterval:   0,
+					MaxLineSize:               defaultMaxLineSize,
+				},
+			}
+			svc := &OpenAIGatewayService{cfg: cfg}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			bindResponseFailedKeywordPassthroughRule(c)
+
+			failedPayload := `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+					"event: response.output_text.delta",
+					`data: {"type":"response.output_text.delta","delta":"partial"}`,
+					"",
+					"event: response.failed",
+					"data: " + failedPayload,
+					"",
+				}, "\n"))),
+				Header: http.Header{"X-Request-Id": []string{"rid-keyword-rule"}},
+			}
+			account := &Account{ID: 4, Platform: PlatformOpenAI, Name: "acc"}
+
+			var err error
+			if passthrough {
+				_, err = svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, account, time.Now(), "", "")
+			} else {
+				_, err = svc.handleStreamingResponse(c.Request.Context(), resp, c, account, time.Now(), "gpt-test", "gpt-test")
+			}
+
+			require.Error(t, err)
+			require.Equal(t, http.StatusOK, rec.Code, "the HTTP stream status is already committed")
+			require.Contains(t, rec.Body.String(), responseFailedCustomMessage)
+			require.NotContains(t, rec.Body.String(), responseFailedUpstreamMessage)
+			streamErr, marked := GetOpsStreamError(c)
+			require.True(t, marked)
+			require.Equal(t, responseFailedCustomStatus, streamErr.IntendedStatus)
+			require.Equal(t, responseFailedCustomMessage, streamErr.Message)
+			skipMonitoring, exists := c.Get(OpsSkipPassthroughKey)
+			require.True(t, exists)
+			require.Equal(t, true, skipMonitoring)
+		})
+	}
+}

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -942,6 +942,15 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					})
 				}
 			}
+			terminalFailurePayload := upstreamMessage
+			if eventType == "response.failed" {
+				failedMessage := extractOpenAISSEErrorMessage(upstreamMessage)
+				updatedMessage, status, errType, errMsg, _ := applyOpenAIStreamFailedEventPassthroughRule(
+					c, account, upstreamMessage, failedMessage,
+				)
+				upstreamMessage = updatedMessage
+				MarkOpsStreamError(c, errType, errMsg, status)
+			}
 
 			if !clientDisconnected {
 				if needModelReplace && len(mappedModelBytes) > 0 && openAIWSEventMayContainModel(eventType) && bytes.Contains(upstreamMessage, mappedModelBytes) {
@@ -978,7 +987,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			if isTerminalEvent {
 				canonicalModel := canonicalOpenAIAccountSchedulingModel(account, originalModel)
-				terminalEvent := s.handleOpenAIWSTerminalTransientFailure(ctx, account, canonicalModel, lease.HandshakeHeaders(), upstreamMessage)
+				terminalEvent := s.handleOpenAIWSTerminalTransientFailure(ctx, account, canonicalModel, lease.HandshakeHeaders(), terminalFailurePayload)
 				// 客户端已断连时，上游连接的 session 状态不可信，标记 broken 避免回池复用。
 				if clientDisconnected {
 					lease.MarkBroken()

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -575,6 +575,18 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 				})
 			}
 		}
+		terminalFailurePayload := message
+		if eventType == "response.failed" {
+			failedMessage := extractOpenAISSEErrorMessage(message)
+			updatedMessage, status, errType, errMsg, matched := applyOpenAIStreamFailedEventPassthroughRule(
+				c, account, message, failedMessage,
+			)
+			if matched {
+				message = updatedMessage
+				_, _, responseField = parseOpenAIWSEventEnvelope(message)
+			}
+			MarkOpsStreamError(c, errType, errMsg, status)
+		}
 
 		if eventType == "error" {
 			s.handleOpenAIWSErrorEventTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), message)
@@ -676,7 +688,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		}
 
 		if isTerminalEvent {
-			upstreamTerminalEvent = s.handleOpenAIWSTerminalTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), message)
+			upstreamTerminalEvent = s.handleOpenAIWSTerminalTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), terminalFailurePayload)
 			// A terminal event must be the final JSON document in its WS message.
 			// Ignore any tail for the completed client turn, but never reuse the
 			// ambiguous upstream connection for another request.

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -385,6 +385,15 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 				upstreamMessage = corrected
 			}
 		}
+		terminalFailurePayload := upstreamMessage
+		if eventType == "response.failed" {
+			failedMessage := extractOpenAISSEErrorMessage(upstreamMessage)
+			updatedMessage, status, errType, errMsg, _ := applyOpenAIStreamFailedEventPassthroughRule(
+				c, account, upstreamMessage, failedMessage,
+			)
+			upstreamMessage = updatedMessage
+			MarkOpsStreamError(c, errType, errMsg, status)
+		}
 		replayCollector.AddEvent(eventType, upstreamMessage)
 
 		var upstreamEventErr error
@@ -449,7 +458,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 			return resultWithUsage(), upstreamEventErr
 		}
 		if isOpenAIWSTerminalEvent(eventType) {
-			upstreamTerminalEvent = s.handleOpenAIWSTerminalTransientFailure(ctx, account, canonicalOpenAIAccountSchedulingModel(account, originalModel), resp.Header, upstreamMessage)
+			upstreamTerminalEvent = s.handleOpenAIWSTerminalTransientFailure(ctx, account, canonicalOpenAIAccountSchedulingModel(account, originalModel), resp.Header, terminalFailurePayload)
 			terminalEventCount++
 			firstTokenMsValue := -1
 			if firstTokenMs != nil {

--- a/backend/internal/service/openai_ws_response_failed_passthrough_test.go
+++ b/backend/internal/service/openai_ws_response_failed_passthrough_test.go
@@ -1,0 +1,257 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	coderws "github.com/coder/websocket"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIGatewayServiceForwardWSV2ResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.98.0")
+	bindResponseFailedKeywordPassthroughRule(c)
+
+	cfg := newOpenAIWSV2TestConfig()
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	captureConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.failed","response":{"id":"resp_ws_failed","model":"gpt-test","error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`),
+	}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(&openAIWSCaptureDialer{conn: captureConn})
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          1701,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+		Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-test","stream":true,"input":"hello"}`))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "response.failed", result.UpstreamTerminalEvent)
+	require.Contains(t, rec.Body.String(), responseFailedCustomMessage)
+	require.NotContains(t, rec.Body.String(), responseFailedUpstreamMessage)
+	streamErr, marked := GetOpsStreamError(c)
+	require.True(t, marked)
+	require.Equal(t, responseFailedCustomStatus, streamErr.IntendedStatus)
+	require.Equal(t, responseFailedCustomMessage, streamErr.Message)
+}
+
+func TestProxyResponsesWebSocketFromClientCtxPoolResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := newOpenAIWSV2TestConfig()
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModeCtxPool
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	upstreamConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.failed","response":{"id":"resp_ingress_failed","model":"gpt-test","error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`),
+	}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(&openAIWSCaptureDialer{conn: upstreamConn})
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          1702,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_mode": OpenAIWSIngressModeCtxPool,
+		},
+	}
+
+	type proxyResult struct {
+		err       error
+		streamErr OpsStreamError
+		marked    bool
+		skipped   bool
+	}
+	resultCh := make(chan proxyResult, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			resultCh <- proxyResult{err: err}
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		readCtx, cancelRead := context.WithTimeout(r.Context(), 3*time.Second)
+		_, firstMessage, readErr := conn.Read(readCtx)
+		cancelRead()
+		if readErr != nil {
+			resultCh <- proxyResult{err: readErr}
+			return
+		}
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		ginCtx.Request = r.Clone(r.Context())
+		bindResponseFailedKeywordPassthroughRule(ginCtx)
+		proxyErr := svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+		streamErr, marked := GetOpsStreamError(ginCtx)
+		skipped, _ := ginCtx.Get(OpsSkipPassthroughKey)
+		resultCh <- proxyResult{err: proxyErr, streamErr: streamErr, marked: marked, skipped: skipped == true}
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-test","stream":false}`))
+	cancelWrite()
+	require.NoError(t, err)
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, event, err := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, responseFailedCustomMessage, gjson.GetBytes(event, "response.error.message").String())
+	require.NotContains(t, string(event), responseFailedUpstreamMessage)
+	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+
+	select {
+	case proxy := <-resultCh:
+		require.NoError(t, proxy.err)
+		require.True(t, proxy.marked)
+		require.Equal(t, responseFailedCustomStatus, proxy.streamErr.IntendedStatus)
+		require.Equal(t, responseFailedCustomMessage, proxy.streamErr.Message)
+		require.True(t, proxy.skipped)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ctx_pool websocket proxy to exit")
+	}
+}
+
+func TestProxyOpenAIWSHTTPBridgeTurnResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	failedEvent := `{"type":"response.failed","response":{"id":"resp_bridge_failed","error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader("data: " + failedEvent + "\n\n")),
+	}}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream, toolCorrector: NewCodexToolCorrector()}
+	account := &Account{
+		ID:          1703,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	bindResponseFailedKeywordPassthroughRule(c)
+	payload := []byte(`{"type":"response.create","model":"gpt-test","stream":false,"input":"hello"}`)
+	var frames [][]byte
+
+	result, err := svc.proxyOpenAIWSHTTPBridgeTurn(
+		context.Background(),
+		c,
+		account,
+		"sk-test",
+		payload,
+		len(payload),
+		"gpt-test",
+		"",
+		"",
+		"",
+		"",
+		1,
+		func(frame []byte) error {
+			frames = append(frames, append([]byte(nil), frame...))
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "response.failed", result.UpstreamTerminalEvent)
+	require.Len(t, frames, 1)
+	require.Equal(t, responseFailedCustomMessage, gjson.GetBytes(frames[0], "response.error.message").String())
+	require.NotContains(t, string(frames[0]), responseFailedUpstreamMessage)
+	streamErr, marked := GetOpsStreamError(c)
+	require.True(t, marked)
+	require.Equal(t, responseFailedCustomStatus, streamErr.IntendedStatus)
+}
+
+func TestOpenAIWSPassthroughResponseFailedHonorsKeywordPassthroughRule(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.failed","response":{"id":"resp_passthrough_failed","error":{"code":"server_is_overloaded","message":"` + responseFailedUpstreamMessage + `"}}}`)
+	server, serverErr := startPassthroughLifecycleServer(
+		t,
+		controlCtx,
+		newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
+		passthroughLifecycleAccount(),
+		newResponseFailedKeywordPassthroughService(),
+	)
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	event, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, responseFailedCustomMessage, gjson.GetBytes(event, "response.error.message").String())
+	require.NotContains(t, string(event), responseFailedUpstreamMessage)
+	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+
+	select {
+	case <-serverErr:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for passthrough websocket proxy to exit")
+	}
+}

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -28,6 +28,7 @@ type openAIWSClientFrameConn struct {
 	// The relay observes upstream payloads, while clients must keep seeing the
 	// model identifier they supplied for the current turn.
 	restoreResponseModel func([]byte) []byte
+	rewriteResponse      func([]byte) []byte
 }
 
 // openAIWSPolicyEnforcingFrameConn wraps a client-side FrameConn and runs
@@ -639,6 +640,9 @@ func (c *openAIWSClientFrameConn) WriteFrame(ctx context.Context, msgType coderw
 		if c.restoreResponseModel != nil {
 			payload = c.restoreResponseModel(payload)
 		}
+		if c.rewriteResponse != nil {
+			payload = c.rewriteResponse(payload)
+		}
 	}
 	return c.conn.Write(ctx, msgType, payload)
 }
@@ -915,6 +919,18 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			}
 			requestModel, upstreamModel := usageMeta.turnModels("")
 			return replaceOpenAIWSMessageModel(payload, upstreamModel, requestModel)
+		},
+		rewriteResponse: func(payload []byte) []byte {
+			eventType, _, _ := parseOpenAIWSEventEnvelope(payload)
+			if eventType != "response.failed" {
+				return payload
+			}
+			failedMessage := extractOpenAISSEErrorMessage(payload)
+			updatedPayload, status, errType, errMsg, _ := applyOpenAIStreamFailedEventPassthroughRule(
+				c, account, payload, failedMessage,
+			)
+			MarkOpsStreamError(c, errType, errMsg, status)
+			return updatedPayload
 		},
 	}
 	policyClientConn := &openAIWSPolicyEnforcingFrameConn{

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -152,6 +152,7 @@ func startPassthroughLifecycleServer(
 	controlCtx context.Context,
 	svc *OpenAIGatewayService,
 	account *Account,
+	ruleServices ...*ErrorPassthroughService,
 ) (*httptest.Server, <-chan error) {
 	t.Helper()
 	serverErr := make(chan error, 1)
@@ -184,6 +185,9 @@ func startPassthroughLifecycleServer(
 		req := r.Clone(controlCtx)
 		req.Header = req.Header.Clone()
 		ginCtx.Request = req
+		if len(ruleServices) > 0 {
+			BindErrorPassthroughService(ginCtx, ruleServices[0])
+		}
 		serverErr <- svc.ProxyResponsesWebSocketFromClient(controlCtx, ginCtx, conn, account, "sk-test", firstMessage, nil)
 	}))
 	return server, serverErr


### PR DESCRIPTION
## Summary

- apply existing error passthrough rules to in-band OpenAI `response.failed` events after an SSE response has already started
- cover non-streaming SSE-to-JSON conversion and all Responses WebSocket forwarding modes
- preserve the original upstream payload for failover, account health, and cooldown decisions while only rewriting the client-facing error message
- record the configured logical status and `skip_monitoring` result even when the wire status is already HTTP 200 or the transport is WebSocket

## Problem

The Responses API can return HTTP 200 and later terminate with a `response.failed` event. The existing implementation only evaluated passthrough rules before client output started, and WebSocket requests did not bind/evaluate the passthrough service. Keyword rules such as `Our servers are currently overloaded` were therefore skipped on those paths.

## Verification

- targeted HTTP and WebSocket `response.failed` regression tests
- `go test ./internal/service ./internal/handler -count=1`
- `go test ./... -count=1`
- `golangci-lint run ./...`
- `CGO_ENABLED=0 go build -trimpath -o /tmp/sub2api-upstream-pr-server ./cmd/server`
- `git diff --check upstream/main...HEAD`