### PR TITLE
fix(payment): 保存系统设置时不再清空可见支付方式配置

### DIFF
--- a/backend/internal/service/payment_config_service.go
+++ b/backend/internal/service/payment_config_service.go
@@ -343,38 +343,87 @@ func (s *PaymentConfigService) UpdatePaymentConfig(ctx context.Context, req Upda
 			return infraerrors.BadRequest("INVALID_RECHARGE_FEE_RATE", "recharge fee rate allows at most 2 decimal places")
 		}
 	}
-	m := map[string]string{
-		SettingPaymentEnabled:                    formatBoolOrEmpty(req.Enabled),
-		SettingMinRechargeAmount:                 formatPositiveFloat(req.MinAmount),
-		SettingMaxRechargeAmount:                 formatPositiveFloat(req.MaxAmount),
-		SettingDailyRechargeLimit:                formatPositiveFloat(req.DailyLimit),
-		SettingOrderTimeoutMinutes:               formatPositiveInt(req.OrderTimeoutMin),
-		SettingMaxPendingOrders:                  formatPositiveInt(req.MaxPendingOrders),
-		SettingBalancePayDisabled:                formatBoolOrEmpty(req.BalanceDisabled),
-		SettingBalanceRechargeMult:               formatPositiveFloat(req.BalanceRechargeMultiplier),
-		SettingSubscriptionUSDToCNYRate:          formatPositiveFloatExact(req.SubscriptionUSDToCNYRate),
-		SettingRechargeFeeRate:                   formatNonNegativeFloat(req.RechargeFeeRate),
-		SettingLoadBalanceStrategy:               derefStr(req.LoadBalanceStrategy),
-		SettingProductNamePrefix:                 derefStr(req.ProductNamePrefix),
-		SettingProductNameSuffix:                 derefStr(req.ProductNameSuffix),
-		SettingHelpImageURL:                      derefStr(req.HelpImageURL),
-		SettingHelpText:                          derefStr(req.HelpText),
-		SettingCancelRateLimitOn:                 formatBoolOrEmpty(req.CancelRateLimitEnabled),
-		SettingCancelRateLimitMax:                formatPositiveInt(req.CancelRateLimitMax),
-		SettingCancelWindowSize:                  formatPositiveInt(req.CancelRateLimitWindow),
-		SettingCancelWindowUnit:                  derefStr(req.CancelRateLimitUnit),
-		SettingCancelWindowMode:                  derefStr(req.CancelRateLimitMode),
-		SettingAlipayForceQRCode:                 formatBoolOrEmpty(req.AlipayForceQRCode),
-		SettingAlipayMobilePrecreateDeepLink:     formatBoolOrEmpty(req.AlipayMobilePrecreateDeepLink),
-		SettingPaymentVisibleMethodAlipaySource:  derefStr(req.VisibleMethodAlipaySource),
-		SettingPaymentVisibleMethodWxpaySource:   derefStr(req.VisibleMethodWxpaySource),
-		SettingPaymentVisibleMethodAlipayEnabled: formatBoolOrEmpty(req.VisibleMethodAlipayEnabled),
-		SettingPaymentVisibleMethodWxpayEnabled:  formatBoolOrEmpty(req.VisibleMethodWxpayEnabled),
+	m := make(map[string]string)
+	if req.Enabled != nil {
+		m[SettingPaymentEnabled] = formatBoolOrEmpty(req.Enabled)
+	}
+	if req.MinAmount != nil {
+		m[SettingMinRechargeAmount] = formatPositiveFloat(req.MinAmount)
+	}
+	if req.MaxAmount != nil {
+		m[SettingMaxRechargeAmount] = formatPositiveFloat(req.MaxAmount)
+	}
+	if req.DailyLimit != nil {
+		m[SettingDailyRechargeLimit] = formatPositiveFloat(req.DailyLimit)
+	}
+	if req.OrderTimeoutMin != nil {
+		m[SettingOrderTimeoutMinutes] = formatPositiveInt(req.OrderTimeoutMin)
+	}
+	if req.MaxPendingOrders != nil {
+		m[SettingMaxPendingOrders] = formatPositiveInt(req.MaxPendingOrders)
 	}
 	if req.EnabledTypes != nil {
 		m[SettingEnabledPaymentTypes] = strings.Join(req.EnabledTypes, ",")
-	} else {
-		m[SettingEnabledPaymentTypes] = ""
+	}
+	if req.BalanceDisabled != nil {
+		m[SettingBalancePayDisabled] = formatBoolOrEmpty(req.BalanceDisabled)
+	}
+	if req.BalanceRechargeMultiplier != nil {
+		m[SettingBalanceRechargeMult] = formatPositiveFloat(req.BalanceRechargeMultiplier)
+	}
+	if req.SubscriptionUSDToCNYRate != nil {
+		m[SettingSubscriptionUSDToCNYRate] = formatPositiveFloatExact(req.SubscriptionUSDToCNYRate)
+	}
+	if req.RechargeFeeRate != nil {
+		m[SettingRechargeFeeRate] = formatNonNegativeFloat(req.RechargeFeeRate)
+	}
+	if req.LoadBalanceStrategy != nil {
+		m[SettingLoadBalanceStrategy] = derefStr(req.LoadBalanceStrategy)
+	}
+	if req.ProductNamePrefix != nil {
+		m[SettingProductNamePrefix] = derefStr(req.ProductNamePrefix)
+	}
+	if req.ProductNameSuffix != nil {
+		m[SettingProductNameSuffix] = derefStr(req.ProductNameSuffix)
+	}
+	if req.HelpImageURL != nil {
+		m[SettingHelpImageURL] = derefStr(req.HelpImageURL)
+	}
+	if req.HelpText != nil {
+		m[SettingHelpText] = derefStr(req.HelpText)
+	}
+	if req.CancelRateLimitEnabled != nil {
+		m[SettingCancelRateLimitOn] = formatBoolOrEmpty(req.CancelRateLimitEnabled)
+	}
+	if req.CancelRateLimitMax != nil {
+		m[SettingCancelRateLimitMax] = formatPositiveInt(req.CancelRateLimitMax)
+	}
+	if req.CancelRateLimitWindow != nil {
+		m[SettingCancelWindowSize] = formatPositiveInt(req.CancelRateLimitWindow)
+	}
+	if req.CancelRateLimitUnit != nil {
+		m[SettingCancelWindowUnit] = derefStr(req.CancelRateLimitUnit)
+	}
+	if req.CancelRateLimitMode != nil {
+		m[SettingCancelWindowMode] = derefStr(req.CancelRateLimitMode)
+	}
+	if req.AlipayForceQRCode != nil {
+		m[SettingAlipayForceQRCode] = formatBoolOrEmpty(req.AlipayForceQRCode)
+	}
+	if req.AlipayMobilePrecreateDeepLink != nil {
+		m[SettingAlipayMobilePrecreateDeepLink] = formatBoolOrEmpty(req.AlipayMobilePrecreateDeepLink)
+	}
+	if req.VisibleMethodAlipaySource != nil {
+		m[SettingPaymentVisibleMethodAlipaySource] = derefStr(req.VisibleMethodAlipaySource)
+	}
+	if req.VisibleMethodWxpaySource != nil {
+		m[SettingPaymentVisibleMethodWxpaySource] = derefStr(req.VisibleMethodWxpaySource)
+	}
+	if req.VisibleMethodAlipayEnabled != nil {
+		m[SettingPaymentVisibleMethodAlipayEnabled] = formatBoolOrEmpty(req.VisibleMethodAlipayEnabled)
+	}
+	if req.VisibleMethodWxpayEnabled != nil {
+		m[SettingPaymentVisibleMethodWxpayEnabled] = formatBoolOrEmpty(req.VisibleMethodWxpayEnabled)
 	}
 	return s.settingRepo.SetMultiple(ctx, m)
 }

--- a/backend/internal/service/payment_config_service_test.go
+++ b/backend/internal/service/payment_config_service_test.go
@@ -441,7 +441,12 @@ func (s *paymentConfigSettingRepoStub) GetAll(context.Context) (map[string]strin
 func (s *paymentConfigSettingRepoStub) Delete(context.Context, string) error { return nil }
 
 func TestUpdatePaymentConfig_PersistsVisibleMethodRouting(t *testing.T) {
-	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{
+		SettingPaymentVisibleMethodAlipayEnabled: "false",
+		SettingPaymentVisibleMethodAlipaySource:  VisibleMethodSourceOfficialAlipay,
+		SettingPaymentVisibleMethodWxpayEnabled:  "true",
+		SettingPaymentVisibleMethodWxpaySource:   VisibleMethodSourceEasyPayWechat,
+	}}
 	svc := &PaymentConfigService{settingRepo: repo}
 
 	alipayEnabled := true
@@ -467,6 +472,82 @@ func TestUpdatePaymentConfig_PersistsVisibleMethodRouting(t *testing.T) {
 	}
 	if repo.values[SettingPaymentVisibleMethodWxpaySource] != VisibleMethodSourceOfficialWechat {
 		t.Fatalf("wxpay source = %q, want %q", repo.values[SettingPaymentVisibleMethodWxpaySource], VisibleMethodSourceOfficialWechat)
+	}
+}
+
+func TestUpdatePaymentConfig_OmittedVisibleMethodRoutingIsPreserved(t *testing.T) {
+	wantVisibleMethods := map[string]string{
+		SettingPaymentVisibleMethodAlipayEnabled: "true",
+		SettingPaymentVisibleMethodAlipaySource:  VisibleMethodSourceEasyPayAlipay,
+		SettingPaymentVisibleMethodWxpayEnabled:  "false",
+		SettingPaymentVisibleMethodWxpaySource:   VisibleMethodSourceOfficialWechat,
+	}
+	initial := make(map[string]string, len(wantVisibleMethods))
+	for key, value := range wantVisibleMethods {
+		initial[key] = value
+	}
+	repo := &paymentConfigSettingRepoStub{values: initial}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	enabled := true
+	err := svc.UpdatePaymentConfig(context.Background(), UpdatePaymentConfigRequest{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("UpdatePaymentConfig returned error: %v", err)
+	}
+
+	visibleMethodKeys := []string{
+		SettingPaymentVisibleMethodAlipayEnabled,
+		SettingPaymentVisibleMethodAlipaySource,
+		SettingPaymentVisibleMethodWxpayEnabled,
+		SettingPaymentVisibleMethodWxpaySource,
+	}
+	for _, key := range visibleMethodKeys {
+		if _, ok := repo.updates[key]; ok {
+			t.Fatalf("omitted visible method setting %q was written", key)
+		}
+		if repo.values[key] != wantVisibleMethods[key] {
+			t.Fatalf("visible method setting %q = %q, want preserved value %q", key, repo.values[key], wantVisibleMethods[key])
+		}
+	}
+	if repo.updates[SettingPaymentEnabled] != "true" {
+		t.Fatalf("payment enabled update = %q, want true", repo.updates[SettingPaymentEnabled])
+	}
+}
+
+func TestUpdatePaymentConfig_PersistsExplicitEmptyAndFalseValues(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{
+		SettingEnabledPaymentTypes: "alipay,wxpay",
+		SettingBalancePayDisabled:  "true",
+		SettingProductNamePrefix:   "existing",
+	}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	falseValue := false
+	emptyString := ""
+	err := svc.UpdatePaymentConfig(context.Background(), UpdatePaymentConfigRequest{
+		EnabledTypes:      []string{},
+		BalanceDisabled:   &falseValue,
+		ProductNamePrefix: &emptyString,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePaymentConfig returned error: %v", err)
+	}
+
+	want := map[string]string{
+		SettingEnabledPaymentTypes: "",
+		SettingBalancePayDisabled:  "false",
+		SettingProductNamePrefix:   "",
+	}
+	if len(repo.updates) != len(want) {
+		t.Fatalf("updates = %v, want exactly %v", repo.updates, want)
+	}
+	for key, value := range want {
+		if repo.updates[key] != value {
+			t.Fatalf("update %q = %q, want %q", key, repo.updates[key], value)
+		}
+		if repo.values[key] != value {
+			t.Fatalf("stored %q = %q, want %q", key, repo.values[key], value)
+		}
 	}
 }
 


### PR DESCRIPTION
## 问题

管理员每次在系统设置页点保存，支付宝/微信的**可见支付方式路由配置都会被静默重置**，无任何提示。

### 成因

`UpdatePaymentConfig` 无条件写入全部设置键。未传的指针字段经 `derefStr(nil)` / `formatBoolOrEmpty(nil)` 转成空串后，**照样会落库**：

```go
m := map[string]string{
    // ...
    SettingPaymentVisibleMethodAlipaySource:  derefStr(req.VisibleMethodAlipaySource),   // nil → ""
    SettingPaymentVisibleMethodAlipayEnabled: formatBoolOrEmpty(req.VisibleMethodAlipayEnabled), // nil → ""
    // ...
}
```

而 `setting_handler_update.go` 构造 `UpdatePaymentConfigRequest` 时**从不填充** `VisibleMethod*` 这四个字段。加上写入顺序，结果是先写对、再擦掉：

1. `UpdateSettingsWithAuthSourceDefaultsOmitting` 先写入正确的 visible-method 值（`setting_update.go`）
2. `UpdatePaymentConfig` 紧接着把这四个键覆盖成 `""`（`setting_handler_update.go`）
3. `setting_parse.go` 把 `""` 解析为「来源未设置 + enabled=false」

于是配置被静默清空。

### 影响范围

任何启用了自定义可见支付方式路由（如支付宝走官方、微信走易支付）的部署，只要管理员保存过一次系统设置，路由就会退回默认值，用户侧可能看到错误的支付渠道或支付方式消失。

## 修复

改为**仅写入调用方显式提供的字段**，符合 PATCH 语义：

```go
m := make(map[string]string)
if req.Enabled != nil {
    m[SettingPaymentEnabled] = formatBoolOrEmpty(req.Enabled)
}
// ... 其余字段同理
```

`EnabledTypes` 是 `[]string` 而非指针，传空切片 `[]string{}` 仍可显式清空，行为不变。

## 为什么原有回归测试没抓到

`TestSettingHandler_UpdateSettings_PersistsPaymentVisibleMethodsAndAdvancedScheduler` 构造 handler 时传的 `paymentConfigService = nil`，`hasPaymentFields(req)` 那个分支根本没有执行，覆盖不到这条路径。

## 验证

新增两个测试：

- `TestUpdatePaymentConfig_OmittedVisibleMethodRoutingIsPreserved` —— 只更新 `Enabled` 时，四个 visible-method 键不被写入、原值保留
- `TestUpdatePaymentConfig_PersistsExplicitEmptyAndFalseValues` —— 显式传 `[]string{}` / `false` / `""` 仍能正确落库，且不误写其他键

同时给 `TestUpdatePaymentConfig_PersistsVisibleMethodRouting` 补上初始值，让它能验证「覆盖」而非「从空写入」。

在**未修复**的代码上跑新测试会失败，输出直观暴露了问题——只想更新 3 个字段，实际写了 26 个键：

```
--- FAIL: TestUpdatePaymentConfig_OmittedVisibleMethodRoutingIsPreserved
    omitted visible method setting "payment_visible_method_alipay_enabled" was written
--- FAIL: TestUpdatePaymentConfig_PersistsExplicitEmptyAndFalseValues
    updates = map[... payment_visible_method_alipay_enabled: payment_visible_method_alipay_source:
    payment_visible_method_wxpay_enabled: payment_visible_method_wxpay_source: ...],
    want exactly map[BALANCE_PAYMENT_DISABLED:false ENABLED_PAYMENT_TYPES: PRODUCT_NAME_PREFIX:]
```

修复后：

```
go build ./...                                          # 通过
go vet ./internal/service/... ./internal/handler/...     # 通过
go test ./internal/service/... ./internal/handler/...    # 全部 ok
```

## 兼容性说明

`PUT /admin/payment/config` 的行为有一处变化：省略 `enabled_payment_types` 不再等同于清空。前端每次保存都会发送该字段（非 nil），因此站内无影响；外部脚本若依赖「省略即清空」这一未文档化行为，需改为显式传 `[]`。
