### PR TITLE
feat(security-audit): 提示词审计支持不同的内容审核模式

### DIFF
--- a/backend/internal/securityaudit/prompt_config.go
+++ b/backend/internal/securityaudit/prompt_config.go
@@ -14,17 +14,20 @@ import (
 )
 
 const (
-	DefaultWorkerCount   = 4
-	MaxWorkerCount       = 32
-	DefaultQueueCapacity = 32768
-	MaxQueueCapacity     = 100000
-	DefaultTimeoutMS     = 3000
-	MinTimeoutMS         = 100
-	MaxTimeoutMS         = 30000
-	DefaultInputLimit    = 4000
-	MinInputLimit        = 128
-	MaxInputLimit        = 100000
-	DefaultPayloadTTL    = 30 * time.Minute
+	DefaultWorkerCount          = 4
+	MaxWorkerCount              = 32
+	DefaultQueueCapacity        = 32768
+	MaxQueueCapacity            = 100000
+	DefaultTimeoutMS            = 3000
+	MinTimeoutMS                = 100
+	MaxTimeoutMS                = 30000
+	DefaultInputLimit           = 4000
+	MinInputLimit               = 128
+	MaxInputLimit               = 100000
+	DefaultPayloadTTL           = 30 * time.Minute
+	PromptSelectionLastUserOnly = "last_user_only"
+	PromptSelectionAfterLastAI  = "after_last_ai"
+	PromptSelectionFullContext  = "full_context"
 )
 
 type SecretEncryptor interface {
@@ -67,6 +70,7 @@ type storageConfig struct {
 	Enabled         bool              `json:"enabled"`
 	BlockingEnabled bool              `json:"blocking_enabled"`
 	StorePassEvents bool              `json:"store_pass_events"`
+	PromptSelection string            `json:"prompt_selection"`
 	Strategy        string            `json:"strategy"`
 	WorkerCount     int               `json:"worker_count"`
 	QueueCapacity   int               `json:"queue_capacity"`
@@ -102,6 +106,7 @@ type ActiveConfig struct {
 	Enabled            bool
 	BlockingEnabled    bool
 	StorePassEvents    bool
+	PromptSelection    string
 	Strategy           string
 	WorkerCount        int
 	QueueCapacity      int
@@ -132,6 +137,7 @@ type PublicConfig struct {
 	Enabled         bool             `json:"enabled"`
 	BlockingEnabled bool             `json:"blocking_enabled"`
 	StorePassEvents bool             `json:"store_pass_events"`
+	PromptSelection string           `json:"prompt_selection"`
 	EffectiveMode   Mode             `json:"effective_mode"`
 	Strategy        string           `json:"strategy"`
 	WorkerCount     int              `json:"worker_count"`
@@ -164,6 +170,7 @@ type UpdateConfigRequest struct {
 	Enabled               bool             `json:"enabled"`
 	BlockingEnabled       bool             `json:"blocking_enabled"`
 	StorePassEvents       bool             `json:"store_pass_events"`
+	PromptSelection       string           `json:"prompt_selection"`
 	Strategy              string           `json:"strategy"`
 	WorkerCount           int              `json:"worker_count"`
 	QueueCapacity         int              `json:"queue_capacity"`
@@ -178,6 +185,7 @@ func DefaultStorageConfig() storageConfig {
 		Enabled:         false,
 		BlockingEnabled: false,
 		StorePassEvents: false,
+		PromptSelection: PromptSelectionFullContext,
 		Strategy:        "priority",
 		WorkerCount:     DefaultWorkerCount,
 		QueueCapacity:   DefaultQueueCapacity,
@@ -225,6 +233,10 @@ func normalizeStorageConfig(cfg *storageConfig) {
 	}
 	cfg.Scanners = canonicalScannerIDs(cfg.Scanners)
 	cfg.GroupIDs = canonicalInt64s(cfg.GroupIDs)
+	cfg.PromptSelection = strings.ToLower(strings.TrimSpace(cfg.PromptSelection))
+	if cfg.PromptSelection == "" {
+		cfg.PromptSelection = PromptSelectionFullContext
+	}
 	// Preserve an invalid blocking-without-audit combination so validation can
 	// reject it instead of silently changing administrator intent.
 	for i := range cfg.Endpoints {
@@ -255,6 +267,9 @@ func validateStorageConfig(cfg storageConfig) error {
 	}
 	if cfg.Strategy != "priority" {
 		return infraerrors.BadRequest("prompt_audit_invalid_strategy", "提示词审计策略仅支持 priority")
+	}
+	if cfg.PromptSelection != PromptSelectionLastUserOnly && cfg.PromptSelection != PromptSelectionAfterLastAI && cfg.PromptSelection != PromptSelectionFullContext {
+		return infraerrors.BadRequest("prompt_audit_invalid_prompt_selection", "提示词审计选取策略无效")
 	}
 	if cfg.WorkerCount < 1 || cfg.WorkerCount > MaxWorkerCount {
 		return infraerrors.BadRequest("prompt_audit_invalid_worker_count", "Worker 数量超出允许范围")
@@ -303,6 +318,10 @@ func validateStorageConfig(cfg storageConfig) error {
 func validateUpdateConfigRequest(req UpdateConfigRequest) error {
 	if strings.TrimSpace(req.Strategy) != "priority" {
 		return infraerrors.BadRequest("prompt_audit_invalid_strategy", "提示词审计策略仅支持 priority")
+	}
+	selection := strings.ToLower(strings.TrimSpace(req.PromptSelection))
+	if selection != "" && selection != PromptSelectionLastUserOnly && selection != PromptSelectionAfterLastAI && selection != PromptSelectionFullContext {
+		return infraerrors.BadRequest("prompt_audit_invalid_prompt_selection", "提示词审计选取策略无效")
 	}
 	if req.WorkerCount < 1 || req.WorkerCount > MaxWorkerCount {
 		return infraerrors.BadRequest("prompt_audit_invalid_worker_count", "Worker 数量超出允许范围")
@@ -407,7 +426,7 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 	}
 	active := ActiveConfig{RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled}
 	return PublicConfig{
-		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, StorePassEvents: cfg.StorePassEvents,
+		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, StorePassEvents: cfg.StorePassEvents, PromptSelection: cfg.PromptSelection,
 		EffectiveMode: active.EffectiveMode(), Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: scanners, AllGroups: cfg.AllGroups,
 		GroupIDs: groupIDs, Endpoints: endpoints, ConfigVersion: cfg.ConfigVersion,
@@ -417,7 +436,7 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool, invalidTokenE
 
 func ActiveFromStorage(cfg storageConfig, riskControlEnabled bool, encryptor SecretEncryptor) (ActiveConfig, error) {
 	active := ActiveConfig{
-		RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled,
+		RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, PromptSelection: cfg.PromptSelection,
 		StorePassEvents: cfg.StorePassEvents, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: append([]string(nil), cfg.Scanners...), AllGroups: cfg.AllGroups,
 		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ConfigVersion: cfg.ConfigVersion,
@@ -457,12 +476,13 @@ func changeSummary(cfg storageConfig) string {
 		Enabled         bool   `json:"enabled"`
 		BlockingEnabled bool   `json:"blocking_enabled"`
 		StorePassEvents bool   `json:"store_pass_events"`
+		PromptSelection string `json:"prompt_selection"`
 		EndpointCount   int    `json:"endpoint_count"`
 		ScannerCount    int    `json:"scanner_count"`
 		AllGroups       bool   `json:"all_groups"`
 		GroupCount      int    `json:"group_count"`
 		GroupHash       string `json:"group_hash"`
-	}{cfg.Enabled, cfg.BlockingEnabled, cfg.StorePassEvents, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), ""}
+	}{cfg.Enabled, cfg.BlockingEnabled, cfg.StorePassEvents, cfg.PromptSelection, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), ""}
 	rawGroups, _ := json.Marshal(cfg.GroupIDs)
 	digest := sha256.Sum256(rawGroups)
 	summary.GroupHash = hex.EncodeToString(digest[:])

--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -335,7 +335,7 @@ func (m *ConfigManager) buildNextStorage(current storageConfig, req UpdateConfig
 		currentByID[endpoint.ID] = endpoint
 	}
 	next := storageConfig{
-		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, StorePassEvents: req.StorePassEvents,
+		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, StorePassEvents: req.StorePassEvents, PromptSelection: strings.ToLower(strings.TrimSpace(req.PromptSelection)),
 		Strategy: strings.TrimSpace(req.Strategy), WorkerCount: req.WorkerCount,
 		QueueCapacity: req.QueueCapacity, Scanners: append([]string(nil), req.Scanners...),
 		AllGroups: req.AllGroups, GroupIDs: append([]int64(nil), req.GroupIDs...),

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -36,10 +36,31 @@ func TestDefaultConfigIsOff(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ModeOff, active.EffectiveMode())
 	require.Equal(t, AllScannerIDs, storage.Scanners)
+	require.Equal(t, PromptSelectionFullContext, storage.PromptSelection)
 	publicJSON, err := json.Marshal(PublicFromStorage(storage, true, nil))
 	require.NoError(t, err)
 	require.Contains(t, string(publicJSON), `"group_ids":[]`)
 	require.Contains(t, string(publicJSON), `"endpoints":[]`)
+}
+
+func TestPromptSelectionDefaults(t *testing.T) {
+	legacy, err := ParseStorageConfig(`{"last_user_only":true}`)
+	require.NoError(t, err)
+	require.Equal(t, PromptSelectionFullContext, legacy.PromptSelection)
+
+	empty, err := ParseStorageConfig(`{"prompt_selection":""}`)
+	require.NoError(t, err)
+	require.Equal(t, PromptSelectionFullContext, empty.PromptSelection)
+
+	_, err = ParseStorageConfig(`{"prompt_selection":"unsupported"}`)
+	require.Error(t, err)
+	require.Equal(t, "prompt_audit_invalid_prompt_selection", infraerrors.Reason(err))
+
+	req := promptAuditUpdateRequest(1, 1, "")
+	req.PromptSelection = PromptSelectionAfterLastAI
+	require.NoError(t, validateUpdateConfigRequest(req))
+	req.PromptSelection = "unsupported"
+	require.Equal(t, "prompt_audit_invalid_prompt_selection", infraerrors.Reason(validateUpdateConfigRequest(req)))
 }
 
 func TestConfigRejectsBlockingWithoutAudit(t *testing.T) {

--- a/backend/internal/securityaudit/prompt_enqueue.go
+++ b/backend/internal/securityaudit/prompt_enqueue.go
@@ -40,7 +40,7 @@ func (e *Enqueuer) Enqueue(ctx context.Context, req Request) error {
 		LogWarn(EventEnqueueDropped, mergeLogFields(baseFields, map[string]any{"status": "dropped", "error_code": "no_enabled_endpoint"}))
 		return nil
 	}
-	snapshot, err := ExtractPromptSnapshot(req)
+	snapshot, err := ExtractPromptSnapshotWithSelection(req, cfg.PromptSelection)
 	if errors.Is(err, ErrNoPromptText) {
 		LogInfo(EventEnqueueSkipped, mergeLogFields(baseFields, map[string]any{"status": "skipped", "error_code": "no_user_text"}))
 		return nil

--- a/backend/internal/securityaudit/prompt_handler.go
+++ b/backend/internal/securityaudit/prompt_handler.go
@@ -227,7 +227,7 @@ func configAuditFields(request UpdateConfigRequest, saved *PublicConfig) map[str
 		version = saved.ConfigVersion
 	}
 	return map[string]any{
-		"enabled": request.Enabled, "blocking_enabled": request.BlockingEnabled,
+		"enabled": request.Enabled, "blocking_enabled": request.BlockingEnabled, "prompt_selection": request.PromptSelection,
 		"config_version": version, "endpoint_count": len(request.Endpoints),
 		"scanner_count": len(request.Scanners), "all_groups": request.AllGroups,
 		"group_count": len(request.GroupIDs),

--- a/backend/internal/securityaudit/prompt_service.go
+++ b/backend/internal/securityaudit/prompt_service.go
@@ -156,7 +156,7 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 	if cfg.EffectiveMode() != ModeBlocking || !cfg.IncludesGroup(req.GroupID) {
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}
-	snapshot, err := ExtractPromptSnapshot(req)
+	snapshot, err := ExtractPromptSnapshotWithSelection(req, cfg.PromptSelection)
 	if errors.Is(err, ErrNoPromptText) {
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}
@@ -345,7 +345,7 @@ func (s *PromptService) resolveProbeEndpoint(input UpdateEndpoint) (ActiveEndpoi
 	if limit == 0 {
 		limit = DefaultInputLimit
 	}
-	storage := storageConfig{Enabled: false, Strategy: "priority", WorkerCount: DefaultWorkerCount, QueueCapacity: DefaultQueueCapacity, Scanners: append([]string(nil), AllScannerIDs...), AllGroups: true,
+	storage := storageConfig{Enabled: false, PromptSelection: PromptSelectionFullContext, Strategy: "priority", WorkerCount: DefaultWorkerCount, QueueCapacity: DefaultQueueCapacity, Scanners: append([]string(nil), AllScannerIDs...), AllGroups: true,
 		Endpoints: []StorageEndpoint{{ID: strings.TrimSpace(input.ID), Name: strings.TrimSpace(input.Name), Protocol: "openai_compatible", BaseURL: baseURL, Model: model, TimeoutMS: timeout, InputLimit: limit}}}
 	if storage.Endpoints[0].ID == "" {
 		storage.Endpoints[0].ID = "probe"

--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -24,16 +24,33 @@ var (
 const promptAuditPrioritySeparator = "\x00SUB2API_PROMPT_AUDIT_PRIORITY_END\x00"
 
 type promptSegment struct {
-	text string
-	user bool
+	text         string
+	user         bool
+	ai           bool
+	messageStart bool
 }
 
 func ExtractPromptSnapshot(req Request) (PromptSnapshot, error) {
+	return ExtractPromptSnapshotWithSelection(req, PromptSelectionFullContext)
+}
+
+func ExtractPromptSnapshotWithSelection(req Request, selection string) (PromptSnapshot, error) {
 	var document any
 	if err := json.Unmarshal(req.Body, &document); err != nil {
 		return PromptSnapshot{}, errors.New("prompt audit request JSON is invalid")
 	}
 	extracted := extractProtocolSegments(req.Protocol, document)
+	switch strings.ToLower(strings.TrimSpace(selection)) {
+	case "", PromptSelectionFullContext:
+		// Keep the full request for the default and historical policy.
+	case PromptSelectionLastUserOnly:
+		// Select the latest user turn even when an assistant or tool turn follows it.
+		extracted = lastUserMessageSegments(extracted)
+	case PromptSelectionAfterLastAI:
+		extracted = segmentsAfterLastAI(extracted)
+	default:
+		return PromptSnapshot{}, errors.New("prompt audit prompt selection is invalid")
+	}
 	segments := normalizeSegmentsLatestUserFirst(extracted)
 	if len(segments) == 0 {
 		return PromptSnapshot{}, ErrNoPromptText
@@ -137,9 +154,7 @@ func extractMessages(value any, wantedRoles ...string) []promptSegment {
 			continue
 		}
 		texts := contentTexts(message["content"])
-		for _, text := range texts {
-			result = append(result, promptSegment{text: text, user: role == "user"})
-		}
+		result = append(result, promptSegmentsForRole(texts, role)...)
 	}
 	return result
 }
@@ -175,7 +190,7 @@ func extractAnthropicSystem(value any) []promptSegment {
 func extractResponses(value any) []promptSegment {
 	switch typed := value.(type) {
 	case string:
-		return []promptSegment{{text: typed, user: true}}
+		return userPromptSegments([]string{typed})
 	case []any:
 		result := make([]promptSegment, 0, len(typed))
 		for _, item := range typed {
@@ -188,11 +203,9 @@ func extractResponses(value any) []promptSegment {
 					continue
 				}
 				if content, exists := entry["content"]; exists {
-					for _, text := range contentTexts(content) {
-						result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
-					}
+					result = append(result, promptSegmentsForRole(contentTexts(content), role)...)
 				} else if text := stringValue(entry["text"]); text != "" {
-					result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
+					result = append(result, promptSegmentsForRole([]string{text}, role)...)
 				}
 			}
 		}
@@ -238,13 +251,15 @@ func extractGemini(value any) []promptSegment {
 			continue
 		}
 		parts, _ := content["parts"].([]any)
+		texts := make([]string, 0, len(parts))
 		for _, part := range parts {
 			if object, ok := part.(map[string]any); ok {
 				if text := stringValue(object["text"]); text != "" {
-					result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
+					texts = append(texts, text)
 				}
 			}
 		}
+		result = append(result, promptSegmentsForRole(texts, role)...)
 	}
 	return result
 }
@@ -312,7 +327,7 @@ func extractGeminiInstances(value any) []promptSegment {
 	for _, item := range instances {
 		if instance, ok := item.(map[string]any); ok {
 			if prompt := stringValue(instance["prompt"]); prompt != "" {
-				result = append(result, promptSegment{text: prompt, user: true})
+				result = append(result, userPromptSegments([]string{prompt})...)
 			}
 		}
 	}
@@ -457,8 +472,70 @@ func buildPrioritizedScanText(segments []string) (scanText string, metadataText 
 
 func promptSegmentsForRole(texts []string, role string) []promptSegment {
 	result := make([]promptSegment, 0, len(texts))
+	role = strings.ToLower(strings.TrimSpace(role))
+	if len(texts) == 0 {
+		if isAIReplyRole(role) {
+			// Tool-call-only replies still delimit prior conversation history.
+			return []promptSegment{{ai: true, messageStart: true}}
+		}
+		return nil
+	}
 	for _, text := range texts {
-		result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
+		result = append(result, promptSegment{text: text, user: role == "" || role == "user", ai: isAIReplyRole(role), messageStart: len(result) == 0})
+	}
+	return result
+}
+
+func isAIReplyRole(role string) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "assistant", "model":
+		return true
+	default:
+		return false
+	}
+}
+
+func segmentsAfterLastAI(values []promptSegment) []promptSegment {
+	lastAI := -1
+	for index, value := range values {
+		if value.ai {
+			lastAI = index
+		}
+	}
+	if lastAI < 0 {
+		return userOnlySegments(values)
+	}
+	return values[lastAI+1:]
+}
+
+func lastUserMessageSegments(values []promptSegment) []promptSegment {
+	lastUser := -1
+	for index := len(values) - 1; index >= 0; index-- {
+		if values[index].user {
+			lastUser = index
+			break
+		}
+	}
+	if lastUser < 0 {
+		return nil
+	}
+	start := lastUser
+	for start > 0 && values[start-1].user && !values[start].messageStart {
+		start--
+	}
+	texts := make([]string, 0, lastUser-start+1)
+	for _, value := range values[start : lastUser+1] {
+		texts = append(texts, value.text)
+	}
+	return userPromptSegments([]string{strings.Join(strings.Fields(strings.Join(texts, "\n")), " ")})
+}
+
+func userOnlySegments(values []promptSegment) []promptSegment {
+	result := make([]promptSegment, 0, len(values))
+	for _, value := range values {
+		if value.user {
+			result = append(result, value)
+		}
 	}
 	return result
 }

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -37,6 +37,68 @@ func TestExtractPromptSnapshotProtocols(t *testing.T) {
 	}
 }
 
+func TestPromptSnapshotSelection(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"system","content":"system policy"},{"role":"user","content":"earlier input"},{"role":"assistant","content":"prior reply"},{"role":"tool","content":"tool context"},{"role":"user","content":"latest input"}]}`)
+
+	full, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: body}, PromptSelectionFullContext)
+	require.NoError(t, err)
+	for _, value := range []string{"system policy", "earlier input", "prior reply", "tool context", "latest input"} {
+		require.Contains(t, full.ScanText, value)
+	}
+
+	lastUser, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: body}, PromptSelectionLastUserOnly)
+	require.NoError(t, err)
+	require.Equal(t, "latest input", metadataTextForTest(lastUser.ScanText))
+
+	afterLastAI, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: body}, PromptSelectionAfterLastAI)
+	require.NoError(t, err)
+	require.Equal(t, "latest input\n\ntool context", metadataTextForTest(afterLastAI.ScanText))
+
+	gemini := []byte(`{"contents":[{"role":"user","parts":[{"text":"before"}]},{"role":"model","parts":[{"text":"model reply"}]},{"role":"user","parts":[{"text":"after"}]}]}`)
+	modelBoundary, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "gemini", Body: gemini}, PromptSelectionAfterLastAI)
+	require.NoError(t, err)
+	require.Equal(t, "after", metadataTextForTest(modelBoundary.ScanText))
+
+	noAI := []byte(`{"messages":[{"role":"system","content":"system policy"},{"role":"user","content":"earlier user input"},{"role":"tool","content":"tool context"},{"role":"user","content":"latest user input"}]}`)
+	userOnly, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: noAI}, PromptSelectionAfterLastAI)
+	require.NoError(t, err)
+	require.Equal(t, "latest user input\n\nearlier user input", metadataTextForTest(userOnly.ScanText))
+
+	noUser := []byte(`{"messages":[{"role":"system","content":"system policy"},{"role":"tool","content":"tool context"}]}`)
+	_, err = ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: noUser}, PromptSelectionAfterLastAI)
+	require.ErrorIs(t, err, ErrNoPromptText)
+}
+
+func TestPromptSnapshotLastUserOnlySelectsLatestUserMessage(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"system","content":"system instruction"},
+			{"role":"user","content":"historical user input"},
+			{"role":"assistant","content":"historical assistant output"},
+			{"role":"user","content":[{"type":"text","text":"  final   user input  "}]},
+			{"role":"assistant","content":"tool call"}
+		]
+	}`)
+	snapshot, err := ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: body}, PromptSelectionLastUserOnly)
+	require.NoError(t, err)
+	require.Equal(t, "final user input", snapshot.FullPrompt)
+	require.Equal(t, 1, snapshot.MessageCount)
+
+	toolLoop := []byte(`{"messages":[{"role":"user","content":"original request"},{"role":"assistant","content":"tool call"}]}`)
+	snapshot, err = ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: toolLoop}, PromptSelectionLastUserOnly)
+	require.NoError(t, err)
+	require.Equal(t, "original request", snapshot.ScanText)
+
+	adjacentUsers := []byte(`{"messages":[{"role":"user","content":"first user message"},{"role":"user","content":"last user message"}]}`)
+	snapshot, err = ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: adjacentUsers}, PromptSelectionLastUserOnly)
+	require.NoError(t, err)
+	require.Equal(t, "last user message", snapshot.ScanText)
+
+	noUser := []byte(`{"messages":[{"role":"system","content":"system instruction"},{"role":"assistant","content":"assistant output"}]}`)
+	_, err = ExtractPromptSnapshotWithSelection(Request{Protocol: "openai_chat_completions", Body: noUser}, PromptSelectionLastUserOnly)
+	require.ErrorIs(t, err, ErrNoPromptText)
+}
+
 func TestSnapshotRedactsCanariesAndPreservesHashOfScanText(t *testing.T) {
 	body := `{"messages":[{"role":"user","content":"PROMPT_CANARY_ABC123 email@example.com +86 138 0013 8000 Bearer AUTH_CANARY_XYZ sk-secretvalue123 password=supersecret123"}]}`
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(body)})

--- a/frontend/src/features/prompt-audit/PromptAuditView.vue
+++ b/frontend/src/features/prompt-audit/PromptAuditView.vue
@@ -96,6 +96,20 @@
           <SaveToggle :label="t('admin.promptAudit.saveBar.enabled')" :model-value="draft.enabled" data-test="enabled-toggle" @update:model-value="setEnabled" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.blocking')" :model-value="draft.blocking_enabled" :disabled="!draft.enabled" data-test="blocking-toggle" @update:model-value="setBlocking" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.storePass')" :model-value="draft.store_pass_events" data-test="store-pass-toggle" @update:model-value="replaceDraft({ ...draft!, store_pass_events: $event })" />
+          <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-dark-200">
+            <span>{{ t('admin.promptAudit.saveBar.promptSelection') }}</span>
+            <select
+              :value="draft.prompt_selection"
+              class="input py-1.5 text-sm"
+              data-test="prompt-selection"
+              :aria-label="t('admin.promptAudit.saveBar.promptSelection')"
+              @change="replaceDraft({ ...draft!, prompt_selection: ($event.target as HTMLSelectElement).value as PromptAuditDraft['prompt_selection'] })"
+            >
+              <option value="full_context">{{ t('admin.promptAudit.saveBar.fullContext') }}</option>
+              <option value="last_user_only">{{ t('admin.promptAudit.saveBar.lastUserOnly') }}</option>
+              <option value="after_last_ai">{{ t('admin.promptAudit.saveBar.afterLastAI') }}</option>
+            </select>
+          </label>
         </div>
         <div class="flex items-center gap-3">
           <span class="text-sm" :class="dirty ? 'text-amber-700 dark:text-amber-300' : 'text-gray-500 dark:text-dark-400'">

--- a/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
@@ -19,7 +19,7 @@ vi.mock('vue-i18n', async () => {
 })
 
 const baseConfig = (): PromptAuditConfig => ({
-  enabled: true, blocking_enabled: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+  enabled: true, blocking_enabled: false, store_pass_events: false, prompt_selection: 'full_context', effective_mode: 'async_audit', strategy: 'priority',
   worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: true, group_ids: [],
   endpoints: [{ id: 'guard-1', name: 'Guard One', protocol: 'openai_compatible', base_url: 'http://127.0.0.1:8000', model: 'guard-model', timeout_ms: 3000, input_limit: 4000, enabled: true, has_token: true, token_status: 'configured' }],
   config_version: 7, updated_at: '2026-07-16T00:00:00Z', updated_by: 1, change_summary: '{}',
@@ -177,6 +177,11 @@ describe('PromptAuditView', () => {
     const switches = wrapper.findAll('[role="switch"]')
     expect(switches).toHaveLength(3)
     expect(switches.every((item) => Boolean(item.attributes('aria-label')))).toBe(true)
+    const selection = wrapper.get<HTMLSelectElement>('[data-test="prompt-selection"]')
+    expect(selection.element.value).toBe('full_context')
+    await selection.setValue('after_last_ai')
+    await wrapper.get('[data-test="save-config"]').trigger('click')
+    expect(mocks.updateConfig).toHaveBeenCalledWith(expect.objectContaining({ prompt_selection: 'after_last_ai' }))
     expect(wrapper.html()).toContain('fixed inset-x-0 bottom-0')
     expect(wrapper.html()).toContain('flex-wrap')
   })

--- a/frontend/src/features/prompt-audit/__tests__/components.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/components.spec.ts
@@ -67,7 +67,7 @@ describe('Prompt Audit components', () => {
 
   it('supports group search, stale configured groups, nine scanners, and bounded worker inputs', async () => {
     const draft: PromptAuditDraft = {
-      enabled: true, blocking_enabled: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+      enabled: true, blocking_enabled: false, store_pass_events: false, prompt_selection: 'full_context', effective_mode: 'async_audit', strategy: 'priority',
       worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: false, group_ids: [1, 99],
       endpoints: [endpoint()], config_version: 1, updated_at: '', updated_by: 0, change_summary: '',
     }

--- a/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
@@ -14,6 +14,7 @@ const config = (): PromptAuditConfig => ({
   enabled: true,
   blocking_enabled: false,
   store_pass_events: false,
+  prompt_selection: 'full_context',
   effective_mode: 'async_audit',
   strategy: 'priority',
   worker_count: 4,
@@ -54,6 +55,15 @@ describe('Prompt Audit view model', () => {
     draft.endpoints[0].token = ''
     draft.endpoints[0].clear_token = true
     expect(buildUpdateRequest(draft).endpoints[0]).toMatchObject({ token: undefined, clear_token: true })
+  })
+
+  it('defaults and sends the prompt selection option', () => {
+    const legacy = { ...config(), prompt_selection: undefined } as unknown as PromptAuditConfig
+    expect(configToDraft(legacy).prompt_selection).toBe('full_context')
+
+    const draft = configToDraft(config())
+    draft.prompt_selection = 'after_last_ai'
+    expect(buildUpdateRequest(draft)).toMatchObject({ prompt_selection: 'after_last_ai' })
   })
 
   it('tracks dirty state from the full normalized save payload', () => {

--- a/frontend/src/features/prompt-audit/types.ts
+++ b/frontend/src/features/prompt-audit/types.ts
@@ -1,6 +1,7 @@
 export type PromptAuditMode = 'off' | 'async_audit' | 'blocking'
 export type PromptDecision = 'pass' | 'flag' | 'critical'
 export type PromptRiskLevel = 'low' | 'medium' | 'high' | 'critical'
+export type PromptSelection = 'full_context' | 'last_user_only' | 'after_last_ai'
 
 export interface PromptAuditEndpoint {
   id: string
@@ -24,6 +25,7 @@ export interface PromptAuditConfig {
   enabled: boolean
   blocking_enabled: boolean
   store_pass_events: boolean
+  prompt_selection: PromptSelection
   effective_mode: PromptAuditMode
   strategy: 'priority'
   worker_count: number
@@ -47,6 +49,7 @@ export interface PromptAuditUpdateRequest {
   enabled: boolean
   blocking_enabled: boolean
   store_pass_events: boolean
+  prompt_selection: PromptSelection
   strategy: 'priority'
   worker_count: number
   queue_capacity: number

--- a/frontend/src/features/prompt-audit/viewModel.ts
+++ b/frontend/src/features/prompt-audit/viewModel.ts
@@ -30,6 +30,7 @@ export function cloneData<T>(value: T): T {
 export function configToDraft(config: PromptAuditConfig): PromptAuditDraft {
   return {
     ...cloneData(config),
+    prompt_selection: config.prompt_selection || 'full_context',
     group_ids: [...(config.group_ids ?? [])],
     scanners: [...(config.scanners ?? [])],
     endpoints: (config.endpoints ?? []).map((endpoint) => ({
@@ -63,6 +64,7 @@ export function buildUpdateRequest(draft: PromptAuditDraft): PromptAuditUpdateRe
     enabled: draft.enabled,
     blocking_enabled: draft.enabled && draft.blocking_enabled,
     store_pass_events: draft.store_pass_events,
+    prompt_selection: draft.prompt_selection,
     strategy: 'priority',
     worker_count: Number(draft.worker_count),
     queue_capacity: Number(draft.queue_capacity),

--- a/frontend/src/i18n/locales/en/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/en/admin/promptAudit.ts
@@ -55,7 +55,7 @@ export default {
       searchGroups: 'Search groups', noGroups: 'No matching groups', missingGroups: 'Configured IDs for groups that no longer exist', selectedCount: '{count} groups selected',
       scanners: 'Qwen3Guard input-risk categories', workerCount: 'Worker count', queueCapacity: 'Persistent queue capacity', strategy: 'Node strategy', strategyHint: 'Try nodes in configuration order and fail over when allowed.',
     },
-    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', storePass: 'Store safe events', dirty: 'Unsaved changes', synced: 'Configuration synced' },
+    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', storePass: 'Store safe events', promptSelection: 'Prompt selection', fullContext: 'Audit full context', lastUserOnly: 'Only the final user message', afterLastAI: 'All content after the final AI reply', dirty: 'Unsaved changes', synced: 'Configuration synced' },
     blockingConfirm: {
       title: 'Enable synchronous blocking?',
       message: 'Applicable requests wait for Guard before account selection, billing, or upstream access. Block, unavailable Guard, and invalid responses all prevent upstream access.',

--- a/frontend/src/i18n/locales/zh/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/zh/admin/promptAudit.ts
@@ -55,7 +55,7 @@ export default {
       searchGroups: '搜索分组', noGroups: '没有匹配分组', missingGroups: '配置中包含已删除的分组 ID', selectedCount: '已选择 {count} 个分组',
       scanners: 'Qwen3Guard 输入风险分类', workerCount: 'Worker 数量', queueCapacity: '持久队列容量', strategy: '节点策略', strategyHint: '按配置顺序优先尝试，必要时故障切换。',
     },
-    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', storePass: '保存安全事件', dirty: '有未保存的更改', synced: '配置已同步' },
+    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', storePass: '保存安全事件', promptSelection: '提示词选取', fullContext: '审核完整上下文', lastUserOnly: '仅审核最后一条用户消息', afterLastAI: '审核最后一条 AI 回复之后的全部内容', dirty: '有未保存的更改', synced: '配置已同步' },
     blockingConfirm: {
       title: '开启同步阻止？',
       message: '适用请求会在账号选择、计费和访问上游之前等待 Guard。命中 Block、Guard 不可用或响应非法时，请求都不会访问上游。',


### PR DESCRIPTION
## 背景

始终发送完整上下文进行提示词审核太慢，期望多几种选择

## 改动说明

### 配置与接口

- 新增 `prompt_selection`，支持 `full_context`、`last_user_only` 和 `after_last_ai` 三种策略。
- 默认值为 `full_context`。

### 审核文本选择

- `full_context`：审核请求中可识别的完整上下文。
- `last_user_only`：选择整个请求内最后一条可提取的 `user` 消息；后续出现 assistant/tool 不影响选择。同一条消息的多个文本片段会合并，相邻独立的 user 消息不会合并。
- `after_last_ai`：将 `assistant` 和 Gemini `model` 统一视为 AI 边界，审核最后一次 AI 回复后的全部可识别内容；没有 AI 回复时仅审核全部 `user` 消息；没有可用 user 或 AI 后无内容时跳过审核。
- 为 Responses/Gemini 纯文本输入标记 user 角色，并保留工具调用型 AI 回复的边界，避免错误拼接会话片段。

### 测试

- 后端覆盖配置默认值和非法策略、三种选取策略、assistant/model 边界、AI 后工具内容、无 AI 时仅 user、无 user 跳过，以及最后 user 后跟 assistant/tool 和相邻 user 消息等场景。
- 前端覆盖选择器渲染、payload 透传和 `full_context` 默认回退。

## 验证

```sh
cd backend
GOTOOLCHAIN=auto GOCACHE=/tmp/sub2api-go-cache GOTMPDIR=/tmp/sub2api-go-tmp go test ./internal/securityaudit -count=1

cd frontend
npm run test -- --run src/features/prompt-audit/__tests__/viewModel.spec.ts src/features/prompt-audit/__tests__/components.spec.ts src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
```
