### PR TITLE
fix(billing): preserve channel service-tier pricing

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -117,7 +117,14 @@ const (
 )
 
 func normalizeBillingServiceTier(serviceTier string) string {
-	return strings.ToLower(strings.TrimSpace(serviceTier))
+	normalized := strings.ToLower(strings.TrimSpace(serviceTier))
+	// OpenAI renamed priority processing to Fast mode while continuing to
+	// accept both request values. Treat the new response value as the same
+	// billable tier so it cannot silently fall back to Standard pricing.
+	if normalized == "fast" {
+		return "priority"
+	}
+	return normalized
 }
 
 func usePriorityServiceTierPricing(serviceTier string, pricing *ModelPricing) bool {
@@ -890,25 +897,7 @@ func (s *BillingService) GetModelPricingWithChannel(model string, channelPricing
 	// 防止修改 fallbackPrices 中的共享指针
 	cloned := *pricing
 	pricing = &cloned
-	if channelPricing.InputPrice != nil {
-		pricing.InputPricePerToken = *channelPricing.InputPrice
-		pricing.InputPricePerTokenPriority = *channelPricing.InputPrice
-	}
-	if channelPricing.OutputPrice != nil {
-		pricing.OutputPricePerToken = *channelPricing.OutputPrice
-		pricing.OutputPricePerTokenPriority = *channelPricing.OutputPrice
-	}
-	if channelPricing.CacheWritePrice != nil {
-		pricing.CacheCreationPricePerToken = *channelPricing.CacheWritePrice
-		pricing.CacheCreationPricePerTokenPriority = *channelPricing.CacheWritePrice
-		pricing.CacheCreationPriceExplicit = true
-		pricing.CacheCreation5mPrice = *channelPricing.CacheWritePrice
-		pricing.CacheCreation1hPrice = *channelPricing.CacheWritePrice
-	}
-	if channelPricing.CacheReadPrice != nil {
-		pricing.CacheReadPricePerToken = *channelPricing.CacheReadPrice
-		pricing.CacheReadPricePerTokenPriority = *channelPricing.CacheReadPrice
-	}
+	applyChannelTokenPriceOverrides(pricing, channelPricing)
 	if channelPricing.ImageOutputPrice != nil {
 		pricing.ImageOutputPricePerToken = *channelPricing.ImageOutputPrice
 	} else {
@@ -917,6 +906,65 @@ func (s *BillingService) GetModelPricingWithChannel(model string, channelPricing
 	pricing.ImageOutputPriceExplicit = true
 	applyChannelImageInputPrice(channelPricing, pricing)
 	return pricing, nil
+}
+
+// channelTierOverridePrice applies a channel's Standard-tier override while
+// preserving an explicit upstream tier ratio (for example OpenAI Fast/Priority
+// at 2x Standard). Models without an explicit tier price retain the historical
+// behavior where the channel override is used for both tiers.
+func channelTierOverridePrice(baseStandard, baseTier, channelStandard float64) float64 {
+	if baseStandard > 0 && baseTier > 0 {
+		return channelStandard * (baseTier / baseStandard)
+	}
+	return channelStandard
+}
+
+// applyChannelTokenPriceOverrides overlays flat channel prices on a cloned
+// ModelPricing. Priority/Fast prices keep the model catalog's tier ratio rather
+// than being collapsed to the Standard price.
+func applyChannelTokenPriceOverrides(pricing *ModelPricing, channelPricing *ChannelModelPricing) {
+	if pricing == nil || channelPricing == nil {
+		return
+	}
+	if channelPricing.InputPrice != nil {
+		priority := channelTierOverridePrice(
+			pricing.InputPricePerToken,
+			pricing.InputPricePerTokenPriority,
+			*channelPricing.InputPrice,
+		)
+		pricing.InputPricePerToken = *channelPricing.InputPrice
+		pricing.InputPricePerTokenPriority = priority
+	}
+	if channelPricing.OutputPrice != nil {
+		priority := channelTierOverridePrice(
+			pricing.OutputPricePerToken,
+			pricing.OutputPricePerTokenPriority,
+			*channelPricing.OutputPrice,
+		)
+		pricing.OutputPricePerToken = *channelPricing.OutputPrice
+		pricing.OutputPricePerTokenPriority = priority
+	}
+	if channelPricing.CacheWritePrice != nil {
+		priority := channelTierOverridePrice(
+			pricing.CacheCreationPricePerToken,
+			pricing.CacheCreationPricePerTokenPriority,
+			*channelPricing.CacheWritePrice,
+		)
+		pricing.CacheCreationPricePerToken = *channelPricing.CacheWritePrice
+		pricing.CacheCreationPricePerTokenPriority = priority
+		pricing.CacheCreationPriceExplicit = true
+		pricing.CacheCreation5mPrice = *channelPricing.CacheWritePrice
+		pricing.CacheCreation1hPrice = *channelPricing.CacheWritePrice
+	}
+	if channelPricing.CacheReadPrice != nil {
+		priority := channelTierOverridePrice(
+			pricing.CacheReadPricePerToken,
+			pricing.CacheReadPricePerTokenPriority,
+			*channelPricing.CacheReadPrice,
+		)
+		pricing.CacheReadPricePerToken = *channelPricing.CacheReadPrice
+		pricing.CacheReadPricePerTokenPriority = priority
+	}
 }
 
 // --- 统一计费入口 ---

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1591,6 +1591,42 @@ func TestGetModelPricingWithChannel_CacheReadPriceAffectsPriority(t *testing.T) 
 	require.InDelta(t, 2e-6, pricing.CacheReadPricePerTokenPriority, 1e-12)
 }
 
+func TestGetModelPricingWithChannel_GPT56PreservesPriorityRatio(t *testing.T) {
+	svc := newTestBillingService()
+
+	chPricing := &ChannelModelPricing{
+		InputPrice:      testPtrFloat64(0.2e-6),
+		OutputPrice:     testPtrFloat64(1.2e-6),
+		CacheWritePrice: testPtrFloat64(0.25e-6),
+		CacheReadPrice:  testPtrFloat64(0.02e-6),
+	}
+	pricing, err := svc.GetModelPricingWithChannel("gpt-5.6-luna", chPricing)
+	require.NoError(t, err)
+
+	require.InDelta(t, 0.2e-6, pricing.InputPricePerToken, 1e-12)
+	require.InDelta(t, 0.4e-6, pricing.InputPricePerTokenPriority, 1e-12)
+	require.InDelta(t, 1.2e-6, pricing.OutputPricePerToken, 1e-12)
+	require.InDelta(t, 2.4e-6, pricing.OutputPricePerTokenPriority, 1e-12)
+	require.InDelta(t, 0.25e-6, pricing.CacheCreationPricePerToken, 1e-12)
+	require.InDelta(t, 0.5e-6, pricing.CacheCreationPricePerTokenPriority, 1e-12)
+	require.InDelta(t, 0.02e-6, pricing.CacheReadPricePerToken, 1e-12)
+	require.InDelta(t, 0.04e-6, pricing.CacheReadPricePerTokenPriority, 1e-12)
+}
+
+func TestCalculateCostWithServiceTier_FastAliasUsesPriorityPricing(t *testing.T) {
+	svc := newTestBillingService()
+
+	cost, err := svc.CalculateCostWithServiceTier(
+		"gpt-5.6-luna",
+		UsageTokens{InputTokens: 1000, OutputTokens: 100},
+		1,
+		"fast",
+	)
+	require.NoError(t, err)
+	require.InDelta(t, 1000*0.4e-6, cost.InputCost, 1e-12)
+	require.InDelta(t, 100*2.4e-6, cost.OutputCost, 1e-12)
+}
+
 func TestGetModelPricingWithChannel_UnknownModelReturnsError(t *testing.T) {
 	svc := newTestBillingService()
 

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -144,28 +144,13 @@ func (r *ModelPricingResolver) applyTokenOverrides(chPricing *ChannelModelPricin
 	// 过滤掉所有价格字段都为空的无效 interval
 	validIntervals := filterValidIntervals(chPricing.Intervals)
 
-	// 如果有有效的区间定价，使用区间
+	// 有效区间覆盖命中的上下文；未命中时仍应使用下方渠道默认价格。
+	// 这与管理界面的“默认价格（未命中区间时使用）”语义保持一致。
 	if len(validIntervals) > 0 {
 		resolved.Intervals = validIntervals
-		// 区间不匹配时回退到 BasePricing，也需要覆盖图片价格
-		if resolved.BasePricing == nil {
-			resolved.BasePricing = &ModelPricing{}
-		} else {
-			// 防止修改 fallbackPrices 中的共享指针
-			cloned := *resolved.BasePricing
-			resolved.BasePricing = &cloned
-		}
-		if chPricing.ImageOutputPrice != nil {
-			resolved.BasePricing.ImageOutputPricePerToken = *chPricing.ImageOutputPrice
-		} else {
-			resolved.BasePricing.ImageOutputPricePerToken = 0
-		}
-		resolved.BasePricing.ImageOutputPriceExplicit = true
-		applyChannelImageInputPrice(chPricing, resolved.BasePricing)
-		return
 	}
 
-	// 否则用 flat 字段覆盖 BasePricing
+	// flat 字段始终覆盖 BasePricing，既用于无区间场景，也作为区间未命中时的兜底。
 	if resolved.BasePricing == nil {
 		resolved.BasePricing = &ModelPricing{}
 	} else {
@@ -174,25 +159,7 @@ func (r *ModelPricingResolver) applyTokenOverrides(chPricing *ChannelModelPricin
 		resolved.BasePricing = &cloned
 	}
 
-	if chPricing.InputPrice != nil {
-		resolved.BasePricing.InputPricePerToken = *chPricing.InputPrice
-		resolved.BasePricing.InputPricePerTokenPriority = *chPricing.InputPrice
-	}
-	if chPricing.OutputPrice != nil {
-		resolved.BasePricing.OutputPricePerToken = *chPricing.OutputPrice
-		resolved.BasePricing.OutputPricePerTokenPriority = *chPricing.OutputPrice
-	}
-	if chPricing.CacheWritePrice != nil {
-		resolved.BasePricing.CacheCreationPricePerToken = *chPricing.CacheWritePrice
-		resolved.BasePricing.CacheCreationPricePerTokenPriority = *chPricing.CacheWritePrice
-		resolved.BasePricing.CacheCreationPriceExplicit = true
-		resolved.BasePricing.CacheCreation5mPrice = *chPricing.CacheWritePrice
-		resolved.BasePricing.CacheCreation1hPrice = *chPricing.CacheWritePrice
-	}
-	if chPricing.CacheReadPrice != nil {
-		resolved.BasePricing.CacheReadPricePerToken = *chPricing.CacheReadPrice
-		resolved.BasePricing.CacheReadPricePerTokenPriority = *chPricing.CacheReadPrice
-	}
+	applyChannelTokenPriceOverrides(resolved.BasePricing, chPricing)
 	// 渠道定价覆盖一切：显式配置则用配置值，未配置则归零（不回退到 LiteLLM）
 	if chPricing.ImageOutputPrice != nil {
 		resolved.BasePricing.ImageOutputPricePerToken = *chPricing.ImageOutputPrice
@@ -250,32 +217,53 @@ func (r *ModelPricingResolver) GetIntervalPricing(resolved *ResolvedPricing, tot
 		return resolved.BasePricing
 	}
 
-	return intervalToModelPricing(iv, resolved.SupportsCacheBreakdown, resolved.channelPricing)
+	return intervalToModelPricing(iv, resolved.SupportsCacheBreakdown, resolved.channelPricing, resolved.BasePricing)
 }
 
 // intervalToModelPricing 将区间定价转换为 ModelPricing
-func intervalToModelPricing(iv *PricingInterval, supportsCacheBreakdown bool, chPricing *ChannelModelPricing) *ModelPricing {
+func intervalToModelPricing(
+	iv *PricingInterval,
+	supportsCacheBreakdown bool,
+	chPricing *ChannelModelPricing,
+	basePricing *ModelPricing,
+) *ModelPricing {
 	pricing := &ModelPricing{
 		SupportsCacheBreakdown: supportsCacheBreakdown,
 	}
 	if iv.InputPrice != nil {
 		pricing.InputPricePerToken = *iv.InputPrice
-		pricing.InputPricePerTokenPriority = *iv.InputPrice
+		pricing.InputPricePerTokenPriority = channelTierOverridePrice(
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.InputPricePerToken }),
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.InputPricePerTokenPriority }),
+			*iv.InputPrice,
+		)
 	}
 	if iv.OutputPrice != nil {
 		pricing.OutputPricePerToken = *iv.OutputPrice
-		pricing.OutputPricePerTokenPriority = *iv.OutputPrice
+		pricing.OutputPricePerTokenPriority = channelTierOverridePrice(
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.OutputPricePerToken }),
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.OutputPricePerTokenPriority }),
+			*iv.OutputPrice,
+		)
 	}
 	if iv.CacheWritePrice != nil {
 		pricing.CacheCreationPricePerToken = *iv.CacheWritePrice
-		pricing.CacheCreationPricePerTokenPriority = *iv.CacheWritePrice
+		pricing.CacheCreationPricePerTokenPriority = channelTierOverridePrice(
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.CacheCreationPricePerToken }),
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.CacheCreationPricePerTokenPriority }),
+			*iv.CacheWritePrice,
+		)
 		pricing.CacheCreationPriceExplicit = true
 		pricing.CacheCreation5mPrice = *iv.CacheWritePrice
 		pricing.CacheCreation1hPrice = *iv.CacheWritePrice
 	}
 	if iv.CacheReadPrice != nil {
 		pricing.CacheReadPricePerToken = *iv.CacheReadPrice
-		pricing.CacheReadPricePerTokenPriority = *iv.CacheReadPrice
+		pricing.CacheReadPricePerTokenPriority = channelTierOverridePrice(
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.CacheReadPricePerToken }),
+			basePricingValue(basePricing, func(p *ModelPricing) float64 { return p.CacheReadPricePerTokenPriority }),
+			*iv.CacheReadPrice,
+		)
 	}
 	// 渠道定价存在时，ImageOutputPrice 显式覆盖；图片输入价用渠道级配置
 	// （区间不携带图片输入价，与 image_output 一致）。
@@ -287,6 +275,13 @@ func intervalToModelPricing(iv *PricingInterval, supportsCacheBreakdown bool, ch
 		applyChannelImageInputPrice(chPricing, pricing)
 	}
 	return pricing
+}
+
+func basePricingValue(pricing *ModelPricing, getter func(*ModelPricing) float64) float64 {
+	if pricing == nil {
+		return 0
+	}
+	return getter(pricing)
 }
 
 // GetRequestTierPrice 根据层级标签获取按次价格

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -322,6 +322,48 @@ func TestResolve_WithChannelOverride_TokenWithIntervals(t *testing.T) {
 	require.InDelta(t, 16e-6, iv2.OutputPricePerToken, 1e-12)
 }
 
+func TestResolve_WithChannelOverride_IntervalMissUsesChannelDefaultPrices(t *testing.T) {
+	r := newResolverWithChannel(t, []ChannelModelPricing{{
+		Platform:        "anthropic",
+		Models:          []string{"claude-sonnet-4"},
+		BillingMode:     BillingModeToken,
+		InputPrice:      testPtrFloat64(10e-6),
+		OutputPrice:     testPtrFloat64(50e-6),
+		CacheWritePrice: testPtrFloat64(12.5e-6),
+		CacheReadPrice:  testPtrFloat64(1e-6),
+		Intervals: []PricingInterval{{
+			MinTokens:       272000,
+			MaxTokens:       nil,
+			InputPrice:      testPtrFloat64(20e-6),
+			OutputPrice:     testPtrFloat64(75e-6),
+			CacheWritePrice: testPtrFloat64(25e-6),
+			CacheReadPrice:  testPtrFloat64(2e-6),
+		}},
+	}})
+
+	resolved := r.Resolve(context.Background(), PricingInput{
+		Model:   "claude-sonnet-4",
+		GroupID: groupIDPtr(),
+	})
+
+	require.Equal(t, PricingSourceChannel, resolved.Source)
+	require.Len(t, resolved.Intervals, 1)
+
+	// Below the only configured interval, the channel's flat/default prices
+	// must win instead of falling back to the model catalog.
+	shortContext := r.GetIntervalPricing(resolved, 100000)
+	require.NotNil(t, shortContext)
+	require.InDelta(t, 10e-6, shortContext.InputPricePerToken, 1e-12)
+	require.InDelta(t, 50e-6, shortContext.OutputPricePerToken, 1e-12)
+	require.InDelta(t, 12.5e-6, shortContext.CacheCreationPricePerToken, 1e-12)
+	require.InDelta(t, 1e-6, shortContext.CacheReadPricePerToken, 1e-12)
+
+	longContext := r.GetIntervalPricing(resolved, 300000)
+	require.NotNil(t, longContext)
+	require.InDelta(t, 20e-6, longContext.InputPricePerToken, 1e-12)
+	require.InDelta(t, 75e-6, longContext.OutputPricePerToken, 1e-12)
+}
+
 func TestResolve_WithChannelOverride_TokenNilBasePricing(t *testing.T) {
 	// Base pricing is nil (unknown model), channel has flat prices → creates new BasePricing.
 	r := newResolverWithChannel(t, []ChannelModelPricing{{

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -142,7 +142,7 @@ func TestGPT56ExplicitZeroCacheWritePriceIsPreserved(t *testing.T) {
 	})
 
 	t.Run("interval price", func(t *testing.T) {
-		pricing := intervalToModelPricing(&PricingInterval{CacheWritePrice: &zero}, false, nil)
+		pricing := intervalToModelPricing(&PricingInterval{CacheWritePrice: &zero}, false, nil, nil)
 		require.True(t, pricing.CacheCreationPriceExplicit)
 
 		cost, err := bs.CalculateCostUnified(CostInput{


### PR DESCRIPTION
## What changed

- Treat the OpenAI `fast` service-tier label as `priority` for billing.
- Preserve a model catalog's explicit Priority/Fast-to-Standard ratio when a channel overrides Standard token prices.
- Apply channel flat/default prices when no configured context interval matches.
- Add regression coverage for GPT-5.6 channel overrides, the `fast` alias, and interval misses.

## Why

Channel token overrides currently copy the Standard price into both Standard and Priority fields. For models with an explicit Priority/Fast price, this silently undercharges Priority traffic. In addition, defining any context interval causes unmatched contexts to fall back to the model catalog instead of the channel's configured default prices.

The fix keeps existing behavior for models without explicit tier pricing, while preserving the catalog ratio for models that do define it.

## Impact

This PR does not change published model price values. GPT-5.6 Luna and Terra base-rate updates already landed upstream in v0.1.169. It only fixes how service tiers and channel overrides are resolved.

## Validation

- Added focused unit tests for all three regressions.
- `git diff --check` passes.
- Fork CI passes: Go unit tests, integration tests, golangci-lint, frontend checks, and security scan.
