### PR TITLE
feat(channel-monitor): retry group accounts on probe failure

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -170,7 +170,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	announcementService := service.NewAnnouncementService(announcementRepository, announcementReadRepository, userRepository, userSubscriptionRepository)
 	announcementHandler := handler.NewAnnouncementHandler(announcementService)
 	channelMonitorRepository := repository.NewChannelMonitorRepository(client, db)
-	channelMonitorService := service.ProvideChannelMonitorService(channelMonitorRepository, secretEncryptor)
+	channelMonitorService := service.ProvideChannelMonitorService(channelMonitorRepository, secretEncryptor, apiKeyRepository, gatewayService, openAIGatewayService)
 	channelMonitorUserHandler := handler.NewChannelMonitorUserHandler(channelMonitorService, settingService)
 	dashboardAggregationRepository := repository.NewDashboardAggregationRepository(db)
 	dashboardStatsCache := repository.NewDashboardCache(redisClient, configConfig)

--- a/backend/internal/service/channel_monitor_anthropic_group_probe.go
+++ b/backend/internal/service/channel_monitor_anthropic_group_probe.go
@@ -1,0 +1,180 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (s *ChannelMonitorService) runAnthropicGroupAccountProbeForModel(ctx context.Context, m *ChannelMonitor, model string, opts *CheckOptions, group *monitorProbeGroup) *CheckResult {
+	start := time.Now()
+	if m == nil || m.Provider != MonitorProviderAnthropic {
+		return groupAccountProbeErrorResult(model, start, "anthropic group account probe supports anthropic provider only")
+	}
+	if group == nil || group.id <= 0 {
+		return groupAccountProbeErrorResult(model, start, "monitor api key is not bound to a group")
+	}
+	if s.gateway == nil {
+		return groupAccountProbeErrorResult(model, start, "gateway is not configured")
+	}
+
+	challenge := generateChallenge()
+	body, err := buildRequestBody(providerAdapters[MonitorProviderAnthropic], MonitorProviderAnthropic, MonitorAPIModeChatCompletions, model, challenge.Prompt, opts)
+	if err != nil {
+		return groupAccountProbeErrorResult(model, start, err.Error())
+	}
+
+	failedAccountIDs := make(map[int64]struct{})
+	attempts := make([]string, 0)
+	sessionHash := fmt.Sprintf("channel-monitor:%d:%s:%s", group.id, model, challenge.Expected)
+	var bestDegraded *CheckResult
+
+	for {
+		if len(failedAccountIDs) > 0 && !sleepMonitorWithContext(ctx, monitorModelCheckGap) {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeErrorResult(model, start, "check cancelled during anthropic account probe")
+		}
+
+		selection, err := s.gateway.SelectAccountWithLoadAwareness(ctx, &group.id, sessionHash, model, failedAccountIDs, "", 0)
+		if err != nil {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, fmt.Sprintf("select group account: %v", err))
+		}
+		if selection == nil || selection.Account == nil {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, "select group account: no available accounts")
+		}
+
+		account := selection.Account
+		if _, seen := failedAccountIDs[account.ID]; seen {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, fmt.Sprintf("scheduler returned excluded account %d", account.ID))
+		}
+		if !selection.Acquired {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			attempts = append(attempts, accountProbeAttemptSummary(account, MonitorStatusFailed, "account concurrency slot unavailable"))
+			failedAccountIDs[account.ID] = struct{}{}
+			continue
+		}
+
+		attemptStart := time.Now()
+		result, attempt, passed := s.runAnthropicGroupProbeAttempt(ctx, group, account, model, body, challenge, opts, attemptStart)
+		if selection.ReleaseFunc != nil {
+			selection.ReleaseFunc()
+		}
+		if passed {
+			if acceptGroupProbeResult(result, &bestDegraded) {
+				return result
+			}
+			if result == nil {
+				return groupAccountProbeErrorResult(model, start, "anthropic group account probe passed without result")
+			}
+			attempts = append(attempts, accountProbeAttemptSummary(account, result.Status, result.Message))
+			failedAccountIDs[account.ID] = struct{}{}
+			continue
+		}
+
+		attempts = append(attempts, attempt)
+		failedAccountIDs[account.ID] = struct{}{}
+	}
+}
+
+func (s *ChannelMonitorService) runAnthropicGroupProbeAttempt(
+	ctx context.Context,
+	group *monitorProbeGroup,
+	account *Account,
+	model string,
+	body []byte,
+	challenge monitorChallenge,
+	opts *CheckOptions,
+	start time.Time,
+) (*CheckResult, string, bool) {
+	c, recorder, err := newMonitorAnthropicProbeContext(ctx, group, body)
+	if err != nil {
+		return nil, accountProbeAttemptSummary(account, MonitorStatusError, err.Error()), false
+	}
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(append([]byte(nil), body...)), PlatformAnthropic)
+	if err != nil {
+		return nil, accountProbeAttemptSummary(account, MonitorStatusError, fmt.Sprintf("parse monitor request: %v", err)), false
+	}
+
+	result, err := s.gateway.Forward(ctx, c, account, parsed)
+	if err != nil {
+		return nil, accountProbeAttemptSummary(account, MonitorStatusError, monitorProbeForwardErrorMessage(err, recorder)), false
+	}
+	if result == nil {
+		return nil, accountProbeAttemptSummary(account, MonitorStatusError, "gateway returned empty result"), false
+	}
+
+	status := recorder.Code
+	if status < http.StatusOK || status >= http.StatusMultipleChoices {
+		return nil, accountProbeAttemptSummary(account, MonitorStatusError, fmt.Sprintf("upstream HTTP %d: %s", status, truncateForErrorBody(recorder.Body.String()))), false
+	}
+
+	respText := extractMonitorResponseText(providerAdapters[MonitorProviderAnthropic], recorder.Body.Bytes())
+	if bodyOverrideMode(opts) == MonitorBodyOverrideModeReplace {
+		if strings.TrimSpace(respText) == "" {
+			return nil, accountProbeAttemptSummary(account, MonitorStatusFailed, "replace-mode: upstream returned 2xx with empty text"), false
+		}
+		return anthropicGroupProbeSuccessResult(model, start, account), "", true
+	}
+	if !validateChallenge(respText, challenge.Expected) {
+		message := fmt.Sprintf("challenge mismatch (expected %s, got %q)", challenge.Expected, respText)
+		return nil, accountProbeAttemptSummary(account, MonitorStatusFailed, message), false
+	}
+	return anthropicGroupProbeSuccessResult(model, start, account), "", true
+}
+
+func newMonitorAnthropicProbeContext(ctx context.Context, group *monitorProbeGroup, body []byte) (*gin.Context, *httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, providerAnthropicPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "sub2api-channel-monitor")
+	req.Header.Set("anthropic-version", monitorAnthropicAPIVersion)
+	c.Request = req
+	if group != nil && group.apiKey != nil {
+		c.Set("api_key", group.apiKey)
+	}
+	return c, recorder, nil
+}
+
+func anthropicGroupProbeSuccessResult(model string, start time.Time, account *Account) *CheckResult {
+	latencyMs := int(time.Since(start).Milliseconds())
+	res := &CheckResult{
+		Model:     model,
+		Status:    MonitorStatusOperational,
+		LatencyMs: &latencyMs,
+		CheckedAt: time.Now().UTC(),
+		Message: appendMonitorMessage("", fmt.Sprintf(
+			"anthropic group account probe passed account %d (%s)",
+			account.ID,
+			strings.TrimSpace(account.Name),
+		)),
+	}
+	if time.Since(start) >= monitorDegradedThreshold {
+		res.Status = MonitorStatusDegraded
+		res.Message = appendMonitorMessage(res.Message, fmt.Sprintf("slow anthropic group account probe: %dms", latencyMs))
+	}
+	return res
+}

--- a/backend/internal/service/channel_monitor_anthropic_group_probe_test.go
+++ b/backend/internal/service/channel_monitor_anthropic_group_probe_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type fakeAnthropicGroupProbeGateway struct {
+	accounts         []*Account
+	excludedBySelect []map[int64]struct{}
+	forwardCalls     []int64
+}
+
+func (f *fakeAnthropicGroupProbeGateway) SelectAccountWithLoadAwareness(_ context.Context, _ *int64, _ string, _ string, excludedIDs map[int64]struct{}, _ string, _ int64) (*AccountSelectionResult, error) {
+	copied := make(map[int64]struct{}, len(excludedIDs))
+	for id := range excludedIDs {
+		copied[id] = struct{}{}
+	}
+	f.excludedBySelect = append(f.excludedBySelect, copied)
+	for _, account := range f.accounts {
+		if _, excluded := excludedIDs[account.ID]; excluded {
+			continue
+		}
+		return &AccountSelectionResult{Account: account, Acquired: true}, nil
+	}
+	return nil, errors.New("no available accounts")
+}
+
+func (f *fakeAnthropicGroupProbeGateway) Forward(_ context.Context, c *gin.Context, account *Account, parsed *ParsedRequest) (*ForwardResult, error) {
+	f.forwardCalls = append(f.forwardCalls, account.ID)
+	if account.ID == 1 {
+		return nil, &UpstreamFailoverError{StatusCode: http.StatusBadGateway}
+	}
+	prompt := gjson.GetBytes(parsed.Body.Bytes(), "messages.0.content").String()
+	expected := monitorExpectedFromPrompt(prompt)
+	c.JSON(http.StatusOK, gin.H{
+		"id":   "msg-monitor",
+		"type": "message",
+		"content": []gin.H{{
+			"type": "text",
+			"text": expected,
+		}},
+	})
+	return &ForwardResult{Model: parsed.Model}, nil
+}
+
+func TestRunAnthropicGroupAccountProbeForModel_TriesNextAccountUntilSuccess(t *testing.T) {
+	gateway := &fakeAnthropicGroupProbeGateway{accounts: []*Account{
+		{ID: 1, Name: "bad-kiro", Platform: PlatformAnthropic, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1},
+		{ID: 2, Name: "good-kiro", Platform: PlatformAnthropic, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1},
+	}}
+	svc := NewChannelMonitorService(nil, nil)
+	svc.SetGroupAccountProbeDependencies(nil, gateway, nil)
+
+	result := svc.runAnthropicGroupAccountProbeForModel(context.Background(), &ChannelMonitor{
+		Provider:     MonitorProviderAnthropic,
+		PrimaryModel: "claude-sonnet-4-6",
+	}, "claude-sonnet-4-6", nil, &monitorProbeGroup{id: 9})
+
+	require.NotNil(t, result)
+	require.Equal(t, MonitorStatusOperational, result.Status)
+	require.Contains(t, result.Message, "account 2")
+	require.Equal(t, []int64{1, 2}, gateway.forwardCalls)
+	require.Len(t, gateway.excludedBySelect, 2)
+	require.NotContains(t, gateway.excludedBySelect[0], int64(1))
+	require.Contains(t, gateway.excludedBySelect[1], int64(1))
+}
+
+func monitorExpectedFromPrompt(prompt string) string {
+	re := regexp.MustCompile(`(?s)Q:\s*(-?\d+)\s*([+-])\s*(-?\d+)\s*=\s*\?\s*A:\s*$`)
+	matches := re.FindStringSubmatch(prompt)
+	if len(matches) != 4 {
+		return "0"
+	}
+	a, errA := strconv.Atoi(matches[1])
+	b, errB := strconv.Atoi(matches[3])
+	if errA != nil || errB != nil {
+		return "0"
+	}
+	if matches[2] == "+" {
+		return fmt.Sprintf("%d", a+b)
+	}
+	return fmt.Sprintf("%d", a-b)
+}

--- a/backend/internal/service/channel_monitor_checker.go
+++ b/backend/internal/service/channel_monitor_checker.go
@@ -324,6 +324,33 @@ func extractAnthropicMonitorText(respBytes []byte) string {
 	return strings.Join(parts, "\n")
 }
 
+func extractOpenAIChatText(respBytes []byte) string {
+	message := gjson.GetBytes(respBytes, "choices.0.message")
+	if message.Exists() {
+		if text := message.Get("content").String(); strings.TrimSpace(text) != "" {
+			return text
+		}
+		if text := collectOpenAIContentText(message.Get("content")); strings.TrimSpace(text) != "" {
+			return text
+		}
+	}
+	return gjson.GetBytes(respBytes, providerAdapters[MonitorProviderOpenAI].textPath).String()
+}
+
+func collectOpenAIContentText(content gjson.Result) string {
+	if !content.IsArray() {
+		return content.String()
+	}
+	parts := make([]string, 0)
+	content.ForEach(func(_, item gjson.Result) bool {
+		if text := item.Get("text").String(); strings.TrimSpace(text) != "" {
+			parts = append(parts, text)
+		}
+		return true
+	})
+	return strings.Join(parts, "")
+}
+
 // extractOpenAIResponsesText 聚合 Responses API 的最终 assistant 文本。
 // Responses 的 output 数组顺序由模型决定：reasoning / tool-call item 可能排在 message 前面，
 // 因此不能假设文本永远在 output.0.content.0.text。
@@ -548,6 +575,13 @@ func extractOrigin(endpoint string) (string, error) {
 		return "", errors.New("endpoint missing scheme or host")
 	}
 	return u.Scheme + "://" + u.Host, nil
+}
+
+func isMonitorTransientHTTPStatus(status int) bool {
+	if status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout {
+		return true
+	}
+	return status >= 520 && status <= 529
 }
 
 // monitorSensitiveQueryParamRegex 匹配 URL query 中可能泄露凭证的参数：

--- a/backend/internal/service/channel_monitor_const.go
+++ b/backend/internal/service/channel_monitor_const.go
@@ -93,6 +93,12 @@ const (
 	monitorAnthropicAPIVersion = "2023-06-01"
 	// monitorChallengeMaxTokens 单次 challenge 请求的 max_tokens（足够回答个位数算术）。
 	monitorChallengeMaxTokens = 50
+	// monitorModelCheckGap 同一 monitor 内多个 model 或 group probe 候选之间的保护间隔。
+	monitorModelCheckGap = 1200 * time.Millisecond
+	// monitorTransientRetryDelay 短暂 5xx 重试前的保护间隔。
+	monitorTransientRetryDelay = 1200 * time.Millisecond
+	// monitorTransientMaxAttempts 短暂 5xx 最多尝试次数（含首次请求）。
+	monitorTransientMaxAttempts = 2
 
 	// monitorRunOneBuffer runOne 的总超时缓冲（除请求超时与 ping 超时外的额外裕量）。
 	monitorRunOneBuffer = 10 * time.Second

--- a/backend/internal/service/channel_monitor_group_probe.go
+++ b/backend/internal/service/channel_monitor_group_probe.go
@@ -1,0 +1,496 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type openAIGroupProbeGateway interface {
+	SelectAccountWithSchedulerForCapability(
+		ctx context.Context,
+		groupID *int64,
+		previousResponseID string,
+		sessionHash string,
+		requestedModel string,
+		excludedIDs map[int64]struct{},
+		requiredTransport OpenAIUpstreamTransport,
+		requiredCapability OpenAIEndpointCapability,
+		requireCompact bool,
+		previousResponseCanMove bool,
+		useUpstreamTokenCost bool,
+		clientHints ...string,
+	) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error)
+	ForwardAsChatCompletions(ctx context.Context, c *gin.Context, account *Account, body []byte, promptCacheKey string, defaultMappedModel string) (*OpenAIForwardResult, error)
+	ResolveChannelMappingAndRestrict(ctx context.Context, groupID *int64, model string) (ChannelMappingResult, bool)
+	ReplaceModelInBody(body []byte, newModel string) []byte
+	GenerateSessionHash(c *gin.Context, body []byte) string
+	ExtractSessionID(c *gin.Context, body []byte) string
+	ReportOpenAIAccountScheduleResult(accountID int64, model string, success bool, firstTokenMs *int)
+	RecordOpenAIAccountSwitch()
+}
+
+type anthropicGroupProbeGateway interface {
+	SelectAccountWithLoadAwareness(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, metadataUserID string, sub2apiUserID int64) (*AccountSelectionResult, error)
+	Forward(ctx context.Context, c *gin.Context, account *Account, parsed *ParsedRequest) (*ForwardResult, error)
+}
+
+type monitorProbeGroup struct {
+	id     int64
+	apiKey *APIKey
+}
+
+func (s *ChannelMonitorService) resolveMonitorProbeGroup(ctx context.Context, m *ChannelMonitor) (*monitorProbeGroup, error) {
+	if m == nil || (m.Provider != MonitorProviderOpenAI && m.Provider != MonitorProviderAnthropic) {
+		return nil, nil
+	}
+	if s.apiKeyRepo == nil {
+		return nil, nil
+	}
+	if m.Provider == MonitorProviderOpenAI && s.openAIGateway == nil {
+		return nil, nil
+	}
+	if m.Provider == MonitorProviderAnthropic && s.gateway == nil {
+		return nil, nil
+	}
+
+	apiKey, err := s.apiKeyRepo.GetByKey(ctx, normalizeMonitorProbeAPIKey(m.APIKey))
+	if errors.Is(err, ErrAPIKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load monitor api key: %w", err)
+	}
+	if apiKey == nil || apiKey.GroupID == nil || *apiKey.GroupID <= 0 {
+		return nil, nil
+	}
+	groupID := *apiKey.GroupID
+	return &monitorProbeGroup{id: groupID, apiKey: apiKey}, nil
+}
+
+func normalizeMonitorProbeAPIKey(key string) string {
+	key = strings.TrimSpace(key)
+	if parts := strings.SplitN(key, " ", 2); len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+		return strings.TrimSpace(parts[1])
+	}
+	return key
+}
+
+func (s *ChannelMonitorService) runGroupAccountProbeForModel(ctx context.Context, m *ChannelMonitor, model string, opts *CheckOptions, group *monitorProbeGroup) *CheckResult {
+	start := time.Now()
+	if m == nil || m.Provider != MonitorProviderOpenAI {
+		return groupAccountProbeErrorResult(model, start, "group account probe supports openai provider only")
+	}
+	if group == nil || group.id <= 0 {
+		return groupAccountProbeErrorResult(model, start, "monitor api key is not bound to a group")
+	}
+	if s.openAIGateway == nil {
+		return groupAccountProbeErrorResult(model, start, "openai gateway is not configured")
+	}
+	groupID := group.id
+	apiKey := group.apiKey
+	if apiKey == nil {
+		apiKey = &APIKey{Key: normalizeMonitorProbeAPIKey(m.APIKey), GroupID: &groupID}
+	}
+
+	challenge := generateChallenge()
+	body, apiMode, err := buildOpenAIGroupProbeBody(model, challenge, opts)
+	if err != nil {
+		return groupAccountProbeErrorResult(model, start, err.Error())
+	}
+
+	hashCtx, _ := newMonitorOpenAIProbeContext(ctx, apiKey, body)
+	sessionHash := s.openAIGateway.GenerateSessionHash(hashCtx, body)
+	promptCacheKey := s.openAIGateway.ExtractSessionID(hashCtx, body)
+	failedAccountIDs := make(map[int64]struct{})
+	attempts := make([]string, 0)
+	var bestDegraded *CheckResult
+
+	for {
+		if len(failedAccountIDs) > 0 && !sleepMonitorWithContext(ctx, monitorModelCheckGap) {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeErrorResult(model, start, "check cancelled during account probe")
+		}
+
+		selection, _, err := s.openAIGateway.SelectAccountWithSchedulerForCapability(
+			ctx,
+			&groupID,
+			"",
+			sessionHash,
+			model,
+			failedAccountIDs,
+			OpenAIUpstreamTransportAny,
+			OpenAIEndpointCapabilityChatCompletions,
+			false,
+			false,
+			false,
+		)
+		if err != nil {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, fmt.Sprintf("select group account: %v", err))
+		}
+		if selection == nil || selection.Account == nil {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, "select group account: no available accounts")
+		}
+
+		account := selection.Account
+		if _, seen := failedAccountIDs[account.ID]; seen {
+			if bestDegraded != nil {
+				return bestDegraded
+			}
+			return groupAccountProbeExhaustedResult(model, start, attempts, fmt.Sprintf("scheduler returned excluded account %d", account.ID))
+		}
+		if !selection.Acquired {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			attempts = append(attempts, accountProbeAttemptSummary(account, MonitorStatusFailed, "account concurrency slot unavailable"))
+			failedAccountIDs[account.ID] = struct{}{}
+			continue
+		}
+
+		attemptStart := time.Now()
+		result, attempt, passed, reportFailure := s.runOpenAIGroupProbeAttempt(ctx, m, apiKey, account, &groupID, model, body, apiMode, challenge, promptCacheKey, opts, attemptStart)
+		if selection.ReleaseFunc != nil {
+			selection.ReleaseFunc()
+		}
+		if passed {
+			if acceptGroupProbeResult(result, &bestDegraded) {
+				return result
+			}
+			if result == nil {
+				return groupAccountProbeErrorResult(model, start, "group account probe passed without result")
+			}
+			attempts = append(attempts, accountProbeAttemptSummary(account, result.Status, result.Message))
+			failedAccountIDs[account.ID] = struct{}{}
+			continue
+		}
+
+		attempts = append(attempts, attempt)
+		failedAccountIDs[account.ID] = struct{}{}
+		if reportFailure {
+			s.openAIGateway.ReportOpenAIAccountScheduleResult(account.ID, model, false, nil)
+			s.openAIGateway.RecordOpenAIAccountSwitch()
+		}
+	}
+}
+
+func acceptGroupProbeResult(result *CheckResult, bestDegraded **CheckResult) bool {
+	if result == nil {
+		return false
+	}
+	if result.Status == MonitorStatusOperational {
+		return true
+	}
+	if result.Status != MonitorStatusDegraded {
+		return true
+	}
+	if bestDegraded == nil {
+		return false
+	}
+	if *bestDegraded == nil || monitorResultLatencyLess(result, *bestDegraded) {
+		*bestDegraded = result
+	}
+	return false
+}
+
+func monitorResultLatencyLess(a, b *CheckResult) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.LatencyMs == nil {
+		return false
+	}
+	if b.LatencyMs == nil {
+		return true
+	}
+	return *a.LatencyMs < *b.LatencyMs
+}
+
+func buildOpenAIGroupProbeBody(model string, challenge monitorChallenge, opts *CheckOptions) ([]byte, string, error) {
+	requestedAPIMode := MonitorAPIModeChatCompletions
+	if err := validateAPIMode(MonitorProviderOpenAI, requestedAPIMode); err != nil {
+		return nil, "", err
+	}
+	adapter, apiMode, ok := providerAdapterFor(MonitorProviderOpenAI, requestedAPIMode)
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported provider %q", MonitorProviderOpenAI)
+	}
+	body, err := buildRequestBody(adapter, MonitorProviderOpenAI, apiMode, model, challenge.Prompt, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, apiMode, nil
+}
+
+func (s *ChannelMonitorService) runOpenAIGroupProbeAttempt(
+	ctx context.Context,
+	m *ChannelMonitor,
+	apiKey *APIKey,
+	account *Account,
+	groupID *int64,
+	model string,
+	body []byte,
+	apiMode string,
+	challenge monitorChallenge,
+	promptCacheKey string,
+	opts *CheckOptions,
+	start time.Time,
+) (*CheckResult, string, bool, bool) {
+	forwardBody := body
+	if mapping, _ := s.openAIGateway.ResolveChannelMappingAndRestrict(ctx, groupID, model); mapping.Mapped {
+		forwardBody = s.openAIGateway.ReplaceModelInBody(body, mapping.MappedModel)
+	}
+
+	attempts := monitorTransientMaxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		result, attemptSummary, passed, reportFailure, retrySameAccount := s.runOpenAIGroupProbeForwardOnce(
+			ctx,
+			m,
+			apiKey,
+			account,
+			model,
+			forwardBody,
+			apiMode,
+			challenge,
+			promptCacheKey,
+			opts,
+			start,
+		)
+		if passed || !retrySameAccount || attempt == attempts {
+			return result, attemptSummary, passed, reportFailure
+		}
+		if !sleepMonitorWithContext(ctx, monitorTransientRetryDelay) {
+			return nil, accountProbeAttemptSummary(account, MonitorStatusError, "check cancelled during transient retry"), false, false
+		}
+	}
+
+	return nil, accountProbeAttemptSummary(account, MonitorStatusError, "group account probe exhausted transient retries"), false, false
+}
+
+func (s *ChannelMonitorService) runOpenAIGroupProbeForwardOnce(
+	ctx context.Context,
+	m *ChannelMonitor,
+	apiKey *APIKey,
+	account *Account,
+	model string,
+	forwardBody []byte,
+	apiMode string,
+	challenge monitorChallenge,
+	promptCacheKey string,
+	opts *CheckOptions,
+	start time.Time,
+) (*CheckResult, string, bool, bool, bool) {
+	c, recorder := newMonitorOpenAIProbeContext(ctx, apiKey, forwardBody)
+	result, err := s.openAIGateway.ForwardAsChatCompletions(ctx, c, account, forwardBody, promptCacheKey, "")
+	if err != nil {
+		attemptSummary := accountProbeAttemptSummary(account, MonitorStatusError, monitorProbeForwardErrorMessage(err, recorder))
+		if shouldRetryOpenAIGroupProbeForwardFailure(account, err, recorder) {
+			return nil, attemptSummary, false, false, true
+		}
+		return nil, attemptSummary, false, true, false
+	}
+	if recorder.Code < http.StatusOK || recorder.Code >= http.StatusMultipleChoices {
+		message := fmt.Sprintf("upstream HTTP %d: %s", recorder.Code, truncateForErrorBody(recorder.Body.String()))
+		attemptSummary := accountProbeAttemptSummary(account, MonitorStatusError, message)
+		if shouldRetryOpenAIGroupProbeHTTPStatus(account, recorder.Code) {
+			return nil, attemptSummary, false, false, true
+		}
+		return nil, attemptSummary, false, true, false
+	}
+
+	respText := extractOpenAIChatText(recorder.Body.Bytes())
+	if bodyOverrideMode(opts) == MonitorBodyOverrideModeReplace {
+		if strings.TrimSpace(respText) == "" {
+			return nil, accountProbeAttemptSummary(account, MonitorStatusFailed, "replace-mode: upstream returned 2xx with empty text"), false, false, false
+		}
+		res, attemptSummary, passed, reportFailure := s.groupAccountProbeSuccessResult(model, start, account, result)
+		return res, attemptSummary, passed, reportFailure, false
+	}
+	if apiMode == MonitorAPIModeResponses && strings.TrimSpace(respText) == "" {
+		respText = extractOpenAIResponsesText(recorder.Body.Bytes())
+	}
+	if !validateChallenge(respText, challenge.Expected) {
+		message := fmt.Sprintf("challenge mismatch (expected %s, got %q)", challenge.Expected, respText)
+		return nil, accountProbeAttemptSummary(account, MonitorStatusFailed, message), false, false, false
+	}
+	res, attemptSummary, passed, reportFailure := s.groupAccountProbeSuccessResult(model, start, account, result)
+	return res, attemptSummary, passed, reportFailure, false
+}
+
+func newMonitorOpenAIProbeContext(ctx context.Context, apiKey *APIKey, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, providerOpenAIPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "sub2api-channel-monitor")
+	c.Request = req
+	if apiKey != nil {
+		c.Set("api_key", apiKey)
+	}
+	return c, recorder
+}
+
+func (s *ChannelMonitorService) groupAccountProbeSuccessResult(model string, start time.Time, account *Account, forwardResult *OpenAIForwardResult) (*CheckResult, string, bool, bool) {
+	latencyMs := int(time.Since(start).Milliseconds())
+	res := &CheckResult{
+		Model:     model,
+		Status:    MonitorStatusOperational,
+		LatencyMs: &latencyMs,
+		CheckedAt: time.Now().UTC(),
+		Message: appendMonitorMessage("", fmt.Sprintf(
+			"group account probe passed account %d (%s)",
+			account.ID,
+			strings.TrimSpace(account.Name),
+		)),
+	}
+	if time.Since(start) >= monitorDegradedThreshold {
+		res.Status = MonitorStatusDegraded
+		res.Message = appendMonitorMessage(res.Message, fmt.Sprintf("slow group account probe: %dms", latencyMs))
+	}
+	if forwardResult != nil {
+		s.openAIGateway.ReportOpenAIAccountScheduleResult(account.ID, model, true, forwardResult.FirstTokenMs)
+	} else {
+		s.openAIGateway.ReportOpenAIAccountScheduleResult(account.ID, model, true, nil)
+	}
+	return res, "", true, false
+}
+
+func groupAccountProbeExhaustedResult(model string, start time.Time, attempts []string, terminal string) *CheckResult {
+	if len(attempts) == 0 {
+		return groupAccountProbeErrorResult(model, start, terminal)
+	}
+	status := MonitorStatusFailed
+	for _, attempt := range attempts {
+		if strings.Contains(attempt, MonitorStatusError+":") {
+			status = MonitorStatusError
+			break
+		}
+	}
+	latencyMs := int(time.Since(start).Milliseconds())
+	message := fmt.Sprintf("group account probe all accounts failed: %s", strings.Join(attempts, "; "))
+	if strings.TrimSpace(terminal) != "" {
+		message += "; " + terminal
+	}
+	return &CheckResult{
+		Model:     model,
+		Status:    status,
+		LatencyMs: &latencyMs,
+		Message:   truncateMessage(sanitizeErrorMessage(message)),
+		CheckedAt: time.Now().UTC(),
+	}
+}
+
+func groupAccountProbeErrorResult(model string, start time.Time, message string) *CheckResult {
+	latencyMs := int(time.Since(start).Milliseconds())
+	return &CheckResult{
+		Model:     model,
+		Status:    MonitorStatusError,
+		LatencyMs: &latencyMs,
+		Message:   truncateMessage(sanitizeErrorMessage(message)),
+		CheckedAt: time.Now().UTC(),
+	}
+}
+
+func accountProbeAttemptSummary(acc *Account, status, message string) string {
+	accountID := int64(0)
+	name := "unnamed"
+	if acc != nil {
+		accountID = acc.ID
+		if trimmed := strings.TrimSpace(acc.Name); trimmed != "" {
+			name = trimmed
+		}
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "no detail"
+	}
+	return fmt.Sprintf("#%d %s %s: %s", accountID, name, status, message)
+}
+
+func appendMonitorMessage(existing, extra string) string {
+	existing = strings.TrimSpace(existing)
+	extra = strings.TrimSpace(extra)
+	if existing == "" {
+		return truncateMessage(sanitizeErrorMessage(extra))
+	}
+	if extra == "" {
+		return truncateMessage(sanitizeErrorMessage(existing))
+	}
+	return truncateMessage(sanitizeErrorMessage(existing + "; " + extra))
+}
+
+func monitorProbeForwardErrorMessage(err error, recorder *httptest.ResponseRecorder) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	if recorder != nil {
+		body := strings.TrimSpace(recorder.Body.String())
+		if body != "" {
+			message += ": " + truncateForErrorBody(body)
+		}
+	}
+	return message
+}
+
+func shouldRetryOpenAIGroupProbeForwardFailure(account *Account, err error, recorder *httptest.ResponseRecorder) bool {
+	var failoverErr *UpstreamFailoverError
+	if errors.As(err, &failoverErr) {
+		if failoverErr.RetryableOnSameAccount || shouldRetryOpenAIGroupProbeHTTPStatus(account, failoverErr.StatusCode) {
+			return true
+		}
+	}
+	if recorder != nil && shouldRetryOpenAIGroupProbeHTTPStatus(account, recorder.Code) {
+		return true
+	}
+	lowerMessage := strings.ToLower(monitorProbeForwardErrorMessage(err, recorder))
+	switch {
+	case strings.Contains(lowerMessage, "unexpected eof"),
+		strings.HasSuffix(lowerMessage, " eof"),
+		strings.Contains(lowerMessage, " eof:"),
+		strings.Contains(lowerMessage, "connection reset"),
+		strings.Contains(lowerMessage, "gateway timeout"),
+		strings.Contains(lowerMessage, "service unavailable"),
+		strings.Contains(lowerMessage, "bad gateway"),
+		strings.Contains(lowerMessage, "timeout"):
+		return true
+	}
+	return strings.Contains(lowerMessage, "upstream request failed") && !classifyOpenAITransportError(err).Persistent
+}
+
+func shouldRetryOpenAIGroupProbeHTTPStatus(account *Account, statusCode int) bool {
+	if isMonitorTransientHTTPStatus(statusCode) {
+		return true
+	}
+	if account == nil || !account.IsPoolMode() {
+		return false
+	}
+	return account.IsPoolModeRetryableStatus(statusCode)
+}
+
+func (m *ChannelMonitor) APIKeyObject() *APIKey {
+	if m == nil {
+		return nil
+	}
+	return &APIKey{ID: 0, Key: m.APIKey}
+}

--- a/backend/internal/service/channel_monitor_group_probe_test.go
+++ b/backend/internal/service/channel_monitor_group_probe_test.go
@@ -1,0 +1,32 @@
+package service
+
+import "testing"
+
+func TestAcceptGroupProbeResult_PrefersOperationalOverDegraded(t *testing.T) {
+	var best *CheckResult
+	slowLatency := 8000
+	fastLatency := 1200
+
+	if acceptGroupProbeResult(&CheckResult{Status: MonitorStatusDegraded, LatencyMs: &slowLatency}, &best) {
+		t.Fatal("degraded result should be kept as fallback, not accepted immediately")
+	}
+	if best == nil || best.LatencyMs == nil || *best.LatencyMs != slowLatency {
+		t.Fatalf("degraded fallback not recorded correctly: %#v", best)
+	}
+	if !acceptGroupProbeResult(&CheckResult{Status: MonitorStatusOperational, LatencyMs: &fastLatency}, &best) {
+		t.Fatal("operational result should be accepted immediately")
+	}
+}
+
+func TestAcceptGroupProbeResult_KeepsFastestDegradedFallback(t *testing.T) {
+	var best *CheckResult
+	slowLatency := 9000
+	fasterLatency := 7000
+
+	acceptGroupProbeResult(&CheckResult{Status: MonitorStatusDegraded, LatencyMs: &slowLatency}, &best)
+	acceptGroupProbeResult(&CheckResult{Status: MonitorStatusDegraded, LatencyMs: &fasterLatency}, &best)
+
+	if best == nil || best.LatencyMs == nil || *best.LatencyMs != fasterLatency {
+		t.Fatalf("fastest degraded fallback not retained: %#v", best)
+	}
+}

--- a/backend/internal/service/channel_monitor_service.go
+++ b/backend/internal/service/channel_monitor_service.go
@@ -8,10 +8,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 )
 
 // ChannelMonitorRepository 渠道监控数据访问接口。
@@ -63,8 +60,11 @@ type ChannelMonitorRepository interface {
 
 // ChannelMonitorService 渠道监控管理服务。
 type ChannelMonitorService struct {
-	repo      ChannelMonitorRepository
-	encryptor SecretEncryptor
+	repo          ChannelMonitorRepository
+	encryptor     SecretEncryptor
+	apiKeyRepo    APIKeyRepository
+	gateway       anthropicGroupProbeGateway
+	openAIGateway openAIGroupProbeGateway
 	// scheduler 由 wire 通过 SetScheduler 注入；CRUD 后调用对应钩子即时同步任务。
 	// 测试或未注入场景下保持 nil，所有钩子调用变为 no-op。
 	scheduler MonitorScheduler
@@ -81,6 +81,13 @@ const ChannelMonitorDuplicateOperationIDMetadataKey = "sub2api:duplicate_operati
 // NewChannelMonitorService 创建渠道监控服务实例。
 func NewChannelMonitorService(repo ChannelMonitorRepository, encryptor SecretEncryptor) *ChannelMonitorService {
 	return &ChannelMonitorService{repo: repo, encryptor: encryptor}
+}
+
+// SetGroupAccountProbeDependencies injects optional dependencies for scheduler-backed group probing.
+func (s *ChannelMonitorService) SetGroupAccountProbeDependencies(apiKeyRepo APIKeyRepository, gateway anthropicGroupProbeGateway, openAIGateway openAIGroupProbeGateway) {
+	s.apiKeyRepo = apiKeyRepo
+	s.gateway = gateway
+	s.openAIGateway = openAIGateway
 }
 
 // ---------- CRUD ----------
@@ -425,7 +432,7 @@ func (s *ChannelMonitorService) ListHistory(ctx context.Context, id int64, model
 
 // ---------- 业务 ----------
 
-// RunCheck 同步触发对一个监控的检测：并发跑 primary + extra 模型，
+// RunCheck 同步触发对一个监控的检测：依次检测 primary + extra 模型，
 // 写历史记录并更新 last_checked_at。返回每个模型的检测结果。
 func (s *ChannelMonitorService) RunCheck(ctx context.Context, id int64) ([]*CheckResult, error) {
 	m, err := s.Get(ctx, id) // 已解密 APIKey
@@ -435,7 +442,7 @@ func (s *ChannelMonitorService) RunCheck(ctx context.Context, id int64) ([]*Chec
 	if m.APIKeyDecryptFailed {
 		return nil, ErrChannelMonitorAPIKeyDecryptFailed
 	}
-	results := s.runChecksConcurrent(ctx, m)
+	results := s.runChecksSerial(ctx, m)
 	s.persistCheckResults(ctx, m, results)
 	return results, nil
 }
@@ -465,38 +472,75 @@ func (s *ChannelMonitorService) persistCheckResults(ctx context.Context, m *Chan
 	}
 }
 
-// runChecksConcurrent 对 primary + extra 模型并发执行检测。
-// errgroup 仅用于等待，不传播错误（每个 model 失败都已打包进 CheckResult）。
-func (s *ChannelMonitorService) runChecksConcurrent(ctx context.Context, m *ChannelMonitor) []*CheckResult {
+// runChecksSerial 对 primary + extra 模型串行执行检测，避免同一监控在短时间内
+// 对同一上游或账号发出并发请求。
+func (s *ChannelMonitorService) runChecksSerial(ctx context.Context, m *ChannelMonitor) []*CheckResult {
 	models := append([]string{m.PrimaryModel}, m.ExtraModels...)
 	results := make([]*CheckResult, len(models))
 
 	// ping 共享一次，所有模型记录同一个 ping 延迟。
 	pingMs := pingEndpointOrigin(ctx, m.Endpoint)
 
-	// 所有模型共用同一份 CheckOptions（来自监控的快照字段）。
-	opts := &CheckOptions{
+	opts := monitorRuntimeCheckOptions(m)
+	group, groupProbeErr := s.resolveMonitorProbeGroup(ctx, m)
+
+	for i, model := range models {
+		if i > 0 && !sleepMonitorWithContext(ctx, monitorModelCheckGap) {
+			results[i] = cancelledMonitorCheckResult(model)
+			continue
+		}
+
+		var r *CheckResult
+		if groupProbeErr != nil {
+			r = groupAccountProbeErrorResult(model, time.Now(), groupProbeErr.Error())
+		} else if group != nil {
+			if m.Provider == MonitorProviderAnthropic {
+				r = s.runAnthropicGroupAccountProbeForModel(ctx, m, model, opts, group)
+			} else {
+				r = s.runGroupAccountProbeForModel(ctx, m, model, opts, group)
+			}
+		} else {
+			r := runCheckForModel(ctx, m.Provider, m.Endpoint, m.APIKey, model, opts)
+			r.PingLatencyMs = pingMs
+			results[i] = r
+			continue
+		}
+		r.PingLatencyMs = pingMs
+		results[i] = r
+	}
+	return results
+}
+
+func monitorRuntimeCheckOptions(m *ChannelMonitor) *CheckOptions {
+	return &CheckOptions{
 		APIMode:          m.APIMode,
 		ExtraHeaders:     m.ExtraHeaders,
 		BodyOverrideMode: m.BodyOverrideMode,
 		BodyOverride:     m.BodyOverride,
 	}
+}
 
-	var eg errgroup.Group
-	var mu sync.Mutex
-	for i, model := range models {
-		i, model := i, model
-		eg.Go(func() error {
-			r := runCheckForModel(ctx, m.Provider, m.Endpoint, m.APIKey, model, opts)
-			r.PingLatencyMs = pingMs
-			mu.Lock()
-			results[i] = r
-			mu.Unlock()
-			return nil
-		})
+func sleepMonitorWithContext(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
 	}
-	_ = eg.Wait()
-	return results
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func cancelledMonitorCheckResult(model string) *CheckResult {
+	return &CheckResult{
+		Model:     model,
+		Status:    MonitorStatusError,
+		Message:   "check cancelled",
+		CheckedAt: time.Now(),
+	}
 }
 
 // ---------- 调度器协作 ----------

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -830,8 +830,13 @@ func ProvidePaymentOrderExpiryService(paymentSvc *PaymentService, lockCache Lead
 func ProvideChannelMonitorService(
 	repo ChannelMonitorRepository,
 	encryptor SecretEncryptor,
+	apiKeyRepo APIKeyRepository,
+	gateway *GatewayService,
+	openAIGateway *OpenAIGatewayService,
 ) *ChannelMonitorService {
-	return NewChannelMonitorService(repo, encryptor)
+	svc := NewChannelMonitorService(repo, encryptor)
+	svc.SetGroupAccountProbeDependencies(apiKeyRepo, gateway, openAIGateway)
+	return svc
 }
 
 // ProvideChannelMonitorRunner 创建并启动渠道监控调度器。


### PR DESCRIPTION
## Summary

- resolve a channel monitor API key to its configured group
- retry scheduler-selected accounts after retryable or account-specific probe failures
- prefer an operational result while retaining the fastest degraded result as fallback
- support both OpenAI and Anthropic group-backed monitors

## Validation

This contribution branch was not rebuilt or retested locally at submission time. The behavior is already used in a production-derived deployment, while repository-specific validation is intentionally left to the upstream CI. Regression tests are included but were not executed locally for this submission.

## Scope

This PR contains only provider-neutral group probing and fallback behavior. It does not include deployment configuration, account data, pricing rules, private endpoints, or product-specific media adapters.