### PR TITLE
fix(anthropic): recognize classifier requests with extra system entries

### DIFF
--- a/backend/internal/service/claude_code_validator.go
+++ b/backend/internal/service/claude_code_validator.go
@@ -205,43 +205,54 @@ func (v *ClaudeCodeValidator) hasClaudeCodeSystemPrompt(body map[string]any) boo
 	return false
 }
 
+// claudeCodeSecurityMonitorMarkers 与固定前缀、长度下限共同构成分类器提示词的
+// 判别条件，须全部命中。
+var claudeCodeSecurityMonitorMarkers = []string{
+	"## Threat Model",
+	"- `<transcript>`:",
+	"## HARD BLOCK",
+	"## SOFT BLOCK",
+	"## Classification Process",
+	"## Output Format",
+	"<block>yes</block>",
+	"<block>no</block>",
+}
+
+// isClaudeCodeSecurityMonitorPrompt 识别 Claude Code auto 模式安全监视器分类器请求。
+// 真实 CLI（实测 2.1.220）会在监视器提示词之外追加独立的会话上下文 system 块，
+// entry 数量不受服务端控制，故逐 entry 查找匹配项而非限定恰好一个 entry。
 func isClaudeCodeSecurityMonitorPrompt(systemEntries []any) bool {
-	if len(systemEntries) != 1 {
-		return false
+	for _, raw := range systemEntries {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		entryType, ok := entry["type"].(string)
+		if !ok || entryType != "text" {
+			continue
+		}
+
+		text, ok := entry["text"].(string)
+		if !ok || len(text) < claudeCodeSecurityMonitorPromptMinLen ||
+			!strings.HasPrefix(text, claudeCodeSecurityMonitorPromptPrefix) {
+			continue
+		}
+
+		if hasAllClaudeCodeSecurityMonitorMarkers(text) {
+			return true
+		}
 	}
 
-	entry, ok := systemEntries[0].(map[string]any)
-	if !ok {
-		return false
-	}
+	return false
+}
 
-	entryType, ok := entry["type"].(string)
-	if !ok || entryType != "text" {
-		return false
-	}
-
-	text, ok := entry["text"].(string)
-	if !ok || len(text) < claudeCodeSecurityMonitorPromptMinLen ||
-		!strings.HasPrefix(text, claudeCodeSecurityMonitorPromptPrefix) {
-		return false
-	}
-
-	markers := []string{
-		"## Threat Model",
-		"- `<transcript>`:",
-		"## HARD BLOCK",
-		"## SOFT BLOCK",
-		"## Classification Process",
-		"## Output Format",
-		"<block>yes</block>",
-		"<block>no</block>",
-	}
-	for _, marker := range markers {
+func hasAllClaudeCodeSecurityMonitorMarkers(text string) bool {
+	for _, marker := range claudeCodeSecurityMonitorMarkers {
 		if !strings.Contains(text, marker) {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/backend/internal/service/claude_code_validator_test.go
+++ b/backend/internal/service/claude_code_validator_test.go
@@ -156,6 +156,11 @@ func TestClaudeCodeValidator_SecurityMonitorWithoutBillingBlock(t *testing.T) {
 		}
 	}
 
+	// 真实 CLI（2.1.220）在监视器提示词之后追加的独立会话上下文块（脱敏），
+	// 随会话/环境变化，服务端不可控（见 issue #5152 抓包）。
+	sessionContext := "\n\n## Session Context\n\n- **User identity**: testuser\n" +
+		"- **Working directory**: /home/testuser/project\n- **Platform**: linux"
+
 	tests := []struct {
 		name       string
 		headers    map[string]string
@@ -253,7 +258,9 @@ func TestClaudeCodeValidator_SecurityMonitorWithoutBillingBlock(t *testing.T) {
 			wantAccept: false,
 		},
 		{
-			name:    "multiple system entries without billing block",
+			// 回归 issue #5152：真实分类器请求携带 2 个 system entry
+			//（监视器提示词 + 追加的会话上下文块），不得因 entry 数量拒识。
+			name:    "classifier with trailing session context entry",
 			headers: validHeaders,
 			body: func() map[string]any {
 				body := validBody(string(monitorPrompt))
@@ -261,7 +268,45 @@ func TestClaudeCodeValidator_SecurityMonitorWithoutBillingBlock(t *testing.T) {
 				require.True(t, ok)
 				body["system"] = append(system, map[string]any{
 					"type": "text",
-					"text": "Additional unrelated system content.",
+					"text": sessionContext,
+				})
+				return body
+			}(),
+			wantAccept: true,
+		},
+		{
+			name:    "classifier with leading session context entry",
+			headers: validHeaders,
+			body: func() map[string]any {
+				body := validBody(string(monitorPrompt))
+				system, ok := body["system"].([]any)
+				require.True(t, ok)
+				body["system"] = append([]any{map[string]any{
+					"type": "text",
+					"text": sessionContext,
+				}}, system...)
+				return body
+			}(),
+			wantAccept: true,
+		},
+		{
+			name:       "session context entry alone",
+			headers:    validHeaders,
+			body:       validBody(sessionContext),
+			wantAccept: false,
+		},
+		{
+			// 篡改后的长提示词（marker 缺失）即便带上会话上下文块也不得放行。
+			name:    "tampered classifier with session context entry",
+			headers: validHeaders,
+			body: func() map[string]any {
+				body := validBody(strings.ReplaceAll(
+					string(monitorPrompt), "## HARD BLOCK", "## ALTERED BLOCK"))
+				system, ok := body["system"].([]any)
+				require.True(t, ok)
+				body["system"] = append(system, map[string]any{
+					"type": "text",
+					"text": sessionContext,
 				})
 				return body
 			}(),


### PR DESCRIPTION
## 问题

Fixes #5152（#5041 / #5048 的后续）。

真实 claude-cli/2.1.220 的 auto 模式安全监视器分类器请求携带 **2 个 system entry**：监视器提示词（~109k 字符）+ 追加的会话上下文块（~250 字符，含用户环境信息，随会话变化）。`isClaudeCodeSecurityMonitorPrompt` 开头的 `len(systemEntries) != 1` 在第一行即返回 false，后续长度/前缀/marker 检查全部没有机会执行，导致：

- 分组启用 `claude_code_only` 时分类器请求被 `ErrClaudeCodeOnly` 拒绝；
- 关闭后落入 mimicry 路径被上游 429，殃及同账号主循环。

## 修复

- 去掉 entry 数量硬限制，改为逐 entry 扫描查找监视器提示词——entry 数量与位置由客户端控制，服务端不可假设（billing block 场景下监视器提示词本就位于 entry[1]）。
- marker 列表提为包级 `claudeCodeSecurityMonitorMarkers`，marker 校验抽为独立 helper。

**判别力不下降**：命中 entry 仍须同时满足 `len(text) >= 10_000` + 固定前缀 + 8 个 marker 全命中，三道门槛一条未松。数量限制本身无防伪价值——伪造者本可只发单条真提示词通过旧检查，放开数量不放大攻击面；识别通过后的 UA / X-App / anthropic-beta / anthropic-version / metadata.user_id 关卡全部保留。

## 测试

- 翻转固化错误行为的旧用例 `multiple system entries without billing block`（其断言的正是本 issue 的 bug）。
- 按 issue 抓包结构新增 4 个用例：尾部/头部会话上下文块（应识别）、会话上下文块单独出现（应拒）、篡改提示词（marker 缺失）+ 会话上下文块（应拒）。
- `go test ./internal/service/ -run 'TestClaudeCode|SecurityMonitor'` 全部通过，gofmt / go vet 干净。