### PR TITLE
fix(proxy): prefer HTTPS probes and skip hijacked HTTP redirects

### DIFF
--- a/backend/internal/repository/proxy_probe_service.go
+++ b/backend/internal/repository/proxy_probe_service.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -44,12 +45,19 @@ const (
 	defaultProxyProbeResponseMaxBytes = int64(1024 * 1024)
 )
 
-// probeURLs 按优先级排列的探测 URL 列表
-// 某些 AI API 专用代理只允许访问特定域名，因此需要多个备选
-var probeURLs = []struct {
+type probeTarget struct {
 	url    string
 	parser string // "ip-api" or "ipify"
-}{
+}
+
+// defaultProbeURLs 按优先级排列的探测 URL 列表。
+//
+// 优先使用 HTTPS：真实 AI 出站流量也是 HTTPS，且明文 HTTP 探测在国内云厂商
+// 出口上常被 DNS/备案中间页劫持（302 → webblock HTML），导致代理明明可用却被误判失败。
+// HTTP 作为兜底，兼容只放行特定明文域名的专用代理。
+var defaultProbeURLs = []probeTarget{
+	{"https://api64.ipify.org?format=json", "ipify"},
+	{"https://api.ipify.org?format=json", "ipify"},
 	{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
 	{"http://api64.ipify.org?format=json", "ipify"},
 }
@@ -59,10 +67,19 @@ type proxyProbeService struct {
 	allowPrivateHosts  bool
 	validateResolvedIP bool
 	maxResponseBytes   int64
+	// probeURLs 仅测试可注入；生产为空时使用 defaultProbeURLs。
+	probeURLs []probeTarget
+}
+
+func (s *proxyProbeService) targets() []probeTarget {
+	if len(s.probeURLs) > 0 {
+		return s.probeURLs
+	}
+	return defaultProbeURLs
 }
 
 func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*service.ProxyExitInfo, int64, error) {
-	client, err := httpclient.GetClient(httpclient.Options{
+	base, err := httpclient.GetClient(httpclient.Options{
 		ProxyURL:           proxyURL,
 		Timeout:            defaultProxyProbeTimeout,
 		InsecureSkipVerify: s.insecureSkipVerify,
@@ -73,8 +90,18 @@ func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*s
 		return nil, 0, fmt.Errorf("failed to create proxy client: %w", err)
 	}
 
+	// 不跟随重定向：被劫持时常见 302 → 备案拦截 HTML，跟随后得到 200 HTML 只会污染错误信息。
+	// 直接把 3xx 当失败，快速切换到下一个探测目标（尤其是 HTTPS）。
+	client := &http.Client{
+		Transport: base.Transport,
+		Timeout:   base.Timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
 	var lastErr error
-	for _, probe := range probeURLs {
+	for _, probe := range s.targets() {
 		exitInfo, latencyMs, err := s.probeWithURL(ctx, client, probe.url, probe.parser)
 		if err == nil {
 			return exitInfo, latencyMs, nil
@@ -91,6 +118,9 @@ func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Clien
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to create request: %w", err)
 	}
+	// 降低被中间页/WAF 当成浏览器爬虫的概率（对探测接口通常无害）
+	req.Header.Set("Accept", "application/json,text/plain,*/*")
+	req.Header.Set("User-Agent", "sub2api-proxy-probe/1.0")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -116,6 +146,11 @@ func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Clien
 		return nil, latencyMs, fmt.Errorf("proxy probe response exceeds limit: %d", maxResponseBytes)
 	}
 
+	// 明文 HTTP 被劫持时常见：状态 200 但 body 是 HTML 拦截页
+	if looksLikeHTMLProbeBody(body) {
+		return nil, latencyMs, fmt.Errorf("probe returned HTML instead of IP JSON (possible intercept/webblock)")
+	}
+
 	switch parser {
 	case "ip-api":
 		return s.parseIPAPI(body, latencyMs)
@@ -124,6 +159,23 @@ func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Clien
 	default:
 		return nil, latencyMs, fmt.Errorf("unknown parser: %s", parser)
 	}
+}
+
+func looksLikeHTMLProbeBody(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return false
+	}
+	// 快速路径：标准 HTML 文档
+	if bytes.HasPrefix(trimmed, []byte("<!")) ||
+		bytes.HasPrefix(trimmed, []byte("<html")) ||
+		bytes.HasPrefix(trimmed, []byte("<HTML")) {
+		return true
+	}
+	lower := bytes.ToLower(trimmed)
+	return bytes.Contains(lower, []byte("<html")) ||
+		bytes.Contains(lower, []byte("webblock")) ||
+		bytes.Contains(lower, []byte("beian-block"))
 }
 
 func (s *proxyProbeService) parseIPAPI(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {

--- a/backend/internal/repository/proxy_probe_service.go
+++ b/backend/internal/repository/proxy_probe_service.go
@@ -92,13 +92,12 @@ func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*s
 
 	// 不跟随重定向：被劫持时常见 302 → 备案拦截 HTML，跟随后得到 200 HTML 只会污染错误信息。
 	// 直接把 3xx 当失败，快速切换到下一个探测目标（尤其是 HTTPS）。
-	client := &http.Client{
-		Transport: base.Transport,
-		Timeout:   base.Timeout,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	// 浅拷贝 base 以保留 httpclient.GetClient 设置的其它字段（与 http_upstream 惯例一致）。
+	clone := *base
+	clone.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
+	client := &clone
 
 	var lastErr error
 	for _, probe := range s.targets() {

--- a/backend/internal/repository/proxy_probe_service_test.go
+++ b/backend/internal/repository/proxy_probe_service_test.go
@@ -50,14 +50,17 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_UnsupportedProxyScheme() {
 }
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPAPI() {
+	// 限制为 HTTP 探测目标，避免 mock HTTP 代理无法处理 HTTPS CONNECT 导致超时。
+	s.prober.probeURLs = []probeTarget{
+		{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 检查是否是 ip-api 请求
 		if strings.Contains(r.RequestURI, "ip-api.com") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"status":"success","query":"1.2.3.4","city":"c","regionName":"r","country":"cc","countryCode":"CC"}`)
 			return
 		}
-		// 其他请求返回错误
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 
@@ -72,13 +75,15 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPAPI() {
 }
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPifyFallback() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// ip-api 失败
 		if strings.Contains(r.RequestURI, "ip-api.com") {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		// ipify 成功
 		if strings.Contains(r.RequestURI, "api64.ipify.org") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"ip": "5.6.7.8"}`)
@@ -93,7 +98,71 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPifyFallback() {
 	require.Equal(s.T(), "5.6.7.8", info.IP)
 }
 
+func (s *ProxyProbeServiceSuite) TestProbeProxy_SkipsHTTPWebblockAndFallsBack() {
+	// 模拟：明文 HTTP 探测被 302 劫持；后续目标返回真实出口 IP JSON。
+	s.prober.probeURLs = []probeTarget{
+		{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
+	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "ip-api.com") {
+			w.Header().Set("Location", "https://dnspod.qcloud.com/static/webblock.html?d=ip-api.com")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		if strings.Contains(r.RequestURI, "api64.ipify.org") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ip":"9.9.9.9"}`)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	info, _, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "9.9.9.9", info.IP)
+}
+
+func (s *ProxyProbeServiceSuite) TestProbeProxy_RejectsHTMLBody() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
+	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `<!DOCTYPE html><html><body class="beian-block">blocked</body></html>`)
+	}))
+
+	_, _, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL)
+	require.Error(s.T(), err)
+	require.ErrorContains(s.T(), err, "HTML")
+}
+
+func (s *ProxyProbeServiceSuite) TestProbeProxy_DoesNotFollowRedirect() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
+	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "api64.ipify.org") {
+			w.Header().Set("Location", "http://example.invalid/webblock")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		// 若错误地跟随了重定向，这里会返回“假成功”
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ip":"should-not-use"}`)
+	}))
+
+	_, _, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL)
+	require.Error(s.T(), err)
+	require.ErrorContains(s.T(), err, "status: 302")
+}
+
 func (s *ProxyProbeServiceSuite) TestProbeProxy_AllFailed() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
@@ -104,13 +173,16 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_AllFailed() {
 }
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_InvalidJSON() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.RequestURI, "ip-api.com") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "not-json")
 			return
 		}
-		// ipify 也返回无效响应
 		if strings.Contains(r.RequestURI, "api64.ipify.org") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "not-json")
@@ -125,6 +197,9 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_InvalidJSON() {
 }
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_ProxyServerClosed() {
+	s.prober.probeURLs = []probeTarget{
+		{"http://api64.ipify.org?format=json", "ipify"},
+	}
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	s.proxySrv.Close()
 
@@ -164,6 +239,20 @@ func (s *ProxyProbeServiceSuite) TestParseIPify_NoIP() {
 	_, _, err := s.prober.parseIPify(body, 50)
 	require.Error(s.T(), err)
 	require.ErrorContains(s.T(), err, "no IP found")
+}
+
+func (s *ProxyProbeServiceSuite) TestLooksLikeHTMLProbeBody() {
+	require.True(s.T(), looksLikeHTMLProbeBody([]byte("<!DOCTYPE html><html></html>")))
+	require.True(s.T(), looksLikeHTMLProbeBody([]byte(` <div class="beian-block">x</div>`)))
+	require.True(s.T(), looksLikeHTMLProbeBody([]byte(`webblock intercept`)))
+	require.False(s.T(), looksLikeHTMLProbeBody([]byte(`{"ip":"1.2.3.4"}`)))
+	require.False(s.T(), looksLikeHTMLProbeBody(nil))
+}
+
+func (s *ProxyProbeServiceSuite) TestDefaultProbeURLsPreferHTTPS() {
+	require.GreaterOrEqual(s.T(), len(defaultProbeURLs), 2)
+	require.True(s.T(), strings.HasPrefix(defaultProbeURLs[0].url, "https://"))
+	require.True(s.T(), strings.HasPrefix(defaultProbeURLs[1].url, "https://"))
 }
 
 func TestProxyProbeServiceSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

Improves proxy "测试连接" reliability when plain HTTP IP lookup endpoints are hijacked (common on some CN cloud egresses: `302 → webblock HTML`).

### Changes
- Prefer **HTTPS** `ipify` probes first (matches real AI HTTPS egress)
- Keep HTTP `ip-api` / `ipify` as fallbacks
- **Do not follow redirects** (treat 3xx as failure and try next target)
- Reject **HTML / webblock** response bodies even when status is 200
- Set modest `Accept` / `User-Agent` for probe requests
- Tests: 302 webblock fallback, HTML rejection, no-redirect, HTTPS-first defaults

### Test plan
- [x] `go test ./internal/repository/ -run "ProxyProbe|LooksLikeHTML|DefaultProbe" -count=1` → PASS
- [ ] UI: 代理管理 → 测试连接 on a known-good proxy