### PR TITLE
feat(settings): configure custom media model patterns

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -279,6 +279,8 @@ func (h *SettingHandler) GetSettings(c *gin.Context) {
 		EnableClientDatelineNormalization:                      settings.EnableClientDatelineNormalization,
 		AntigravityUserAgentVersion:                            settings.AntigravityUserAgentVersion,
 		OpenAICodexUserAgent:                                   settings.OpenAICodexUserAgent,
+		CustomImageModelPatterns:                               settings.CustomImageModelPatterns,
+		CustomVideoModelPatterns:                               settings.CustomVideoModelPatterns,
 		MinCodexVersion:                                        settings.MinCodexVersion,
 		MaxCodexVersion:                                        settings.MaxCodexVersion,
 		CodexCLIOnlyBlacklist:                                  settings.CodexCLIOnlyBlacklist,

--- a/backend/internal/handler/admin/setting_handler_audit.go
+++ b/backend/internal/handler/admin/setting_handler_audit.go
@@ -443,6 +443,12 @@ func diffSettings(before *service.SystemSettings, after *service.SystemSettings,
 	if before.OpenAICodexUserAgent != after.OpenAICodexUserAgent {
 		changed = append(changed, "openai_codex_user_agent")
 	}
+	if before.CustomImageModelPatterns != after.CustomImageModelPatterns {
+		changed = append(changed, service.SettingKeyCustomImageModelPatterns)
+	}
+	if before.CustomVideoModelPatterns != after.CustomVideoModelPatterns {
+		changed = append(changed, service.SettingKeyCustomVideoModelPatterns)
+	}
 	if before.PaymentVisibleMethodAlipaySource != after.PaymentVisibleMethodAlipaySource {
 		changed = append(changed, "payment_visible_method_alipay_source")
 	}

--- a/backend/internal/handler/admin/setting_handler_update.go
+++ b/backend/internal/handler/admin/setting_handler_update.go
@@ -236,6 +236,8 @@ type UpdateSettingsRequest struct {
 	EnableClientDatelineNormalization      *bool   `json:"enable_client_dateline_normalization"`
 	AntigravityUserAgentVersion            *string `json:"antigravity_user_agent_version"`
 	OpenAICodexUserAgent                   *string `json:"openai_codex_user_agent"`
+	CustomImageModelPatterns               *string `json:"custom_image_model_patterns"`
+	CustomVideoModelPatterns               *string `json:"custom_video_model_patterns"`
 
 	// codex_cli_only 加固（global-only）
 	MinCodexVersion                      string `json:"min_codex_version"`
@@ -1276,6 +1278,17 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 			return
 		}
 	}
+	for key, raw := range map[string]*string{
+		service.SettingKeyCustomImageModelPatterns: req.CustomImageModelPatterns,
+		service.SettingKeyCustomVideoModelPatterns: req.CustomVideoModelPatterns,
+	} {
+		if raw != nil {
+			if err := service.ValidateCustomMediaModelPatterns(*raw); err != nil {
+				response.Error(c, http.StatusBadRequest, key+" "+err.Error())
+				return
+			}
+		}
+	}
 
 	// codex_cli_only 加固：最低/最高 Codex 版本（空=禁用，或合法 semver；max>=min）
 	if req.MinCodexVersion != "" && !semverPattern.MatchString(req.MinCodexVersion) {
@@ -1554,6 +1567,18 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 				return *req.OpenAICodexUserAgent
 			}
 			return previousSettings.OpenAICodexUserAgent
+		}(),
+		CustomImageModelPatterns: func() string {
+			if req.CustomImageModelPatterns != nil {
+				return *req.CustomImageModelPatterns
+			}
+			return previousSettings.CustomImageModelPatterns
+		}(),
+		CustomVideoModelPatterns: func() string {
+			if req.CustomVideoModelPatterns != nil {
+				return *req.CustomVideoModelPatterns
+			}
+			return previousSettings.CustomVideoModelPatterns
 		}(),
 		MinCodexVersion:       strings.TrimSpace(req.MinCodexVersion),
 		MaxCodexVersion:       strings.TrimSpace(req.MaxCodexVersion),
@@ -2027,6 +2052,8 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		EnableClientDatelineNormalization:                      updatedSettings.EnableClientDatelineNormalization,
 		AntigravityUserAgentVersion:                            updatedSettings.AntigravityUserAgentVersion,
 		OpenAICodexUserAgent:                                   updatedSettings.OpenAICodexUserAgent,
+		CustomImageModelPatterns:                               updatedSettings.CustomImageModelPatterns,
+		CustomVideoModelPatterns:                               updatedSettings.CustomVideoModelPatterns,
 		MinCodexVersion:                                        updatedSettings.MinCodexVersion,
 		MaxCodexVersion:                                        updatedSettings.MaxCodexVersion,
 		CodexCLIOnlyBlacklist:                                  updatedSettings.CodexCLIOnlyBlacklist,

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -199,6 +199,8 @@ type SystemSettings struct {
 	EnableClientDatelineNormalization      bool   `json:"enable_client_dateline_normalization"`
 	AntigravityUserAgentVersion            string `json:"antigravity_user_agent_version"`
 	OpenAICodexUserAgent                   string `json:"openai_codex_user_agent"`
+	CustomImageModelPatterns               string `json:"custom_image_model_patterns"`
+	CustomVideoModelPatterns               string `json:"custom_video_model_patterns"`
 
 	// codex_cli_only 加固
 	MinCodexVersion                      string `json:"min_codex_version"`

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -85,7 +85,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", invalidStreamFieldTypeMessage)
 		return
 	}
-	if service.IsGPTImageGenerationModel(reqModel) {
+	if service.IsImageGenerationModel(reqModel) {
 		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "This model is not supported on the Chat Completions endpoint")
 		return
 	}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -90,7 +90,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", invalidStreamFieldTypeMessage)
 		return
 	}
-	if service.IsGPTImageGenerationModel(reqModel) {
+	if service.IsImageGenerationModel(reqModel) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "This model is not supported on the Chat Completions endpoint")
 		return
 	}

--- a/backend/internal/service/custom_media_model_rules.go
+++ b/backend/internal/service/custom_media_model_rules.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+)
+
+const maxCustomMediaModelPatternsLength = 8192
+
+type mediaModelKind uint8
+
+const (
+	mediaModelUnknown mediaModelKind = iota
+	mediaModelImage
+	mediaModelVideo
+)
+
+type customMediaModelRules struct {
+	imagePatterns []string
+	videoPatterns []string
+}
+
+var activeCustomMediaModelRules atomic.Pointer[customMediaModelRules]
+
+func init() {
+	activeCustomMediaModelRules.Store(&customMediaModelRules{})
+}
+
+func normalizeCustomMediaModelPatterns(raw string) string {
+	patterns := parseCustomMediaModelPatterns(raw)
+	return strings.Join(patterns, "\n")
+}
+
+func parseCustomMediaModelPatterns(raw string) []string {
+	parts := strings.FieldsFunc(strings.ToLower(raw), func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	seen := make(map[string]struct{}, len(parts))
+	patterns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		patterns = append(patterns, part)
+	}
+	return patterns
+}
+
+func ValidateCustomMediaModelPatterns(raw string) error {
+	if len(raw) > maxCustomMediaModelPatternsLength {
+		return fmt.Errorf("custom media model patterns must be at most %d characters", maxCustomMediaModelPatternsLength)
+	}
+	for _, pattern := range parseCustomMediaModelPatterns(raw) {
+		if len(pattern) > 256 {
+			return fmt.Errorf("custom media model pattern %q must be at most 256 characters", pattern)
+		}
+	}
+	return nil
+}
+
+func setCustomMediaModelPatterns(imagePatterns, videoPatterns string) {
+	activeCustomMediaModelRules.Store(&customMediaModelRules{
+		imagePatterns: parseCustomMediaModelPatterns(imagePatterns),
+		videoPatterns: parseCustomMediaModelPatterns(videoPatterns),
+	})
+}
+
+func classifyCustomMediaModel(model string) mediaModelKind {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return mediaModelUnknown
+	}
+	rules := activeCustomMediaModelRules.Load()
+	if rules == nil {
+		return mediaModelUnknown
+	}
+	for _, pattern := range rules.videoPatterns {
+		if matchCustomMediaModelPattern(pattern, model) {
+			return mediaModelVideo
+		}
+	}
+	for _, pattern := range rules.imagePatterns {
+		if matchCustomMediaModelPattern(pattern, model) {
+			return mediaModelImage
+		}
+	}
+	return mediaModelUnknown
+}
+
+func matchCustomMediaModelPattern(pattern, model string) bool {
+	if !strings.Contains(pattern, "*") {
+		return model == pattern
+	}
+	parts := strings.Split(pattern, "*")
+	position := 0
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		index := strings.Index(model[position:], part)
+		if index < 0 || (i == 0 && index != 0) {
+			return false
+		}
+		position += index + len(part)
+	}
+	last := parts[len(parts)-1]
+	return last == "" || strings.HasSuffix(model, last)
+}
+
+func (s *SettingService) LoadCustomMediaModelPatterns(ctx context.Context) error {
+	load := func(key string) (string, error) {
+		value, err := s.settingRepo.GetValue(ctx, key)
+		if errors.Is(err, ErrSettingNotFound) {
+			return "", nil
+		}
+		return value, err
+	}
+	imagePatterns, err := load(SettingKeyCustomImageModelPatterns)
+	if err != nil {
+		return fmt.Errorf("load custom image model patterns: %w", err)
+	}
+	videoPatterns, err := load(SettingKeyCustomVideoModelPatterns)
+	if err != nil {
+		return fmt.Errorf("load custom video model patterns: %w", err)
+	}
+	setCustomMediaModelPatterns(imagePatterns, videoPatterns)
+	return nil
+}

--- a/backend/internal/service/custom_media_model_rules_test.go
+++ b/backend/internal/service/custom_media_model_rules_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type customMediaModelSettingRepo struct {
+	values map[string]string
+}
+
+func (r *customMediaModelSettingRepo) Get(context.Context, string) (*Setting, error) {
+	return nil, ErrSettingNotFound
+}
+func (r *customMediaModelSettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	value, ok := r.values[key]
+	if !ok {
+		return "", ErrSettingNotFound
+	}
+	return value, nil
+}
+func (r *customMediaModelSettingRepo) Set(context.Context, string, string) error { return nil }
+func (r *customMediaModelSettingRepo) GetMultiple(context.Context, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (r *customMediaModelSettingRepo) SetMultiple(context.Context, map[string]string) error {
+	return nil
+}
+func (r *customMediaModelSettingRepo) GetAll(context.Context) (map[string]string, error) {
+	return r.values, nil
+}
+func (r *customMediaModelSettingRepo) Delete(context.Context, string) error { return nil }
+
+func TestCustomMediaModelPatterns(t *testing.T) {
+	previous := activeCustomMediaModelRules.Load()
+	t.Cleanup(func() { activeCustomMediaModelRules.Store(previous) })
+
+	setCustomMediaModelPatterns("acme-image-*\nexact-image", "acme-video-*, acme-image-video-*")
+
+	require.True(t, isOpenAIImageGenerationModel("ACME-IMAGE-V2"))
+	require.True(t, isOpenAIImageGenerationModel("exact-image"))
+	require.False(t, isOpenAIImageGenerationModel("acme-video-v1"))
+	require.Equal(t, mediaModelVideo, classifyCustomMediaModel("acme-video-v1"))
+	require.Equal(t, mediaModelVideo, classifyCustomMediaModel("acme-image-video-v1"))
+	require.False(t, isOpenAIImageGenerationModel("unlisted-model"))
+}
+
+func TestCustomMediaModelPatternsVideoWins(t *testing.T) {
+	previous := activeCustomMediaModelRules.Load()
+	t.Cleanup(func() { activeCustomMediaModelRules.Store(previous) })
+
+	setCustomMediaModelPatterns("shared-*", "shared-video-*")
+
+	require.Equal(t, mediaModelVideo, classifyCustomMediaModel("shared-video-v2"))
+	require.False(t, isOpenAIImageGenerationModel("shared-video-v2"))
+	require.True(t, isOpenAIImageGenerationModel("shared-image-v2"))
+}
+
+func TestNormalizeCustomMediaModelPatterns(t *testing.T) {
+	require.Equal(t, "foo-*\nbar", normalizeCustomMediaModelPatterns(" Foo-* , bar\nfoo-* "))
+	require.NoError(t, ValidateCustomMediaModelPatterns(strings.Repeat("a", 256)))
+	require.Error(t, ValidateCustomMediaModelPatterns(strings.Repeat("a", 257)))
+}
+
+func TestLoadCustomMediaModelPatterns(t *testing.T) {
+	previous := activeCustomMediaModelRules.Load()
+	t.Cleanup(func() { activeCustomMediaModelRules.Store(previous) })
+
+	svc := NewSettingService(&customMediaModelSettingRepo{values: map[string]string{
+		SettingKeyCustomImageModelPatterns: "db-image-*",
+		SettingKeyCustomVideoModelPatterns: "db-video-*",
+	}}, nil)
+
+	require.NoError(t, svc.LoadCustomMediaModelPatterns(context.Background()))
+	require.True(t, isOpenAIImageGenerationModel("db-image-v1"))
+	require.Equal(t, mediaModelVideo, classifyCustomMediaModel("db-video-v1"))
+}

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -526,6 +526,9 @@ const (
 	// 当客户端 UA 被识别为浏览器（Chrome/Firefox/Safari/Edge 等）时，转发给 OpenAI 上游前会替换为此值，
 	// 用于避免 Cloudflare 对浏览器型 UA 的质询拦截。
 	SettingKeyOpenAICodexUserAgent = "openai_codex_user_agent"
+	// Administrator-managed media model rules extend, rather than replace, built-in model families.
+	SettingKeyCustomImageModelPatterns = "custom_image_model_patterns"
+	SettingKeyCustomVideoModelPatterns = "custom_video_model_patterns"
 	// SettingKeyOpenAIAllowClaudeCodeCodexPlugin 已废弃：历史全局开关只作为升级迁移输入读取。
 	// 迁移后等价规则写入 SettingKeyCodexCLIOnlyWhitelist，不再参与运行时判定。
 	SettingKeyOpenAIAllowClaudeCodeCodexPlugin = "openai_allow_claude_code_codex_plugin"

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -455,7 +455,19 @@ func applyOpenAIImagesDefaults(req *OpenAIImagesRequest) {
 }
 
 func isOpenAIImageGenerationModel(model string) bool {
+	switch classifyCustomMediaModel(model) {
+	case mediaModelVideo:
+		return false
+	case mediaModelImage:
+		return true
+	}
 	return IsGPTImageGenerationModel(model) || isGrokImageGenerationModel(model)
+}
+
+// IsImageGenerationModel identifies built-in and configured image-generation models.
+// Video rules take precedence when a model matches both rule sets.
+func IsImageGenerationModel(model string) bool {
+	return isOpenAIImageGenerationModel(model)
 }
 
 // IsGPTImageGenerationModel identifies the GPT native image-generation model family.

--- a/backend/internal/service/setting_parse.go
+++ b/backend/internal/service/setting_parse.go
@@ -227,6 +227,8 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		SettingKeyEnableClientDatelineNormalization:                  "true",
 		SettingKeyAntigravityUserAgentVersion:                        "",
 		SettingKeyOpenAICodexUserAgent:                               "",
+		SettingKeyCustomImageModelPatterns:                           "",
+		SettingKeyCustomVideoModelPatterns:                           "",
 		SettingPaymentVisibleMethodAlipaySource:                      "",
 		SettingPaymentVisibleMethodWxpaySource:                       "",
 		SettingPaymentVisibleMethodAlipayEnabled:                     "false",
@@ -824,6 +826,8 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 	}
 	result.AntigravityUserAgentVersion = antigravity.NormalizeUserAgentVersion(settings[SettingKeyAntigravityUserAgentVersion])
 	result.OpenAICodexUserAgent = strings.TrimSpace(settings[SettingKeyOpenAICodexUserAgent])
+	result.CustomImageModelPatterns = normalizeCustomMediaModelPatterns(settings[SettingKeyCustomImageModelPatterns])
+	result.CustomVideoModelPatterns = normalizeCustomMediaModelPatterns(settings[SettingKeyCustomVideoModelPatterns])
 	// codex_cli_only 加固
 	result.MinCodexVersion = settings[SettingKeyMinCodexVersion]
 	result.MaxCodexVersion = settings[SettingKeyMaxCodexVersion]

--- a/backend/internal/service/setting_update.go
+++ b/backend/internal/service/setting_update.go
@@ -438,6 +438,16 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	updates[SettingKeyEnableClientDatelineNormalization] = strconv.FormatBool(settings.EnableClientDatelineNormalization)
 	updates[SettingKeyAntigravityUserAgentVersion] = antigravity.NormalizeUserAgentVersion(settings.AntigravityUserAgentVersion)
 	updates[SettingKeyOpenAICodexUserAgent] = strings.TrimSpace(settings.OpenAICodexUserAgent)
+	if err := ValidateCustomMediaModelPatterns(settings.CustomImageModelPatterns); err != nil {
+		return nil, err
+	}
+	if err := ValidateCustomMediaModelPatterns(settings.CustomVideoModelPatterns); err != nil {
+		return nil, err
+	}
+	settings.CustomImageModelPatterns = normalizeCustomMediaModelPatterns(settings.CustomImageModelPatterns)
+	settings.CustomVideoModelPatterns = normalizeCustomMediaModelPatterns(settings.CustomVideoModelPatterns)
+	updates[SettingKeyCustomImageModelPatterns] = settings.CustomImageModelPatterns
+	updates[SettingKeyCustomVideoModelPatterns] = settings.CustomVideoModelPatterns
 	// codex_cli_only 加固
 	updates[SettingKeyMinCodexVersion] = strings.TrimSpace(settings.MinCodexVersion)
 	updates[SettingKeyMaxCodexVersion] = strings.TrimSpace(settings.MaxCodexVersion)
@@ -566,6 +576,7 @@ func (s *SettingService) refreshCachedSettings(settings *SystemSettings) {
 	if settings == nil {
 		return
 	}
+	setCustomMediaModelPatterns(settings.CustomImageModelPatterns, settings.CustomVideoModelPatterns)
 
 	// 先使 inflight singleflight 失效，再刷新缓存，缩小旧值覆盖新值的竞态窗口
 	versionBoundsSF.Forget("version_bounds")

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -213,6 +213,8 @@ type SystemSettings struct {
 	RewriteMessageCacheControl             bool   // 是否改写 messages[*].content[*].cache_control（默认 false）
 	AntigravityUserAgentVersion            string // Antigravity 上游 User-Agent 版本号；空值使用配置/默认值
 	OpenAICodexUserAgent                   string // OpenAI Codex 上游完整 User-Agent；空值使用内置默认
+	CustomImageModelPatterns               string // 额外生图模型规则；支持 * 通配
+	CustomVideoModelPatterns               string // 额外视频模型规则；支持 * 通配
 	MinCodexVersion                        string // codex_cli_only 最低 Codex 引擎版本；空=不检查
 	MaxCodexVersion                        string // codex_cli_only 最高 Codex 引擎版本；空=不检查
 	CodexCLIOnlyBlacklist                  string // codex_cli_only 全局黑名单 JSON（[]AllowedClientEntry，OR deny）

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -636,6 +636,9 @@ func ProvideSettingService(settingRepo SettingRepository, groupRepo GroupReposit
 	if err := svc.MigrateCodexBodyFingerprintToSignals(context.Background()); err != nil {
 		logger.LegacyPrintf("service.setting", "Warning: migrate codex body fingerprint to signals failed: %v", err)
 	}
+	if err := svc.LoadCustomMediaModelPatterns(context.Background()); err != nil {
+		logger.LegacyPrintf("service.setting", "Warning: load custom media model patterns failed: %v", err)
+	}
 	antigravity.SetUserAgentVersionResolver(svc.GetAntigravityUserAgentVersion)
 	return svc
 }

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -574,6 +574,8 @@ export interface SystemSettings {
   enable_client_dateline_normalization: boolean;
   antigravity_user_agent_version: string;
   openai_codex_user_agent: string;
+  custom_image_model_patterns: string;
+  custom_video_model_patterns: string;
   // codex_cli_only 加固
   min_codex_version: string;
   max_codex_version: string;
@@ -865,6 +867,8 @@ export interface UpdateSettingsRequest {
   enable_client_dateline_normalization?: boolean;
   antigravity_user_agent_version?: string;
   openai_codex_user_agent?: string;
+  custom_image_model_patterns?: string;
+  custom_video_model_patterns?: string;
   // codex_cli_only 加固
   min_codex_version?: string;
   max_codex_version?: string;

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -425,6 +425,12 @@ export default {
         openaiCodexUserAgent: 'OpenAI Codex UA',
         openaiCodexUserAgentPlaceholder: 'codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)',
         openaiCodexUserAgentHint: 'Used to bypass Cloudflare browser-UA challenges on the OpenAI upstream. Only applies when the client User-Agent is detected as a browser (Mozilla/...). Leave empty to use the built-in default.',
+        customImageModelPatterns: 'Custom Image Model Rules',
+        customImageModelPatternsPlaceholder: 'Exact model ID\nmodel-prefix-*',
+        customImageModelPatternsHint: 'Use exact model IDs or * as a wildcard. Separate multiple rules with new lines, commas, or spaces. Matching rules are included in image-model classification and routing decisions. Built-in models do not need to be listed.',
+        customVideoModelPatterns: 'Custom Video Model Rules',
+        customVideoModelPatternsPlaceholder: 'Exact model ID\nvideo-prefix-*',
+        customVideoModelPatternsHint: 'Use exact model IDs or * as a wildcard. Separate multiple rules with new lines, commas, or spaces. Video rules take precedence over image rules when both match and remain available for media capability checks. Built-in models do not need to be listed.',
         codexHardeningTitle: "Codex Settings",
         codexClientRestrictionTitle: "Codex client restriction",
         codexHardeningDesc:

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -418,6 +418,12 @@ export default {
         openaiCodexUserAgent: 'OpenAI Codex UA',
         openaiCodexUserAgentPlaceholder: 'codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)',
         openaiCodexUserAgentHint: '用于规避 OpenAI 上游 Cloudflare 对浏览器 UA 的访问质询。仅在检测到客户端 User-Agent 为浏览器（Mozilla/...）时生效，其他客户端原样透传。留空使用内置默认值。',
+        customImageModelPatterns: '自定义图片模型规则',
+        customImageModelPatternsPlaceholder: '精确模型 ID\n模型前缀-*',
+        customImageModelPatternsHint: '填写精确模型 ID，或使用 * 作为通配符。多个规则可用换行、逗号或空格分隔。匹配后纳入图片模型分类和路由判断。内置模型无需重复填写。',
+        customVideoModelPatterns: '自定义视频模型规则',
+        customVideoModelPatternsPlaceholder: '精确模型 ID\n视频前缀-*',
+        customVideoModelPatternsHint: '填写精确模型 ID，或使用 * 作为通配符。多个规则可用换行、逗号或空格分隔。两类规则同时匹配时视频规则优先，并保留给媒体能力判断使用。内置模型无需重复填写。',
         codexHardeningTitle: 'Codex 设置',
         codexClientRestrictionTitle: 'Codex 客户端限制',
         codexHardeningDesc:

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -5168,6 +5168,48 @@
                 </p>
               </div>
 
+              <div>
+                <label
+                  class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  {{ t("admin.settings.gatewayForwarding.customImageModelPatterns") }}
+                </label>
+                <textarea
+                  v-model="form.custom_image_model_patterns"
+                  rows="4"
+                  class="input min-h-24 w-full resize-y font-mono text-sm"
+                  :placeholder="
+                    t(
+                      'admin.settings.gatewayForwarding.customImageModelPatternsPlaceholder',
+                    )
+                  "
+                />
+                <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{ t("admin.settings.gatewayForwarding.customImageModelPatternsHint") }}
+                </p>
+              </div>
+
+              <div>
+                <label
+                  class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  {{ t("admin.settings.gatewayForwarding.customVideoModelPatterns") }}
+                </label>
+                <textarea
+                  v-model="form.custom_video_model_patterns"
+                  rows="4"
+                  class="input min-h-24 w-full resize-y font-mono text-sm"
+                  :placeholder="
+                    t(
+                      'admin.settings.gatewayForwarding.customVideoModelPatternsPlaceholder',
+                    )
+                  "
+                />
+                <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{ t("admin.settings.gatewayForwarding.customVideoModelPatternsHint") }}
+                </p>
+              </div>
+
             </div>
           </div>
 
@@ -9038,6 +9080,8 @@ const form = reactive<SettingsForm>({
   enable_client_dateline_normalization: true,
   antigravity_user_agent_version: "",
   openai_codex_user_agent: "",
+  custom_image_model_patterns: "",
+  custom_video_model_patterns: "",
   // codex_cli_only 加固
   min_codex_version: "",
   max_codex_version: "",
@@ -10510,6 +10554,10 @@ async function saveSettings() {
         form.antigravity_user_agent_version?.trim() || "",
       openai_codex_user_agent:
         form.openai_codex_user_agent?.trim() || "",
+      custom_image_model_patterns:
+        form.custom_image_model_patterns?.trim() || "",
+      custom_video_model_patterns:
+        form.custom_video_model_patterns?.trim() || "",
       min_codex_version: form.min_codex_version?.trim() || "",
       max_codex_version: form.max_codex_version?.trim() || "",
       codex_cli_only_allow_app_server_clients:

--- a/frontend/src/views/admin/__tests__/SettingsViewMediaModels.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsViewMediaModels.spec.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const viewPath = resolve(dirname(fileURLToPath(import.meta.url)), '../SettingsView.vue')
+const viewSource = readFileSync(viewPath, 'utf8')
+
+describe('SettingsView custom media model rules', () => {
+  it('renders and saves image and video model patterns', () => {
+    for (const field of ['custom_image_model_patterns', 'custom_video_model_patterns']) {
+      expect(viewSource).toContain(`v-model="form.${field}"`)
+      expect(viewSource).toMatch(new RegExp(`${field}:\\s*form\\.${field}`))
+    }
+
+    expect(viewSource).toContain('customVideoModelPatternsHint')
+  })
+})


### PR DESCRIPTION
## Summary
- add administrator-configurable exact and `*` wildcard patterns for custom image and video model IDs
- normalize, deduplicate, validate, persist, cache, and expose the patterns in the admin settings UI
- make video classification win when a model matches both rule sets
- route Chat Completions image-model rejection through the unified media classifier

## Scope and safety
- This PR is based directly on `Wei-Shaw/sub2api:main` and contains only the listed settings/classification changes.
- No production source, credentials, backups, deployment files, release assets, or private project history are included.
- Local tests/builds/Docker/production acceptance were intentionally not run per contributor request; the included Go and frontend tests are for upstream CI.
- No real upstream media request is made by the change.