### PR TITLE
fix(oauth): use claude.com/cai authorize endpoint

### DIFF
--- a/backend/internal/pkg/oauth/oauth.go
+++ b/backend/internal/pkg/oauth/oauth.go
@@ -19,7 +19,7 @@ const (
 	ClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 	// OAuth endpoints
-	AuthorizeURL = "https://claude.ai/oauth/authorize"
+	AuthorizeURL = "https://claude.com/cai/oauth/authorize"
 	TokenURL     = "https://platform.claude.com/v1/oauth/token"
 	RedirectURI  = "https://platform.claude.com/oauth/code/callback"
 

--- a/backend/internal/pkg/oauth/oauth_test.go
+++ b/backend/internal/pkg/oauth/oauth_test.go
@@ -1,10 +1,35 @@
 package oauth
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+func TestAuthorizeURLMatchesClaudeCodeCLI(t *testing.T) {
+	const want = "https://claude.com/cai/oauth/authorize"
+	if AuthorizeURL != want {
+		t.Fatalf("AuthorizeURL = %q, want %q", AuthorizeURL, want)
+	}
+
+	authURL := BuildAuthorizationURL("state-value", "challenge-value", ScopeOAuth)
+	if !strings.HasPrefix(authURL, want+"?") {
+		t.Fatalf("BuildAuthorizationURL() = %q, want prefix %q", authURL, want+"?")
+	}
+	for _, part := range []string{
+		"code=true",
+		"client_id=" + ClientID,
+		"response_type=code",
+		"code_challenge=challenge-value",
+		"code_challenge_method=S256",
+		"state=state-value",
+	} {
+		if !strings.Contains(authURL, part) {
+			t.Fatalf("BuildAuthorizationURL() missing %q\nURL: %s", part, authURL)
+		}
+	}
+}
 
 func TestSessionStore_Stop_Idempotent(t *testing.T) {
 	store := NewSessionStore()


### PR DESCRIPTION
## Summary

Align Claude/Anthropic OAuth authorize URL with the current Claude Code CLI endpoint.

### Change
- `https://claude.ai/oauth/authorize` -> `https://claude.com/cai/oauth/authorize`

### Unchanged
- `client_id`, scopes, PKCE, and `redirect_uri` (`https://platform.claude.com/oauth/code/callback`)

### Test plan
- [x] `go test ./internal/pkg/oauth/`
- [ ] Admin: add Anthropic OAuth account and confirm authorize URL host is `claude.com/cai`
