### PR TITLE
feat(accounts): add explicit image test mode

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -176,7 +176,7 @@ func createTestPayload(modelID string) (map[string]any, error) {
 // TestAccountConnection tests an account's connection by sending a test request
 // All account types use full Claude Code client characteristics, only auth header differs
 // modelID is optional - if empty, defaults to claude.DefaultTestModel
-// mode is optional - "compact" routes OpenAI accounts to the /responses/compact probe path
+// mode is optional - "compact" routes OpenAI accounts to /responses/compact, while "image" explicitly forces the image-generation probe
 func (s *AccountTestService) TestAccountConnection(c *gin.Context, accountID int64, modelID string, prompt string, mode string) error {
 	ctx := c.Request.Context()
 
@@ -528,13 +528,10 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	// Align test routing with gateway behavior: OpenAI accounts apply normal
 	// account model mapping, and compact mode applies compact-only mapping on top.
 	testModelID = account.GetMappedModel(testModelID)
-	if mode == AccountTestModeCompact {
-		testModelID = resolveOpenAICompactForwardModel(account, testModelID)
-		return s.testOpenAICompactConnection(c, account, testModelID)
-	}
 
-	// Route to image generation test if an image model is selected
-	if isOpenAIImageModel(testModelID) {
+	// Preserve automatic image-model detection, while allowing an explicit image
+	// test mode for compatible model names that the detector does not yet know.
+	if mode == AccountTestModeImage || isOpenAIImageModel(testModelID) {
 		imagePrompt := strings.TrimSpace(prompt)
 		if imagePrompt == "" {
 			imagePrompt = defaultOpenAIImageTestPrompt
@@ -543,6 +540,11 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 			return s.testOpenAIImageAPIKey(c, ctx, account, testModelID, imagePrompt)
 		}
 		return s.testOpenAIImageOAuth(c, ctx, account, testModelID, imagePrompt)
+	}
+
+	if mode == AccountTestModeCompact {
+		testModelID = resolveOpenAICompactForwardModel(account, testModelID)
+		return s.testOpenAICompactConnection(c, account, testModelID)
 	}
 
 	credentialAccount := account

--- a/backend/internal/service/account_test_service_openai_image_test.go
+++ b/backend/internal/service/account_test_service_openai_image_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -50,6 +51,55 @@ func TestAccountTestService_OpenAIImageOAuthHandlesOutputItemDoneFallback(t *tes
 	require.Contains(t, rec.Body.String(), "Calling Codex /responses image tool")
 	require.Contains(t, rec.Body.String(), "data:image/png;base64,aGVsbG8=")
 	require.Contains(t, rec.Body.String(), "\"success\":true")
+}
+
+func TestAccountTestService_OpenAIImageModePreservesAutomaticDetectionAndSupportsExplicitOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		mode    string
+	}{
+		{name: "automatic detector wins over compact mode", modelID: "gpt-image-2", mode: AccountTestModeCompact},
+		{name: "explicit image mode supports unrecognized compatible model", modelID: "custom-image-v2", mode: AccountTestModeImage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/1/test", nil)
+
+			upstream := &httpUpstreamRecorder{
+				resp: &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"data":[{"b64_json":"aGVsbG8="}]}`)),
+				},
+			}
+			svc := &AccountTestService{httpUpstream: upstream, cfg: &config.Config{}}
+			account := &Account{
+				ID:       55,
+				Name:     "openai-apikey",
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"api_key":  "test-api-key",
+					"base_url": "https://image-upstream.example/v1",
+				},
+			}
+
+			err := svc.testOpenAIAccountConnection(c, account, tt.modelID, "draw a test image", tt.mode)
+			require.NoError(t, err)
+			require.NotNil(t, upstream.lastReq)
+			require.Equal(t, "https://image-upstream.example/v1/images/generations", upstream.lastReq.URL.String())
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(upstream.lastBody, &payload))
+			require.Equal(t, tt.modelID, payload["model"])
+			require.Equal(t, "draw a test image", payload["prompt"])
+		})
+	}
 }
 
 func TestAccountTestService_OpenAIImageAPIKeyUsesConfiguredV1BaseURL(t *testing.T) {

--- a/backend/internal/service/openai_compact_probe.go
+++ b/backend/internal/service/openai_compact_probe.go
@@ -12,12 +12,16 @@ const (
 	AccountTestModeDefault = "default"
 	// AccountTestModeCompact drives the /responses/compact compact-probe test.
 	AccountTestModeCompact = "compact"
+	// AccountTestModeImage explicitly forces the OpenAI-compatible image-generation probe.
+	AccountTestModeImage = "image"
 )
 
 func normalizeAccountTestMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case AccountTestModeCompact:
 		return AccountTestModeCompact
+	case AccountTestModeImage:
+		return AccountTestModeImage
 	default:
 		return AccountTestModeDefault
 	}

--- a/backend/internal/service/openai_compact_probe_test.go
+++ b/backend/internal/service/openai_compact_probe_test.go
@@ -16,6 +16,8 @@ func TestNormalizeAccountTestMode(t *testing.T) {
 		{input: "default", want: AccountTestModeDefault},
 		{input: " compact ", want: AccountTestModeCompact},
 		{input: "COMPACT", want: AccountTestModeCompact},
+		{input: " image ", want: AccountTestModeImage},
+		{input: "IMAGE", want: AccountTestModeImage},
 		{input: "unknown", want: AccountTestModeDefault},
 	}
 

--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -55,7 +55,7 @@
         />
       </div>
 
-      <div v-if="isOpenAIAccount" class="space-y-1.5">
+      <div v-if="isOpenAIAccount && !supportsOpenAIImageTest" class="space-y-1.5">
         <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
           {{ t('admin.accounts.openai.testMode') }}
         </label>
@@ -286,11 +286,12 @@ const testPrompt = ref('')
 const loadingModels = ref(false)
 let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
-const testMode = ref<'default' | 'compact'>('default')
+const testMode = ref<'default' | 'compact' | 'image'>('default')
 const isOpenAIAccount = computed(() => props.account?.platform === 'openai')
 const openAITestModeOptions = computed(() => [
   { value: 'default', label: t('admin.accounts.openai.testModeDefault') },
-  { value: 'compact', label: t('admin.accounts.openai.testModeCompact') }
+  { value: 'compact', label: t('admin.accounts.openai.testModeCompact') },
+  { value: 'image', label: t('admin.accounts.openai.testModeImage') }
 ])
 const previewImageUrl = ref('')
 const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
@@ -307,7 +308,10 @@ const supportsOpenAIImageTest = computed(() => {
   return props.account?.platform === 'openai'
 })
 
-const supportsImageTest = computed(() => supportsGeminiImageTest.value || supportsOpenAIImageTest.value)
+const forcesOpenAIImageTest = computed(() => isOpenAIAccount.value && testMode.value === 'image')
+const supportsImageTest = computed(() =>
+  supportsGeminiImageTest.value || supportsOpenAIImageTest.value || forcesOpenAIImageTest.value
+)
 
 const sortTestModels = (models: ClaudeModel[]) => {
   const priorityMap = new Map(prioritizedGeminiModels.map((id, index) => [id, index]))
@@ -336,7 +340,13 @@ watch(
 )
 
 watch(selectedModelId, () => {
-  if (supportsImageTest.value && !testPrompt.value.trim()) {
+  if ((supportsGeminiImageTest.value || supportsOpenAIImageTest.value) && !testPrompt.value.trim()) {
+    testPrompt.value = t('admin.accounts.imagePromptDefault')
+  }
+})
+
+watch(testMode, (mode) => {
+  if (mode === 'image' && !testPrompt.value.trim()) {
     testPrompt.value = t('admin.accounts.imagePromptDefault')
   }
 })
@@ -431,7 +441,9 @@ const startTest = async () => {
       body: JSON.stringify({
         model_id: selectedModelId.value,
         prompt: supportsImageTest.value ? testPrompt.value.trim() : '',
-        mode: isOpenAIAccount.value ? testMode.value : 'default'
+        mode: isOpenAIAccount.value
+          ? (supportsOpenAIImageTest.value ? 'default' : testMode.value)
+          : 'default'
       }),
       signal: abortController.signal
     })

--- a/frontend/src/components/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountTestModal.spec.ts
@@ -148,6 +148,45 @@ describe('AccountTestModal', () => {
     })
   })
 
+  it('posts explicit image mode for an unrecognized OpenAI image model', async () => {
+    getAvailableModelsMock.mockResolvedValue([
+      { id: 'custom-image-v2', display_name: 'Custom Image V2' }
+    ])
+
+    const wrapper = mount(AccountTestModal, {
+      props: {
+        show: true,
+        account: buildAccount()
+      },
+      global: {
+        stubs: {
+          BaseDialog: BaseDialogStub,
+          Select: SelectStub,
+          TextArea: TextAreaStub,
+          Icon: true
+        }
+      }
+    })
+
+    await flushPromises()
+    ;(wrapper.vm as any).selectedModelId = 'custom-image-v2'
+    expect((wrapper.vm as any).supportsOpenAIImageTest).toBe(false)
+    ;(wrapper.vm as any).testMode = 'image'
+    await flushPromises()
+    expect((wrapper.vm as any).supportsImageTest).toBe(true)
+
+    await (wrapper.vm as any).startTest()
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [, options] = (global.fetch as any).mock.calls[0]
+    expect(JSON.parse(options.body)).toMatchObject({
+      model_id: 'custom-image-v2',
+      prompt: 'admin.accounts.imagePromptDefault',
+      mode: 'image'
+    })
+  })
+
   it('renders Chat Completions path status from test SSE', async () => {
     const encoder = new TextEncoder()
     const chunks = [

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -55,7 +55,7 @@
         />
       </div>
 
-      <div v-if="isOpenAIAccount" class="space-y-1.5">
+      <div v-if="isOpenAIAccount && !supportsOpenAIImageTest" class="space-y-1.5">
         <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
           {{ t('admin.accounts.openai.testMode') }}
         </label>
@@ -288,11 +288,12 @@ const loadingModels = ref(false)
 let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
 const previewImageUrl = ref('')
-const testMode = ref<'default' | 'compact'>('default')
+const testMode = ref<'default' | 'compact' | 'image'>('default')
 const isOpenAIAccount = computed(() => props.account?.platform === 'openai')
 const openAITestModeOptions = computed(() => [
   { value: 'default', label: t('admin.accounts.openai.testModeDefault') },
-  { value: 'compact', label: t('admin.accounts.openai.testModeCompact') }
+  { value: 'compact', label: t('admin.accounts.openai.testModeCompact') },
+  { value: 'image', label: t('admin.accounts.openai.testModeImage') }
 ])
 const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
@@ -308,7 +309,10 @@ const supportsOpenAIImageTest = computed(() => {
   return props.account?.platform === 'openai'
 })
 
-const supportsImageTest = computed(() => supportsGeminiImageTest.value || supportsOpenAIImageTest.value)
+const forcesOpenAIImageTest = computed(() => isOpenAIAccount.value && testMode.value === 'image')
+const supportsImageTest = computed(() =>
+  supportsGeminiImageTest.value || supportsOpenAIImageTest.value || forcesOpenAIImageTest.value
+)
 
 const sortTestModels = (models: ClaudeModel[]) => {
   const priorityMap = new Map(prioritizedGeminiModels.map((id, index) => [id, index]))
@@ -337,7 +341,13 @@ watch(
 )
 
 watch(selectedModelId, () => {
-  if (supportsImageTest.value && !testPrompt.value.trim()) {
+  if ((supportsGeminiImageTest.value || supportsOpenAIImageTest.value) && !testPrompt.value.trim()) {
+    testPrompt.value = t('admin.accounts.imagePromptDefault')
+  }
+})
+
+watch(testMode, (mode) => {
+  if (mode === 'image' && !testPrompt.value.trim()) {
     testPrompt.value = t('admin.accounts.imagePromptDefault')
   }
 })
@@ -422,13 +432,13 @@ const startTest = async () => {
     const requestBody: {
       model_id: string
       prompt: string
-      mode?: 'default' | 'compact'
+      mode?: 'default' | 'compact' | 'image'
     } = {
       model_id: selectedModelId.value,
       prompt: supportsImageTest.value ? testPrompt.value.trim() : ''
     }
     if (isOpenAIAccount.value) {
-      requestBody.mode = testMode.value
+      requestBody.mode = supportsOpenAIImageTest.value ? 'default' : testMode.value
     }
 
     // Use the configured API base; EventSource does not support POST.

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -216,4 +216,43 @@ describe('AccountTestModal', () => {
       mode: 'compact'
     })
   })
+
+  it('OpenAI 未识别模型可由用户显式选择生图测试', async () => {
+    getAvailableModels.mockResolvedValue([
+      { id: 'custom-image-v2', display_name: 'Custom Image V2' }
+    ])
+    global.fetch = vi.fn().mockResolvedValue(
+      createStreamResponse([
+        'data: {\"type\":\"test_complete\",\"success\":true}\n'
+      ])
+    ) as any
+
+    const wrapper = mountModal({
+      id: 78,
+      name: 'OpenAI Custom Image Account',
+      platform: 'openai',
+      type: 'apikey',
+      status: 'active'
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    ;(wrapper.vm as any).selectedModelId = 'custom-image-v2'
+    expect((wrapper.vm as any).supportsOpenAIImageTest).toBe(false)
+    ;(wrapper.vm as any).testMode = 'image'
+    await flushPromises()
+    expect((wrapper.vm as any).supportsImageTest).toBe(true)
+    expect((wrapper.vm as any).testPrompt).toContain('orange cat astronaut')
+
+    await (wrapper.vm as any).startTest()
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [, request] = (global.fetch as any).mock.calls[0]
+    expect(JSON.parse(request.body)).toMatchObject({
+      model_id: 'custom-image-v2',
+      prompt: 'Generate a cute orange cat astronaut sticker on a clean pastel background.',
+      mode: 'image'
+    })
+  })
 })

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -588,6 +588,7 @@ export default {
         testMode: 'Test mode',
         testModeDefault: 'Default request',
         testModeCompact: 'Compact probe',
+        testModeImage: 'Image generation test',
         modelRestrictionDisabledByPassthrough: 'Automatic passthrough is enabled: model whitelist/mapping will not take effect.',
       },
       grok: {

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -648,6 +648,7 @@ export default {
         testMode: '测试模式',
         testModeDefault: '常规请求',
         testModeCompact: 'Compact 探测',
+        testModeImage: '生图测试',
         modelRestrictionDisabledByPassthrough: '已开启自动透传：模型白名单/映射不会生效。',
       },
       grok: {


### PR DESCRIPTION
## Summary
- add an explicit `image` account-test mode for OpenAI-compatible accounts
- preserve automatic image-model detection while allowing administrators to test model IDs the built-in detector does not recognize yet
- keep empty and unknown modes normalized to `default`
- expose the mode in both account-test modals and include backend/frontend coverage for upstream CI

## Scope and safety
- This PR is based directly on `Wei-Shaw/sub2api:main` and contains only account-test mode changes.
- No production source, credentials, backups, deployment files, release assets, video adapters, relay/task stacks, billing migrations, or private project history are included.
- Local tests/builds/Docker/production acceptance were intentionally not run per contributor request; the included tests are for upstream CI.
- Test coverage uses fake HTTP responses and does not send real paid media requests.