### PR TITLE
fix(openai): add opt-in Responses web-search bridge

### DIFF
--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -219,6 +219,12 @@ func TestResolveOpenAIUpstreamEndpointPrefersForwardResult(t *testing.T) {
 			result:  &service.OpenAIForwardResult{},
 			want:    EndpointResponses,
 		},
+		{
+			name:    "standalone search bridge reports responses",
+			account: &service.Account{Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey},
+			result:  &service.OpenAIForwardResult{UpstreamEndpoint: EndpointResponses},
+			want:    EndpointResponses,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -236,7 +236,7 @@ func (h *OpenAIGatewayHandler) recordAlphaSearchUsage(
 	sessionID := service.ExtractClientSessionID(c)
 	requestPayloadHash := service.HashUsageRequestPayload(body)
 	inboundEndpoint := GetInboundEndpoint(c)
-	upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+	upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account, result)
 	quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 
 	h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1860,6 +1860,20 @@ func (a *Account) IsOpenAIResponsesFlattenNamespacesEnabled() bool {
 	return ok && enabled
 }
 
+// IsOpenAIAlphaSearchResponsesFallbackEnabled 返回 API Key 账号是否将网关的
+// standalone search 请求转换为标准 Responses API web_search 请求。
+// 字段：accounts.extra.openai_alpha_search_responses_fallback，缺省 false。
+//
+// 该兼容开关只适用于支持 Responses API web_search、但没有兼容 standalone
+// search 端点的 OpenAI 兼容上游。
+func (a *Account) IsOpenAIAlphaSearchResponsesFallbackEnabled() bool {
+	if a == nil || !a.IsOpenAIApiKey() || a.Extra == nil {
+		return false
+	}
+	enabled, ok := a.Extra["openai_alpha_search_responses_fallback"].(bool)
+	return ok && enabled
+}
+
 // IsOpenAIWSAllowStoreRecoveryEnabled 返回账号级 store 恢复开关。
 // 字段：accounts.extra.openai_ws_allow_store_recovery。
 func (a *Account) IsOpenAIWSAllowStoreRecoveryEnabled() bool {

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -59,11 +59,10 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 		return nil, err
 	}
 
-	// Codex Personal Access Token（at-...）目前可访问 ChatGPT Codex
-	// /responses，但会被 standalone /alpha/search 的 access enforcement
-	// 拒绝为 no_matching_rule。对 PAT 账号使用等价的 hosted web_search
-	// Responses 路径兜底，避免把可用账号误判为搜索不可用。
-	if account.IsOpenAIPersonalAccessToken() {
+	// PAT 账号沿用 ChatGPT Responses fallback。API Key 账号仅在显式声明
+	// 上游支持 Responses API web_search 时复用同一响应适配器；默认仍原样
+	// 转发 standalone search 请求。
+	if account.IsOpenAIPersonalAccessToken() || account.IsOpenAIAlphaSearchResponsesFallbackEnabled() {
 		return s.forwardAlphaSearchViaResponsesWebSearch(ctx, c, account, body, token, proxyURL, requestedModel, upstreamModel)
 	}
 
@@ -212,7 +211,16 @@ func (s *OpenAIGatewayService) forwardAlphaSearchViaResponsesWebSearch(
 }
 
 func (s *OpenAIGatewayService) buildOpenAIAlphaSearchResponsesWebSearchRequest(ctx context.Context, c *gin.Context, account *Account, alphaBody []byte, body []byte, token string) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, chatgptCodexURL, bytes.NewReader(body))
+	targetURL := chatgptCodexURL
+	if account != nil && account.IsOpenAIApiKey() {
+		baseURL := account.GetOpenAIBaseURL()
+		validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+		if err != nil {
+			return nil, err
+		}
+		targetURL = buildOpenAIEndpointURL(validatedURL, "/v1/responses")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -227,13 +235,23 @@ func (s *OpenAIGatewayService) buildOpenAIAlphaSearchResponsesWebSearchRequest(c
 			req.Header.Add(key, value)
 		}
 	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	if account != nil && account.IsOpenAIApiKey() {
+		// API Key upstreams receive only the public Responses API contract.
+		// ChatGPT transport identity, version, session, and beta headers are specific
+		// to the OAuth/PAT transport and must not leak into generic relays.
+		if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+			req.Header.Set("User-Agent", customUA)
+		}
+		account.ApplyHeaderOverrides(req.Header)
+		return req, nil
+	}
+
 	req.Host = "chatgpt.com"
 	if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
 		return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
 	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("OpenAI-Beta", "responses=experimental")
 	if turnMetadata := openAIAlphaSearchInboundHeader(c, "X-Codex-Turn-Metadata"); turnMetadata != "" {
 		req.Header.Set("X-Codex-Turn-Metadata", turnMetadata)
@@ -306,8 +324,8 @@ func buildOpenAIAlphaSearchResponsesWebSearchBody(alphaBody []byte, model string
 
 func openAIAlphaSearchResponsesWebSearchPrompt(alphaBody []byte) string {
 	var b strings.Builder
-	_, _ = b.WriteString("Execute this Codex standalone web.run request for another model.\n")
-	_, _ = b.WriteString("Use the hosted web_search tool when web/current information is needed.\n")
+	_, _ = b.WriteString("Execute the requested standalone web search for another model.\n")
+	_, _ = b.WriteString("Use the Responses API web_search tool when current information is needed.\n")
 	_, _ = b.WriteString("Return concise source-backed results. Include titles, URLs, dates, and direct answers when available.\n")
 	if commands := strings.TrimSpace(gjson.GetBytes(alphaBody, "commands").Raw); commands != "" {
 		_, _ = b.WriteString("\nCommands JSON:\n")

--- a/backend/internal/service/openai_alpha_search_test.go
+++ b/backend/internal/service/openai_alpha_search_test.go
@@ -271,6 +271,120 @@ func TestForwardAlphaSearchAPIKeyMapsModelAndPassesThroughError(t *testing.T) {
 	require.True(t, gjson.GetBytes(upstream.lastBody, "commands.search_query").IsArray())
 }
 
+func TestAccountAlphaSearchResponsesFallbackRequiresAPIKeyOptIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{name: "nil account", account: nil},
+		{
+			name: "API key default off",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+			},
+		},
+		{
+			name: "API key wrong value type",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Extra:    map[string]any{"openai_alpha_search_responses_fallback": "true"},
+			},
+		},
+		{
+			name: "OAuth ignores API key capability",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"openai_alpha_search_responses_fallback": true},
+			},
+		},
+		{
+			name: "API key explicitly enabled",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Extra:    map[string]any{"openai_alpha_search_responses_fallback": true},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsOpenAIAlphaSearchResponsesFallbackEnabled())
+		})
+	}
+}
+
+func TestForwardAlphaSearchAPIKeyBridgesToResponsesWebSearchWhenEnabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{
+		"id":"search-session",
+		"model":"client-search-model",
+		"commands":{"search_query":[{"q":"example query"}]},
+		"settings":{"search_context_size":"medium"}
+	}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Version", "client-version")
+	c.Request.Header.Set("Originator", "standalone-search-client")
+	c.Request.Header.Set("User-Agent", "standalone-search-client/version")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"client-turn"}`)
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"req-search"}},
+		Body:       io.NopCloser(strings.NewReader(alphaSearchResponsesSSE("search result"))),
+	}}
+	service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          47,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "test-api-key",
+			"base_url": "https://compat.example/v1",
+			"model_mapping": map[string]any{
+				"client-search-model": "upstream-search-model",
+			},
+		},
+		Extra: map[string]any{
+			"openai_alpha_search_responses_fallback": true,
+		},
+	}
+
+	result, err := service.ForwardAlphaSearch(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.WebSearchCalls)
+	require.Equal(t, "/v1/responses", result.UpstreamEndpoint)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{"output":"search result","results":[{"type":"text_result","ref_id":"turn0search0","url":"https://example.com/news","title":"Example News"}]}`, recorder.Body.String())
+	require.Equal(t, "https://compat.example/v1/responses", upstream.lastReq.URL.String())
+	require.Equal(t, "compat.example", upstream.lastReq.Host)
+	require.Equal(t, "Bearer test-api-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
+	require.Empty(t, upstream.lastReq.Header.Get("ChatGPT-Account-ID"))
+	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Empty(t, upstream.lastReq.Header.Get("Version"))
+	require.Empty(t, upstream.lastReq.Header.Get("Originator"))
+	require.Empty(t, upstream.lastReq.Header.Get("User-Agent"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"))
+	require.Empty(t, upstream.lastReq.Header.Get("Session_ID"))
+	require.Empty(t, upstream.lastReq.Header.Get("Conversation_ID"))
+	require.Equal(t, "upstream-search-model", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "web_search", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
+	require.Equal(t, "medium", gjson.GetBytes(upstream.lastBody, "tools.0.search_context_size").String())
+}
+
 func TestForwardAlphaSearchReturnsFailoverBeforeWriting(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"id":"search-session","model":"gpt-5.6-sol","commands":{}}`)

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -133,6 +133,57 @@
         </div>
       </div>
 
+      <!-- OpenAI API Key upstream standalone-search bridge -->
+      <div
+        v-if="allOpenAIAPIKey"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="mb-3 flex items-center justify-between">
+          <div class="flex-1 pr-4">
+            <label
+              id="bulk-edit-openai-alpha-search-responses-fallback-label"
+              class="input-label mb-0"
+              for="bulk-edit-openai-alpha-search-responses-fallback-enabled"
+            >
+              {{ t('admin.accounts.openai.alphaSearchResponsesFallback') }}
+            </label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.alphaSearchResponsesFallbackDesc') }}
+            </p>
+          </div>
+          <input
+            v-model="enableOpenAIAlphaSearchResponsesFallback"
+            id="bulk-edit-openai-alpha-search-responses-fallback-enabled"
+            type="checkbox"
+            aria-controls="bulk-edit-openai-alpha-search-responses-fallback-body"
+            class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+        </div>
+        <div
+          id="bulk-edit-openai-alpha-search-responses-fallback-body"
+          :class="!enableOpenAIAlphaSearchResponsesFallback && 'pointer-events-none opacity-50'"
+          role="group"
+          aria-labelledby="bulk-edit-openai-alpha-search-responses-fallback-label"
+        >
+          <button
+            id="bulk-edit-openai-alpha-search-responses-fallback-toggle"
+            type="button"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              openaiAlphaSearchResponsesFallbackEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+            @click="openaiAlphaSearchResponsesFallbackEnabled = !openaiAlphaSearchResponsesFallbackEnabled"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                openaiAlphaSearchResponsesFallbackEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- Base URL (API Key only) -->
       <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
         <div class="mb-3 flex items-center justify-between">
@@ -1460,6 +1511,7 @@ const enableStatus = ref(false)
 const enableGroups = ref(false)
 const enableOpenAIPassthrough = ref(false)
 const enableOpenAIFlattenNamespaces = ref(false)
+const enableOpenAIAlphaSearchResponsesFallback = ref(false)
 const enableOpenAIWSMode = ref(false)
 const enableOpenAIAPIKeyWSMode = ref(false)
 const enableUpstreamBillingAutoProbe = ref(false)
@@ -1493,6 +1545,8 @@ const groupIds = ref<number[]>([])
 const openaiPassthroughEnabled = ref(false)
 // Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+// API Key 上游可显式声明用 Responses API web_search 承接 standalone search
+const openaiAlphaSearchResponsesFallbackEnabled = ref(false)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const upstreamBillingAutoProbeMode = ref<'enabled' | 'disabled'>('enabled')
@@ -1708,6 +1762,11 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     extra.openai_responses_flatten_namespaces = openaiFlattenNamespacesEnabled.value
   }
 
+  if (enableOpenAIAlphaSearchResponsesFallback.value && allOpenAIAPIKey.value) {
+    const extra = ensureExtra()
+    extra.openai_alpha_search_responses_fallback = openaiAlphaSearchResponsesFallbackEnabled.value
+  }
+
   if (enableModelRestriction.value && !isOpenAIModelRestrictionDisabled.value) {
     // 统一使用 model_mapping 字段
     if (modelRestrictionMode.value === 'whitelist') {
@@ -1877,6 +1936,7 @@ const handleSubmit = async () => {
     enableBaseUrl.value ||
     enableOpenAIPassthrough.value ||
     enableOpenAIFlattenNamespaces.value ||
+    enableOpenAIAlphaSearchResponsesFallback.value ||
     enableModelRestriction.value ||
     enableCustomErrorCodes.value ||
     enableInterceptWarmup.value ||
@@ -2018,6 +2078,7 @@ watch(
       enableGroups.value = false
       enableOpenAIPassthrough.value = false
       enableOpenAIFlattenNamespaces.value = false
+      enableOpenAIAlphaSearchResponsesFallback.value = false
       enableOpenAIWSMode.value = false
       enableOpenAIAPIKeyWSMode.value = false
       enableUpstreamBillingAutoProbe.value = false
@@ -2031,6 +2092,7 @@ watch(
       baseUrl.value = ''
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
+      openaiAlphaSearchResponsesFallbackEnabled.value = false
       modelRestrictionMode.value = 'whitelist'
       allowedModels.value = []
       modelMappings.value = []

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2812,6 +2812,37 @@
         </div>
       </div>
 
+      <!-- OpenAI API Key upstream standalone-search bridge -->
+      <div
+        v-if="form.platform === 'openai' && form.type === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.alphaSearchResponsesFallback') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.alphaSearchResponsesFallbackDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="create-openai-alpha-search-responses-fallback-toggle"
+            @click="openaiAlphaSearchResponsesFallbackEnabled = !openaiAlphaSearchResponsesFallbackEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              openaiAlphaSearchResponsesFallbackEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                openaiAlphaSearchResponsesFallbackEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -3811,6 +3842,8 @@ const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+// API Key 上游可显式声明用 Responses API web_search 承接 standalone search
+const openaiAlphaSearchResponsesFallbackEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
@@ -4265,6 +4298,7 @@ watch(
     if (newPlatform !== 'openai') {
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
+      openaiAlphaSearchResponsesFallbackEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -4691,6 +4725,7 @@ const resetForm = () => {
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  openaiAlphaSearchResponsesFallbackEnabled.value = false
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
   openAICompactMode.value = 'auto'
@@ -4780,6 +4815,11 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_responses_flatten_namespaces = true
   } else {
     delete extra.openai_responses_flatten_namespaces
+  }
+  if (form.type === 'apikey' && openaiAlphaSearchResponsesFallbackEnabled.value) {
+    extra.openai_alpha_search_responses_fallback = true
+  } else {
+    delete extra.openai_alpha_search_responses_fallback
   }
   extra.openai_long_context_billing_enabled = openAILongContextBillingEnabled.value
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1512,6 +1512,37 @@
         </div>
       </div>
 
+      <!-- OpenAI API Key upstream standalone-search bridge -->
+      <div
+        v-if="account?.platform === 'openai' && account?.type === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.alphaSearchResponsesFallback') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.alphaSearchResponsesFallbackDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="edit-openai-alpha-search-responses-fallback-toggle"
+            @click="openaiAlphaSearchResponsesFallbackEnabled = !openaiAlphaSearchResponsesFallbackEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              openaiAlphaSearchResponsesFallbackEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                openaiAlphaSearchResponsesFallbackEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -2874,6 +2905,8 @@ const customBaseUrl = ref('')
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+// API Key 上游可显式声明用 Responses API web_search 承接 standalone search
+const openaiAlphaSearchResponsesFallbackEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -3310,6 +3343,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  openaiAlphaSearchResponsesFallbackEnabled.value = false
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -3328,6 +3362,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openaiFlattenNamespacesEnabled.value =
       newAccount.type === 'oauth' && extra?.openai_responses_flatten_namespaces === true
+    openaiAlphaSearchResponsesFallbackEnabled.value =
+      newAccount.type === 'apikey' && extra?.openai_alpha_search_responses_fallback === true
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
     openAILongContextBillingEnabled.value = longContextBillingValue === true
     // plan_type 手动覆盖仅 OAuth 有实际调度语义(IsOpenAIChatGPTSubscription 要求 oauth),故只对 oauth 回填
@@ -4567,6 +4603,11 @@ const handleSubmit = async () => {
         newExtra.openai_responses_flatten_namespaces = true
       } else {
         delete newExtra.openai_responses_flatten_namespaces
+      }
+      if (props.account.type === 'apikey' && openaiAlphaSearchResponsesFallbackEnabled.value) {
+        newExtra.openai_alpha_search_responses_fallback = true
+      } else {
+        delete newExtra.openai_alpha_search_responses_fallback
       }
       if (isSparkShadow.value) {
         delete newExtra.openai_long_context_billing_enabled

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -265,6 +265,25 @@ describe('BulkEditAccountModal', () => {
     expect(wrapper.find('#bulk-edit-openai-flatten-namespaces-enabled').exists()).toBe(false)
   })
 
+  it('OpenAI API Key 批量编辑可开启 standalone search Responses bridge', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['apikey']
+    })
+
+    await wrapper.get('#bulk-edit-openai-alpha-search-responses-fallback-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-alpha-search-responses-fallback-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        openai_alpha_search_responses_fallback: true
+      }
+    })
+  })
+
   it('OpenAI OAuth 批量编辑应提交 OAuth 专属 WS mode 字段（含 http_bridge）', async () => {
     const wrapper = mountModal({
       selectedPlatforms: ['openai'],

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -175,10 +175,32 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(wrapper.find('[data-testid="create-openai-flatten-namespaces-toggle"]').exists()).toBe(
       true
     )
+    expect(wrapper.find('[data-testid="create-openai-alpha-search-responses-fallback-toggle"]').exists()).toBe(
+      false
+    )
 
     await selectButtonByText(wrapper, 'API Key')
     expect(wrapper.find('[data-testid="create-openai-flatten-namespaces-toggle"]').exists()).toBe(
       false
+    )
+    expect(wrapper.find('[data-testid="create-openai-alpha-search-responses-fallback-toggle"]').exists()).toBe(
+      true
+    )
+  })
+
+  it('submits the API-key standalone search Responses bridge when enabled', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('[data-testid="create-openai-alpha-search-responses-fallback-toggle"]').trigger('click')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI compatible')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra?.openai_alpha_search_responses_fallback).toBe(
+      true
     )
   })
 

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -467,6 +467,27 @@ describe('EditAccountModal', () => {
     )
   })
 
+  it('loads and clears the API-key standalone search Responses bridge', async () => {
+    const account = buildAccount()
+    account.extra = {
+      openai_alpha_search_responses_fallback: true
+    }
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="edit-openai-alpha-search-responses-fallback-toggle"]')
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
+      'openai_alpha_search_responses_fallback'
+    )
+  })
+
   it('defaults legacy OpenAI accounts to long-context billing disabled', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -710,7 +710,7 @@ function generateOpenAIFiles(baseUrl: string, apiKey: string): FileConfig[] {
   const configDir = isWindows ? '%userprofile%\\.codex' : '~/.codex'
 
   // config.toml content
-  const configContent = `model_provider = "OpenAI"
+  const configContent = `model_provider = "sub2api"
 model = "gpt-5.5"
 review_model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
@@ -718,8 +718,8 @@ disable_response_storage = true
 network_access = "enabled"
 windows_wsl_setup_acknowledged = true
 
-[model_providers.OpenAI]
-name = "OpenAI"
+[model_providers.sub2api]
+name = "Sub2API"
 base_url = "${baseUrl}"
 wire_api = "responses"
 ${generateCodexProviderAuthConfig()}
@@ -819,7 +819,7 @@ function generateOpenAIWsFiles(baseUrl: string, apiKey: string): FileConfig[] {
   const configDir = isWindows ? '%userprofile%\\.codex' : '~/.codex'
 
   // config.toml content with WebSocket v2
-  const configContent = `model_provider = "OpenAI"
+  const configContent = `model_provider = "sub2api"
 model = "gpt-5.5"
 review_model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
@@ -827,8 +827,8 @@ disable_response_storage = true
 network_access = "enabled"
 windows_wsl_setup_acknowledged = true
 
-[model_providers.OpenAI]
-name = "OpenAI"
+[model_providers.sub2api]
+name = "Sub2API"
 base_url = "${baseUrl}"
 wire_api = "responses"
 supports_websockets = true

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -251,7 +251,7 @@ describe('UseKeyModal', () => {
     })
 
     const codeBlocks = wrapper.findAll('pre code').map((code) => code.text())
-    const configToml = codeBlocks.find((content) => content.includes('model_provider = "OpenAI"'))
+    const configToml = codeBlocks.find((content) => content.includes('model_provider = "sub2api"'))
 
     expect(configToml).toBeDefined()
     expect(configToml).toContain('model = "gpt-5.5"')
@@ -264,6 +264,7 @@ describe('UseKeyModal', () => {
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
     expect(configToml).not.toContain('supports_websockets')
+    expect(configToml).toContain('name = "Sub2API"')
     expect(configToml).not.toContain('responses_websockets_v2')
     expect(configToml).toContain('[features]\ngoals = true')
     expect(codeBlocks).toContain('{\n  "OPENAI_API_KEY": "sk-test"\n}')
@@ -296,11 +297,12 @@ describe('UseKeyModal', () => {
     await nextTick()
 
     const codeBlocks = wrapper.findAll('pre code').map((code) => code.text())
-    const configToml = codeBlocks.find((content) => content.includes('model_provider = "OpenAI"'))
+    const configToml = codeBlocks.find((content) => content.includes('model_provider = "sub2api"'))
 
     expect(apiKeyMode.attributes('aria-checked')).toBe('true')
     expect(configToml).toBeDefined()
     expect(configToml).toContain('requires_openai_auth = false')
+    expect(configToml).toContain('name = "Sub2API"')
     expect(configToml).toContain('http_headers = { "x-openai-actor-authorization" = "local-image-extension" }')
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
@@ -363,6 +365,7 @@ describe('UseKeyModal', () => {
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
     expect(configToml).toContain('supports_websockets = true')
+    expect(configToml).toContain('name = "Sub2API"')
     expect(configToml).toContain('[features]\nresponses_websockets_v2 = true\ngoals = true')
     expect(codeBlocks).toContain('{\n  "OPENAI_API_KEY": "sk-test"\n}')
     expect(wrapper.text()).toContain('auth.json')
@@ -408,6 +411,7 @@ describe('UseKeyModal', () => {
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
     expect(configToml).toContain('supports_websockets = true')
+    expect(configToml).toContain('name = "Sub2API"')
     expect(configToml).toContain('[features]\nresponses_websockets_v2 = true\ngoals = true')
     expect(codeBlocks).toContain('{\n  "OPENAI_API_KEY": "sk-test"\n}')
   })

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -498,6 +498,9 @@ export default {
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',
+        alphaSearchResponsesFallback: 'Bridge standalone search via Responses',
+        alphaSearchResponsesFallbackDesc:
+          'Disabled by default. Enable for an API-key upstream that supports the standard Responses API web_search tool but has no compatible standalone-search endpoint.',
         longContextBilling: 'API long-context pricing',
         longContextBillingDesc:
           'Disabled by default. Enable only when this account\'s upstream charges OpenAI API long-context rates above the model threshold.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -565,6 +565,9 @@ export default {
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',
+        alphaSearchResponsesFallback: '通过 Responses 桥接独立搜索',
+        alphaSearchResponsesFallbackDesc:
+          '默认关闭。仅当 API Key 上游支持标准 Responses API web_search 工具、但没有兼容的独立搜索端点时开启。',
         longContextBilling: 'API 长上下文计费',
         longContextBillingDesc: '默认关闭。仅当该账号的上游会按模型阈值收取 OpenAI API 长上下文费率时开启。',
         responsesWebsocketsV2: 'Responses WebSocket v2',


### PR DESCRIPTION
## Summary

- Add a default-off API-key account capability that translates Sub2API's existing standalone-search request into a standard Responses API request using the `web_search` tool.
- Route the translated request through the account's configured base URL, bearer token, model mapping, proxy, and explicit header overrides, without adding ChatGPT-only identity, session, version, or beta headers.
- Record `/v1/responses` as the actual upstream endpoint when the bridge is used, while retaining `/v1/alpha/search` as the inbound endpoint.
- Expose the capability in create, edit, and bulk-edit account flows.
- Generate custom-provider configuration with the `sub2api` / `Sub2API` identity instead of labeling a third-party base URL as the built-in OpenAI provider.

## Contract and scope

The bridge is an explicit compatibility adapter:

- Input: Sub2API's existing `/v1/alpha/search` gateway request.
- Upstream: the API-key account's `/v1/responses` endpoint with `stream: true`, `store: false`, and `tools: [{"type":"web_search"}]`.
- Output: the existing standalone-search response adapter, with usage accounting tied to the actual upstream endpoint.

The account capability is disabled by default. When it is absent or false, API-key standalone-search forwarding is unchanged. OAuth and personal-access-token behavior is unchanged.

This PR does not depend on a particular client version or model. It does not change model manifests, namespace-tool transforms, Responses Lite selection, multi-agent routing, or compaction behavior. The generated config change only corrects custom-provider identity; it does not declare undocumented client capabilities.

Related to #4949; this is a server-side compatibility mechanism, not a claim that all client-side search discovery cases are fixed.

## Tests

- `make test-unit`
- `TESTCONTAINERS_RYUK_DISABLED=true make test-integration`
- `make test-frontend`
- 90 focused Vitest cases for account forms and generated provider config
- `pnpm build`

The local integration command disables the testcontainers reaper because the local Docker daemon had a stale reaper in `removing` state; the complete integration suite passed with normal per-test container cleanup.
