### PR TITLE
fix(openai): safely retry websocket capacity failures

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1668,6 +1668,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	failedAccountIDs := make(map[int64]struct{})
+	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
 	var oauth429FailoverState service.OpenAIOAuth429FailoverState
 	handleWSFailover := func(account *service.Account, failoverErr *service.UpstreamFailoverError) bool {
@@ -1684,6 +1685,23 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		}
 		if ctx.Err() != nil {
 			return false
+		}
+		if failoverErr.RetryableOnSameAccount {
+			lastFailoverErr = failoverErr
+			retryLimit := account.GetPoolModeRetryCount()
+			if sameAccountRetryCount[account.ID] < retryLimit {
+				sameAccountRetryCount[account.ID]++
+				reqLog.Warn("openai.websocket_pool_mode_same_account_retry",
+					zap.Int64("account_id", account.ID),
+					zap.Int("upstream_status", failoverErr.StatusCode),
+					zap.Int("retry_count", sameAccountRetryCount[account.ID]),
+					zap.Int("retry_limit", retryLimit),
+				)
+				if !sleepWithContext(ctx, sameAccountRetryDelay) {
+					return false
+				}
+				return ensureUserSlotHeld()
+			}
 		}
 		h.gatewayService.RecordOpenAIAccountSwitch()
 		failedAccountIDs[account.ID] = struct{}{}

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -2128,13 +2128,15 @@ func TestOpenAIResponses_APIKeyPassthroughSSERateLimitUsesConfiguredPoolRetry(t 
 	require.Equal(t, "Upstream rate limit exceeded, please retry later", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
 }
 
-func TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent(t *testing.T) {
+func TestOpenAIResponsesWebSocket_RetriesCapacityThenFailsOverOnUsageLimitEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	firstHitCh := make(chan []byte, 1)
+	firstHitCh := make(chan []byte, 2)
 	secondHitCh := make(chan []byte, 1)
+	var firstConnections atomic.Int32
 
 	firstUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionNo := firstConnections.Add(1)
 		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
 		if err != nil {
 			return
@@ -2148,8 +2150,12 @@ func TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent(t *testing.T
 			firstHitCh <- payload
 		}
 
+		upstreamEvent := `{"type":"error","error":{"code":"rate_limit_exceeded","type":"usage_limit_reached","message":"The usage limit has been reached"}}`
+		if connectionNo == 1 {
+			upstreamEvent = `{"type":"response.failed","response":{"id":"resp_ws_capacity","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`
+		}
 		writeCtx, cancelWrite := context.WithTimeout(r.Context(), 3*time.Second)
-		_ = conn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"error","error":{"code":"rate_limit_exceeded","type":"usage_limit_reached","message":"The usage limit has been reached"}}`))
+		_ = conn.Write(writeCtx, coderws.MessageText, []byte(upstreamEvent))
 		cancelWrite()
 	}))
 	defer firstUpstream.Close()
@@ -2187,8 +2193,10 @@ func TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent(t *testing.T
 			Concurrency: 1,
 			Priority:    1,
 			Credentials: map[string]any{
-				"api_key":  "sk-first",
-				"base_url": firstUpstream.URL,
+				"api_key":               "sk-first",
+				"base_url":              firstUpstream.URL,
+				"pool_mode":             true,
+				"pool_mode_retry_count": float64(1),
 			},
 			Extra: map[string]any{
 				"openai_apikey_responses_websockets_v2_enabled": true,
@@ -2311,17 +2319,20 @@ func TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent(t *testing.T
 	require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
 	require.Equal(t, "resp_ws_failover_ok", gjson.GetBytes(event, "response.id").String())
 
-	select {
-	case <-firstHitCh:
-	case <-time.After(3 * time.Second):
-		t.Fatal("等待第一个上游收到首帧超时")
+	for attempt := 1; attempt <= 2; attempt++ {
+		select {
+		case <-firstHitCh:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("等待第一个上游收到第 %d 次请求超时", attempt)
+		}
 	}
 	select {
 	case <-secondHitCh:
 	case <-time.After(3 * time.Second):
 		t.Fatal("等待第二个上游收到重放首帧超时")
 	}
-	require.Equal(t, []int64{int64(9902)}, accountRepo.rateLimitedIDs)
+	require.Equal(t, int32(2), firstConnections.Load())
+	require.Empty(t, accountRepo.rateLimitedIDs)
 }
 
 func TestOpenAIResponsesWebSocket_FirstOutputTimeoutWithoutDownstreamReusesClientForOneFailover(t *testing.T) {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -990,6 +990,10 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 		message = "OpenAI stream disconnected before completion"
 	}
 	statusCode := openAIStreamFailureStatus(payload, message)
+	transientProcessingError := isOpenAITransientProcessingError(http.StatusBadRequest, message, payload)
+	if transientProcessingError {
+		statusCode = http.StatusServiceUnavailable
+	}
 	var headers http.Header
 	if len(responseHeaders) > 0 && responseHeaders[0] != nil {
 		headers = responseHeaders[0].Clone()
@@ -998,6 +1002,10 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 	// 不写账号级限流/封禁状态；重试与切号由 failover 引擎按
 	// StatusCode/RetryableOnSameAccount 决定。
 	message = s.recordOpenAIStreamUpstreamError(c, account, passthrough, upstreamRequestID, "failover", payload, message)
+	clientMessage := message
+	if transientProcessingError {
+		clientMessage = openAIWSTransientFailureClientMessage
+	}
 	errType := "upstream_error"
 	if statusCode == http.StatusTooManyRequests {
 		errType = "rate_limit_error"
@@ -1005,15 +1013,20 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 	body, _ := json.Marshal(gin.H{
 		"error": gin.H{
 			"type":    errType,
-			"message": message,
+			"message": clientMessage,
 		},
 	})
-	return &UpstreamFailoverError{
+	failoverErr := &UpstreamFailoverError{
 		StatusCode:             statusCode,
 		ResponseBody:           body,
 		ResponseHeaders:        headers,
 		RetryableOnSameAccount: openAIStreamFailedEventRetryableOnSameAccount(account, payload, message),
 	}
+	if transientProcessingError {
+		failoverErr.ClientStatusCode = http.StatusServiceUnavailable
+		failoverErr.ClientMessage = openAIWSTransientFailureClientMessage
+	}
+	return failoverErr
 }
 
 func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1314,7 +1314,8 @@ func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string
 		return payload, false
 	}
 	updated := payload
-	if clientOutputStarted && isOpenAIContextWindowError(extractOpenAISSEErrorMessage(payload), payload) {
+	upstreamMessage := extractOpenAISSEErrorMessage(payload)
+	if clientOutputStarted {
 		errorPath := ""
 		switch {
 		case gjson.GetBytes(updated, "response.error").Exists():
@@ -1322,7 +1323,20 @@ func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string
 		case gjson.GetBytes(updated, "error").Exists():
 			errorPath = "error"
 		}
-		if errorPath != "" {
+		switch {
+		case errorPath != "" && isOpenAITransientProcessingError(http.StatusBadRequest, upstreamMessage, payload):
+			for path, value := range map[string]string{
+				errorPath + ".type":    "server_error",
+				errorPath + ".code":    "upstream_temporarily_unavailable",
+				errorPath + ".message": openAIWSTransientFailureClientMessage,
+			} {
+				next, err := sjson.SetBytes(updated, path, value)
+				if err != nil {
+					return payload, false
+				}
+				updated = next
+			}
+		case errorPath != "" && isOpenAIContextWindowError(upstreamMessage, payload):
 			next, err := sjson.SetBytes(updated, errorPath+".type", "invalid_request_error")
 			if err != nil {
 				return payload, false

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1481,9 +1481,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputReturnsFailover(t *testing.T) 
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
 	require.False(t, failoverErr.RetryableOnSameAccount)
-	require.Contains(t, string(failoverErr.ResponseBody), "An error occurred while processing your request")
+	require.NotContains(t, string(failoverErr.ResponseBody), "An error occurred while processing your request")
+	require.Contains(t, string(failoverErr.ResponseBody), openAIWSTransientFailureClientMessage)
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
 }
@@ -1532,9 +1533,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover(t
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
 	require.True(t, failoverErr.RetryableOnSameAccount)
-	require.Contains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+	require.NotContains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+	require.Contains(t, string(failoverErr.ResponseBody), openAIWSTransientFailureClientMessage)
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
 }
@@ -1571,8 +1573,9 @@ func TestOpenAIStreamingResponseFailedBeforeOutputServerOverloadedCodeReturnsFai
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
-	require.Contains(t, string(failoverErr.ResponseBody), "Please retry later")
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.NotContains(t, string(failoverErr.ResponseBody), "Please retry later")
+	require.Contains(t, string(failoverErr.ResponseBody), openAIWSTransientFailureClientMessage)
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
 }
@@ -1686,6 +1689,48 @@ func TestOpenAIStreamingResponseFailedRateLimitDoesNotBlockAccountScheduling(t *
 	require.Equal(t, http.StatusTooManyRequests, failoverErr.StatusCode)
 	require.False(t, failoverErr.RetryableOnSameAccount)
 	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+}
+
+func TestOpenAIStreamingResponseFailedAfterOutputSanitizesCapacityError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_capacity"}}`,
+			"",
+			"event: response.output_text.delta",
+			`data: {"type":"response.output_text.delta","delta":"partial"}`,
+			"",
+			"event: response.failed",
+			`data: {"type":"response.failed","response":{"id":"resp_capacity","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-capacity-after-output"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.Error(t, err)
+
+	body := rec.Body.String()
+	require.Contains(t, body, "partial")
+	require.Contains(t, body, "event: response.failed")
+	require.NotContains(t, body, "Selected model is at capacity")
+	require.Contains(t, body, `"code":"upstream_temporarily_unavailable"`)
+	require.Contains(t, body, openAIWSTransientFailureClientMessage)
 }
 
 func TestOpenAIStreamingResponseFailedAfterOutputSanitizesVerboseResponseForClient(t *testing.T) {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -803,6 +803,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		replayCollector := &openAIWSToolCallReplayCollector{}
 		firstEventType := ""
 		lastEventType := ""
+		bufferedClientMessages := make([][]byte, 0, 4)
 		needModelReplace := false
 		clientDisconnected := false
 		mappedModel := ""
@@ -941,6 +942,22 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 						UpstreamOutTok: usage.OutputTokens,
 					})
 				}
+				if !wroteDownstream {
+					canonicalModel := canonicalOpenAIAccountSchedulingModel(account, originalModel)
+					if failoverErr := s.newOpenAIWSTransientResponseFailoverError(
+						ctx,
+						c,
+						account,
+						canonicalModel,
+						lease.HandshakeHeaders(),
+						upstreamMessage,
+					); failoverErr != nil {
+						lease.MarkBroken()
+						return nil, failoverErr
+					}
+				} else if isOpenAITransientProcessingError(http.StatusBadRequest, extractOpenAISSEErrorMessage(upstreamMessage), upstreamMessage) {
+					upstreamMessage = sanitizeOpenAIWSTransientFailureEvent(upstreamMessage)
+				}
 			}
 
 			if !clientDisconnected {
@@ -953,27 +970,39 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					}
 				}
 				replayCollector.AddEvent(eventType, upstreamMessage)
-				if err := writeClientMessage(upstreamMessage); err != nil {
-					if isOpenAIWSClientDisconnectError(err) {
-						clientDisconnected = true
-						closeStatus, closeReason := summarizeOpenAIWSReadCloseError(err)
-						logOpenAIWSModeInfo(
-							"ingress_ws_client_disconnected_drain account_id=%d turn=%d conn_id=%s close_status=%s close_reason=%s",
-							account.ID,
-							turn,
-							truncateOpenAIWSLogValue(lease.ConnID(), openAIWSIDValueMaxLen),
-							closeStatus,
-							truncateOpenAIWSLogValue(closeReason, openAIWSHeaderValueMaxLen),
-						)
+				shouldBuffer := eventType != "error" && firstTokenMs == nil && !isTokenEvent && !isTerminalEvent
+				if shouldBuffer {
+					bufferedClientMessages = append(bufferedClientMessages, append([]byte(nil), upstreamMessage...))
+					continue
+				}
+				messages := append(bufferedClientMessages, upstreamMessage)
+				bufferedClientMessages = bufferedClientMessages[:0]
+				for _, clientMessage := range messages {
+					if err := writeClientMessage(clientMessage); err != nil {
+						if isOpenAIWSClientDisconnectError(err) {
+							clientDisconnected = true
+							closeStatus, closeReason := summarizeOpenAIWSReadCloseError(err)
+							logOpenAIWSModeInfo(
+								"ingress_ws_client_disconnected_drain account_id=%d turn=%d conn_id=%s close_status=%s close_reason=%s",
+								account.ID,
+								turn,
+								truncateOpenAIWSLogValue(lease.ConnID(), openAIWSIDValueMaxLen),
+								closeStatus,
+								truncateOpenAIWSLogValue(closeReason, openAIWSHeaderValueMaxLen),
+							)
+						} else {
+							return nil, wrapOpenAIWSIngressTurnError(
+								"write_client",
+								fmt.Errorf("write client websocket event: %w", err),
+								wroteDownstream,
+							)
+						}
 					} else {
-						return nil, wrapOpenAIWSIngressTurnError(
-							"write_client",
-							fmt.Errorf("write client websocket event: %w", err),
-							wroteDownstream,
-						)
+						wroteDownstream = true
 					}
-				} else {
-					wroteDownstream = true
+					if clientDisconnected {
+						break
+					}
 				}
 			}
 			if isTerminalEvent {

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -552,6 +552,60 @@ func TestOpenAIGatewayService_Forward_WSv2_ResponseFailedIsNotSchedulingSuccess(
 	require.True(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "gpt-5.5"))
 }
 
+func TestOpenAIGatewayService_Forward_WSv2_CapacityFailureBeforeOutputReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.98.0")
+
+	cfg := newOpenAIWSV2TestConfig()
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+
+	captureConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.created","response":{"id":"resp_capacity_1","model":"gpt-5.5"}}`),
+		[]byte(`{"type":"response.failed","response":{"id":"resp_capacity_1","model":"gpt-5.5","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`),
+	}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(&openAIWSCaptureDialer{conn: captureConn})
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          1303,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":               "sk-test",
+			"pool_mode":             true,
+			"pool_mode_retry_count": float64(1),
+		},
+		Extra: map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.5","stream":true,"input":"hello"}`))
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, rec.Body.String())
+	require.NotContains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+}
+
 func TestOpenAIWSPayloadString_OnlyAcceptsStringValues(t *testing.T) {
 	payload := map[string]any{
 		"type":                 nil,

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const openAIWSTransientFailureClientMessage = "Upstream service temporarily unavailable"
+
 func (s *OpenAIGatewayService) isOpenAIWSGeneratePrewarmEnabled() bool {
 	return s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.PrewarmGenerateEnabled
 }
@@ -225,6 +227,9 @@ func openAIWSPayloadTransientStatus(payload []byte) int {
 	if len(payload) == 0 {
 		return 0
 	}
+	if isOpenAITransientProcessingError(http.StatusBadRequest, "", payload) {
+		return http.StatusServiceUnavailable
+	}
 	status := int(gjson.GetBytes(payload, "response.error.status_code").Int())
 	if status == 0 {
 		status = int(gjson.GetBytes(payload, "response.error.status").Int())
@@ -262,6 +267,92 @@ func openAIWSPayloadTransientStatus(payload []byte) int {
 	default:
 		return 0
 	}
+}
+
+func (s *OpenAIGatewayService) newOpenAIWSTransientResponseFailoverError(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	canonicalModel string,
+	headers http.Header,
+	payload []byte,
+) *UpstreamFailoverError {
+	eventType, _, _ := parseOpenAIWSEventEnvelope(payload)
+	if eventType != "response.failed" {
+		return nil
+	}
+	upstreamMessage := extractOpenAISSEErrorMessage(payload)
+	if !isOpenAITransientProcessingError(http.StatusBadRequest, upstreamMessage, payload) {
+		return nil
+	}
+	status := openAIWSPayloadTransientStatus(payload)
+	if status == 0 {
+		return nil
+	}
+
+	if upstreamMessage == "" {
+		upstreamMessage = "OpenAI upstream response failed"
+	}
+	shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, status, headers, payload, canonicalModel)
+	retryableOnSameAccount := account != nil && !shouldDisable && account.IsPoolMode() &&
+		(account.IsPoolModeRetryableStatus(status) || isOpenAITransientProcessingError(http.StatusBadRequest, upstreamMessage, payload))
+
+	if c != nil {
+		setOpsUpstreamError(c, status, upstreamMessage, "")
+		if account != nil {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: status,
+				Kind:               "ws_response_failed",
+				Message:            upstreamMessage,
+			})
+		}
+	}
+
+	responseBody, err := marshalOpenAIUpstreamJSON(gin.H{
+		"error": gin.H{
+			"type":    "upstream_error",
+			"message": openAIWSTransientFailureClientMessage,
+		},
+	})
+	if err != nil {
+		responseBody = []byte(`{"error":{"type":"upstream_error","message":"Upstream service temporarily unavailable"}}`)
+	}
+	failoverErr := newOpenAIUpstreamFailoverError(
+		status,
+		headers,
+		responseBody,
+		upstreamMessage,
+		retryableOnSameAccount,
+	)
+	failoverErr.ClientStatusCode = http.StatusServiceUnavailable
+	failoverErr.ClientMessage = openAIWSTransientFailureClientMessage
+	return failoverErr
+}
+
+func sanitizeOpenAIWSTransientFailureEvent(payload []byte) []byte {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+	updated, _ := sanitizeOpenAIResponseFailedEventForClient(payload, "response.failed", true)
+	errorPath := "error"
+	if gjson.GetBytes(updated, "response").Exists() {
+		errorPath = "response.error"
+	}
+	for path, value := range map[string]string{
+		errorPath + ".type":    "server_error",
+		errorPath + ".code":    "upstream_temporarily_unavailable",
+		errorPath + ".message": openAIWSTransientFailureClientMessage,
+	} {
+		next, err := sjson.SetBytes(updated, path, value)
+		if err != nil {
+			return payload
+		}
+		updated = next
+	}
+	return updated
 }
 
 func (s *OpenAIGatewayService) handleOpenAIWSTerminalTransientFailure(ctx context.Context, account *Account, canonicalModel string, headers http.Header, payload []byte) string {

--- a/backend/internal/service/openai_ws_forwarder_test.go
+++ b/backend/internal/service/openai_ws_forwarder_test.go
@@ -167,6 +167,56 @@ func TestOpenAIWSPayloadTransientStatus_Explicit529IsNotModelTransient(t *testin
 	require.Zero(t, openAIWSPayloadTransientStatus(payload))
 }
 
+func TestOpenAIWSTransientResponseFailover_CapacityOnly(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		ID:       5204,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"pool_mode":             true,
+			"pool_mode_retry_count": float64(1),
+		},
+	}
+	capacityPayload := []byte(`{"type":"response.failed","response":{"error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	failoverErr := svc.newOpenAIWSTransientResponseFailoverError(
+		context.Background(),
+		nil,
+		account,
+		"gpt-5.5",
+		http.Header{},
+		capacityPayload,
+	)
+	require.NotNil(t, failoverErr)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.ClientStatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.NotContains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+	require.Contains(t, string(failoverErr.ResponseBody), openAIWSTransientFailureClientMessage)
+
+	serverErrorPayload := []byte(`{"type":"response.failed","response":{"error":{"code":"server_error","message":"Internal error"}}}`)
+	require.Nil(t, svc.newOpenAIWSTransientResponseFailoverError(
+		context.Background(), nil, account, "gpt-5.5", http.Header{}, serverErrorPayload,
+	))
+
+	contextPayload := []byte(`{"type":"response.failed","response":{"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model."}}}`)
+	require.Nil(t, svc.newOpenAIWSTransientResponseFailoverError(
+		context.Background(), nil, account, "gpt-5.5", http.Header{}, contextPayload,
+	))
+}
+
+func TestSanitizeOpenAIWSTransientFailureEvent_RemovesCapacityDetails(t *testing.T) {
+	payload := []byte(`{"type":"response.failed","response":{"id":"resp_capacity","output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}],"usage":{"input_tokens":12,"output_tokens":1},"error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	sanitized := sanitizeOpenAIWSTransientFailureEvent(payload)
+	require.NotContains(t, string(sanitized), "Selected model is at capacity")
+	require.NotContains(t, string(sanitized), `"output"`)
+	require.NotContains(t, string(sanitized), `"usage"`)
+	require.Contains(t, string(sanitized), `"code":"upstream_temporarily_unavailable"`)
+	require.Contains(t, string(sanitized), openAIWSTransientFailureClientMessage)
+}
+
 func TestOpenAIWSDial5xxRecordsModelTransient(t *testing.T) {
 	svc := &OpenAIGatewayService{}
 	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, &config.Config{}, nil, nil)

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -574,6 +574,21 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 					UpstreamOutTok: usage.OutputTokens,
 				})
 			}
+			if !wroteDownstream {
+				if failoverErr := s.newOpenAIWSTransientResponseFailoverError(
+					ctx,
+					c,
+					account,
+					mappedModel,
+					lease.HandshakeHeaders(),
+					message,
+				); failoverErr != nil {
+					lease.MarkBroken()
+					return nil, failoverErr
+				}
+			} else if isOpenAITransientProcessingError(http.StatusBadRequest, extractOpenAISSEErrorMessage(message), message) {
+				message = sanitizeOpenAIWSTransientFailureEvent(message)
+			}
 		}
 
 		if eventType == "error" {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -576,6 +576,15 @@ func openAIWSPassthroughStartsSemanticOutput(payload []byte) bool {
 		strings.HasPrefix(eventType, "response.output")
 }
 
+func openAIWSRetryReplayUnsafeOutput(payload []byte) bool {
+	switch strings.TrimSpace(gjson.GetBytes(payload, "type").String()) {
+	case "", "response.created", "response.queued", "response.in_progress":
+		return false
+	default:
+		return true
+	}
+}
+
 func openAIWSPassthroughIsTerminalOutput(payload []byte) bool {
 	switch strings.TrimSpace(gjson.GetBytes(payload, "type").String()) {
 	case "response.completed", "response.done", "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
@@ -902,6 +911,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	}
 
 	completedTurns := atomic.Int32{}
+	replayUnsafeOutputStarted := atomic.Bool{}
 	turnLifecycle := newOpenAIWSPassthroughTurnLifecycle(true)
 	clientFrameConn := &openAIWSClientFrameConn{
 		conn:                 clientConn,
@@ -1158,13 +1168,35 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 					return nil
 				}
 				eventType, _, _ := parseOpenAIWSEventEnvelope(payload)
+				if eventType == "response.failed" && !replayUnsafeOutputStarted.Load() {
+					if failoverErr := s.newOpenAIWSTransientResponseFailoverError(
+						ctx,
+						c,
+						account,
+						capturedSessionModel,
+						handshakeHeaders,
+						payload,
+					); failoverErr != nil {
+						return failoverErr
+					}
+				}
 				if isOpenAIWSTerminalEvent(eventType) {
 					s.handleOpenAIWSTerminalTransientFailure(ctx, account, capturedSessionModel, handshakeHeaders, payload)
+				}
+				if eventType == "response.failed" && replayUnsafeOutputStarted.Load() && isOpenAITransientProcessingError(http.StatusBadRequest, extractOpenAISSEErrorMessage(payload), payload) {
+					return NewOpenAIWSClientCloseError(
+						coderws.StatusTryAgainLater,
+						openAIWSTransientFailureClientMessage,
+						nil,
+					)
 				}
 				if eventType == "error" {
 					s.handleOpenAIWSErrorEventTransientFailure(ctx, account, capturedSessionModel, handshakeHeaders, payload)
 				}
 				if wroteDownstream || eventType != "error" {
+					if openAIWSRetryReplayUnsafeOutput(payload) {
+						replayUnsafeOutputStarted.Store(true)
+					}
 					return nil
 				}
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(payload)

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -285,6 +285,77 @@ func TestPassthroughLifecycle_LeaseLossSendsRetryClose(t *testing.T) {
 	}
 }
 
+func TestPassthroughLifecycle_CapacityAfterCreatedReturnsFailoverWithoutErrorFrame(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.created","response":{"id":"resp_capacity","model":"gpt-5.1"}}`)
+	upstream.Send(`{"type":"response.failed","response":{"id":"resp_capacity","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`)
+	account := passthroughLifecycleAccount()
+	account.Credentials["pool_mode"] = true
+	account.Credentials["pool_mode_retry_count"] = float64(1)
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream), account)
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	created, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.created", gjson.GetBytes(created, "type").String())
+
+	_, err = readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.Error(t, err)
+	select {
+	case proxyErr := <-serverErr:
+		var failoverErr *UpstreamFailoverError
+		require.ErrorAs(t, proxyErr, &failoverErr)
+		require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+		require.True(t, failoverErr.RetryableOnSameAccount)
+		require.NotContains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough capacity failure did not return to the failover loop")
+	}
+}
+
+func TestPassthroughLifecycle_CapacityAfterToolOutputClosesWithoutReplayOrErrorFrame(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.output_item.added","response_id":"resp_capacity_tool","item":{"id":"item_1","type":"function_call","call_id":"call_1","name":"shell","arguments":""}}`)
+	upstream.Send(`{"type":"response.failed","response":{"id":"resp_capacity_tool","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`)
+	account := passthroughLifecycleAccount()
+	account.Credentials["pool_mode"] = true
+	account.Credentials["pool_mode_retry_count"] = float64(1)
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream), account)
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	toolEvent, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.output_item.added", gjson.GetBytes(toolEvent, "type").String())
+
+	_, err = readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	var websocketCloseErr coderws.CloseError
+	require.ErrorAs(t, err, &websocketCloseErr)
+	require.Equal(t, coderws.StatusTryAgainLater, websocketCloseErr.Code)
+	require.Equal(t, openAIWSTransientFailureClientMessage, websocketCloseErr.Reason)
+	select {
+	case proxyErr := <-serverErr:
+		var failoverErr *UpstreamFailoverError
+		require.False(t, errors.As(proxyErr, &failoverErr))
+		var clientCloseErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, proxyErr, &clientCloseErr)
+		require.Equal(t, coderws.StatusTryAgainLater, clientCloseErr.StatusCode())
+		require.Equal(t, openAIWSTransientFailureClientMessage, clientCloseErr.Reason())
+		require.NotContains(t, proxyErr.Error(), "Selected model is at capacity")
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough post-output capacity failure did not terminate")
+	}
+}
+
 func TestPassthroughLifecycle_CompletedTurnStartsInterTurnIdle(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	controlCtx, cancelControl := context.WithCancelCause(context.Background())
@@ -587,5 +658,46 @@ func TestPassthroughLifecycle_SecondTurnTimeoutIsNotFailoverSafe(t *testing.T) {
 		require.Equal(t, coderws.StatusGoingAway, closeErr.StatusCode())
 	case <-time.After(2500 * time.Millisecond):
 		t.Fatal("second turn first semantic output was left unbounded")
+	}
+}
+
+func TestPassthroughLifecycle_SecondTurnCapacityIsNotFailoverSafe(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_first","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+	account := passthroughLifecycleAccount()
+	account.Credentials["pool_mode"] = true
+	account.Credentials["pool_mode_retry_count"] = float64(1)
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream), account)
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	completed, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(completed, "type").String())
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","previous_response_id":"resp_first"}`))
+	cancelWrite()
+	require.NoError(t, err)
+	upstream.Send(`{"type":"response.failed","response":{"id":"resp_second","error":{"type":"invalid_request_error","message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	_, err = readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	var websocketCloseErr coderws.CloseError
+	require.ErrorAs(t, err, &websocketCloseErr)
+	require.Equal(t, coderws.StatusTryAgainLater, websocketCloseErr.Code)
+	require.Equal(t, openAIWSTransientFailureClientMessage, websocketCloseErr.Reason)
+	select {
+	case proxyErr := <-serverErr:
+		var failoverErr *UpstreamFailoverError
+		require.NotErrorAs(t, proxyErr, &failoverErr, "handler must not replay the initial request for a later-turn capacity failure")
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, proxyErr, &closeErr)
+		require.Equal(t, coderws.StatusTryAgainLater, closeErr.StatusCode())
+		require.NotContains(t, proxyErr.Error(), "Selected model is at capacity")
+	case <-time.After(3 * time.Second):
+		t.Fatal("second-turn capacity failure did not terminate")
 	}
 }


### PR DESCRIPTION
## Background

OpenAI Responses WebSocket can report a transient capacity failure through `response.failed` after the handshake succeeds. The previous flow forwarded that terminal event directly, bypassing the existing account-pool retry and failover path and exposing the upstream capacity message to clients.

## Changes

- Convert transient capacity `response.failed` events into the existing failover signal only on the first turn and before text or tool output starts.
- In pool mode, retry the same account up to `pool_mode_retry_count`, then exclude it and select another account.
- When all attempts fail, return only a generic `503 Upstream service temporarily unavailable` response.
- Once text/tool output or a later turn has started, do not replay the request; close with generic `1013 Try Again Later` to avoid duplicate output and side effects.
- Cover ingress, WS v2, and WS v2 passthrough paths.

## Scope

- This PR only changes Responses WebSocket behavior; regular HTTP `/v1/responses` behavior is unchanged.
- Passthrough still forwards `response.created` immediately to preserve prompt cancellation, so a safe retry can produce another `response.created` prelude.

## Tests

- `go test -tags=unit ./... -count=1`
- `go test ./internal/service ./internal/handler -count=1`
- Added focused regression coverage for retry/failover, message sanitization, tool-output replay prevention, and later-turn replay prevention.