### PR TITLE
fix(openai-ws): keep downstream writes off the relay cancellation context

### DIFF
--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -173,7 +173,13 @@ func Relay(
 		return writeUpstream(msgType, payload)
 	}
 	writeClient := func(msgType coderws.MessageType, payload []byte) error {
-		writeCtx, cancel := context.WithTimeout(relayCtx, writeTimeout)
+		// 下行写超时故意不挂在 relayCtx 上：coder/websocket 在已武装的 write
+		// ctx 被取消时会直接硬关连接（context.AfterFunc 的 stop 不等待执行中
+		// 的回调），外部取消若落在一次已成功写入的解除武装窗口内，会连同尚未
+		// 发出的 close 帧一起冲掉，客户端只能看到裸 EOF 而收不到关闭码。与读
+		// 侧 conn.Read(context.Background()) 同理，取消路径的连接回收由各退出
+		// 分支的显式 Close/CloseNow 兜底。
+		writeCtx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 		defer cancel()
 		return clientConn.WriteFrame(writeCtx, msgType, payload)
 	}


### PR DESCRIPTION
## 问题

v0.1.170 tag CI 在 `TestPassthroughLifecycle_LeaseLossSendsRetryClose` 偶发失败:客户端期望收到 1013 close 帧,实际读到裸 EOF(https://github.com/Wei-Shaw/sub2api/actions/runs/30697884247)。该测试与 WS v2 链路自 v0.1.161 起零改动,非本次发布回归,是既有时序竞态。

## 根因

coder/websocket v1.8.14 的 `writeFrame` 用 `context.AfterFunc(ctx, ... c.close())` 做写超时守卫,写完后 `clearWriteTimeout()` 调 stop——但 **stop 不等待已经开跑的回调**(context.AfterFunc 文档语义)。

租约丢失时 `cancelControl` 取消整棵 ctx 树;下行写的 writeCtx 派生自 relayCtx,若取消恰好落在 upstream→client 一次已成功写入(response.created)的解除武装窗口内,AfterFunc 直接硬关 TCP。随后 `closeAndJoin` 的 `Close(1013)` 撞上 `<-c.closed` 返回 `net.ErrClosed` 被吞掉,1013 帧永远没写出,客户端只看到 EOF——与 CI 现场全部痕迹吻合(`read_client_fail err=1013` 正常发出、客户端 `failed to read frame header: EOF`)。

读侧早已用 `conn.Read(context.Background())` 防了这个坑(openai_ws_client_read.go 的注释即为此),写侧漏了。

## 修复

下行写 ctx 从 relayCtx 摘下,仅保留 writeTimeout 上界。取消路径的连接回收不受影响:所有 relay 退出分支(adapter 收尾、closeAndJoin、graceful close)都会显式 Close/CloseNow,库内 5s 握手超时兜底,卡死客户端场景 teardown 上界 ~5s。

这不只是测试稳定性问题:生产上真实客户端同样可能在该窗口偶发收到裸 EOF 而拿不到 1013「请重连」信号。

## 验证

- `go build ./...` 通过
- `go test ./internal/service/openai_ws_v2/` 全绿
- `go test ./internal/service/ -run 'TestPassthroughLifecycle|TestOpenAIWSPassthrough' -count=5` 全绿
- 原 flaky 测试 `-count=300 -race` 全绿(该竞态窗口仅几条指令宽,本地难触发,修复依据为库源码机制分析)

## 已知未改项

- 上行写(writeUpstream)保留 relayCtx:上游连接无优雅关闭帧要求,保留取消即中断的快速回收语义。
- 非 v2 forwarder 路径理论上存在同类窗口,未在本 PR 扩散处理。