### PR TITLE
feat(admin): automatically retest and recover failed account models

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -1097,7 +1097,7 @@ func (h *AccountHandler) Test(c *gin.Context) {
 	}
 
 	if h.rateLimitService != nil {
-		if _, err := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), accountID); err != nil {
+		if _, err := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), accountID, req.ModelID); err != nil {
 			_ = c.Error(err)
 		}
 	}

--- a/backend/internal/handler/admin/scheduled_test_handler.go
+++ b/backend/internal/handler/admin/scheduled_test_handler.go
@@ -20,20 +20,28 @@ func NewScheduledTestHandler(scheduledTestSvc *service.ScheduledTestService) *Sc
 }
 
 type createScheduledTestPlanRequest struct {
-	AccountID      int64  `json:"account_id" binding:"required"`
-	ModelID        string `json:"model_id"`
-	CronExpression string `json:"cron_expression" binding:"required"`
-	Enabled        *bool  `json:"enabled"`
-	MaxResults     int    `json:"max_results"`
-	AutoRecover    *bool  `json:"auto_recover"`
+	AccountID            int64    `json:"account_id" binding:"required"`
+	ModelID              string   `json:"model_id"`
+	ModelIDs             []string `json:"model_ids"`
+	CronExpression       string   `json:"cron_expression"`
+	TriggerMode          string   `json:"trigger_mode"`
+	RetryIntervalMinutes *int     `json:"retry_interval_minutes"`
+	RetryCronExpression  *string  `json:"retry_cron_expression"`
+	Enabled              *bool    `json:"enabled"`
+	MaxResults           int      `json:"max_results"`
+	AutoRecover          *bool    `json:"auto_recover"`
 }
 
 type updateScheduledTestPlanRequest struct {
-	ModelID        string `json:"model_id"`
-	CronExpression string `json:"cron_expression"`
-	Enabled        *bool  `json:"enabled"`
-	MaxResults     int    `json:"max_results"`
-	AutoRecover    *bool  `json:"auto_recover"`
+	ModelID              string    `json:"model_id"`
+	ModelIDs             *[]string `json:"model_ids"`
+	CronExpression       string    `json:"cron_expression"`
+	TriggerMode          string    `json:"trigger_mode"`
+	RetryIntervalMinutes *int      `json:"retry_interval_minutes"`
+	RetryCronExpression  *string   `json:"retry_cron_expression"`
+	Enabled              *bool     `json:"enabled"`
+	MaxResults           int       `json:"max_results"`
+	AutoRecover          *bool     `json:"auto_recover"`
 }
 
 // ListByAccount GET /admin/accounts/:id/scheduled-test-plans
@@ -61,11 +69,15 @@ func (h *ScheduledTestHandler) Create(c *gin.Context) {
 	}
 
 	plan := &service.ScheduledTestPlan{
-		AccountID:      req.AccountID,
-		ModelID:        req.ModelID,
-		CronExpression: req.CronExpression,
-		Enabled:        true,
-		MaxResults:     req.MaxResults,
+		AccountID:            req.AccountID,
+		ModelID:              req.ModelID,
+		ModelIDs:             req.ModelIDs,
+		CronExpression:       req.CronExpression,
+		TriggerMode:          req.TriggerMode,
+		RetryIntervalMinutes: req.RetryIntervalMinutes,
+		RetryCronExpression:  req.RetryCronExpression,
+		Enabled:              true,
+		MaxResults:           req.MaxResults,
 	}
 	if req.Enabled != nil {
 		plan.Enabled = *req.Enabled
@@ -105,8 +117,22 @@ func (h *ScheduledTestHandler) Update(c *gin.Context) {
 	if req.ModelID != "" {
 		existing.ModelID = req.ModelID
 	}
+	if req.ModelIDs != nil {
+		existing.ModelIDs = *req.ModelIDs
+	}
 	if req.CronExpression != "" {
 		existing.CronExpression = req.CronExpression
+	}
+	if req.TriggerMode != "" {
+		existing.TriggerMode = req.TriggerMode
+	}
+	if req.RetryIntervalMinutes != nil {
+		existing.RetryIntervalMinutes = req.RetryIntervalMinutes
+		existing.RetryCronExpression = nil
+	}
+	if req.RetryCronExpression != nil {
+		existing.RetryCronExpression = req.RetryCronExpression
+		existing.RetryIntervalMinutes = nil
 	}
 	if req.Enabled != nil {
 		existing.Enabled = *req.Enabled

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2137,6 +2137,7 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 	payload := map[string]string{
 		"rate_limited_at":     now.Format(time.RFC3339),
 		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+		"updated_at":          now.Format(time.RFC3339Nano),
 	}
 	if len(reason) > 0 {
 		if value := strings.TrimSpace(reason[0]); value != "" {
@@ -2352,6 +2353,92 @@ func (r *accountRepository) ClearModelRateLimits(ctx context.Context, id int64) 
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
 	return nil
+}
+
+func (r *accountRepository) ClearModelRateLimit(ctx context.Context, id int64, modelID string) error {
+	if modelID == "" {
+		return nil
+	}
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(
+		ctx,
+		`UPDATE accounts
+		 SET extra = COALESCE(extra, '{}'::jsonb) #- ARRAY['model_rate_limits', $1]::text[], updated_at = NOW()
+		 WHERE id = $2 AND deleted_at IS NULL`,
+		modelID,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return service.ErrAccountNotFound
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear model rate limit failed: account=%d model=%s err=%v", id, modelID, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return nil
+}
+
+func (r *accountRepository) ClearModelRateLimitIfMatch(ctx context.Context, id int64, modelID string, observed json.RawMessage) (bool, error) {
+	if modelID == "" || len(observed) == 0 {
+		return false, nil
+	}
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(ctx, `
+		UPDATE accounts
+		SET extra = COALESCE(extra, '{}'::jsonb) #- ARRAY['model_rate_limits', $1]::text[], updated_at = NOW()
+		WHERE id = $2
+			AND deleted_at IS NULL
+			AND extra #> ARRAY['model_rate_limits', $1]::text[] = $3::jsonb
+	`, modelID, id, string(observed))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional model recovery failed: account=%d model=%s err=%v", id, modelID, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
+}
+
+func (r *accountRepository) RecoverAccountRuntimeStateIfUnchanged(ctx context.Context, id int64, observedUpdatedAt time.Time) (bool, error) {
+	result, err := r.sql.ExecContext(ctx, `
+		UPDATE accounts
+		SET status = CASE WHEN status = $3 THEN $4 ELSE status END,
+			error_message = CASE WHEN status = $3 THEN '' ELSE error_message END,
+			schedulable = CASE WHEN status = $3 THEN TRUE ELSE schedulable END,
+			rate_limited_at = NULL,
+			rate_limit_reset_at = NULL,
+			overload_until = NULL,
+			temp_unschedulable_until = NULL,
+			temp_unschedulable_reason = NULL,
+			extra = COALESCE(extra, '{}'::jsonb) - 'antigravity_quota_scopes',
+			updated_at = NOW()
+		WHERE id = $1 AND deleted_at IS NULL AND updated_at = $2
+	`, id, observedUpdatedAt, service.StatusError, service.StatusActive)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional account recovery failed: account=%d err=%v", id, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
 }
 
 func (r *accountRepository) UpdateSessionWindow(ctx context.Context, id int64, start, end *time.Time, status string) error {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -954,6 +955,101 @@ func (s *AccountRepoSuite) TestClearRateLimit() {
 	s.Require().Nil(got.RateLimitedAt)
 	s.Require().Nil(got.RateLimitResetAt)
 	s.Require().Nil(got.OverloadUntil)
+}
+
+func (s *AccountRepoSuite) TestClearModelRateLimitPreservesSiblingModels() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-model-clear"})
+	resetAt := time.Now().Add(time.Hour)
+	for _, modelID := range []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "AICredits"} {
+		s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, modelID, resetAt))
+	}
+
+	before, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	observed, err := json.Marshal(before.Extra["model_rate_limits"].(map[string]any)["gpt-5.6-sol"])
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-sol", resetAt))
+	cleared, err := s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, "gpt-5.6-sol", observed)
+	s.Require().NoError(err)
+	s.Require().False(cleared)
+
+	current, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	observed, err = json.Marshal(current.Extra["model_rate_limits"].(map[string]any)["gpt-5.6-sol"])
+	s.Require().NoError(err)
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+	cleared, err = s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, "gpt-5.6-sol", observed)
+	s.Require().NoError(err)
+	s.Require().True(cleared)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	limits, ok := got.Extra["model_rate_limits"].(map[string]any)
+	s.Require().True(ok)
+	s.Require().NotContains(limits, "gpt-5.6-sol")
+	s.Require().Contains(limits, "gpt-5.6-luna")
+	s.Require().Contains(limits, "gpt-5.6-terra")
+	s.Require().Contains(limits, "AICredits")
+}
+
+func (s *AccountRepoSuite) TestRecoverAccountRuntimeStateOnlyIfUnchanged() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name: "acc-conditional-recovery", Status: service.StatusActive, Schedulable: true,
+	})
+	until := time.Now().Add(time.Hour)
+	s.Require().NoError(s.repo.SetError(s.ctx, account.ID, "automatic upstream error"))
+	s.Require().NoError(s.repo.SetTempUnschedulable(s.ctx, account.ID, until, "automatic cooldown"))
+
+	observed, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	_, err = s.repo.sql.ExecContext(s.ctx, "UPDATE accounts SET updated_at = $2 WHERE id = $1", account.ID, observed.UpdatedAt.Add(time.Second))
+	s.Require().NoError(err)
+	recovered, err := s.repo.RecoverAccountRuntimeStateIfUnchanged(s.ctx, account.ID, observed.UpdatedAt)
+	s.Require().NoError(err)
+	s.Require().False(recovered)
+
+	current, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+	recovered, err = s.repo.RecoverAccountRuntimeStateIfUnchanged(s.ctx, account.ID, current.UpdatedAt)
+	s.Require().NoError(err)
+	s.Require().True(recovered)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Equal(service.StatusActive, got.Status)
+	s.Require().True(got.Schedulable)
+	s.Require().Nil(got.TempUnschedulableUntil)
+	s.Require().Nil(got.RateLimitResetAt)
+}
+
+func (s *AccountRepoSuite) TestConditionalModelRecoveryClearsTwoSiblingModels() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-two-model-recovery"})
+	resetAt := time.Now().Add(time.Hour)
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-luna", resetAt))
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-sol", resetAt))
+
+	observed, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	limits := observed.Extra["model_rate_limits"].(map[string]any)
+	for _, modelID := range []string{"gpt-5.6-luna", "gpt-5.6-sol"} {
+		raw, marshalErr := json.Marshal(limits[modelID])
+		s.Require().NoError(marshalErr)
+		cleared, clearErr := s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, modelID, raw)
+		s.Require().NoError(clearErr)
+		s.Require().True(cleared)
+	}
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	remaining := got.Extra["model_rate_limits"].(map[string]any)
+	s.Require().NotContains(remaining, "gpt-5.6-luna")
+	s.Require().NotContains(remaining, "gpt-5.6-sol")
 }
 
 func (s *AccountRepoSuite) TestTempUnschedulableFieldsLoadedByGetByIDAndGetByIDs() {

--- a/backend/internal/repository/scheduled_test_repo.go
+++ b/backend/internal/repository/scheduled_test_repo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/lib/pq"
 )
 
 // --- Plan Repository ---
@@ -20,16 +21,16 @@ func NewScheduledTestPlanRepository(db *sql.DB) service.ScheduledTestPlanReposit
 
 func (r *scheduledTestPlanRepository) Create(ctx context.Context, plan *service.ScheduledTestPlan) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO scheduled_test_plans (account_id, model_id, cron_expression, enabled, max_results, auto_recover, next_run_at, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
-		RETURNING id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
-	`, plan.AccountID, plan.ModelID, plan.CronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
+		INSERT INTO scheduled_test_plans (account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, next_run_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
+		RETURNING id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+	`, plan.AccountID, plan.ModelID, pq.Array(nonNilModelIDs(plan.ModelIDs)), plan.CronExpression, plan.TriggerMode, plan.RetryIntervalMinutes, plan.RetryCronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
 	return scanPlan(row)
 }
 
 func (r *scheduledTestPlanRepository) GetByID(ctx context.Context, id int64) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+		SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans WHERE id = $1
 	`, id)
 	return scanPlan(row)
@@ -37,7 +38,7 @@ func (r *scheduledTestPlanRepository) GetByID(ctx context.Context, id int64) (*s
 
 func (r *scheduledTestPlanRepository) ListByAccountID(ctx context.Context, accountID int64) ([]*service.ScheduledTestPlan, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+		SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans WHERE account_id = $1
 		ORDER BY created_at DESC
 	`, accountID)
@@ -50,7 +51,7 @@ func (r *scheduledTestPlanRepository) ListByAccountID(ctx context.Context, accou
 
 func (r *scheduledTestPlanRepository) ListDue(ctx context.Context, now time.Time) ([]*service.ScheduledTestPlan, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+			SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans
 		WHERE enabled = true AND next_run_at <= $1
 		ORDER BY next_run_at ASC
@@ -65,11 +66,18 @@ func (r *scheduledTestPlanRepository) ListDue(ctx context.Context, now time.Time
 func (r *scheduledTestPlanRepository) Update(ctx context.Context, plan *service.ScheduledTestPlan) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
 		UPDATE scheduled_test_plans
-		SET model_id = $2, cron_expression = $3, enabled = $4, max_results = $5, auto_recover = $6, next_run_at = $7, updated_at = NOW()
+		SET model_id = $2, model_ids = $3, cron_expression = $4, trigger_mode = $5, retry_interval_minutes = $6, retry_cron_expression = $7, enabled = $8, max_results = $9, auto_recover = $10, next_run_at = $11, updated_at = NOW()
 		WHERE id = $1
-		RETURNING id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
-	`, plan.ID, plan.ModelID, plan.CronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
+		RETURNING id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+	`, plan.ID, plan.ModelID, pq.Array(nonNilModelIDs(plan.ModelIDs)), plan.CronExpression, plan.TriggerMode, plan.RetryIntervalMinutes, plan.RetryCronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
 	return scanPlan(row)
+}
+
+func nonNilModelIDs(modelIDs []string) []string {
+	if modelIDs == nil {
+		return []string{}
+	}
+	return modelIDs
 }
 
 func (r *scheduledTestPlanRepository) Delete(ctx context.Context, id int64) error {
@@ -81,6 +89,13 @@ func (r *scheduledTestPlanRepository) UpdateAfterRun(ctx context.Context, id int
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE scheduled_test_plans SET last_run_at = $2, next_run_at = $3, updated_at = NOW() WHERE id = $1
 	`, id, lastRunAt, nextRunAt)
+	return err
+}
+
+func (r *scheduledTestPlanRepository) UpdateNextRun(ctx context.Context, id int64, nextRunAt time.Time) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduled_test_plans SET next_run_at = $2, updated_at = NOW() WHERE id = $1
+	`, id, nextRunAt)
 	return err
 }
 
@@ -96,14 +111,14 @@ func NewScheduledTestResultRepository(db *sql.DB) service.ScheduledTestResultRep
 
 func (r *scheduledTestResultRepository) Create(ctx context.Context, result *service.ScheduledTestResult) (*service.ScheduledTestResult, error) {
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO scheduled_test_results (plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-		RETURNING id, plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
-	`, result.PlanID, result.Status, result.ResponseText, result.ErrorMessage, result.LatencyMs, result.StartedAt, result.FinishedAt)
+		INSERT INTO scheduled_test_results (plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+		RETURNING id, plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
+	`, result.PlanID, result.ModelID, result.Status, result.ResponseText, result.ErrorMessage, result.LatencyMs, result.StartedAt, result.FinishedAt)
 
 	out := &service.ScheduledTestResult{}
 	if err := row.Scan(
-		&out.ID, &out.PlanID, &out.Status, &out.ResponseText, &out.ErrorMessage,
+		&out.ID, &out.PlanID, &out.ModelID, &out.Status, &out.ResponseText, &out.ErrorMessage,
 		&out.LatencyMs, &out.StartedAt, &out.FinishedAt, &out.CreatedAt,
 	); err != nil {
 		return nil, err
@@ -111,9 +126,20 @@ func (r *scheduledTestResultRepository) Create(ctx context.Context, result *serv
 	return out, nil
 }
 
+func (r *scheduledTestResultRepository) Update(ctx context.Context, result *service.ScheduledTestResult) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduled_test_results
+		SET model_id = $2, status = $3, response_text = $4, error_message = $5,
+		    latency_ms = $6, started_at = $7, finished_at = $8
+		WHERE id = $1
+	`, result.ID, result.ModelID, result.Status, result.ResponseText, result.ErrorMessage,
+		result.LatencyMs, result.StartedAt, result.FinishedAt)
+	return err
+}
+
 func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID int64, limit int) ([]*service.ScheduledTestResult, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
+		SELECT id, plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
 		FROM scheduled_test_results
 		WHERE plan_id = $1
 		ORDER BY created_at DESC
@@ -128,7 +154,7 @@ func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID
 	for rows.Next() {
 		r := &service.ScheduledTestResult{}
 		if err := rows.Scan(
-			&r.ID, &r.PlanID, &r.Status, &r.ResponseText, &r.ErrorMessage,
+			&r.ID, &r.PlanID, &r.ModelID, &r.Status, &r.ResponseText, &r.ErrorMessage,
 			&r.LatencyMs, &r.StartedAt, &r.FinishedAt, &r.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -138,18 +164,18 @@ func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID
 	return results, rows.Err()
 }
 
-func (r *scheduledTestResultRepository) PruneOldResults(ctx context.Context, planID int64, keepCount int) error {
+func (r *scheduledTestResultRepository) PruneOldResults(ctx context.Context, planID int64, modelID string, keepCount int) error {
 	_, err := r.db.ExecContext(ctx, `
 		DELETE FROM scheduled_test_results
 		WHERE id IN (
 			SELECT id FROM (
-				SELECT id, ROW_NUMBER() OVER (PARTITION BY plan_id ORDER BY created_at DESC) AS rn
+				SELECT id, ROW_NUMBER() OVER (PARTITION BY plan_id, model_id ORDER BY created_at DESC) AS rn
 				FROM scheduled_test_results
-				WHERE plan_id = $1
+				WHERE plan_id = $1 AND model_id = $2
 			) ranked
-			WHERE rn > $2
+			WHERE rn > $3
 		)
-	`, planID, keepCount)
+	`, planID, modelID, keepCount)
 	return err
 }
 
@@ -162,7 +188,7 @@ type scannable interface {
 func scanPlan(row scannable) (*service.ScheduledTestPlan, error) {
 	p := &service.ScheduledTestPlan{}
 	if err := row.Scan(
-		&p.ID, &p.AccountID, &p.ModelID, &p.CronExpression, &p.Enabled, &p.MaxResults, &p.AutoRecover,
+		&p.ID, &p.AccountID, &p.ModelID, pq.Array(&p.ModelIDs), &p.CronExpression, &p.TriggerMode, &p.RetryIntervalMinutes, &p.RetryCronExpression, &p.Enabled, &p.MaxResults, &p.AutoRecover,
 		&p.LastRunAt, &p.NextRunAt, &p.CreatedAt, &p.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/backend/internal/repository/scheduled_test_repo_integration_test.go
+++ b/backend/internal/repository/scheduled_test_repo_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduledTestRepositoriesErrorRecoveryRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	account := mustCreateAccount(t, integrationEntClient, &service.Account{Name: "scheduled-recovery-roundtrip"})
+	t.Cleanup(func() { _ = integrationEntClient.Account.DeleteOneID(account.ID).Exec(ctx) })
+
+	planRepo := NewScheduledTestPlanRepository(integrationDB)
+	resultRepo := NewScheduledTestResultRepository(integrationDB)
+	interval := 5
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	plan, err := planRepo.Create(ctx, &service.ScheduledTestPlan{
+		AccountID: account.ID, ModelID: "gpt-5.6-luna", CronExpression: "*/30 * * * *",
+		ModelIDs: []string{"gpt-5.6-luna", "gpt-5.6-sol"},
+		TriggerMode: service.ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval,
+		Enabled: true, MaxResults: 100, AutoRecover: true, NextRunAt: &now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, service.ScheduledTestTriggerErrorRecovery, plan.TriggerMode)
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, plan.ModelIDs)
+	require.Equal(t, 5, *plan.RetryIntervalMinutes)
+	require.Nil(t, plan.RetryCronExpression)
+
+	result, err := resultRepo.Create(ctx, &service.ScheduledTestResult{
+		PlanID: plan.ID, ModelID: "gpt-5.6-sol", Status: "running",
+		StartedAt: now, FinishedAt: now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "gpt-5.6-sol", result.ModelID)
+	result.Status = "success"
+	result.ResponseText = "ok"
+	result.FinishedAt = now.Add(time.Second)
+	result.LatencyMs = 1000
+	require.NoError(t, resultRepo.Update(ctx, result))
+
+	results, err := resultRepo.ListByPlanID(ctx, plan.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "gpt-5.6-sol", results[0].ModelID)
+	require.Equal(t, "success", results[0].Status)
+	require.Equal(t, "ok", results[0].ResponseText)
+
+	nextRun := now.Add(time.Minute)
+	require.NoError(t, planRepo.UpdateNextRun(ctx, plan.ID, nextRun))
+	updated, err := planRepo.GetByID(ctx, plan.ID)
+	require.NoError(t, err)
+	require.WithinDuration(t, nextRun, *updated.NextRunAt, time.Millisecond)
+}
+
+func TestScheduledTestRepositoriesEmptyModelIDsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	account := mustCreateAccount(t, integrationEntClient, &service.Account{Name: "scheduled-recovery-all-models"})
+	t.Cleanup(func() { _ = integrationEntClient.Account.DeleteOneID(account.ID).Exec(ctx) })
+
+	interval := 5
+	plan, err := NewScheduledTestPlanRepository(integrationDB).Create(ctx, &service.ScheduledTestPlan{
+		AccountID: account.ID, ModelID: "gpt-5.6-luna", CronExpression: "*/30 * * * *",
+		TriggerMode: service.ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval,
+		Enabled: true, MaxResults: 100, AutoRecover: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, plan.ModelIDs)
+
+	plan.ModelIDs = nil
+	updated, err := NewScheduledTestPlanRepository(integrationDB).Update(ctx, plan)
+	require.NoError(t, err)
+	require.Empty(t, updated.ModelIDs)
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -1963,6 +1963,7 @@ func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID in
 
 	return &ScheduledTestResult{
 		Status:       status,
+		ModelID:      modelID,
 		ResponseText: responseText,
 		ErrorMessage: errMsg,
 		LatencyMs:    finishedAt.Sub(startedAt).Milliseconds(),

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -17,6 +17,15 @@ const (
 	anthropicFableRateLimitKey = "claude-fable-5"
 )
 
+func isInternalModelRateLimitScope(modelID string) bool {
+	switch strings.TrimSpace(modelID) {
+	case antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey:
+		return true
+	default:
+		return false
+	}
+}
+
 // isRateLimitActiveForKey 检查指定 key 的限流是否生效
 func (a *Account) isRateLimitActiveForKey(key string) bool {
 	resetAt := a.modelRateLimitResetAt(key)
@@ -45,6 +54,17 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 	return false
 }
 
+func (a *Account) modelRateLimitKeyWithContext(ctx context.Context, requestedModel string) string {
+	if a == nil {
+		return ""
+	}
+	modelKey := a.GetMappedModel(requestedModel)
+	if a.Platform == PlatformAntigravity {
+		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
+	}
+	return strings.TrimSpace(modelKey)
+}
+
 // GetModelRateLimitRemainingTime 获取模型限流剩余时间
 // 返回 0 表示未限流或已过期
 func (a *Account) GetModelRateLimitRemainingTime(requestedModel string) time.Duration {
@@ -66,11 +86,7 @@ func (a *Account) modelRateLimitKeysForRequest(ctx context.Context, requestedMod
 		return nil
 	}
 
-	modelKey := a.GetMappedModel(requestedModel)
-	if a.Platform == PlatformAntigravity {
-		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
-	}
-	modelKey = strings.TrimSpace(modelKey)
+	modelKey := a.modelRateLimitKeyWithContext(ctx, requestedModel)
 	if modelKey == "" {
 		return nil
 	}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,10 +40,24 @@ type AccountRuntimeBlocker interface {
 	ClearAccountSchedulingBlock(accountID int64)
 }
 
+type modelRateLimitRecoveryRepository interface {
+	ClearModelRateLimit(ctx context.Context, id int64, modelID string) error
+	ClearModelRateLimitIfMatch(ctx context.Context, id int64, modelID string, observed json.RawMessage) (bool, error)
+	RecoverAccountRuntimeStateIfUnchanged(ctx context.Context, id int64, observedUpdatedAt time.Time) (bool, error)
+}
+
+type ErrorRecoveryTarget struct {
+	ModelID                  string
+	ObservedModelRateLimit   json.RawMessage
+	ObservedAccountUpdatedAt time.Time
+	RecoverAccountState      bool
+}
+
 // SuccessfulTestRecoveryResult 表示测试成功后恢复了哪些运行时状态。
 type SuccessfulTestRecoveryResult struct {
-	ClearedError     bool
-	ClearedRateLimit bool
+	ClearedError          bool
+	ClearedRateLimit      bool
+	ClearedModelRateLimit bool
 }
 
 // AccountRecoveryOptions 控制账号恢复时的附加行为。
@@ -1732,14 +1747,20 @@ func (s *RateLimitService) samplePassiveUsageFromHeaders(ctx context.Context, ac
 
 // ClearRateLimit 清除账号的限流状态
 func (s *RateLimitService) ClearRateLimit(ctx context.Context, accountID int64) error {
+	return s.clearRateLimit(ctx, accountID, true)
+}
+
+func (s *RateLimitService) clearRateLimit(ctx context.Context, accountID int64, clearAllModels bool) error {
 	if err := s.accountRepo.ClearRateLimit(ctx, accountID); err != nil {
 		return err
 	}
 	if err := s.accountRepo.ClearAntigravityQuotaScopes(ctx, accountID); err != nil {
 		return err
 	}
-	if err := s.accountRepo.ClearModelRateLimits(ctx, accountID); err != nil {
-		return err
+	if clearAllModels {
+		if err := s.accountRepo.ClearModelRateLimits(ctx, accountID); err != nil {
+			return err
+		}
 	}
 	// 清除限流时一并清理临时不可调度状态，避免周限/窗口重置后仍被本地临时状态阻断。
 	if err := s.accountRepo.ClearTempUnschedulable(ctx, accountID); err != nil {
@@ -1800,10 +1821,77 @@ func (s *RateLimitService) RecoverAccountState(ctx context.Context, accountID in
 	return result, nil
 }
 
-// RecoverAccountAfterSuccessfulTest 将一次成功测试视为正常请求，
-// 按需恢复 error / rate-limit / overload / temp-unsched / model-rate-limit 等运行时状态。
-func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64) (*SuccessfulTestRecoveryResult, error) {
-	return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+// RecoverAccountAfterSuccessfulTest 将成功测试视为目标模型已恢复，账号级自动状态也可一并恢复。
+func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64, modelID string) (*SuccessfulTestRecoveryResult, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SuccessfulTestRecoveryResult{}
+	if account.Status == StatusError {
+		if err := s.accountRepo.ClearError(ctx, accountID); err != nil {
+			return nil, err
+		}
+		result.ClearedError = true
+	}
+	if hasAccountRecoverableRuntimeState(account) {
+		if err := s.clearRateLimit(ctx, accountID, false); err != nil {
+			return nil, err
+		}
+		result.ClearedRateLimit = true
+	}
+
+	modelKey := strings.TrimSpace(modelID)
+	if !account.isRateLimitActiveForKey(modelKey) {
+		modelKey = account.modelRateLimitKeyWithContext(ctx, modelID)
+	}
+	if modelKey != "" && modelKey != creditsExhaustedKey && account.isRateLimitActiveForKey(modelKey) {
+		repo, ok := s.accountRepo.(modelRateLimitRecoveryRepository)
+		if !ok {
+			return nil, fmt.Errorf("account repository does not support targeted model recovery")
+		}
+		if err := repo.ClearModelRateLimit(ctx, accountID, modelKey); err != nil {
+			return nil, err
+		}
+		result.ClearedModelRateLimit = true
+	}
+	if result.ClearedError || result.ClearedRateLimit || result.ClearedModelRateLimit {
+		s.ResetOpenAI403Counter(ctx, accountID)
+		if result.ClearedError && !result.ClearedRateLimit {
+			s.notifyAccountSchedulingBlockCleared(accountID)
+		}
+	}
+	return result, nil
+}
+
+func (s *RateLimitService) RecoverErrorTargetAfterSuccessfulTest(ctx context.Context, accountID int64, target ErrorRecoveryTarget) (*SuccessfulTestRecoveryResult, error) {
+	repo, ok := s.accountRepo.(modelRateLimitRecoveryRepository)
+	if !ok {
+		return nil, fmt.Errorf("account repository does not support conditional error recovery")
+	}
+
+	result := &SuccessfulTestRecoveryResult{}
+	if target.RecoverAccountState {
+		recovered, err := repo.RecoverAccountRuntimeStateIfUnchanged(ctx, accountID, target.ObservedAccountUpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		result.ClearedError = recovered
+		result.ClearedRateLimit = recovered
+	}
+	if len(target.ObservedModelRateLimit) > 0 {
+		cleared, err := repo.ClearModelRateLimitIfMatch(ctx, accountID, target.ModelID, target.ObservedModelRateLimit)
+		if err != nil {
+			return nil, err
+		}
+		result.ClearedModelRateLimit = cleared
+	}
+	if result.ClearedError || result.ClearedModelRateLimit {
+		s.ResetOpenAI403Counter(ctx, accountID)
+		s.notifyAccountSchedulingBlockCleared(accountID)
+	}
+	return result, nil
 }
 
 func (s *RateLimitService) ClearTempUnschedulable(ctx context.Context, accountID int64) error {
@@ -1835,6 +1923,78 @@ func hasRecoverableRuntimeState(account *Account) bool {
 	}
 	return hasNonEmptyMapValue(account.Extra, "model_rate_limits") ||
 		hasNonEmptyMapValue(account.Extra, "antigravity_quota_scopes")
+}
+
+func hasAccountRecoverableRuntimeState(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	now := time.Now()
+	if (account.RateLimitResetAt != nil && now.Before(*account.RateLimitResetAt)) ||
+		(account.OverloadUntil != nil && now.Before(*account.OverloadUntil)) ||
+		(account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil)) {
+		return true
+	}
+	return hasNonEmptyMapValue(account.Extra, "antigravity_quota_scopes")
+}
+
+func (s *RateLimitService) ErrorRecoveryTargets(ctx context.Context, accountID int64, accountProbeModel string) ([]ErrorRecoveryTarget, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if account.Status != StatusActive && account.Status != StatusError {
+		return nil, nil
+	}
+	if account.Status == StatusActive && !account.Schedulable {
+		return nil, nil
+	}
+	if account.ExpiresAt != nil && !time.Now().Before(*account.ExpiresAt) {
+		return nil, nil
+	}
+	hasAccountState := hasAccountRecoverableRuntimeState(account)
+	if account.Status == StatusError && !hasAccountState {
+		return nil, nil
+	}
+
+	targets := make(map[string]ErrorRecoveryTarget)
+	if limits, ok := account.Extra[modelRateLimitsKey].(map[string]any); ok {
+		for modelID, limit := range limits {
+			if modelID != creditsExhaustedKey &&
+				!isInternalModelRateLimitScope(modelID) &&
+				account.isRateLimitActiveForKey(modelID) {
+				observed, err := json.Marshal(limit)
+				if err != nil {
+					return nil, err
+				}
+				targets[modelID] = ErrorRecoveryTarget{
+					ModelID: modelID, ObservedModelRateLimit: observed, ObservedAccountUpdatedAt: account.UpdatedAt,
+				}
+			}
+		}
+	}
+	if hasAccountState && accountProbeModel != "" && !isInternalModelRateLimitScope(accountProbeModel) {
+		target := targets[accountProbeModel]
+		target.ModelID = accountProbeModel
+		target.ObservedAccountUpdatedAt = account.UpdatedAt
+		target.RecoverAccountState = true
+		targets[accountProbeModel] = target
+	}
+
+	modelIDs := make([]string, 0, len(targets))
+	for modelID := range targets {
+		modelIDs = append(modelIDs, modelID)
+	}
+	sort.Strings(modelIDs)
+	result := make([]ErrorRecoveryTarget, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if targets[modelID].RecoverAccountState {
+			result = append([]ErrorRecoveryTarget{targets[modelID]}, result...)
+			continue
+		}
+		result = append(result, targets[modelID])
+	}
+	return result, nil
 }
 
 func hasNonEmptyMapValue(extra map[string]any, key string) bool {

--- a/backend/internal/service/ratelimit_service_clear_test.go
+++ b/backend/internal/service/ratelimit_service_clear_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -21,6 +22,8 @@ type rateLimitClearRepoStub struct {
 	clearRateLimitCalls       int
 	clearAntigravityCalls     int
 	clearModelRateLimitCalls  int
+	clearModelRateLimitKeys   []string
+	recoverRuntimeCalls       int
 	clearTempUnschedCalls     int
 	clearErrorErr             error
 	clearRateLimitErr         error
@@ -55,6 +58,41 @@ func (r *rateLimitClearRepoStub) ClearAntigravityQuotaScopes(ctx context.Context
 func (r *rateLimitClearRepoStub) ClearModelRateLimits(ctx context.Context, id int64) error {
 	r.clearModelRateLimitCalls++
 	return r.clearModelRateLimitErr
+}
+
+func (r *rateLimitClearRepoStub) ClearModelRateLimit(ctx context.Context, id int64, modelID string) error {
+	r.clearModelRateLimitKeys = append(r.clearModelRateLimitKeys, modelID)
+	return r.clearModelRateLimitErr
+}
+
+func (r *rateLimitClearRepoStub) ClearModelRateLimitIfMatch(_ context.Context, _ int64, modelID string, observed json.RawMessage) (bool, error) {
+	if r.clearModelRateLimitErr != nil || r.getByIDAccount == nil {
+		return false, r.clearModelRateLimitErr
+	}
+	limits, _ := r.getByIDAccount.Extra[modelRateLimitsKey].(map[string]any)
+	current, ok := limits[modelID]
+	if !ok {
+		return false, nil
+	}
+	encoded, err := json.Marshal(current)
+	if err != nil || string(encoded) != string(observed) {
+		return false, err
+	}
+	delete(limits, modelID)
+	r.clearModelRateLimitKeys = append(r.clearModelRateLimitKeys, modelID)
+	r.getByIDAccount.UpdatedAt = r.getByIDAccount.UpdatedAt.Add(time.Nanosecond)
+	return true, nil
+}
+
+func (r *rateLimitClearRepoStub) RecoverAccountRuntimeStateIfUnchanged(_ context.Context, _ int64, observedUpdatedAt time.Time) (bool, error) {
+	if r.getByIDAccount == nil || !r.getByIDAccount.UpdatedAt.Equal(observedUpdatedAt) {
+		return false, nil
+	}
+	r.recoverRuntimeCalls++
+	r.getByIDAccount.Status = StatusActive
+	r.getByIDAccount.Schedulable = true
+	r.getByIDAccount.UpdatedAt = r.getByIDAccount.UpdatedAt.Add(time.Nanosecond)
+	return true, nil
 }
 
 func (r *rateLimitClearRepoStub) ClearTempUnschedulable(ctx context.Context, id int64) error {
@@ -202,6 +240,7 @@ func TestRateLimitService_ClearRateLimit_WithoutTempUnschedCache(t *testing.T) {
 
 func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLimitRelatedState(t *testing.T) {
 	now := time.Now()
+	resetAt := now.Add(time.Hour)
 	repo := &rateLimitClearRepoStub{
 		getByIDAccount: &Account{
 			ID:                     42,
@@ -210,8 +249,14 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLi
 			TempUnschedulableUntil: &now,
 			Extra: map[string]any{
 				"model_rate_limits": map[string]any{
-					"claude-sonnet-4-5": map[string]any{
-						"rate_limit_reset_at": now.Format(time.RFC3339),
+					"gpt-5.6-sol": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+					},
+					"gpt-5.6-luna": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+					},
+					"AICredits": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
 					},
 				},
 				"antigravity_quota_scopes": map[string]any{"gemini": true},
@@ -223,17 +268,19 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLi
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, cache)
 	svc.SetAccountRuntimeBlocker(blocker)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 42)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 42, "gpt-5.6-sol")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.ClearedError)
 	require.True(t, result.ClearedRateLimit)
+	require.True(t, result.ClearedModelRateLimit)
 
 	require.Equal(t, 1, repo.getByIDCalls)
 	require.Equal(t, 1, repo.clearErrorCalls)
 	require.Equal(t, 1, repo.clearRateLimitCalls)
 	require.Equal(t, 1, repo.clearAntigravityCalls)
-	require.Equal(t, 1, repo.clearModelRateLimitCalls)
+	require.Equal(t, 0, repo.clearModelRateLimitCalls)
+	require.Equal(t, []string{"gpt-5.6-sol"}, repo.clearModelRateLimitKeys)
 	require.Equal(t, 1, repo.clearTempUnschedCalls)
 	require.Equal(t, []int64{42}, cache.deletedIDs)
 	require.Equal(t, []int64{42}, blocker.clearedIDs)
@@ -251,17 +298,19 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_NoRecoverableStateIs
 	cache := &tempUnschedCacheRecorder{}
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, cache)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 7)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 7, "gpt-5.6-sol")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.ClearedError)
 	require.False(t, result.ClearedRateLimit)
+	require.False(t, result.ClearedModelRateLimit)
 
 	require.Equal(t, 1, repo.getByIDCalls)
 	require.Equal(t, 0, repo.clearErrorCalls)
 	require.Equal(t, 0, repo.clearRateLimitCalls)
 	require.Equal(t, 0, repo.clearAntigravityCalls)
 	require.Equal(t, 0, repo.clearModelRateLimitCalls)
+	require.Empty(t, repo.clearModelRateLimitKeys)
 	require.Equal(t, 0, repo.clearTempUnschedCalls)
 	require.Empty(t, cache.deletedIDs)
 }
@@ -276,7 +325,7 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearErrorFailed(t *
 	}
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 9)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 9, "gpt-5.6-sol")
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.Equal(t, 1, repo.getByIDCalls)

--- a/backend/internal/service/scheduled_test_port.go
+++ b/backend/internal/service/scheduled_test_port.go
@@ -7,23 +7,28 @@ import (
 
 // ScheduledTestPlan represents a scheduled test plan domain model.
 type ScheduledTestPlan struct {
-	ID             int64      `json:"id"`
-	AccountID      int64      `json:"account_id"`
-	ModelID        string     `json:"model_id"`
-	CronExpression string     `json:"cron_expression"`
-	Enabled        bool       `json:"enabled"`
-	MaxResults     int        `json:"max_results"`
-	AutoRecover    bool       `json:"auto_recover"`
-	LastRunAt      *time.Time `json:"last_run_at"`
-	NextRunAt      *time.Time `json:"next_run_at"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	ID                   int64      `json:"id"`
+	AccountID            int64      `json:"account_id"`
+	ModelID              string     `json:"model_id"`
+	ModelIDs             []string   `json:"model_ids"`
+	CronExpression       string     `json:"cron_expression"`
+	TriggerMode          string     `json:"trigger_mode"`
+	RetryIntervalMinutes *int       `json:"retry_interval_minutes"`
+	RetryCronExpression  *string    `json:"retry_cron_expression"`
+	Enabled              bool       `json:"enabled"`
+	MaxResults           int        `json:"max_results"`
+	AutoRecover          bool       `json:"auto_recover"`
+	LastRunAt            *time.Time `json:"last_run_at"`
+	NextRunAt            *time.Time `json:"next_run_at"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
 }
 
 // ScheduledTestResult represents a single test execution result.
 type ScheduledTestResult struct {
 	ID           int64     `json:"id"`
 	PlanID       int64     `json:"plan_id"`
+	ModelID      string    `json:"model_id"`
 	Status       string    `json:"status"`
 	ResponseText string    `json:"response_text"`
 	ErrorMessage string    `json:"error_message"`
@@ -42,11 +47,13 @@ type ScheduledTestPlanRepository interface {
 	Update(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error)
 	Delete(ctx context.Context, id int64) error
 	UpdateAfterRun(ctx context.Context, id int64, lastRunAt time.Time, nextRunAt time.Time) error
+	UpdateNextRun(ctx context.Context, id int64, nextRunAt time.Time) error
 }
 
 // ScheduledTestResultRepository defines the data access interface for test results.
 type ScheduledTestResultRepository interface {
 	Create(ctx context.Context, result *ScheduledTestResult) (*ScheduledTestResult, error)
+	Update(ctx context.Context, result *ScheduledTestResult) error
 	ListByPlanID(ctx context.Context, planID int64, limit int) ([]*ScheduledTestResult, error)
-	PruneOldResults(ctx context.Context, planID int64, keepCount int) error
+	PruneOldResults(ctx context.Context, planID int64, modelID string, keepCount int) error
 }

--- a/backend/internal/service/scheduled_test_runner_service.go
+++ b/backend/internal/service/scheduled_test_runner_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -12,17 +13,22 @@ import (
 
 const scheduledTestDefaultMaxWorkers = 10
 
+type scheduledAccountTester interface {
+	RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error)
+}
+
 // ScheduledTestRunnerService periodically scans due test plans and executes them.
 type ScheduledTestRunnerService struct {
 	planRepo       ScheduledTestPlanRepository
 	scheduledSvc   *ScheduledTestService
-	accountTestSvc *AccountTestService
+	accountTestSvc scheduledAccountTester
 	rateLimitSvc   *RateLimitService
 	cfg            *config.Config
 
 	cron      *cron.Cron
 	startOnce sync.Once
 	stopOnce  sync.Once
+	running   sync.Map
 }
 
 // NewScheduledTestRunnerService creates a new runner.
@@ -120,39 +126,147 @@ func (s *ScheduledTestRunnerService) runScheduled() {
 }
 
 func (s *ScheduledTestRunnerService) runOnePlan(ctx context.Context, plan *ScheduledTestPlan) {
-	result, err := s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, plan.ModelID)
-	if err != nil {
-		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d RunTestBackground error: %v", plan.ID, err)
+	if _, loaded := s.running.LoadOrStore(plan.ID, struct{}{}); loaded {
+		return
+	}
+	defer s.running.Delete(plan.ID)
+
+	if plan.TriggerMode == ScheduledTestTriggerErrorRecovery {
+		s.runErrorRecoveryPlan(ctx, plan)
 		return
 	}
 
-	if err := s.scheduledSvc.SaveResult(ctx, plan.ID, plan.MaxResults, result); err != nil {
-		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d SaveResult error: %v", plan.ID, err)
-	}
-
-	// Auto-recover account if test succeeded and auto_recover is enabled.
-	if result.Status == "success" && plan.AutoRecover {
-		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID)
-	}
-
+	s.runModelTest(ctx, plan, plan.ModelID)
 	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d computeNextRun error: %v", plan.ID, err)
 		return
 	}
-
 	if err := s.planRepo.UpdateAfterRun(ctx, plan.ID, time.Now(), nextRun); err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateAfterRun error: %v", plan.ID, err)
 	}
 }
 
+func (s *ScheduledTestRunnerService) runErrorRecoveryPlan(ctx context.Context, plan *ScheduledTestPlan) {
+	if s.rateLimitSvc == nil {
+		return
+	}
+	startedAt := time.Now().Truncate(time.Second)
+	targets, err := s.rateLimitSvc.ErrorRecoveryTargets(ctx, plan.AccountID, plan.ModelID)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d recovery targets error: %v", plan.ID, err)
+		return
+	}
+	if len(targets) == 0 {
+		if err := s.planRepo.UpdateNextRun(ctx, plan.ID, startedAt.Add(time.Minute)); err != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateNextRun error: %v", plan.ID, err)
+		}
+		return
+	}
+
+	for _, target := range targets {
+		if len(plan.ModelIDs) > 0 && !containsModelID(plan.ModelIDs, target.ModelID) && !target.RecoverAccountState {
+			continue
+		}
+		s.runModelTest(ctx, plan, target.ModelID, &target)
+	}
+	nextRun, err := computeRecoveryNextRun(plan, startedAt)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d compute recovery next run error: %v", plan.ID, err)
+		return
+	}
+	if err := s.planRepo.UpdateAfterRun(ctx, plan.ID, time.Now(), nextRun); err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateAfterRun error: %v", plan.ID, err)
+	}
+}
+
+func containsModelID(modelIDs []string, modelID string) bool {
+	for _, candidate := range modelIDs {
+		if candidate == modelID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ScheduledTestRunnerService) runModelTest(ctx context.Context, plan *ScheduledTestPlan, modelID string, recoveryTarget ...*ErrorRecoveryTarget) {
+	startedAt := time.Now()
+	runningResult := &ScheduledTestResult{
+		ModelID:    modelID,
+		Status:     "running",
+		StartedAt:  startedAt,
+		FinishedAt: startedAt,
+	}
+	savedResult, err := s.scheduledSvc.StartResult(ctx, plan.ID, runningResult)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s StartResult error: %v", plan.ID, modelID, err)
+		return
+	}
+
+	result, err := s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, modelID)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s RunTestBackground error: %v", plan.ID, modelID, err)
+		runningResult.ID = savedResult.ID
+		runningResult.Status = "failed"
+		runningResult.ErrorMessage = err.Error()
+		runningResult.FinishedAt = time.Now()
+		runningResult.LatencyMs = runningResult.FinishedAt.Sub(startedAt).Milliseconds()
+		if updateErr := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, runningResult); updateErr != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s failed result update error: %v", plan.ID, modelID, updateErr)
+		}
+		return
+	}
+	if result == nil {
+		runningResult.ID = savedResult.ID
+		runningResult.Status = "failed"
+		runningResult.ErrorMessage = fmt.Sprintf("background test returned no result for model %s", modelID)
+		runningResult.FinishedAt = time.Now()
+		runningResult.LatencyMs = runningResult.FinishedAt.Sub(startedAt).Milliseconds()
+		if updateErr := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, runningResult); updateErr != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s nil result update error: %v", plan.ID, modelID, updateErr)
+		}
+		return
+	}
+	result.ModelID = modelID
+	result.ID = savedResult.ID
+	if result.StartedAt.IsZero() {
+		result.StartedAt = startedAt
+	}
+	if result.FinishedAt.IsZero() {
+		result.FinishedAt = time.Now()
+	}
+	if err := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, result); err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d SaveResult error: %v", plan.ID, err)
+	}
+
+	// Auto-recover account if test succeeded and auto_recover is enabled.
+	if result.Status == "success" && plan.AutoRecover {
+		if len(recoveryTarget) > 0 && recoveryTarget[0] != nil {
+			s.tryRecoverErrorTarget(ctx, plan.AccountID, plan.ID, *recoveryTarget[0])
+			return
+		}
+		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID, modelID)
+	}
+}
+
+func (s *ScheduledTestRunnerService) tryRecoverErrorTarget(ctx context.Context, accountID int64, planID int64, target ErrorRecoveryTarget) {
+	recovery, err := s.rateLimitSvc.RecoverErrorTargetAfterSuccessfulTest(ctx, accountID, target)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d conditional auto-recover failed: %v", planID, err)
+		return
+	}
+	if recovery.ClearedModelRateLimit {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d model=%s recovered", planID, accountID, target.ModelID)
+	}
+}
+
 // tryRecoverAccount attempts to recover an account from recoverable runtime state.
-func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64) {
+func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64, modelID string) {
 	if s.rateLimitSvc == nil {
 		return
 	}
 
-	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID)
+	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID, modelID)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover failed: %v", planID, err)
 		return
@@ -166,5 +280,8 @@ func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, acco
 	}
 	if recovery.ClearedRateLimit {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d cleared rate-limit/runtime state", planID, accountID)
+	}
+	if recovery.ClearedModelRateLimit {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d model=%s recovered", planID, accountID, modelID)
 	}
 }

--- a/backend/internal/service/scheduled_test_runner_service_test.go
+++ b/backend/internal/service/scheduled_test_runner_service_test.go
@@ -1,0 +1,432 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type scheduledPlanRepoStub struct {
+	nextRuns      []time.Time
+	afterRunTimes []time.Time
+}
+
+func (r *scheduledPlanRepoStub) Create(context.Context, *ScheduledTestPlan) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) GetByID(context.Context, int64) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) ListByAccountID(context.Context, int64) ([]*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) ListDue(context.Context, time.Time) ([]*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) Update(context.Context, *ScheduledTestPlan) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) Delete(context.Context, int64) error { panic("unexpected call") }
+func (r *scheduledPlanRepoStub) UpdateAfterRun(_ context.Context, _ int64, _ time.Time, next time.Time) error {
+	r.afterRunTimes = append(r.afterRunTimes, next)
+	return nil
+}
+func (r *scheduledPlanRepoStub) UpdateNextRun(_ context.Context, _ int64, next time.Time) error {
+	r.nextRuns = append(r.nextRuns, next)
+	return nil
+}
+
+type scheduledResultRepoStub struct {
+	results        []*ScheduledTestResult
+	createStatuses []string
+	updateStatuses []string
+}
+
+func (r *scheduledResultRepoStub) Create(_ context.Context, result *ScheduledTestResult) (*ScheduledTestResult, error) {
+	copy := *result
+	copy.ID = int64(len(r.results) + 1)
+	r.results = append(r.results, &copy)
+	r.createStatuses = append(r.createStatuses, result.Status)
+	return &copy, nil
+}
+func (r *scheduledResultRepoStub) Update(_ context.Context, result *ScheduledTestResult) error {
+	r.updateStatuses = append(r.updateStatuses, result.Status)
+	for _, existing := range r.results {
+		if existing.ID == result.ID {
+			*existing = *result
+			return nil
+		}
+	}
+	return nil
+}
+func (r *scheduledResultRepoStub) ListByPlanID(context.Context, int64, int) ([]*ScheduledTestResult, error) {
+	return r.results, nil
+}
+func (r *scheduledResultRepoStub) PruneOldResults(context.Context, int64, string, int) error {
+	return nil
+}
+
+type scheduledTesterStub struct {
+	models       []string
+	status       map[string]string
+	err          map[string]error
+	delay        time.Duration
+	beforeReturn func(string)
+}
+
+func (s *scheduledTesterStub) RunTestBackground(_ context.Context, _ int64, modelID string) (*ScheduledTestResult, error) {
+	s.models = append(s.models, modelID)
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if s.beforeReturn != nil {
+		s.beforeReturn(modelID)
+	}
+	if err := s.err[modelID]; err != nil {
+		return nil, err
+	}
+	return &ScheduledTestResult{ModelID: modelID, Status: s.status[modelID]}, nil
+}
+
+func targetModelIDs(targets []ErrorRecoveryTarget) []string {
+	models := make([]string, 0, len(targets))
+	for _, target := range targets {
+		models = append(models, target.ModelID)
+	}
+	return models
+}
+
+func activeModelLimits(resetAt time.Time, models ...string) map[string]any {
+	limits := make(map[string]any, len(models))
+	for _, modelID := range models {
+		limits[modelID] = map[string]any{
+			"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+			"updated_at":          time.Now().UTC().Format(time.RFC3339Nano),
+		}
+	}
+	return limits
+}
+
+func TestScheduledTestRunner_ErrorRecoveryTestsEachModelAndClearsOnlySuccess(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID:          42,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(
+			time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra",
+			creditsExhaustedKey, antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey,
+		)},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	resultRepo := &scheduledResultRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{
+		"gpt-5.6-luna":  "failed",
+		"gpt-5.6-sol":   "success",
+		"gpt-5.6-terra": "failed",
+	}}
+	rateLimits := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+	runner := &ScheduledTestRunnerService{
+		planRepo:       planRepo,
+		scheduledSvc:   NewScheduledTestService(planRepo, resultRepo),
+		accountTestSvc: tester,
+		rateLimitSvc:   rateLimits,
+	}
+	plan := &ScheduledTestPlan{
+		ID: 7, AccountID: 42, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	}
+
+	runner.runOnePlan(context.Background(), plan)
+
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}, tester.models)
+	require.Len(t, resultRepo.results, 3)
+	require.Equal(t, []string{"running", "running", "running"}, resultRepo.createStatuses)
+	require.Equal(t, []string{"failed", "success", "failed"}, resultRepo.updateStatuses)
+	require.Equal(t, []string{"gpt-5.6-sol"}, accountRepo.clearModelRateLimitKeys)
+	require.Len(t, planRepo.afterRunTimes, 1)
+	require.WithinDuration(t, time.Now().Add(5*time.Minute), planRepo.afterRunTimes[0], 2*time.Second)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryOnlyTestsSelectedFailedModels(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 43, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(
+			time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra",
+		)},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "failed"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 13, AccountID: 43, ModelID: "gpt-5.6-sol", ModelIDs: []string{"gpt-5.6-sol"},
+		TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryDoesNotRecoverWhenDisabled(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 44, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 14, AccountID: 44, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+	require.Empty(t, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoverySkipsHealthyAndRunningPlans(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 8, Status: StatusActive, Schedulable: true, Extra: map[string]any{},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{}}
+	runner := &ScheduledTestRunnerService{
+		planRepo:       planRepo,
+		scheduledSvc:   NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester,
+		rateLimitSvc:   NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	plan := &ScheduledTestPlan{
+		ID: 9, AccountID: 8, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	}
+
+	startedAt := time.Now()
+	runner.runOnePlan(context.Background(), plan)
+	require.Empty(t, tester.models)
+	require.Len(t, planRepo.nextRuns, 1)
+	require.Empty(t, planRepo.afterRunTimes)
+	require.WithinDuration(t, startedAt.Add(time.Minute), planRepo.nextRuns[0], time.Second)
+	require.False(t, planRepo.nextRuns[0].After(startedAt.Add(time.Minute)))
+	require.Zero(t, planRepo.nextRuns[0].Nanosecond())
+
+	runner.running.Store(plan.ID, struct{}{})
+	runner.runOnePlan(context.Background(), plan)
+	require.Empty(t, tester.models)
+	require.Len(t, planRepo.nextRuns, 1)
+}
+
+func TestScheduledTestRunner_ErrorRecoverySchedulesFromStartAfterSlowProbe(t *testing.T) {
+	interval := 1
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 15, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{
+		status: map[string]string{"gpt-5.6-sol": "failed"},
+		delay:  200 * time.Millisecond,
+	}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	startedAt := time.Now()
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 15, AccountID: 15, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Len(t, planRepo.afterRunTimes, 1)
+	require.WithinDuration(t, startedAt.Add(time.Minute), planRepo.afterRunTimes[0], time.Second)
+	require.False(t, planRepo.afterRunTimes[0].After(startedAt.Add(time.Minute)))
+	require.Zero(t, planRepo.afterRunTimes[0].Nanosecond(), "next run must not retain sub-second drift past the fixed scheduler tick")
+}
+
+func TestScheduledTestRunner_SavesFailedResultWhenBackgroundTestErrors(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 16, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	resultRepo := &scheduledResultRepoStub{}
+	tester := &scheduledTesterStub{err: map[string]error{"gpt-5.6-sol": context.DeadlineExceeded}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, resultRepo),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 16, AccountID: 16, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Len(t, resultRepo.results, 1)
+	require.Equal(t, []string{"running"}, resultRepo.createStatuses)
+	require.Equal(t, []string{"failed"}, resultRepo.updateStatuses)
+	require.Equal(t, "failed", resultRepo.results[0].Status)
+	require.Equal(t, context.DeadlineExceeded.Error(), resultRepo.results[0].ErrorMessage)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryClearsTwoSuccessfulModelsInOneRun(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 12, Status: StatusActive, Schedulable: true, UpdatedAt: time.Now(),
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-luna": "success", "gpt-5.6-sol": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 12, AccountID: 12, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryDoesNotClearNewerModelError(t *testing.T) {
+	interval := 5
+	oldReset := time.Now().Add(time.Hour)
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 10, Status: StatusActive, Schedulable: true, UpdatedAt: time.Now(),
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(oldReset, "gpt-5.6-sol")},
+	}}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "success"}}
+	tester.beforeReturn = func(modelID string) {
+		limits := accountRepo.getByIDAccount.Extra["model_rate_limits"].(map[string]any)
+		limits[modelID].(map[string]any)["updated_at"] = time.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
+	}
+	planRepo := &scheduledPlanRepoStub{}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 10, AccountID: 10, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Empty(t, accountRepo.clearModelRateLimitKeys)
+	require.True(t, accountRepo.getByIDAccount.isRateLimitActiveForKey("gpt-5.6-sol"))
+}
+
+func TestRateLimitService_ErrorRecoveryTargetsExcludeManualAndCreditsStates(t *testing.T) {
+	resetAt := time.Now().Add(time.Hour)
+	account := &Account{
+		ID: 11, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol", creditsExhaustedKey)},
+	}
+	repo := &rateLimitClearRepoStub{getByIDAccount: account}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6-sol"}, targetModelIDs(targets))
+
+	account.Schedulable = false
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.Status = StatusError
+	account.Extra = map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol")}
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.UpdatedAt = time.Now()
+	futureWindow := time.Now().Add(time.Hour)
+	account.TempUnschedulableUntil = &futureWindow
+	for _, internalScope := range []string{antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey} {
+		targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, internalScope)
+		require.NoError(t, err)
+		require.Equal(t, []string{"gpt-5.6-sol"}, targetModelIDs(targets))
+	}
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, targetModelIDs(targets))
+	require.True(t, targets[0].RecoverAccountState)
+
+	account.Status = StatusActive
+	account.Schedulable = true
+	account.TempUnschedulableUntil = nil
+	account.Extra = map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol")}
+	expiredAt := time.Now().Add(-time.Minute)
+	account.ExpiresAt = &expiredAt
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.ExpiresAt = nil
+	account.Extra = map[string]any{}
+	expiredWindow := time.Now().Add(-time.Minute)
+	account.RateLimitedAt = &expiredWindow
+	account.RateLimitResetAt = &expiredWindow
+	account.OverloadUntil = &expiredWindow
+	account.TempUnschedulableUntil = &expiredWindow
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+}
+
+func TestScheduledTestService_ErrorRecoveryScheduleValidation(t *testing.T) {
+	from := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	interval := 5
+	plan := &ScheduledTestPlan{
+		ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true,
+	}
+	next, err := validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, from, next)
+	require.True(t, plan.AutoRecover)
+
+	plan.AutoRecover = false
+	next, err = validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, from, next)
+	require.False(t, plan.AutoRecover)
+
+	cronExpr := "*/7 * * * *"
+	plan.RetryIntervalMinutes = nil
+	plan.RetryCronExpression = &cronExpr
+	_, err = validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	next, err = computeRecoveryNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 8, 1, 10, 7, 0, 0, time.UTC), next)
+
+	plan.RetryIntervalMinutes = &interval
+	_, err = validateAndComputePlanNextRun(plan, from)
+	require.ErrorContains(t, err, "cannot be combined")
+
+	for _, internalScope := range []string{antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey} {
+		plan.RetryCronExpression = nil
+		plan.ModelID = internalScope
+		plan.ModelIDs = nil
+		_, err = validateAndComputePlanNextRun(plan, from)
+		require.ErrorContains(t, err, "internal rate-limit scope")
+
+		plan.ModelID = "gpt-5.6-luna"
+		plan.ModelIDs = []string{internalScope}
+		_, err = validateAndComputePlanNextRun(plan, from)
+		require.ErrorContains(t, err, "internal rate-limit scope")
+	}
+}

--- a/backend/internal/service/scheduled_test_service.go
+++ b/backend/internal/service/scheduled_test_service.go
@@ -3,12 +3,19 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
 )
 
 var scheduledTestCronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+const (
+	ScheduledTestTriggerScheduled     = "scheduled"
+	ScheduledTestTriggerErrorRecovery = "error_recovery"
+	scheduledTestDefaultCron          = "*/30 * * * *"
+)
 
 // ScheduledTestService provides CRUD operations for scheduled test plans and results.
 type ScheduledTestService struct {
@@ -29,7 +36,7 @@ func NewScheduledTestService(
 
 // CreatePlan validates the cron expression, computes next_run_at, and persists the plan.
 func (s *ScheduledTestService) CreatePlan(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error) {
-	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
+	nextRun, err := validateAndComputePlanNextRun(plan, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("invalid cron expression: %w", err)
 	}
@@ -54,7 +61,7 @@ func (s *ScheduledTestService) ListPlansByAccount(ctx context.Context, accountID
 
 // UpdatePlan validates cron and updates the plan.
 func (s *ScheduledTestService) UpdatePlan(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error) {
-	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
+	nextRun, err := validateAndComputePlanNextRun(plan, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("invalid cron expression: %w", err)
 	}
@@ -82,7 +89,100 @@ func (s *ScheduledTestService) SaveResult(ctx context.Context, planID int64, max
 	if _, err := s.resultRepo.Create(ctx, result); err != nil {
 		return err
 	}
-	return s.resultRepo.PruneOldResults(ctx, planID, maxResults)
+	return s.resultRepo.PruneOldResults(ctx, planID, result.ModelID, maxResults)
+}
+
+func (s *ScheduledTestService) StartResult(ctx context.Context, planID int64, result *ScheduledTestResult) (*ScheduledTestResult, error) {
+	result.PlanID = planID
+	return s.resultRepo.Create(ctx, result)
+}
+
+func (s *ScheduledTestService) UpdateResult(ctx context.Context, planID int64, maxResults int, result *ScheduledTestResult) error {
+	result.PlanID = planID
+	if err := s.resultRepo.Update(ctx, result); err != nil {
+		return err
+	}
+	return s.resultRepo.PruneOldResults(ctx, planID, result.ModelID, maxResults)
+}
+
+func validateAndComputePlanNextRun(plan *ScheduledTestPlan, from time.Time) (time.Time, error) {
+	plan.ModelID = strings.TrimSpace(plan.ModelID)
+	plan.ModelIDs = normalizeModelIDs(plan.ModelIDs)
+	if plan.TriggerMode == "" {
+		plan.TriggerMode = ScheduledTestTriggerScheduled
+	}
+	if plan.TriggerMode == ScheduledTestTriggerScheduled {
+		plan.RetryIntervalMinutes = nil
+		plan.RetryCronExpression = nil
+		return computeNextRun(plan.CronExpression, from)
+	}
+	if plan.TriggerMode != ScheduledTestTriggerErrorRecovery {
+		return time.Time{}, fmt.Errorf("invalid trigger mode: %s", plan.TriggerMode)
+	}
+	if isInternalModelRateLimitScope(plan.ModelID) {
+		return time.Time{}, fmt.Errorf("internal rate-limit scope cannot be used as a probe model: %s", plan.ModelID)
+	}
+	for _, modelID := range plan.ModelIDs {
+		if isInternalModelRateLimitScope(modelID) {
+			return time.Time{}, fmt.Errorf("internal rate-limit scope cannot be used as a probe model: %s", modelID)
+		}
+	}
+	if len(plan.ModelIDs) > 0 {
+		plan.ModelID = plan.ModelIDs[0]
+	}
+	if plan.ModelID == "" {
+		return time.Time{}, fmt.Errorf("error recovery requires an account probe model")
+	}
+
+	if plan.CronExpression == "" {
+		plan.CronExpression = scheduledTestDefaultCron
+	}
+	if plan.RetryIntervalMinutes != nil {
+		if *plan.RetryIntervalMinutes < 1 || *plan.RetryIntervalMinutes > 1440 || plan.RetryCronExpression != nil {
+			return time.Time{}, fmt.Errorf("retry interval must be 1..1440 minutes and cannot be combined with cron")
+		}
+		return from, nil
+	}
+	if plan.RetryCronExpression == nil || *plan.RetryCronExpression == "" {
+		return time.Time{}, fmt.Errorf("error recovery requires retry interval or cron expression")
+	}
+	if _, err := computeNextRun(*plan.RetryCronExpression, from); err != nil {
+		return time.Time{}, fmt.Errorf("invalid retry cron expression: %w", err)
+	}
+	return from, nil
+}
+
+func normalizeModelIDs(modelIDs []string) []string {
+	if len(modelIDs) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(modelIDs))
+	result := make([]string, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" {
+			continue
+		}
+		if _, ok := seen[modelID]; ok {
+			continue
+		}
+		seen[modelID] = struct{}{}
+		result = append(result, modelID)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func computeRecoveryNextRun(plan *ScheduledTestPlan, from time.Time) (time.Time, error) {
+	if plan.RetryIntervalMinutes != nil {
+		return from.Add(time.Duration(*plan.RetryIntervalMinutes) * time.Minute), nil
+	}
+	if plan.RetryCronExpression == nil {
+		return time.Time{}, fmt.Errorf("missing retry schedule")
+	}
+	return computeNextRun(*plan.RetryCronExpression, from)
 }
 
 func computeNextRun(cronExpr string, from time.Time) (time.Time, error) {

--- a/backend/migrations/192_add_scheduled_test_error_recovery.sql
+++ b/backend/migrations/192_add_scheduled_test_error_recovery.sql
@@ -1,0 +1,28 @@
+-- Add error-triggered scheduled tests while preserving existing cron plans.
+ALTER TABLE scheduled_test_plans
+    ADD COLUMN IF NOT EXISTS trigger_mode VARCHAR(20) NOT NULL DEFAULT 'scheduled',
+    ADD COLUMN IF NOT EXISTS retry_interval_minutes INT,
+    ADD COLUMN IF NOT EXISTS retry_cron_expression VARCHAR(100);
+
+ALTER TABLE scheduled_test_plans DROP CONSTRAINT IF EXISTS chk_stp_trigger_mode;
+ALTER TABLE scheduled_test_plans ADD CONSTRAINT chk_stp_trigger_mode
+    CHECK (trigger_mode IN ('scheduled', 'error_recovery'));
+
+ALTER TABLE scheduled_test_plans DROP CONSTRAINT IF EXISTS chk_stp_recovery_schedule;
+ALTER TABLE scheduled_test_plans ADD CONSTRAINT chk_stp_recovery_schedule CHECK (
+    trigger_mode = 'scheduled' OR
+    ((retry_interval_minutes BETWEEN 1 AND 1440 AND retry_cron_expression IS NULL) OR
+     (retry_interval_minutes IS NULL AND NULLIF(BTRIM(retry_cron_expression), '') IS NOT NULL))
+);
+
+ALTER TABLE scheduled_test_results ADD COLUMN IF NOT EXISTS model_id VARCHAR(100);
+UPDATE scheduled_test_results r
+SET model_id = p.model_id
+FROM scheduled_test_plans p
+WHERE p.id = r.plan_id AND r.model_id IS NULL;
+ALTER TABLE scheduled_test_results ALTER COLUMN model_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_stp_account_error_recovery
+    ON scheduled_test_plans(account_id) WHERE trigger_mode = 'error_recovery';
+CREATE INDEX IF NOT EXISTS idx_str_plan_model_created
+    ON scheduled_test_results(plan_id, model_id, created_at DESC);

--- a/backend/migrations/193_add_scheduled_test_error_model_ids.sql
+++ b/backend/migrations/193_add_scheduled_test_error_model_ids.sql
@@ -1,0 +1,3 @@
+-- 193: Persist the selected failed-model allowlist for error recovery plans.
+ALTER TABLE scheduled_test_plans
+    ADD COLUMN IF NOT EXISTS model_ids TEXT[] NOT NULL DEFAULT '{}';

--- a/docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md
+++ b/docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md
@@ -1,0 +1,147 @@
+---
+summary: 让账号按模型自动复测系统记录的临时错误，并在上游恢复后立即精确恢复该模型调度
+doc_kind: spec
+status: active
+review_status: approved
+---
+
+# 模型错误自动复测与精确恢复
+
+执行者只以本 Spec 为任务来源；批准后先进入任务 worktree，创建并持续更新 `PROGRESS.md`，拿不准或前提不符时写 `BLOCKED.md`。中断后先读这两个文件接着做。取舍顺序是：不误恢复仍失败的模型 > 自动尽快恢复 > 设置简单。本文“只允许 / 不许”是验收合同，“建议”可在 `PROGRESS.md` 说明理由后调整。
+
+## 这活为什么干
+
+账号可能仍为正常状态，但 `accounts.extra.model_rate_limits` 同时记录 `gpt-5.6-luna`、`gpt-5.6-sol`、`gpt-5.6-terra` 等模型的临时错误。现在只能等倒计时结束或手工测试；目标是仅在系统自动记录错误后按模型复测，哪个模型恢复就立刻只恢复哪个模型。
+
+## 领导已经拍板
+
+- 错误恢复默认每 5 分钟重试，可输入分钟数；高级模式默认隐藏，可改用 5 字段 Cron。
+- 分钟间隔按测试启动时间计算；同一计划不并发重入，若上一轮超过间隔仍未完成，则在完成后的下一次扫描补跑。
+- 健康账号不测试；手工禁用、手工不可调度、过期等人工或永久状态绝不自动恢复。
+- 多个模型独立重试和恢复；一个模型成功不得清除其他模型的错误。
+- 有结构化来源的账号级自动错误也可恢复；错误恢复计划可多选探测模型，默认全选。模型级错误始终测试实际报错模型；账号级错误使用首个已选模型探测一次。裸 `status=error` 无法区分人工与系统来源，不自动恢复。
+
+## 我替领导拍的板（待确认）
+
+- 每账号只允许 1 个 `error_recovery` 计划，避免重复请求；普通定时计划仍可有多个。
+- 分钟间隔允许 `1..1440`；Cron 使用现有 5 字段解析器。`AICredits` 是额度状态而非模型，排除自动复测和自动清除。
+- 检测到新错误后在下一次每分钟扫描中首次测试；之后按间隔或 Cron 重试，不额外等待一个完整周期。
+
+## 范围与非目标
+
+- 只允许修改 scheduled-test 的 migration、repository/service/handler、API/types、`ScheduledTestsPanel.vue`、中英文文案及对应测试；其他路径只读。
+- 复用现有每分钟 `ScheduledTestRunnerService`、10 worker 上限和账号错误真源；不新增 worker、消息队列、依赖或从错误文本解析模型。
+- 实现与自动测试不写 live 数据；完整验证通过后才允许替换本地 Sub2API app 镜像，保留当前镜像作为回滚点，不重建 PostgreSQL/Redis。真实测试只使用 AIINPUT，CIII 只读且不得恢复。
+- 上游交付使用 feature branch PR；只有发现能脱离 PR 独立追踪的问题时才创建 issue。
+
+## 改完后是什么样
+
+现有普通计划请求保持兼容：
+
+```json
+{"account_id":42,"model_id":"gpt-5.6-luna","cron_expression":"*/30 * * * *","enabled":true,"max_results":100,"auto_recover":true}
+```
+
+新增错误恢复计划请求示例：
+
+```json
+{"account_id":42,"model_id":"gpt-5.6-luna","model_ids":[],"trigger_mode":"error_recovery","retry_interval_minutes":5,"retry_cron_expression":null,"enabled":true,"max_results":100,"auto_recover":true}
+```
+
+`model_ids=[]` 表示全部失败模型，非空数组表示只复测选中的失败模型；`model_id` 保留为账号级错误的 fallback probe model，并由服务端规范化为首个选中模型。历史错误恢复计划没有 `model_ids` 时按全部失败模型处理。
+
+高级模式把 `retry_interval_minutes` 设为 `null`，并写入如 `*/5 * * * *` 的 `retry_cron_expression`。测试结果新增实际执行的 `model_id`，例如：
+
+```json
+{"id":901,"plan_id":7,"model_id":"gpt-5.6-sol","status":"success","response_text":"ok","error_message":"","latency_ms":842}
+```
+
+后台测试开始时先写入同一模型的 `status=running` 结果，完成后原地更新为 `success` 或 `failed`；管理界面仅在展开结果且存在运行项时轮询刷新。超过 runner 5 分钟执行上限仍为 `running` 的历史项显示为“执行中断”，但不据此恢复模型。
+
+错误恢复基础字段由 `192_add_scheduled_test_error_recovery.sql` 提供；模型选择 allowlist 由新增 migration `193_add_scheduled_test_error_model_ids.sql` 提供：
+
+```sql
+ALTER TABLE scheduled_test_plans
+  ADD COLUMN trigger_mode VARCHAR(20) NOT NULL DEFAULT 'scheduled',
+  ADD COLUMN retry_interval_minutes INT,
+  ADD COLUMN retry_cron_expression VARCHAR(100);
+ALTER TABLE scheduled_test_plans
+  ADD CONSTRAINT chk_stp_trigger_mode CHECK (trigger_mode IN ('scheduled', 'error_recovery')),
+  ADD CONSTRAINT chk_stp_recovery_schedule CHECK (
+    trigger_mode = 'scheduled' OR
+    ((retry_interval_minutes BETWEEN 1 AND 1440 AND retry_cron_expression IS NULL) OR
+     (retry_interval_minutes IS NULL AND NULLIF(BTRIM(retry_cron_expression), '') IS NOT NULL))
+  );
+ALTER TABLE scheduled_test_results ADD COLUMN model_id VARCHAR(100);
+UPDATE scheduled_test_results r SET model_id = p.model_id FROM scheduled_test_plans p WHERE p.id = r.plan_id;
+ALTER TABLE scheduled_test_results ALTER COLUMN model_id SET NOT NULL;
+CREATE UNIQUE INDEX uq_stp_account_error_recovery ON scheduled_test_plans(account_id) WHERE trigger_mode = 'error_recovery';
+CREATE INDEX idx_str_plan_model_created ON scheduled_test_results(plan_id, model_id, created_at DESC);
+```
+
+```sql
+ALTER TABLE scheduled_test_plans
+  ADD COLUMN model_ids TEXT[] NOT NULL DEFAULT '{}';
+```
+
+新增字段由 plan API 写入、runner/repository 读取；`result.model_id` 由测试执行写入，所有仍失败的模型共享计划的下一次重试时间，但分别测试和清除。服务端必须校验错误恢复计划只能在“有效分钟间隔”和“有效 Cron”中二选一。历史 plan 通过默认值保持 `scheduled`，历史 result 从所属 plan 回填模型；错误恢复计划的 `max_results` 按 `plan_id + model_id` 分别保留，普通计划继续按 plan 保留。
+
+## 现状与任务 0
+
+- 2026-08-01 实测：runner 每分钟扫描、并发上限 10；手工测试成功调用无 `model_id` 的账号级恢复，`ClearModelRateLimits` 会删除整个 `model_rate_limits`。
+- 基线：`go test ./internal/service ./internal/handler/admin -count=1` 通过；`pnpm --dir frontend exec vitest run src/components/account/__tests__/AccountStatusIndicator.spec.ts` 为 4/4；`pnpm --dir frontend run typecheck` 与 `pnpm --dir frontend run build` 通过。
+- 开工先复跑上述命令并确认 migration 192 不存在；任一不符即停止受影响任务，把证据置顶写入 `BLOCKED.md`。核对后先写不超过 10 行的目标、顺序和最大风险到 `PROGRESS.md`。
+
+## 任务 1：建立按模型恢复合同
+
+- 目标：成功测试 `sol` 时只原子删除 `model_rate_limits.sol`，保留 `luna`、`terra`、`AICredits`；账号级自动状态可同时恢复但不得连带清其他模型。
+- 顺序：先补 repository/service 的失败测试，再实现带 `model_id` 的 targeted recovery，并让手工测试与后台测试共用它。
+- 死规矩：JSON key 删除、scheduler outbox/缓存刷新必须走账号 repository owner；否则 DB 与调度快照会分叉。
+- 验收：`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`；全部通过且新增用例覆盖“只删成功模型、失败不删、兄弟模型保留、AICredits 保留”。
+- 反向验证：临时把 targeted clear 改回全量 clear，确认兄弟模型保留用例失败；还原后全绿。
+
+## 任务 2：只在自动错误存在时独立重试
+
+- 目标：一个账号的 3 个活动模型错误产生 3 个独立测试目标；成功目标停止，失败目标按分钟或 Cron 继续，健康状态执行 0 次。
+- 顺序：在任务 1 的精确恢复后扩展 plan schema、请求校验、结果 `model_id` 和 runner；复用计划的下一次运行时间，不建第二套调度器。
+- 死规矩：只读取结构化 `model_rate_limits` 和现有账号级自动状态，不解析 reason/message；手工状态及 `AICredits` 必须过滤。
+- 验收：`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`；新增 runner 用例机器判定 3 个目标、独立 next run、无重叠执行、健康/手工状态 0 次。
+- 时间语义：分钟间隔从本轮启动时间计算；慢请求不得把固定间隔额外拖长一个完整周期，内部错误也必须把已创建的 `running` 结果更新为 `failed`。
+- 反向验证：移除健康状态过滤，确认“健康账号 0 次”用例失败；还原后全绿。
+
+## 任务 3：交付简单设置界面
+
+- 目标：计划表单提供“定时测试 / 错误恢复”；错误恢复默认显示 5 分钟输入、自动恢复和全部失败模型，探测模型可多选，只有打开高级模式才显示 Cron，并展示每条结果的实际模型。错误恢复旁提供问号说明边界。
+- 顺序：后端合同稳定后更新 API types、表单、列表和中英文文案，避免前端先猜 payload。
+- 死规矩：普通模式不得要求 Cron；高级 Cron 与分钟输入不得同时提交；现有定时计划编辑行为保持不变。
+- 验收：`pnpm --dir frontend run typecheck && pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts && pnpm --dir frontend run build`；组件测试覆盖默认 5 分钟、自动恢复默认勾选、默认全选、子集 payload、问号说明、展开高级、互斥 payload、旧计划回显。
+- 运行可见性：结果展开后显示模型级“执行中”，完成后自动刷新为最终状态；超过 5 分钟的遗留运行项显示“执行中断”，关闭面板或没有运行项时停止轮询。
+- 反向验证：临时恢复“Cron 必填”，确认默认错误恢复提交用例失败；还原后全绿。使用本地测试数据打开账号定时测试面板，确认 console 无错误，并按 selector 截取受影响面板的桌面与移动端截图作为证据。
+
+## 任务 4：安全部署并提交上游
+
+- 目标：先备份当前 app 镜像引用和 Compose 配置摘要，再只替换 `sub2api` app 容器；health、登录页、AIINPUT 测试与错误恢复 UI 全部通过后提交 PR。
+- 顺序：完整测试与独立 review 通过后构建本地镜像；迁移自动执行并验活，PostgreSQL/Redis 容器和数据卷保持不变。
+- 死规矩：不得对 CIII 发测试或恢复请求；任一 health、migration、console 或 AIINPUT 检查失败立即回滚 app 镜像并停止 PR。
+- 验收：`docker compose -f /Users/admin/sub2api/docker-compose.yml ps`、`curl -fsS http://127.0.0.1:8080/health` 与浏览器 AIINPUT 测试成功；截图及容器状态写入 `PROGRESS.md`。
+
+## 规矩
+
+- 不许 skip/todo、删测试、放宽断言、mock 被测恢复 owner、修改验收命令或加 `|| true`；测试数量不得低于开工基线。
+- migration 只能新增，不能改历史文件；不得清洗 live `accounts.extra`。同一验收连续失败 3 次即停止该项；结果比基线差就撤销本任务新增改动并如实记录，不以扩大范围补洞。
+- `BLOCKED.md` 随交付提交，空也写“无”。未经最新用户授权不得部署或创建 PR；当前授权仅涵盖本地 Sub2API 与该功能的上游 PR。
+
+## 完成条件
+
+- 固定样本 `luna=失败、sol=成功、terra=失败、AICredits=存在` 跑一轮后，只消失 `sol`；5 分钟后只重试 `luna/terra`，健康账号和手工禁用账号请求数为 0。
+- 旧定时计划无需迁移操作且行为不变；后端 broad tests、前端 typecheck/build/组件测试全绿，UI 截图无重叠且 console 无错误。
+- 本地部署后 health、AIINPUT 与 UI 通过，CIII 状态未被修改；PR 只包含本功能、测试与 Spec。每条验收必须提交实际命令、红→绿反向证据和证据路径；同一验收连败 3 次则停止并列出缺口。
+
+## Goal
+
+- 验收摘要: 用 `luna/sol/terra + AICredits` 固定样本跑通自动错误发现、按模型复测到精确恢复；看到只清成功模型、失败模型继续重试、健康及手工状态零请求才算通过，且不得写 live 数据。
+- 执行依据: `docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md` 的任务 0 → 4；任务级 RED/GREEN 与反向验证只按正文执行。
+- 真实验收: 固定 4-key 账号样本｜两轮 runner 到精确恢复｜`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`｜成功=目标独立且只删 `sol`｜证据=`PROGRESS.md`。
+- 真实验收: 错误恢复设置面板｜默认分钟与高级 Cron 互斥｜`pnpm --dir frontend run typecheck && pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts && pnpm --dir frontend run build`｜成功=全绿并产出桌面/移动截图｜证据=`PROGRESS.md` 与截图路径。
+- 非回归: `go test ./internal/service ./internal/handler/admin -count=1 && pnpm --dir frontend exec vitest run src/components/account/__tests__/AccountStatusIndicator.spec.ts`。
+- 边界: 只改白名单路径；完整验证后仅替换本地 app 容器，真实测试只用 AIINPUT，CIII 只读；不满足 schema/基线时写 `BLOCKED.md` 并停止受影响任务。

--- a/frontend/src/components/admin/account/ModelMultiSelect.vue
+++ b/frontend/src/components/admin/account/ModelMultiSelect.vue
@@ -1,0 +1,104 @@
+<template>
+  <div ref="container" class="relative">
+    <button
+      :id="id"
+      type="button"
+      class="select-trigger w-full"
+      :aria-label="ariaLabel"
+      :aria-expanded="open"
+      :aria-controls="id ? `${id}-options` : undefined"
+      @click="open = !open"
+    >
+      <span class="select-value truncate text-left">{{ summary }}</span>
+      <Icon name="chevronDown" size="md" :class="['transition-transform duration-200', open && 'rotate-180']" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="id ? `${id}-options` : undefined"
+      class="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-lg border border-gray-200 bg-white p-2 shadow-lg dark:border-dark-600 dark:bg-dark-800"
+      role="group"
+      :aria-label="ariaLabel"
+      @click.stop
+    >
+      <div class="mb-2 flex items-center justify-between gap-2 border-b border-gray-100 pb-2 text-xs dark:border-dark-700">
+        <button type="button" class="text-primary-600 hover:underline dark:text-primary-400" @click="selectAll">
+          {{ allLabel }}
+        </button>
+        <button type="button" class="text-gray-500 hover:underline dark:text-gray-400" @click="clearAll">
+          {{ clearLabel }}
+        </button>
+      </div>
+      <label
+        v-for="option in options"
+        :key="String(option.value)"
+        class="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-dark-700"
+      >
+        <input
+          type="checkbox"
+          :checked="selected.has(String(option.value))"
+          :disabled="option.disabled"
+          @change="toggle(String(option.value))"
+        />
+        <span class="truncate">{{ option.label }}</span>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@/components/icons'
+import type { SelectOption } from '@/components/common/Select.vue'
+
+const { t } = useI18n()
+
+const props = withDefaults(defineProps<{
+  modelValue: string[]
+  options: SelectOption[]
+  id?: string
+  ariaLabel?: string
+  placeholder?: string
+  allLabel?: string
+  clearLabel?: string
+}>(), {
+  placeholder: '',
+  id: undefined,
+  ariaLabel: undefined,
+  allLabel: '',
+  clearLabel: ''
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string[]): void
+}>()
+
+const open = ref(false)
+const container = ref<HTMLElement | null>(null)
+const selected = computed(() => new Set(props.modelValue.map(String)))
+const availableValues = computed(() => props.options.map(option => String(option.value)))
+const summary = computed(() => {
+  if (selected.value.size === 0) return props.placeholder || t('common.selectOption')
+  if (selected.value.size === availableValues.value.length && availableValues.value.length > 0) {
+    return props.allLabel || t('admin.scheduledTests.allFailedModels')
+  }
+  return t('admin.scheduledTests.selectedModels', { count: selected.value.size })
+})
+
+const selectAll = () => emit('update:modelValue', [...availableValues.value])
+const clearAll = () => emit('update:modelValue', [])
+const toggle = (modelID: string) => {
+  const next = new Set(selected.value)
+  if (next.has(modelID)) next.delete(modelID)
+  else next.add(modelID)
+  emit('update:modelValue', availableValues.value.filter(value => next.has(value)))
+}
+
+const onDocumentClick = (event: MouseEvent) => {
+  if (container.value && !container.value.contains(event.target as Node)) open.value = false
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick))
+onUnmounted(() => document.removeEventListener('click', onDocumentClick))
+</script>

--- a/frontend/src/components/admin/account/ScheduledTestsPanel.vue
+++ b/frontend/src/components/admin/account/ScheduledTestsPanel.vue
@@ -29,18 +29,69 @@
           {{ t('admin.scheduledTests.addPlan') }}
         </div>
         <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div class="sm:col-span-2">
+            <div class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+              {{ t('admin.scheduledTests.triggerMode') }}
+              <HelpTooltip trigger="click">
+                <template #trigger>
+                  <button
+                    type="button"
+                    :aria-label="t('admin.scheduledTests.errorRecoveryHelpAriaLabel')"
+                    class="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-gray-400/70 text-[10px] font-semibold text-gray-400 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-gray-500 dark:text-gray-500 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                  >
+                    ?
+                  </button>
+                </template>
+                <div class="max-w-xs space-y-1.5">
+                  <p>{{ t('admin.scheduledTests.errorRecoveryTooltipFailedModels') }}</p>
+                  <p>{{ t('admin.scheduledTests.errorRecoveryTooltipBoundaries') }}</p>
+                </div>
+              </HelpTooltip>
+            </div>
+            <div class="inline-flex rounded-lg border border-gray-200 p-0.5 dark:border-dark-500">
+              <button
+                v-for="mode in triggerModes"
+                :key="mode.value"
+                type="button"
+                :aria-pressed="newPlan.trigger_mode === mode.value"
+                :class="[
+                  'rounded-md px-3 py-1.5 text-sm transition-colors',
+                  newPlan.trigger_mode === mode.value
+                    ? 'bg-primary-500 text-white'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-600'
+                ]"
+                @click="setTriggerMode(newPlan, mode.value)"
+              >
+                {{ mode.label }}
+              </button>
+            </div>
+          </div>
           <div>
-            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
-              {{ t('admin.scheduledTests.model') }}
+            <label
+              :for="newPlan.trigger_mode === 'error_recovery' ? 'new-plan-error-models' : undefined"
+              class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+            >
+              {{ t(newPlan.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.probeModel' : 'admin.scheduledTests.model') }}
             </label>
+            <ModelMultiSelect
+              v-if="newPlan.trigger_mode === 'error_recovery'"
+              id="new-plan-error-models"
+              v-model="newPlan.model_ids"
+              :options="modelOptions"
+              :aria-label="t('admin.scheduledTests.probeModel')"
+              :placeholder="t('admin.scheduledTests.selectModels')"
+              :all-label="t('admin.scheduledTests.allFailedModels')"
+              :clear-label="t('admin.scheduledTests.clearSelection')"
+            />
             <Select
+              v-else
               v-model="newPlan.model_id"
               :options="modelOptions"
               :placeholder="t('admin.scheduledTests.model')"
               :searchable="modelOptions.length > 5"
             />
           </div>
-          <div>
+          <div v-if="newPlan.trigger_mode === 'scheduled'">
             <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
               {{ t('admin.scheduledTests.cronExpression') }}
               <HelpTooltip>
@@ -66,6 +117,27 @@
               :hint="t('admin.scheduledTests.cronHelp')"
             />
           </div>
+          <div v-else>
+            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+              {{ newPlan.advanced_cron ? t('admin.scheduledTests.cronExpression') : t('admin.scheduledTests.retryInterval') }}
+            </label>
+            <Input
+              v-if="!newPlan.advanced_cron"
+              v-model="newPlan.retry_interval_minutes"
+              type="number"
+              min="1"
+              max="1440"
+            />
+            <Input
+              v-else
+              v-model="newPlan.retry_cron_expression"
+              :placeholder="'*/5 * * * *'"
+            />
+            <label class="mt-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <Toggle v-model="newPlan.advanced_cron" />
+              {{ t('admin.scheduledTests.advancedCron') }}
+            </label>
+          </div>
           <div>
             <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
               {{ t('admin.scheduledTests.maxResults') }}
@@ -90,7 +162,7 @@
               placeholder="100"
             />
           </div>
-          <div class="flex items-end">
+          <div v-if="newPlan.trigger_mode === 'scheduled'" class="flex items-end">
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <Toggle v-model="newPlan.enabled" />
               {{ t('admin.scheduledTests.enabled') }}
@@ -117,7 +189,7 @@
           </button>
           <button
             @click="handleCreate"
-            :disabled="!newPlan.model_id || !newPlan.cron_expression || creating"
+            :disabled="!isPlanFormValid(newPlan) || creating"
             class="flex items-center gap-1.5 rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Icon v-if="creating" name="refresh" size="sm" class="animate-spin" :stroke-width="2" />
@@ -158,11 +230,11 @@
             <div class="flex flex-1 items-center gap-4">
               <!-- Model -->
               <div class="min-w-0">
-                <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {{ plan.model_id }}
+                <div class="truncate text-sm font-medium text-gray-900 dark:text-gray-100" :title="formatPlanModels(plan)">
+                  {{ formatPlanModels(plan) }}
                 </div>
                 <div class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">
-                  {{ plan.cron_expression }}
+                  {{ formatPlanSchedule(plan) }}
                 </div>
               </div>
 
@@ -179,10 +251,10 @@
 
               <!-- Auto Recover Badge -->
               <span
-                v-if="plan.auto_recover"
+                v-if="plan.trigger_mode === 'error_recovery' || plan.auto_recover"
                 class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
               >
-                {{ t('admin.scheduledTests.autoRecover') }}
+                {{ t(plan.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.errorRecoveryMode' : 'admin.scheduledTests.autoRecover') }}
               </span>
             </div>
 
@@ -239,18 +311,69 @@
               {{ t('admin.scheduledTests.editPlan') }}
             </div>
             <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <div class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {{ t('admin.scheduledTests.triggerMode') }}
+                  <HelpTooltip trigger="click">
+                    <template #trigger>
+                      <button
+                        type="button"
+                        :aria-label="t('admin.scheduledTests.errorRecoveryHelpAriaLabel')"
+                        class="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-gray-400/70 text-[10px] font-semibold text-gray-400 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-gray-500 dark:text-gray-500 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                      >
+                        ?
+                      </button>
+                    </template>
+                    <div class="max-w-xs space-y-1.5">
+                      <p>{{ t('admin.scheduledTests.errorRecoveryTooltipFailedModels') }}</p>
+                      <p>{{ t('admin.scheduledTests.errorRecoveryTooltipBoundaries') }}</p>
+                    </div>
+                  </HelpTooltip>
+                </div>
+                <div class="inline-flex rounded-lg border border-gray-200 p-0.5 dark:border-dark-500">
+                  <button
+                    v-for="mode in triggerModes"
+                    :key="mode.value"
+                    type="button"
+                    :aria-pressed="editForm.trigger_mode === mode.value"
+                    :class="[
+                      'rounded-md px-3 py-1.5 text-sm transition-colors',
+                      editForm.trigger_mode === mode.value
+                        ? 'bg-primary-500 text-white'
+                        : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-600'
+                    ]"
+                    @click="setTriggerMode(editForm, mode.value)"
+                  >
+                    {{ mode.label }}
+                  </button>
+                </div>
+              </div>
               <div>
-                <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
-                  {{ t('admin.scheduledTests.model') }}
+                <label
+                  :for="editForm.trigger_mode === 'error_recovery' ? 'edit-plan-error-models' : undefined"
+                  class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                >
+                  {{ t(editForm.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.probeModel' : 'admin.scheduledTests.model') }}
                 </label>
+                <ModelMultiSelect
+                  v-if="editForm.trigger_mode === 'error_recovery'"
+                  id="edit-plan-error-models"
+                  v-model="editForm.model_ids"
+                  :options="modelOptions"
+                  :aria-label="t('admin.scheduledTests.probeModel')"
+                  :placeholder="t('admin.scheduledTests.selectModels')"
+                  :all-label="t('admin.scheduledTests.allFailedModels')"
+                  :clear-label="t('admin.scheduledTests.clearSelection')"
+                />
                 <Select
+                  v-else
                   v-model="editForm.model_id"
                   :options="modelOptions"
                   :placeholder="t('admin.scheduledTests.model')"
                   :searchable="modelOptions.length > 5"
                 />
               </div>
-              <div>
+              <div v-if="editForm.trigger_mode === 'scheduled'">
                 <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
                   {{ t('admin.scheduledTests.cronExpression') }}
                   <HelpTooltip>
@@ -276,6 +399,27 @@
                   :hint="t('admin.scheduledTests.cronHelp')"
                 />
               </div>
+              <div v-else>
+                <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {{ editForm.advanced_cron ? t('admin.scheduledTests.cronExpression') : t('admin.scheduledTests.retryInterval') }}
+                </label>
+                <Input
+                  v-if="!editForm.advanced_cron"
+                  v-model="editForm.retry_interval_minutes"
+                  type="number"
+                  min="1"
+                  max="1440"
+                />
+                <Input
+                  v-else
+                  v-model="editForm.retry_cron_expression"
+                  :placeholder="'*/5 * * * *'"
+                />
+                <label class="mt-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                  <Toggle v-model="editForm.advanced_cron" />
+                  {{ t('admin.scheduledTests.advancedCron') }}
+                </label>
+              </div>
               <div>
                 <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
                   {{ t('admin.scheduledTests.maxResults') }}
@@ -300,7 +444,7 @@
                   placeholder="100"
                 />
               </div>
-              <div class="flex items-end">
+              <div v-if="editForm.trigger_mode === 'scheduled'" class="flex items-end">
                 <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                   <Toggle v-model="editForm.enabled" />
                   {{ t('admin.scheduledTests.enabled') }}
@@ -327,7 +471,7 @@
               </button>
               <button
                 @click="handleEdit"
-                :disabled="!editForm.model_id || !editForm.cron_expression || updating"
+                :disabled="!isPlanFormValid(editForm) || updating"
                 class="flex items-center gap-1.5 rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Icon v-if="updating" name="refresh" size="sm" class="animate-spin" :stroke-width="2" />
@@ -368,23 +512,30 @@
               >
                 <div class="flex items-center justify-between">
                   <div class="flex items-center gap-2">
+                    <span class="font-mono text-xs text-gray-600 dark:text-gray-300">
+                      {{ result.model_id }}
+                    </span>
                     <!-- Status Badge -->
                     <span
                       :class="[
                         'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                        result.status === 'success'
+                        displayResultStatus(result) === 'success'
                           ? 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400'
-                          : result.status === 'running'
+                          : displayResultStatus(result) === 'running'
                             ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400'
-                            : 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400'
+                            : displayResultStatus(result) === 'interrupted'
+                              ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400'
+                              : 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400'
                       ]"
                     >
                       {{
-                        result.status === 'success'
+                        displayResultStatus(result) === 'success'
                           ? t('admin.scheduledTests.success')
-                          : result.status === 'running'
+                          : displayResultStatus(result) === 'running'
                             ? t('admin.scheduledTests.running')
-                            : t('admin.scheduledTests.failed')
+                            : displayResultStatus(result) === 'interrupted'
+                              ? t('admin.scheduledTests.interrupted')
+                              : t('admin.scheduledTests.failed')
                       }}
                     </span>
 
@@ -463,19 +614,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue'
+import { computed, ref, reactive, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import HelpTooltip from '@/components/common/HelpTooltip.vue'
 import Select, { type SelectOption } from '@/components/common/Select.vue'
+import ModelMultiSelect from './ModelMultiSelect.vue'
 import Input from '@/components/common/Input.vue'
 import Toggle from '@/components/common/Toggle.vue'
 import { Icon } from '@/components/icons'
 import { adminAPI } from '@/api/admin'
 import { useAppStore } from '@/stores/app'
 import { formatDateTime } from '@/utils/format'
-import type { ScheduledTestPlan, ScheduledTestResult } from '@/types'
+import type { CreateScheduledTestPlanRequest, ScheduledTestPlan, ScheduledTestResult, UpdateScheduledTestPlanRequest } from '@/types'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -498,34 +650,177 @@ const plans = ref<ScheduledTestPlan[]>([])
 const results = ref<ScheduledTestResult[]>([])
 const expandedPlanId = ref<number | null>(null)
 const expandedResultIds = reactive(new Set<number>())
+const resultsStatusNow = ref(Date.now())
+const resultsRefreshIntervalMs = 5000
+const runningResultTimeoutMs = 5 * 60 * 1000
+let resultsRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let resultsRequestGeneration = 0
 const showAddForm = ref(false)
 const showDeleteConfirm = ref(false)
 const deletingPlan = ref<ScheduledTestPlan | null>(null)
 const editingPlanId = ref<number | null>(null)
 const updating = ref(false)
+type TriggerMode = 'scheduled' | 'error_recovery'
+type PlanForm = {
+  model_id: string
+  model_ids: string[]
+  cron_expression: string
+  trigger_mode: TriggerMode
+  retry_interval_minutes: string
+  retry_cron_expression: string
+  advanced_cron: boolean
+  max_results: string
+  enabled: boolean
+  auto_recover: boolean
+}
+
+const triggerModes = computed(() => [
+  { value: 'scheduled' as const, label: t('admin.scheduledTests.scheduledMode') },
+  { value: 'error_recovery' as const, label: t('admin.scheduledTests.errorRecoveryMode') }
+])
+
 const editForm = reactive({
   model_id: '' as string,
+  model_ids: [] as string[],
   cron_expression: '' as string,
+  trigger_mode: 'scheduled' as TriggerMode,
+  retry_interval_minutes: '5' as string,
+  retry_cron_expression: '' as string,
+  advanced_cron: false,
   max_results: '100' as string,
   enabled: true,
-  auto_recover: false
+  auto_recover: true
 })
 
 const newPlan = reactive({
   model_id: '' as string,
-  cron_expression: '' as string,
+  model_ids: props.modelOptions.map(option => String(option.value)),
+  cron_expression: '*/30 * * * *' as string,
+  trigger_mode: 'error_recovery' as TriggerMode,
+  retry_interval_minutes: '5' as string,
+  retry_cron_expression: '' as string,
+  advanced_cron: false,
   max_results: '100' as string,
   enabled: true,
-  auto_recover: false
+  auto_recover: true
 })
 
+const modelOptionIDs = computed(() => props.modelOptions.map(option => String(option.value)))
+
+const allModelsSelected = (modelIDs: string[]) => {
+  const available = modelOptionIDs.value
+  return available.length > 0 && modelIDs.length === available.length && available.every(modelID => modelIDs.includes(modelID))
+}
+
+const canonicalModelIDs = (modelIDs: string[]) => allModelsSelected(modelIDs) ? [] : [...modelIDs]
+
+const setTriggerMode = (form: PlanForm, mode: TriggerMode) => {
+  form.trigger_mode = mode
+  if (mode === 'error_recovery' && form.model_ids.length === 0) {
+    form.model_ids = [...modelOptionIDs.value]
+    form.model_id = form.model_ids[0] || form.model_id
+  }
+}
+
 const resetNewPlan = () => {
-  newPlan.model_id = ''
-  newPlan.cron_expression = ''
+  newPlan.model_ids = [...modelOptionIDs.value]
+  newPlan.model_id = newPlan.model_ids[0] || ''
+  newPlan.cron_expression = '*/30 * * * *'
+  newPlan.trigger_mode = 'error_recovery'
+  newPlan.retry_interval_minutes = '5'
+  newPlan.retry_cron_expression = ''
+  newPlan.advanced_cron = false
   newPlan.max_results = '100'
   newPlan.enabled = true
-  newPlan.auto_recover = false
+  newPlan.auto_recover = true
 }
+
+const isPlanFormValid = (form: PlanForm) => {
+  if (form.trigger_mode === 'error_recovery' && form.model_ids.length === 0) return false
+  if (form.trigger_mode === 'scheduled' && !form.model_id) return false
+  if (form.trigger_mode === 'scheduled') return Boolean(form.cron_expression.trim())
+  if (form.advanced_cron) return Boolean(form.retry_cron_expression.trim())
+  const interval = Number(form.retry_interval_minutes)
+  return Number.isInteger(interval) && interval >= 1 && interval <= 1440
+}
+
+const recoveryFields = (form: PlanForm) => {
+  if (form.trigger_mode === 'scheduled') {
+    return {
+      trigger_mode: 'scheduled' as const,
+      cron_expression: form.cron_expression,
+      retry_interval_minutes: null,
+      retry_cron_expression: null,
+      auto_recover: form.auto_recover,
+      model_ids: []
+    }
+  }
+  return {
+    trigger_mode: 'error_recovery' as const,
+    retry_interval_minutes: form.advanced_cron ? null : Number(form.retry_interval_minutes),
+    retry_cron_expression: form.advanced_cron ? form.retry_cron_expression.trim() : null,
+    auto_recover: form.auto_recover,
+    model_ids: canonicalModelIDs(form.model_ids)
+  }
+}
+
+const formatPlanSchedule = (plan: ScheduledTestPlan) => {
+  if (plan.trigger_mode !== 'error_recovery') return plan.cron_expression
+  if (plan.retry_cron_expression) return plan.retry_cron_expression
+  return t('admin.scheduledTests.everyMinutes', { minutes: plan.retry_interval_minutes ?? 5 })
+}
+
+const formatPlanModels = (plan: ScheduledTestPlan) => {
+  if (plan.trigger_mode !== 'error_recovery') return plan.model_id
+  if (!plan.model_ids?.length) return t('admin.scheduledTests.allFailedModels')
+  return plan.model_ids.join(', ')
+}
+
+const isStaleRunningResult = (result: ScheduledTestResult) => {
+  if (result.status !== 'running') return false
+  const startedAt = Date.parse(result.started_at)
+  return Number.isFinite(startedAt) && resultsStatusNow.value - startedAt > runningResultTimeoutMs
+}
+
+const displayResultStatus = (result: ScheduledTestResult) => {
+  return isStaleRunningResult(result) ? 'interrupted' : result.status
+}
+
+const hasActiveRunningResult = (items: ScheduledTestResult[]) => {
+  return items.some((result) => result.status === 'running' && !isStaleRunningResult(result))
+}
+
+const stopResultsPolling = () => {
+  if (resultsRefreshTimer !== null) {
+    clearTimeout(resultsRefreshTimer)
+    resultsRefreshTimer = null
+  }
+}
+
+const invalidateResultsRequests = () => {
+  resultsRequestGeneration += 1
+}
+
+const startResultsPolling = () => {
+  if (resultsRefreshTimer !== null) return
+  resultsRefreshTimer = setTimeout(async () => {
+    resultsRefreshTimer = null
+    resultsStatusNow.value = Date.now()
+    const planId = expandedPlanId.value
+    if (!planId || !hasActiveRunningResult(results.value)) return
+    await loadResults(planId, false)
+  }, resultsRefreshIntervalMs)
+}
+
+watch(
+  () => props.modelOptions,
+  () => {
+    if (newPlan.trigger_mode === 'error_recovery' && newPlan.model_ids.length === 0) {
+      resetNewPlan()
+    }
+  },
+  { immediate: true, deep: true }
+)
 
 // Load plans when dialog opens
 watch(
@@ -534,6 +829,8 @@ watch(
     if (visible && props.accountId) {
       await loadPlans()
     } else {
+      invalidateResultsRequests()
+      stopResultsPolling()
       plans.value = []
       results.value = []
       expandedPlanId.value = null
@@ -557,18 +854,18 @@ const loadPlans = async () => {
 }
 
 const handleCreate = async () => {
-  if (!props.accountId || !newPlan.model_id || !newPlan.cron_expression) return
+  if (!props.accountId || !isPlanFormValid(newPlan)) return
   creating.value = true
   try {
     const maxResults = Number(newPlan.max_results) || 100
-    await adminAPI.scheduledTests.create({
+    const request: CreateScheduledTestPlanRequest = {
       account_id: props.accountId,
-      model_id: newPlan.model_id,
-      cron_expression: newPlan.cron_expression,
+      model_id: newPlan.trigger_mode === 'error_recovery' ? newPlan.model_ids[0] : newPlan.model_id,
       enabled: newPlan.enabled,
       max_results: maxResults,
-      auto_recover: newPlan.auto_recover
-    })
+      ...recoveryFields(newPlan)
+    }
+    await adminAPI.scheduledTests.create(request)
     appStore.showSuccess(t('admin.scheduledTests.createSuccess'))
     showAddForm.value = false
     resetNewPlan()
@@ -596,7 +893,17 @@ const handleToggleEnabled = async (plan: ScheduledTestPlan, enabled: boolean) =>
 const startEdit = (plan: ScheduledTestPlan) => {
   editingPlanId.value = plan.id
   editForm.model_id = plan.model_id
+  editForm.model_ids = plan.trigger_mode === 'error_recovery'
+    ? (plan.model_ids?.length ? [...plan.model_ids] : [...modelOptionIDs.value])
+    : []
+  if (plan.trigger_mode === 'error_recovery' && editForm.model_ids.length > 0) {
+    editForm.model_id = editForm.model_ids[0]
+  }
   editForm.cron_expression = plan.cron_expression
+  editForm.trigger_mode = plan.trigger_mode || 'scheduled'
+  editForm.retry_interval_minutes = String(plan.retry_interval_minutes ?? 5)
+  editForm.retry_cron_expression = plan.retry_cron_expression || ''
+  editForm.advanced_cron = Boolean(plan.retry_cron_expression)
   editForm.max_results = String(plan.max_results)
   editForm.enabled = plan.enabled
   editForm.auto_recover = plan.auto_recover
@@ -607,16 +914,16 @@ const cancelEdit = () => {
 }
 
 const handleEdit = async () => {
-  if (!editingPlanId.value || !editForm.model_id || !editForm.cron_expression) return
+  if (!editingPlanId.value || !isPlanFormValid(editForm)) return
   updating.value = true
   try {
-    const updated = await adminAPI.scheduledTests.update(editingPlanId.value, {
-      model_id: editForm.model_id,
-      cron_expression: editForm.cron_expression,
+    const request: UpdateScheduledTestPlanRequest = {
+      model_id: editForm.trigger_mode === 'error_recovery' ? editForm.model_ids[0] : editForm.model_id,
       max_results: Number(editForm.max_results) || 100,
       enabled: editForm.enabled,
-      auto_recover: editForm.auto_recover
-    })
+      ...recoveryFields(editForm)
+    }
+    const updated = await adminAPI.scheduledTests.update(editingPlanId.value, request)
     const index = plans.value.findIndex((p) => p.id === editingPlanId.value)
     if (index !== -1) {
       plans.value[index] = updated
@@ -642,6 +949,8 @@ const handleDelete = async () => {
     appStore.showSuccess(t('admin.scheduledTests.deleteSuccess'))
     plans.value = plans.value.filter((p) => p.id !== deletingPlan.value!.id)
     if (expandedPlanId.value === deletingPlan.value.id) {
+      invalidateResultsRequests()
+      stopResultsPolling()
       expandedPlanId.value = null
       results.value = []
     }
@@ -653,25 +962,43 @@ const handleDelete = async () => {
   }
 }
 
+const loadResults = async (planId: number, showLoading = true) => {
+  const requestGeneration = ++resultsRequestGeneration
+  if (showLoading) loadingResults.value = true
+  try {
+    const loaded = await adminAPI.scheduledTests.listResults(planId, 20)
+    if (requestGeneration === resultsRequestGeneration && expandedPlanId.value === planId) {
+      resultsStatusNow.value = Date.now()
+      results.value = loaded
+      if (hasActiveRunningResult(loaded)) startResultsPolling()
+      else stopResultsPolling()
+    }
+  } catch (error: any) {
+    if (requestGeneration !== resultsRequestGeneration || expandedPlanId.value !== planId) return
+    results.value = []
+    stopResultsPolling()
+    appStore.showError(error?.message || 'Failed to load results')
+  } finally {
+    if (showLoading && requestGeneration === resultsRequestGeneration) loadingResults.value = false
+  }
+}
+
 const toggleExpand = async (planId: number) => {
   if (expandedPlanId.value === planId) {
+    invalidateResultsRequests()
+    stopResultsPolling()
     expandedPlanId.value = null
     results.value = []
     expandedResultIds.clear()
     return
   }
 
+  invalidateResultsRequests()
+  stopResultsPolling()
   expandedPlanId.value = planId
   expandedResultIds.clear()
-  loadingResults.value = true
-  try {
-    results.value = await adminAPI.scheduledTests.listResults(planId, 20)
-  } catch (error: any) {
-    appStore.showError(error?.message || 'Failed to load results')
-    results.value = []
-  } finally {
-    loadingResults.value = false
-  }
+  results.value = []
+  await loadResults(planId)
 }
 
 const toggleResultDetail = (resultId: number) => {
@@ -681,4 +1008,9 @@ const toggleResultDetail = (resultId: number) => {
     expandedResultIds.add(resultId)
   }
 }
+
+onUnmounted(() => {
+  invalidateResultsRequests()
+  stopResultsPolling()
+})
 </script>

--- a/frontend/src/components/admin/account/__tests__/ModelMultiSelect.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/ModelMultiSelect.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ModelMultiSelect from '../ModelMultiSelect.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key })
+  }
+})
+
+describe('ModelMultiSelect', () => {
+  it('selects failed models independently and supports all or none', async () => {
+    const wrapper = mount(ModelMultiSelect, {
+      props: {
+        modelValue: ['luna', 'sol'],
+        options: [
+          { value: 'luna', label: 'Luna' },
+          { value: 'sol', label: 'Sol' }
+        ],
+        id: 'failed-models',
+        ariaLabel: 'Failed models',
+        allLabel: 'All failed models',
+        clearLabel: 'Clear'
+      },
+      global: { stubs: { Icon: true } }
+    })
+
+    const trigger = wrapper.get('.select-trigger')
+    expect(trigger.attributes()).toMatchObject({ id: 'failed-models', 'aria-label': 'Failed models' })
+    expect(wrapper.text()).toContain('All failed models')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-controls')).toBe('failed-models-options')
+    expect(wrapper.find('[role="listbox"]').exists()).toBe(false)
+    expect(wrapper.get('[role="group"]').attributes('aria-label')).toBe('Failed models')
+    await wrapper.findAll('input[type="checkbox"]')[0].trigger('change')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['sol']])
+
+    await wrapper.findAll('button').find(button => button.text() === 'Clear')!.trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([[]])
+
+    await wrapper.findAll('button').filter(button => button.text() === 'All failed models').pop()!.trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[2]).toEqual([['luna', 'sol']])
+  })
+})

--- a/frontend/src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts
@@ -1,0 +1,397 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ScheduledTestsPanel from '../ScheduledTestsPanel.vue'
+
+const api = vi.hoisted(() => ({
+  listByAccount: vi.fn().mockResolvedValue([]),
+  create: vi.fn().mockResolvedValue({}),
+  update: vi.fn(),
+  delete: vi.fn(),
+  listResults: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({ adminAPI: { scheduledTests: api } }))
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showSuccess: vi.fn(), showError: vi.fn() })
+}))
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string, params?: { minutes?: number }) => params?.minutes ? `${key}:${params.minutes}` : key })
+  }
+})
+
+const stubs = {
+  BaseDialog: { props: ['show'], template: '<div v-if="show"><slot /></div>' },
+  ConfirmDialog: true,
+  HelpTooltip: { template: '<span><slot name="trigger" /><slot /></span>' },
+  Select: {
+    props: ['modelValue', 'options', 'placeholder', 'searchable'],
+    emits: ['update:modelValue'],
+    template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option value=""></option><option value="gpt-5.6-luna">luna</option></select>'
+  },
+  ModelMultiSelect: {
+    props: ['modelValue', 'options', 'placeholder'],
+    emits: ['update:modelValue'],
+    template: '<div data-testid="model-multi-select"><span>{{ modelValue.join(",") }}</span><button data-testid="select-sol-only" @click="$emit(\'update:modelValue\', [\'gpt-5.6-sol\'])">sol only</button></div>'
+  },
+  Input: {
+    props: ['modelValue', 'type', 'min', 'max', 'placeholder', 'hint'],
+    emits: ['update:modelValue'],
+    template: '<input :type="type || \'text\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+  },
+  Toggle: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />'
+  },
+  Icon: true
+}
+
+function mountPanel() {
+  return mount(ScheduledTestsPanel, {
+    props: {
+      show: true,
+      accountId: 42,
+      modelOptions: [
+        { value: 'gpt-5.6-luna', label: 'luna' },
+        { value: 'gpt-5.6-sol', label: 'sol' }
+      ]
+    },
+    global: { stubs }
+  })
+}
+
+async function openForm(wrapper: ReturnType<typeof mountPanel>) {
+  const addButton = wrapper.findAll('button').find(button => button.text().includes('admin.scheduledTests.addPlan'))
+  await addButton!.trigger('click')
+}
+
+async function openScheduledFormAndSelectModel(wrapper: ReturnType<typeof mountPanel>) {
+  await openForm(wrapper)
+  const scheduledButton = wrapper.findAll('button').find(button => button.text() === 'admin.scheduledTests.scheduledMode')
+  await scheduledButton!.trigger('click')
+  await wrapper.find('select').setValue('gpt-5.6-luna')
+}
+
+async function save(wrapper: ReturnType<typeof mountPanel>) {
+  const saveButton = wrapper.findAll('button').find(button => button.text() === 'common.save')
+  await saveButton!.trigger('click')
+  await flushPromises()
+}
+
+beforeEach(() => {
+  api.create.mockClear()
+  api.update.mockClear()
+  api.listByAccount.mockClear()
+  api.listByAccount.mockResolvedValue([])
+  api.listResults.mockReset()
+})
+
+const runningResult = (startedAt = new Date(Date.now() - 1000).toISOString()) => ({
+  id: 1,
+  plan_id: 9,
+  model_id: 'gpt-5.6-sol',
+  status: 'running',
+  response_text: '',
+  error_message: '',
+  latency_ms: 0,
+  started_at: startedAt,
+  finished_at: startedAt,
+  created_at: startedAt
+})
+
+async function openResults(results: object[], refreshResults?: object[]) {
+  const plan = {
+    id: 9,
+    account_id: 42,
+    model_id: 'gpt-5.6-sol',
+    model_ids: [],
+    cron_expression: '*/30 * * * *',
+    trigger_mode: 'error_recovery' as const,
+    retry_interval_minutes: 5,
+    retry_cron_expression: null,
+    enabled: true,
+    max_results: 100,
+    auto_recover: true,
+    last_run_at: null,
+    next_run_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  }
+  api.listByAccount.mockResolvedValue([plan])
+  api.listResults.mockResolvedValueOnce(results)
+  if (refreshResults) api.listResults.mockResolvedValueOnce(refreshResults)
+  const wrapper = mountPanel()
+  await wrapper.setProps({ show: false })
+  await wrapper.setProps({ show: true })
+  await flushPromises()
+  await wrapper.find('[class*="cursor-pointer"][class*="justify-between"]').trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+describe('ScheduledTestsPanel error recovery form', () => {
+  it('defaults to a five-minute error recovery plan', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    expect(wrapper.get('[data-testid="model-multi-select"]').text()).toContain('gpt-5.6-luna,gpt-5.6-sol')
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    expect((autoRecover!.find('input').element as HTMLInputElement).checked).toBe(true)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith({
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      model_ids: [],
+      enabled: true,
+      max_results: 100,
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: 5,
+      retry_cron_expression: null,
+      auto_recover: true
+    })
+  })
+
+  it('uses advanced cron instead of the minute interval', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    const advancedLabel = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.advancedCron'))
+    await advancedLabel!.find('input').setValue(true)
+    const cronInput = wrapper.findAll('input').find(input => input.element.type === 'text')
+    await cronInput!.setValue('*/7 * * * *')
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: null,
+      retry_cron_expression: '*/7 * * * *'
+    }))
+  })
+
+  it('preserves an explicitly disabled auto-recovery setting on create', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    await autoRecover!.find('input').setValue(false)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      auto_recover: false
+    }))
+  })
+
+  it('preserves the existing scheduled cron payload', async () => {
+    const wrapper = mountPanel()
+    await openScheduledFormAndSelectModel(wrapper)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'scheduled',
+      cron_expression: '*/30 * * * *',
+      retry_interval_minutes: null,
+      retry_cron_expression: null
+    }))
+  })
+
+  it('sends only the selected failed-model subset', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    await wrapper.get('[data-testid="select-sol-only"]').trigger('click')
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      model_id: 'gpt-5.6-sol',
+      model_ids: ['gpt-5.6-sol']
+    }))
+  })
+
+  it('explains that error recovery probes the models that actually failed', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    expect(wrapper.text()).toContain('admin.scheduledTests.errorRecoveryTooltipFailedModels')
+    expect(wrapper.get('button[aria-label="admin.scheduledTests.errorRecoveryHelpAriaLabel"]').exists()).toBe(true)
+  })
+
+  it('loads and edits a legacy scheduled plan without recovery fields', async () => {
+    const legacyPlan = {
+      id: 7,
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      cron_expression: '*/17 * * * *',
+      enabled: true,
+      max_results: 100,
+      auto_recover: false,
+      last_run_at: null,
+      next_run_at: null,
+      created_at: '2026-08-01T00:00:00Z',
+      updated_at: '2026-08-01T00:00:00Z'
+    }
+    api.listByAccount.mockResolvedValue([legacyPlan])
+    api.update.mockResolvedValueOnce({ ...legacyPlan, trigger_mode: 'scheduled' })
+    const wrapper = mountPanel()
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find(button => button.attributes('title') === 'admin.scheduledTests.editPlan')
+    await editButton!.trigger('click')
+    expect(wrapper.find('input[value="*/17 * * * *"]').exists()).toBe(true)
+    await save(wrapper)
+
+    expect(api.update).toHaveBeenCalledWith(7, expect.objectContaining({
+      model_id: 'gpt-5.6-luna',
+      trigger_mode: 'scheduled',
+      cron_expression: '*/17 * * * *',
+      retry_interval_minutes: null,
+      retry_cron_expression: null
+    }))
+  })
+
+  it('preserves an explicitly disabled auto-recovery setting on edit', async () => {
+    const plan = {
+      id: 8,
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      model_ids: [],
+      cron_expression: '*/30 * * * *',
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: 5,
+      retry_cron_expression: null,
+      enabled: true,
+      max_results: 100,
+      auto_recover: true,
+      last_run_at: null,
+      next_run_at: null,
+      created_at: '2026-08-01T00:00:00Z',
+      updated_at: '2026-08-01T00:00:00Z'
+    }
+    api.listByAccount.mockResolvedValue([plan])
+    api.update.mockResolvedValueOnce(plan)
+    const wrapper = mountPanel()
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find(button => button.attributes('title') === 'admin.scheduledTests.editPlan')
+    await editButton!.trigger('click')
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    await autoRecover!.find('input').setValue(false)
+    await save(wrapper)
+
+    expect(api.update).toHaveBeenCalledWith(8, expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      auto_recover: false
+    }))
+  })
+})
+
+describe('ScheduledTestsPanel running results', () => {
+  it('refreshes expanded results while a test is running', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([runningResult()], [{ ...runningResult(), status: 'success' }])
+
+      expect(api.listResults).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('marks a stale running result as interrupted after the runner timeout', async () => {
+    const wrapper = await openResults([runningResult(new Date(Date.now() - 6 * 60 * 1000).toISOString())])
+
+    expect(wrapper.text()).toContain('admin.scheduledTests.interrupted')
+  })
+
+  it('changes a visible running result to interrupted when it crosses the timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([
+        runningResult(new Date(Date.now() - 5 * 60 * 1000 + 1000).toISOString())
+      ])
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.running')
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.interrupted')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not overlap result polls while the previous request is pending', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolvePoll!: (results: object[]) => void
+      const pendingPoll = new Promise<object[]>((resolve) => { resolvePoll = resolve })
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockReturnValueOnce(pendingPoll)
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      resolvePoll([{ ...runningResult(), status: 'success' }])
+      await flushPromises()
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores an old poll response after the same plan is closed and reopened', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolveOldPoll!: (results: object[]) => void
+      const oldPoll = new Promise<object[]>((resolve) => { resolveOldPoll = resolve })
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockReturnValueOnce(oldPoll)
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      const planHeader = wrapper.find('[class*="cursor-pointer"][class*="justify-between"]')
+      await planHeader.trigger('click')
+      api.listResults.mockResolvedValueOnce([{ ...runningResult(), status: 'success' }])
+      await planHeader.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+
+      resolveOldPoll([runningResult()])
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+      expect(wrapper.text()).not.toContain('admin.scheduledTests.running')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops refreshing when a running-result poll fails', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockRejectedValueOnce(new Error('network unavailable'))
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      expect(wrapper.exists()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -5,6 +5,18 @@ export default {
       editPlan: 'Edit Plan',
       deletePlan: 'Delete Plan',
       model: 'Model',
+      probeModel: 'Account Probe Model',
+      selectModels: 'Select failed models',
+      selectedModels: '{count} models selected',
+      allFailedModels: 'All failed models',
+      clearSelection: 'Clear',
+      triggerMode: 'Test Mode',
+      scheduledMode: 'Scheduled',
+      errorRecoveryMode: 'Error Recovery',
+      errorRecoveryHelpAriaLabel: 'Explain error recovery',
+      retryInterval: 'Retry Interval (minutes)',
+      advancedCron: 'Advanced Cron',
+      everyMinutes: 'Every {minutes} minutes',
       cronExpression: 'Cron Expression',
       enabled: 'Enabled',
       lastRun: 'Last Run',
@@ -22,6 +34,7 @@ export default {
       success: 'Success',
       failed: 'Failed',
       running: 'Running',
+      interrupted: 'Execution interrupted',
       schedule: 'Schedule',
       cronHelp: 'Standard 5-field cron expression (e.g., */30 * * * *)',
       cronTooltipTitle: 'Cron expression examples:',
@@ -37,7 +50,9 @@ export default {
       maxResultsTooltipExample: 'For example, 100 means keeping at most the latest 100 test results. When the 101st result is saved, the oldest one is removed.',
       maxResultsTooltipRange: 'Recommended range: usually 20 to 200. Use 20-50 when you only care about recent health status, or 100-200 if you want a longer trend history.',
       autoRecover: 'Auto Recover',
-      autoRecoverHelp: 'Automatically recover account from error/rate-limited state on successful test'
+      autoRecoverHelp: 'Automatically recover account from error/rate-limited state on successful test',
+      errorRecoveryTooltipFailedModels: 'Only structured errors recorded by the system are tested. Each failed model is tested individually; all models are included by default. Account-level errors use the first selected model once.',
+      errorRecoveryTooltipBoundaries: 'AICredits, manually disabled or unschedulable states, and expired accounts are not recovered by this feature.'
     },
 
     // Proxies

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -5,6 +5,18 @@ export default {
       editPlan: '编辑计划',
       deletePlan: '删除计划',
       model: '模型',
+      probeModel: '账号探测模型',
+      selectModels: '选择失败模型',
+      selectedModels: '已选择 {count} 个模型',
+      allFailedModels: '全部失败模型',
+      clearSelection: '清空',
+      triggerMode: '测试方式',
+      scheduledMode: '定时测试',
+      errorRecoveryMode: '错误恢复',
+      errorRecoveryHelpAriaLabel: '说明错误恢复',
+      retryInterval: '重试间隔（分钟）',
+      advancedCron: '高级 Cron',
+      everyMinutes: '每 {minutes} 分钟',
       cronExpression: 'Cron 表达式',
       enabled: '启用',
       lastRun: '上次运行',
@@ -22,6 +34,7 @@ export default {
       success: '成功',
       failed: '失败',
       running: '运行中',
+      interrupted: '执行中断',
       schedule: '定时测试',
       cronHelp: '标准 5 字段 cron 表达式（例如 */30 * * * *）',
       cronTooltipTitle: 'Cron 表达式示例：',
@@ -37,7 +50,9 @@ export default {
       maxResultsTooltipExample: '例如填写 100，表示最多保存最近 100 次测试结果；第 101 次结果写入后，最早的一条会被清理。',
       maxResultsTooltipRange: '推荐填写范围：一般可填 20 到 200。只关注近期可用性时可填 20-50；需要回看较长时间的波动趋势时可填 100-200。',
       autoRecover: '自动恢复',
-      autoRecoverHelp: '测试成功后自动恢复异常状态的账号'
+      autoRecoverHelp: '测试成功后自动恢复异常状态的账号',
+      errorRecoveryTooltipFailedModels: '只测试系统记录的结构化错误；哪个模型失败就测试哪个模型。默认包含全部模型，也可以缩小范围。账号级错误使用首个已选模型探测一次。',
+      errorRecoveryTooltipBoundaries: 'AICredits、人工禁用或不可调度、过期状态不会通过此功能恢复。'
     },
 
     // Proxies Management

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2223,7 +2223,11 @@ export interface ScheduledTestPlan {
   id: number
   account_id: number
   model_id: string
+  model_ids?: string[]
   cron_expression: string
+  trigger_mode: 'scheduled' | 'error_recovery'
+  retry_interval_minutes: number | null
+  retry_cron_expression: string | null
   enabled: boolean
   max_results: number
   auto_recover: boolean
@@ -2236,6 +2240,7 @@ export interface ScheduledTestPlan {
 export interface ScheduledTestResult {
   id: number
   plan_id: number
+  model_id: string
   status: string
   response_text: string
   error_message: string
@@ -2248,7 +2253,11 @@ export interface ScheduledTestResult {
 export interface CreateScheduledTestPlanRequest {
   account_id: number
   model_id: string
-  cron_expression: string
+  model_ids?: string[]
+  cron_expression?: string
+  trigger_mode?: 'scheduled' | 'error_recovery'
+  retry_interval_minutes?: number | null
+  retry_cron_expression?: string | null
   enabled?: boolean
   max_results?: number
   auto_recover?: boolean
@@ -2256,7 +2265,11 @@ export interface CreateScheduledTestPlanRequest {
 
 export interface UpdateScheduledTestPlanRequest {
   model_id?: string
+  model_ids?: string[]
   cron_expression?: string
+  trigger_mode?: 'scheduled' | 'error_recovery'
+  retry_interval_minutes?: number | null
+  retry_cron_expression?: string | null
   enabled?: boolean
   max_results?: number
   auto_recover?: boolean


### PR DESCRIPTION
## Summary

- add an `error_recovery` scheduled-test mode with a simple minute interval (5 minutes by default) and an optional advanced 5-field cron schedule
- discover system-recorded account and model errors, test affected models independently, and stop retrying each model as soon as it recovers
- let operators multi-select probe models; error recovery defaults to all available models and stores the full selection canonically as `model_ids: []`
- enable auto recovery by default while preserving an explicit probe-only opt-out, and add click/keyboard-accessible help describing the recovery boundary
- clear only the successful model's unchanged JSON state and immediately synchronize the scheduler snapshot

## Safety boundaries

- only structured errors recorded by the system are eligible
- `AICredits`, manually disabled or unschedulable accounts, expired accounts, elapsed historical windows, and bare `status=error` states are not retried or recovered
- model-level errors always test their actual `model_id`; a non-empty `model_ids` list acts only as a failed-model allowlist
- account-level structured errors are probed once with the first selected model
- model recovery uses a PostgreSQL JSONB compare-and-delete so a concurrent new error or sibling-model update cannot be cleared accidentally
- account-level recovery is also conditional on the observed account version
- each account can have at most one error-recovery plan, and a process-local guard prevents overlapping runs of the same plan

## Database and compatibility

- migration `192_add_scheduled_test_error_recovery.sql` adds the trigger and retry schedule fields and backfills `scheduled_test_results.model_id`
- migration `193_add_scheduled_test_error_model_ids.sql` adds `model_ids TEXT[] NOT NULL DEFAULT '{}'`
- repository writes normalize nil/full selections to an empty PostgreSQL array, never SQL `NULL`
- existing scheduled plans retain their current behavior through the default `scheduled` trigger mode
- no dependencies or additional worker systems are introduced; the existing per-minute scheduled-test runner is reused

## Validation

- `go test ./internal/service ./internal/repository ./internal/handler/admin -count=1` (5,361 tests passed)
- `go test -tags=unit ./internal/service ./internal/repository ./internal/handler/admin -count=1` (8,187 tests passed)
- PostgreSQL integration tests for non-empty and canonical empty `model_ids` create/update round-trips (2 tests passed)
- focused PostgreSQL integration coverage for conditional per-model recovery, account recovery, sibling-model success, and same-reset rewrites
- `ScheduledTestsPanel.spec.ts` (8 tests passed) and `ModelMultiSelect.spec.ts` (1 test passed)
- focused runner/service tests for disabled auto recovery (7 tests passed)
- `pnpm run typecheck`, `pnpm run lint:check`, and `pnpm run build`
- independent code review: PASS, no blocking findings

The feature was deployed to a local Sub2API instance as `sub2api:0.1.169-model-error-recovery-models-optout-ac75612b` by replacing only the app container. PostgreSQL and Redis were not recreated. Health, migrations 192/193, desktop UI, default-all model selection, subset selection, help text, and create/read/delete of an AIINPUT recovery plan all passed.

Live AIINPUT evidence also showed the intended state machine: failed models were retried independently, successful models were cleared, later upstream regressions created new active errors and resumed retrying, and failed probes did not clear those new errors. Implementation validation actions were limited to AIINPUT accounts; no validation plan or test request was sent to other providers.

The approved behavior contract and detailed evidence are included in `docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md` and `PROGRESS.md`.

## Relation to #4821

#4821 adds a one-click way to create ordinary periodic scheduled tests across accounts. This PR adds a distinct failure-only trigger mode and model-granular recovery semantics. The two features are complementary rather than competing implementations.

Closes #5184
