### PR TITLE
fix(openai): preserve completed stream output items

### DIFF
--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1596,7 +1596,16 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 	sort.Ints(doneIndices)
 	for _, index := range doneIndices {
 		doneItem := items.byIndex[index]
-		positioned[index] = doneItem
+		targetIndex := index
+		if identity := responsesOutputItemIdentity(doneItem); identity != "" {
+			for terminalIndex, terminalItem := range positioned {
+				if responsesOutputItemIdentity(terminalItem) == identity {
+					targetIndex = terminalIndex
+					break
+				}
+			}
+		}
+		positioned[targetIndex] = doneItem
 	}
 
 	for _, fallbackItem := range fallbackItems {
@@ -1670,7 +1679,7 @@ func responsesSyntheticItemsEquivalent(fallback, done json.RawMessage) bool {
 func responsesItemText(item gjson.Result, path string) string {
 	var text strings.Builder
 	for _, part := range item.Get(path).Array() {
-		text.WriteString(part.Get("text").String())
+		_, _ = text.WriteString(part.Get("text").String())
 	}
 	return text.String()
 }

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -286,6 +288,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 
 	needModelReplace := originalModel != mappedModel
 	streamOutputAccumulator := apicompat.NewBufferedResponseAccumulator()
+	streamDoneOutputItems := newResponsesDoneOutputItems()
 	streamImageOutputs := make([]json.RawMessage, 0, 1)
 	streamSeenImages := make(map[string]struct{})
 	resultWithUsage := func() *openaiStreamingResult {
@@ -479,7 +482,8 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 					streamOutputAccumulator.ProcessEvent(&streamEvent)
 				}
 			}
-			if normalizedData, normalized := normalizeResponsesStreamingTerminalOutput(dataBytes, streamOutputAccumulator, streamImageOutputs); normalized {
+			streamDoneOutputItems.ProcessEvent(dataBytes, eventType)
+			if normalizedData, normalized := normalizeResponsesStreamingTerminalOutput(dataBytes, streamOutputAccumulator, streamDoneOutputItems, streamImageOutputs); normalized {
 				dataBytes = normalizedData
 				data = string(normalizedData)
 				line = "data: " + data
@@ -1459,7 +1463,243 @@ func normalizeCompletedImageGenerationStatus(data []byte) ([]byte, bool) {
 	}
 }
 
-func normalizeResponsesStreamingTerminalOutput(data []byte, acc *apicompat.BufferedResponseAccumulator, imageOutputs []json.RawMessage) ([]byte, bool) {
+type responsesDoneOutputItems struct {
+	byIndex      map[int]json.RawMessage
+	withoutIndex []json.RawMessage
+	totalBytes   int
+	overflowed   bool
+}
+
+const (
+	maxResponsesOutputIndex     = 4096
+	maxResponsesDoneOutputItems = 1024
+	maxResponsesDoneOutputBytes = 8 << 20
+)
+
+func newResponsesDoneOutputItems() *responsesDoneOutputItems {
+	return &responsesDoneOutputItems{byIndex: make(map[int]json.RawMessage)}
+}
+
+func (items *responsesDoneOutputItems) ProcessEvent(data []byte, eventType string) {
+	if items == nil || eventType != "response.output_item.done" {
+		return
+	}
+	item := gjson.GetBytes(data, "item")
+	if !item.IsObject() {
+		return
+	}
+	if items.overflowed {
+		return
+	}
+	raw := json.RawMessage(item.Raw)
+	if len(raw) > maxResponsesDoneOutputBytes {
+		items.discardOnOverflow()
+		return
+	}
+	indexResult := gjson.GetBytes(data, "output_index")
+	if !indexResult.Exists() {
+		items.removeIdentity(responsesOutputItemIdentity(raw))
+		if !items.reserve(raw, 0) {
+			return
+		}
+		items.withoutIndex = append(items.withoutIndex, raw)
+		items.totalBytes += len(raw)
+		return
+	}
+	index, ok := validResponsesOutputIndex(indexResult)
+	if !ok {
+		return
+	}
+	items.removeIdentity(responsesOutputItemIdentity(raw))
+	previous := items.byIndex[index]
+	if !items.reserve(raw, len(previous)) {
+		return
+	}
+	if previous, ok := items.byIndex[index]; ok {
+		items.totalBytes -= len(previous)
+	}
+	items.byIndex[index] = raw
+	items.totalBytes += len(raw)
+}
+
+func (items *responsesDoneOutputItems) reserve(item json.RawMessage, replacedBytes int) bool {
+	count := len(items.byIndex) + len(items.withoutIndex)
+	if (replacedBytes == 0 && count >= maxResponsesDoneOutputItems) || items.totalBytes-replacedBytes+len(item) > maxResponsesDoneOutputBytes {
+		items.discardOnOverflow()
+		return false
+	}
+	return true
+}
+
+func (items *responsesDoneOutputItems) discardOnOverflow() {
+	items.byIndex = make(map[int]json.RawMessage)
+	items.withoutIndex = nil
+	items.totalBytes = 0
+	items.overflowed = true
+}
+
+func (items *responsesDoneOutputItems) removeIdentity(identity string) {
+	if identity == "" {
+		return
+	}
+	for index, item := range items.byIndex {
+		if responsesOutputItemIdentity(item) == identity {
+			items.totalBytes -= len(item)
+			delete(items.byIndex, index)
+		}
+	}
+	for index := len(items.withoutIndex) - 1; index >= 0; index-- {
+		if responsesOutputItemIdentity(items.withoutIndex[index]) == identity {
+			items.totalBytes -= len(items.withoutIndex[index])
+			items.withoutIndex = append(items.withoutIndex[:index], items.withoutIndex[index+1:]...)
+		}
+	}
+}
+
+func validResponsesOutputIndex(result gjson.Result) (int, bool) {
+	if result.Type != gjson.Number {
+		return 0, false
+	}
+	value, err := strconv.ParseUint(result.Raw, 10, strconv.IntSize)
+	if err != nil || value > maxResponsesOutputIndex {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func (items *responsesDoneOutputItems) HasContent() bool {
+	return items != nil && !items.overflowed && (len(items.byIndex) > 0 || len(items.withoutIndex) > 0)
+}
+
+func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, fallback []byte) ([]byte, bool) {
+	if (items == nil || !items.HasContent()) && len(fallback) == 0 {
+		return nil, false
+	}
+	positioned := make(map[int]json.RawMessage)
+	var fallbackItems []json.RawMessage
+	if output.Exists() && output.IsArray() {
+		for index, terminalItem := range output.Array() {
+			positioned[index] = json.RawMessage(terminalItem.Raw)
+		}
+	}
+	if len(fallback) > 0 {
+		_ = json.Unmarshal(fallback, &fallbackItems)
+	}
+	if items == nil {
+		encoded, err := json.Marshal(fallbackItems)
+		return encoded, err == nil
+	}
+	doneIndices := make([]int, 0, len(items.byIndex))
+	for index := range items.byIndex {
+		doneIndices = append(doneIndices, index)
+	}
+	sort.Ints(doneIndices)
+	for _, index := range doneIndices {
+		doneItem := items.byIndex[index]
+		positioned[index] = doneItem
+	}
+
+	for _, fallbackItem := range fallbackItems {
+		if responsesFallbackRepresentedByDoneItem(fallbackItem, items) {
+			continue
+		}
+		index := 0
+		for {
+			if _, occupied := positioned[index]; !occupied {
+				positioned[index] = fallbackItem
+				break
+			}
+			index++
+		}
+	}
+
+	positions := make([]int, 0, len(positioned))
+	for index := range positioned {
+		positions = append(positions, index)
+	}
+	sort.Ints(positions)
+	merged := make([]json.RawMessage, 0, len(positioned)+len(items.withoutIndex))
+	for _, index := range positions {
+		merged = appendResponsesOutputItem(merged, positioned[index])
+	}
+	for _, doneItem := range items.withoutIndex {
+		merged = appendResponsesOutputItem(merged, doneItem)
+	}
+	encoded, err := json.Marshal(merged)
+	return encoded, err == nil
+}
+
+func responsesFallbackRepresentedByDoneItem(fallback json.RawMessage, items *responsesDoneOutputItems) bool {
+	for _, done := range items.byIndex {
+		if responsesSyntheticItemsEquivalent(fallback, done) {
+			return true
+		}
+	}
+	for _, done := range items.withoutIndex {
+		if responsesSyntheticItemsEquivalent(fallback, done) {
+			return true
+		}
+	}
+	return false
+}
+
+func responsesSyntheticItemsEquivalent(fallback, done json.RawMessage) bool {
+	fallbackItem := gjson.ParseBytes(fallback)
+	doneItem := gjson.ParseBytes(done)
+	itemType := strings.TrimSpace(fallbackItem.Get("type").String())
+	if itemType == "" || itemType != strings.TrimSpace(doneItem.Get("type").String()) {
+		return false
+	}
+	switch itemType {
+	case "message":
+		fallbackText := responsesItemText(fallbackItem, "content")
+		return fallbackText != "" && fallbackItem.Get("role").String() == doneItem.Get("role").String() &&
+			fallbackText == responsesItemText(doneItem, "content")
+	case "reasoning":
+		fallbackText := responsesItemText(fallbackItem, "summary")
+		return fallbackText != "" && fallbackText == responsesItemText(doneItem, "summary")
+	case "image_generation_call":
+		return fallbackItem.Get("result").String() != "" &&
+			fallbackItem.Get("result").String() == doneItem.Get("result").String() &&
+			fallbackItem.Get("output_format").String() == doneItem.Get("output_format").String()
+	default:
+		return false
+	}
+}
+
+func responsesItemText(item gjson.Result, path string) string {
+	var text strings.Builder
+	for _, part := range item.Get(path).Array() {
+		text.WriteString(part.Get("text").String())
+	}
+	return text.String()
+}
+
+func responsesOutputItemIdentity(item json.RawMessage) string {
+	parsed := gjson.ParseBytes(item)
+	if id := strings.TrimSpace(parsed.Get("id").String()); id != "" {
+		return "id:" + id
+	}
+	if callID := strings.TrimSpace(parsed.Get("call_id").String()); callID != "" {
+		return "call_id:" + callID
+	}
+	return ""
+}
+
+func appendResponsesOutputItem(output []json.RawMessage, item json.RawMessage) []json.RawMessage {
+	identity := responsesOutputItemIdentity(item)
+	if identity != "" {
+		for index, candidate := range output {
+			if responsesOutputItemIdentity(candidate) == identity {
+				output[index] = item
+				return output
+			}
+		}
+	}
+	return append(output, item)
+}
+
+func normalizeResponsesStreamingTerminalOutput(data []byte, acc *apicompat.BufferedResponseAccumulator, doneItems *responsesDoneOutputItems, imageOutputs []json.RawMessage) ([]byte, bool) {
 	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
 	switch eventType {
 	case "response.completed", "response.done", "response.incomplete", "response.cancelled", "response.canceled":
@@ -1468,22 +1708,40 @@ func normalizeResponsesStreamingTerminalOutput(data []byte, acc *apicompat.Buffe
 	}
 
 	output := gjson.GetBytes(data, "response.output")
-	hasAccumulatedOutput := (acc != nil && acc.HasContent()) || len(imageOutputs) > 0
+	hasAccumulatedOutput := (acc != nil && acc.HasContent()) || doneItems.HasContent() || len(imageOutputs) > 0
 	if output.Exists() && output.IsArray() {
-		if len(output.Array()) > 0 || !hasAccumulatedOutput {
+		if len(output.Array()) > 0 && !doneItems.HasContent() {
+			return data, false
+		}
+		if len(output.Array()) == 0 && !hasAccumulatedOutput {
 			return data, false
 		}
 	}
 
 	outputJSON := []byte("[]")
-	if reconstructed, ok := buildResponsesOutputJSON(acc, imageOutputs); ok {
+	fallback, _ := buildResponsesOutputJSON(acc, imageOutputs)
+	if reconstructed, ok := doneItems.MergeTerminalOutput(output, fallback); ok {
 		outputJSON = reconstructed
+	} else if len(fallback) > 0 {
+		outputJSON = fallback
+	}
+	if output.Exists() && output.IsArray() && jsonValuesEqual(outputJSON, []byte(output.Raw)) {
+		return data, false
 	}
 	updated, err := sjson.SetRawBytes(data, "response.output", outputJSON)
 	if err != nil {
 		return data, false
 	}
 	return updated, true
+}
+
+func jsonValuesEqual(left, right []byte) bool {
+	var leftValue any
+	var rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
 }
 
 func responsesStreamEventMayContributeToOutput(eventType string) bool {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -1616,16 +1615,23 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 	if (items == nil || !items.HasContent()) && len(fallback) == 0 {
 		return nil, false
 	}
-	positioned := make(map[int]json.RawMessage)
+	type positionedOutputItem struct {
+		raw      json.RawMessage
+		identity string
+	}
+	positioned := make(map[int]positionedOutputItem)
 	terminalByIdentity := make(map[string]int)
+	maxPosition := -1
 	var fallbackItems []json.RawMessage
 	if output.Exists() && output.IsArray() {
 		for index, terminalItem := range output.Array() {
 			raw := json.RawMessage(terminalItem.Raw)
-			positioned[index] = raw
-			if identity := responsesOutputItemIdentityResult(terminalItem); identity != "" {
+			identity := responsesOutputItemIdentityResult(terminalItem)
+			positioned[index] = positionedOutputItem{raw: raw, identity: identity}
+			if identity != "" {
 				terminalByIdentity[identity] = index
 			}
+			maxPosition = index
 		}
 	}
 	if len(fallback) > 0 {
@@ -1635,52 +1641,112 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 		encoded, err := json.Marshal(fallbackItems)
 		return encoded, err == nil
 	}
-	doneIndices := make([]int, 0, len(items.byIndex))
-	for index := range items.byIndex {
-		doneIndices = append(doneIndices, index)
-	}
-	sort.Ints(doneIndices)
-	for _, index := range doneIndices {
-		doneItem := items.byIndex[index].raw
-		targetIndex := index
-		if identity := items.byIndex[index].identity; identity != "" {
-			if terminalIndex, found := terminalByIdentity[identity]; found {
-				targetIndex = terminalIndex
-				doneItem = mergeMissingResponsesOutputItemFields(positioned[terminalIndex], doneItem)
-			}
-		}
-		positioned[targetIndex] = doneItem
-	}
-
-	doneIdentities := items.byIdentity
-	for _, fallbackItem := range fallbackItems {
-		if responsesFallbackRepresentedByDoneItem(fallbackItem, items, doneIdentities) {
+	doneSyntheticKeys := make(map[responsesSyntheticItemKey]struct{}, len(items.byIndex)+len(items.withoutIndex))
+	for index := 0; index <= maxResponsesOutputIndex; index++ {
+		entry := items.byIndex[index]
+		if entry == nil {
 			continue
 		}
-		index := 0
-		for {
-			if _, occupied := positioned[index]; !occupied {
-				positioned[index] = fallbackItem
-				break
+		doneItem := entry.raw
+		targetIndex := index
+		if identity := entry.identity; identity != "" {
+			if terminalIndex, found := terminalByIdentity[identity]; found {
+				targetIndex = terminalIndex
+				doneItem = mergeMissingResponsesOutputItemFields(positioned[terminalIndex].raw, doneItem)
 			}
-			index++
+		}
+		positioned[targetIndex] = positionedOutputItem{raw: doneItem, identity: entry.identity}
+		if targetIndex > maxPosition {
+			maxPosition = targetIndex
+		}
+		if key, ok := responsesSyntheticItemKeyFor(gjson.ParseBytes(entry.raw)); ok {
+			doneSyntheticKeys[key] = struct{}{}
 		}
 	}
 
-	positions := make([]int, 0, len(positioned))
-	for index := range positioned {
-		positions = append(positions, index)
+	for _, entry := range items.withoutIndex {
+		if key, ok := responsesSyntheticItemKeyFor(gjson.ParseBytes(entry.raw)); ok {
+			doneSyntheticKeys[key] = struct{}{}
+		}
 	}
-	sort.Ints(positions)
+	nextFallbackPosition := 0
+	for _, fallbackItem := range fallbackItems {
+		fallbackParsed := gjson.ParseBytes(fallbackItem)
+		if key, ok := responsesSyntheticItemKeyFor(fallbackParsed); ok {
+			if _, represented := doneSyntheticKeys[key]; represented {
+				continue
+			}
+		}
+		for {
+			if _, occupied := positioned[nextFallbackPosition]; !occupied {
+				break
+			}
+			nextFallbackPosition++
+		}
+		positioned[nextFallbackPosition] = positionedOutputItem{
+			raw:      fallbackItem,
+			identity: responsesOutputItemIdentityResult(fallbackParsed),
+		}
+		if nextFallbackPosition > maxPosition {
+			maxPosition = nextFallbackPosition
+		}
+		nextFallbackPosition++
+	}
+
 	merged := make([]json.RawMessage, 0, len(positioned)+len(items.withoutIndex))
-	for _, index := range positions {
-		merged = appendResponsesOutputItem(merged, positioned[index])
+	mergedByIdentity := make(map[string]int, len(positioned)+len(items.withoutIndex))
+	appendItem := func(item positionedOutputItem) {
+		if item.identity != "" {
+			if index, found := mergedByIdentity[item.identity]; found {
+				merged[index] = item.raw
+				return
+			}
+			mergedByIdentity[item.identity] = len(merged)
+		}
+		merged = append(merged, item.raw)
+	}
+	for index := 0; index <= maxPosition; index++ {
+		if item, exists := positioned[index]; exists {
+			appendItem(item)
+		}
 	}
 	for _, doneItem := range items.withoutIndex {
-		merged = appendResponsesOutputItem(merged, doneItem.raw)
+		appendItem(positionedOutputItem{raw: doneItem.raw, identity: doneItem.identity})
 	}
 	encoded, err := json.Marshal(merged)
 	return encoded, err == nil
+}
+
+type responsesSyntheticItemKey struct {
+	itemType  string
+	primary   string
+	secondary string
+}
+
+func responsesSyntheticItemKeyFor(item gjson.Result) (responsesSyntheticItemKey, bool) {
+	itemType := strings.TrimSpace(item.Get("type").String())
+	switch itemType {
+	case "message":
+		text := responsesItemText(item, "content")
+		if text == "" {
+			return responsesSyntheticItemKey{}, false
+		}
+		return responsesSyntheticItemKey{itemType: itemType, primary: item.Get("role").String(), secondary: text}, true
+	case "reasoning":
+		text := responsesItemText(item, "summary")
+		if text == "" {
+			return responsesSyntheticItemKey{}, false
+		}
+		return responsesSyntheticItemKey{itemType: itemType, primary: text}, true
+	case "image_generation_call":
+		result := item.Get("result").String()
+		if result == "" {
+			return responsesSyntheticItemKey{}, false
+		}
+		return responsesSyntheticItemKey{itemType: itemType, primary: result, secondary: item.Get("output_format").String()}, true
+	default:
+		return responsesSyntheticItemKey{}, false
+	}
 }
 
 func mergeMissingResponsesOutputItemFields(terminal, done json.RawMessage) json.RawMessage {
@@ -1701,55 +1767,12 @@ func mergeMissingResponsesOutputItemFields(terminal, done json.RawMessage) json.
 	return merged
 }
 
-func responsesFallbackRepresentedByDoneItem(fallback json.RawMessage, items *responsesDoneOutputItems, _ map[string]*responsesDoneOutputItem) bool {
-	for _, done := range items.byIndex {
-		if responsesSyntheticItemsEquivalent(fallback, done.raw) {
-			return true
-		}
-	}
-	for _, done := range items.withoutIndex {
-		if responsesSyntheticItemsEquivalent(fallback, done.raw) {
-			return true
-		}
-	}
-	return false
-}
-
-func responsesSyntheticItemsEquivalent(fallback, done json.RawMessage) bool {
-	fallbackItem := gjson.ParseBytes(fallback)
-	doneItem := gjson.ParseBytes(done)
-	itemType := strings.TrimSpace(fallbackItem.Get("type").String())
-	if itemType == "" || itemType != strings.TrimSpace(doneItem.Get("type").String()) {
-		return false
-	}
-	switch itemType {
-	case "message":
-		fallbackText := responsesItemText(fallbackItem, "content")
-		return fallbackText != "" && fallbackItem.Get("role").String() == doneItem.Get("role").String() &&
-			fallbackText == responsesItemText(doneItem, "content")
-	case "reasoning":
-		fallbackText := responsesItemText(fallbackItem, "summary")
-		return fallbackText != "" && fallbackText == responsesItemText(doneItem, "summary")
-	case "image_generation_call":
-		return fallbackItem.Get("result").String() != "" &&
-			fallbackItem.Get("result").String() == doneItem.Get("result").String() &&
-			fallbackItem.Get("output_format").String() == doneItem.Get("output_format").String()
-	default:
-		return false
-	}
-}
-
 func responsesItemText(item gjson.Result, path string) string {
 	var text strings.Builder
 	for _, part := range item.Get(path).Array() {
 		_, _ = text.WriteString(part.Get("text").String())
 	}
 	return text.String()
-}
-
-func responsesOutputItemIdentity(item json.RawMessage) string {
-	parsed := gjson.ParseBytes(item)
-	return responsesOutputItemIdentityResult(parsed)
 }
 
 func responsesOutputItemIdentityResult(parsed gjson.Result) string {
@@ -1760,19 +1783,6 @@ func responsesOutputItemIdentityResult(parsed gjson.Result) string {
 		return "call_id:" + callID
 	}
 	return ""
-}
-
-func appendResponsesOutputItem(output []json.RawMessage, item json.RawMessage) []json.RawMessage {
-	identity := responsesOutputItemIdentity(item)
-	if identity != "" {
-		for index, candidate := range output {
-			if responsesOutputItemIdentity(candidate) == identity {
-				output[index] = item
-				return output
-			}
-		}
-	}
-	return append(output, item)
 }
 
 func normalizeResponsesStreamingTerminalOutput(data []byte, acc *apicompat.BufferedResponseAccumulator, doneItems *responsesDoneOutputItems, imageOutputs []json.RawMessage) ([]byte, bool) {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1464,10 +1464,19 @@ func normalizeCompletedImageGenerationStatus(data []byte) ([]byte, bool) {
 }
 
 type responsesDoneOutputItems struct {
-	byIndex      map[int]json.RawMessage
-	withoutIndex []json.RawMessage
+	byIndex      map[int]*responsesDoneOutputItem
+	withoutIndex []*responsesDoneOutputItem
+	byIdentity   map[string]*responsesDoneOutputItem
 	totalBytes   int
 	overflowed   bool
+}
+
+type responsesDoneOutputItem struct {
+	raw                  json.RawMessage
+	identity             string
+	outputIndex          int
+	withoutIndexPosition int
+	hasOutputIndex       bool
 }
 
 const (
@@ -1477,7 +1486,10 @@ const (
 )
 
 func newResponsesDoneOutputItems() *responsesDoneOutputItems {
-	return &responsesDoneOutputItems{byIndex: make(map[int]json.RawMessage)}
+	return &responsesDoneOutputItems{
+		byIndex:    make(map[int]*responsesDoneOutputItem),
+		byIdentity: make(map[string]*responsesDoneOutputItem),
+	}
 }
 
 func (items *responsesDoneOutputItems) ProcessEvent(data []byte, eventType string) {
@@ -1491,18 +1503,24 @@ func (items *responsesDoneOutputItems) ProcessEvent(data []byte, eventType strin
 	if items.overflowed {
 		return
 	}
-	raw := json.RawMessage(item.Raw)
+	entry := &responsesDoneOutputItem{
+		raw:      json.RawMessage(item.Raw),
+		identity: responsesOutputItemIdentityResult(item),
+	}
+	raw := entry.raw
 	if len(raw) > maxResponsesDoneOutputBytes {
 		items.discardOnOverflow()
 		return
 	}
 	indexResult := gjson.GetBytes(data, "output_index")
 	if !indexResult.Exists() {
-		items.removeIdentity(responsesOutputItemIdentity(raw))
+		items.removeIdentity(entry.identity)
 		if !items.reserve(raw, 0) {
 			return
 		}
-		items.withoutIndex = append(items.withoutIndex, raw)
+		entry.withoutIndexPosition = len(items.withoutIndex)
+		items.withoutIndex = append(items.withoutIndex, entry)
+		items.indexIdentity(entry)
 		items.totalBytes += len(raw)
 		return
 	}
@@ -1510,15 +1528,17 @@ func (items *responsesDoneOutputItems) ProcessEvent(data []byte, eventType strin
 	if !ok {
 		return
 	}
-	items.removeIdentity(responsesOutputItemIdentity(raw))
-	previous := items.byIndex[index]
-	if !items.reserve(raw, len(previous)) {
+	items.removeIdentity(entry.identity)
+	if previous := items.byIndex[index]; previous != nil {
+		items.remove(previous)
+	}
+	if !items.reserve(raw, 0) {
 		return
 	}
-	if previous, ok := items.byIndex[index]; ok {
-		items.totalBytes -= len(previous)
-	}
-	items.byIndex[index] = raw
+	entry.outputIndex = index
+	entry.hasOutputIndex = true
+	items.byIndex[index] = entry
+	items.indexIdentity(entry)
 	items.totalBytes += len(raw)
 }
 
@@ -1532,8 +1552,9 @@ func (items *responsesDoneOutputItems) reserve(item json.RawMessage, replacedByt
 }
 
 func (items *responsesDoneOutputItems) discardOnOverflow() {
-	items.byIndex = make(map[int]json.RawMessage)
+	items.byIndex = make(map[int]*responsesDoneOutputItem)
 	items.withoutIndex = nil
+	items.byIdentity = make(map[string]*responsesDoneOutputItem)
 	items.totalBytes = 0
 	items.overflowed = true
 }
@@ -1542,18 +1563,38 @@ func (items *responsesDoneOutputItems) removeIdentity(identity string) {
 	if identity == "" {
 		return
 	}
-	for index, item := range items.byIndex {
-		if responsesOutputItemIdentity(item) == identity {
-			items.totalBytes -= len(item)
-			delete(items.byIndex, index)
+	if entry := items.byIdentity[identity]; entry != nil {
+		items.remove(entry)
+	}
+}
+
+func (items *responsesDoneOutputItems) indexIdentity(entry *responsesDoneOutputItem) {
+	if entry.identity != "" {
+		items.byIdentity[entry.identity] = entry
+	}
+}
+
+func (items *responsesDoneOutputItems) remove(entry *responsesDoneOutputItem) {
+	if entry.identity != "" && items.byIdentity[entry.identity] == entry {
+		delete(items.byIdentity, entry.identity)
+	}
+	if entry.hasOutputIndex {
+		if items.byIndex[entry.outputIndex] == entry {
+			delete(items.byIndex, entry.outputIndex)
+		}
+	} else {
+		position := entry.withoutIndexPosition
+		last := len(items.withoutIndex) - 1
+		if position >= 0 && position <= last && items.withoutIndex[position] == entry {
+			if position != last {
+				moved := items.withoutIndex[last]
+				items.withoutIndex[position] = moved
+				moved.withoutIndexPosition = position
+			}
+			items.withoutIndex = items.withoutIndex[:last]
 		}
 	}
-	for index := len(items.withoutIndex) - 1; index >= 0; index-- {
-		if responsesOutputItemIdentity(items.withoutIndex[index]) == identity {
-			items.totalBytes -= len(items.withoutIndex[index])
-			items.withoutIndex = append(items.withoutIndex[:index], items.withoutIndex[index+1:]...)
-		}
-	}
+	items.totalBytes -= len(entry.raw)
 }
 
 func validResponsesOutputIndex(result gjson.Result) (int, bool) {
@@ -1576,10 +1617,15 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 		return nil, false
 	}
 	positioned := make(map[int]json.RawMessage)
+	terminalByIdentity := make(map[string]int)
 	var fallbackItems []json.RawMessage
 	if output.Exists() && output.IsArray() {
 		for index, terminalItem := range output.Array() {
-			positioned[index] = json.RawMessage(terminalItem.Raw)
+			raw := json.RawMessage(terminalItem.Raw)
+			positioned[index] = raw
+			if identity := responsesOutputItemIdentityResult(terminalItem); identity != "" {
+				terminalByIdentity[identity] = index
+			}
 		}
 	}
 	if len(fallback) > 0 {
@@ -1595,21 +1641,20 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 	}
 	sort.Ints(doneIndices)
 	for _, index := range doneIndices {
-		doneItem := items.byIndex[index]
+		doneItem := items.byIndex[index].raw
 		targetIndex := index
-		if identity := responsesOutputItemIdentity(doneItem); identity != "" {
-			for terminalIndex, terminalItem := range positioned {
-				if responsesOutputItemIdentity(terminalItem) == identity {
-					targetIndex = terminalIndex
-					break
-				}
+		if identity := items.byIndex[index].identity; identity != "" {
+			if terminalIndex, found := terminalByIdentity[identity]; found {
+				targetIndex = terminalIndex
+				doneItem = mergeMissingResponsesOutputItemFields(positioned[terminalIndex], doneItem)
 			}
 		}
 		positioned[targetIndex] = doneItem
 	}
 
+	doneIdentities := items.byIdentity
 	for _, fallbackItem := range fallbackItems {
-		if responsesFallbackRepresentedByDoneItem(fallbackItem, items) {
+		if responsesFallbackRepresentedByDoneItem(fallbackItem, items, doneIdentities) {
 			continue
 		}
 		index := 0
@@ -1632,20 +1677,38 @@ func (items *responsesDoneOutputItems) MergeTerminalOutput(output gjson.Result, 
 		merged = appendResponsesOutputItem(merged, positioned[index])
 	}
 	for _, doneItem := range items.withoutIndex {
-		merged = appendResponsesOutputItem(merged, doneItem)
+		merged = appendResponsesOutputItem(merged, doneItem.raw)
 	}
 	encoded, err := json.Marshal(merged)
 	return encoded, err == nil
 }
 
-func responsesFallbackRepresentedByDoneItem(fallback json.RawMessage, items *responsesDoneOutputItems) bool {
+func mergeMissingResponsesOutputItemFields(terminal, done json.RawMessage) json.RawMessage {
+	var terminalFields map[string]json.RawMessage
+	var doneFields map[string]json.RawMessage
+	if json.Unmarshal(terminal, &terminalFields) != nil || json.Unmarshal(done, &doneFields) != nil {
+		return terminal
+	}
+	for field, value := range doneFields {
+		if _, exists := terminalFields[field]; !exists {
+			terminalFields[field] = value
+		}
+	}
+	merged, err := json.Marshal(terminalFields)
+	if err != nil {
+		return terminal
+	}
+	return merged
+}
+
+func responsesFallbackRepresentedByDoneItem(fallback json.RawMessage, items *responsesDoneOutputItems, _ map[string]*responsesDoneOutputItem) bool {
 	for _, done := range items.byIndex {
-		if responsesSyntheticItemsEquivalent(fallback, done) {
+		if responsesSyntheticItemsEquivalent(fallback, done.raw) {
 			return true
 		}
 	}
 	for _, done := range items.withoutIndex {
-		if responsesSyntheticItemsEquivalent(fallback, done) {
+		if responsesSyntheticItemsEquivalent(fallback, done.raw) {
 			return true
 		}
 	}
@@ -1686,6 +1749,10 @@ func responsesItemText(item gjson.Result, path string) string {
 
 func responsesOutputItemIdentity(item json.RawMessage) string {
 	parsed := gjson.ParseBytes(item)
+	return responsesOutputItemIdentityResult(parsed)
+}
+
+func responsesOutputItemIdentityResult(parsed gjson.Result) string {
 	if id := strings.TrimSpace(parsed.Get("id").String()); id != "" {
 		return "id:" + id
 	}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -2008,12 +2007,14 @@ func TestResponsesDoneOutputItemsMergeMatchesTerminalIdentityBeforeIndex(t *test
 	output := gjson.Parse(`[{"id":"call-function","type":"function_call","status":"in_progress"},{"id":"call-search","type":"tool_search_call","status":"in_progress"}]`)
 	merged, ok := items.MergeTerminalOutput(output, nil)
 	require.True(t, ok)
+	// 位置按 identity 重排：terminal 中 call-function 在 0，call-search 在 1
 	require.Equal(t, "call-function", gjson.GetBytes(merged, "0.id").String())
 	require.Equal(t, "function_call", gjson.GetBytes(merged, "0.type").String())
-	require.Equal(t, "completed", gjson.GetBytes(merged, "0.status").String())
+	// terminal 已有字段权威，保留 in_progress
+	require.Equal(t, "in_progress", gjson.GetBytes(merged, "0.status").String())
 	require.Equal(t, "call-search", gjson.GetBytes(merged, "1.id").String())
 	require.Equal(t, "tool_search_call", gjson.GetBytes(merged, "1.type").String())
-	require.Equal(t, "completed", gjson.GetBytes(merged, "1.status").String())
+	require.Equal(t, "in_progress", gjson.GetBytes(merged, "1.status").String())
 }
 
 func TestResponsesDoneOutputItemsMergeRetainsDeltaFallback(t *testing.T) {
@@ -2038,10 +2039,10 @@ func TestResponsesDoneOutputItemsRejectsMalformedIndicesAndAssignsMissing(t *tes
 	items.ProcessEvent([]byte(`{"item":{"id":"missing-1"}}`), "response.output_item.done")
 
 	require.Empty(t, items.byIndex)
-	require.Equal(t, []json.RawMessage{
-		json.RawMessage(`{"id":"missing-0"}`),
-		json.RawMessage(`{"id":"missing-1"}`),
-	}, items.withoutIndex)
+	require.Equal(t, []string{"missing-0", "missing-1"}, []string{
+		items.withoutIndex[0].identity[len("id:"):],
+		items.withoutIndex[1].identity[len("id:"):],
+	})
 }
 
 func TestResponsesDoneOutputItemsRejectsHugeIndexWithoutGrowingOutput(t *testing.T) {
@@ -2076,6 +2077,17 @@ func TestResponsesDoneOutputItemsMissingIndexAlreadyInTerminalOutput(t *testing.
 	require.Equal(t, "completed", gjson.GetBytes(merged, "0.status").String())
 }
 
+func TestResponsesDoneOutputItemsTerminalFieldsWinWhileDoneOnlyFieldsAreAdded(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"msg-1","type":"message","status":"completed","encrypted_content":"opaque"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[{"id":"msg-1","type":"message","status":"in_progress","content":[{"type":"output_text","text":"terminal"}]}]`), nil)
+	require.True(t, ok)
+	require.Equal(t, "in_progress", gjson.GetBytes(merged, "0.status").String())
+	require.Equal(t, "terminal", gjson.GetBytes(merged, "0.content.0.text").String())
+	require.Equal(t, "opaque", gjson.GetBytes(merged, "0.encrypted_content").String())
+}
+
 func TestResponsesDoneOutputItemsDuplicateIdentityAtDifferentIndices(t *testing.T) {
 	items := newResponsesDoneOutputItems()
 	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"fc-1","type":"function_call","arguments":"old"}}`), "response.output_item.done")
@@ -2085,6 +2097,15 @@ func TestResponsesDoneOutputItemsDuplicateIdentityAtDifferentIndices(t *testing.
 	require.True(t, ok)
 	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
 	require.Equal(t, "final", gjson.GetBytes(merged, "0.arguments").String())
+}
+
+func TestResponsesDoneOutputItemsCachesIdentityAndMaintainsLookupIndex(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":3,"item":{"id":"fc-1","type":"function_call"}}`), "response.output_item.done")
+
+	entry := items.byIndex[3]
+	require.Equal(t, "id:fc-1", entry.identity)
+	require.Same(t, entry, items.byIdentity["id:fc-1"])
 }
 
 func TestResponsesDoneOutputItemsRetainsMultipleSameTypeFallbackItems(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2200,6 +2200,21 @@ func TestResponsesDoneOutputItemsSparseDoneOnlyOutputHasNoNulls(t *testing.T) {
 	require.NotContains(t, string(merged), "null")
 }
 
+func TestResponsesDoneOutputItemsFinalIdentityDedupKeepsFirstPositionAndLatestItem(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"item":{"id":"shared","type":"message","status":"completed"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(
+		gjson.Parse(`[{"id":"shared","type":"message","status":"in_progress"},{"id":"other","type":"reasoning"}]`),
+		nil,
+	)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 2)
+	require.Equal(t, "shared", gjson.GetBytes(merged, "0.id").String())
+	require.Equal(t, "completed", gjson.GetBytes(merged, "0.status").String())
+	require.Equal(t, "other", gjson.GetBytes(merged, "1.id").String())
+}
+
 func TestOpenAIStreamingNormalizesTerminalOutputToEmptyArray(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/cespare/xxhash/v2"
 	"github.com/gin-gonic/gin"
@@ -1947,6 +1949,218 @@ func TestOpenAIStreamingNormalizesTerminalOutputFromDeltas(t *testing.T) {
 	require.True(t, output.IsArray())
 	require.Len(t, output.Array(), 1)
 	require.Equal(t, "pong", gjson.GetBytes(terminalPayload, "response.output.0.content.0.text").String())
+}
+
+func TestOpenAIStreamingTerminalOutputUsesLatestAuthoritativeDoneItem(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_old","type":"message","role":"assistant","status":"in_progress","content":[{"type":"output_text","text":"old","annotations":[]}]}}`,
+			"",
+			`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_done","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"final","annotations":[]}]}}`,
+			"",
+			`data: {"type":"response.completed","response":{"id":"resp_done","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"final"}]}],"usage":{"input_tokens":1,"output_tokens":1}}}`,
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	terminalType, terminalPayload, ok := extractOpenAISSETerminalEvent(rec.Body.String())
+	require.True(t, ok)
+	require.Equal(t, "response.completed", terminalType)
+	item := gjson.GetBytes(terminalPayload, "response.output.0")
+	require.Equal(t, "msg_done", item.Get("id").String())
+	require.Equal(t, "completed", item.Get("status").String())
+	require.Equal(t, "final", item.Get("content.0.text").String())
+	annotations := item.Get("content.0.annotations")
+	require.True(t, annotations.Exists())
+	require.True(t, annotations.IsArray())
+}
+
+func TestResponsesDoneOutputItemsMergeSparseOutOfOrder(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":2,"item":{"id":"done-2","type":"function_call"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"done-0","type":"reasoning"}}`), "response.output_item.done")
+
+	output := gjson.Parse(`[{"id":"slim-0","type":"reasoning"},{"id":"terminal-1","type":"message"}]`)
+	merged, ok := items.MergeTerminalOutput(output, nil)
+	require.True(t, ok)
+	require.Equal(t, "done-0", gjson.GetBytes(merged, "0.id").String())
+	require.Equal(t, "terminal-1", gjson.GetBytes(merged, "1.id").String())
+	require.Equal(t, "done-2", gjson.GetBytes(merged, "2.id").String())
+}
+
+func TestResponsesDoneOutputItemsMergeRetainsDeltaFallback(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"compact-0","type":"compaction","encrypted_content":"opaque"}}`), "response.output_item.done")
+	acc := apicompat.NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&apicompat.ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "fallback text"})
+
+	terminal := []byte(`{"type":"response.completed","response":{"output":[]}}`)
+	normalized, ok := normalizeResponsesStreamingTerminalOutput(terminal, acc, items, nil)
+	require.True(t, ok)
+	require.Equal(t, "compact-0", gjson.GetBytes(normalized, "response.output.0.id").String())
+	require.Equal(t, "fallback text", gjson.GetBytes(normalized, "response.output.1.content.0.text").String())
+}
+
+func TestResponsesDoneOutputItemsRejectsMalformedIndicesAndAssignsMissing(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":-1,"item":{"id":"negative"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":0.5,"item":{"id":"fractional"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":"0","item":{"id":"string"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"item":{"id":"missing-0"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"item":{"id":"missing-1"}}`), "response.output_item.done")
+
+	require.Empty(t, items.byIndex)
+	require.Equal(t, []json.RawMessage{
+		json.RawMessage(`{"id":"missing-0"}`),
+		json.RawMessage(`{"id":"missing-1"}`),
+	}, items.withoutIndex)
+}
+
+func TestResponsesDoneOutputItemsRejectsHugeIndexWithoutGrowingOutput(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":999999999999999999999999,"item":{"id":"huge"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":4097,"item":{"id":"over-limit"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[{"id":"terminal"}]`), nil)
+	require.False(t, ok)
+	require.Nil(t, merged)
+	require.Empty(t, items.byIndex)
+}
+
+func TestResponsesDoneOutputItemsKeepsMissingItemWhenExplicitIndexArrives(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"item":{"id":"missing"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"explicit"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), nil)
+	require.True(t, ok)
+	require.Equal(t, "explicit", gjson.GetBytes(merged, "0.id").String())
+	require.Equal(t, "missing", gjson.GetBytes(merged, "1.id").String())
+}
+
+func TestResponsesDoneOutputItemsMissingIndexAlreadyInTerminalOutput(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"item":{"id":"msg-1","type":"message","status":"completed"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[{"id":"msg-1","type":"message"}]`), nil)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
+	require.Equal(t, "completed", gjson.GetBytes(merged, "0.status").String())
+}
+
+func TestResponsesDoneOutputItemsDuplicateIdentityAtDifferentIndices(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"fc-1","type":"function_call","arguments":"old"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":4,"item":{"id":"fc-1","type":"function_call","arguments":"final"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), nil)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
+	require.Equal(t, "final", gjson.GetBytes(merged, "0.arguments").String())
+}
+
+func TestResponsesDoneOutputItemsRetainsMultipleSameTypeFallbackItems(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	fallback := []byte(`[{"type":"message","content":[{"type":"output_text","text":"one"}]},{"type":"message","content":[{"type":"output_text","text":"two"}]}]`)
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 2)
+	require.Equal(t, "one", gjson.GetBytes(merged, "0.content.0.text").String())
+	require.Equal(t, "two", gjson.GetBytes(merged, "1.content.0.text").String())
+}
+
+func TestResponsesDoneOutputItemsSparseIndicesDoNotOverwriteFallbackItems(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":3,"item":{"id":"fc-done","type":"function_call","call_id":"call-1"}}`), "response.output_item.done")
+	fallback := []byte(`[{"id":"reasoning-fallback","type":"reasoning"},{"id":"message-fallback","type":"message"},{"id":"fc-fallback","type":"function_call","call_id":"call-2"}]`)
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.JSONEq(t, `[{"id":"reasoning-fallback","type":"reasoning"},{"id":"message-fallback","type":"message"},{"id":"fc-fallback","type":"function_call","call_id":"call-2"},{"id":"fc-done","type":"function_call","call_id":"call-1"}]`, string(merged))
+}
+
+func TestResponsesDoneMessageSuppressesTextDeltaFallback(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"final"}]}}`), "response.output_item.done")
+	acc := apicompat.NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&apicompat.ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "final"})
+	fallback, ok := buildResponsesOutputJSON(acc, nil)
+	require.True(t, ok)
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
+	require.Equal(t, "final", gjson.GetBytes(merged, "0.content.0.text").String())
+}
+
+func TestResponsesDoneReasoningSuppressesReasoningDeltaFallback(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}]}}`), "response.output_item.done")
+	acc := apicompat.NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&apicompat.ResponsesStreamEvent{Type: "response.reasoning_summary_text.delta", Delta: "thought"})
+	fallback, ok := buildResponsesOutputJSON(acc, nil)
+	require.True(t, ok)
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
+	require.Equal(t, "thought", gjson.GetBytes(merged, "0.summary.0.text").String())
+}
+
+func TestResponsesDoneImageSuppressesIDLessImageFallback(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"type":"image_generation_call","status":"completed","output_format":"png","result":"image-data"}}`), "response.output_item.done")
+	fallback := []byte(`[{"type":"image_generation_call","status":"completed","output_format":"png","result":"image-data"}]`)
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.Len(t, gjson.ParseBytes(merged).Array(), 1)
+	require.Equal(t, "image-data", gjson.GetBytes(merged, "0.result").String())
+}
+
+func TestResponsesDoneOutputItemsNilWithFallback(t *testing.T) {
+	fallback := []byte(`[{"type":"message","content":[{"type":"output_text","text":"fallback"}]}]`)
+
+	merged, ok := (*responsesDoneOutputItems)(nil).MergeTerminalOutput(gjson.Parse(`[]`), fallback)
+	require.True(t, ok)
+	require.JSONEq(t, string(fallback), string(merged))
+}
+
+func TestResponsesDoneOutputItemsOverflowFallsBackToTerminalOutput(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	for index := 0; index <= maxResponsesDoneOutputItems; index++ {
+		items.ProcessEvent([]byte(fmt.Sprintf(`{"item":{"id":"item-%d"}}`, index)), "response.output_item.done")
+	}
+
+	require.True(t, items.overflowed)
+	require.False(t, items.HasContent())
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[{"id":"terminal","type":"message"}]`), nil)
+	require.False(t, ok)
+	require.Nil(t, merged)
+}
+
+func TestResponsesDoneOutputItemsSparseDoneOnlyOutputHasNoNulls(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":1000,"item":{"id":"done-1000"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":2,"item":{"id":"done-2"}}`), "response.output_item.done")
+
+	merged, ok := items.MergeTerminalOutput(gjson.Parse(`[]`), nil)
+	require.True(t, ok)
+	require.JSONEq(t, `[{"id":"done-2"},{"id":"done-1000"}]`, string(merged))
+	require.NotContains(t, string(merged), "null")
 }
 
 func TestOpenAIStreamingNormalizesTerminalOutputToEmptyArray(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2000,6 +2000,22 @@ func TestResponsesDoneOutputItemsMergeSparseOutOfOrder(t *testing.T) {
 	require.Equal(t, "done-2", gjson.GetBytes(merged, "2.id").String())
 }
 
+func TestResponsesDoneOutputItemsMergeMatchesTerminalIdentityBeforeIndex(t *testing.T) {
+	items := newResponsesDoneOutputItems()
+	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"call-search","type":"tool_search_call","status":"completed"}}`), "response.output_item.done")
+	items.ProcessEvent([]byte(`{"output_index":1,"item":{"id":"call-function","type":"function_call","status":"completed"}}`), "response.output_item.done")
+
+	output := gjson.Parse(`[{"id":"call-function","type":"function_call","status":"in_progress"},{"id":"call-search","type":"tool_search_call","status":"in_progress"}]`)
+	merged, ok := items.MergeTerminalOutput(output, nil)
+	require.True(t, ok)
+	require.Equal(t, "call-function", gjson.GetBytes(merged, "0.id").String())
+	require.Equal(t, "function_call", gjson.GetBytes(merged, "0.type").String())
+	require.Equal(t, "completed", gjson.GetBytes(merged, "0.status").String())
+	require.Equal(t, "call-search", gjson.GetBytes(merged, "1.id").String())
+	require.Equal(t, "tool_search_call", gjson.GetBytes(merged, "1.type").String())
+	require.Equal(t, "completed", gjson.GetBytes(merged, "1.status").String())
+}
+
 func TestResponsesDoneOutputItemsMergeRetainsDeltaFallback(t *testing.T) {
 	items := newResponsesDoneOutputItems()
 	items.ProcessEvent([]byte(`{"output_index":0,"item":{"id":"compact-0","type":"compaction","encrypted_content":"opaque"}}`), "response.output_item.done")


### PR DESCRIPTION
## 问题

OpenAI 流式响应完成后，终态响应中的 `output` 项可能丢失已完成的消息、推理或图像生成结果，导致下游收到不完整的输出结构。

## 根因

流式事件聚合仅保留了部分终态字段，未按输出项类型完整累积并还原已完成内容。此外，流式 done 事件的 `output_index` 顺序可能与终态 `response.output` 顺序不同，按索引直接覆盖会破坏已恢复的客户端工具类型。

## 改动

- 在流式响应处理中保留并组装已完成的消息、推理和图像输出项。
- 合并终态输出时优先通过 `id` / `call_id` 匹配项目，保留终态输出顺序。
- 补充终态输出项、消息、推理、图像及输出顺序场景的回归测试。

## 测试

- `go test -tags=unit ./internal/service -run "TestOpenAIStreamingTerminalOutput|TestResponsesDone(OutputItems|Message|Reasoning|Image)" -count=1`
- `go test -tags=unit ./internal/service -run '^TestForwardGrokResponsesAPIKeyRestoresClientToolsStreaming$' -count=1`
- `env -u OPENAI_API_KEY make test-unit`
- `env -u OPENAI_API_KEY make test-integration`
- `go vet ./internal/service`
- `golangci-lint v2.9.0 run --timeout=30m`
- `git diff --check`
- 静态新增行安全扫描无发现。
- GitHub Actions 的 test、golangci-lint、frontend、shell 和安全检查均通过。

Fixes #5140