### PR TITLE
fix(admin-ui): 退款 require_force 前端接线，补上无法完成的退款场景

### DIFF
--- a/frontend/src/views/admin/orders/AdminOrdersView.vue
+++ b/frontend/src/views/admin/orders/AdminOrdersView.vue
@@ -111,7 +111,7 @@
       </div>
     </BaseDialog>
 
-    <AdminRefundDialog :show="showRefundDialog" :order="selectedOrder" :submitting="refundSubmitting" @confirm="handleRefund" @cancel="showRefundDialog = false" />
+    <AdminRefundDialog :show="showRefundDialog" :order="selectedOrder" :submitting="refundSubmitting" :require-force="refundRequireForce" :warning="refundWarning" @confirm="handleRefund" @cancel="closeRefundDialog" />
   </AppLayout>
 </template>
 
@@ -153,6 +153,8 @@ const selectedOrder = ref<PaymentOrder | null>(null)
 const showDetailDialog = ref(false)
 const showRefundDialog = ref(false)
 const refundSubmitting = ref(false)
+const refundRequireForce = ref(false)
+const refundWarning = ref('')
 const refundQueryingIds = ref(new Set<number>())
 const orderAuditLogs = ref<AuditLog[]>([])
 const creditedAmountSymbol = currencySymbol('USD')
@@ -235,7 +237,18 @@ async function handleRetryOrder(order: PaymentOrder) {
   catch (err: unknown) { appStore.showError(extractI18nErrorMessage(err, t, 'payment.errors', t('common.error'))) }
 }
 
-function openRefundDialog(order: PaymentOrder) { selectedOrder.value = order; showRefundDialog.value = true }
+function openRefundDialog(order: PaymentOrder) {
+  selectedOrder.value = order
+  refundRequireForce.value = false
+  refundWarning.value = ''
+  showRefundDialog.value = true
+}
+
+function closeRefundDialog() {
+  showRefundDialog.value = false
+  refundRequireForce.value = false
+  refundWarning.value = ''
+}
 
 function isRefundPendingWarning(warning: string | undefined): boolean {
   return /pending|处理中|待/.test(String(warning || '').toLowerCase())
@@ -248,14 +261,22 @@ async function handleRefund(data: { amount: number; reason: string; deduct_balan
     const res = await adminPaymentAPI.refundOrder(selectedOrder.value.id, { amount: data.amount, reason: data.reason, deduct_balance: data.deduct_balance, force: data.force })
     if (res.data.success) {
       appStore.showSuccess(t('payment.admin.refundSuccess'))
-      showRefundDialog.value = false
+      closeRefundDialog()
       loadOrders()
       return
     }
     if (isRefundPendingWarning(res.data.warning)) {
       appStore.showSuccess(t('payment.admin.refundPending'))
-      showRefundDialog.value = false
+      closeRefundDialog()
       loadOrders()
+      return
+    }
+    if (res.data.require_force) {
+      // Backend needs an explicit force confirmation (e.g. the user spent their
+      // balance after requesting the refund). Keep the dialog open and surface
+      // the force checkbox instead of dropping the admin back to the list.
+      refundRequireForce.value = true
+      refundWarning.value = res.data.warning || ''
       return
     }
     appStore.showError(res.data.warning || t('common.error'))


### PR DESCRIPTION
## 问题

`AdminRefundDialog` 本身已经实现了 `requireForce` prop——会渲染 force 复选框、并在未勾选时禁用提交按钮（`AdminRefundDialog.vue:156`、`:240`）。但 `AdminOrdersView` 既没有消费退款响应里的 `require_force` 字段，也没有给弹窗绑定 `:require-force`（`AdminOrdersView.vue:114`），**所以这个复选框永远不会渲染**。

后果：当后端返回 `require_force`（比如用户在申请退款后把余额消费掉了）时，管理员只看到一个错误 toast、弹窗直接关闭，**在 UI 上没有任何办法完成这笔退款**，只能去改库或走 API。

`require_force` 字段在 API 类型里本来就有定义（`api/admin/payment.ts:59`），纯粹是 View 层漏了接线。

## 改动

- 新增 `refundRequireForce` / `refundWarning` 两个 ref，绑定给弹窗
- `handleRefund` 收到 `require_force` 时**保持弹窗打开**、置位标志并把后端 warning 透传给弹窗展示，管理员勾选确认后可直接重新提交
- 抽出 `closeRefundDialog()`，在弹窗打开和关闭时复位标志，避免状态残留到下一个订单

弹窗组件自身逻辑本来就是完整的，本 PR 只补 View 层缺失的接线，未改动组件行为。

## 验证

`npm run typecheck`（`vue-tsc --noEmit`）通过，无报错。

## 相关

这个 UI 缺口在 #5191 里被顺带提到（后端在余额不足时静默缩水扣减的问题）。即使不采纳那个 issue 的后端改动，本 PR 也是独立有效的——现有代码已经存在会返回 `require_force` 的分支（例如「找不到有效订阅」），同样受这个缺口影响。