### PR TITLE
fix(payment): make Stripe refunds idempotent

### DIFF
--- a/backend/internal/payment/provider/stripe.go
+++ b/backend/internal/payment/provider/stripe.go
@@ -230,6 +230,7 @@ func (s *Stripe) Refund(ctx context.Context, req payment.RefundRequest) (*paymen
 		Amount:        stripe.Int64(amountInMinorUnit),
 		Reason:        stripe.String(string(stripe.RefundReasonRequestedByCustomer)),
 	}
+	params.SetIdempotencyKey(fmt.Sprintf("re-%s-%d", req.OrderID, amountInMinorUnit))
 	params.Context = ctx
 
 	r, err := s.sc.V1Refunds.Create(ctx, params)

--- a/backend/internal/payment/provider/stripe_test.go
+++ b/backend/internal/payment/provider/stripe_test.go
@@ -1,0 +1,70 @@
+//go:build unit
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/payment"
+	"github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v85"
+)
+
+type stripeRefundBackend struct {
+	params []*stripe.RefundCreateParams
+}
+
+func (b *stripeRefundBackend) Call(_ string, _ string, _ string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+	b.params = append(b.params, params.(*stripe.RefundCreateParams))
+	refund := v.(*stripe.Refund)
+	refund.ID = "re_123"
+	refund.Status = stripe.RefundStatusSucceeded
+	return nil
+}
+
+func (*stripeRefundBackend) CallStreaming(string, string, string, stripe.ParamsContainer, stripe.StreamingLastResponseSetter) error {
+	return nil
+}
+
+func (*stripeRefundBackend) CallRaw(string, string, string, []byte, *stripe.Params, stripe.LastResponseSetter) error {
+	return nil
+}
+
+func (*stripeRefundBackend) CallMultipart(string, string, string, string, *bytes.Buffer, *stripe.Params, stripe.LastResponseSetter) error {
+	return nil
+}
+
+func (*stripeRefundBackend) SetMaxNetworkRetries(int64) {}
+
+func TestStripeRefundUsesStableAmountSpecificIdempotencyKey(t *testing.T) {
+	backend := &stripeRefundBackend{}
+	client := stripe.NewClient("sk_test", stripe.WithBackends(&stripe.Backends{API: backend}))
+	provider := &Stripe{
+		config:      map[string]string{"currency": "CNY"},
+		initialized: true,
+		sc:          client,
+	}
+
+	refund := func(amount string) {
+		_, err := provider.Refund(context.Background(), payment.RefundRequest{
+			TradeNo: "pi_123",
+			OrderID: "sub2_order_456",
+			Amount:  amount,
+		})
+		require.NoError(t, err)
+	}
+
+	refund("12.34")
+	refund("12.34")
+	refund("12.35")
+
+	require.Len(t, backend.params, 3)
+	require.Equal(t, int64(1234), *backend.params[0].Amount)
+	require.Equal(t, "re-sub2_order_456-1234", *backend.params[0].IdempotencyKey)
+	require.Equal(t, backend.params[0].IdempotencyKey, backend.params[1].IdempotencyKey)
+	require.Equal(t, int64(1235), *backend.params[2].Amount)
+	require.Equal(t, "re-sub2_order_456-1235", *backend.params[2].IdempotencyKey)
+	require.NotEqual(t, *backend.params[0].IdempotencyKey, *backend.params[2].IdempotencyKey)
+}


### PR DESCRIPTION
## 问题

Stripe 退款请求在结果不确定后重试时缺少稳定的幂等键，可能在 Stripe 侧重复创建真实退款，部分退款尤其容易造成资损。

## 根因

`Stripe.Refund` 已将退款金额转换为最小货币单位，但未像支付创建路径一样设置 Stripe 幂等键。stripe-go 因而会为每次调用生成不同键，无法把同一退款的重试归并到首次请求。

## 改动

- 使用订单 ID 和最小货币单位金额构造稳定的退款幂等键
- 同一订单、同一金额的重试复用同一键，不同金额保持独立
- 增加 Stripe SDK 参数级单元测试，覆盖稳定性和金额区分

重复预检未发现与 #5187 重叠的开放或已关闭 PR。

## 验证

- `cd backend && go test ./internal/payment/provider -count=1`
- `cd backend && go test -tags=unit ./internal/payment/provider -count=1`
- `cd backend && go vet ./internal/payment/provider`
- `git diff --check`

以上命令均通过。

Fixes #5187
