### PR TITLE
feat(usage): 使用记录表新增 TPS 列

### DIFF
--- a/frontend/src/components/admin/usage/UsageTable.vue
+++ b/frontend/src/components/admin/usage/UsageTable.vue
@@ -216,6 +216,12 @@
           </div>
         </template>
 
+        <template #cell-tps="{ row }">
+          <span class="font-medium tabular-nums text-gray-900 dark:text-white">
+            {{ formatTps(row) }}
+          </span>
+        </template>
+
         <template #cell-created_at="{ value }">
           <span class="text-sm text-gray-600 dark:text-gray-400">{{ formatDateTime(value) }}</span>
         </template>
@@ -614,6 +620,20 @@ const formatDuration = (ms: number | null | undefined): string => {
   const totalSec = Math.round(ms / 1000)
   if (totalSec < 3600) return `${Math.floor(totalSec / 60)}m ${totalSec % 60}s`
   return `${Math.floor(totalSec / 3600)}h ${Math.floor((totalSec % 3600) / 60)}m`
+}
+
+const formatTps = (row: Pick<AdminUsageLog, 'output_tokens' | 'duration_ms' | 'image_count' | 'image_output_tokens'>): string => {
+  if (
+    row.image_count > 0
+    || row.image_output_tokens > 0
+    || !Number.isFinite(row.output_tokens)
+    || row.output_tokens <= 0
+    || !Number.isFinite(row.duration_ms)
+    || row.duration_ms == null
+    || row.duration_ms <= 0
+  ) return '-'
+
+  return (row.output_tokens * 1000 / row.duration_ms).toFixed(2)
 }
 
 // Cost tooltip functions

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -312,6 +312,7 @@ export default {
     latency: 'Latency',
     latencyFirstToken: 'First',
     latencyDuration: 'Total',
+    tps: 'TPS (tokens/s)',
     time: 'Time',
     ws: 'WS',
     stream: 'Stream',

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -317,6 +317,7 @@ export default {
     latency: '延迟',
     latencyFirstToken: '首字',
     latencyDuration: '总耗时',
+    tps: 'TPS（Token/s）',
     time: '时间',
     ws: 'WS',
     stream: '流式',

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -639,6 +639,7 @@ const allColumns = computed(() => [
   { key: 'tokens', label: t('usage.tokens'), sortable: false },
   { key: 'cost', label: t('usage.cost'), sortable: false },
   { key: 'latency', label: t('usage.latency'), sortable: false },
+  { key: 'tps', label: t('usage.tps'), sortable: false },
   { key: 'created_at', label: t('usage.time'), sortable: true },
   { key: 'user_agent', label: t('usage.userAgent'), sortable: false },
   { key: 'ip_address', label: t('admin.usage.ipAddress'), sortable: false }

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -712,6 +712,7 @@ const allColumns = computed<Column[]>(() => [
   { key: 'tokens', label: t('usage.tokens'), sortable: false },
   { key: 'cost', label: t('usage.cost'), sortable: false },
   { key: 'latency', label: t('usage.latency'), sortable: false },
+  { key: 'tps', label: t('usage.tps'), sortable: false },
   { key: 'created_at', label: t('usage.time'), sortable: true },
   { key: 'user_agent', label: t('usage.userAgent'), sortable: false },
 ])


### PR DESCRIPTION
## 问题

使用记录表虽然已有输出 Token 和总耗时，但没有直接展示单位时间内的输出速度，排查响应性能时需要手工换算。

## 改动

- 在管理员和用户使用记录表增加 TPS 列，并提供中英文表头。
- 按 `output_tokens * 1000 / duration_ms` 计算端到端输出吞吐，保留两位小数。
- 图片请求、非正 output token、无效或非正耗时时显示 `-`。
- 不新增 API、数据库字段或 migration。

## 重叠检查

已有开放 PR #5014 处理管理员使用记录的 Token/s 列。本 PR 在同一指标口径下补充用户端使用记录，并统一管理员和用户两端的 TPS 展示；管理员端改动与 #5014 存在部分重叠，供维护者合并时统一处理。

## 验证

- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
