### PR TITLE
[codex] Edit account priority inline

### DIFF
--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -810,6 +810,7 @@ export default {
       loadFactorHint: 'Higher load factor increases scheduling frequency',
       priority: 'Priority',
       priorityHint: 'Lower value accounts are used first',
+      priorityInvalid: 'Priority must be an integer greater than or equal to 1',
       billingRateMultiplier: 'Billing Rate Multiplier',
       billingRateMultiplierHint: '0 = free, affects account billing only',
       expiresAt: 'Expires At',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -869,6 +869,7 @@ export default {
       loadFactorHint: '提高负载因子可以提高对账号的调度频率',
       priority: '优先级',
       priorityHint: '优先级越小的账号优先使用',
+      priorityInvalid: '优先级必须是大于或等于 1 的整数',
       billingRateMultiplier: '账号计费倍率',
       billingRateMultiplierHint: '0 表示不计费，仅影响账号计费',
       expiresAt: '过期时间',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -373,8 +373,62 @@
               @probe="handleProbeUpstreamBilling(row)"
             />
           </template>
-          <template #cell-priority="{ value }">
-            <span class="text-sm text-gray-700 dark:text-gray-300">{{ value }}</span>
+          <template #cell-priority="{ row }">
+            <div class="flex min-w-[7.5rem] items-center gap-1" @click.stop>
+              <template v-if="editingPriorityAccountID === row.id">
+                <input
+                  v-model.number="priorityDraft"
+                  type="number"
+                  min="1"
+                  step="1"
+                  class="input h-8 w-16 px-2 py-1 font-mono text-sm"
+                  :aria-label="t('admin.accounts.priority')"
+                  :disabled="savingPriorityAccountIDs.has(row.id)"
+                  data-testid="account-priority-input"
+                  @keydown.enter.prevent="savePriority(row)"
+                  @keydown.esc.prevent="cancelPriorityEdit"
+                />
+                <button
+                  type="button"
+                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-emerald-600 transition-colors hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-900/20"
+                  :title="t('common.save')"
+                  :aria-label="t('common.save')"
+                  :disabled="savingPriorityAccountIDs.has(row.id)"
+                  data-testid="account-priority-save"
+                  @click="savePriority(row)"
+                >
+                  <Icon
+                    :name="savingPriorityAccountIDs.has(row.id) ? 'refresh' : 'check'"
+                    size="sm"
+                    :class="savingPriorityAccountIDs.has(row.id) ? 'animate-spin' : ''"
+                  />
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-dark-700"
+                  :title="t('common.cancel')"
+                  :aria-label="t('common.cancel')"
+                  :disabled="savingPriorityAccountIDs.has(row.id)"
+                  data-testid="account-priority-cancel"
+                  @click="cancelPriorityEdit"
+                >
+                  <Icon name="x" size="sm" />
+                </button>
+              </template>
+              <template v-else>
+                <span class="min-w-6 font-mono text-sm text-gray-700 dark:text-gray-300">{{ row.priority }}</span>
+                <button
+                  type="button"
+                  class="inline-flex h-7 w-7 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:text-dark-400 dark:hover:bg-dark-700 dark:hover:text-primary-400"
+                  :title="t('common.edit')"
+                  :aria-label="`${t('common.edit')} ${t('admin.accounts.priority')}`"
+                  data-testid="account-priority-edit"
+                  @click="startPriorityEdit(row)"
+                >
+                  <Icon name="edit" size="xs" />
+                </button>
+              </template>
+            </div>
           </template>
           <template #header-scheduler_score="{ column }">
             <div class="flex items-center">
@@ -606,6 +660,9 @@ const togglingSchedulable = ref<number | null>(null)
 const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
 const exportingData = ref(false)
 const probingUpstreamBilling = reactive(new Set<number>())
+const editingPriorityAccountID = ref<number | null>(null)
+const priorityDraft = ref<number | null>(null)
+const savingPriorityAccountIDs = reactive(new Set<number>())
 const upstreamBillingProbeGloballyEnabled = ref<boolean | undefined>(undefined)
 const upstreamBillingNow = ref(Date.now())
 let lastUpstreamBillingSortRefreshMinute = -1
@@ -1105,7 +1162,8 @@ const isAnyModalOpen = computed(() => {
     showStats.value ||
     showSchedulePanel.value ||
     showErrorPassthrough.value ||
-    showTLSFingerprintProfiles.value
+    showTLSFingerprintProfiles.value ||
+    editingPriorityAccountID.value !== null
   )
 })
 
@@ -1927,6 +1985,44 @@ const handleProbeUpstreamBilling = async (account: Account) => {
 const handleAccountUpdated = (updatedAccount: Account) => {
   patchAccountInList(updatedAccount)
   enterAutoRefreshSilentWindow()
+}
+const startPriorityEdit = (account: Account) => {
+  if (savingPriorityAccountIDs.has(account.id)) return
+  editingPriorityAccountID.value = account.id
+  priorityDraft.value = account.priority
+}
+const cancelPriorityEdit = () => {
+  editingPriorityAccountID.value = null
+  priorityDraft.value = null
+}
+const savePriority = async (account: Account) => {
+  if (editingPriorityAccountID.value !== account.id || savingPriorityAccountIDs.has(account.id)) return
+
+  const nextPriority = Number(priorityDraft.value)
+  if (!Number.isInteger(nextPriority) || nextPriority < 1) {
+    appStore.showError(t('admin.accounts.priorityInvalid'))
+    return
+  }
+  if (nextPriority === account.priority) {
+    cancelPriorityEdit()
+    return
+  }
+
+  savingPriorityAccountIDs.add(account.id)
+  try {
+    const updated = await adminAPI.accounts.update(account.id, { priority: nextPriority })
+    patchAccountInList(updated)
+    enterAutoRefreshSilentWindow()
+    cancelPriorityEdit()
+    if (sortState.sort_by === 'priority') {
+      await reload()
+    }
+  } catch (error) {
+    console.error('Failed to update account priority:', error)
+    appStore.showError(extractApiErrorMessage(error, t('admin.accounts.failedToUpdate')))
+  } finally {
+    savingPriorityAccountIDs.delete(account.id)
+  }
 }
 const formatExportTimestamp = () => {
   const now = new Date()

--- a/frontend/src/views/admin/__tests__/AccountsView.inlinePriority.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.inlinePriority.spec.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import AccountsView from '../AccountsView.vue'
+
+const {
+  listAccounts,
+  listWithEtag,
+  updateAccount,
+  getBatchTodayStats,
+  getAllProxies,
+  getAllGroups,
+  showError
+} = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  listWithEtag: vi.fn(),
+  updateAccount: vi.fn(),
+  getBatchTodayStats: vi.fn(),
+  getAllProxies: vi.fn(),
+  getAllGroups: vi.fn(),
+  showError: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      list: listAccounts,
+      listWithEtag,
+      update: updateAccount,
+      getBatchTodayStats,
+      getUpstreamBillingProbeSettings: vi.fn().mockResolvedValue({ enabled: true, interval_minutes: 30 })
+    },
+    proxies: { getAll: getAllProxies },
+    groups: { getAll: getAllGroups }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError,
+    showSuccess: vi.fn(),
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key })
+  }
+})
+
+const DataTableStub = {
+  props: ['data'],
+  template: `
+    <div>
+      <div v-for="row in data" :key="row.id" data-test="priority-cell">
+        <slot name="cell-priority" :value="row.priority" :row="row" />
+      </div>
+    </div>
+  `
+}
+
+const baseAccount = {
+  id: 1,
+  name: 'primary-openai',
+  platform: 'openai',
+  type: 'oauth',
+  status: 'active',
+  schedulable: true,
+  concurrency: 1,
+  priority: 10,
+  error_message: null,
+  last_used_at: null,
+  expires_at: null,
+  auto_pause_on_expired: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z'
+}
+
+function mountView() {
+  return mount(AccountsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: { template: '<div><slot name="table" /></div>' },
+        DataTable: DataTableStub,
+        Pagination: true,
+        ConfirmDialog: true,
+        AccountTableActions: true,
+        AccountTableFilters: true,
+        AccountBulkActionsBar: true,
+        AccountActionMenu: true,
+        ImportDataModal: true,
+        ReAuthAccountModal: true,
+        AccountTestModal: true,
+        AccountStatsModal: true,
+        ScheduledTestsPanel: true,
+        SyncFromCrsModal: true,
+        TempUnschedStatusModal: true,
+        ErrorPassthroughRulesModal: true,
+        TLSFingerprintProfilesModal: true,
+        CreateAccountModal: true,
+        EditAccountModal: true,
+        BulkEditAccountModal: true,
+        PlatformTypeBadge: true,
+        AccountCapacityCell: true,
+        AccountStatusIndicator: true,
+        AccountTodayStatsCell: true,
+        AccountGroupsCell: true,
+        AccountUsageCell: true,
+        UpstreamBillingRateCell: true,
+        HelpTooltip: true,
+        Icon: true
+      }
+    }
+  })
+}
+
+describe('admin AccountsView inline priority editing', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    listAccounts.mockReset()
+    listWithEtag.mockReset()
+    updateAccount.mockReset()
+    getBatchTodayStats.mockReset()
+    getAllProxies.mockReset()
+    getAllGroups.mockReset()
+    showError.mockReset()
+
+    listAccounts.mockResolvedValue({
+      items: [{ ...baseAccount }],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+    listWithEtag.mockResolvedValue({ notModified: true, etag: null, data: null })
+    getBatchTodayStats.mockResolvedValue({ stats: {} })
+    getAllProxies.mockResolvedValue([])
+    getAllGroups.mockResolvedValue([])
+  })
+
+  it('updates only priority and patches the returned account into the row', async () => {
+    updateAccount.mockResolvedValue({ ...baseAccount, priority: 3, updated_at: '2026-08-03T00:00:00Z' })
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="account-priority-edit"]').trigger('click')
+    const input = wrapper.get('[data-testid="account-priority-input"]')
+    expect((input.element as HTMLInputElement).value).toBe('10')
+
+    await input.setValue('3')
+    await input.trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(updateAccount).toHaveBeenCalledWith(1, { priority: 3 })
+    expect(wrapper.find('[data-testid="account-priority-input"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="priority-cell"]').text()).toContain('3')
+  })
+
+  it('rejects non-positive priority without sending a request', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="account-priority-edit"]').trigger('click')
+    await wrapper.get('[data-testid="account-priority-input"]').setValue('0')
+    await wrapper.get('[data-testid="account-priority-save"]').trigger('click')
+
+    expect(updateAccount).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith('admin.accounts.priorityInvalid')
+    expect(wrapper.find('[data-testid="account-priority-input"]').exists()).toBe(true)
+  })
+
+  it('keeps the editor open when the update fails', async () => {
+    updateAccount.mockRejectedValue(new Error('update failed'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="account-priority-edit"]').trigger('click')
+    await wrapper.get('[data-testid="account-priority-input"]').setValue('4')
+    await wrapper.get('[data-testid="account-priority-save"]').trigger('click')
+    await flushPromises()
+
+    expect(showError).toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="account-priority-input"]').exists()).toBe(true)
+    expect((wrapper.get('[data-testid="account-priority-input"]').element as HTMLInputElement).value).toBe('4')
+  })
+
+  it('cancels editing without sending a request', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="account-priority-edit"]').trigger('click')
+    await wrapper.get('[data-testid="account-priority-input"]').setValue('5')
+    await wrapper.get('[data-testid="account-priority-input"]').trigger('keydown', { key: 'Escape' })
+
+    expect(updateAccount).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="account-priority-input"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="priority-cell"]').text()).toContain('10')
+  })
+})


### PR DESCRIPTION
## What changed

- make the account priority table cell directly editable from the accounts list
- provide explicit save/cancel actions plus Enter/Escape keyboard controls
- validate that priority is an integer greater than or equal to 1
- pause auto-refresh while a priority editor is open and refresh server ordering after edits when sorting by priority
- add English and Chinese validation messages

## Why

Administrators can already display and sort the priority column, but changing a priority requires opening the full account editor. Inline editing makes frequent primary/backup scheduling adjustments faster without changing the backend contract.

The update sends only `{ priority }` through the existing account update endpoint, so unrelated account settings are not overwritten.

## Validation

- `pnpm exec vitest run src/views/admin/__tests__/AccountsView` (30 tests passed)
- `pnpm typecheck`
- ESLint on the changed frontend files
- `pnpm build`

The new tests cover successful updates, invalid values, API failures, and cancellation.
