### PR TITLE
fix(prompt-audit): parse responses output text

### DIFF
--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -419,7 +419,7 @@ func contentTexts(value any) []string {
 				continue
 			}
 			typeName := strings.ToLower(stringValue(object["type"]))
-			if typeName != "" && typeName != "text" && typeName != "input_text" {
+			if typeName != "" && typeName != "text" && typeName != "input_text" && typeName != "output_text" {
 				continue
 			}
 			if text := stringValue(object["text"]); text != "" {

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -336,6 +336,38 @@ func TestBlockingPromptSnapshotLimitsInputToLatestUserAndPreviousOutput(t *testi
 	}
 }
 
+func TestContentTextsIncludesSupportedTextTypes(t *testing.T) {
+	value := []any{
+		map[string]any{"type": "text", "text": "plain text"},
+		map[string]any{"type": "input_text", "text": "input text"},
+		map[string]any{"type": "output_text", "text": "output text"},
+		map[string]any{"type": "image_url", "text": "ignored text"},
+	}
+
+	require.Equal(t, []string{"plain text", "input text", "output text"}, contentTexts(value))
+}
+
+func TestResponsesOutputTextIncludedInFullAndLatestTurnSnapshots(t *testing.T) {
+	body := []byte(`{"input":[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"earlier user input"}]},
+		{"type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","annotations":[],"text":"captured previous assistant output"}]},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"captured latest user input"}]}
+	]}`)
+
+	req := Request{Protocol: "openai_responses", Body: body}
+	full, err := ExtractPromptSnapshot(req)
+	require.NoError(t, err)
+	require.Contains(t, full.ScanText, "captured previous assistant output")
+	require.Contains(t, full.FullPrompt, "captured previous assistant output")
+	require.Equal(t, 3, full.MessageCount)
+
+	latestTurn, err := ExtractBlockingPromptSnapshot(req, true)
+	require.NoError(t, err)
+	require.Equal(t, "captured latest user input"+promptAuditPrioritySeparator+"captured previous assistant output", latestTurn.ScanText)
+	require.Equal(t, 2, latestTurn.MessageCount)
+	require.NotContains(t, latestTurn.ScanText, "earlier user input")
+}
+
 func TestBlockingPromptSnapshotPreservesFullScopeByDefaultAndWithoutUserInput(t *testing.T) {
 	req := Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"system","content":"system instruction"},{"role":"user","content":"older user input"},{"role":"assistant","content":"previous output"},{"role":"user","content":"latest user input"}]}`)}
 	full, err := ExtractPromptSnapshot(req)


### PR DESCRIPTION
提示词审计解析OpenAI Codex响应'output_text'内容部分

背景：
Closes #5216
`codex`的消息数组中，`assistant`回复的内容 `type == output_text`，而`contentTexts`函数只解析了text / input_text 两种内容类型，所以导致turn模式仍然会发送完整的上下文
而其它cli，例如claude cli，type类型是text，所以可以正常解析；例如opencode completions格式，无type字段，也可以正常解析assistant输出


经过抓包 claude cli和opencode cli 的请求体message格式，确认了解析assistant的输出内容是合理的，因为目前这两种cli已经会成功解析assistant输出，所以直接在 `contentTexts` 添加了 `output_text`的解析
如果不想要直接在 `contentTexts` 添加，请进行评论，我将修改为只针对 responses 和 latestTurnOnly 场景才解析 output_text