### PR TITLE
支持滚动周限额窗口

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1943,6 +1943,7 @@ var (
 		{Name: "monthly_usage_usd", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
 		{Name: "daily_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "weekly_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
+		{Name: "weekly_window_reset_at", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "monthly_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "user_id", Type: field.TypeInt64},
 	}
@@ -1954,7 +1955,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "user_platform_quotas_users_platform_quotas",
-				Columns:    []*schema.Column{UserPlatformQuotasColumns[14]},
+				Columns:    []*schema.Column{UserPlatformQuotasColumns[15]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -1963,7 +1964,7 @@ var (
 			{
 				Name:    "userplatformquota_user_id_platform",
 				Unique:  true,
-				Columns: []*schema.Column{UserPlatformQuotasColumns[14], UserPlatformQuotasColumns[4]},
+				Columns: []*schema.Column{UserPlatformQuotasColumns[15], UserPlatformQuotasColumns[4]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -1971,7 +1972,7 @@ var (
 			{
 				Name:    "userplatformquota_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{UserPlatformQuotasColumns[14]},
+				Columns: []*schema.Column{UserPlatformQuotasColumns[15]},
 			},
 		},
 	}

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -52565,34 +52565,35 @@ func (m *UserAttributeValueMutation) ResetEdge(name string) error {
 // UserPlatformQuotaMutation represents an operation that mutates the UserPlatformQuota nodes in the graph.
 type UserPlatformQuotaMutation struct {
 	config
-	op                   Op
-	typ                  string
-	id                   *int64
-	created_at           *time.Time
-	updated_at           *time.Time
-	deleted_at           *time.Time
-	platform             *string
-	daily_limit_usd      *float64
-	adddaily_limit_usd   *float64
-	weekly_limit_usd     *float64
-	addweekly_limit_usd  *float64
-	monthly_limit_usd    *float64
-	addmonthly_limit_usd *float64
-	daily_usage_usd      *float64
-	adddaily_usage_usd   *float64
-	weekly_usage_usd     *float64
-	addweekly_usage_usd  *float64
-	monthly_usage_usd    *float64
-	addmonthly_usage_usd *float64
-	daily_window_start   *time.Time
-	weekly_window_start  *time.Time
-	monthly_window_start *time.Time
-	clearedFields        map[string]struct{}
-	user                 *int64
-	cleareduser          bool
-	done                 bool
-	oldValue             func(context.Context) (*UserPlatformQuota, error)
-	predicates           []predicate.UserPlatformQuota
+	op                     Op
+	typ                    string
+	id                     *int64
+	created_at             *time.Time
+	updated_at             *time.Time
+	deleted_at             *time.Time
+	platform               *string
+	daily_limit_usd        *float64
+	adddaily_limit_usd     *float64
+	weekly_limit_usd       *float64
+	addweekly_limit_usd    *float64
+	monthly_limit_usd      *float64
+	addmonthly_limit_usd   *float64
+	daily_usage_usd        *float64
+	adddaily_usage_usd     *float64
+	weekly_usage_usd       *float64
+	addweekly_usage_usd    *float64
+	monthly_usage_usd      *float64
+	addmonthly_usage_usd   *float64
+	daily_window_start     *time.Time
+	weekly_window_start    *time.Time
+	weekly_window_reset_at *time.Time
+	monthly_window_start   *time.Time
+	clearedFields          map[string]struct{}
+	user                   *int64
+	cleareduser            bool
+	done                   bool
+	oldValue               func(context.Context) (*UserPlatformQuota, error)
+	predicates             []predicate.UserPlatformQuota
 }
 
 var _ ent.Mutation = (*UserPlatformQuotaMutation)(nil)
@@ -53362,6 +53363,55 @@ func (m *UserPlatformQuotaMutation) ResetWeeklyWindowStart() {
 	delete(m.clearedFields, userplatformquota.FieldWeeklyWindowStart)
 }
 
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (m *UserPlatformQuotaMutation) SetWeeklyWindowResetAt(t time.Time) {
+	m.weekly_window_reset_at = &t
+}
+
+// WeeklyWindowResetAt returns the value of the "weekly_window_reset_at" field in the mutation.
+func (m *UserPlatformQuotaMutation) WeeklyWindowResetAt() (r time.Time, exists bool) {
+	v := m.weekly_window_reset_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldWeeklyWindowResetAt returns the old "weekly_window_reset_at" field's value of the UserPlatformQuota entity.
+// If the UserPlatformQuota object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserPlatformQuotaMutation) OldWeeklyWindowResetAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldWeeklyWindowResetAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldWeeklyWindowResetAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldWeeklyWindowResetAt: %w", err)
+	}
+	return oldValue.WeeklyWindowResetAt, nil
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (m *UserPlatformQuotaMutation) ClearWeeklyWindowResetAt() {
+	m.weekly_window_reset_at = nil
+	m.clearedFields[userplatformquota.FieldWeeklyWindowResetAt] = struct{}{}
+}
+
+// WeeklyWindowResetAtCleared returns if the "weekly_window_reset_at" field was cleared in this mutation.
+func (m *UserPlatformQuotaMutation) WeeklyWindowResetAtCleared() bool {
+	_, ok := m.clearedFields[userplatformquota.FieldWeeklyWindowResetAt]
+	return ok
+}
+
+// ResetWeeklyWindowResetAt resets all changes to the "weekly_window_reset_at" field.
+func (m *UserPlatformQuotaMutation) ResetWeeklyWindowResetAt() {
+	m.weekly_window_reset_at = nil
+	delete(m.clearedFields, userplatformquota.FieldWeeklyWindowResetAt)
+}
+
 // SetMonthlyWindowStart sets the "monthly_window_start" field.
 func (m *UserPlatformQuotaMutation) SetMonthlyWindowStart(t time.Time) {
 	m.monthly_window_start = &t
@@ -53472,7 +53522,7 @@ func (m *UserPlatformQuotaMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserPlatformQuotaMutation) Fields() []string {
-	fields := make([]string, 0, 14)
+	fields := make([]string, 0, 15)
 	if m.created_at != nil {
 		fields = append(fields, userplatformquota.FieldCreatedAt)
 	}
@@ -53512,6 +53562,9 @@ func (m *UserPlatformQuotaMutation) Fields() []string {
 	if m.weekly_window_start != nil {
 		fields = append(fields, userplatformquota.FieldWeeklyWindowStart)
 	}
+	if m.weekly_window_reset_at != nil {
+		fields = append(fields, userplatformquota.FieldWeeklyWindowResetAt)
+	}
 	if m.monthly_window_start != nil {
 		fields = append(fields, userplatformquota.FieldMonthlyWindowStart)
 	}
@@ -53549,6 +53602,8 @@ func (m *UserPlatformQuotaMutation) Field(name string) (ent.Value, bool) {
 		return m.DailyWindowStart()
 	case userplatformquota.FieldWeeklyWindowStart:
 		return m.WeeklyWindowStart()
+	case userplatformquota.FieldWeeklyWindowResetAt:
+		return m.WeeklyWindowResetAt()
 	case userplatformquota.FieldMonthlyWindowStart:
 		return m.MonthlyWindowStart()
 	}
@@ -53586,6 +53641,8 @@ func (m *UserPlatformQuotaMutation) OldField(ctx context.Context, name string) (
 		return m.OldDailyWindowStart(ctx)
 	case userplatformquota.FieldWeeklyWindowStart:
 		return m.OldWeeklyWindowStart(ctx)
+	case userplatformquota.FieldWeeklyWindowResetAt:
+		return m.OldWeeklyWindowResetAt(ctx)
 	case userplatformquota.FieldMonthlyWindowStart:
 		return m.OldMonthlyWindowStart(ctx)
 	}
@@ -53687,6 +53744,13 @@ func (m *UserPlatformQuotaMutation) SetField(name string, value ent.Value) error
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetWeeklyWindowStart(v)
+		return nil
+	case userplatformquota.FieldWeeklyWindowResetAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetWeeklyWindowResetAt(v)
 		return nil
 	case userplatformquota.FieldMonthlyWindowStart:
 		v, ok := value.(time.Time)
@@ -53818,6 +53882,9 @@ func (m *UserPlatformQuotaMutation) ClearedFields() []string {
 	if m.FieldCleared(userplatformquota.FieldWeeklyWindowStart) {
 		fields = append(fields, userplatformquota.FieldWeeklyWindowStart)
 	}
+	if m.FieldCleared(userplatformquota.FieldWeeklyWindowResetAt) {
+		fields = append(fields, userplatformquota.FieldWeeklyWindowResetAt)
+	}
 	if m.FieldCleared(userplatformquota.FieldMonthlyWindowStart) {
 		fields = append(fields, userplatformquota.FieldMonthlyWindowStart)
 	}
@@ -53852,6 +53919,9 @@ func (m *UserPlatformQuotaMutation) ClearField(name string) error {
 		return nil
 	case userplatformquota.FieldWeeklyWindowStart:
 		m.ClearWeeklyWindowStart()
+		return nil
+	case userplatformquota.FieldWeeklyWindowResetAt:
+		m.ClearWeeklyWindowResetAt()
 		return nil
 	case userplatformquota.FieldMonthlyWindowStart:
 		m.ClearMonthlyWindowStart()
@@ -53902,6 +53972,9 @@ func (m *UserPlatformQuotaMutation) ResetField(name string) error {
 		return nil
 	case userplatformquota.FieldWeeklyWindowStart:
 		m.ResetWeeklyWindowStart()
+		return nil
+	case userplatformquota.FieldWeeklyWindowResetAt:
+		m.ResetWeeklyWindowResetAt()
 		return nil
 	case userplatformquota.FieldMonthlyWindowStart:
 		m.ResetMonthlyWindowStart()

--- a/backend/ent/schema/user_platform_quota.go
+++ b/backend/ent/schema/user_platform_quota.go
@@ -85,6 +85,12 @@ func (UserPlatformQuota) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			SchemaType(map[string]string{dialect.Postgres: "timestamptz"}),
+		// NULL keeps the legacy natural-week window. Non-NULL marks a manually
+		// anchored rolling seven-day window and stores its exclusive end time.
+		field.Time("weekly_window_reset_at").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "timestamptz"}),
 		field.Time("monthly_window_start").
 			Optional().
 			Nillable().

--- a/backend/ent/userplatformquota.go
+++ b/backend/ent/userplatformquota.go
@@ -44,6 +44,8 @@ type UserPlatformQuota struct {
 	DailyWindowStart *time.Time `json:"daily_window_start,omitempty"`
 	// WeeklyWindowStart holds the value of the "weekly_window_start" field.
 	WeeklyWindowStart *time.Time `json:"weekly_window_start,omitempty"`
+	// WeeklyWindowResetAt holds the value of the "weekly_window_reset_at" field.
+	WeeklyWindowResetAt *time.Time `json:"weekly_window_reset_at,omitempty"`
 	// MonthlyWindowStart holds the value of the "monthly_window_start" field.
 	MonthlyWindowStart *time.Time `json:"monthly_window_start,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -83,7 +85,7 @@ func (*UserPlatformQuota) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case userplatformquota.FieldPlatform:
 			values[i] = new(sql.NullString)
-		case userplatformquota.FieldCreatedAt, userplatformquota.FieldUpdatedAt, userplatformquota.FieldDeletedAt, userplatformquota.FieldDailyWindowStart, userplatformquota.FieldWeeklyWindowStart, userplatformquota.FieldMonthlyWindowStart:
+		case userplatformquota.FieldCreatedAt, userplatformquota.FieldUpdatedAt, userplatformquota.FieldDeletedAt, userplatformquota.FieldDailyWindowStart, userplatformquota.FieldWeeklyWindowStart, userplatformquota.FieldWeeklyWindowResetAt, userplatformquota.FieldMonthlyWindowStart:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -190,6 +192,13 @@ func (_m *UserPlatformQuota) assignValues(columns []string, values []any) error 
 				_m.WeeklyWindowStart = new(time.Time)
 				*_m.WeeklyWindowStart = value.Time
 			}
+		case userplatformquota.FieldWeeklyWindowResetAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field weekly_window_reset_at", values[i])
+			} else if value.Valid {
+				_m.WeeklyWindowResetAt = new(time.Time)
+				*_m.WeeklyWindowResetAt = value.Time
+			}
 		case userplatformquota.FieldMonthlyWindowStart:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field monthly_window_start", values[i])
@@ -286,6 +295,11 @@ func (_m *UserPlatformQuota) String() string {
 	builder.WriteString(", ")
 	if v := _m.WeeklyWindowStart; v != nil {
 		builder.WriteString("weekly_window_start=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := _m.WeeklyWindowResetAt; v != nil {
+		builder.WriteString("weekly_window_reset_at=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteString(", ")

--- a/backend/ent/userplatformquota/userplatformquota.go
+++ b/backend/ent/userplatformquota/userplatformquota.go
@@ -41,6 +41,8 @@ const (
 	FieldDailyWindowStart = "daily_window_start"
 	// FieldWeeklyWindowStart holds the string denoting the weekly_window_start field in the database.
 	FieldWeeklyWindowStart = "weekly_window_start"
+	// FieldWeeklyWindowResetAt holds the string denoting the weekly_window_reset_at field in the database.
+	FieldWeeklyWindowResetAt = "weekly_window_reset_at"
 	// FieldMonthlyWindowStart holds the string denoting the monthly_window_start field in the database.
 	FieldMonthlyWindowStart = "monthly_window_start"
 	// EdgeUser holds the string denoting the user edge name in mutations.
@@ -72,6 +74,7 @@ var Columns = []string{
 	FieldMonthlyUsageUsd,
 	FieldDailyWindowStart,
 	FieldWeeklyWindowStart,
+	FieldWeeklyWindowResetAt,
 	FieldMonthlyWindowStart,
 }
 
@@ -180,6 +183,11 @@ func ByDailyWindowStart(opts ...sql.OrderTermOption) OrderOption {
 // ByWeeklyWindowStart orders the results by the weekly_window_start field.
 func ByWeeklyWindowStart(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWeeklyWindowStart, opts...).ToFunc()
+}
+
+// ByWeeklyWindowResetAt orders the results by the weekly_window_reset_at field.
+func ByWeeklyWindowResetAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldWeeklyWindowResetAt, opts...).ToFunc()
 }
 
 // ByMonthlyWindowStart orders the results by the monthly_window_start field.

--- a/backend/ent/userplatformquota/where.go
+++ b/backend/ent/userplatformquota/where.go
@@ -120,6 +120,11 @@ func WeeklyWindowStart(v time.Time) predicate.UserPlatformQuota {
 	return predicate.UserPlatformQuota(sql.FieldEQ(FieldWeeklyWindowStart, v))
 }
 
+// WeeklyWindowResetAt applies equality check predicate on the "weekly_window_reset_at" field. It's identical to WeeklyWindowResetAtEQ.
+func WeeklyWindowResetAt(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldEQ(FieldWeeklyWindowResetAt, v))
+}
+
 // MonthlyWindowStart applies equality check predicate on the "monthly_window_start" field. It's identical to MonthlyWindowStartEQ.
 func MonthlyWindowStart(v time.Time) predicate.UserPlatformQuota {
 	return predicate.UserPlatformQuota(sql.FieldEQ(FieldMonthlyWindowStart, v))
@@ -708,6 +713,56 @@ func WeeklyWindowStartIsNil() predicate.UserPlatformQuota {
 // WeeklyWindowStartNotNil applies the NotNil predicate on the "weekly_window_start" field.
 func WeeklyWindowStartNotNil() predicate.UserPlatformQuota {
 	return predicate.UserPlatformQuota(sql.FieldNotNull(FieldWeeklyWindowStart))
+}
+
+// WeeklyWindowResetAtEQ applies the EQ predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtEQ(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldEQ(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtNEQ applies the NEQ predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtNEQ(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldNEQ(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtIn applies the In predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtIn(vs ...time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldIn(FieldWeeklyWindowResetAt, vs...))
+}
+
+// WeeklyWindowResetAtNotIn applies the NotIn predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtNotIn(vs ...time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldNotIn(FieldWeeklyWindowResetAt, vs...))
+}
+
+// WeeklyWindowResetAtGT applies the GT predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtGT(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldGT(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtGTE applies the GTE predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtGTE(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldGTE(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtLT applies the LT predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtLT(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldLT(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtLTE applies the LTE predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtLTE(v time.Time) predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldLTE(FieldWeeklyWindowResetAt, v))
+}
+
+// WeeklyWindowResetAtIsNil applies the IsNil predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtIsNil() predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldIsNull(FieldWeeklyWindowResetAt))
+}
+
+// WeeklyWindowResetAtNotNil applies the NotNil predicate on the "weekly_window_reset_at" field.
+func WeeklyWindowResetAtNotNil() predicate.UserPlatformQuota {
+	return predicate.UserPlatformQuota(sql.FieldNotNull(FieldWeeklyWindowResetAt))
 }
 
 // MonthlyWindowStartEQ applies the EQ predicate on the "monthly_window_start" field.

--- a/backend/ent/userplatformquota_create.go
+++ b/backend/ent/userplatformquota_create.go
@@ -189,6 +189,20 @@ func (_c *UserPlatformQuotaCreate) SetNillableWeeklyWindowStart(v *time.Time) *U
 	return _c
 }
 
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (_c *UserPlatformQuotaCreate) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaCreate {
+	_c.mutation.SetWeeklyWindowResetAt(v)
+	return _c
+}
+
+// SetNillableWeeklyWindowResetAt sets the "weekly_window_reset_at" field if the given value is not nil.
+func (_c *UserPlatformQuotaCreate) SetNillableWeeklyWindowResetAt(v *time.Time) *UserPlatformQuotaCreate {
+	if v != nil {
+		_c.SetWeeklyWindowResetAt(*v)
+	}
+	return _c
+}
+
 // SetMonthlyWindowStart sets the "monthly_window_start" field.
 func (_c *UserPlatformQuotaCreate) SetMonthlyWindowStart(v time.Time) *UserPlatformQuotaCreate {
 	_c.mutation.SetMonthlyWindowStart(v)
@@ -379,6 +393,10 @@ func (_c *UserPlatformQuotaCreate) createSpec() (*UserPlatformQuota, *sqlgraph.C
 	if value, ok := _c.mutation.WeeklyWindowStart(); ok {
 		_spec.SetField(userplatformquota.FieldWeeklyWindowStart, field.TypeTime, value)
 		_node.WeeklyWindowStart = &value
+	}
+	if value, ok := _c.mutation.WeeklyWindowResetAt(); ok {
+		_spec.SetField(userplatformquota.FieldWeeklyWindowResetAt, field.TypeTime, value)
+		_node.WeeklyWindowResetAt = &value
 	}
 	if value, ok := _c.mutation.MonthlyWindowStart(); ok {
 		_spec.SetField(userplatformquota.FieldMonthlyWindowStart, field.TypeTime, value)
@@ -666,6 +684,24 @@ func (u *UserPlatformQuotaUpsert) UpdateWeeklyWindowStart() *UserPlatformQuotaUp
 // ClearWeeklyWindowStart clears the value of the "weekly_window_start" field.
 func (u *UserPlatformQuotaUpsert) ClearWeeklyWindowStart() *UserPlatformQuotaUpsert {
 	u.SetNull(userplatformquota.FieldWeeklyWindowStart)
+	return u
+}
+
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsert) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaUpsert {
+	u.Set(userplatformquota.FieldWeeklyWindowResetAt, v)
+	return u
+}
+
+// UpdateWeeklyWindowResetAt sets the "weekly_window_reset_at" field to the value that was provided on create.
+func (u *UserPlatformQuotaUpsert) UpdateWeeklyWindowResetAt() *UserPlatformQuotaUpsert {
+	u.SetExcluded(userplatformquota.FieldWeeklyWindowResetAt)
+	return u
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsert) ClearWeeklyWindowResetAt() *UserPlatformQuotaUpsert {
+	u.SetNull(userplatformquota.FieldWeeklyWindowResetAt)
 	return u
 }
 
@@ -981,6 +1017,27 @@ func (u *UserPlatformQuotaUpsertOne) UpdateWeeklyWindowStart() *UserPlatformQuot
 func (u *UserPlatformQuotaUpsertOne) ClearWeeklyWindowStart() *UserPlatformQuotaUpsertOne {
 	return u.Update(func(s *UserPlatformQuotaUpsert) {
 		s.ClearWeeklyWindowStart()
+	})
+}
+
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsertOne) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaUpsertOne {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.SetWeeklyWindowResetAt(v)
+	})
+}
+
+// UpdateWeeklyWindowResetAt sets the "weekly_window_reset_at" field to the value that was provided on create.
+func (u *UserPlatformQuotaUpsertOne) UpdateWeeklyWindowResetAt() *UserPlatformQuotaUpsertOne {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.UpdateWeeklyWindowResetAt()
+	})
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsertOne) ClearWeeklyWindowResetAt() *UserPlatformQuotaUpsertOne {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.ClearWeeklyWindowResetAt()
 	})
 }
 
@@ -1465,6 +1522,27 @@ func (u *UserPlatformQuotaUpsertBulk) UpdateWeeklyWindowStart() *UserPlatformQuo
 func (u *UserPlatformQuotaUpsertBulk) ClearWeeklyWindowStart() *UserPlatformQuotaUpsertBulk {
 	return u.Update(func(s *UserPlatformQuotaUpsert) {
 		s.ClearWeeklyWindowStart()
+	})
+}
+
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsertBulk) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaUpsertBulk {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.SetWeeklyWindowResetAt(v)
+	})
+}
+
+// UpdateWeeklyWindowResetAt sets the "weekly_window_reset_at" field to the value that was provided on create.
+func (u *UserPlatformQuotaUpsertBulk) UpdateWeeklyWindowResetAt() *UserPlatformQuotaUpsertBulk {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.UpdateWeeklyWindowResetAt()
+	})
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (u *UserPlatformQuotaUpsertBulk) ClearWeeklyWindowResetAt() *UserPlatformQuotaUpsertBulk {
+	return u.Update(func(s *UserPlatformQuotaUpsert) {
+		s.ClearWeeklyWindowResetAt()
 	})
 }
 

--- a/backend/ent/userplatformquota_update.go
+++ b/backend/ent/userplatformquota_update.go
@@ -267,6 +267,26 @@ func (_u *UserPlatformQuotaUpdate) ClearWeeklyWindowStart() *UserPlatformQuotaUp
 	return _u
 }
 
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (_u *UserPlatformQuotaUpdate) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaUpdate {
+	_u.mutation.SetWeeklyWindowResetAt(v)
+	return _u
+}
+
+// SetNillableWeeklyWindowResetAt sets the "weekly_window_reset_at" field if the given value is not nil.
+func (_u *UserPlatformQuotaUpdate) SetNillableWeeklyWindowResetAt(v *time.Time) *UserPlatformQuotaUpdate {
+	if v != nil {
+		_u.SetWeeklyWindowResetAt(*v)
+	}
+	return _u
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (_u *UserPlatformQuotaUpdate) ClearWeeklyWindowResetAt() *UserPlatformQuotaUpdate {
+	_u.mutation.ClearWeeklyWindowResetAt()
+	return _u
+}
+
 // SetMonthlyWindowStart sets the "monthly_window_start" field.
 func (_u *UserPlatformQuotaUpdate) SetMonthlyWindowStart(v time.Time) *UserPlatformQuotaUpdate {
 	_u.mutation.SetMonthlyWindowStart(v)
@@ -438,6 +458,12 @@ func (_u *UserPlatformQuotaUpdate) sqlSave(ctx context.Context) (_node int, err 
 	}
 	if _u.mutation.WeeklyWindowStartCleared() {
 		_spec.ClearField(userplatformquota.FieldWeeklyWindowStart, field.TypeTime)
+	}
+	if value, ok := _u.mutation.WeeklyWindowResetAt(); ok {
+		_spec.SetField(userplatformquota.FieldWeeklyWindowResetAt, field.TypeTime, value)
+	}
+	if _u.mutation.WeeklyWindowResetAtCleared() {
+		_spec.ClearField(userplatformquota.FieldWeeklyWindowResetAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.MonthlyWindowStart(); ok {
 		_spec.SetField(userplatformquota.FieldMonthlyWindowStart, field.TypeTime, value)
@@ -732,6 +758,26 @@ func (_u *UserPlatformQuotaUpdateOne) ClearWeeklyWindowStart() *UserPlatformQuot
 	return _u
 }
 
+// SetWeeklyWindowResetAt sets the "weekly_window_reset_at" field.
+func (_u *UserPlatformQuotaUpdateOne) SetWeeklyWindowResetAt(v time.Time) *UserPlatformQuotaUpdateOne {
+	_u.mutation.SetWeeklyWindowResetAt(v)
+	return _u
+}
+
+// SetNillableWeeklyWindowResetAt sets the "weekly_window_reset_at" field if the given value is not nil.
+func (_u *UserPlatformQuotaUpdateOne) SetNillableWeeklyWindowResetAt(v *time.Time) *UserPlatformQuotaUpdateOne {
+	if v != nil {
+		_u.SetWeeklyWindowResetAt(*v)
+	}
+	return _u
+}
+
+// ClearWeeklyWindowResetAt clears the value of the "weekly_window_reset_at" field.
+func (_u *UserPlatformQuotaUpdateOne) ClearWeeklyWindowResetAt() *UserPlatformQuotaUpdateOne {
+	_u.mutation.ClearWeeklyWindowResetAt()
+	return _u
+}
+
 // SetMonthlyWindowStart sets the "monthly_window_start" field.
 func (_u *UserPlatformQuotaUpdateOne) SetMonthlyWindowStart(v time.Time) *UserPlatformQuotaUpdateOne {
 	_u.mutation.SetMonthlyWindowStart(v)
@@ -933,6 +979,12 @@ func (_u *UserPlatformQuotaUpdateOne) sqlSave(ctx context.Context) (_node *UserP
 	}
 	if _u.mutation.WeeklyWindowStartCleared() {
 		_spec.ClearField(userplatformquota.FieldWeeklyWindowStart, field.TypeTime)
+	}
+	if value, ok := _u.mutation.WeeklyWindowResetAt(); ok {
+		_spec.SetField(userplatformquota.FieldWeeklyWindowResetAt, field.TypeTime, value)
+	}
+	if _u.mutation.WeeklyWindowResetAtCleared() {
+		_spec.ClearField(userplatformquota.FieldWeeklyWindowResetAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.MonthlyWindowStart(); ok {
 		_spec.SetField(userplatformquota.FieldMonthlyWindowStart, field.TypeTime, value)

--- a/backend/internal/handler/quotaview/helpers.go
+++ b/backend/internal/handler/quotaview/helpers.go
@@ -13,7 +13,12 @@ import (
 // includeWindowStart=true 时输出 *_window_start 字段（admin 视角调试用）
 func LazyZeroQuotaForResponse(r service.UserPlatformQuotaRecord, now time.Time, includeWindowStart bool) map[string]any {
 	daily := buildWindowSlice(r.DailyUsageUSD, r.DailyLimitUSD, r.DailyWindowStart, NeedsDailyReset(r.DailyWindowStart, now), nextDailyResetTime(now), includeWindowStart)
-	weekly := buildWindowSlice(r.WeeklyUsageUSD, r.WeeklyLimitUSD, r.WeeklyWindowStart, NeedsWeeklyReset(r.WeeklyWindowStart, now), nextWeeklyResetTime(now), includeWindowStart)
+	weeklyExpired, weeklyStart, weeklyResetAt := weeklyWindowState(r.WeeklyWindowStart, r.WeeklyWindowResetAt, now)
+	weeklyNextReset := nextWeeklyResetTime(now)
+	if weeklyResetAt != nil {
+		weeklyNextReset = *weeklyResetAt
+	}
+	weekly := buildWindowSlice(r.WeeklyUsageUSD, r.WeeklyLimitUSD, weeklyStart, weeklyExpired, weeklyNextReset, includeWindowStart)
 	monthly := buildWindowSlice(r.MonthlyUsageUSD, r.MonthlyLimitUSD, r.MonthlyWindowStart, NeedsMonthlyReset(r.MonthlyWindowStart, now), NextMonthlyResetTimeFrom(r.MonthlyWindowStart, now), includeWindowStart)
 	out := map[string]any{
 		"platform":                 r.Platform,
@@ -68,10 +73,33 @@ func NeedsDailyReset(start *time.Time, now time.Time) bool {
 }
 
 func NeedsWeeklyReset(start *time.Time, now time.Time) bool {
-	if start == nil {
-		return false
+	expired, _, _ := weeklyWindowState(start, nil, now)
+	return expired
+}
+
+func weeklyWindowState(start, resetAt *time.Time, now time.Time) (expired bool, nextStart, nextResetAt *time.Time) {
+	if resetAt == nil {
+		currentStart := timezone.StartOfWeek(now)
+		if start == nil || start.Before(currentStart) {
+			return true, &currentStart, nil
+		}
+		return false, start, nil
 	}
-	return start.Before(timezone.StartOfWeek(now))
+	windowStart := start
+	if windowStart == nil {
+		fallbackStart := resetAt.Add(-7 * 24 * time.Hour)
+		windowStart = &fallbackStart
+	}
+	if now.Before(*resetAt) {
+		return false, windowStart, resetAt
+	}
+	newStart := *resetAt
+	next := resetAt.Add(7 * 24 * time.Hour)
+	for !now.Before(next) {
+		newStart = next
+		next = next.Add(7 * 24 * time.Hour)
+	}
+	return true, &newStart, &next
 }
 
 // NeedsMonthlyReset 30 天滚动窗口语义（与订阅模式 NeedsMonthlyReset 一致）。

--- a/backend/internal/handler/quotaview/helpers_test.go
+++ b/backend/internal/handler/quotaview/helpers_test.go
@@ -131,3 +131,39 @@ func TestNextWeeklyResetTime_FollowsServerTimezone(t *testing.T) {
 		t.Errorf("nextWeeklyResetTime = %v, want %v", got, want)
 	}
 }
+
+func TestWeeklyWindowState_AnchoredWindowActive(t *testing.T) {
+	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := start.Add(7 * 24 * time.Hour)
+	now := start.Add(2 * 24 * time.Hour)
+
+	expired, gotStart, gotResetAt := weeklyWindowState(&start, &resetAt, now)
+	if expired {
+		t.Fatal("active anchored window should not be expired")
+	}
+	if gotStart == nil || !gotStart.Equal(start) {
+		t.Fatalf("window start = %v, want %v", gotStart, start)
+	}
+	if gotResetAt == nil || !gotResetAt.Equal(resetAt) {
+		t.Fatalf("reset time = %v, want %v", gotResetAt, resetAt)
+	}
+}
+
+func TestWeeklyWindowState_AnchoredWindowAdvancesAfterDue(t *testing.T) {
+	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := start.Add(7 * 24 * time.Hour)
+	now := resetAt.Add(8 * 24 * time.Hour)
+	wantStart := resetAt.Add(7 * 24 * time.Hour)
+	wantResetAt := resetAt.Add(14 * 24 * time.Hour)
+
+	expired, gotStart, gotResetAt := weeklyWindowState(&start, &resetAt, now)
+	if !expired {
+		t.Fatal("expired anchored window should be reported as expired")
+	}
+	if gotStart == nil || !gotStart.Equal(wantStart) {
+		t.Fatalf("window start = %v, want %v", gotStart, wantStart)
+	}
+	if gotResetAt == nil || !gotResetAt.Equal(wantResetAt) {
+		t.Fatalf("reset time = %v, want %v", gotResetAt, wantResetAt)
+	}
+}

--- a/backend/internal/repository/billing_cache.go
+++ b/backend/internal/repository/billing_cache.go
@@ -423,17 +423,18 @@ func parseUserPlatformQuotaHash(m map[string]string) *service.UserPlatformQuotaC
 		return n
 	}
 	return &service.UserPlatformQuotaCacheEntry{
-		DailyUsageUSD:      parseFloat(m["daily_usage"]),
-		WeeklyUsageUSD:     parseFloat(m["weekly_usage"]),
-		MonthlyUsageUSD:    parseFloat(m["monthly_usage"]),
-		Version:            parseInt64(m["version"]),
-		SchemaVersion:      parseInt64(m["schema_version"]),
-		DailyLimitUSD:      parseFloatPtr(m["daily_limit"]),
-		WeeklyLimitUSD:     parseFloatPtr(m["weekly_limit"]),
-		MonthlyLimitUSD:    parseFloatPtr(m["monthly_limit"]),
-		DailyWindowStart:   parseTimePtr(m["daily_window_start"]),
-		WeeklyWindowStart:  parseTimePtr(m["weekly_window_start"]),
-		MonthlyWindowStart: parseTimePtr(m["monthly_window_start"]),
+		DailyUsageUSD:       parseFloat(m["daily_usage"]),
+		WeeklyUsageUSD:      parseFloat(m["weekly_usage"]),
+		MonthlyUsageUSD:     parseFloat(m["monthly_usage"]),
+		Version:             parseInt64(m["version"]),
+		SchemaVersion:       parseInt64(m["schema_version"]),
+		DailyLimitUSD:       parseFloatPtr(m["daily_limit"]),
+		WeeklyLimitUSD:      parseFloatPtr(m["weekly_limit"]),
+		MonthlyLimitUSD:     parseFloatPtr(m["monthly_limit"]),
+		DailyWindowStart:    parseTimePtr(m["daily_window_start"]),
+		WeeklyWindowStart:   parseTimePtr(m["weekly_window_start"]),
+		WeeklyWindowResetAt: parseTimePtr(m["weekly_window_reset_at"]),
+		MonthlyWindowStart:  parseTimePtr(m["monthly_window_start"]),
 	}
 }
 
@@ -484,6 +485,7 @@ func (c *billingCache) SetUserPlatformQuotaCache(ctx context.Context, userID int
 		"monthly_limit", fmtFloatPtr(entry.MonthlyLimitUSD),
 		"daily_window_start", fmtTimePtr(entry.DailyWindowStart),
 		"weekly_window_start", fmtTimePtr(entry.WeeklyWindowStart),
+		"weekly_window_reset_at", fmtTimePtr(entry.WeeklyWindowResetAt),
 		"monthly_window_start", fmtTimePtr(entry.MonthlyWindowStart),
 	)
 	pipe.Expire(ctx, key, ttl)

--- a/backend/internal/repository/user_platform_quota_repo.go
+++ b/backend/internal/repository/user_platform_quota_repo.go
@@ -16,17 +16,18 @@ import (
 // UserPlatformQuotaRecord 是 repository 层的传输结构体，
 // 与 ent.UserPlatformQuota 实体解耦，供业务层使用。
 type UserPlatformQuotaRecord struct {
-	UserID             int64
-	Platform           string
-	DailyLimitUSD      *float64
-	WeeklyLimitUSD     *float64
-	MonthlyLimitUSD    *float64
-	DailyUsageUSD      float64
-	WeeklyUsageUSD     float64
-	MonthlyUsageUSD    float64
-	DailyWindowStart   *time.Time
-	WeeklyWindowStart  *time.Time
-	MonthlyWindowStart *time.Time
+	UserID              int64
+	Platform            string
+	DailyLimitUSD       *float64
+	WeeklyLimitUSD      *float64
+	MonthlyLimitUSD     *float64
+	DailyUsageUSD       float64
+	WeeklyUsageUSD      float64
+	MonthlyUsageUSD     float64
+	DailyWindowStart    *time.Time
+	WeeklyWindowStart   *time.Time
+	WeeklyWindowResetAt *time.Time
+	MonthlyWindowStart  *time.Time
 }
 
 // ErrUserPlatformQuotaNotFound 用于 ResetExpiredWindow 等需要"必须命中已有记录"的方法。
@@ -38,14 +39,15 @@ var ErrUserPlatformQuotaFKViolation = errors.New("user platform quota snapshot F
 // UserPlatformQuotaSnapshot 是 BatchSnapshotUsage 的输入结构体，
 // 表示 Redis 当前窗口快照（用于绝对值覆盖写入 DB）。
 type UserPlatformQuotaSnapshot struct {
-	UserID             int64
-	Platform           string
-	DailyUsageUSD      float64
-	WeeklyUsageUSD     float64
-	MonthlyUsageUSD    float64
-	DailyWindowStart   time.Time
-	WeeklyWindowStart  time.Time
-	MonthlyWindowStart time.Time
+	UserID              int64
+	Platform            string
+	DailyUsageUSD       float64
+	WeeklyUsageUSD      float64
+	MonthlyUsageUSD     float64
+	DailyWindowStart    time.Time
+	WeeklyWindowStart   time.Time
+	WeeklyWindowResetAt *time.Time
+	MonthlyWindowStart  time.Time
 }
 
 // UserPlatformQuotaRepository 定义用户平台配额的数据访问接口。
@@ -212,7 +214,9 @@ func (r *userPlatformQuotaRepository) IncrementUsageWithReset(ctx context.Contex
 		}
 
 		newDaily := maybeReset(existing.DailyUsageUsd, existing.DailyWindowStart, timezone.StartOfDay(now), cost)
-		newWeekly := maybeReset(existing.WeeklyUsageUsd, existing.WeeklyWindowStart, timezone.StartOfWeek(now), cost)
+		newWeekly, newWeeklyStart, newWeeklyResetAt := weeklyMaybeReset(
+			existing.WeeklyUsageUsd, existing.WeeklyWindowStart, existing.WeeklyWindowResetAt, cost, now,
+		)
 		// 30 天滚动月度窗口：过期时重置为 cost 并以 now 为新起始，否则累加保留原起始
 		newMonthly, newMonthlyStart := monthlyMaybeReset(existing.MonthlyUsageUsd, existing.MonthlyWindowStart, cost, now)
 
@@ -221,7 +225,8 @@ func (r *userPlatformQuotaRepository) IncrementUsageWithReset(ctx context.Contex
 			SetWeeklyUsageUsd(newWeekly).
 			SetMonthlyUsageUsd(newMonthly).
 			SetDailyWindowStart(timezone.StartOfDay(now)).
-			SetWeeklyWindowStart(timezone.StartOfWeek(now)).
+			SetWeeklyWindowStart(newWeeklyStart).
+			SetNillableWeeklyWindowResetAt(newWeeklyResetAt).
 			SetMonthlyWindowStart(newMonthlyStart). // 30 天滚动：仅过期时更新起始
 			Save(txCtx)
 		return e
@@ -253,7 +258,8 @@ func (r *userPlatformQuotaRepository) ResetExpiredWindow(ctx context.Context, us
 	case "daily":
 		upd = upd.SetDailyUsageUsd(0).SetDailyWindowStart(newStart)
 	case "weekly":
-		upd = upd.SetWeeklyUsageUsd(0).SetWeeklyWindowStart(newStart)
+		upd = upd.SetWeeklyUsageUsd(0).SetWeeklyWindowStart(newStart).
+			SetWeeklyWindowResetAt(newStart.Add(7 * 24 * time.Hour))
 	case "monthly":
 		upd = upd.SetMonthlyUsageUsd(0).SetMonthlyWindowStart(newStart)
 	default:
@@ -267,6 +273,39 @@ func (r *userPlatformQuotaRepository) ResetExpiredWindow(ctx context.Context, us
 		return ErrUserPlatformQuotaNotFound
 	}
 	return nil
+}
+
+// ResetAllWeeklyWindows atomically resets every active user quota row for a
+// platform and returns the affected user IDs so callers can invalidate Redis.
+func (r *userPlatformQuotaRepository) ResetAllWeeklyWindows(ctx context.Context, platform string, newStart, newResetAt time.Time) ([]int64, error) {
+	client := clientFromContext(ctx, r.client)
+	if newResetAt.IsZero() {
+		newResetAt = newStart.Add(7 * 24 * time.Hour)
+	}
+	rows, err := client.QueryContext(ctx, `
+		UPDATE user_platform_quotas
+		SET weekly_usage_usd = 0,
+		    weekly_window_start = $2,
+		    weekly_window_reset_at = $3,
+		    updated_at = $4
+		WHERE platform = $1 AND deleted_at IS NULL
+		RETURNING user_id`, platform, newStart, newResetAt, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var userIDs []int64
+	for rows.Next() {
+		var userID int64
+		if err := rows.Scan(&userID); err != nil {
+			return nil, err
+		}
+		userIDs = append(userIDs, userID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return userIDs, nil
 }
 
 // withTx 在事务中执行 fn，若 ctx 中已有事务则复用。
@@ -296,17 +335,18 @@ func (r *userPlatformQuotaRepository) withTx(ctx context.Context, fn func(txCtx 
 // 注意 ent 生成字段名为 DailyLimitUsd（非 DailyLimitUSD）。
 func entQuotaToRecord(e *dbent.UserPlatformQuota) *UserPlatformQuotaRecord {
 	return &UserPlatformQuotaRecord{
-		UserID:             e.UserID,
-		Platform:           e.Platform,
-		DailyLimitUSD:      e.DailyLimitUsd,
-		WeeklyLimitUSD:     e.WeeklyLimitUsd,
-		MonthlyLimitUSD:    e.MonthlyLimitUsd,
-		DailyUsageUSD:      e.DailyUsageUsd,
-		WeeklyUsageUSD:     e.WeeklyUsageUsd,
-		MonthlyUsageUSD:    e.MonthlyUsageUsd,
-		DailyWindowStart:   e.DailyWindowStart,
-		WeeklyWindowStart:  e.WeeklyWindowStart,
-		MonthlyWindowStart: e.MonthlyWindowStart,
+		UserID:              e.UserID,
+		Platform:            e.Platform,
+		DailyLimitUSD:       e.DailyLimitUsd,
+		WeeklyLimitUSD:      e.WeeklyLimitUsd,
+		MonthlyLimitUSD:     e.MonthlyLimitUsd,
+		DailyUsageUSD:       e.DailyUsageUsd,
+		WeeklyUsageUSD:      e.WeeklyUsageUsd,
+		MonthlyUsageUSD:     e.MonthlyUsageUsd,
+		DailyWindowStart:    e.DailyWindowStart,
+		WeeklyWindowStart:   e.WeeklyWindowStart,
+		WeeklyWindowResetAt: e.WeeklyWindowResetAt,
+		MonthlyWindowStart:  e.MonthlyWindowStart,
 	}
 }
 
@@ -318,6 +358,29 @@ func maybeReset(prevUsage float64, prevStart *time.Time, currStart time.Time, co
 		return cost
 	}
 	return prevUsage + cost
+}
+
+// weeklyMaybeReset supports both legacy natural-week windows and explicitly
+// anchored rolling seven-day windows. A manual/anchored window keeps its
+// cadence at reset_at + 7 days; a legacy row continues to use Monday 00:00.
+func weeklyMaybeReset(prevUsage float64, prevStart, prevResetAt *time.Time, cost float64, now time.Time) (float64, time.Time, *time.Time) {
+	if prevResetAt != nil {
+		start := prevResetAt.Add(-7 * 24 * time.Hour)
+		if prevStart != nil {
+			start = *prevStart
+		}
+		resetAt := *prevResetAt
+		if !now.Before(resetAt) {
+			for !now.Before(resetAt) {
+				start = resetAt
+				resetAt = resetAt.Add(7 * 24 * time.Hour)
+			}
+			return cost, start, &resetAt
+		}
+		return prevUsage + cost, start, prevResetAt
+	}
+	currStart := timezone.StartOfWeek(now)
+	return maybeReset(prevUsage, prevStart, currStart, cost), currStart, nil
 }
 
 // monthlyMaybeReset 判断 30 天滚动月度窗口是否需要重置。
@@ -441,7 +504,7 @@ func insertLimitsRow(ctx context.Context, client *dbent.Client, userID int64, re
 const batchRows = 6000
 
 // BatchSnapshotUsage 用一条多行 UPSERT 把整批 usage 以绝对值覆盖写入（非累加）。
-// 每批最多 batchRows 行；$1=now 共用；每行 8 个 per-row 参（user_id, platform, 3×usage, 3×window_start）。
+// 每批最多 batchRows 行；$1=now 共用；每行 9 个 per-row 参（user_id, platform, 3×usage, 4×window_start/reset）。
 // FK 违反（user_id 不存在）返回 ErrUserPlatformQuotaFKViolation。
 //
 // 注意:snapshots 超过 batchRows 会分多条 SQL 执行且【非单事务】——若某子批 FK 失败,
@@ -467,22 +530,22 @@ func (r *userPlatformQuotaRepository) BatchSnapshotUsage(ctx context.Context, sn
 		_, _ = sb.WriteString(
 			"INSERT INTO user_platform_quotas" +
 				" (user_id, platform, daily_usage_usd, weekly_usage_usd, monthly_usage_usd," +
-				" daily_window_start, weekly_window_start, monthly_window_start, created_at, updated_at)" +
+				" daily_window_start, weekly_window_start, weekly_window_reset_at, monthly_window_start, created_at, updated_at)" +
 				" VALUES ")
 
-		// $1 = now（共用）；每行 8 个 per-row 参，从 $2 起连续编号。
+		// $1 = now（共用）；每行 9 个 per-row 参，从 $2 起连续编号。
 		args := []any{now}
 		for i, s := range batch {
 			if i > 0 {
 				_, _ = sb.WriteString(",")
 			}
 			b := len(args) // 当前 per-row 第一个参数的 0-based 索引，实际占位符 = b+1
-			fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$1,$1)",
-				b+1, b+2, b+3, b+4, b+5, b+6, b+7, b+8)
+			fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$1,$1)",
+				b+1, b+2, b+3, b+4, b+5, b+6, b+7, b+8, b+9)
 			args = append(args,
 				s.UserID, s.Platform,
 				s.DailyUsageUSD, s.WeeklyUsageUSD, s.MonthlyUsageUSD,
-				s.DailyWindowStart, s.WeeklyWindowStart, s.MonthlyWindowStart,
+				s.DailyWindowStart, s.WeeklyWindowStart, s.WeeklyWindowResetAt, s.MonthlyWindowStart,
 			)
 		}
 
@@ -493,6 +556,7 @@ func (r *userPlatformQuotaRepository) BatchSnapshotUsage(ctx context.Context, sn
 				"  monthly_usage_usd    = EXCLUDED.monthly_usage_usd," +
 				"  daily_window_start   = EXCLUDED.daily_window_start," +
 				"  weekly_window_start  = EXCLUDED.weekly_window_start," +
+				"  weekly_window_reset_at = EXCLUDED.weekly_window_reset_at," +
 				"  monthly_window_start = EXCLUDED.monthly_window_start," +
 				"  updated_at           = EXCLUDED.updated_at")
 

--- a/backend/internal/repository/user_platform_quota_service_adapter.go
+++ b/backend/internal/repository/user_platform_quota_service_adapter.go
@@ -48,17 +48,18 @@ func (a *userPlatformQuotaServiceAdapter) ListByUser(ctx context.Context, userID
 	out := make([]service.UserPlatformQuotaRecord, len(rows))
 	for i, r := range rows {
 		out[i] = service.UserPlatformQuotaRecord{
-			UserID:             r.UserID,
-			Platform:           r.Platform,
-			DailyLimitUSD:      r.DailyLimitUSD,
-			WeeklyLimitUSD:     r.WeeklyLimitUSD,
-			MonthlyLimitUSD:    r.MonthlyLimitUSD,
-			DailyUsageUSD:      r.DailyUsageUSD,
-			WeeklyUsageUSD:     r.WeeklyUsageUSD,
-			MonthlyUsageUSD:    r.MonthlyUsageUSD,
-			DailyWindowStart:   r.DailyWindowStart,
-			WeeklyWindowStart:  r.WeeklyWindowStart,
-			MonthlyWindowStart: r.MonthlyWindowStart,
+			UserID:              r.UserID,
+			Platform:            r.Platform,
+			DailyLimitUSD:       r.DailyLimitUSD,
+			WeeklyLimitUSD:      r.WeeklyLimitUSD,
+			MonthlyLimitUSD:     r.MonthlyLimitUSD,
+			DailyUsageUSD:       r.DailyUsageUSD,
+			WeeklyUsageUSD:      r.WeeklyUsageUSD,
+			MonthlyUsageUSD:     r.MonthlyUsageUSD,
+			DailyWindowStart:    r.DailyWindowStart,
+			WeeklyWindowStart:   r.WeeklyWindowStart,
+			WeeklyWindowResetAt: r.WeeklyWindowResetAt,
+			MonthlyWindowStart:  r.MonthlyWindowStart,
 		}
 	}
 	return out, nil
@@ -94,20 +95,26 @@ func (a *userPlatformQuotaServiceAdapter) ResetExpiredWindow(ctx context.Context
 	return err
 }
 
+// ResetAllWeeklyWindows resets every active quota row for a platform.
+func (a *userPlatformQuotaServiceAdapter) ResetAllWeeklyWindows(ctx context.Context, platform string, newStart, newResetAt time.Time) ([]int64, error) {
+	return a.inner.ResetAllWeeklyWindows(ctx, platform, newStart, newResetAt)
+}
+
 // BatchSnapshotUsage 转换 []service.UserPlatformQuotaSnapshot → []UserPlatformQuotaSnapshot，
 // 调底层 repo，并将 repository FK sentinel 包装为 service sentinel。
 func (a *userPlatformQuotaServiceAdapter) BatchSnapshotUsage(ctx context.Context, snapshots []service.UserPlatformQuotaSnapshot, now time.Time) error {
 	repoSnaps := make([]UserPlatformQuotaSnapshot, len(snapshots))
 	for i, s := range snapshots {
 		repoSnaps[i] = UserPlatformQuotaSnapshot{
-			UserID:             s.UserID,
-			Platform:           s.Platform,
-			DailyUsageUSD:      s.DailyUsageUSD,
-			WeeklyUsageUSD:     s.WeeklyUsageUSD,
-			MonthlyUsageUSD:    s.MonthlyUsageUSD,
-			DailyWindowStart:   s.DailyWindowStart,
-			WeeklyWindowStart:  s.WeeklyWindowStart,
-			MonthlyWindowStart: s.MonthlyWindowStart,
+			UserID:              s.UserID,
+			Platform:            s.Platform,
+			DailyUsageUSD:       s.DailyUsageUSD,
+			WeeklyUsageUSD:      s.WeeklyUsageUSD,
+			MonthlyUsageUSD:     s.MonthlyUsageUSD,
+			DailyWindowStart:    s.DailyWindowStart,
+			WeeklyWindowStart:   s.WeeklyWindowStart,
+			WeeklyWindowResetAt: s.WeeklyWindowResetAt,
+			MonthlyWindowStart:  s.MonthlyWindowStart,
 		}
 	}
 	err := a.inner.BatchSnapshotUsage(ctx, repoSnaps, now)
@@ -144,17 +151,18 @@ func (a *genericUserPlatformQuotaAdapter) ListByUser(ctx context.Context, userID
 	out := make([]service.UserPlatformQuotaRecord, len(rows))
 	for i, r := range rows {
 		out[i] = service.UserPlatformQuotaRecord{
-			UserID:             r.UserID,
-			Platform:           r.Platform,
-			DailyLimitUSD:      r.DailyLimitUSD,
-			WeeklyLimitUSD:     r.WeeklyLimitUSD,
-			MonthlyLimitUSD:    r.MonthlyLimitUSD,
-			DailyUsageUSD:      r.DailyUsageUSD,
-			WeeklyUsageUSD:     r.WeeklyUsageUSD,
-			MonthlyUsageUSD:    r.MonthlyUsageUSD,
-			DailyWindowStart:   r.DailyWindowStart,
-			WeeklyWindowStart:  r.WeeklyWindowStart,
-			MonthlyWindowStart: r.MonthlyWindowStart,
+			UserID:              r.UserID,
+			Platform:            r.Platform,
+			DailyLimitUSD:       r.DailyLimitUSD,
+			WeeklyLimitUSD:      r.WeeklyLimitUSD,
+			MonthlyLimitUSD:     r.MonthlyLimitUSD,
+			DailyUsageUSD:       r.DailyUsageUSD,
+			WeeklyUsageUSD:      r.WeeklyUsageUSD,
+			MonthlyUsageUSD:     r.MonthlyUsageUSD,
+			DailyWindowStart:    r.DailyWindowStart,
+			WeeklyWindowStart:   r.WeeklyWindowStart,
+			WeeklyWindowResetAt: r.WeeklyWindowResetAt,
+			MonthlyWindowStart:  r.MonthlyWindowStart,
 		}
 	}
 	return out, nil
@@ -190,20 +198,26 @@ func (a *genericUserPlatformQuotaAdapter) ResetExpiredWindow(ctx context.Context
 	return err
 }
 
+// ResetAllWeeklyWindows is unavailable for lightweight test/fake repositories.
+func (a *genericUserPlatformQuotaAdapter) ResetAllWeeklyWindows(ctx context.Context, platform string, newStart, newResetAt time.Time) ([]int64, error) {
+	return nil, errors.New("bulk weekly quota reset is unavailable")
+}
+
 // BatchSnapshotUsage 转换 []service.UserPlatformQuotaSnapshot → []UserPlatformQuotaSnapshot（通用 adapter），
 // 并将 repository FK sentinel 包装为 service sentinel。
 func (a *genericUserPlatformQuotaAdapter) BatchSnapshotUsage(ctx context.Context, snapshots []service.UserPlatformQuotaSnapshot, now time.Time) error {
 	repoSnaps := make([]UserPlatformQuotaSnapshot, len(snapshots))
 	for i, s := range snapshots {
 		repoSnaps[i] = UserPlatformQuotaSnapshot{
-			UserID:             s.UserID,
-			Platform:           s.Platform,
-			DailyUsageUSD:      s.DailyUsageUSD,
-			WeeklyUsageUSD:     s.WeeklyUsageUSD,
-			MonthlyUsageUSD:    s.MonthlyUsageUSD,
-			DailyWindowStart:   s.DailyWindowStart,
-			WeeklyWindowStart:  s.WeeklyWindowStart,
-			MonthlyWindowStart: s.MonthlyWindowStart,
+			UserID:              s.UserID,
+			Platform:            s.Platform,
+			DailyUsageUSD:       s.DailyUsageUSD,
+			WeeklyUsageUSD:      s.WeeklyUsageUSD,
+			MonthlyUsageUSD:     s.MonthlyUsageUSD,
+			DailyWindowStart:    s.DailyWindowStart,
+			WeeklyWindowStart:   s.WeeklyWindowStart,
+			WeeklyWindowResetAt: s.WeeklyWindowResetAt,
+			MonthlyWindowStart:  s.MonthlyWindowStart,
 		}
 	}
 	err := a.inner.BatchSnapshotUsage(ctx, repoSnaps, now)
@@ -216,17 +230,18 @@ func (a *genericUserPlatformQuotaAdapter) BatchSnapshotUsage(ctx context.Context
 // toServiceRecord 将 repository.UserPlatformQuotaRecord 转换为 service.UserPlatformQuotaRecord。
 func toServiceRecord(rec *UserPlatformQuotaRecord) *service.UserPlatformQuotaRecord {
 	return &service.UserPlatformQuotaRecord{
-		UserID:             rec.UserID,
-		Platform:           rec.Platform,
-		DailyLimitUSD:      rec.DailyLimitUSD,
-		WeeklyLimitUSD:     rec.WeeklyLimitUSD,
-		MonthlyLimitUSD:    rec.MonthlyLimitUSD,
-		DailyUsageUSD:      rec.DailyUsageUSD,
-		WeeklyUsageUSD:     rec.WeeklyUsageUSD,
-		MonthlyUsageUSD:    rec.MonthlyUsageUSD,
-		DailyWindowStart:   rec.DailyWindowStart,
-		WeeklyWindowStart:  rec.WeeklyWindowStart,
-		MonthlyWindowStart: rec.MonthlyWindowStart,
+		UserID:              rec.UserID,
+		Platform:            rec.Platform,
+		DailyLimitUSD:       rec.DailyLimitUSD,
+		WeeklyLimitUSD:      rec.WeeklyLimitUSD,
+		MonthlyLimitUSD:     rec.MonthlyLimitUSD,
+		DailyUsageUSD:       rec.DailyUsageUSD,
+		WeeklyUsageUSD:      rec.WeeklyUsageUSD,
+		MonthlyUsageUSD:     rec.MonthlyUsageUSD,
+		DailyWindowStart:    rec.DailyWindowStart,
+		WeeklyWindowStart:   rec.WeeklyWindowStart,
+		WeeklyWindowResetAt: rec.WeeklyWindowResetAt,
+		MonthlyWindowStart:  rec.MonthlyWindowStart,
 	}
 }
 
@@ -235,17 +250,18 @@ func toRepoRecords(records []service.UserPlatformQuotaRecord) []UserPlatformQuot
 	out := make([]UserPlatformQuotaRecord, len(records))
 	for i, r := range records {
 		out[i] = UserPlatformQuotaRecord{
-			UserID:             r.UserID,
-			Platform:           r.Platform,
-			DailyLimitUSD:      r.DailyLimitUSD,
-			WeeklyLimitUSD:     r.WeeklyLimitUSD,
-			MonthlyLimitUSD:    r.MonthlyLimitUSD,
-			DailyUsageUSD:      r.DailyUsageUSD,
-			WeeklyUsageUSD:     r.WeeklyUsageUSD,
-			MonthlyUsageUSD:    r.MonthlyUsageUSD,
-			DailyWindowStart:   r.DailyWindowStart,
-			WeeklyWindowStart:  r.WeeklyWindowStart,
-			MonthlyWindowStart: r.MonthlyWindowStart,
+			UserID:              r.UserID,
+			Platform:            r.Platform,
+			DailyLimitUSD:       r.DailyLimitUSD,
+			WeeklyLimitUSD:      r.WeeklyLimitUSD,
+			MonthlyLimitUSD:     r.MonthlyLimitUSD,
+			DailyUsageUSD:       r.DailyUsageUSD,
+			WeeklyUsageUSD:      r.WeeklyUsageUSD,
+			MonthlyUsageUSD:     r.MonthlyUsageUSD,
+			DailyWindowStart:    r.DailyWindowStart,
+			WeeklyWindowStart:   r.WeeklyWindowStart,
+			WeeklyWindowResetAt: r.WeeklyWindowResetAt,
+			MonthlyWindowStart:  r.MonthlyWindowStart,
 		}
 	}
 	return out

--- a/backend/internal/service/billing_cache_service.go
+++ b/backend/internal/service/billing_cache_service.go
@@ -1113,6 +1113,7 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 		windowExpired := false
 		newDailyStart := entry.DailyWindowStart
 		newWeeklyStart := entry.WeeklyWindowStart
+		newWeeklyResetAt := entry.WeeklyWindowResetAt
 		newMonthlyStart := entry.MonthlyWindowStart
 		if quotaWindowExpired(entry.DailyWindowStart, timezone.StartOfDay(now)) {
 			dailyUsage = 0
@@ -1120,11 +1121,12 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			dayStart := timezone.StartOfDay(now)
 			newDailyStart = &dayStart
 		}
-		if quotaWindowExpired(entry.WeeklyWindowStart, timezone.StartOfWeek(now)) {
+		weeklyExpired, weeklyStart, weeklyResetAt := weeklyQuotaWindowState(entry.WeeklyWindowStart, entry.WeeklyWindowResetAt, now)
+		if weeklyExpired {
 			weeklyUsage = 0
 			windowExpired = true
-			weekStart := timezone.StartOfWeek(now)
-			newWeeklyStart = &weekStart
+			newWeeklyStart = weeklyStart
+			newWeeklyResetAt = weeklyResetAt
 		}
 		if monthlyQuotaWindowExpired(entry.MonthlyWindowStart, now) {
 			monthlyUsage = 0
@@ -1146,16 +1148,17 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 		isSentinel := entry.DailyLimitUSD == nil && entry.WeeklyLimitUSD == nil && entry.MonthlyLimitUSD == nil
 		if windowExpired && s.cache != nil && !isSentinel {
 			refreshed := &UserPlatformQuotaCacheEntry{
-				DailyUsageUSD:      dailyUsage,
-				WeeklyUsageUSD:     weeklyUsage,
-				MonthlyUsageUSD:    monthlyUsage,
-				SchemaVersion:      UserPlatformQuotaCacheSchemaV1,
-				DailyLimitUSD:      entry.DailyLimitUSD,
-				WeeklyLimitUSD:     entry.WeeklyLimitUSD,
-				MonthlyLimitUSD:    entry.MonthlyLimitUSD,
-				DailyWindowStart:   newDailyStart,
-				WeeklyWindowStart:  newWeeklyStart,
-				MonthlyWindowStart: newMonthlyStart,
+				DailyUsageUSD:       dailyUsage,
+				WeeklyUsageUSD:      weeklyUsage,
+				MonthlyUsageUSD:     monthlyUsage,
+				SchemaVersion:       UserPlatformQuotaCacheSchemaV1,
+				DailyLimitUSD:       entry.DailyLimitUSD,
+				WeeklyLimitUSD:      entry.WeeklyLimitUSD,
+				MonthlyLimitUSD:     entry.MonthlyLimitUSD,
+				DailyWindowStart:    newDailyStart,
+				WeeklyWindowStart:   newWeeklyStart,
+				WeeklyWindowResetAt: newWeeklyResetAt,
+				MonthlyWindowStart:  newMonthlyStart,
 			}
 			ttl := time.Duration(s.cfg.Billing.UserPlatformQuotaCacheTTLSeconds) * time.Second
 			setCtx, setCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -1170,7 +1173,11 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 		}
 		if entry.WeeklyLimitUSD != nil && weeklyUsage >= *entry.WeeklyLimitUSD {
-			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+			resetAt := nextWeeklyReset(now)
+			if newWeeklyResetAt != nil {
+				resetAt = *newWeeklyResetAt
+			}
+			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, resetAt)
 		}
 		if entry.MonthlyLimitUSD != nil && monthlyUsage >= *entry.MonthlyLimitUSD {
 			return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(entry.MonthlyWindowStart, now))
@@ -1244,7 +1251,8 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 	if quotaWindowExpired(rec.DailyWindowStart, timezone.StartOfDay(now)) {
 		dailyUsage = 0
 	}
-	if quotaWindowExpired(rec.WeeklyWindowStart, timezone.StartOfWeek(now)) {
+	weeklyExpired, dbWeeklyStart, dbWeeklyResetAt := weeklyQuotaWindowState(rec.WeeklyWindowStart, rec.WeeklyWindowResetAt, now)
+	if weeklyExpired {
 		weeklyUsage = 0
 	}
 	if monthlyQuotaWindowExpired(rec.MonthlyWindowStart, now) {
@@ -1257,7 +1265,11 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 		}
 		if rec.WeeklyLimitUSD != nil && weeklyUsage >= *rec.WeeklyLimitUSD {
-			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+			resetAt := nextWeeklyReset(now)
+			if dbWeeklyResetAt != nil {
+				resetAt = *dbWeeklyResetAt
+			}
+			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, resetAt)
 		}
 		if rec.MonthlyLimitUSD != nil && monthlyUsage >= *rec.MonthlyLimitUSD {
 			return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(rec.MonthlyWindowStart, now))
@@ -1267,16 +1279,17 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 
 	// cache MISS 或旧版 entry → 回填完整 entry（含 limits 和 window_start）
 	newEntry := &UserPlatformQuotaCacheEntry{
-		DailyUsageUSD:      dailyUsage,
-		WeeklyUsageUSD:     weeklyUsage,
-		MonthlyUsageUSD:    monthlyUsage,
-		SchemaVersion:      UserPlatformQuotaCacheSchemaV1,
-		DailyLimitUSD:      rec.DailyLimitUSD,
-		WeeklyLimitUSD:     rec.WeeklyLimitUSD,
-		MonthlyLimitUSD:    rec.MonthlyLimitUSD,
-		DailyWindowStart:   rec.DailyWindowStart,
-		WeeklyWindowStart:  rec.WeeklyWindowStart,
-		MonthlyWindowStart: rec.MonthlyWindowStart,
+		DailyUsageUSD:       dailyUsage,
+		WeeklyUsageUSD:      weeklyUsage,
+		MonthlyUsageUSD:     monthlyUsage,
+		SchemaVersion:       UserPlatformQuotaCacheSchemaV1,
+		DailyLimitUSD:       rec.DailyLimitUSD,
+		WeeklyLimitUSD:      rec.WeeklyLimitUSD,
+		MonthlyLimitUSD:     rec.MonthlyLimitUSD,
+		DailyWindowStart:    rec.DailyWindowStart,
+		WeeklyWindowStart:   dbWeeklyStart,
+		WeeklyWindowResetAt: dbWeeklyResetAt,
+		MonthlyWindowStart:  rec.MonthlyWindowStart,
 	}
 	if s.cache != nil {
 		ttl := time.Duration(s.cfg.Billing.UserPlatformQuotaCacheTTLSeconds) * time.Second
@@ -1294,7 +1307,11 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 		return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 	}
 	if rec.WeeklyLimitUSD != nil && weeklyUsage >= *rec.WeeklyLimitUSD {
-		return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+		resetAt := nextWeeklyReset(now)
+		if dbWeeklyResetAt != nil {
+			resetAt = *dbWeeklyResetAt
+		}
+		return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, resetAt)
 	}
 	if rec.MonthlyLimitUSD != nil && monthlyUsage >= *rec.MonthlyLimitUSD {
 		return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(rec.MonthlyWindowStart, now))
@@ -1342,6 +1359,36 @@ func quotaWindowExpired(start *time.Time, currWindowStart time.Time) bool {
 		return true
 	}
 	return start.Before(currWindowStart)
+}
+
+// weeklyQuotaWindowState returns the effective weekly window state. A nil
+// reset_at keeps the legacy Monday-based window; a non-nil reset_at advances
+// an anchored rolling seven-day window without losing cadence after downtime.
+func weeklyQuotaWindowState(start, resetAt *time.Time, now time.Time) (expired bool, nextStart, nextResetAt *time.Time) {
+	if resetAt == nil {
+		currentStart := timezone.StartOfWeek(now)
+		if quotaWindowExpired(start, currentStart) {
+			return true, &currentStart, nil
+		}
+		return false, start, nil
+	}
+
+	windowStart := start
+	if windowStart == nil {
+		fallbackStart := resetAt.Add(-7 * 24 * time.Hour)
+		windowStart = &fallbackStart
+	}
+	if now.Before(*resetAt) {
+		return false, windowStart, resetAt
+	}
+
+	newStart := *resetAt
+	next := resetAt.Add(7 * 24 * time.Hour)
+	for !now.Before(next) {
+		newStart = next
+		next = next.Add(7 * 24 * time.Hour)
+	}
+	return true, &newStart, &next
 }
 
 // monthlyQuotaWindowExpired 判断 30 天滚动月度窗口是否已过期。

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -49,9 +49,10 @@ type UserPlatformQuotaCacheEntry struct {
 	WeeklyLimitUSD  *float64
 	MonthlyLimitUSD *float64
 
-	DailyWindowStart   *time.Time
-	WeeklyWindowStart  *time.Time
-	MonthlyWindowStart *time.Time
+	DailyWindowStart    *time.Time
+	WeeklyWindowStart   *time.Time
+	WeeklyWindowResetAt *time.Time
+	MonthlyWindowStart  *time.Time
 }
 
 // BillingCache defines cache operations for billing service

--- a/backend/internal/service/user_platform_quota_flusher.go
+++ b/backend/internal/service/user_platform_quota_flusher.go
@@ -154,14 +154,15 @@ func (s *UserPlatformQuotaUsageFlusher) flushOneBatch(parentCtx context.Context)
 			continue
 		}
 		snaps = append(snaps, UserPlatformQuotaSnapshot{
-			UserID:             key.UserID,
-			Platform:           key.Platform,
-			DailyUsageUSD:      e.DailyUsageUSD,
-			WeeklyUsageUSD:     e.WeeklyUsageUSD,
-			MonthlyUsageUSD:    e.MonthlyUsageUSD,
-			DailyWindowStart:   *e.DailyWindowStart,
-			WeeklyWindowStart:  *e.WeeklyWindowStart,
-			MonthlyWindowStart: *e.MonthlyWindowStart,
+			UserID:              key.UserID,
+			Platform:            key.Platform,
+			DailyUsageUSD:       e.DailyUsageUSD,
+			WeeklyUsageUSD:      e.WeeklyUsageUSD,
+			MonthlyUsageUSD:     e.MonthlyUsageUSD,
+			DailyWindowStart:    *e.DailyWindowStart,
+			WeeklyWindowStart:   *e.WeeklyWindowStart,
+			WeeklyWindowResetAt: e.WeeklyWindowResetAt,
+			MonthlyWindowStart:  *e.MonthlyWindowStart,
 		})
 	}
 

--- a/backend/internal/service/user_platform_quota_port.go
+++ b/backend/internal/service/user_platform_quota_port.go
@@ -18,14 +18,15 @@ var ErrUserPlatformQuotaFKViolation = errors.New("user platform quota snapshot F
 // UserPlatformQuotaSnapshot 是 service 层 flusher 向 DB 写入快照时使用的传输结构。
 // 字段语义与 repository.UserPlatformQuotaSnapshot 完全对应，由 adapter 负责转换。
 type UserPlatformQuotaSnapshot struct {
-	UserID             int64
-	Platform           string
-	DailyUsageUSD      float64
-	WeeklyUsageUSD     float64
-	MonthlyUsageUSD    float64
-	DailyWindowStart   time.Time
-	WeeklyWindowStart  time.Time
-	MonthlyWindowStart time.Time
+	UserID              int64
+	Platform            string
+	DailyUsageUSD       float64
+	WeeklyUsageUSD      float64
+	MonthlyUsageUSD     float64
+	DailyWindowStart    time.Time
+	WeeklyWindowStart   time.Time
+	WeeklyWindowResetAt *time.Time
+	MonthlyWindowStart  time.Time
 }
 
 // UserPlatformQuotaRecord service 层传输结构体（与 repository 层解耦）。
@@ -39,9 +40,17 @@ type UserPlatformQuotaRecord struct {
 	WeeklyUsageUSD  float64
 	MonthlyUsageUSD float64
 	// 窗口起始时间（可选，用于未来 reset 校验）
-	DailyWindowStart   *time.Time
-	WeeklyWindowStart  *time.Time
-	MonthlyWindowStart *time.Time
+	DailyWindowStart    *time.Time
+	WeeklyWindowStart   *time.Time
+	WeeklyWindowResetAt *time.Time
+	MonthlyWindowStart  *time.Time
+}
+
+// UserPlatformQuotaWeeklyResetter resets the weekly window for every active
+// user on a platform. It is intentionally separate from the ordinary quota
+// repository port so lightweight callers and tests do not need the bulk hook.
+type UserPlatformQuotaWeeklyResetter interface {
+	ResetAllWeeklyWindows(ctx context.Context, platform string, newStart, newResetAt time.Time) ([]int64, error)
 }
 
 // UserPlatformQuotaRepository 定义 service 层所需的 user × platform quota 数据访问端口。

--- a/backend/migrations/192_user_platform_quotas_weekly_reset_at.sql
+++ b/backend/migrations/192_user_platform_quotas_weekly_reset_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_platform_quotas
+    ADD COLUMN IF NOT EXISTS weekly_window_reset_at TIMESTAMPTZ;


### PR DESCRIPTION
## 变更内容

- 为用户平台配额增加可选的滚动周限额结束时间。
- 手动重置周限额时，同时设置新的七天窗口。
- Redis 缓存、数据库批量回写、限额校验和配额展示统一使用滚动窗口。
- 没有结束时间的旧记录继续沿用原有的自然周兼容逻辑。

## 验证

- go test ./internal/handler/quotaview ./internal/repository ./internal/service
- go build -o /tmp/sub2api-pr-anchor-build ./cmd/server

## 兼容性

旧记录无需数据回填；首次手动重置后进入滚动七天窗口。
