### PR TITLE
fix(openai): admit client-compatible accounts before forwarding

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -628,6 +628,11 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			)
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), currentAPIKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, parsedReq.MetadataUserID, subject.UserID)
 			if err != nil {
+				if errors.Is(err, service.ErrClaudeCodeOnly) {
+					service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+					h.handleStreamingAwareError(c, http.StatusForbidden, "permission_error", err.Error(), streamStarted)
+					return
+				}
 				if len(fs.FailedAccountIDs) == 0 {
 					cls := classifyNoAccountErrorFromGin(c, h.gatewayService, currentAPIKey, reqModel, reqModel, platform)
 					if !cls.ModelNotFound {
@@ -2058,6 +2063,11 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 	account, err := h.gatewayService.SelectAccountForModel(c.Request.Context(), apiKey.GroupID, sessionHash, parsedReq.Model)
 	if err != nil {
 		reqLog.Warn("gateway.count_tokens_select_account_failed", zap.Error(err))
+		if errors.Is(err, service.ErrClaudeCodeOnly) {
+			service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+			h.errorResponse(c, http.StatusForbidden, "permission_error", err.Error())
+			return
+		}
 		cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, parsedReq.Model, parsedReq.Model, service.PlatformAnthropic)
 		if !cls.ModelNotFound {
 			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -108,6 +108,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 	searchID := strings.TrimSpace(gjson.GetBytes(body, "id").String())
 	sessionHash := h.gatewayService.GenerateSessionHashWithFallback(c, nil, searchID)
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	var lastFailoverErr *service.UpstreamFailoverError
 	switchCount := 0
@@ -117,6 +118,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 	// 分组利润控制：alpha search 文本入口请求级装门并固定 pricingAt
 	//（记录路径经 service.OpenAIPricingAtFromContext 从请求 ctx 回读）。
 	asPricingCtx, _ := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	asPricingCtx = h.gatewayService.WithOpenAICodexClientAdmission(asPricingCtx, c, body)
 	c.Request = c.Request.WithContext(asPricingCtx)
 
 	for {
@@ -137,6 +139,13 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 		if err != nil || selection == nil || selection.Account == nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai_alpha_search.account_select_aborted_client_disconnected", zap.Error(err))
+				return
+			}
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, false) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
 				return
 			}
 			if len(failedAccountIDs) == 0 {
@@ -166,9 +175,17 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		writerSizeBeforeForward := c.Writer.Size()
 		forwardStart := time.Now()
@@ -187,6 +204,13 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 				h.recordAlphaSearchUsage(c, apiKey, account, subscription, channelMapping, requestedModel, body, result, subject.UserID)
 			}
 			return
+		}
+		if errors.Is(err, service.ErrCodexClientRestricted) {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
+			continue
 		}
 
 		var failoverErr *service.UpstreamFailoverError

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -175,6 +175,10 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
@@ -203,6 +207,10 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			if result != nil {
 				h.recordAlphaSearchUsage(c, apiKey, account, subscription, channelMapping, requestedModel, body, result, subject.UserID)
 			}
+			return
+		}
+		if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+			h.handleOpenAICodexAdmissionError(c, err, false, false)
 			return
 		}
 		if errors.Is(err, service.ErrCodexClientRestricted) {

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -143,6 +143,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
@@ -150,6 +151,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 	// 分组利润控制：chat completions 文本入口请求级装门并固定 pricingAt。
 	ccPricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	ccPricingCtx = h.gatewayService.WithOpenAICodexClientAdmission(ccPricingCtx, c, body)
 	c.Request = c.Request.WithContext(ccPricingCtx)
 
 	for {
@@ -180,6 +182,13 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, false) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel)
 				if !cls.ModelNotFound {
@@ -219,9 +228,17 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
@@ -256,6 +273,13 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+					return
+				}
+				continue
+			}
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai_chat_completions.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -228,6 +228,10 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
@@ -273,6 +277,10 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, streamStarted, false)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)

--- a/backend/internal/handler/openai_client_admission.go
+++ b/backend/internal/handler/openai_client_admission.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+const maxClientAdmissionVetoAttempts = service.MaxCodexClientAdmissionVetoAttempts
+
+func recordOpenAIClientAdmissionVeto(failedAccountIDs map[int64]struct{}, accountID int64, vetoCount *int) bool {
+	failedAccountIDs[accountID] = struct{}{}
+	*vetoCount = *vetoCount + 1
+	return *vetoCount < maxClientAdmissionVetoAttempts
+}
+
+func allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs map[int64]struct{}, vetoCount int) bool {
+	return vetoCount > 0 && len(failedAccountIDs) == vetoCount
+}
+
+func (h *OpenAIGatewayHandler) handleOpenAIClientAdmissionExhausted(
+	c *gin.Context,
+	ctx context.Context,
+	streamStarted bool,
+	anthropicFormat bool,
+) {
+	err := service.CodexClientAdmissionErrorFromContext(ctx)
+	if h.handleOpenAICodexAdmissionError(c, err, streamStarted, anthropicFormat) {
+		return
+	}
+	if anthropicFormat {
+		h.anthropicStreamingAwareError(c, http.StatusForbidden, "permission_error", "This account only allows Codex official clients", streamStarted)
+		return
+	}
+	h.handleStreamingAwareError(c, http.StatusForbidden, "forbidden_error", "This account only allows Codex official clients", streamStarted)
+}
+
+func (h *OpenAIGatewayHandler) handleOpenAICodexAdmissionError(
+	c *gin.Context,
+	err error,
+	streamStarted bool,
+	anthropicFormat bool,
+) bool {
+	if !errors.Is(err, service.ErrCodexClientRestricted) {
+		return false
+	}
+	result, ok := service.CodexClientRestrictionResultFromError(err)
+	if !ok {
+		result = service.CodexClientRestrictionDetectionResult{
+			Enabled: true,
+			Matched: false,
+		}
+	}
+	service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+	message := service.CodexClientRestrictionMessage(result)
+	if anthropicFormat {
+		h.anthropicStreamingAwareError(c, http.StatusForbidden, "permission_error", message, streamStarted)
+	} else {
+		h.handleStreamingAwareError(c, http.StatusForbidden, "forbidden_error", message, streamStarted)
+	}
+	return true
+}

--- a/backend/internal/handler/openai_client_admission.go
+++ b/backend/internal/handler/openai_client_admission.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 )
 
@@ -44,6 +45,15 @@ func (h *OpenAIGatewayHandler) handleOpenAICodexAdmissionError(
 	streamStarted bool,
 	anthropicFormat bool,
 ) bool {
+	if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+		const message = "Account client policy is temporarily unavailable, please retry later"
+		if anthropicFormat {
+			h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", message, streamStarted)
+		} else {
+			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", message, streamStarted)
+		}
+		return true
+	}
 	if !errors.Is(err, service.ErrCodexClientRestricted) {
 		return false
 	}
@@ -62,4 +72,11 @@ func (h *OpenAIGatewayHandler) handleOpenAICodexAdmissionError(
 		h.handleStreamingAwareError(c, http.StatusForbidden, "forbidden_error", message, streamStarted)
 	}
 	return true
+}
+
+func openAIClientAdmissionWSClose(err error, result service.CodexClientRestrictionDetectionResult) (coderws.StatusCode, string) {
+	if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+		return coderws.StatusTryAgainLater, "account client policy is temporarily unavailable, please retry"
+	}
+	return coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result)
 }

--- a/backend/internal/handler/openai_client_admission_slot_test.go
+++ b/backend/internal/handler/openai_client_admission_slot_test.go
@@ -1,0 +1,173 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+type clientAdmissionSequenceConcurrencyCache struct {
+	fakeConcurrencyCache
+	acquireCalls   atomic.Int64
+	accountRelease atomic.Int64
+}
+
+func (c *clientAdmissionSequenceConcurrencyCache) AcquireAccountSlot(context.Context, int64, int, string) (bool, error) {
+	// acquireResponsesAccountSlot 先走一次快速抢槽；返回 false 后，WaitPlan
+	// helper 会再次尝试。第二次成功即可稳定覆盖真实等待分支而不引入 sleep。
+	return c.acquireCalls.Add(1) >= 2, nil
+}
+
+func (c *clientAdmissionSequenceConcurrencyCache) ReleaseAccountSlot(context.Context, int64, string) error {
+	c.accountRelease.Add(1)
+	return nil
+}
+
+func clientAdmissionRejectedAccount(id int64) *service.Account {
+	rate := 0.1
+	return &service.Account{
+		ID:             id,
+		Platform:       service.PlatformOpenAI,
+		Type:           service.AccountTypeOAuth,
+		Status:         service.StatusActive,
+		Schedulable:    true,
+		Concurrency:    2,
+		RateMultiplier: &rate,
+		Extra: map[string]any{
+			"codex_cli_only": true,
+		},
+	}
+}
+
+func clientAdmissionRejectedContext(t *testing.T, gw *service.OpenAIGatewayService, c *gin.Context) context.Context {
+	t.Helper()
+	if c.Request == nil {
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	}
+	c.Request.Header.Set("User-Agent", "curl/8.0")
+	ctx := gw.WithOpenAICodexClientAdmission(c.Request.Context(), c, []byte(`{"model":"gpt-5.1"}`))
+	require.True(t, service.OpenAICodexClientAdmissionActive(ctx))
+	c.Request = c.Request.WithContext(ctx)
+	return ctx
+}
+
+func TestAcquireResponsesAccountSlotClientAdmissionRecheckAllSlotPaths(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gw := &service.OpenAIGatewayService{}
+	groupID := int64(50)
+
+	t.Run("scheduler already acquired", func(t *testing.T) {
+		cache := &profitCountingConcurrencyCache{}
+		h := &OpenAIGatewayHandler{
+			gatewayService:    gw,
+			concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatClaude, 0),
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		clientAdmissionRejectedContext(t, gw, c)
+		var directRelease atomic.Int64
+		selection := &service.AccountSelectionResult{
+			Account:  clientAdmissionRejectedAccount(101),
+			Acquired: true,
+			ReleaseFunc: func() {
+				directRelease.Add(1)
+			},
+		}
+		streamStarted := false
+
+		release, result := h.acquireResponsesAccountSlot(c, &groupID, "", selection, false, &streamStarted, zap.NewNop())
+		require.Equal(t, openAISlotAcquireClientVetoed, result)
+		require.Nil(t, release)
+		require.Equal(t, int64(1), directRelease.Load(), "已抢槽路径否决后必须释放且只释放一次")
+		require.Zero(t, cache.accountReleases.Load(), "不得额外释放未由 helper 获取的槽位")
+		require.Zero(t, w.Body.Len(), "终检否决由调用方重选，不得提前写响应")
+	})
+
+	t.Run("fast acquire", func(t *testing.T) {
+		cache := &profitCountingConcurrencyCache{}
+		h := &OpenAIGatewayHandler{
+			gatewayService:    gw,
+			concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatClaude, 0),
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		clientAdmissionRejectedContext(t, gw, c)
+		account := clientAdmissionRejectedAccount(102)
+		selection := &service.AccountSelectionResult{
+			Account:  account,
+			Acquired: false,
+			WaitPlan: &service.AccountWaitPlan{AccountID: account.ID, MaxConcurrency: 2, Timeout: time.Second, MaxWaiting: 2},
+		}
+		streamStarted := false
+
+		release, result := h.acquireResponsesAccountSlot(c, &groupID, "", selection, false, &streamStarted, zap.NewNop())
+		require.Equal(t, openAISlotAcquireClientVetoed, result)
+		require.Nil(t, release)
+		require.Equal(t, int64(1), cache.accountReleases.Load(), "快速抢槽否决后必须释放且只释放一次")
+		require.Zero(t, w.Body.Len())
+	})
+
+	t.Run("wait plan", func(t *testing.T) {
+		cache := &clientAdmissionSequenceConcurrencyCache{}
+		h := &OpenAIGatewayHandler{
+			gatewayService:    gw,
+			concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatClaude, 0),
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		clientAdmissionRejectedContext(t, gw, c)
+		account := clientAdmissionRejectedAccount(103)
+		selection := &service.AccountSelectionResult{
+			Account:  account,
+			Acquired: false,
+			WaitPlan: &service.AccountWaitPlan{AccountID: account.ID, MaxConcurrency: 2, Timeout: time.Second, MaxWaiting: 2},
+		}
+		streamStarted := false
+
+		release, result := h.acquireResponsesAccountSlot(c, &groupID, "", selection, false, &streamStarted, zap.NewNop())
+		require.Equal(t, openAISlotAcquireClientVetoed, result)
+		require.Nil(t, release)
+		require.Equal(t, int64(2), cache.acquireCalls.Load(), "必须先快速抢槽失败，再进入 WaitPlan 获取")
+		require.Equal(t, int64(1), cache.accountRelease.Load(), "WaitPlan 终检否决后必须释放且只释放一次")
+		require.Zero(t, w.Body.Len())
+	})
+}
+
+func TestOpenAIClientAdmissionAllPoolVetoReturnsExactForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gw := &service.OpenAIGatewayService{}
+	h := &OpenAIGatewayHandler{}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx := clientAdmissionRejectedContext(t, gw, c)
+
+	admission := gw.OpenAITerminalAdmissionLatest(ctx, clientAdmissionRejectedAccount(201))
+	require.True(t, admission.ClientVetoed, "必须先实际否决账号，不能仅凭预计算结果推断 403")
+
+	failed := make(map[int64]struct{})
+	vetoCount := 0
+	for id := int64(1); id <= int64(maxClientAdmissionVetoAttempts); id++ {
+		if recordOpenAIClientAdmissionVeto(failed, id, &vetoCount) {
+			continue
+		}
+		h.handleOpenAIClientAdmissionExhausted(c, ctx, false, false)
+		break
+	}
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Equal(t, "forbidden_error", gjson.Get(w.Body.String(), "error.type").String())
+	require.Equal(t, service.CodexOfficialClientsOnlyMessage, gjson.Get(w.Body.String(), "error.message").String())
+	require.Len(t, failed, maxClientAdmissionVetoAttempts)
+	require.Equal(t, maxClientAdmissionVetoAttempts, vetoCount)
+}

--- a/backend/internal/handler/openai_client_admission_slot_test.go
+++ b/backend/internal/handler/openai_client_admission_slot_test.go
@@ -4,13 +4,16 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -21,6 +24,27 @@ type clientAdmissionSequenceConcurrencyCache struct {
 	fakeConcurrencyCache
 	acquireCalls   atomic.Int64
 	accountRelease atomic.Int64
+}
+
+type clientAdmissionAccountRepo struct {
+	service.AccountRepository
+	getErr error
+}
+
+func (r clientAdmissionAccountRepo) GetByID(_ context.Context, id int64) (*service.Account, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	return clientAdmissionRejectedAccount(id), nil
+}
+
+func newClientAdmissionGateway(repo service.AccountRepository) *service.OpenAIGatewayService {
+	return service.NewOpenAIGatewayService(
+		repo,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
 }
 
 func (c *clientAdmissionSequenceConcurrencyCache) AcquireAccountSlot(context.Context, int64, int, string) (bool, error) {
@@ -64,7 +88,7 @@ func clientAdmissionRejectedContext(t *testing.T, gw *service.OpenAIGatewayServi
 
 func TestAcquireResponsesAccountSlotClientAdmissionRecheckAllSlotPaths(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	gw := &service.OpenAIGatewayService{}
+	gw := newClientAdmissionGateway(clientAdmissionAccountRepo{})
 	groupID := int64(50)
 
 	t.Run("scheduler already acquired", func(t *testing.T) {
@@ -146,13 +170,14 @@ func TestAcquireResponsesAccountSlotClientAdmissionRecheckAllSlotPaths(t *testin
 
 func TestOpenAIClientAdmissionAllPoolVetoReturnsExactForbidden(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	gw := &service.OpenAIGatewayService{}
+	gw := newClientAdmissionGateway(clientAdmissionAccountRepo{})
 	h := &OpenAIGatewayHandler{}
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	ctx := clientAdmissionRejectedContext(t, gw, c)
 
-	admission := gw.OpenAITerminalAdmissionLatest(ctx, clientAdmissionRejectedAccount(201))
+	admission, admissionErr := gw.OpenAITerminalAdmissionLatest(ctx, clientAdmissionRejectedAccount(201))
+	require.NoError(t, admissionErr)
 	require.True(t, admission.ClientVetoed, "必须先实际否决账号，不能仅凭预计算结果推断 403")
 
 	failed := make(map[int64]struct{})
@@ -170,4 +195,117 @@ func TestOpenAIClientAdmissionAllPoolVetoReturnsExactForbidden(t *testing.T) {
 	require.Equal(t, service.CodexOfficialClientsOnlyMessage, gjson.Get(w.Body.String(), "error.message").String())
 	require.Len(t, failed, maxClientAdmissionVetoAttempts)
 	require.Equal(t, maxClientAdmissionVetoAttempts, vetoCount)
+}
+
+func TestOpenAIClientAdmissionUnavailableReturns503AndReleasesSlot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gw := newClientAdmissionGateway(clientAdmissionAccountRepo{getErr: errors.New("database unavailable")})
+	h := &OpenAIGatewayHandler{}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx := clientAdmissionRejectedContext(t, gw, c)
+	var directRelease atomic.Int64
+	selection := &service.AccountSelectionResult{
+		Account:  clientAdmissionRejectedAccount(301),
+		Acquired: true,
+		ReleaseFunc: func() {
+			directRelease.Add(1)
+		},
+	}
+	h.gatewayService = gw
+	streamStarted := false
+
+	release, result := h.acquireResponsesAccountSlot(c, nil, "", selection, false, &streamStarted, zap.NewNop())
+	require.Equal(t, openAISlotAcquireClientAdmissionUnavailable, result)
+	require.Nil(t, release)
+	require.Equal(t, int64(1), directRelease.Load())
+	require.Zero(t, w.Body.Len())
+
+	h.handleOpenAIClientAdmissionExhausted(c, ctx, false, false)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Equal(t, "api_error", gjson.Get(w.Body.String(), "error.type").String())
+	require.NotContains(t, w.Body.String(), service.CodexOfficialClientsOnlyMessage)
+	require.False(t, service.HasOpsClientBusinessLimited(c), "数据库故障不得被标记为客户端业务限流")
+}
+
+func TestOpenAIClientAdmissionUnavailableReleasesFastAndWaitSlots(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gw := newClientAdmissionGateway(clientAdmissionAccountRepo{getErr: errors.New("database unavailable")})
+
+	t.Run("fast acquire", func(t *testing.T) {
+		cache := &profitCountingConcurrencyCache{}
+		h := &OpenAIGatewayHandler{
+			gatewayService:    gw,
+			concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatClaude, 0),
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		clientAdmissionRejectedContext(t, gw, c)
+		account := clientAdmissionRejectedAccount(302)
+		selection := &service.AccountSelectionResult{
+			Account:  account,
+			Acquired: false,
+			WaitPlan: &service.AccountWaitPlan{AccountID: account.ID, MaxConcurrency: 2, Timeout: time.Second, MaxWaiting: 2},
+		}
+		streamStarted := false
+
+		release, result := h.acquireResponsesAccountSlot(c, nil, "", selection, false, &streamStarted, zap.NewNop())
+		require.Equal(t, openAISlotAcquireClientAdmissionUnavailable, result)
+		require.Nil(t, release)
+		require.Equal(t, int64(1), cache.accountReleases.Load())
+		require.Zero(t, w.Body.Len())
+	})
+
+	t.Run("wait plan", func(t *testing.T) {
+		cache := &clientAdmissionSequenceConcurrencyCache{}
+		h := &OpenAIGatewayHandler{
+			gatewayService:    gw,
+			concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatClaude, 0),
+		}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		clientAdmissionRejectedContext(t, gw, c)
+		account := clientAdmissionRejectedAccount(303)
+		selection := &service.AccountSelectionResult{
+			Account:  account,
+			Acquired: false,
+			WaitPlan: &service.AccountWaitPlan{AccountID: account.ID, MaxConcurrency: 2, Timeout: time.Second, MaxWaiting: 2},
+		}
+		streamStarted := false
+
+		release, result := h.acquireResponsesAccountSlot(c, nil, "", selection, false, &streamStarted, zap.NewNop())
+		require.Equal(t, openAISlotAcquireClientAdmissionUnavailable, result)
+		require.Nil(t, release)
+		require.Equal(t, int64(2), cache.acquireCalls.Load())
+		require.Equal(t, int64(1), cache.accountRelease.Load())
+		require.Zero(t, w.Body.Len())
+	})
+}
+
+func TestOpenAIClientAdmissionWSCloseClassification(t *testing.T) {
+	status, message := openAIClientAdmissionWSClose(service.ErrCodexClientAdmissionUnavailable, service.CodexClientRestrictionDetectionResult{})
+	require.Equal(t, coderws.StatusTryAgainLater, status)
+	require.Contains(t, message, "temporarily unavailable")
+
+	restricted := &service.CodexClientAdmissionError{Result: service.CodexClientRestrictionDetectionResult{
+		Enabled: true,
+		Matched: false,
+		Reason:  service.CodexClientRestrictionReasonNotMatchedUA,
+	}}
+	status, message = openAIClientAdmissionWSClose(restricted, restricted.Result)
+	require.Equal(t, coderws.StatusPolicyViolation, status)
+	require.Equal(t, service.CodexOfficialClientsOnlyMessage, message)
+}
+
+func TestOpenAIClientAdmissionUnavailablePreservesStreamingResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	h := &OpenAIGatewayHandler{}
+
+	require.True(t, h.handleOpenAICodexAdmissionError(c, service.ErrCodexClientAdmissionUnavailable, true, false))
+	require.Contains(t, w.Body.String(), "event: error")
+	require.Contains(t, w.Body.String(), "temporarily unavailable")
+	require.False(t, strings.HasPrefix(strings.TrimSpace(w.Body.String()), "{"), "已开始的 Images SSE 不得尾随普通 JSON")
 }

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -31,12 +32,15 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		h.errorResponse(c, http.StatusNotFound, "not_found_error", "Codex models manifest is only available for OpenAI groups")
 		return
 	}
+	modelsCtx := h.gatewayService.WithOpenAICodexClientAdmission(c.Request.Context(), c, nil)
+	c.Request = c.Request.WithContext(modelsCtx)
 
 	maxAccountSwitches := h.maxAccountSwitches
 	if maxAccountSwitches <= 0 {
 		maxAccountSwitches = 3
 	}
 	failedAccountIDs := make(map[int64]struct{})
+	clientVetoCount := 0
 	switchCount := 0
 	var lastUpstreamErr error
 
@@ -50,9 +54,25 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 				h.errorResponse(c, infraerrors.Code(lastUpstreamErr), "upstream_error", infraerrors.Message(lastUpstreamErr))
 				return
 			}
+			if h.handleOpenAICodexAdmissionError(c, err, false, false) {
+				return
+			}
+			if allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
+				return
+			}
 			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
 			return
 		}
+		admission := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		if admission.ClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
+				return
+			}
+			continue
+		}
+		account = admission.Account
 		// 让 ops 错误日志携带实际选中的上游账号，便于定位失效账号（#4544）。
 		setOpsSelectedAccount(c, account.ID, account.Platform)
 
@@ -60,6 +80,13 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		if err != nil {
 			if c.Request.Context().Err() != nil {
 				return
+			}
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
+					return
+				}
+				continue
 			}
 			if service.IsRetryableCodexModelsManifestError(err) && switchCount < maxAccountSwitches {
 				failedAccountIDs[account.ID] = struct{}{}

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -64,7 +64,11 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
 			return
 		}
-		admission := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		if admissionErr != nil {
+			h.handleOpenAICodexAdmissionError(c, admissionErr, false, false)
+			return
+		}
 		if admission.ClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
@@ -79,6 +83,10 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		manifest, err := h.gatewayService.FetchCodexModelsManifest(c.Request.Context(), account, c.Query("client_version"), c.GetHeader("If-None-Match"))
 		if err != nil {
 			if c.Request.Context().Err() != nil {
+				return
+			}
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, false, false)
 				return
 			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {

--- a/backend/internal/handler/openai_embeddings.go
+++ b/backend/internal/handler/openai_embeddings.go
@@ -188,6 +188,10 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, false)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
@@ -226,6 +230,10 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
 
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, false, false)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)

--- a/backend/internal/handler/openai_embeddings.go
+++ b/backend/internal/handler/openai_embeddings.go
@@ -108,6 +108,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 	}
 
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	var lastFailoverErr *service.UpstreamFailoverError
 	switchCount := 0
@@ -119,6 +120,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 
 	// 分组利润控制：embeddings 文本入口请求级装门并固定 pricingAt。
 	embPricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	embPricingCtx = h.gatewayService.WithOpenAICodexClientAdmission(embPricingCtx, c, body)
 	c.Request = c.Request.WithContext(embPricingCtx)
 
 	for {
@@ -144,6 +146,13 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 				zap.Error(err),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, false) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, service.PlatformOpenAI)
 				if !cls.ModelNotFound {
@@ -179,9 +188,17 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
@@ -209,6 +226,13 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
 
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+					return
+				}
+				continue
+			}
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				if c.Writer.Size() != writerSizeBeforeForward {

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -145,55 +146,94 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 	requestStart := time.Now()
 	// count_tokens 不计费：显式豁免利润门，避免高倍率账号池被门排除后连
 	// token 计数都返回 no available accounts。
-	c.Request = c.Request.WithContext(service.WithOpenAIProfitControlSuppressed(c.Request.Context()))
+	countCtx := service.WithOpenAIProfitControlSuppressed(c.Request.Context())
+	countCtx = h.gatewayService.WithOpenAICodexClientAdmission(countCtx, c, body)
+	c.Request = c.Request.WithContext(countCtx)
 	sessionHash := h.gatewayService.GenerateSessionHash(c, body)
 	currentRoutingModel := routingModel
 	if preferredMappedModel != "" {
 		currentRoutingModel = preferredMappedModel
 	}
-	selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
-		c.Request.Context(),
-		apiKey.GroupID,
-		"",
-		sessionHash,
-		currentRoutingModel,
-		nil,
-		service.OpenAIUpstreamTransportAny,
-		service.OpenAIEndpointCapabilityChatCompletions,
-		false,
-		false,
-		false,
-		openAICompatibleRequestPlatform(c.Request.Context(), apiKey),
-	)
-	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
-	if err != nil {
-		requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)
-		reqLog.Warn("openai_count_tokens.account_select_failed", zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)))
-		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, currentRoutingModel, reqModel)
-		if !cls.ModelNotFound {
-			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+	failedAccountIDs := make(map[int64]struct{})
+	clientVetoCount := 0
+	for {
+		selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+			c.Request.Context(),
+			apiKey.GroupID,
+			"",
+			sessionHash,
+			currentRoutingModel,
+			failedAccountIDs,
+			service.OpenAIUpstreamTransportAny,
+			service.OpenAIEndpointCapabilityChatCompletions,
+			false,
+			false,
+			false,
+			openAICompatibleRequestPlatform(c.Request.Context(), apiKey),
+		)
+		service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+		if err != nil {
+			requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)
+			reqLog.Warn("openai_count_tokens.account_select_failed", zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)))
+			if h.handleOpenAICodexAdmissionError(c, err, false, true) {
+				return
+			}
+			if allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, true)
+				return
+			}
+			cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, currentRoutingModel, reqModel)
+			if !cls.ModelNotFound {
+				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+			}
+			h.anthropicErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
+			return
 		}
-		h.anthropicErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
-		return
-	}
-	if selection == nil || selection.Account == nil {
-		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, currentRoutingModel, reqModel)
-		if !cls.ModelNotFound {
-			markOpsRoutingCapacityLimited(c)
+		if selection == nil || selection.Account == nil {
+			cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, currentRoutingModel, reqModel)
+			if !cls.ModelNotFound {
+				markOpsRoutingCapacityLimited(c)
+			}
+			h.anthropicErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
+			return
 		}
-		h.anthropicErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
+
+		account := selection.Account
+		admission := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		if admission.ClientVetoed {
+			if selection.Acquired && selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, true)
+				return
+			}
+			continue
+		}
+		account = admission.Account
+		if err := h.gatewayService.BindStickySessionAfterProfitAdmission(c.Request.Context(), apiKey.GroupID, sessionHash, account.ID); err != nil {
+			reqLog.Warn("openai_count_tokens.bind_sticky_session_after_admission_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+		}
+		setOpsSelectedAccount(c, account.ID, account.Platform)
+		forwardBody := mappedBodyForMessages(channelMapping.Mapped, channelMapping.MappedModel)
+		defaultMappedModel := preferredMappedModel
+
+		forwardErr := func() error {
+			if selection.Acquired && selection.ReleaseFunc != nil {
+				defer selection.ReleaseFunc()
+			}
+			return h.gatewayService.ForwardCountTokensAsAnthropic(c.Request.Context(), c, account, forwardBody, defaultMappedModel)
+		}()
+		if errors.Is(forwardErr, service.ErrCodexClientRestricted) {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, true)
+				return
+			}
+			continue
+		}
+		if forwardErr != nil {
+			reqLog.Error("openai_count_tokens.forward_failed", zap.Int64("account_id", account.ID), zap.Error(forwardErr))
+		}
 		return
-	}
-
-	account := selection.Account
-	setOpsSelectedAccount(c, account.ID, account.Platform)
-	if selection.Acquired && selection.ReleaseFunc != nil {
-		defer selection.ReleaseFunc()
-	}
-	forwardBody := mappedBodyForMessages(channelMapping.Mapped, channelMapping.MappedModel)
-	defaultMappedModel := preferredMappedModel
-
-	if err := h.gatewayService.ForwardCountTokensAsAnthropic(c.Request.Context(), c, account, forwardBody, defaultMappedModel); err != nil {
-		reqLog.Error("openai_count_tokens.forward_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 	}
 }

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -199,7 +199,14 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 		}
 
 		account := selection.Account
-		admission := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(c.Request.Context(), account)
+		if admissionErr != nil {
+			if selection.Acquired && selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			h.handleOpenAICodexAdmissionError(c, admissionErr, false, true)
+			return
+		}
 		if admission.ClientVetoed {
 			if selection.Acquired && selection.ReleaseFunc != nil {
 				selection.ReleaseFunc()
@@ -224,6 +231,10 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 			}
 			return h.gatewayService.ForwardCountTokensAsAnthropic(c.Request.Context(), c, account, forwardBody, defaultMappedModel)
 		}()
+		if errors.Is(forwardErr, service.ErrCodexClientAdmissionUnavailable) {
+			h.handleOpenAICodexAdmissionError(c, forwardErr, false, true)
+			return
+		}
 		if errors.Is(forwardErr, service.ErrCodexClientRestricted) {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), false, true)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -542,6 +542,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
@@ -588,6 +592,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, streamStarted, false)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
@@ -1124,6 +1132,10 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
@@ -1167,6 +1179,10 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, streamStarted, true)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
@@ -1443,6 +1459,10 @@ const (
 	// openAISlotAcquireClientVetoed：槽位获取成功后发现账号最新客户端限制
 	// 与本请求不兼容。槽位已释放、未写响应；调用方应排除该账号重新选号。
 	openAISlotAcquireClientVetoed
+	// openAISlotAcquireClientAdmissionUnavailable：槽位获取成功后无法从数据库
+	// 权威确认账号客户端策略。槽位已释放、未写响应；调用方应立即返回
+	// 503，不得换号放大数据库故障，也不得冒充真实策略拒绝返回 403。
+	openAISlotAcquireClientAdmissionUnavailable
 )
 
 // openAIWSTurnPricing 持有 WebSocket 连接内「当前 turn」的计费定价时刻。
@@ -1520,7 +1540,14 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	ctx := service.ContextWithSelectionProfitGate(c.Request.Context(), selection)
 	account := selection.Account
 	if selection.Acquired {
-		admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		if admissionErr != nil {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			reqLog.Warn("openai.account_slot_client_admission_unavailable", zap.Int64("account_id", account.ID), zap.Error(admissionErr))
+			return nil, openAISlotAcquireClientAdmissionUnavailable
+		}
 		if admission.ProfitVetoed {
 			if selection.ReleaseFunc != nil {
 				selection.ReleaseFunc()
@@ -1565,7 +1592,14 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	if fastAcquired {
 		// 分组利润控制：快速抢槽成功后终检。选号与抢槽之间账号
 		// 倍率可能刷新，越线则释放槽位交由调用方排除重选，不绑定粘连。
-		admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		if admissionErr != nil {
+			if fastReleaseFunc != nil {
+				fastReleaseFunc()
+			}
+			reqLog.Warn("openai.account_slot_client_admission_unavailable", zap.Int64("account_id", account.ID), zap.Error(admissionErr))
+			return nil, openAISlotAcquireClientAdmissionUnavailable
+		}
 		if admission.ProfitVetoed {
 			if fastReleaseFunc != nil {
 				fastReleaseFunc()
@@ -1627,7 +1661,14 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	releaseWait()
 	// 分组利润控制：WaitPlan 排队成功后终检。排队期间账号倍率
 	// 可能上调，越线则释放槽位交由调用方排除重选，不绑定粘连。
-	admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+	admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+	if admissionErr != nil {
+		if accountReleaseFunc != nil {
+			accountReleaseFunc()
+		}
+		reqLog.Warn("openai.account_slot_client_admission_unavailable", zap.Int64("account_id", account.ID), zap.Error(admissionErr))
+		return nil, openAISlotAcquireClientAdmissionUnavailable
+	}
 	if admission.ProfitVetoed {
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -1970,11 +2011,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			)
 			if lastFailoverErr == nil && (errors.Is(err, service.ErrCodexClientRestricted) ||
 				allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount)) {
-				result, _ := service.CodexClientRestrictionResultFromError(err)
+				admissionErr := err
 				if !errors.Is(err, service.ErrCodexClientRestricted) {
-					result, _ = service.CodexClientRestrictionResultFromError(service.CodexClientAdmissionErrorFromContext(ctx))
+					admissionErr = service.CodexClientAdmissionErrorFromContext(ctx)
 				}
-				closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+				result, _ := service.CodexClientRestrictionResultFromError(admissionErr)
+				status, message := openAIClientAdmissionWSClose(admissionErr, result)
+				closeOpenAIClientWS(wsConn, status, message)
 			} else if lastFailoverErr != nil {
 				closeOpenAIWSFailoverExhausted(wsConn, lastFailoverErr)
 			} else {
@@ -2002,7 +2045,16 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		accountReleaseFunc := selection.ReleaseFunc
 		if selection.Acquired {
 			// 调度器已抢槽路径同样终检：选号与抢槽之间账号倍率可能刷新。
-			admission := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			if admissionErr != nil {
+				if accountReleaseFunc != nil {
+					accountReleaseFunc()
+				}
+				reqLog.Warn("openai.websocket_account_slot_client_admission_unavailable", zap.Int64("account_id", account.ID), zap.Error(admissionErr))
+				status, message := openAIClientAdmissionWSClose(admissionErr, service.CodexClientRestrictionDetectionResult{})
+				closeOpenAIClientWS(wsConn, status, message)
+				return
+			}
 			if admission.ProfitVetoed {
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
@@ -2050,7 +2102,16 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			}
 			// 分组利润控制：WS 快速抢槽成功后终检，越线则释放
 			// 槽位、排除该账号重新选号，全池耗尽由下一轮选号关闭连接。
-			admission := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			if admissionErr != nil {
+				if fastReleaseFunc != nil {
+					fastReleaseFunc()
+				}
+				reqLog.Warn("openai.websocket_account_slot_client_admission_unavailable", zap.Int64("account_id", account.ID), zap.Error(admissionErr))
+				status, message := openAIClientAdmissionWSClose(admissionErr, service.CodexClientRestrictionDetectionResult{})
+				closeOpenAIClientWS(wsConn, status, message)
+				return
+			}
 			if admission.ProfitVetoed {
 				if fastReleaseFunc != nil {
 					fastReleaseFunc()
@@ -2170,7 +2231,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				turnCtx, turnAt := h.gatewayService.WithOpenAITurnPricingContext(ctx, apiKey.GroupID)
 				turnPricing.freeze(turnAt)
 				if turn == 1 {
-					admission := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+					admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+					if admissionErr != nil {
+						releaseTurnSlots()
+						status, message := openAIClientAdmissionWSClose(admissionErr, service.CodexClientRestrictionDetectionResult{})
+						return service.NewOpenAIWSClientCloseError(status, message, admissionErr)
+					}
 					if admission.ProfitVetoed {
 						releaseTurnSlots()
 						reqLog.Info("openai.websocket_turn_profit_vetoed",
@@ -2186,6 +2252,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 							zap.Int64("account_id", account.ID),
 							zap.String("reason", admission.ClientRestriction.Reason))
 						return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction), nil)
+					}
+					if !h.gatewayService.GrantOpenAIWSTerminalAdmission(turnCtx, account, admission.Account) {
+						releaseTurnSlots()
+						reqLog.Warn("openai.websocket_turn_account_binding_changed",
+							zap.Int("turn", turn),
+							zap.Int64("account_id", account.ID))
+						return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account binding changed, please reconnect", nil)
 					}
 					return nil
 				}
@@ -2214,7 +2287,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				currentUserRelease = wrapReleaseOnDone(ctx, userReleaseFunc)
 				currentAccountRelease = wrapReleaseOnDone(ctx, accountReleaseFunc)
-				admission := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+				admission, admissionErr := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+				if admissionErr != nil {
+					releaseTurnSlots()
+					status, message := openAIClientAdmissionWSClose(admissionErr, service.CodexClientRestrictionDetectionResult{})
+					return service.NewOpenAIWSClientCloseError(status, message, admissionErr)
+				}
 				if admission.ProfitVetoed {
 					releaseTurnSlots()
 					reqLog.Info("openai.websocket_turn_profit_vetoed",
@@ -2230,6 +2308,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 						zap.Int64("account_id", account.ID),
 						zap.String("reason", admission.ClientRestriction.Reason))
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction), nil)
+				}
+				if !h.gatewayService.GrantOpenAIWSTerminalAdmission(turnCtx, account, admission.Account) {
+					releaseTurnSlots()
+					reqLog.Warn("openai.websocket_turn_account_binding_changed",
+						zap.Int("turn", turn),
+						zap.Int64("account_id", account.ID))
+					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account binding changed, please reconnect", nil)
 				}
 				return nil
 			},
@@ -2349,11 +2434,18 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		requestPayloadHash = service.HashUsageRequestPayload(wsFirstMessage)
 
 		if err := h.gatewayService.ProxyResponsesWebSocketFromClient(ctx, c, wsConn, account, token, wsFirstMessage, hooks); err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				releaseAccountSlot()
+				status, message := openAIClientAdmissionWSClose(err, service.CodexClientRestrictionDetectionResult{})
+				closeOpenAIClientWS(wsConn, status, message)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				releaseAccountSlot()
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					result, _ := service.CodexClientRestrictionResultFromError(err)
-					closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+					status, message := openAIClientAdmissionWSClose(err, result)
+					closeOpenAIClientWS(wsConn, status, message)
 					return
 				}
 				continue

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -426,6 +426,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	switchCount := 0
 	firstOutputTimeoutSwitchCount := 0
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
@@ -444,6 +445,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 生图意图只影响能力路由与图片计费，不关门：混合 /v1/responses 请求的
 	// token 计费部分仍受利润门保护，独立图片/视频端点才在门外。
 	pricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	pricingCtx = h.gatewayService.WithOpenAICodexClientAdmission(pricingCtx, c, body)
 	c.Request = c.Request.WithContext(pricingCtx)
 
 	for {
@@ -478,6 +480,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, false) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				if errors.Is(err, service.ErrNoAvailableCompactAccounts) {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
@@ -533,9 +542,17 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 
 		// Forward request
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
@@ -571,6 +588,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, false)
+					return
+				}
+				continue
+			}
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),
@@ -1007,6 +1031,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
@@ -1015,6 +1040,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 
 	// 分组利润控制：Messages 文本入口同样请求级装门并固定 pricingAt。
 	msgPricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	msgPricingCtx = h.gatewayService.WithOpenAICodexClientAdmission(msgPricingCtx, c, body)
 	c.Request = c.Request.WithContext(msgPricingCtx)
 
 	for {
@@ -1049,6 +1075,13 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, true) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				if err != nil {
 					cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, currentRoutingModel, reqModel)
@@ -1091,9 +1124,17 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
@@ -1126,6 +1167,13 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, c.Request.Context(), streamStarted, true)
+					return
+				}
+				continue
+			}
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai_messages.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),
@@ -1381,7 +1429,7 @@ func (h *OpenAIGatewayHandler) acquireResponsesUserSlot(
 	return wrapReleaseOnDone(ctx, userReleaseFunc), true
 }
 
-// openAISlotAcquireResult 是账号槽位获取的三态结果。
+// openAISlotAcquireResult 是账号槽位获取结果。
 type openAISlotAcquireResult int
 
 const (
@@ -1392,18 +1440,21 @@ const (
 	// 未写任何响应；调用方应经 recordOpenAIProfitVeto 把该账号加入本请求排除集
 	// 后重新选号，全池耗尽由下一轮选号返回标准 no available accounts。
 	openAISlotAcquireProfitVetoed
+	// openAISlotAcquireClientVetoed：槽位获取成功后发现账号最新客户端限制
+	// 与本请求不兼容。槽位已释放、未写响应；调用方应排除该账号重新选号。
+	openAISlotAcquireClientVetoed
 )
 
 // openAIWSTurnPricing 持有 WebSocket 连接内「当前 turn」的计费定价时刻。
 // 由 BeforeTurn 在每个 turn 开始时冻结，AfterTurn 的用量提交读取它；turn 在
 // 连接内串行推进，互斥锁只为跨用量提交 goroutine 的读取安全。
 //
-// 零值语义（重要）：ws_v2 passthrough ingress 只实现了 AfterTurn，没有任何
-// turn 起始回调，BeforeTurn 永远不会被调用。此时本值保持零，RecordUsage 经
-// openAIUsagePricingAt 回退到记录时刻——与引入分组利润控制前的基线一致。
-// 绝不能用建连时刻初始化：那会把透传连接的所有 turn 钉死在建连时的高峰因子，
-// 客户端只要峰前一分钟建连并保活，整条连接就能全程按谷价结算，正是利润控制
-// 想堵的漏洞。透传 ingress 目前不做 turn 级利润复核，只有建连时的准入门。
+// 零值语义（重要）：所有 ingress 模式都在每个 response.create 前通过 BeforeTurn
+// 冻结本 turn 的定价时刻并复核终端准入。若某条异常路径未触发 turn 起始回调，
+// 本值保持零，RecordUsage 经 openAIUsagePricingAt 回退到记录时刻——与引入
+// 分组利润控制前的基线一致。绝不能用建连时刻初始化：那会把连接的所有 turn
+// 钉死在建连时的高峰因子，客户端只要峰前一分钟建连并保活，整条连接就能全程
+// 按谷价结算。
 type openAIWSTurnPricing struct {
 	mu sync.Mutex
 	at time.Time
@@ -1469,19 +1520,26 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	ctx := service.ContextWithSelectionProfitGate(c.Request.Context(), selection)
 	account := selection.Account
 	if selection.Acquired {
-		latest, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(ctx, account)
-		if vetoed {
+		admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		if admission.ProfitVetoed {
 			if selection.ReleaseFunc != nil {
 				selection.ReleaseFunc()
 			}
-			reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
+			reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ProfitReason))
 			return nil, openAISlotAcquireProfitVetoed
 		}
-		account = latest
-		selection.Account = latest
+		if admission.ClientVetoed {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			reqLog.Debug("openai.account_slot_client_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ClientRestriction.Reason))
+			return nil, openAISlotAcquireClientVetoed
+		}
+		account = admission.Account
+		selection.Account = admission.Account
 		// 调度器已抢槽路径无门时由选号内部完成 eager 绑定；门下选号内部
 		// 推迟绑定，这里在终检通过后补准入后绑定。
-		if selection.ProfitGateActive() {
+		if selection.ProfitGateActive() || service.OpenAICodexClientAdmissionActive(ctx) {
 			if err := h.gatewayService.BindStickySessionAfterProfitAdmission(ctx, groupID, sessionHash, account.ID); err != nil {
 				reqLog.Warn("openai.bind_sticky_session_after_profit_admission_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 			}
@@ -1507,16 +1565,23 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	if fastAcquired {
 		// 分组利润控制：快速抢槽成功后终检。选号与抢槽之间账号
 		// 倍率可能刷新，越线则释放槽位交由调用方排除重选，不绑定粘连。
-		latest, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(ctx, account)
-		if vetoed {
+		admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+		if admission.ProfitVetoed {
 			if fastReleaseFunc != nil {
 				fastReleaseFunc()
 			}
-			reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
+			reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ProfitReason))
 			return nil, openAISlotAcquireProfitVetoed
 		}
-		account = latest
-		selection.Account = latest
+		if admission.ClientVetoed {
+			if fastReleaseFunc != nil {
+				fastReleaseFunc()
+			}
+			reqLog.Debug("openai.account_slot_client_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ClientRestriction.Reason))
+			return nil, openAISlotAcquireClientVetoed
+		}
+		account = admission.Account
+		selection.Account = admission.Account
 		if err := h.gatewayService.BindStickySessionAfterProfitAdmission(ctx, groupID, sessionHash, account.ID); err != nil {
 			reqLog.Warn("openai.bind_sticky_session_after_profit_admission_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 		}
@@ -1562,16 +1627,23 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	releaseWait()
 	// 分组利润控制：WaitPlan 排队成功后终检。排队期间账号倍率
 	// 可能上调，越线则释放槽位交由调用方排除重选，不绑定粘连。
-	latest, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(ctx, account)
-	if vetoed {
+	admission := h.gatewayService.OpenAITerminalAdmissionLatest(ctx, account)
+	if admission.ProfitVetoed {
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
 		}
-		reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
+		reqLog.Debug("openai.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ProfitReason))
 		return nil, openAISlotAcquireProfitVetoed
 	}
-	account = latest
-	selection.Account = latest
+	if admission.ClientVetoed {
+		if accountReleaseFunc != nil {
+			accountReleaseFunc()
+		}
+		reqLog.Debug("openai.account_slot_client_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ClientRestriction.Reason))
+		return nil, openAISlotAcquireClientVetoed
+	}
+	account = admission.Account
+	selection.Account = admission.Account
 	if err := h.gatewayService.BindStickySessionAfterProfitAdmission(ctx, groupID, sessionHash, account.ID); err != nil {
 		reqLog.Warn("openai.bind_sticky_session_after_profit_admission_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 	}
@@ -1812,6 +1884,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	var lastFailoverErr *service.UpstreamFailoverError
 	var oauth429FailoverState service.OpenAIOAuth429FailoverState
@@ -1868,7 +1941,8 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	// 继续按建连时刻的谷价计费。生图意图只影响能力路由与图片计费，不关门。
 	// 建连时刻只用于选号/准入，不作为任何 turn 的计费定价时刻。
 	wsPricingCtx, _ := h.gatewayService.WithOpenAIRequestPricingContext(ctx, apiKey.GroupID)
-	ctx = wsPricingCtx
+	ctx = h.gatewayService.WithOpenAICodexClientAdmission(wsPricingCtx, c, firstMessage)
+	c.Request = c.Request.WithContext(ctx)
 
 	for {
 		if ctx.Err() != nil {
@@ -1894,7 +1968,14 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
-			if lastFailoverErr != nil {
+			if lastFailoverErr == nil && (errors.Is(err, service.ErrCodexClientRestricted) ||
+				allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount)) {
+				result, _ := service.CodexClientRestrictionResultFromError(err)
+				if !errors.Is(err, service.ErrCodexClientRestricted) {
+					result, _ = service.CodexClientRestrictionResultFromError(service.CodexClientAdmissionErrorFromContext(ctx))
+				}
+				closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+			} else if lastFailoverErr != nil {
 				closeOpenAIWSFailoverExhausted(wsConn, lastFailoverErr)
 			} else {
 				closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "no available account")
@@ -1921,12 +2002,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		accountReleaseFunc := selection.ReleaseFunc
 		if selection.Acquired {
 			// 调度器已抢槽路径同样终检：选号与抢槽之间账号倍率可能刷新。
-			latest, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(admissionCtx, account)
-			if vetoed {
+			admission := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			if admission.ProfitVetoed {
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
-				reqLog.Debug("openai.websocket_account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
+				reqLog.Debug("openai.websocket_account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ProfitReason))
 				if !recordOpenAIProfitVeto(failedAccountIDs, account.ID, &profitVetoCount) {
 					reqLog.Warn("openai.websocket_profit_veto_attempts_exhausted", zap.Int("profit_veto_count", profitVetoCount))
 					closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "no available account")
@@ -1934,8 +2015,19 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				continue
 			}
-			account = latest
-			selection.Account = latest
+			if admission.ClientVetoed {
+				if accountReleaseFunc != nil {
+					accountReleaseFunc()
+				}
+				reqLog.Debug("openai.websocket_account_slot_client_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ClientRestriction.Reason))
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction))
+					return
+				}
+				continue
+			}
+			account = admission.Account
+			selection.Account = admission.Account
 		}
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
@@ -1958,12 +2050,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			}
 			// 分组利润控制：WS 快速抢槽成功后终检，越线则释放
 			// 槽位、排除该账号重新选号，全池耗尽由下一轮选号关闭连接。
-			latest, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(admissionCtx, account)
-			if vetoed {
+			admission := h.gatewayService.OpenAITerminalAdmissionLatest(admissionCtx, account)
+			if admission.ProfitVetoed {
 				if fastReleaseFunc != nil {
 					fastReleaseFunc()
 				}
-				reqLog.Debug("openai.websocket_account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
+				reqLog.Debug("openai.websocket_account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ProfitReason))
 				if !recordOpenAIProfitVeto(failedAccountIDs, account.ID, &profitVetoCount) {
 					reqLog.Warn("openai.websocket_profit_veto_attempts_exhausted", zap.Int("profit_veto_count", profitVetoCount))
 					closeOpenAIClientWS(wsConn, coderws.StatusTryAgainLater, "no available account")
@@ -1971,8 +2063,19 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				continue
 			}
-			account = latest
-			selection.Account = latest
+			if admission.ClientVetoed {
+				if fastReleaseFunc != nil {
+					fastReleaseFunc()
+				}
+				reqLog.Debug("openai.websocket_account_slot_client_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", admission.ClientRestriction.Reason))
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction))
+					return
+				}
+				continue
+			}
+			account = admission.Account
+			selection.Account = admission.Account
 			accountReleaseFunc = fastReleaseFunc
 		}
 		// 准入完成：门并入连接 ctx，turn 级复核与 failover 重选共用。
@@ -2065,15 +2168,25 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				// 当前账号，越线即要求客户端重连重选（连接绑定单一上游账号，
 				// 无法中途换号）。本 turn 的准入与计费共用同一 pricingAt。
 				turnCtx, turnAt := h.gatewayService.WithOpenAITurnPricingContext(ctx, apiKey.GroupID)
-				if _, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(turnCtx, account); vetoed {
-					reqLog.Info("openai.websocket_turn_profit_vetoed",
-						zap.Int("turn", turn),
-						zap.Int64("account_id", account.ID),
-						zap.String("reason", reason))
-					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is no longer eligible for this connection, please reconnect", nil)
-				}
 				turnPricing.freeze(turnAt)
 				if turn == 1 {
+					admission := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+					if admission.ProfitVetoed {
+						releaseTurnSlots()
+						reqLog.Info("openai.websocket_turn_profit_vetoed",
+							zap.Int("turn", turn),
+							zap.Int64("account_id", account.ID),
+							zap.String("reason", admission.ProfitReason))
+						return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is no longer eligible for this connection, please reconnect", nil)
+					}
+					if admission.ClientVetoed {
+						releaseTurnSlots()
+						reqLog.Info("openai.websocket_turn_client_vetoed",
+							zap.Int("turn", turn),
+							zap.Int64("account_id", account.ID),
+							zap.String("reason", admission.ClientRestriction.Reason))
+						return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction), nil)
+					}
 					return nil
 				}
 				// 防御式清理：避免异常路径下旧槽位覆盖导致泄漏。
@@ -2101,6 +2214,23 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				currentUserRelease = wrapReleaseOnDone(ctx, userReleaseFunc)
 				currentAccountRelease = wrapReleaseOnDone(ctx, accountReleaseFunc)
+				admission := h.gatewayService.OpenAITerminalAdmissionLatest(turnCtx, account)
+				if admission.ProfitVetoed {
+					releaseTurnSlots()
+					reqLog.Info("openai.websocket_turn_profit_vetoed",
+						zap.Int("turn", turn),
+						zap.Int64("account_id", account.ID),
+						zap.String("reason", admission.ProfitReason))
+					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is no longer eligible for this connection, please reconnect", nil)
+				}
+				if admission.ClientVetoed {
+					releaseTurnSlots()
+					reqLog.Info("openai.websocket_turn_client_vetoed",
+						zap.Int("turn", turn),
+						zap.Int64("account_id", account.ID),
+						zap.String("reason", admission.ClientRestriction.Reason))
+					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(admission.ClientRestriction), nil)
+				}
 				return nil
 			},
 			AfterTurn: func(turn int, result *service.OpenAIForwardResult, turnErr error) {
@@ -2219,6 +2349,15 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		requestPayloadHash = service.HashUsageRequestPayload(wsFirstMessage)
 
 		if err := h.gatewayService.ProxyResponsesWebSocketFromClient(ctx, c, wsConn, account, token, wsFirstMessage, hooks); err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				releaseAccountSlot()
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					result, _ := service.CodexClientRestrictionResultFromError(err)
+					closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+					return
+				}
+				continue
+			}
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				if handleWSFailover(account, failoverErr) {

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -241,6 +241,10 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientAdmissionUnavailable {
+			h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)
+			return
+		}
 		if slotResult == openAISlotAcquireClientVetoed {
 			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 				h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)
@@ -279,6 +283,10 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) {
+				h.handleOpenAICodexAdmissionError(c, err, streamStarted, false)
+				return
+			}
 			if errors.Is(err, service.ErrCodexClientRestricted) {
 				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
 					h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -144,11 +144,14 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 	}
 
 	sessionHash := h.gatewayService.GenerateExplicitSessionHash(c, body)
-	requestCtx := service.WithOpenAIImageGenerationIntent(c.Request.Context())
+	admissionCtx := h.gatewayService.WithOpenAICodexClientAdmission(c.Request.Context(), c, body)
+	c.Request = c.Request.WithContext(admissionCtx)
+	requestCtx := service.WithOpenAIImageGenerationIntent(admissionCtx)
 
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	profitVetoCount := 0
+	clientVetoCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
@@ -176,6 +179,13 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				zap.Error(err),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if lastFailoverErr == nil && h.handleOpenAICodexAdmissionError(c, err, streamStarted, false) {
+				return
+			}
+			if lastFailoverErr == nil && allExcludedOpenAIAccountsWereClientVetoed(failedAccountIDs, clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, clientRequestModel, routingModel, service.PlatformOpenAI)
 				if !cls.ModelNotFound {
@@ -231,9 +241,17 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			}
 			continue
 		}
+		if slotResult == openAISlotAcquireClientVetoed {
+			if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+				h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)
+				return
+			}
+			continue
+		}
 		if slotResult != openAISlotAcquireOK {
 			return
 		}
+		account = selection.Account
 
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		if !parsed.Stream && !jsonKeepaliveStarted {
@@ -261,6 +279,13 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			if errors.Is(err, service.ErrCodexClientRestricted) {
+				if !recordOpenAIClientAdmissionVeto(failedAccountIDs, account.ID, &clientVetoCount) {
+					h.handleOpenAIClientAdmissionExhausted(c, requestCtx, streamStarted, false)
+					return
+				}
+				continue
+			}
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai.images.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),

--- a/backend/internal/handler/openai_live.go
+++ b/backend/internal/handler/openai_live.go
@@ -168,6 +168,8 @@ func liveCallIdentity(
 
 func (h *OpenAIGatewayHandler) writeLiveCreateError(c *gin.Context, err error) {
 	switch {
+	case errors.Is(err, service.ErrCodexClientAdmissionUnavailable):
+		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Account client policy is temporarily unavailable, please retry later")
 	case errors.Is(err, service.ErrCodexClientRestricted):
 		h.handleOpenAICodexAdmissionError(c, err, false, false)
 	case errors.Is(err, service.ErrLiveConcurrencyFull):
@@ -235,9 +237,10 @@ func (h *OpenAIGatewayHandler) LiveSideband(c *gin.Context) {
 	}
 	defer func() { _ = downstream.CloseNow() }()
 	if err := h.gatewayService.ProxyLiveSideband(c.Request.Context(), record, downstream); err != nil {
-		if errors.Is(err, service.ErrCodexClientRestricted) {
+		if errors.Is(err, service.ErrCodexClientAdmissionUnavailable) || errors.Is(err, service.ErrCodexClientRestricted) {
 			result, _ := service.CodexClientRestrictionResultFromError(err)
-			_ = downstream.Close(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+			status, message := openAIClientAdmissionWSClose(err, result)
+			_ = downstream.Close(status, message)
 			return
 		}
 		_ = downstream.Close(coderws.StatusInternalError, "live sideband closed")

--- a/backend/internal/handler/openai_live.go
+++ b/backend/internal/handler/openai_live.go
@@ -42,6 +42,8 @@ func (h *OpenAIGatewayHandler) Live(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
+	liveCtx := h.gatewayService.WithOpenAICodexClientAdmission(c.Request.Context(), c, request.Session)
+	c.Request = c.Request.WithContext(liveCtx)
 	model := strings.TrimSpace(gjson.GetBytes(request.Session, "model").String())
 	reqLog := requestLogger(
 		c,
@@ -166,6 +168,8 @@ func liveCallIdentity(
 
 func (h *OpenAIGatewayHandler) writeLiveCreateError(c *gin.Context, err error) {
 	switch {
+	case errors.Is(err, service.ErrCodexClientRestricted):
+		h.handleOpenAICodexAdmissionError(c, err, false, false)
 	case errors.Is(err, service.ErrLiveConcurrencyFull):
 		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", "Live concurrency limit reached")
 	case errors.Is(err, service.ErrLiveUnavailable):
@@ -200,6 +204,8 @@ func (h *OpenAIGatewayHandler) LiveSideband(c *gin.Context) {
 		h.errorResponse(c, http.StatusForbidden, "permission_error", "Live is not enabled for this group")
 		return
 	}
+	sidebandCtx := h.gatewayService.WithOpenAICodexClientAdmission(c.Request.Context(), c, nil)
+	c.Request = c.Request.WithContext(sidebandCtx)
 	identity := service.LiveCallIdentity{
 		APIKeyID: apiKey.ID,
 		UserID:   subject.UserID,
@@ -214,6 +220,13 @@ func (h *OpenAIGatewayHandler) LiveSideband(c *gin.Context) {
 		h.errorResponse(c, http.StatusNotFound, "not_found_error", "Live call not found")
 		return
 	}
+	if err := h.gatewayService.ValidateLiveSidebandClientAdmission(c.Request.Context(), record); err != nil {
+		if h.handleOpenAICodexAdmissionError(c, err, false, false) {
+			return
+		}
+		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Live account is unavailable")
+		return
+	}
 	downstream, err := coderws.Accept(c.Writer, c.Request, &coderws.AcceptOptions{
 		InsecureSkipVerify: true,
 	})
@@ -222,6 +235,11 @@ func (h *OpenAIGatewayHandler) LiveSideband(c *gin.Context) {
 	}
 	defer func() { _ = downstream.CloseNow() }()
 	if err := h.gatewayService.ProxyLiveSideband(c.Request.Context(), record, downstream); err != nil {
+		if errors.Is(err, service.ErrCodexClientRestricted) {
+			result, _ := service.CodexClientRestrictionResultFromError(err)
+			_ = downstream.Close(coderws.StatusPolicyViolation, service.CodexClientRestrictionMessage(result))
+			return
+		}
 		_ = downstream.Close(coderws.StatusInternalError, "live sideband closed")
 		return
 	}

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -27,6 +27,8 @@ const (
 	schedulerRetiredPrefix         = "sched:retired:"
 	schedulerSnapshotPrefix        = "sched:"
 	schedulerLockPrefix            = "sched:lock:"
+	schedulerMetadataVersionKey    = "_scheduler_metadata_version"
+	schedulerMetadataVersion       = 1
 
 	defaultSchedulerSnapshotMGetChunkSize  = 128
 	defaultSchedulerSnapshotWriteChunkSize = 256
@@ -299,6 +301,13 @@ func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.Schedul
 		account, err := decodeCachedAccount(val)
 		if err != nil {
 			return nil, false, err
+		}
+		if !consumeCurrentSchedulerMetadataVersion(account) {
+			// Metadata snapshots are intentionally compact and their explicit
+			// allow-list grows over time. Treat entries written by older binaries
+			// as misses so a newly required admission field can never silently
+			// default to its zero value until the background rebuild catches up.
+			return nil, false, nil
 		}
 		if err := applySchedulerLastUsed(account, lastUsedValues[i]); err != nil {
 			return nil, false, err
@@ -863,6 +872,13 @@ func (c *schedulerCache) mgetChunked(ctx context.Context, keys []string) ([]any,
 }
 
 func buildSchedulerMetadataAccount(account service.Account) service.Account {
+	extra := filterSchedulerExtra(account.Extra)
+	if account.Platform == service.PlatformOpenAI {
+		if extra == nil {
+			extra = make(map[string]any, 1)
+		}
+		extra[schedulerMetadataVersionKey] = schedulerMetadataVersion
+	}
 	return service.Account{
 		ID:                      account.ID,
 		Name:                    account.Name,
@@ -890,8 +906,33 @@ func buildSchedulerMetadataAccount(account service.Account) service.Account {
 		AccountGroups:           filterSchedulerAccountGroups(account.AccountGroups),
 		GroupIDs:                filterSchedulerGroupIDs(account.GroupIDs, account.AccountGroups),
 		Credentials:             filterSchedulerCredentials(account.Credentials),
-		Extra:                   filterSchedulerExtra(account.Extra),
+		Extra:                   extra,
 	}
+}
+
+func consumeCurrentSchedulerMetadataVersion(account *service.Account) bool {
+	if account == nil {
+		return false
+	}
+	if account.Platform != service.PlatformOpenAI {
+		return true
+	}
+	if account.Extra == nil {
+		return false
+	}
+	raw, ok := account.Extra[schedulerMetadataVersionKey]
+	if !ok {
+		return false
+	}
+	version, ok := raw.(float64)
+	if !ok || version != float64(schedulerMetadataVersion) {
+		return false
+	}
+	delete(account.Extra, schedulerMetadataVersionKey)
+	if len(account.Extra) == 0 {
+		account.Extra = nil
+	}
+	return true
 }
 
 func filterSchedulerAccountGroups(accountGroups []service.AccountGroup) []service.AccountGroup {
@@ -1007,6 +1048,8 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"codex_5h_reset_after_seconds",
 		"codex_7d_reset_after_seconds",
 		"codex_usage_updated_at",
+		"codex_cli_only",
+		"codex_cli_only_allow_app_server",
 		"auto_pause_5h_threshold",
 		"auto_pause_7d_threshold",
 		"auto_pause_5h_disabled",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -325,6 +325,172 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestSchedulerCacheMetadataVersionAndCodexAdmissionFields(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newSchedulerCacheUnitWithRedis(t)
+	parentID := int64(9100)
+	bucket := service.SchedulerBucket{GroupID: 91, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{
+		ID:              9101,
+		Name:            "shadow-codex",
+		Platform:        service.PlatformOpenAI,
+		Type:            service.AccountTypeOAuth,
+		Status:          service.StatusActive,
+		Schedulable:     true,
+		ParentAccountID: &parentID,
+		GroupIDs:        []int64{bucket.GroupID},
+		Extra: map[string]any{
+			"codex_cli_only":                  true,
+			"codex_cli_only_allow_app_server": true,
+			"unused_large_field":              strings.Repeat("x", 64),
+		},
+	}
+
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+
+	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, parentID, *snapshot[0].ParentAccountID)
+	require.Equal(t, true, snapshot[0].Extra["codex_cli_only"])
+	require.Equal(t, true, snapshot[0].Extra["codex_cli_only_allow_app_server"])
+	require.NotContains(t, snapshot[0].Extra, schedulerMetadataVersionKey, "内部版本字段不得泄漏给调度器")
+	require.NotContains(t, snapshot[0].Extra, "unused_large_field")
+
+	full, err := cache.GetAccount(ctx, account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	require.Equal(t, true, full.Extra["codex_cli_only"])
+	require.Equal(t, true, full.Extra["codex_cli_only_allow_app_server"])
+	require.Equal(t, strings.Repeat("x", 64), full.Extra["unused_large_field"])
+}
+
+func TestSchedulerCacheRejectsStaleOrMalformedMetadataVersions(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 92, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{
+		ID:          9201,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		GroupIDs:    []int64{bucket.GroupID},
+		Extra:       map[string]any{"codex_cli_only": true},
+	}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+
+	validRaw, err := cache.rdb.Get(ctx, schedulerAccountMetaKey(strconv.FormatInt(account.ID, 10))).Bytes()
+	require.NoError(t, err)
+	var valid map[string]any
+	require.NoError(t, json.Unmarshal(validRaw, &valid))
+
+	versions := []struct {
+		name  string
+		value any
+		omit  bool
+	}{
+		{name: "missing", omit: true},
+		{name: "old", value: float64(0)},
+		{name: "future", value: float64(schedulerMetadataVersion + 1)},
+		{name: "fractional", value: 1.5},
+		{name: "wrong_type", value: "1"},
+	}
+	for _, tc := range versions {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := make(map[string]any, len(valid))
+			for key, value := range valid {
+				payload[key] = value
+			}
+			extra, _ := payload["Extra"].(map[string]any)
+			if extra == nil {
+				extra = map[string]any{}
+				payload["Extra"] = extra
+			}
+			if tc.omit {
+				delete(extra, schedulerMetadataVersionKey)
+			} else {
+				extra[schedulerMetadataVersionKey] = tc.value
+			}
+			raw, marshalErr := json.Marshal(payload)
+			require.NoError(t, marshalErr)
+			require.NoError(t, cache.rdb.Set(ctx, schedulerAccountMetaKey(strconv.FormatInt(account.ID, 10)), raw, 0).Err())
+
+			got, hit, getErr := cache.GetSnapshot(ctx, bucket)
+			require.NoError(t, getErr)
+			require.False(t, hit)
+			require.Nil(t, got)
+		})
+	}
+}
+
+type schedulerMetadataFallbackAccountRepo struct {
+	service.AccountRepository
+	account service.Account
+	calls   int
+}
+
+func (r *schedulerMetadataFallbackAccountRepo) ListSchedulableByGroupIDAndPlatform(_ context.Context, _ int64, _ string) ([]service.Account, error) {
+	r.calls++
+	return []service.Account{r.account}, nil
+}
+
+func TestSchedulerSnapshotOldMetadataFallsBackAndRebuildsCurrentPayload(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newSchedulerCacheUnitWithRedis(t)
+	groupID := int64(93)
+	bucket := service.SchedulerBucket{GroupID: groupID, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{
+		ID:          9301,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"codex_cli_only":                  true,
+			"codex_cli_only_allow_app_server": true,
+		},
+	}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+
+	metaKey := schedulerAccountMetaKey(strconv.FormatInt(account.ID, 10))
+	raw, err := cache.rdb.Get(ctx, metaKey).Bytes()
+	require.NoError(t, err)
+	var legacy map[string]any
+	require.NoError(t, json.Unmarshal(raw, &legacy))
+	extra, _ := legacy["Extra"].(map[string]any)
+	require.NotNil(t, extra)
+	delete(extra, schedulerMetadataVersionKey)
+	legacyRaw, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	require.NoError(t, cache.rdb.Set(ctx, metaKey, legacyRaw, 0).Err())
+
+	repo := &schedulerMetadataFallbackAccountRepo{account: account}
+	snapshotService := service.NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+
+	first, _, err := snapshotService.ListSchedulableAccounts(ctx, &groupID, service.PlatformOpenAI, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.calls, "旧 metadata 必须触发一次数据库回源")
+	require.Len(t, first, 1)
+	require.Equal(t, true, first[0].Extra["codex_cli_only"])
+	require.Equal(t, true, first[0].Extra["codex_cli_only_allow_app_server"])
+
+	second, _, err := snapshotService.ListSchedulableAccounts(ctx, &groupID, service.PlatformOpenAI, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.calls, "回源重建后第二次读取应直接命中新格式 metadata")
+	require.Len(t, second, 1)
+	require.Equal(t, true, second[0].Extra["codex_cli_only"])
+	require.NotContains(t, second[0].Extra, schedulerMetadataVersionKey)
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsGrokMediaEligibility(t *testing.T) {
 	t.Run("explicit override", func(t *testing.T) {
 		account := service.Account{

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -410,6 +410,9 @@ func (s *defaultOpenAIAccountScheduler) Select(
 			}
 			return selection, decision, nil
 		}
+		if !req.PreviousResponseCanMove && codexClientAdmissionDenied(ctx) {
+			return nil, decision, codexClientAdmissionErrorFromContext(ctx)
+		}
 	}
 
 	if !req.StickyWeighted {
@@ -487,16 +490,36 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
-	if !s.isAccountRequestCompatible(ctx, account, req) {
+	if !s.isAccountRequestCompatibleBeforeClient(ctx, account, req) {
 		return nil, false, nil
 	}
 	if !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
+	if req.RequireCompact && openAICompactSupportTier(account) == 0 {
+		return nil, false, nil
+	}
+	if vetoed, _ := s.service.codexClientAdmissionVetoReason(ctx, account, func(id int64) *Account {
+		return s.lookupShadowParentAccount(ctx, id)
+	}); vetoed {
+		// Client policy is request-specific. Keep the sticky binding so a later
+		// compatible client can reuse it.
+		recordCodexClientAdmissionStickySkip(ctx, accountID)
+		return nil, false, nil
+	}
 	account = s.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
-	if account == nil || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
+	if account == nil || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) ||
+		!s.isAccountTransportCompatible(account, req.RequiredTransport) ||
+		!s.isAccountRequestCompatibleBeforeClient(ctx, account, req) ||
+		(req.RequireCompact && openAICompactSupportTier(account) == 0) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
+		return nil, false, nil
+	}
+	if vetoed, _ := s.service.codexClientAdmissionVetoReason(ctx, account, func(id int64) *Account {
+		return s.lookupShadowParentAccount(ctx, id)
+	}); vetoed {
+		recordCodexClientAdmissionStickySkip(ctx, accountID)
 		return nil, false, nil
 	}
 	escapeCfg := s.service.openAIStickyEscapeConfig()
@@ -1135,7 +1158,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 		}
 
 		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, fresh, req) {
 			release(result)
 			continue
 		}
@@ -1144,12 +1167,18 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			break
 		}
 		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, fresh, req) {
 			release(result)
 			continue
 		}
 		if req.RequireCompact && openAICompactSupportTier(fresh) == 0 {
 			compactBlocked = true
+			release(result)
+			continue
+		}
+		if vetoed, _ := s.service.codexClientAdmissionVetoReason(ctx, fresh, func(id int64) *Account {
+			return s.lookupShadowParentAccount(ctx, id)
+		}); vetoed {
 			release(result)
 			continue
 		}
@@ -1219,7 +1248,7 @@ func (s *defaultOpenAIAccountScheduler) tryFallbackToWeightedSticky(
 		if err != nil || account == nil {
 			continue
 		}
-		if !s.isAccountRequestCompatible(ctx, account, req) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
+		if !s.isAccountTransportCompatible(account, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, account, req) {
 			continue
 		}
 		account = s.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
@@ -1235,10 +1264,15 @@ func (s *defaultOpenAIAccountScheduler) tryFallbackToWeightedSticky(
 			}
 			continue
 		}
-		if !s.isAccountRequestCompatible(ctx, account, req) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
+		if !s.isAccountTransportCompatible(account, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, account, req) {
 			continue
 		}
 		if req.RequireCompact && openAICompactSupportTier(account) == 0 {
+			continue
+		}
+		if vetoed, _ := s.service.codexClientAdmissionVetoReason(ctx, account, func(id int64) *Account {
+			return s.lookupShadowParentAccount(ctx, id)
+		}); vetoed {
 			continue
 		}
 		result, acquireErr := s.service.tryAcquireAccountSlot(ctx, account.ID, account.Concurrency)
@@ -1368,13 +1402,23 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 			filterStats.exclude("privacy_not_set")
 			continue
 		}
-		if compatible, reason := s.isAccountRequestCompatibleReason(ctx, account, req); !compatible {
+		if compatible, reason := s.isAccountRequestCompatibleBeforeClientReason(ctx, account, req); !compatible {
 			filterStats.exclude(reason)
 			continue
 		}
 		if !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 			filterStats.exclude("transport_incompatible")
 			continue
+		}
+		// Unknown compact support remains eligible for the existing DB retry path;
+		// defer client-policy classification until that fresh recheck.
+		if !req.RequireCompact || openAICompactSupportTier(account) > 0 {
+			if vetoed, reason := s.service.codexClientAdmissionVetoReason(ctx, account, func(id int64) *Account {
+				return s.lookupShadowParentAccount(ctx, id)
+			}); vetoed {
+				filterStats.exclude(reason)
+				continue
+			}
 		}
 		filtered = append(filtered, account)
 		loadReq = append(loadReq, AccountWithConcurrency{
@@ -1383,6 +1427,9 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		})
 	}
 	if len(filtered) == 0 {
+		if filterStats.reasons[codexClientAdmissionFilterReason] > 0 {
+			return nil, 0, 0, 0, codexClientAdmissionErrorFromContext(ctx)
+		}
 		return nil, 0, 0, 0, noAvailableOpenAISelectionError(req.RequestedModel, false, filterStats.summary(""))
 	}
 
@@ -1588,6 +1635,8 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 
 	cfg := s.service.schedulingConfig()
 	compactBlocked := attempt.compactBlocked
+	clientEligible := 0
+	clientVetoed := 0
 	// WaitPlan.MaxConcurrency 使用 Concurrency（非 EffectiveLoadFactor），因为 WaitPlan 控制的是 Redis 实际并发槽位等待。
 	passes := 1
 	if budget != nil && budget.limited {
@@ -1608,18 +1657,25 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 				}
 			}
 			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
-			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, fresh, req) {
 				continue
 			}
 			if !s.consumeOpenAISelectionDBRecheck(budget) {
 				return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked, filterStats.summary("selection_order_exhausted"))
 			}
 			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
-			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatibleBeforeClient(ctx, fresh, req) {
 				continue
 			}
 			if req.RequireCompact && openAICompactSupportTier(fresh) == 0 {
 				compactBlocked = true
+				continue
+			}
+			clientEligible++
+			if vetoed, _ := s.service.codexClientAdmissionVetoReason(ctx, fresh, func(id int64) *Account {
+				return s.lookupShadowParentAccount(ctx, id)
+			}); vetoed {
+				clientVetoed++
 				continue
 			}
 			return attachSelectionProfitGate(ctx, &AccountSelectionResult{
@@ -1634,6 +1690,9 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 		}
 	}
 
+	if clientEligible > 0 && clientVetoed == clientEligible {
+		return nil, candidateCount, topK, loadSkew, codexClientAdmissionErrorFromContext(ctx)
+	}
 	return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked, filterStats.summary("selection_order_exhausted"))
 }
 
@@ -1668,11 +1727,31 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatible(ctx context.C
 	return compatible
 }
 
-// isAccountRequestCompatibleReason reports whether the account can serve the
-// request, and when it cannot, names the veto point. The reason feeds
+func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx context.Context, account *Account, req OpenAIAccountScheduleRequest) (bool, string) {
+	compatible, reason := s.isAccountRequestCompatibleBeforeClientReason(ctx, account, req)
+	if !compatible {
+		return false, reason
+	}
+	if vetoed, reason := s.service.codexClientAdmissionVetoReason(ctx, account, func(id int64) *Account {
+		return s.lookupShadowParentAccount(ctx, id)
+	}); vetoed {
+		return false, reason
+	}
+	return true, ""
+}
+
+func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleBeforeClient(ctx context.Context, account *Account, req OpenAIAccountScheduleRequest) bool {
+	compatible, _ := s.isAccountRequestCompatibleBeforeClientReason(ctx, account, req)
+	return compatible
+}
+
+// isAccountRequestCompatibleBeforeClientReason applies every request-shape
+// compatibility check except the request-specific client admission policy.
+// Keeping that policy last prevents unrelated model/capability mismatches from
+// being reported as a typed client restriction error. The reason feeds
 // openAISelectionFilterStats so that "no available accounts" errors state why
 // each candidate was dropped instead of failing silently (#4599).
-func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx context.Context, account *Account, req OpenAIAccountScheduleRequest) (bool, string) {
+func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleBeforeClientReason(ctx context.Context, account *Account, req OpenAIAccountScheduleRequest) (bool, string) {
 	if account == nil {
 		return false, "account_nil"
 	}
@@ -2114,6 +2193,32 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
 		decision.Layer = openAIAccountScheduleLayerLoadBalance
+		if strings.TrimSpace(previousResponseID) != "" && platform == PlatformOpenAI {
+			previousSelection, previousErr := s.selectAccountByPreviousResponseIDForCapability(
+				ctx,
+				groupID,
+				previousResponseID,
+				requestedModel,
+				excludedIDs,
+				requiredCapability,
+				requireCompact,
+			)
+			if previousErr != nil {
+				return nil, decision, previousErr
+			}
+			if previousSelection != nil && previousSelection.Account != nil &&
+				s.isOpenAIAccountTransportCompatible(previousSelection.Account, requiredTransport) &&
+				accountSupportsOpenAICapabilities(previousSelection.Account, requiredCapability, requiredImageCapability) {
+				decision.Layer = openAIAccountScheduleLayerPreviousResponse
+				decision.StickyPreviousHit = true
+				decision.SelectedAccountID = previousSelection.Account.ID
+				decision.SelectedAccountType = previousSelection.Account.Type
+				return previousSelection, decision, nil
+			}
+			if !previousResponseCanMove && codexClientAdmissionDenied(ctx) {
+				return nil, decision, codexClientAdmissionErrorFromContext(ctx)
+			}
+		}
 		if requiredTransport == OpenAIUpstreamTransportAny || requiredTransport == OpenAIUpstreamTransportHTTPSSE {
 			effectiveExcludedIDs := cloneExcludedAccountIDs(excludedIDs)
 			for {

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -30,6 +30,11 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 	if s == nil || c == nil || account == nil {
 		return nil, fmt.Errorf("service, context, and account are required")
 	}
+	var err error
+	account, err = s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account)
+	if err != nil {
+		return nil, err
+	}
 	modelResult := gjson.GetBytes(body, "model")
 	requestedModel := strings.TrimSpace(modelResult.String())
 	if modelResult.Type != gjson.String || requestedModel == "" {

--- a/backend/internal/service/openai_client_admission.go
+++ b/backend/internal/service/openai_client_admission.go
@@ -20,6 +20,7 @@ const (
 )
 
 var ErrCodexClientRestricted = errors.New("request is not allowed by codex client restriction")
+var ErrCodexClientAdmissionUnavailable = errors.New("codex client admission policy is unavailable")
 
 type CodexClientAdmissionError struct {
 	Result CodexClientRestrictionDetectionResult
@@ -50,6 +51,8 @@ type codexClientAdmissionSnapshot struct {
 	mu                      sync.Mutex
 	lastDenied              *CodexClientRestrictionDetectionResult
 	skippedStickyAccountIDs map[int64]struct{}
+	terminallyAdmitted      *Account
+	admissionUnavailable    bool
 }
 
 func (s *OpenAIGatewayService) WithOpenAICodexClientAdmission(
@@ -138,6 +141,24 @@ func (snapshot *codexClientAdmissionSnapshot) deniedResult() (CodexClientRestric
 	return *snapshot.lastDenied, true
 }
 
+func (snapshot *codexClientAdmissionSnapshot) recordUnavailable() {
+	if snapshot == nil {
+		return
+	}
+	snapshot.mu.Lock()
+	snapshot.admissionUnavailable = true
+	snapshot.mu.Unlock()
+}
+
+func (snapshot *codexClientAdmissionSnapshot) unavailable() bool {
+	if snapshot == nil {
+		return false
+	}
+	snapshot.mu.Lock()
+	defer snapshot.mu.Unlock()
+	return snapshot.admissionUnavailable
+}
+
 // hadDenied reports whether this request actually encountered an account that
 // the frozen client policy rejected. The precomputed standard/app-server
 // results describe what would happen if such an account were evaluated; they
@@ -173,6 +194,68 @@ func (snapshot *codexClientAdmissionSnapshot) stickyWasSkipped(accountID int64) 
 	return ok
 }
 
+func (snapshot *codexClientAdmissionSnapshot) recordTerminalAdmission(account *Account) {
+	if snapshot == nil || account == nil || account.ID <= 0 {
+		return
+	}
+	snapshot.mu.Lock()
+	snapshot.terminallyAdmitted = account
+	snapshot.mu.Unlock()
+}
+
+func (snapshot *codexClientAdmissionSnapshot) clearTerminalAdmission() {
+	if snapshot == nil {
+		return
+	}
+	snapshot.mu.Lock()
+	snapshot.terminallyAdmitted = nil
+	snapshot.mu.Unlock()
+}
+
+func (snapshot *codexClientAdmissionSnapshot) terminalAdmissionRecorded(account *Account) bool {
+	if snapshot == nil || account == nil || account.ID <= 0 {
+		return false
+	}
+	snapshot.mu.Lock()
+	defer snapshot.mu.Unlock()
+	return snapshot.terminallyAdmitted == account
+}
+
+func sameOpenAIWSAdmissionBinding(bound, authoritative *Account) bool {
+	if bound == nil || authoritative == nil || bound.ID != authoritative.ID ||
+		bound.Platform != authoritative.Platform || bound.Type != authoritative.Type {
+		return false
+	}
+	if bound.ParentAccountID == nil || authoritative.ParentAccountID == nil {
+		return bound.ParentAccountID == nil && authoritative.ParentAccountID == nil
+	}
+	return *bound.ParentAccountID == *authoritative.ParentAccountID
+}
+
+// GrantOpenAIWSTerminalAdmission transfers a freshly verified terminal grant
+// to the stable account object owned by an established WebSocket connection.
+// HTTP callers keep the stricter exact-pointer grant: this exception is only
+// safe when the database object already holds the grant and the connection
+// binding identity (including the shadow parent) has not changed.
+func (s *OpenAIGatewayService) GrantOpenAIWSTerminalAdmission(
+	ctx context.Context,
+	bound *Account,
+	authoritative *Account,
+) bool {
+	if !sameOpenAIWSAdmissionBinding(bound, authoritative) {
+		return false
+	}
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok || !snapshot.enforcementActive || !codexClientAdmissionAppliesToAccount(ctx, bound) {
+		return true
+	}
+	if !snapshot.terminalAdmissionRecorded(authoritative) {
+		return false
+	}
+	snapshot.recordTerminalAdmission(bound)
+	return true
+}
+
 func recordCodexClientAdmissionStickySkip(ctx context.Context, accountID int64) {
 	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
 	if !ok {
@@ -203,6 +286,9 @@ func codexClientAdmissionErrorFromContext(ctx context.Context) error {
 	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
 	if !ok {
 		return ErrCodexClientRestricted
+	}
+	if snapshot.unavailable() {
+		return ErrCodexClientAdmissionUnavailable
 	}
 	result, ok := snapshot.deniedResult()
 	if !ok {
@@ -263,6 +349,24 @@ func (s *OpenAIGatewayService) codexRestrictionAccountLatest(ctx context.Context
 	return parent, nil
 }
 
+func (s *OpenAIGatewayService) codexRestrictionAccountAuthoritative(ctx context.Context, account *Account) (*Account, error) {
+	if account == nil || account.ParentAccountID == nil {
+		return account, nil
+	}
+	parentID := *account.ParentAccountID
+	if s == nil || s.accountRepo == nil {
+		return nil, fmt.Errorf("account repository is unavailable for shadow parent %d", parentID)
+	}
+	parent, err := s.accountRepo.GetByID(ctx, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCodexRestrictionParent(parent, parentID); err != nil {
+		return nil, err
+	}
+	return parent, nil
+}
+
 func validateCodexRestrictionParent(parent *Account, parentID int64) error {
 	if parent == nil {
 		return fmt.Errorf("shadow parent %d not found", parentID)
@@ -290,7 +394,7 @@ func (s *OpenAIGatewayService) codexClientAdmissionVetoReason(
 	lookup func(int64) *Account,
 ) (bool, string) {
 	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
-	if !ok {
+	if !ok || !snapshot.enforcementActive {
 		return false, ""
 	}
 	effective, err := s.codexRestrictionAccount(ctx, account, lookup)
@@ -315,27 +419,25 @@ func (s *OpenAIGatewayService) codexClientAdmissionVetoReason(
 func (s *OpenAIGatewayService) codexClientAdmissionVeto(
 	ctx context.Context,
 	account *Account,
-) (bool, CodexClientRestrictionDetectionResult) {
+) (bool, CodexClientRestrictionDetectionResult, error) {
 	if account == nil {
-		return false, CodexClientRestrictionDetectionResult{}
+		return false, CodexClientRestrictionDetectionResult{}, nil
 	}
 	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
-	if !ok {
-		return false, CodexClientRestrictionDetectionResult{}
+	if !ok || !snapshot.enforcementActive {
+		return false, CodexClientRestrictionDetectionResult{}, nil
 	}
-	effective, err := s.codexRestrictionAccountLatest(ctx, account)
+	effective, err := s.codexRestrictionAccountAuthoritative(ctx, account)
 	if err != nil {
-		logger.LegacyPrintf("service.openai_gateway", "[CodexAdmission] shadow parent refresh failed: account_id=%d parent_id=%v error=%v", account.ID, account.ParentAccountID, err)
-		result := codexClientAdmissionShadowParentUnresolvedResult()
-		snapshot.recordDenied(result)
-		return true, result
+		return false, CodexClientRestrictionDetectionResult{}, err
 	}
 	result, active := snapshot.resultFor(effective)
 	if !active || result.Matched {
-		return false, result
+		return false, result, nil
 	}
 	snapshot.recordDenied(result)
-	return true, result
+	snapshot.recordSkippedSticky(account.ID)
+	return true, result, nil
 }
 
 func (s *OpenAIGatewayService) detectCodexClientRestrictionForForward(
@@ -364,10 +466,23 @@ func (s *OpenAIGatewayService) enforceOpenAICodexClientAdmissionForForward(
 	account *Account,
 	body []byte,
 ) error {
+	if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok && !snapshot.enforcementActive {
+		return nil
+	}
 	var result CodexClientRestrictionDetectionResult
 	denied := false
 	if codexClientAdmissionActive(ctx) {
-		denied, result = s.codexClientAdmissionVeto(ctx, account)
+		if !codexClientAdmissionAppliesToAccount(ctx, account) {
+			return nil
+		}
+		snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+		if !ok || !snapshot.terminalAdmissionRecorded(account) {
+			if ok {
+				snapshot.recordUnavailable()
+			}
+			return fmt.Errorf("%w: missing terminal admission grant for account %d", ErrCodexClientAdmissionUnavailable, account.ID)
+		}
+		return nil
 	} else {
 		result = s.detectCodexClientRestrictionForForward(ctx, c, account, body)
 		denied = result.Enabled && !result.Matched

--- a/backend/internal/service/openai_client_admission.go
+++ b/backend/internal/service/openai_client_admission.go
@@ -1,0 +1,381 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	codexClientAdmissionFilterReason                 = "client_restriction_codex"
+	codexClientAdmissionShadowParentUnresolvedReason = "shadow_parent_unresolved"
+	// MaxCodexClientAdmissionVetoAttempts bounds request-local re-selection when
+	// account policy changes between candidate selection and terminal admission.
+	MaxCodexClientAdmissionVetoAttempts = 10
+)
+
+var ErrCodexClientRestricted = errors.New("request is not allowed by codex client restriction")
+
+type CodexClientAdmissionError struct {
+	Result CodexClientRestrictionDetectionResult
+}
+
+func (e *CodexClientAdmissionError) Error() string {
+	if e == nil {
+		return ErrCodexClientRestricted.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrCodexClientRestricted, e.Result.Reason)
+}
+
+func (e *CodexClientAdmissionError) Unwrap() error {
+	return ErrCodexClientRestricted
+}
+
+type codexClientAdmissionContextKey struct{}
+
+// codexClientAdmissionSnapshot freezes the global policy and request identity
+// once at ingress. Account-specific evaluation only has two variants: the
+// normal restricted account and an account that additionally enables the
+// app-server escape hatch.
+type codexClientAdmissionSnapshot struct {
+	standard          CodexClientRestrictionDetectionResult
+	appServer         CodexClientRestrictionDetectionResult
+	enforcementActive bool
+
+	mu                      sync.Mutex
+	lastDenied              *CodexClientRestrictionDetectionResult
+	skippedStickyAccountIDs map[int64]struct{}
+}
+
+func (s *OpenAIGatewayService) WithOpenAICodexClientAdmission(
+	ctx context.Context,
+	c *gin.Context,
+	body []byte,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	policy := CodexRestrictionPolicy{EngineFingerprintSignals: openai.DefaultEngineFingerprintSignals}
+	if s != nil && s.settingService != nil {
+		policy = s.settingService.GetCodexRestrictionPolicy(ctx)
+	}
+	detector := s.getCodexClientRestrictionDetector()
+	standard := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"codex_cli_only": true},
+	}
+	appServer := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_cli_only":                  true,
+			"codex_cli_only_allow_app_server": true,
+		},
+	}
+	snapshot := &codexClientAdmissionSnapshot{
+		standard:  detector.Detect(c, standard, policy, body),
+		appServer: detector.Detect(c, appServer, policy, body),
+	}
+	snapshot.enforcementActive = !snapshot.standard.Matched || !snapshot.appServer.Matched
+	// When both account variants are admitted, no account-level codex_cli_only
+	// setting can reject this request. Keep the frozen detection snapshot for
+	// the final forwarding log/guard, but leave enforcement inactive so official
+	// clients preserve eager sticky binding and the zero-extra-cache-read path.
+	return context.WithValue(ctx, codexClientAdmissionContextKey{}, snapshot)
+}
+
+func codexClientAdmissionSnapshotFromContext(ctx context.Context) (*codexClientAdmissionSnapshot, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	snapshot, ok := ctx.Value(codexClientAdmissionContextKey{}).(*codexClientAdmissionSnapshot)
+	return snapshot, ok && snapshot != nil
+}
+
+func codexClientAdmissionActive(ctx context.Context) bool {
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	return ok && snapshot.enforcementActive
+}
+
+func OpenAICodexClientAdmissionActive(ctx context.Context) bool {
+	return codexClientAdmissionActive(ctx)
+}
+
+func codexClientAdmissionAppliesToAccount(ctx context.Context, account *Account) bool {
+	return codexClientAdmissionActive(ctx) && account != nil &&
+		(account.IsOpenAIOAuth() || account.IsShadow())
+}
+
+func openAIStickyAdmissionDeferred(ctx context.Context) bool {
+	return gatewayProfitControlGateActive(ctx) || codexClientAdmissionActive(ctx)
+}
+
+func (snapshot *codexClientAdmissionSnapshot) resultFor(account *Account) (CodexClientRestrictionDetectionResult, bool) {
+	if snapshot == nil || account == nil || !account.IsCodexCLIOnlyEnabled() {
+		return CodexClientRestrictionDetectionResult{}, false
+	}
+	if account.IsCodexCLIOnlyAppServerAllowed() {
+		return snapshot.appServer, true
+	}
+	return snapshot.standard, true
+}
+
+func (snapshot *codexClientAdmissionSnapshot) deniedResult() (CodexClientRestrictionDetectionResult, bool) {
+	if snapshot == nil {
+		return CodexClientRestrictionDetectionResult{}, false
+	}
+	snapshot.mu.Lock()
+	defer snapshot.mu.Unlock()
+	if snapshot.lastDenied == nil {
+		return CodexClientRestrictionDetectionResult{}, false
+	}
+	return *snapshot.lastDenied, true
+}
+
+// hadDenied reports whether this request actually encountered an account that
+// the frozen client policy rejected. The precomputed standard/app-server
+// results describe what would happen if such an account were evaluated; they
+// must not by themselves turn an unrelated empty pool into a typed 403.
+func (snapshot *codexClientAdmissionSnapshot) hadDenied() bool {
+	if snapshot == nil {
+		return false
+	}
+	snapshot.mu.Lock()
+	defer snapshot.mu.Unlock()
+	return snapshot.lastDenied != nil
+}
+
+func (snapshot *codexClientAdmissionSnapshot) recordSkippedSticky(accountID int64) {
+	if snapshot == nil || accountID <= 0 {
+		return
+	}
+	snapshot.mu.Lock()
+	if snapshot.skippedStickyAccountIDs == nil {
+		snapshot.skippedStickyAccountIDs = make(map[int64]struct{})
+	}
+	snapshot.skippedStickyAccountIDs[accountID] = struct{}{}
+	snapshot.mu.Unlock()
+}
+
+func (snapshot *codexClientAdmissionSnapshot) stickyWasSkipped(accountID int64) bool {
+	if snapshot == nil || accountID <= 0 {
+		return false
+	}
+	snapshot.mu.Lock()
+	defer snapshot.mu.Unlock()
+	_, ok := snapshot.skippedStickyAccountIDs[accountID]
+	return ok
+}
+
+func recordCodexClientAdmissionStickySkip(ctx context.Context, accountID int64) {
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok {
+		return
+	}
+	snapshot.recordSkippedSticky(accountID)
+}
+
+func (snapshot *codexClientAdmissionSnapshot) recordDenied(result CodexClientRestrictionDetectionResult) {
+	if snapshot == nil || !result.Enabled || result.Matched {
+		return
+	}
+	snapshot.mu.Lock()
+	copy := result
+	snapshot.lastDenied = &copy
+	snapshot.mu.Unlock()
+}
+
+func codexClientAdmissionDenied(ctx context.Context) bool {
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok {
+		return false
+	}
+	return snapshot.hadDenied()
+}
+
+func codexClientAdmissionErrorFromContext(ctx context.Context) error {
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok {
+		return ErrCodexClientRestricted
+	}
+	result, ok := snapshot.deniedResult()
+	if !ok {
+		return ErrCodexClientRestricted
+	}
+	return &CodexClientAdmissionError{Result: result}
+}
+
+func CodexClientAdmissionErrorFromContext(ctx context.Context) error {
+	return codexClientAdmissionErrorFromContext(ctx)
+}
+
+func CodexClientRestrictionResultFromError(err error) (CodexClientRestrictionDetectionResult, bool) {
+	var admissionErr *CodexClientAdmissionError
+	if errors.As(err, &admissionErr) && admissionErr != nil {
+		return admissionErr.Result, true
+	}
+	return CodexClientRestrictionDetectionResult{}, false
+}
+
+func (s *OpenAIGatewayService) codexRestrictionAccount(
+	ctx context.Context,
+	account *Account,
+	lookup func(int64) *Account,
+) (*Account, error) {
+	if account == nil || account.ParentAccountID == nil {
+		return account, nil
+	}
+	parentID := *account.ParentAccountID
+	var parent *Account
+	if lookup != nil {
+		parent = lookup(parentID)
+	} else if s != nil && s.schedulerSnapshot != nil {
+		parent, _ = s.schedulerSnapshot.GetAccount(ctx, parentID)
+	} else if s != nil && s.accountRepo != nil {
+		parent, _ = s.accountRepo.GetByID(ctx, parentID)
+	}
+	if err := validateCodexRestrictionParent(parent, parentID); err != nil {
+		return nil, err
+	}
+	return parent, nil
+}
+
+func (s *OpenAIGatewayService) codexRestrictionAccountLatest(ctx context.Context, account *Account) (*Account, error) {
+	if account == nil || account.ParentAccountID == nil {
+		return account, nil
+	}
+	parentID := *account.ParentAccountID
+	var parent *Account
+	if s != nil && s.schedulerSnapshot != nil {
+		parent, _ = s.schedulerSnapshot.GetAccount(ctx, parentID)
+	} else if s != nil && s.accountRepo != nil {
+		parent, _ = s.accountRepo.GetByID(ctx, parentID)
+	}
+	if err := validateCodexRestrictionParent(parent, parentID); err != nil {
+		return nil, err
+	}
+	return parent, nil
+}
+
+func validateCodexRestrictionParent(parent *Account, parentID int64) error {
+	if parent == nil {
+		return fmt.Errorf("shadow parent %d not found", parentID)
+	}
+	if parent.IsShadow() {
+		return fmt.Errorf("shadow parent %d is itself a shadow", parent.ID)
+	}
+	if !parent.IsOpenAIOAuth() {
+		return fmt.Errorf("shadow parent %d is not OpenAI OAuth", parent.ID)
+	}
+	return nil
+}
+
+func codexClientAdmissionShadowParentUnresolvedResult() CodexClientRestrictionDetectionResult {
+	return CodexClientRestrictionDetectionResult{
+		Enabled: true,
+		Matched: false,
+		Reason:  codexClientAdmissionShadowParentUnresolvedReason,
+	}
+}
+
+func (s *OpenAIGatewayService) codexClientAdmissionVetoReason(
+	ctx context.Context,
+	account *Account,
+	lookup func(int64) *Account,
+) (bool, string) {
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok {
+		return false, ""
+	}
+	effective, err := s.codexRestrictionAccount(ctx, account, lookup)
+	if err != nil {
+		// A shadow forwards with its parent's credentials. If that parent cannot
+		// be resolved with the same topology guarantees as credential resolution,
+		// admitting the shadow would create a policy bypass window when the later
+		// token lookup recovers. Exclude it locally and preserve the generic client
+		// policy response without sending anything upstream.
+		result := codexClientAdmissionShadowParentUnresolvedResult()
+		snapshot.recordDenied(result)
+		return true, codexClientAdmissionFilterReason
+	}
+	result, active := snapshot.resultFor(effective)
+	if !active || result.Matched {
+		return false, ""
+	}
+	snapshot.recordDenied(result)
+	return true, codexClientAdmissionFilterReason
+}
+
+func (s *OpenAIGatewayService) codexClientAdmissionVeto(
+	ctx context.Context,
+	account *Account,
+) (bool, CodexClientRestrictionDetectionResult) {
+	if account == nil {
+		return false, CodexClientRestrictionDetectionResult{}
+	}
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok {
+		return false, CodexClientRestrictionDetectionResult{}
+	}
+	effective, err := s.codexRestrictionAccountLatest(ctx, account)
+	if err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "[CodexAdmission] shadow parent refresh failed: account_id=%d parent_id=%v error=%v", account.ID, account.ParentAccountID, err)
+		result := codexClientAdmissionShadowParentUnresolvedResult()
+		snapshot.recordDenied(result)
+		return true, result
+	}
+	result, active := snapshot.resultFor(effective)
+	if !active || result.Matched {
+		return false, result
+	}
+	snapshot.recordDenied(result)
+	return true, result
+}
+
+func (s *OpenAIGatewayService) detectCodexClientRestrictionForForward(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) CodexClientRestrictionDetectionResult {
+	effective, err := s.codexRestrictionAccountLatest(ctx, account)
+	if err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "[CodexAdmission] forward shadow parent resolution failed: account_id=%d parent_id=%v error=%v", account.ID, account.ParentAccountID, err)
+		return codexClientAdmissionShadowParentUnresolvedResult()
+	}
+	if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+		if result, active := snapshot.resultFor(effective); active {
+			return result
+		}
+		return CodexClientRestrictionDetectionResult{Reason: CodexClientRestrictionReasonDisabled}
+	}
+	return s.detectCodexClientRestriction(c, effective, body)
+}
+
+func (s *OpenAIGatewayService) enforceOpenAICodexClientAdmissionForForward(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) error {
+	var result CodexClientRestrictionDetectionResult
+	denied := false
+	if codexClientAdmissionActive(ctx) {
+		denied, result = s.codexClientAdmissionVeto(ctx, account)
+	} else {
+		result = s.detectCodexClientRestrictionForForward(ctx, c, account, body)
+		denied = result.Enabled && !result.Matched
+	}
+	logCodexCLIOnlyDetection(ctx, c, account, getAPIKeyIDFromContext(c), result, body)
+	if !denied {
+		return nil
+	}
+	MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+	return &CodexClientAdmissionError{Result: result}
+}

--- a/backend/internal/service/openai_client_admission_forward.go
+++ b/backend/internal/service/openai_client_admission_forward.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 )
 
 // enforceOpenAICodexClientAdmissionBeforeUpstream is the final local safety net
@@ -12,12 +13,16 @@ func (s *OpenAIGatewayService) enforceOpenAICodexClientAdmissionBeforeUpstream(
 	ctx context.Context,
 	selected *Account,
 ) (*Account, error) {
-	if s == nil || selected == nil || !codexClientAdmissionActive(ctx) {
+	if s == nil || selected == nil || !codexClientAdmissionAppliesToAccount(ctx, selected) {
 		return selected, nil
 	}
 
-	if vetoed, result := s.codexClientAdmissionVeto(ctx, selected); vetoed {
-		return selected, &CodexClientAdmissionError{Result: result}
+	snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+	if !ok || !snapshot.terminalAdmissionRecorded(selected) {
+		if ok {
+			snapshot.recordUnavailable()
+		}
+		return selected, fmt.Errorf("%w: missing terminal admission grant for account %d", ErrCodexClientAdmissionUnavailable, selected.ID)
 	}
 	return selected, nil
 }

--- a/backend/internal/service/openai_client_admission_forward.go
+++ b/backend/internal/service/openai_client_admission_forward.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"context"
+)
+
+// enforceOpenAICodexClientAdmissionBeforeUpstream is the final local safety net
+// for forwarding paths. The handler already performed the fresh post-slot
+// check; this layer reuses the same request-frozen policy and admitted account
+// object without adding another Redis or database round trip.
+func (s *OpenAIGatewayService) enforceOpenAICodexClientAdmissionBeforeUpstream(
+	ctx context.Context,
+	selected *Account,
+) (*Account, error) {
+	if s == nil || selected == nil || !codexClientAdmissionActive(ctx) {
+		return selected, nil
+	}
+
+	if vetoed, result := s.codexClientAdmissionVeto(ctx, selected); vetoed {
+		return selected, &CodexClientAdmissionError{Result: result}
+	}
+	return selected, nil
+}

--- a/backend/internal/service/openai_client_admission_forward_test.go
+++ b/backend/internal/service/openai_client_admission_forward_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newCodexAdmissionForwardGuardFixture(t *testing.T) (*OpenAIGatewayService, context.Context, *Account, *httpUpstreamRecorder) {
+	t.Helper()
+	selected := codexAdmissionAccount(8901, true)
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{
+		cfg:           &config.Config{},
+		httpUpstream:  upstream,
+		codexDetector: &accountAwareCodexAdmissionDetector{},
+	}
+	return svc, newCodexAdmissionContext(t, svc), &selected, upstream
+}
+
+func newCodexAdmissionForwardGinContext(method, target string, body []byte) *gin.Context {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(method, target, bytes.NewReader(body))
+	return c
+}
+
+func TestCodexClientAdmissionFinalGuardsDoNotReachHTTPUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("alpha search", func(t *testing.T) {
+		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
+		body := []byte(`{"model":"gpt-5.1-codex","input":"test"}`)
+		_, err := svc.ForwardAlphaSearch(ctx, newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/alpha/search", body), account, body)
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.Nil(t, upstream.lastReq)
+	})
+
+	t.Run("embeddings", func(t *testing.T) {
+		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
+		body := []byte(`{"model":"text-embedding-3-small","input":"test"}`)
+		_, err := svc.ForwardEmbeddings(ctx, newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/embeddings", body), account, body, "")
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.Nil(t, upstream.lastReq)
+	})
+
+	t.Run("images", func(t *testing.T) {
+		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
+		body := []byte(`{"model":"gpt-image-1","prompt":"test"}`)
+		_, err := svc.ForwardImages(
+			ctx,
+			newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/images/generations", body),
+			account,
+			body,
+			&OpenAIImagesRequest{Model: "gpt-image-1", Prompt: "test"},
+			"",
+		)
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.Nil(t, upstream.lastReq)
+	})
+
+	t.Run("codex models", func(t *testing.T) {
+		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
+		_, err := svc.FetchCodexModelsManifest(ctx, account, "0.145.0", "")
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.Nil(t, upstream.lastReq)
+	})
+
+	t.Run("live create", func(t *testing.T) {
+		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
+		_, err := svc.createUpstreamLiveCall(ctx, account, &LiveCallRequest{
+			SDP:     "v=0\r\n",
+			Session: json.RawMessage(`{"model":"gpt-live"}`),
+		}, "attestation")
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.Nil(t, upstream.lastReq)
+	})
+}
+
+func TestCodexClientAdmissionFinalGuardAllowsUnchangedAccount(t *testing.T) {
+	account := codexAdmissionAccount(8902, false)
+	cache := &codexAdmissionSnapshotCache{account: &account}
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{account.ID: &account}}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &account)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	require.False(t, errors.Is(err, ErrCodexClientRestricted))
+}
+
+func TestOpenAITerminalAdmissionKeepsDBSelectionWhenTimestampTies(t *testing.T) {
+	selected := codexAdmissionAccount(8903, true)
+	selected.UpdatedAt = time.Now().UTC()
+	cached := codexAdmissionAccount(selected.ID, false)
+	cached.UpdatedAt = selected.UpdatedAt
+	cache := &codexAdmissionSnapshotCache{account: &cached}
+	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
+	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.Same(t, &selected, result.Account, "相同时间戳的缓存对象不得覆盖刚完成 DB 复检的选择对象")
+	require.True(t, result.ClientVetoed)
+}

--- a/backend/internal/service/openai_client_admission_forward_test.go
+++ b/backend/internal/service/openai_client_admission_forward_test.go
@@ -18,8 +18,10 @@ import (
 func newCodexAdmissionForwardGuardFixture(t *testing.T) (*OpenAIGatewayService, context.Context, *Account, *httpUpstreamRecorder) {
 	t.Helper()
 	selected := codexAdmissionAccount(8901, true)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &selected}}
 	upstream := &httpUpstreamRecorder{}
 	svc := &OpenAIGatewayService{
+		accountRepo:   repo,
 		cfg:           &config.Config{},
 		httpUpstream:  upstream,
 		codexDetector: &accountAwareCodexAdmissionDetector{},
@@ -41,7 +43,7 @@ func TestCodexClientAdmissionFinalGuardsDoNotReachHTTPUpstream(t *testing.T) {
 		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
 		body := []byte(`{"model":"gpt-5.1-codex","input":"test"}`)
 		_, err := svc.ForwardAlphaSearch(ctx, newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/alpha/search", body), account, body)
-		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 		require.Nil(t, upstream.lastReq)
 	})
 
@@ -49,7 +51,7 @@ func TestCodexClientAdmissionFinalGuardsDoNotReachHTTPUpstream(t *testing.T) {
 		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
 		body := []byte(`{"model":"text-embedding-3-small","input":"test"}`)
 		_, err := svc.ForwardEmbeddings(ctx, newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/embeddings", body), account, body, "")
-		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 		require.Nil(t, upstream.lastReq)
 	})
 
@@ -64,14 +66,14 @@ func TestCodexClientAdmissionFinalGuardsDoNotReachHTTPUpstream(t *testing.T) {
 			&OpenAIImagesRequest{Model: "gpt-image-1", Prompt: "test"},
 			"",
 		)
-		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 		require.Nil(t, upstream.lastReq)
 	})
 
 	t.Run("codex models", func(t *testing.T) {
 		svc, ctx, account, upstream := newCodexAdmissionForwardGuardFixture(t)
 		_, err := svc.FetchCodexModelsManifest(ctx, account, "0.145.0", "")
-		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 		require.Nil(t, upstream.lastReq)
 	})
 
@@ -81,12 +83,12 @@ func TestCodexClientAdmissionFinalGuardsDoNotReachHTTPUpstream(t *testing.T) {
 			SDP:     "v=0\r\n",
 			Session: json.RawMessage(`{"model":"gpt-live"}`),
 		}, "attestation")
-		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 		require.Nil(t, upstream.lastReq)
 	})
 }
 
-func TestCodexClientAdmissionFinalGuardAllowsUnchangedAccount(t *testing.T) {
+func TestCodexClientAdmissionFinalGuardWithoutGrantIsUnavailable(t *testing.T) {
 	account := codexAdmissionAccount(8902, false)
 	cache := &codexAdmissionSnapshotCache{account: &account}
 	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{account.ID: &account}}
@@ -95,9 +97,159 @@ func TestCodexClientAdmissionFinalGuardAllowsUnchangedAccount(t *testing.T) {
 	ctx := newCodexAdmissionContext(t, svc)
 
 	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &account)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
 	require.NotNil(t, latest)
 	require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	require.Zero(t, repo.getCalls.Load(), "发送前保护缺 grant 时不得再次访问数据库")
+}
+
+func TestCodexClientAdmissionFinalGuardReusesTerminalAdmission(t *testing.T) {
+	selected := codexAdmissionAccount(8905, false)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &selected}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	admission, admissionErr := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, admissionErr)
+	require.False(t, admission.ClientVetoed)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+
+	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, admission.Account)
+	require.NoError(t, err)
+	require.Equal(t, admission.Account.ID, latest.ID)
+	require.Equal(t, int64(1), repo.getCalls.Load(), "发送前防线应复用本请求已完成的权威终检")
+}
+
+func TestCodexClientAdmissionProofDoesNotApplyToDifferentObjectWithSameID(t *testing.T) {
+	selected := codexAdmissionAccount(8906, false)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &selected}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	admission, admissionErr := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, admissionErr)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+
+	restricted := codexAdmissionAccount(selected.ID, true)
+	repo.byID[selected.ID] = &restricted
+	copyWithSameID := *admission.Account
+	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &copyWithSameID)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	require.Equal(t, copyWithSameID.ID, latest.ID)
+	require.Equal(t, int64(1), repo.getCalls.Load(), "不匹配 grant 时不得在发送前重新查询数据库")
+}
+
+func TestCodexClientAdmissionWSRegrantsStableBoundObject(t *testing.T) {
+	bound := codexAdmissionAccount(8914, false)
+	authoritative := bound
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{bound.ID: &authoritative}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	admission, err := svc.OpenAITerminalAdmissionLatest(ctx, &bound)
+	require.NoError(t, err)
+	require.NotSame(t, &bound, admission.Account)
+	require.True(t, svc.GrantOpenAIWSTerminalAdmission(ctx, &bound, admission.Account))
+
+	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &bound)
+	require.NoError(t, err)
+	require.Same(t, &bound, latest)
+	require.Equal(t, int64(1), repo.getCalls.Load(), "WS 绑定对象获得 grant 后发送前不得再次访问数据库")
+}
+
+func TestCodexClientAdmissionWSRejectsBindingIdentityChange(t *testing.T) {
+	oldParentID := int64(8915)
+	newParentID := int64(8916)
+	bound := codexAdmissionAccount(8917, false)
+	bound.ParentAccountID = &oldParentID
+	authoritative := bound
+	authoritative.ParentAccountID = &newParentID
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{
+		bound.ID:    &authoritative,
+		newParentID: func() *Account { parent := codexAdmissionAccount(newParentID, false); return &parent }(),
+	}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	admission, err := svc.OpenAITerminalAdmissionLatest(ctx, &bound)
+	require.NoError(t, err)
+	require.False(t, svc.GrantOpenAIWSTerminalAdmission(ctx, &bound, admission.Account))
+
+	_, err = svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &bound)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+}
+
+func TestCodexClientAdmissionNewTerminalAttemptClearsOldGrant(t *testing.T) {
+	first := codexAdmissionAccount(8907, false)
+	second := codexAdmissionAccount(8908, false)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{first.ID: &first, second.ID: &second}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	firstAdmission, err := svc.OpenAITerminalAdmissionLatest(ctx, &first)
+	require.NoError(t, err)
+	repo.getErrByID = map[int64]error{second.ID: errors.New("database unavailable")}
+	_, err = svc.OpenAITerminalAdmissionLatest(ctx, &second)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+
+	_, err = svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, firstAdmission.Account)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable, "新的终检开始后旧账号 grant 必须立即失效")
+}
+
+func TestCodexClientAdmissionEveryTerminalAttemptClearsOldGrant(t *testing.T) {
+	first := codexAdmissionAccount(8912, false)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{first.ID: &first}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	t.Run("nil selection", func(t *testing.T) {
+		admission, err := svc.OpenAITerminalAdmissionLatest(ctx, &first)
+		require.NoError(t, err)
+		_, err = svc.OpenAITerminalAdmissionLatest(ctx, nil)
+		require.NoError(t, err)
+
+		_, err = svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, admission.Account)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	})
+
+	t.Run("non applicable account", func(t *testing.T) {
+		admission, err := svc.OpenAITerminalAdmissionLatest(ctx, &first)
+		require.NoError(t, err)
+		apiKey := &Account{ID: 8913, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		_, err = svc.OpenAITerminalAdmissionLatest(ctx, apiKey)
+		require.NoError(t, err)
+
+		_, err = svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, admission.Account)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	})
+}
+
+func TestCodexClientAdmissionInactiveForwardSkipsDB(t *testing.T) {
+	parentID := int64(8909)
+	shadow := codexAdmissionAccount(8910, false)
+	shadow.ParentAccountID = &parentID
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("must not be called")}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: alwaysMatchedCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.False(t, codexClientAdmissionActive(ctx))
+	c := newCodexAdmissionForwardGinContext(http.MethodPost, "/v1/responses", nil)
+
+	err := svc.enforceOpenAICodexClientAdmissionForForward(ctx, c, &shadow, nil)
+	require.NoError(t, err)
+	require.Zero(t, repo.getCalls.Load())
+}
+
+func TestCodexClientAdmissionActiveForwardSkipsGrantForAPIKeyAccount(t *testing.T) {
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("must not query repository")}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	account := Account{ID: 8911, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	latest, err := svc.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, &account)
+	require.NoError(t, err)
+	require.Same(t, &account, latest)
+	require.Zero(t, repo.getCalls.Load())
 }
 
 func TestOpenAITerminalAdmissionKeepsDBSelectionWhenTimestampTies(t *testing.T) {
@@ -106,11 +258,15 @@ func TestOpenAITerminalAdmissionKeepsDBSelectionWhenTimestampTies(t *testing.T) 
 	cached := codexAdmissionAccount(selected.ID, false)
 	cached.UpdatedAt = selected.UpdatedAt
 	cache := &codexAdmissionSnapshotCache{account: &cached}
-	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
-	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &selected}}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
 	ctx := newCodexAdmissionContext(t, svc)
 
-	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
-	require.Same(t, &selected, result.Account, "相同时间戳的缓存对象不得覆盖刚完成 DB 复检的选择对象")
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
+	require.NotSame(t, &cached, result.Account, "相同时间戳的陈旧缓存不得覆盖数据库权威对象")
+	require.True(t, result.Account.IsCodexCLIOnlyEnabled())
+	require.Zero(t, cache.calls.Load())
 	require.True(t, result.ClientVetoed)
 }

--- a/backend/internal/service/openai_client_admission_scheduling_test.go
+++ b/backend/internal/service/openai_client_admission_scheduling_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexClientAdmissionRestrictedAndBusyCandidateKeepsWaitPlan(t *testing.T) {
+	groupID := int64(8801)
+	newAccounts := func() []Account {
+		restricted := codexAdmissionAccount(88011, true)
+		restricted.GroupIDs = []int64{groupID}
+		restricted.Priority = 0
+		regular := codexAdmissionAccount(88012, false)
+		regular.GroupIDs = []int64{groupID}
+		regular.Priority = 1
+		return []Account{restricted, regular}
+	}
+	newConcurrency := func() *ConcurrencyService {
+		return NewConcurrencyService(schedulerTestConcurrencyCache{
+			loadMap: map[int64]*AccountLoadInfo{
+				88011: {AccountID: 88011, CurrentConcurrency: 1, LoadRate: 100},
+				88012: {AccountID: 88012, CurrentConcurrency: 1, LoadRate: 100},
+			},
+			acquireResults: map[int64]bool{88012: false},
+		})
+	}
+
+	t.Run("legacy load aware", func(t *testing.T) {
+		resetOpenAIAdvancedSchedulerSettingCacheForTest()
+		accounts := newAccounts()
+		repo := &codexAdmissionAccountRepo{
+			accounts: accounts,
+			byID: map[int64]*Account{
+				accounts[0].ID: &accounts[0],
+				accounts[1].ID: &accounts[1],
+			},
+		}
+		svc := &OpenAIGatewayService{
+			accountRepo:        repo,
+			cfg:                &config.Config{},
+			codexDetector:      &accountAwareCodexAdmissionDetector{},
+			concurrencyService: newConcurrency(),
+		}
+		ctx := newCodexAdmissionContext(t, svc)
+
+		selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, int64(88012), selection.Account.ID)
+		require.NotNil(t, selection.WaitPlan)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	})
+
+	t.Run("advanced scheduler", func(t *testing.T) {
+		resetOpenAIAdvancedSchedulerSettingCacheForTest()
+		defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+		accounts := newAccounts()
+		repo := &codexAdmissionAccountRepo{
+			accounts: accounts,
+			byID: map[int64]*Account{
+				accounts[0].ID: &accounts[0],
+				accounts[1].ID: &accounts[1],
+			},
+		}
+		cfg := &config.Config{}
+		svc := &OpenAIGatewayService{
+			accountRepo:        repo,
+			cfg:                cfg,
+			codexDetector:      &accountAwareCodexAdmissionDetector{},
+			rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+			concurrencyService: newConcurrency(),
+		}
+		ctx := newCodexAdmissionContext(t, svc)
+
+		selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, int64(88012), selection.Account.ID)
+		require.NotNil(t, selection.WaitPlan)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	})
+}

--- a/backend/internal/service/openai_client_admission_test.go
+++ b/backend/internal/service/openai_client_admission_test.go
@@ -56,8 +56,11 @@ func codexAdmissionAccount(id int64, restricted bool) Account {
 
 type codexAdmissionAccountRepo struct {
 	AccountRepository
-	accounts []Account
-	byID     map[int64]*Account
+	accounts   []Account
+	byID       map[int64]*Account
+	getErr     error
+	getErrByID map[int64]error
+	getCalls   atomic.Int64
 }
 
 func (r *codexAdmissionAccountRepo) ListSchedulableByGroupIDAndPlatform(context.Context, int64, string) ([]Account, error) {
@@ -73,6 +76,13 @@ func (r *codexAdmissionAccountRepo) ListSchedulableByPlatform(context.Context, s
 }
 
 func (r *codexAdmissionAccountRepo) GetByID(_ context.Context, id int64) (*Account, error) {
+	r.getCalls.Add(1)
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	if err := r.getErrByID[id]; err != nil {
+		return nil, err
+	}
 	if r.byID == nil || r.byID[id] == nil {
 		return nil, nil
 	}
@@ -104,6 +114,7 @@ func (d *mutableCodexAdmissionDetector) Detect(_ *gin.Context, _ *Account, _ Cod
 type codexAdmissionSnapshotCache struct {
 	SchedulerCache
 	account *Account
+	err     error
 	calls   atomic.Int64
 }
 
@@ -144,6 +155,9 @@ func (r *recoveringCodexAdmissionRepo) GetByID(_ context.Context, _ int64) (*Acc
 
 func (c *codexAdmissionSnapshotCache) GetAccount(context.Context, int64) (*Account, error) {
 	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
 	if c.account == nil {
 		return nil, nil
 	}
@@ -333,9 +347,9 @@ func TestCodexClientAdmissionShadowParentTransientRecoveryCannotBypass(t *testin
 	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
 	ctx := newCodexAdmissionContext(t, svc)
 
-	vetoed, result := svc.codexClientAdmissionVeto(ctx, &shadow)
-	require.True(t, vetoed, "母账号首次读取失败时必须在终检 fail-closed")
-	require.Equal(t, codexClientAdmissionShadowParentUnresolvedReason, result.Reason)
+	_, admissionErr := svc.OpenAITerminalAdmissionLatest(ctx, &shadow)
+	require.ErrorIs(t, admissionErr, ErrCodexClientAdmissionUnavailable, "母账号首次读取失败时必须在终检 fail-closed")
+	require.False(t, errors.Is(admissionErr, ErrCodexClientRestricted), "读取失败不能冒充真实客户端策略拒绝")
 
 	resolved, err := resolveCredentialAccount(ctx, repo, &shadow)
 	require.NoError(t, err)
@@ -385,6 +399,26 @@ func TestLiveSidebandLateGuardRejectsBeforeCredentialOrDial(t *testing.T) {
 	conn, err := svc.dialLiveSideband(ctx, &LiveCallRecord{AccountID: restricted.ID, CallID: "call_restricted"})
 	require.Nil(t, conn)
 	require.ErrorIs(t, err, ErrCodexClientRestricted, "晚期保护必须在读取 OAuth 凭据或拨号前拒绝")
+}
+
+func TestLiveSidebandAccountReadFailureIsAdmissionUnavailable(t *testing.T) {
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("database unavailable")}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	record := &LiveCallRecord{AccountID: 490, CallID: "call_unavailable"}
+
+	t.Run("before upgrade", func(t *testing.T) {
+		err := svc.ValidateLiveSidebandClientAdmission(ctx, record)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	})
+
+	t.Run("after upgrade", func(t *testing.T) {
+		conn, err := svc.dialLiveSideband(ctx, record)
+		require.Nil(t, conn)
+		require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	})
 }
 
 func TestCodexClientAdmissionPreviousResponseBindingIsPreserved(t *testing.T) {
@@ -539,7 +573,7 @@ func TestCodexClientAdmissionOrdinaryFailoverStillReplacesStickyBinding(t *testi
 	require.Equal(t, newAccount.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "未被客户端门否决的旧账号不得阻止普通 failover 更新粘性")
 }
 
-func TestCodexClientAdmissionLateVetoDoesNotPreserveNewlyWrittenStickyBinding(t *testing.T) {
+func TestCodexClientAdmissionLateVetoPreservesExistingStickyBinding(t *testing.T) {
 	detector := &accountAwareCodexAdmissionDetector{}
 	groupID := int64(81)
 	restricted := codexAdmissionAccount(482, true)
@@ -555,10 +589,11 @@ func TestCodexClientAdmissionLateVetoDoesNotPreserveNewlyWrittenStickyBinding(t 
 	const sessionHash = "late-client-veto"
 	require.NoError(t, svc.setStickySessionAccountID(ctx, &groupID, sessionHash, restricted.ID, time.Hour))
 
-	vetoed, _ := svc.codexClientAdmissionVetoReason(ctx, &restricted, nil)
+	vetoed, _, vetoErr := svc.codexClientAdmissionVeto(ctx, &restricted)
+	require.NoError(t, vetoErr)
 	require.True(t, vetoed, "模拟准入后、发送前才发现限制变化")
 	require.NoError(t, svc.BindStickySessionAfterProfitAdmission(ctx, &groupID, sessionHash, replacement.ID))
-	require.Equal(t, replacement.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "只有入口前实际跳过的旧 sticky 才能被保留")
+	require.Equal(t, restricted.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "槽后终检否决也必须保留原 sticky，兼容客户端恢复后可自动重粘连")
 }
 
 func TestOpenAITerminalAdmissionRefreshesOnceAndNeverDowngradesFreshSelection(t *testing.T) {
@@ -568,13 +603,16 @@ func TestOpenAITerminalAdmissionRefreshesOnceAndNeverDowngradesFreshSelection(t 
 	stale := codexAdmissionAccount(50, false)
 	stale.UpdatedAt = selected.UpdatedAt.Add(-time.Minute)
 	cache := &codexAdmissionSnapshotCache{account: &stale}
-	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
-	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: detector}
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &selected}}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: detector}
 	ctx := newCodexAdmissionContext(t, svc)
 
-	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
-	require.Equal(t, int64(1), cache.calls.Load(), "利润与客户端终检必须共享一次账号刷新")
-	require.Same(t, &selected, result.Account, "旧缓存不得覆盖刚做过 DB recheck 的新对象")
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), repo.getCalls.Load(), "客户端终检必须只做一次权威账号刷新")
+	require.Zero(t, cache.calls.Load(), "客户端安全门不得采用可能陈旧的 scheduler cache")
+	require.NotSame(t, &selected, result.Account)
 	require.True(t, result.ClientVetoed)
 	require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.ClientRestriction.Reason)
 }
@@ -585,17 +623,144 @@ func TestOpenAITerminalAdmissionUsesNewerReplacementObject(t *testing.T) {
 	selected.UpdatedAt = time.Now().UTC().Add(-time.Minute)
 	replacement := codexAdmissionAccount(51, true)
 	replacement.UpdatedAt = selected.UpdatedAt.Add(time.Minute)
-	cache := &codexAdmissionSnapshotCache{account: &replacement}
-	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
-	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: detector}
+	stale := selected
+	cache := &codexAdmissionSnapshotCache{account: &stale}
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{selected.ID: &replacement}}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: detector}
 	ctx := newCodexAdmissionContext(t, svc)
 
-	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
-	require.Equal(t, int64(1), cache.calls.Load(), "利润与客户端终检必须共享一次账号刷新")
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), repo.getCalls.Load(), "客户端终检必须只做一次权威账号刷新")
+	require.Zero(t, cache.calls.Load(), "陈旧 cache 不得掩盖数据库中新开启的限制")
 	require.NotSame(t, &selected, result.Account, "终检必须采用缓存中替换后的新对象")
 	require.Equal(t, replacement.UpdatedAt, result.Account.UpdatedAt)
 	require.True(t, result.ClientVetoed)
 	require.False(t, selected.IsCodexCLIOnlyEnabled(), "终检不得通过原地修改旧指针伪造刷新")
+}
+
+func TestOpenAITerminalAdmissionRefreshFailureFailsClosed(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	selected := codexAdmissionAccount(53, false)
+	cache := &codexAdmissionSnapshotCache{account: &selected}
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("database unavailable")}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	require.False(t, result.ClientVetoed)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+	require.Zero(t, cache.calls.Load(), "读取失败不能回退到可能陈旧的安全策略缓存")
+	ctxErr := CodexClientAdmissionErrorFromContext(ctx)
+	require.ErrorIs(t, ctxErr, ErrCodexClientAdmissionUnavailable)
+	require.False(t, errors.Is(ctxErr, ErrCodexClientRestricted))
+}
+
+func TestOpenAITerminalAdmissionShadowUsesFreshParentPolicy(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parent := codexAdmissionAccount(54, true)
+	parentID := parent.ID
+	shadow := codexAdmissionAccount(55, false)
+	shadow.ParentAccountID = &parentID
+	staleParent := parent
+	staleParent.Extra = map[string]any{}
+	cache := &codexAdmissionSnapshotCache{account: &staleParent}
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{
+		shadow.ID: &shadow,
+		parent.ID: &parent,
+	}}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &shadow)
+	require.NoError(t, err)
+	require.True(t, result.ClientVetoed)
+	require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.ClientRestriction.Reason)
+	require.Equal(t, int64(2), repo.getCalls.Load(), "影子账号与其母账号都必须从数据库权威读取")
+	require.Zero(t, cache.calls.Load(), "陈旧母账号缓存不得绕过客户端限制")
+}
+
+func TestOpenAITerminalAdmissionShadowUsesFreshParentTopology(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	oldParent := codexAdmissionAccount(56, false)
+	newParent := codexAdmissionAccount(57, true)
+	oldParentID := oldParent.ID
+	newParentID := newParent.ID
+	selected := codexAdmissionAccount(58, false)
+	selected.ParentAccountID = &oldParentID
+	freshShadow := selected
+	freshShadow.ParentAccountID = &newParentID
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{
+		freshShadow.ID: &freshShadow,
+		newParent.ID:   &newParent,
+	}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
+	require.True(t, result.ClientVetoed)
+	require.Equal(t, newParentID, *result.Account.ParentAccountID)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestOpenAITerminalAdmissionShadowParentReadFailureIsUnavailable(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parentID := int64(59)
+	shadow := codexAdmissionAccount(60, false)
+	shadow.ParentAccountID = &parentID
+	repo := &codexAdmissionAccountRepo{
+		byID:       map[int64]*Account{shadow.ID: &shadow},
+		getErrByID: map[int64]error{parentID: errors.New("parent read failed")},
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &shadow)
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	require.False(t, result.ClientVetoed)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestOpenAITerminalAdmissionInactiveOfficialClientSkipsDB(t *testing.T) {
+	selected := codexAdmissionAccount(61, true)
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("must not be called")}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: alwaysMatchedCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.False(t, codexClientAdmissionActive(ctx))
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
+	require.Same(t, &selected, result.Account)
+	require.Zero(t, repo.getCalls.Load())
+}
+
+func TestOpenAITerminalAdmissionInactiveOfficialShadowSkipsDB(t *testing.T) {
+	parentID := int64(611)
+	shadow := codexAdmissionAccount(612, true)
+	shadow.ParentAccountID = &parentID
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("must not be called")}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: alwaysMatchedCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.False(t, codexClientAdmissionActive(ctx))
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &shadow)
+	require.NoError(t, err)
+	require.Same(t, &shadow, result.Account)
+	require.False(t, result.ClientVetoed)
+	require.Zero(t, repo.getCalls.Load(), "官方客户端的影子账号不得新增母账号数据库读取")
+	lookupCalls := 0
+	vetoed, reason := svc.codexClientAdmissionVetoReason(ctx, &shadow, func(int64) *Account {
+		lookupCalls++
+		panic("inactive admission must not resolve shadow parent")
+	})
+	require.False(t, vetoed)
+	require.Empty(t, reason)
+	require.Zero(t, lookupCalls, "官方客户端候选过滤不得解析影子母账号")
 }
 
 func TestOpenAITerminalAdmissionSkipsRefreshForAPIKeyAccount(t *testing.T) {
@@ -607,8 +772,34 @@ func TestOpenAITerminalAdmissionSkipsRefreshForAPIKeyAccount(t *testing.T) {
 	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
 	ctx := newCodexAdmissionContext(t, svc)
 
-	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err)
 	require.Zero(t, cache.calls.Load(), "账号级 Codex 限制不适用于 API Key，普通请求不得增加快照读取")
 	require.Same(t, &selected, result.Account)
 	require.False(t, result.ClientVetoed)
+}
+
+func TestOpenAITerminalAdmissionAPIKeyProfitRefreshFailureRemainsFailOpen(t *testing.T) {
+	selected := codexAdmissionAccount(62, false)
+	selected.Type = AccountTypeAPIKey
+	rate := 0.1
+	selected.RateMultiplier = &rate
+	cache := &codexAdmissionSnapshotCache{err: errors.New("scheduler cache unavailable")}
+	repo := &codexAdmissionAccountRepo{getErr: errors.New("database unavailable")}
+	snapshot := NewSchedulerSnapshotService(cache, nil, repo, nil, nil)
+	svc := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	ctx = context.WithValue(ctx, openAIProfitControlGateCtxKey{}, &openAIProfitControlGate{
+		groupID:   1,
+		platform:  PlatformOpenAI,
+		threshold: 0.2,
+	})
+
+	result, err := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.NoError(t, err, "API Key 仅有利润门时仍沿用快照刷新失败 fail-open 语义")
+	require.Same(t, &selected, result.Account)
+	require.False(t, result.ProfitVetoed)
+	require.False(t, result.ClientVetoed)
+	require.Equal(t, int64(1), cache.calls.Load())
+	require.Equal(t, int64(1), repo.getCalls.Load(), "利润门快照 miss 仍沿用既有数据库 fallback；失败后必须 fail-open")
 }

--- a/backend/internal/service/openai_client_admission_test.go
+++ b/backend/internal/service/openai_client_admission_test.go
@@ -1,0 +1,614 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type accountAwareCodexAdmissionDetector struct {
+	calls atomic.Int64
+}
+
+func (d *accountAwareCodexAdmissionDetector) Detect(_ *gin.Context, account *Account, _ CodexRestrictionPolicy, _ []byte) CodexClientRestrictionDetectionResult {
+	d.calls.Add(1)
+	if account != nil && account.IsCodexCLIOnlyAppServerAllowed() {
+		return CodexClientRestrictionDetectionResult{Enabled: true, Matched: true, Reason: CodexClientRestrictionReasonMatchedAppServerClient}
+	}
+	return CodexClientRestrictionDetectionResult{Enabled: true, Matched: false, Reason: CodexClientRestrictionReasonNotMatchedUA}
+}
+
+func newCodexAdmissionContext(t *testing.T, svc *OpenAIGatewayService) context.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	return svc.WithOpenAICodexClientAdmission(context.Background(), c, []byte(`{"model":"gpt-5.1-codex"}`))
+}
+
+func codexAdmissionAccount(id int64, restricted bool) Account {
+	now := time.Now().UTC()
+	extra := map[string]any{}
+	if restricted {
+		extra["codex_cli_only"] = true
+	}
+	return Account{
+		ID:          id,
+		Name:        "account",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+		UpdatedAt:   now,
+		Extra:       extra,
+	}
+}
+
+type codexAdmissionAccountRepo struct {
+	AccountRepository
+	accounts []Account
+	byID     map[int64]*Account
+}
+
+func (r *codexAdmissionAccountRepo) ListSchedulableByGroupIDAndPlatform(context.Context, int64, string) ([]Account, error) {
+	return append([]Account(nil), r.accounts...), nil
+}
+
+func (r *codexAdmissionAccountRepo) ListSchedulableUngroupedByPlatform(context.Context, string) ([]Account, error) {
+	return append([]Account(nil), r.accounts...), nil
+}
+
+func (r *codexAdmissionAccountRepo) ListSchedulableByPlatform(context.Context, string) ([]Account, error) {
+	return append([]Account(nil), r.accounts...), nil
+}
+
+func (r *codexAdmissionAccountRepo) GetByID(_ context.Context, id int64) (*Account, error) {
+	if r.byID == nil || r.byID[id] == nil {
+		return nil, nil
+	}
+	copy := *r.byID[id]
+	return &copy, nil
+}
+
+type alwaysMatchedCodexAdmissionDetector struct{}
+
+func (alwaysMatchedCodexAdmissionDetector) Detect(_ *gin.Context, _ *Account, _ CodexRestrictionPolicy, _ []byte) CodexClientRestrictionDetectionResult {
+	return CodexClientRestrictionDetectionResult{Enabled: true, Matched: true, Reason: CodexClientRestrictionReasonMatchedUA}
+}
+
+type mutableCodexAdmissionDetector struct {
+	matched atomic.Bool
+	calls   atomic.Int64
+}
+
+func (d *mutableCodexAdmissionDetector) Detect(_ *gin.Context, _ *Account, _ CodexRestrictionPolicy, _ []byte) CodexClientRestrictionDetectionResult {
+	d.calls.Add(1)
+	matched := d.matched.Load()
+	reason := CodexClientRestrictionReasonNotMatchedUA
+	if matched {
+		reason = CodexClientRestrictionReasonMatchedUA
+	}
+	return CodexClientRestrictionDetectionResult{Enabled: true, Matched: matched, Reason: reason}
+}
+
+type codexAdmissionSnapshotCache struct {
+	SchedulerCache
+	account *Account
+	calls   atomic.Int64
+}
+
+type countingCodexStickyCache struct {
+	stubGatewayCache
+	getCalls atomic.Int64
+	setCalls atomic.Int64
+}
+
+func (c *countingCodexStickyCache) GetSessionAccountID(ctx context.Context, groupID int64, sessionHash string) (int64, error) {
+	c.getCalls.Add(1)
+	return c.stubGatewayCache.GetSessionAccountID(ctx, groupID, sessionHash)
+}
+
+func (c *countingCodexStickyCache) SetSessionAccountID(ctx context.Context, groupID int64, sessionHash string, accountID int64, ttl time.Duration) error {
+	c.setCalls.Add(1)
+	return c.stubGatewayCache.SetSessionAccountID(ctx, groupID, sessionHash, accountID, ttl)
+}
+
+type recoveringCodexAdmissionRepo struct {
+	AccountRepository
+	parent      *Account
+	parentCalls atomic.Int64
+	totalCalls  atomic.Int64
+}
+
+func (r *recoveringCodexAdmissionRepo) GetByID(_ context.Context, _ int64) (*Account, error) {
+	r.totalCalls.Add(1)
+	if r.parentCalls.Add(1) == 1 {
+		return nil, nil
+	}
+	if r.parent == nil {
+		return nil, nil
+	}
+	copy := *r.parent
+	return &copy, nil
+}
+
+func (c *codexAdmissionSnapshotCache) GetAccount(context.Context, int64) (*Account, error) {
+	c.calls.Add(1)
+	if c.account == nil {
+		return nil, nil
+	}
+	copy := *c.account
+	return &copy, nil
+}
+
+func TestCodexClientAdmissionFreezesRequestDetection(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	svc := &OpenAIGatewayService{codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.Equal(t, int64(2), detector.calls.Load(), "入口只预计算普通与 app-server 两种结果")
+
+	standard := codexAdmissionAccount(1, true)
+	vetoed, _ := svc.codexClientAdmissionVetoReason(ctx, &standard, nil)
+	require.True(t, vetoed)
+
+	appServer := codexAdmissionAccount(2, true)
+	appServer.Extra["codex_cli_only_allow_app_server"] = true
+	vetoed, _ = svc.codexClientAdmissionVetoReason(ctx, &appServer, nil)
+	require.False(t, vetoed)
+	require.Equal(t, int64(2), detector.calls.Load(), "候选与终检必须复用同一请求快照")
+}
+
+func TestCodexClientAdmissionSkipsNoOpGateForUniversallyMatchedClient(t *testing.T) {
+	svc := &OpenAIGatewayService{codexDetector: alwaysMatchedCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.False(t, codexClientAdmissionActive(ctx))
+	require.False(t, openAIStickyAdmissionDeferred(ctx), "不会被任何账号配置拒绝的客户端必须保留原 eager sticky 语义")
+}
+
+func TestCodexClientAdmissionUniversallyMatchedClientKeepsFrozenForwardDecision(t *testing.T) {
+	detector := &mutableCodexAdmissionDetector{}
+	detector.matched.Store(true)
+	svc := &OpenAIGatewayService{codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.False(t, codexClientAdmissionActive(ctx))
+	require.Equal(t, int64(2), detector.calls.Load())
+
+	detector.matched.Store(false)
+	restricted := codexAdmissionAccount(3, true)
+	result := svc.detectCodexClientRestrictionForForward(ctx, nil, &restricted, nil)
+	require.True(t, result.Matched, "最终保护必须复用入口冻结的策略与请求身份")
+	require.Equal(t, int64(2), detector.calls.Load(), "Forward 不得在同一请求内重新执行检测器")
+}
+
+func TestCodexClientAdmissionLegacySelection(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	groupID := int64(77)
+
+	t.Run("empty pool does not infer forbidden from precomputed denial", func(t *testing.T) {
+		repo := &codexAdmissionAccountRepo{}
+		svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+		ctx := newCodexAdmissionContext(t, svc)
+
+		snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+		require.True(t, ok)
+		require.False(t, snapshot.hadDenied(), "预计算拒绝结果不等于实际发生过账号 veto")
+
+		_, err := svc.SelectAccountForModelWithExclusions(ctx, &groupID, "", "", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoAvailableAccounts)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+		require.False(t, snapshot.hadDenied())
+	})
+
+	t.Run("mixed pool skips restricted account", func(t *testing.T) {
+		restricted := codexAdmissionAccount(10, true)
+		restricted.Priority = 0
+		regular := codexAdmissionAccount(11, false)
+		regular.Priority = 1
+		repo := &codexAdmissionAccountRepo{accounts: []Account{restricted, regular}}
+		svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+		ctx := newCodexAdmissionContext(t, svc)
+
+		selected, err := svc.SelectAccountForModelWithExclusions(ctx, &groupID, "", "", nil)
+		require.NoError(t, err)
+		require.NotNil(t, selected)
+		require.Equal(t, regular.ID, selected.ID)
+	})
+
+	t.Run("all otherwise eligible accounts return typed forbidden", func(t *testing.T) {
+		restricted := codexAdmissionAccount(20, true)
+		repo := &codexAdmissionAccountRepo{accounts: []Account{restricted}}
+		svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+		ctx := newCodexAdmissionContext(t, svc)
+		snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx)
+		require.True(t, ok)
+		require.False(t, snapshot.hadDenied())
+
+		_, err := svc.SelectAccountForModelWithExclusions(ctx, &groupID, "", "", nil)
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		require.True(t, snapshot.hadDenied(), "只有实际候选 veto 后才能升级为 typed 403")
+		result, ok := CodexClientRestrictionResultFromError(err)
+		require.True(t, ok)
+		require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.Reason)
+	})
+
+	t.Run("model incompatible restricted account does not cause false forbidden", func(t *testing.T) {
+		restricted := codexAdmissionAccount(30, true)
+		restricted.Credentials = map[string]any{
+			"model_mapping": map[string]any{"gpt-other": "gpt-other"},
+		}
+		repo := &codexAdmissionAccountRepo{accounts: []Account{restricted}}
+		svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+		ctx := newCodexAdmissionContext(t, svc)
+
+		_, err := svc.SelectAccountForModelWithExclusions(ctx, &groupID, "", "gpt-5.1-codex", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoAvailableAccounts)
+		require.False(t, errors.Is(err, ErrCodexClientRestricted))
+	})
+}
+
+func TestCodexClientAdmissionShadowInheritsParent(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parent := codexAdmissionAccount(40, true)
+	parentID := parent.ID
+	shadow := codexAdmissionAccount(41, false)
+	shadow.ParentAccountID = &parentID
+	repo := &codexAdmissionAccountRepo{
+		accounts: []Account{shadow},
+		byID:     map[int64]*Account{parent.ID: &parent},
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	_, err := svc.SelectAccountForModelWithExclusions(ctx, nil, "", "", nil)
+	require.ErrorIs(t, err, ErrCodexClientRestricted)
+}
+
+func TestCodexClientAdmissionShadowParentResolutionFailsClosed(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parentID := int64(42)
+	shadow := codexAdmissionAccount(43, false)
+	shadow.ParentAccountID = &parentID
+
+	tests := []struct {
+		name   string
+		parent *Account
+	}{
+		{name: "missing parent"},
+		{
+			name: "nested shadow parent",
+			parent: func() *Account {
+				parent := codexAdmissionAccount(parentID, true)
+				grandparentID := int64(41)
+				parent.ParentAccountID = &grandparentID
+				return &parent
+			}(),
+		},
+		{
+			name: "non oauth parent",
+			parent: func() *Account {
+				parent := codexAdmissionAccount(parentID, true)
+				parent.Type = AccountTypeAPIKey
+				return &parent
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &OpenAIGatewayService{codexDetector: detector}
+			ctx := newCodexAdmissionContext(t, svc)
+			vetoed, reason := svc.codexClientAdmissionVetoReason(ctx, &shadow, func(int64) *Account {
+				return tc.parent
+			})
+			require.True(t, vetoed)
+			require.Equal(t, codexClientAdmissionFilterReason, reason)
+			err := codexClientAdmissionErrorFromContext(ctx)
+			require.ErrorIs(t, err, ErrCodexClientRestricted)
+			result, ok := CodexClientRestrictionResultFromError(err)
+			require.True(t, ok)
+			require.Equal(t, codexClientAdmissionShadowParentUnresolvedReason, result.Reason)
+		})
+	}
+}
+
+func TestCodexClientAdmissionShadowParentTransientRecoveryCannotBypass(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parent := codexAdmissionAccount(44, true)
+	parentID := parent.ID
+	shadow := codexAdmissionAccount(45, false)
+	shadow.ParentAccountID = &parentID
+	repo := &recoveringCodexAdmissionRepo{parent: &parent}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	vetoed, result := svc.codexClientAdmissionVeto(ctx, &shadow)
+	require.True(t, vetoed, "母账号首次读取失败时必须在终检 fail-closed")
+	require.Equal(t, codexClientAdmissionShadowParentUnresolvedReason, result.Reason)
+
+	resolved, err := resolveCredentialAccount(ctx, repo, &shadow)
+	require.NoError(t, err)
+	require.Equal(t, parent.ID, resolved.ID, "后续凭据解析恢复证明该窗口原本可把受限母账号发往上游")
+	require.Equal(t, int64(2), repo.totalCalls.Load())
+}
+
+func TestCodexClientAdmissionForwardGuardFailsClosedForUnresolvedShadow(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	parentID := int64(46)
+	shadow := codexAdmissionAccount(47, false)
+	shadow.ParentAccountID = &parentID
+	svc := &OpenAIGatewayService{
+		accountRepo:   &codexAdmissionAccountRepo{},
+		codexDetector: detector,
+	}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result := svc.detectCodexClientRestrictionForForward(ctx, nil, &shadow, nil)
+	require.True(t, result.Enabled)
+	require.False(t, result.Matched)
+	require.Equal(t, codexClientAdmissionShadowParentUnresolvedReason, result.Reason)
+}
+
+func TestLiveSidebandClientAdmissionRejectsRestrictedPinnedAccount(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	restricted := codexAdmissionAccount(48, true)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{restricted.ID: &restricted}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+	record := &LiveCallRecord{AccountID: restricted.ID}
+
+	err := svc.ValidateLiveSidebandClientAdmission(ctx, record)
+	require.ErrorIs(t, err, ErrCodexClientRestricted)
+	result, ok := CodexClientRestrictionResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.Reason)
+}
+
+func TestLiveSidebandLateGuardRejectsBeforeCredentialOrDial(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	restricted := codexAdmissionAccount(49, true)
+	repo := &codexAdmissionAccountRepo{byID: map[int64]*Account{restricted.ID: &restricted}}
+	svc := &OpenAIGatewayService{accountRepo: repo, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	conn, err := svc.dialLiveSideband(ctx, &LiveCallRecord{AccountID: restricted.ID, CallID: "call_restricted"})
+	require.Nil(t, conn)
+	require.ErrorIs(t, err, ErrCodexClientRestricted, "晚期保护必须在读取 OAuth 凭据或拨号前拒绝")
+}
+
+func TestCodexClientAdmissionPreviousResponseBindingIsPreserved(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	groupID := int64(78)
+	restricted := codexAdmissionAccount(45, true)
+	restricted.GroupIDs = []int64{groupID}
+	restricted.Extra["openai_oauth_responses_websockets_v2_enabled"] = true
+	cache := &countingCodexStickyCache{}
+	store := NewOpenAIWSStateStore(cache)
+	repo := &codexAdmissionAccountRepo{
+		accounts: []Account{restricted},
+		byID:     map[int64]*Account{restricted.ID: &restricted},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        repo,
+		cache:              cache,
+		cfg:                newOpenAIWSV2TestConfig(),
+		codexDetector:      detector,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+	ctx := newCodexAdmissionContext(t, svc)
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_codex_restricted", restricted.ID, time.Hour))
+
+	selection, _, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"resp_codex_restricted",
+		"",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		false,
+		true,
+		PlatformOpenAI,
+	)
+	require.Nil(t, selection)
+	require.ErrorIs(t, err, ErrCodexClientRestricted, "不可迁移的 previous_response_id 必须精确拒绝")
+	boundID, getErr := store.GetResponseAccount(ctx, groupID, "resp_codex_restricted")
+	require.NoError(t, getErr)
+	require.Equal(t, restricted.ID, boundID, "客户端不兼容是请求级状态，不得删除 response binding")
+
+	recovered := restricted
+	recovered.Extra = map[string]any{"openai_oauth_responses_websockets_v2_enabled": true}
+	repo.accounts = []Account{recovered}
+	repo.byID[recovered.ID] = &recovered
+	recoveredCtx := newCodexAdmissionContext(t, svc)
+	selection, _, err = svc.SelectAccountWithSchedulerForCapability(
+		recoveredCtx,
+		&groupID,
+		"resp_codex_restricted",
+		"",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		false,
+		true,
+		PlatformOpenAI,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, recovered.ID, selection.Account.ID, "限制解除后同一 binding 应自动恢复命中")
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestCodexClientAdmissionSessionStickySkipsWithoutOverwritingBinding(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	groupID := int64(79)
+	restricted := codexAdmissionAccount(46, true)
+	restricted.GroupIDs = []int64{groupID}
+	restricted.Priority = 0
+	regular := codexAdmissionAccount(47, false)
+	regular.GroupIDs = []int64{groupID}
+	regular.Priority = 1
+	cache := &countingCodexStickyCache{}
+	repo := &codexAdmissionAccountRepo{
+		accounts: []Account{restricted, regular},
+		byID: map[int64]*Account{
+			restricted.ID: &restricted,
+			regular.ID:    &regular,
+		},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        repo,
+		cache:              cache,
+		cfg:                &config.Config{},
+		codexDetector:      detector,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+	}
+	ctx := newCodexAdmissionContext(t, svc)
+	const sessionHash = "codex-restricted-sticky"
+	require.NoError(t, svc.setStickySessionAccountID(ctx, &groupID, sessionHash, restricted.ID, time.Hour))
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", sessionHash, "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, regular.ID, selection.Account.ID, "本请求应跳过不兼容的旧粘性账号")
+	cache.getCalls.Store(0)
+	cache.setCalls.Store(0)
+	require.NoError(t, svc.BindStickySessionAfterProfitAdmission(ctx, &groupID, sessionHash, regular.ID))
+	require.Equal(t, int64(1), cache.getCalls.Load(), "实际跳过旧 sticky 后才需要读取既有 binding")
+	require.Zero(t, cache.setCalls.Load(), "不兼容 fallback 不得覆盖旧 binding")
+	require.Equal(t, restricted.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "fallback 账号不得覆盖既有不兼容 binding")
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+
+	recovered := restricted
+	recovered.Extra = map[string]any{
+		"codex_cli_only":                  true,
+		"codex_cli_only_allow_app_server": true,
+	}
+	repo.accounts = []Account{recovered, regular}
+	repo.byID[recovered.ID] = &recovered
+	selection, _, err = svc.SelectAccountWithScheduler(ctx, &groupID, "", sessionHash, "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, recovered.ID, selection.Account.ID, "账号恢复为当前客户端兼容后应重新命中旧 binding")
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestCodexClientAdmissionOrdinaryFailoverStillReplacesStickyBinding(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	groupID := int64(80)
+	oldAccount := codexAdmissionAccount(480, false)
+	newAccount := codexAdmissionAccount(481, false)
+	cache := &countingCodexStickyCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:   &codexAdmissionAccountRepo{byID: map[int64]*Account{oldAccount.ID: &oldAccount, newAccount.ID: &newAccount}},
+		cache:         cache,
+		cfg:           &config.Config{},
+		codexDetector: detector,
+	}
+	ctx := newCodexAdmissionContext(t, svc)
+	const sessionHash = "ordinary-upstream-failover"
+	require.NoError(t, svc.setStickySessionAccountID(ctx, &groupID, sessionHash, oldAccount.ID, time.Hour))
+	cache.getCalls.Store(0)
+	cache.setCalls.Store(0)
+
+	require.NoError(t, svc.BindStickySessionAfterProfitAdmission(ctx, &groupID, sessionHash, newAccount.ID))
+	require.Zero(t, cache.getCalls.Load(), "未发生客户端否决的普通流量不得增加 Redis GET")
+	require.Equal(t, int64(1), cache.setCalls.Load(), "普通 failover 应保持单次 SET 热路径")
+	require.Equal(t, newAccount.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "未被客户端门否决的旧账号不得阻止普通 failover 更新粘性")
+}
+
+func TestCodexClientAdmissionLateVetoDoesNotPreserveNewlyWrittenStickyBinding(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	groupID := int64(81)
+	restricted := codexAdmissionAccount(482, true)
+	replacement := codexAdmissionAccount(483, false)
+	cache := &countingCodexStickyCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:   &codexAdmissionAccountRepo{byID: map[int64]*Account{restricted.ID: &restricted, replacement.ID: &replacement}},
+		cache:         cache,
+		cfg:           &config.Config{},
+		codexDetector: detector,
+	}
+	ctx := newCodexAdmissionContext(t, svc)
+	const sessionHash = "late-client-veto"
+	require.NoError(t, svc.setStickySessionAccountID(ctx, &groupID, sessionHash, restricted.ID, time.Hour))
+
+	vetoed, _ := svc.codexClientAdmissionVetoReason(ctx, &restricted, nil)
+	require.True(t, vetoed, "模拟准入后、发送前才发现限制变化")
+	require.NoError(t, svc.BindStickySessionAfterProfitAdmission(ctx, &groupID, sessionHash, replacement.ID))
+	require.Equal(t, replacement.ID, cache.sessionBindings[svc.openAISessionCacheKey(sessionHash)], "只有入口前实际跳过的旧 sticky 才能被保留")
+}
+
+func TestOpenAITerminalAdmissionRefreshesOnceAndNeverDowngradesFreshSelection(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	selected := codexAdmissionAccount(50, true)
+	selected.UpdatedAt = time.Now().UTC()
+	stale := codexAdmissionAccount(50, false)
+	stale.UpdatedAt = selected.UpdatedAt.Add(-time.Minute)
+	cache := &codexAdmissionSnapshotCache{account: &stale}
+	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
+	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.Equal(t, int64(1), cache.calls.Load(), "利润与客户端终检必须共享一次账号刷新")
+	require.Same(t, &selected, result.Account, "旧缓存不得覆盖刚做过 DB recheck 的新对象")
+	require.True(t, result.ClientVetoed)
+	require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.ClientRestriction.Reason)
+}
+
+func TestOpenAITerminalAdmissionUsesNewerReplacementObject(t *testing.T) {
+	detector := &accountAwareCodexAdmissionDetector{}
+	selected := codexAdmissionAccount(51, false)
+	selected.UpdatedAt = time.Now().UTC().Add(-time.Minute)
+	replacement := codexAdmissionAccount(51, true)
+	replacement.UpdatedAt = selected.UpdatedAt.Add(time.Minute)
+	cache := &codexAdmissionSnapshotCache{account: &replacement}
+	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
+	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: detector}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.Equal(t, int64(1), cache.calls.Load(), "利润与客户端终检必须共享一次账号刷新")
+	require.NotSame(t, &selected, result.Account, "终检必须采用缓存中替换后的新对象")
+	require.Equal(t, replacement.UpdatedAt, result.Account.UpdatedAt)
+	require.True(t, result.ClientVetoed)
+	require.False(t, selected.IsCodexCLIOnlyEnabled(), "终检不得通过原地修改旧指针伪造刷新")
+}
+
+func TestOpenAITerminalAdmissionSkipsRefreshForAPIKeyAccount(t *testing.T) {
+	selected := codexAdmissionAccount(52, false)
+	selected.Type = AccountTypeAPIKey
+	replacement := selected
+	cache := &codexAdmissionSnapshotCache{account: &replacement}
+	snapshot := NewSchedulerSnapshotService(cache, nil, &codexAdmissionAccountRepo{}, nil, nil)
+	svc := &OpenAIGatewayService{schedulerSnapshot: snapshot, codexDetector: &accountAwareCodexAdmissionDetector{}}
+	ctx := newCodexAdmissionContext(t, svc)
+
+	result := svc.OpenAITerminalAdmissionLatest(ctx, &selected)
+	require.Zero(t, cache.calls.Load(), "账号级 Codex 限制不适用于 API Key，普通请求不得增加快照读取")
+	require.Same(t, &selected, result.Account)
+	require.False(t, result.ClientVetoed)
+}

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -235,6 +235,11 @@ func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, acc
 	if account == nil {
 		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_ACCOUNT_REQUIRED", "account is required")
 	}
+	var err error
+	account, err = s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account)
+	if err != nil {
+		return nil, err
+	}
 	credAccount, err := resolveCredentialAccount(ctx, s.accountRepo, account)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_CREDENTIALS_FAILED", "resolve credential account: %v", err)

--- a/backend/internal/service/openai_embeddings.go
+++ b/backend/internal/service/openai_embeddings.go
@@ -25,6 +25,11 @@ func (s *OpenAIGatewayService) ForwardEmbeddings(
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
 	startTime := time.Now()
+	var err error
+	account, err = s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account)
+	if err != nil {
+		return nil, err
+	}
 
 	originalModel := strings.TrimSpace(gjson.GetBytes(body, "model").String())
 	if originalModel == "" {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -58,17 +58,8 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	promptCacheKey string,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
-	restrictionResult := s.detectCodexClientRestriction(c, account, body)
-	logCodexCLIOnlyDetection(ctx, c, account, getAPIKeyIDFromContext(c), restrictionResult, body)
-	if restrictionResult.Enabled && !restrictionResult.Matched {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "forbidden_error",
-				"message": "This account only allows Codex official clients",
-			},
-		})
-		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
+	if err := s.enforceOpenAICodexClientAdmissionForForward(ctx, c, account, body); err != nil {
+		return nil, err
 	}
 
 	if account.Platform == PlatformGrok {

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -85,6 +85,9 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 		writeAnthropicCountTokensError(c, http.StatusServiceUnavailable, "api_error", "No available OpenAI accounts")
 		return fmt.Errorf("count_tokens: missing account")
 	}
+	if err := s.enforceOpenAICodexClientAdmissionForForward(ctx, c, account, body); err != nil {
+		return err
+	}
 
 	prepared, err := prepareOpenAIInputTokensCountRequest(body, account, defaultMappedModel)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -37,7 +37,7 @@ func (r *countTokensRuntimeStateRepo) SetError(_ context.Context, _ int64, _ str
 	return nil
 }
 
-func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_EnforcesCodexClientRestriction(t *testing.T) {
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_RequiresTerminalAdmissionGrant(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"gpt-5.1","messages":[{"role":"user","content":"hello"}]}`)
 	rec := httptest.NewRecorder()
@@ -60,9 +60,9 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_EnforcesCodexClientR
 	c.Request = c.Request.WithContext(ctx)
 
 	err := svc.ForwardCountTokensAsAnthropic(ctx, c, account, body, "gpt-5.1")
-	require.ErrorIs(t, err, ErrCodexClientRestricted)
-	require.Zero(t, rec.Body.Len(), "service 不得提前写 403，handler 需要排除账号并重选")
-	require.Nil(t, upstream.lastReq, "客户端限制必须在任何上游请求之前生效")
+	require.ErrorIs(t, err, ErrCodexClientAdmissionUnavailable)
+	require.Zero(t, rec.Body.Len(), "service 不得提前写响应，handler 统一映射 503")
+	require.Nil(t, upstream.lastReq, "缺少本请求权威终检 grant 时不得触达上游")
 }
 
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesInputTokens(t *testing.T) {

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -37,6 +37,34 @@ func (r *countTokensRuntimeStateRepo) SetError(_ context.Context, _ int64, _ str
 	return nil
 }
 
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_EnforcesCodexClientRestriction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-5.1","messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "curl/8.0")
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          100,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra:       map[string]any{"codex_cli_only": true},
+	}
+	ctx := svc.WithOpenAICodexClientAdmission(c.Request.Context(), c, body)
+	c.Request = c.Request.WithContext(ctx)
+
+	err := svc.ForwardCountTokensAsAnthropic(ctx, c, account, body, "gpt-5.1")
+	require.ErrorIs(t, err, ErrCodexClientRestricted)
+	require.Zero(t, rec.Body.Len(), "service 不得提前写 403，handler 需要排除账号并重选")
+	require.Nil(t, upstream.lastReq, "客户端限制必须在任何上游请求之前生效")
+}
+
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesInputTokens(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -25,18 +25,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	// 固定渠道映射后的请求级 canonical body；账号 normalize/strip 不得改写跨 failover hint。
 	canonicalImageIntentBody := body
 
-	restrictionResult := s.detectCodexClientRestriction(c, account, body)
-	apiKeyID := getAPIKeyIDFromContext(c)
-	logCodexCLIOnlyDetection(ctx, c, account, apiKeyID, restrictionResult, body)
-	if restrictionResult.Enabled && !restrictionResult.Matched {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "forbidden_error",
-				"message": CodexClientRestrictionMessage(restrictionResult),
-			},
-		})
-		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
+	if err := s.enforceOpenAICodexClientAdmissionForForward(ctx, c, account, body); err != nil {
+		return nil, err
 	}
 
 	normalizedBody, normalized, err := normalizeOpenAICodexCompactReasoningEffortForAccount(c, account, body)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -34,6 +34,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	promptCacheKey string,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
+	if err := s.enforceOpenAICodexClientAdmissionForForward(ctx, c, account, body); err != nil {
+		return nil, err
+	}
+
 	// 入口分流：APIKey 账号 + 上游不支持 Responses API → 走 CC 直转（与
 	// ForwardAsChatCompletions 对称）。缺少此分流时，/v1/messages 入站请求
 	// 会被无条件转为 Responses 格式发往上游 /v1/responses，导致只支持

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -659,9 +659,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 
 	// 3. 按优先级 + LRU 选择最佳账号
 	// Select by priority + LRU
-	selected, compactBlocked := s.selectBestAccount(ctx, groupID, platform, accounts, requestedModel, excludedIDs, requireCompact, requiredCapability, preferLowUpstreamRate)
+	selected, compactBlocked, clientRestricted := s.selectBestAccount(ctx, groupID, platform, accounts, requestedModel, excludedIDs, requireCompact, requiredCapability, preferLowUpstreamRate)
 
 	if selected == nil {
+		if clientRestricted {
+			return nil, codexClientAdmissionErrorFromContext(ctx)
+		}
 		return nil, noAvailableOpenAISelectionError(requestedModel, compactBlocked, "")
 	}
 
@@ -673,7 +676,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 	// 4. 设置粘性会话绑定（利润门下推迟到 handler 终检通过后再绑定，
 	// 终检否决的账号不得成为新的粘性目标；无门保持既有 eager 绑定与 TTL）
 	// Set sticky session binding (deferred until terminal admission under a profit gate)
-	if sessionHash != "" && !gatewayProfitControlGateActive(ctx) {
+	if sessionHash != "" && !openAIStickyAdmissionDeferred(ctx) {
 		_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, selected.ID, openaiStickySessionTTL)
 	}
 
@@ -739,6 +742,12 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
+	if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, account, s.parentAccountLookup(ctx)); vetoed {
+		// A client-incompatible sticky binding is skipped, not deleted. The same
+		// session can reuse it automatically when a compatible client returns.
+		recordCodexClientAdmissionStickySkip(ctx, accountID)
+		return nil
+	}
 
 	// 刷新会话 TTL 并返回账号
 	// Refresh session TTL and return account
@@ -753,12 +762,14 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 // Returns nil if no available account. The second return reports whether at
 // least one candidate was filtered out solely because it lacks compact support
 // (only meaningful when requireCompact=true).
-func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *int64, platform string, accounts []Account, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, requiredCapability OpenAIEndpointCapability, preferLowUpstreamRate bool) (*Account, bool) {
+func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *int64, platform string, accounts []Account, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, requiredCapability OpenAIEndpointCapability, preferLowUpstreamRate bool) (*Account, bool, bool) {
 	platform = normalizeOpenAICompatiblePlatform(platform)
 	compactBlocked := false
+	clientRestricted := false
 	needsUpstreamCheck := s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
 	eligible := make([]*Account, 0, len(accounts))
 	compactTiers := make(map[int64]int, len(accounts))
+	parentLookup := s.parentAccountLookup(ctx)
 
 	for i := range accounts {
 		acc := &accounts[i]
@@ -788,13 +799,17 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 				continue
 			}
 		}
+		if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, fresh, parentLookup); vetoed {
+			clientRestricted = true
+			continue
+		}
 
 		eligible = append(eligible, fresh)
 		compactTiers[fresh.ID] = compactTier
 	}
 
 	if len(eligible) == 0 {
-		return nil, compactBlocked
+		return nil, compactBlocked, clientRestricted
 	}
 	rateOrder := openAILegacyUpstreamRateOrder{}
 	if preferLowUpstreamRate {
@@ -810,7 +825,7 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 		}
 		return s.isBetterAccount(a, b)
 	})
-	return eligible[0], compactBlocked
+	return eligible[0], compactBlocked, clientRestricted
 }
 
 // isBetterAccount 判断 candidate 是否比 current 更优。
@@ -939,6 +954,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
+					} else if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, account, s.parentAccountLookup(ctx)); vetoed {
+						// Keep the binding intact; only this request is incompatible.
+						recordCodexClientAdmissionStickySkip(ctx, accountID)
 					} else {
 						result, err := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 						if err == nil && result != nil && result.Acquired {
@@ -981,6 +999,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		return a
 	}
 	baseCandidateCount := 0
+	clientRestricted := false
 	candidates := make([]*Account, 0, len(accounts))
 	for i := range accounts {
 		acc := &accounts[i]
@@ -1002,11 +1021,18 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
 			continue
 		}
+		if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, acc, parentLookupL2); vetoed {
+			clientRestricted = true
+			continue
+		}
 		baseCandidateCount++
 		candidates = append(candidates, acc)
 	}
 
 	if len(candidates) == 0 {
+		if clientRestricted {
+			return nil, codexClientAdmissionErrorFromContext(ctx)
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 	rateOrder := openAILegacyUpstreamRateOrder{}
@@ -1098,13 +1124,16 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
 				continue
 			}
+			if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, fresh, s.parentAccountLookup(ctx)); vetoed {
+				continue
+			}
 			result, err := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
 			if err == nil && result != nil && result.Acquired {
 				selection, selectErr := s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
 				if selectErr != nil {
 					return nil, true, selectErr
 				}
-				if sessionHash != "" && !gatewayProfitControlGateActive(ctx) {
+				if sessionHash != "" && !openAIStickyAdmissionDeferred(ctx) {
 					_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
 				}
 				return selection, true, nil
@@ -1137,13 +1166,16 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
 				continue
 			}
+			if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, fresh, s.parentAccountLookup(ctx)); vetoed {
+				continue
+			}
 			result, err := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
 			if err == nil && result != nil && result.Acquired {
 				selection, selectErr := s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
 				if selectErr != nil {
 					return nil, selectErr
 				}
-				if sessionHash != "" && !gatewayProfitControlGateActive(ctx) {
+				if sessionHash != "" && !openAIStickyAdmissionDeferred(ctx) {
 					_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
 				}
 				return selection, nil
@@ -1175,6 +1207,8 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if requireCompact {
 		candidates = prioritizeOpenAICompactAccounts(candidates)
 	}
+	clientEligible := 0
+	clientVetoed := 0
 	for _, acc := range candidates {
 		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
 		if fresh == nil {
@@ -1187,6 +1221,11 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
 			continue
 		}
+		clientEligible++
+		if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, fresh, s.parentAccountLookup(ctx)); vetoed {
+			clientVetoed++
+			continue
+		}
 		return s.newSelectionResult(ctx, fresh, false, nil, &AccountWaitPlan{
 			AccountID:      fresh.ID,
 			MaxConcurrency: fresh.Concurrency,
@@ -1197,6 +1236,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 
 	if requireCompact && baseCandidateCount > 0 {
 		return nil, ErrNoAvailableCompactAccounts
+	}
+	if clientEligible > 0 && clientVetoed == clientEligible {
+		return nil, codexClientAdmissionErrorFromContext(ctx)
 	}
 	return nil, ErrNoAvailableAccounts
 }

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -59,7 +59,7 @@ func TestOpenAIGatewayService_GetCodexClientRestrictionDetector(t *testing.T) {
 	})
 }
 
-func TestOpenAIGatewayService_Forward_VersionGateMessage(t *testing.T) {
+func TestOpenAIGatewayService_Forward_ReturnsTypedClientAdmissionErrorWithoutWriting(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	newCtx := func() (*httptest.ResponseRecorder, *gin.Context) {
@@ -73,7 +73,7 @@ func TestOpenAIGatewayService_Forward_VersionGateMessage(t *testing.T) {
 	}
 	body := []byte(`{"model":"gpt-5.1-codex"}`)
 
-	t.Run("版本太低：返回带版本号的差异化文案", func(t *testing.T) {
+	t.Run("版本太低：保留差异化结果供 handler 输出", func(t *testing.T) {
 		rec, c := newCtx()
 		svc := &OpenAIGatewayService{codexDetector: &stubCodexRestrictionDetector{result: CodexClientRestrictionDetectionResult{
 			Enabled:         true,
@@ -84,10 +84,12 @@ func TestOpenAIGatewayService_Forward_VersionGateMessage(t *testing.T) {
 		}}}
 
 		_, err := svc.Forward(context.Background(), c, account(), body)
-		require.Error(t, err)
-		require.Equal(t, http.StatusForbidden, rec.Code)
-		require.Contains(t, rec.Body.String(), "Your Codex version (0.39.0) is below the minimum required version (0.42.0)")
-		require.NotContains(t, rec.Body.String(), "This account only allows Codex official clients")
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		result, ok := CodexClientRestrictionResultFromError(err)
+		require.True(t, ok)
+		require.Equal(t, CodexClientRestrictionReasonVersionTooLow, result.Reason)
+		require.Equal(t, "0.39.0", result.DetectedVersion)
+		require.Zero(t, rec.Body.Len(), "service 不得提前写响应，handler 需要排除账号并重选")
 	})
 
 	t.Run("未命中官方：仍返回通用兜底文案", func(t *testing.T) {
@@ -99,9 +101,11 @@ func TestOpenAIGatewayService_Forward_VersionGateMessage(t *testing.T) {
 		}}}
 
 		_, err := svc.Forward(context.Background(), c, account(), body)
-		require.Error(t, err)
-		require.Equal(t, http.StatusForbidden, rec.Code)
-		require.Contains(t, rec.Body.String(), "This account only allows Codex official clients")
+		require.ErrorIs(t, err, ErrCodexClientRestricted)
+		result, ok := CodexClientRestrictionResultFromError(err)
+		require.True(t, ok)
+		require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.Reason)
+		require.Zero(t, rec.Body.Len())
 	})
 }
 

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -559,6 +559,11 @@ func (s *OpenAIGatewayService) ForwardImages(
 	if parsed == nil {
 		return nil, fmt.Errorf("parsed images request is required")
 	}
+	var err error
+	account, err = s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account)
+	if err != nil {
+		return nil, err
+	}
 	switch account.Type {
 	case AccountTypeAPIKey:
 		return s.forwardOpenAIImagesAPIKey(ctx, c, account, body, parsed, channelMappedModel)

--- a/backend/internal/service/openai_live.go
+++ b/backend/internal/service/openai_live.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	defaultLiveMaxSessionDuration = time.Hour
+	maxLiveCreateUpstreamAttempts = 4
 	liveLeaseRefreshInterval      = 20 * time.Second
 	liveRedisOperationTimeout     = 3 * time.Second
 	liveClosedRecordTTL           = 24 * time.Hour
@@ -31,6 +32,16 @@ const (
 	liveObserverStoreRetryLimit   = 5
 	liveUpstreamBodyLimit         = 2 << 20
 )
+
+type liveCreateAttemptBudget struct {
+	upstreamAttempts int
+	clientVetoes     int
+}
+
+func (b liveCreateAttemptBudget) canContinue() bool {
+	return b.upstreamAttempts < maxLiveCreateUpstreamAttempts &&
+		b.clientVetoes < MaxCodexClientAdmissionVetoAttempts
+}
 
 // liveObserverStoreRetryInterval 是 var 以便测试缩短 store 报错的重试等待。
 var liveObserverStoreRetryInterval = time.Second
@@ -148,7 +159,8 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 	// 防御性装门按文本 D 过滤 Live 账号池且门与计费时刻不同源。
 	ctx = WithOpenAIProfitControlSuppressed(ctx)
 	var lastErr error
-	for attempt := 0; attempt <= 3; attempt++ {
+	budget := liveCreateAttemptBudget{}
+	for budget.canContinue() {
 		selection, _, selectErr := s.SelectAccountWithSchedulerForCapability(
 			ctx,
 			identity.GroupID,
@@ -175,7 +187,16 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 			return nil, ErrLiveConcurrencyFull
 		}
 
-		account := selection.Account
+		admission := s.OpenAITerminalAdmissionLatest(ctx, selection.Account)
+		if admission.ClientVetoed {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			excluded[selection.Account.ID] = struct{}{}
+			budget.clientVetoes++
+			continue
+		}
+		account := admission.Account
 		leaseID := generateRequestID()
 		acquired, acquireErr := liveCache.AcquireLiveLease(
 			ctx,
@@ -199,6 +220,12 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 		selection.ReleaseFunc()
 		if createErr != nil {
 			s.releaseLiveLease(account.ID, identity.UserID, identity.APIKeyID, leaseID)
+			if errors.Is(createErr, ErrCodexClientRestricted) {
+				excluded[account.ID] = struct{}{}
+				budget.clientVetoes++
+				continue
+			}
+			budget.upstreamAttempts++
 			if !s.shouldFailoverLiveCreateError(createErr) {
 				return nil, createErr
 			}
@@ -206,6 +233,7 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 			lastErr = createErr
 			continue
 		}
+		budget.upstreamAttempts++
 
 		now := time.Now()
 		model := strings.TrimSpace(gjson.GetBytes(request.Session, "model").String())
@@ -242,6 +270,9 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 	if lastErr != nil {
 		return nil, lastErr
 	}
+	if codexClientAdmissionDenied(ctx) {
+		return nil, codexClientAdmissionErrorFromContext(ctx)
+	}
 	return nil, ErrLiveUnavailable
 }
 
@@ -264,6 +295,11 @@ func (s *OpenAIGatewayService) createUpstreamLiveCall(
 	request *LiveCallRequest,
 	attestation string,
 ) (*LiveCallCreated, error) {
+	var err error
+	account, err = s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account)
+	if err != nil {
+		return nil, err
+	}
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {
 		logLiveCreateStageFailure(ctx, account.ID, "access_token", err)
@@ -446,6 +482,9 @@ func (s *OpenAIGatewayService) dialLiveSideband(ctx context.Context, record *Liv
 	if account == nil || !account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityLive) {
 		return nil, ErrLiveUnavailable
 	}
+	if vetoed, result := s.codexClientAdmissionVeto(ctx, account); vetoed {
+		return nil, &CodexClientAdmissionError{Result: result}
+	}
 	headers, err := s.liveSidebandHeaders(ctx, account, record)
 	if err != nil {
 		return nil, err
@@ -461,6 +500,33 @@ func (s *OpenAIGatewayService) dialLiveSideband(ctx context.Context, record *Liv
 		return nil, errors.New("live sideband transport does not support raw frames")
 	}
 	return raw, nil
+}
+
+// ValidateLiveSidebandClientAdmission checks the current client identity
+// against the account pinned to an existing Live call before the HTTP upgrade.
+// The same check runs again in dialLiveSideband so a policy update in the small
+// pre-upgrade window still cannot reach the OAuth upstream.
+func (s *OpenAIGatewayService) ValidateLiveSidebandClientAdmission(ctx context.Context, record *LiveCallRecord) error {
+	if record == nil {
+		return ErrLiveCallNotFound
+	}
+	if !codexClientAdmissionActive(ctx) {
+		return nil
+	}
+	if s == nil || s.accountRepo == nil {
+		return ErrLiveUnavailable
+	}
+	account, err := s.accountRepo.GetByID(ctx, record.AccountID)
+	if err != nil {
+		return fmt.Errorf("load live sideband account %d: %w", record.AccountID, err)
+	}
+	if account == nil {
+		return ErrLiveUnavailable
+	}
+	if vetoed, result := s.codexClientAdmissionVeto(ctx, account); vetoed {
+		return &CodexClientAdmissionError{Result: result}
+	}
+	return nil
 }
 
 func (s *OpenAIGatewayService) GetLiveCallForIdentity(

--- a/backend/internal/service/openai_live.go
+++ b/backend/internal/service/openai_live.go
@@ -178,6 +178,9 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 			if lastErr != nil {
 				return nil, lastErr
 			}
+			if codexClientAdmissionDenied(ctx) {
+				return nil, codexClientAdmissionErrorFromContext(ctx)
+			}
 			return nil, selectErr
 		}
 		if selection == nil || selection.Account == nil || !selection.Acquired {
@@ -187,7 +190,13 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 			return nil, ErrLiveConcurrencyFull
 		}
 
-		admission := s.OpenAITerminalAdmissionLatest(ctx, selection.Account)
+		admission, admissionErr := s.OpenAITerminalAdmissionLatest(ctx, selection.Account)
+		if admissionErr != nil {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			return nil, admissionErr
+		}
 		if admission.ClientVetoed {
 			if selection.ReleaseFunc != nil {
 				selection.ReleaseFunc()
@@ -220,6 +229,9 @@ func (s *OpenAIGatewayService) CreateLiveCall(
 		selection.ReleaseFunc()
 		if createErr != nil {
 			s.releaseLiveLease(account.ID, identity.UserID, identity.APIKeyID, leaseID)
+			if errors.Is(createErr, ErrCodexClientAdmissionUnavailable) {
+				return nil, createErr
+			}
 			if errors.Is(createErr, ErrCodexClientRestricted) {
 				excluded[account.ID] = struct{}{}
 				budget.clientVetoes++
@@ -477,12 +489,25 @@ func (s *OpenAIGatewayService) liveSidebandHeaders(
 func (s *OpenAIGatewayService) dialLiveSideband(ctx context.Context, record *LiveCallRecord) (liveFrameConn, error) {
 	account, err := s.accountRepo.GetByID(ctx, record.AccountID)
 	if err != nil {
+		if codexClientAdmissionActive(ctx) {
+			if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+				snapshot.recordUnavailable()
+			}
+			return nil, fmt.Errorf("%w: load live sideband account %d: %v", ErrCodexClientAdmissionUnavailable, record.AccountID, err)
+		}
 		return nil, err
 	}
 	if account == nil || !account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityLive) {
 		return nil, ErrLiveUnavailable
 	}
-	if vetoed, result := s.codexClientAdmissionVeto(ctx, account); vetoed {
+	vetoed, result, admissionErr := s.codexClientAdmissionVeto(ctx, account)
+	if admissionErr != nil {
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordUnavailable()
+		}
+		return nil, fmt.Errorf("%w: resolve live sideband account %d policy: %v", ErrCodexClientAdmissionUnavailable, account.ID, admissionErr)
+	}
+	if vetoed {
 		return nil, &CodexClientAdmissionError{Result: result}
 	}
 	headers, err := s.liveSidebandHeaders(ctx, account, record)
@@ -514,16 +539,29 @@ func (s *OpenAIGatewayService) ValidateLiveSidebandClientAdmission(ctx context.C
 		return nil
 	}
 	if s == nil || s.accountRepo == nil {
-		return ErrLiveUnavailable
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordUnavailable()
+		}
+		return fmt.Errorf("%w: live sideband account repository is unavailable", ErrCodexClientAdmissionUnavailable)
 	}
 	account, err := s.accountRepo.GetByID(ctx, record.AccountID)
 	if err != nil {
-		return fmt.Errorf("load live sideband account %d: %w", record.AccountID, err)
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordUnavailable()
+		}
+		return fmt.Errorf("%w: load live sideband account %d: %v", ErrCodexClientAdmissionUnavailable, record.AccountID, err)
 	}
 	if account == nil {
 		return ErrLiveUnavailable
 	}
-	if vetoed, result := s.codexClientAdmissionVeto(ctx, account); vetoed {
+	vetoed, result, admissionErr := s.codexClientAdmissionVeto(ctx, account)
+	if admissionErr != nil {
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordUnavailable()
+		}
+		return fmt.Errorf("%w: resolve live sideband account %d policy: %v", ErrCodexClientAdmissionUnavailable, account.ID, admissionErr)
+	}
+	if vetoed {
 		return &CodexClientAdmissionError{Result: result}
 	}
 	return nil

--- a/backend/internal/service/openai_live_client_admission_budget_test.go
+++ b/backend/internal/service/openai_live_client_admission_budget_test.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiveCreateAttemptBudgetSeparatesClientVetoesFromUpstreamFailures(t *testing.T) {
+	budget := liveCreateAttemptBudget{}
+	for i := 0; i < MaxCodexClientAdmissionVetoAttempts-1; i++ {
+		budget.clientVetoes++
+		require.True(t, budget.canContinue(), "客户端准入否决不得消耗普通上游重试预算")
+	}
+	require.Zero(t, budget.upstreamAttempts)
+	budget.clientVetoes++
+	require.False(t, budget.canContinue(), "客户端否决必须受独立的 10 次上限约束")
+
+	budget = liveCreateAttemptBudget{clientVetoes: MaxCodexClientAdmissionVetoAttempts - 1}
+	for i := 0; i < maxLiveCreateUpstreamAttempts-1; i++ {
+		budget.upstreamAttempts++
+		require.True(t, budget.canContinue(), "原有上游创建重试应继续允许最多四次尝试")
+	}
+	budget.upstreamAttempts++
+	require.False(t, budget.canContinue(), "客户端否决预算不得把普通上游失败扩大到十次")
+}

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -1909,9 +1909,11 @@ func TestOpenAIGatewayService_CodexCLIOnly_RejectsNonCodexClient(t *testing.T) {
 	}
 
 	_, err := svc.Forward(context.Background(), c, account, inputBody)
-	require.Error(t, err)
-	require.Equal(t, http.StatusForbidden, rec.Code)
-	require.Contains(t, rec.Body.String(), "Codex official clients")
+	require.ErrorIs(t, err, ErrCodexClientRestricted)
+	result, ok := CodexClientRestrictionResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, CodexClientRestrictionReasonNotMatchedUA, result.Reason)
+	require.Zero(t, rec.Body.Len(), "service 只返回 typed error，handler 才能排除账号后重选")
 }
 
 func TestOpenAIGatewayService_CodexCLIOnly_AllowOfficialClientFamilies(t *testing.T) {

--- a/backend/internal/service/openai_profit_control.go
+++ b/backend/internal/service/openai_profit_control.go
@@ -337,28 +337,93 @@ func (s *OpenAIGatewayService) ProfitControlVetoLatest(ctx context.Context, sele
 	return profitControlVetoLatest(ctx, selected, s.schedulerSnapshot)
 }
 
+// OpenAITerminalAdmissionResult is the single post-slot admission decision for
+// an OpenAI-compatible request. The selected account is refreshed at most once
+// and the same object is then used by both profit and client-policy checks.
+type OpenAITerminalAdmissionResult struct {
+	Account           *Account
+	ProfitVetoed      bool
+	ProfitReason      string
+	ClientVetoed      bool
+	ClientRestriction CodexClientRestrictionDetectionResult
+}
+
+// OpenAITerminalAdmissionLatest performs one cache-first post-slot refresh and
+// evaluates both admission policies against the same object. The scheduler
+// snapshot falls back to the repository on cache misses; refresh failures keep
+// the existing fail-open behavior and are observable.
+func (s *OpenAIGatewayService) OpenAITerminalAdmissionLatest(ctx context.Context, selected *Account) OpenAITerminalAdmissionResult {
+	result := OpenAITerminalAdmissionResult{Account: selected}
+	if s == nil || selected == nil {
+		return result
+	}
+
+	latest, err := s.refreshOpenAITerminalAdmissionAccount(ctx, selected)
+	result.Account = latest
+	if err != nil {
+		if gate, _ := ctx.Value(openAIProfitControlGateCtxKey{}).(*openAIProfitControlGate); gate != nil {
+			slog.Warn("profit_control_account_refresh_failed", "group_id", gate.groupID, "platform", gate.platform, "account_id", selected.ID, "error", err)
+			openAIProfitControlObserverInstance.recordRefreshFailure(gate.groupID, gate.platform, gate.threshold)
+		}
+		if codexClientAdmissionActive(ctx) {
+			slog.Warn("codex_client_admission_account_refresh_failed", "account_id", selected.ID, "error", err)
+		}
+	}
+
+	result.ProfitVetoed, result.ProfitReason = openAIProfitControlVetoReason(ctx, latest)
+	result.ClientVetoed, result.ClientRestriction = s.codexClientAdmissionVeto(ctx, latest)
+	return result
+}
+
+func (s *OpenAIGatewayService) refreshOpenAITerminalAdmissionAccount(ctx context.Context, selected *Account) (*Account, error) {
+	if selected == nil || s == nil || s.schedulerSnapshot == nil ||
+		(!gatewayProfitControlGateActive(ctx) && !codexClientAdmissionAppliesToAccount(ctx, selected)) {
+		return selected, nil
+	}
+	refreshed, err := s.schedulerSnapshot.GetAccount(ctx, selected.ID)
+	if err != nil {
+		return selected, err
+	}
+	if refreshed == nil {
+		return selected, fmt.Errorf("selected account %d not found during terminal admission refresh", selected.ID)
+	}
+	// A DB-rechecked selection is authoritative when timestamps tie. Some
+	// update paths can preserve second-level timestamps, so replacing it on
+	// equality could reintroduce an older cache object with different policy.
+	if !refreshed.UpdatedAt.After(selected.UpdatedAt) {
+		return selected, nil
+	}
+	return refreshed, nil
+}
+
 // bindOpenAIStickySessionDuringSelection preserves the official eager binding
-// behavior for requests without a profit gate. Profit-controlled requests bind
-// only after the terminal post-slot check, so an account rejected after a rate
-// refresh cannot become the new sticky target.
+// behavior for requests without a terminal admission check. Profit-controlled
+// and client-restricted requests bind only after the post-slot refresh.
 func (s *OpenAIGatewayService) bindOpenAIStickySessionDuringSelection(ctx context.Context, groupID *int64, sessionHash string, accountID int64) error {
-	if gatewayProfitControlGateActive(ctx) {
+	if openAIStickyAdmissionDeferred(ctx) {
 		return nil
 	}
 	return s.BindStickySession(ctx, groupID, sessionHash, accountID)
 }
 
 // BindStickySessionAfterProfitAdmission records the terminally admitted
-// account. Without a profit gate it preserves the pre-existing eager binding
-// behavior at the handler bind points. With a gate it never overwrites a
-// different binding that already exists, so a temporarily ineligible account
-// remains sticky and becomes eligible again automatically after its rate
-// recovers.
+// account. Profit control preserves its existing non-overwrite behavior. A
+// client-admission-only request preserves a different binding only when that
+// exact account was skipped by the request's client policy; ordinary upstream
+// failover still replaces stale sticky bindings as it did before this feature.
 func (s *OpenAIGatewayService) BindStickySessionAfterProfitAdmission(ctx context.Context, groupID *int64, sessionHash string, accountID int64) error {
 	if sessionHash == "" || accountID <= 0 {
 		return nil
 	}
-	if !gatewayProfitControlGateActive(ctx) {
+	if !openAIStickyAdmissionDeferred(ctx) {
+		return s.BindStickySession(ctx, groupID, sessionHash, accountID)
+	}
+	// A client-admission context is installed for non-Codex callers, but most
+	// requests never encounter a restricted account. Preserve the original
+	// single-SET hot path in that common case; the extra read is only needed
+	// after an actual client-policy veto (or under profit control, whose sticky
+	// semantics always preserve an existing different binding).
+	if !gatewayProfitControlGateActive(ctx) && !codexClientAdmissionDenied(ctx) {
 		return s.BindStickySession(ctx, groupID, sessionHash, accountID)
 	}
 	existingAccountID, err := s.getStickySessionAccountID(ctx, groupID, sessionHash)
@@ -367,7 +432,12 @@ func (s *OpenAIGatewayService) BindStickySessionAfterProfitAdmission(ctx context
 		return nil
 	}
 	if existingAccountID > 0 && existingAccountID != accountID {
-		return nil
+		if gatewayProfitControlGateActive(ctx) {
+			return nil
+		}
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok && snapshot.stickyWasSkipped(existingAccountID) {
+			return nil
+		}
 	}
 	return s.BindStickySession(ctx, groupID, sessionHash, accountID)
 }

--- a/backend/internal/service/openai_profit_control.go
+++ b/backend/internal/service/openai_profit_control.go
@@ -348,15 +348,20 @@ type OpenAITerminalAdmissionResult struct {
 	ClientRestriction CodexClientRestrictionDetectionResult
 }
 
-// OpenAITerminalAdmissionLatest performs one cache-first post-slot refresh and
-// evaluates both admission policies against the same object. The scheduler
-// snapshot falls back to the repository on cache misses; refresh failures keep
-// the existing fail-open behavior and are observable.
-func (s *OpenAIGatewayService) OpenAITerminalAdmissionLatest(ctx context.Context, selected *Account) OpenAITerminalAdmissionResult {
+// OpenAITerminalAdmissionLatest performs one post-slot refresh and evaluates
+// both admission policies against the same object. Client-restricted OAuth
+// traffic reads the repository authoritatively; profit-only traffic preserves
+// the scheduler cache-first behavior. Profit refresh failures remain fail-open,
+// while client-policy refresh failures fail closed.
+func (s *OpenAIGatewayService) OpenAITerminalAdmissionLatest(ctx context.Context, selected *Account) (OpenAITerminalAdmissionResult, error) {
 	result := OpenAITerminalAdmissionResult{Account: selected}
-	if s == nil || selected == nil {
-		return result
+	if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok && snapshot.enforcementActive {
+		snapshot.clearTerminalAdmission()
 	}
+	if s == nil || selected == nil {
+		return result, nil
+	}
+	clientAdmissionApplies := codexClientAdmissionAppliesToAccount(ctx, selected)
 
 	latest, err := s.refreshOpenAITerminalAdmissionAccount(ctx, selected)
 	result.Account = latest
@@ -365,19 +370,52 @@ func (s *OpenAIGatewayService) OpenAITerminalAdmissionLatest(ctx context.Context
 			slog.Warn("profit_control_account_refresh_failed", "group_id", gate.groupID, "platform", gate.platform, "account_id", selected.ID, "error", err)
 			openAIProfitControlObserverInstance.recordRefreshFailure(gate.groupID, gate.platform, gate.threshold)
 		}
-		if codexClientAdmissionActive(ctx) {
+		if clientAdmissionApplies {
 			slog.Warn("codex_client_admission_account_refresh_failed", "account_id", selected.ID, "error", err)
+			if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+				snapshot.recordUnavailable()
+			}
+			return result, fmt.Errorf("%w: refresh account %d: %v", ErrCodexClientAdmissionUnavailable, selected.ID, err)
 		}
 	}
 
 	result.ProfitVetoed, result.ProfitReason = openAIProfitControlVetoReason(ctx, latest)
-	result.ClientVetoed, result.ClientRestriction = s.codexClientAdmissionVeto(ctx, latest)
-	return result
+	var clientErr error
+	result.ClientVetoed, result.ClientRestriction, clientErr = s.codexClientAdmissionVeto(ctx, latest)
+	if clientErr != nil {
+		slog.Warn("codex_client_admission_policy_resolution_failed", "account_id", selected.ID, "error", clientErr)
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordUnavailable()
+		}
+		return result, fmt.Errorf("%w: resolve account %d policy: %v", ErrCodexClientAdmissionUnavailable, selected.ID, clientErr)
+	}
+	if !result.ClientVetoed && codexClientAdmissionAppliesToAccount(ctx, latest) {
+		if snapshot, ok := codexClientAdmissionSnapshotFromContext(ctx); ok {
+			snapshot.recordTerminalAdmission(latest)
+		}
+	}
+	return result, nil
 }
 
 func (s *OpenAIGatewayService) refreshOpenAITerminalAdmissionAccount(ctx context.Context, selected *Account) (*Account, error) {
-	if selected == nil || s == nil || s.schedulerSnapshot == nil ||
+	if selected == nil || s == nil ||
 		(!gatewayProfitControlGateActive(ctx) && !codexClientAdmissionAppliesToAccount(ctx, selected)) {
+		return selected, nil
+	}
+	if codexClientAdmissionAppliesToAccount(ctx, selected) {
+		if s.accountRepo == nil {
+			return selected, errors.New("account repository is unavailable for client admission refresh")
+		}
+		refreshed, err := s.accountRepo.GetByID(ctx, selected.ID)
+		if err != nil {
+			return selected, err
+		}
+		if refreshed == nil {
+			return selected, fmt.Errorf("selected account %d not found during client admission refresh", selected.ID)
+		}
+		return refreshed, nil
+	}
+	if s.schedulerSnapshot == nil {
 		return selected, nil
 	}
 	refreshed, err := s.schedulerSnapshot.GetAccount(ctx, selected.ID)

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -46,6 +46,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	if account == nil {
 		return errors.New("account is nil")
 	}
+	if _, err := s.enforceOpenAICodexClientAdmissionBeforeUpstream(ctx, account); err != nil {
+		return err
+	}
 	if err := validateOpenAIWSBearerToken(account, token); err != nil {
 		return err
 	}
@@ -77,11 +80,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
 				return fmt.Errorf("websocket ingress requires ws_v2 transport, got=%s", wsDecision.Transport)
 			}
-			// 注意：透传 relay 只回调 hooks.AfterTurn，没有 turn 起始回调，
-			// 因此下面这条路径永远不会触发 hooks.BeforeTurn——分组利润控制的
-			// turn 级复核与 turn 级 pricingAt 冻结都不覆盖透传 ingress，
-			// 只有建连时的准入门生效。handler 侧据此把 turn 定价留作零值，
-			// 由 RecordUsage 回退到记录时刻（见 openAIWSTurnPricing 注释）。
+			// Passthrough invokes the same BeforeTurn hook as the pooled ingress
+			// before every response.create frame. This keeps turn pricing, profit
+			// admission, and client restrictions aligned across ingress modes.
 			return s.proxyResponsesWebSocketV2Passthrough(
 				ctx,
 				c,

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -518,6 +518,11 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	if vetoed, _ := openAIProfitControlVetoReason(ctx, account); vetoed {
 		return 0, nil, "", nil
 	}
+	if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, account, s.parentAccountLookup(ctx)); vetoed {
+		// Client identity is request-specific. Preserve the response binding so a
+		// compatible client can continue the chain later.
+		return 0, nil, "", nil
+	}
 	if s.schedulerSnapshot != nil && s.accountRepo != nil {
 		latest, latestErr := s.accountRepo.GetByID(ctx, account.ID)
 		if latestErr != nil || latest == nil {
@@ -543,6 +548,9 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		}
 		// 利润门对最新账号状态复检一次，语义同上：跳过复用、不删绑定。
 		if vetoed, _ := openAIProfitControlVetoReason(ctx, latest); vetoed {
+			return 0, nil, "", nil
+		}
+		if vetoed, _ := s.codexClientAdmissionVetoReason(ctx, latest, s.parentAccountLookup(ctx)); vetoed {
 			return 0, nil, "", nil
 		}
 		if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {

--- a/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
+++ b/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
@@ -118,3 +118,75 @@ func TestPassthroughIngressCallsBeforeTurn(t *testing.T) {
 	require.Equal(t, 1, gotBefore, "首个 response.create 必须触发 BeforeTurn")
 	require.Positive(t, gotAfter, "透传 ingress 仍应回调 AfterTurn 提交用量")
 }
+
+func TestPassthroughIngressBinaryFollowupUsesTurnLifecycle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_binary_turn_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+
+	var hooksMu sync.Mutex
+	beforeTurns := make([]int, 0, 2)
+	afterTurns := make([]int, 0, 2)
+	afterModels := make([]string, 0, 2)
+	hooks := &OpenAIWSIngressHooks{
+		BeforeTurn: func(turn int) error {
+			hooksMu.Lock()
+			beforeTurns = append(beforeTurns, turn)
+			hooksMu.Unlock()
+			return nil
+		},
+		AfterTurn: func(turn int, result *OpenAIForwardResult, _ error) {
+			hooksMu.Lock()
+			defer hooksMu.Unlock()
+			afterTurns = append(afterTurns, turn)
+			if result != nil {
+				afterModels = append(afterModels, result.Model)
+			}
+		},
+	}
+
+	server, serverErr := startPassthroughHookRecordingServer(
+		t,
+		controlCtx,
+		newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
+		passthroughLifecycleAccount(),
+		hooks,
+	)
+	defer server.Close()
+	client := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = client.CloseNow() }()
+
+	firstUpstream := requirePassthroughUpstreamWrite(t, upstream, time.Second)
+	require.Equal(t, "gpt-5.1", gjson.GetBytes(firstUpstream, "model").String())
+	first, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "resp_binary_turn_1", gjson.GetBytes(first, "response.id").String())
+
+	writeWSFrameType(t, client, coderws.MessageBinary, `{"type":"response.create","model":"gpt-5.2","stream":false,"previous_response_id":"resp_binary_turn_1"}`)
+	secondUpstream := requirePassthroughUpstreamWrite(t, upstream, time.Second)
+	require.Equal(t, "response.create", gjson.GetBytes(secondUpstream, "type").String())
+	require.Equal(t, "gpt-5.2", gjson.GetBytes(secondUpstream, "model").String())
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_binary_turn_2","model":"gpt-5.2","usage":{"input_tokens":2,"output_tokens":2}}}`)
+	second, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "resp_binary_turn_2", gjson.GetBytes(second, "response.id").String())
+
+	require.NoError(t, client.Close(coderws.StatusNormalClosure, "done"))
+	select {
+	case <-serverErr:
+	case <-time.After(3 * time.Second):
+		t.Fatal("binary follow-up passthrough did not exit")
+	}
+
+	hooksMu.Lock()
+	gotBefore := append([]int(nil), beforeTurns...)
+	gotAfter := append([]int(nil), afterTurns...)
+	gotModels := append([]string(nil), afterModels...)
+	hooksMu.Unlock()
+	require.Equal(t, []int{1, 2}, gotBefore)
+	require.Equal(t, []int{1, 2}, gotAfter)
+	require.Equal(t, []string{"gpt-5.1", "gpt-5.2"}, gotModels)
+}

--- a/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
+++ b/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
@@ -60,18 +60,10 @@ func startPassthroughHookRecordingServer(
 	return server, serverErr
 }
 
-// TestPassthroughIngressNeverCallsBeforeTurn 钉死 ws_v2 透传 ingress 与 handler
-// 侧 turn 定价的耦合：透传 relay 只回调 AfterTurn，没有任何 turn 起始回调，
-// 因此 hooks.BeforeTurn 永远不会触发。
-//
-// handler 依赖这一点：openAIWSTurnPricing 零值起步，透传连接的每个 turn 都拿
-// 不到冻结的 pricingAt，RecordUsage 回退到记录时刻——与引入分组利润控制前的
-// 基线一致。若把 turn 定价初始化成建连时刻，透传连接的所有 turn 就会被钉死在
-// 建连时的高峰因子，客户端峰前建连保活即可全程按谷价结算。
-//
-// 若本断言因为透传补齐了 turn 起始回调而失败：这是好事，请同步复核
-// openAIWSTurnPricing 的零值语义与透传路径的 turn 级利润复核。
-func TestPassthroughIngressNeverCallsBeforeTurn(t *testing.T) {
+// TestPassthroughIngressCallsBeforeTurn verifies that passthrough uses the
+// same turn-start lifecycle as pooled ingress. The handler freezes pricing and
+// rechecks terminal admission from this callback.
+func TestPassthroughIngressCallsBeforeTurn(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	controlCtx, cancelControl := context.WithCancelCause(context.Background())
 	defer cancelControl(context.Canceled)
@@ -123,6 +115,6 @@ func TestPassthroughIngressNeverCallsBeforeTurn(t *testing.T) {
 	gotBefore, gotAfter := beforeTurnCalls, afterTurnCalls
 	hooksMu.Unlock()
 
-	require.Zero(t, gotBefore, "透传 ingress 没有 turn 起始回调，BeforeTurn 不应被调用")
+	require.Equal(t, 1, gotBefore, "首个 response.create 必须触发 BeforeTurn")
 	require.Positive(t, gotAfter, "透传 ingress 仍应回调 AfterTurn 提交用量")
 }

--- a/backend/internal/service/openai_ws_turn_policy_rejection_test.go
+++ b/backend/internal/service/openai_ws_turn_policy_rejection_test.go
@@ -146,65 +146,79 @@ func TestOpenAIWSIngressRejectsSubsequentTurnBeforeUpstreamWrite(t *testing.T) {
 }
 
 func TestOpenAIWSPassthroughRejectsSubsequentTurnBeforeUpstreamWrite(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	controlCtx, cancelControl := context.WithCancelCause(context.Background())
-	defer cancelControl(context.Canceled)
+	for _, tc := range []struct {
+		name    string
+		msgType coderws.MessageType
+	}{
+		{name: "text", msgType: coderws.MessageText},
+		{name: "binary", msgType: coderws.MessageBinary},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			controlCtx, cancelControl := context.WithCancelCause(context.Background())
+			defer cancelControl(context.Canceled)
 
-	upstream := newStagedPassthroughConn()
-	upstream.Send(`{"type":"response.completed","response":{"id":"resp_passthrough_policy_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
-	var hooksMu sync.Mutex
-	var hookCalls []int
-	hooks := wsTurnPolicyRejectOnSecond(&hookCalls, &hooksMu)
-	server, serverErr := startPassthroughHookRecordingServer(
-		t,
-		controlCtx,
-		newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
-		passthroughLifecycleAccount(),
-		hooks,
-	)
-	defer server.Close()
-	client := dialPassthroughLifecycleClient(t, server)
-	defer func() { _ = client.CloseNow() }()
+			upstream := newStagedPassthroughConn()
+			upstream.Send(`{"type":"response.completed","response":{"id":"resp_passthrough_policy_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+			var hooksMu sync.Mutex
+			var hookCalls []int
+			hooks := wsTurnPolicyRejectOnSecond(&hookCalls, &hooksMu)
+			server, serverErr := startPassthroughHookRecordingServer(
+				t,
+				controlCtx,
+				newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
+				passthroughLifecycleAccount(),
+				hooks,
+			)
+			defer server.Close()
+			client := dialPassthroughLifecycleClient(t, server)
+			defer func() { _ = client.CloseNow() }()
 
-	firstUpstream := requirePassthroughUpstreamWrite(t, upstream, time.Second)
-	require.Equal(t, "response.create", gjson.GetBytes(firstUpstream, "type").String())
-	first, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
-	require.NoError(t, err)
-	require.Equal(t, "resp_passthrough_policy_1", gjson.GetBytes(first, "response.id").String())
+			firstUpstream := requirePassthroughUpstreamWrite(t, upstream, time.Second)
+			require.Equal(t, "response.create", gjson.GetBytes(firstUpstream, "type").String())
+			first, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
+			require.NoError(t, err)
+			require.Equal(t, "resp_passthrough_policy_1", gjson.GetBytes(first, "response.id").String())
 
-	writeWSFrame(t, client, `{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_passthrough_policy_1"}`)
-	_, err = readPassthroughLifecycleFrame(t, client, 3*time.Second)
-	var websocketCloseErr coderws.CloseError
-	require.ErrorAs(t, err, &websocketCloseErr)
-	require.Equal(t, coderws.StatusPolicyViolation, websocketCloseErr.Code)
-	require.Equal(t, testWSTurnPolicyRejectionReason, websocketCloseErr.Reason)
+			writeWSFrameType(t, client, tc.msgType, `{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_passthrough_policy_1"}`)
+			_, err = readPassthroughLifecycleFrame(t, client, 3*time.Second)
+			var websocketCloseErr coderws.CloseError
+			require.ErrorAs(t, err, &websocketCloseErr)
+			require.Equal(t, coderws.StatusPolicyViolation, websocketCloseErr.Code)
+			require.Equal(t, testWSTurnPolicyRejectionReason, websocketCloseErr.Reason)
 
-	select {
-	case err := <-serverErr:
-		var closeErr *OpenAIWSClientCloseError
-		require.ErrorAs(t, err, &closeErr)
-		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
-		require.Equal(t, testWSTurnPolicyRejectionReason, closeErr.Reason())
-	case <-time.After(3 * time.Second):
-		t.Fatal("passthrough policy rejection did not terminate")
+			select {
+			case err := <-serverErr:
+				var closeErr *OpenAIWSClientCloseError
+				require.ErrorAs(t, err, &closeErr)
+				require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
+				require.Equal(t, testWSTurnPolicyRejectionReason, closeErr.Reason())
+			case <-time.After(3 * time.Second):
+				t.Fatal("passthrough policy rejection did not terminate")
+			}
+
+			select {
+			case unexpected := <-upstream.writes:
+				t.Fatalf("第二轮策略拒绝后不应再写上游，got %s", unexpected)
+			case <-time.After(150 * time.Millisecond):
+			}
+			hooksMu.Lock()
+			gotCalls := append([]int(nil), hookCalls...)
+			hooksMu.Unlock()
+			require.Equal(t, []int{1, 2}, gotCalls)
+		})
 	}
-
-	select {
-	case unexpected := <-upstream.writes:
-		t.Fatalf("第二轮策略拒绝后不应再写上游，got %s", unexpected)
-	case <-time.After(150 * time.Millisecond):
-	}
-	hooksMu.Lock()
-	gotCalls := append([]int(nil), hookCalls...)
-	hooksMu.Unlock()
-	require.Equal(t, []int{1, 2}, gotCalls)
 }
 
 func writeWSFrame(t *testing.T, conn *coderws.Conn, payload string) {
+	writeWSFrameType(t, conn, coderws.MessageText, payload)
+}
+
+func writeWSFrameType(t *testing.T, conn *coderws.Conn, msgType coderws.MessageType, payload string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	require.NoError(t, conn.Write(ctx, coderws.MessageText, []byte(payload)))
+	require.NoError(t, conn.Write(ctx, msgType, []byte(payload)))
 }
 
 func readWSFrame(t *testing.T, conn *coderws.Conn) []byte {

--- a/backend/internal/service/openai_ws_turn_policy_rejection_test.go
+++ b/backend/internal/service/openai_ws_turn_policy_rejection_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	coderws "github.com/coder/websocket"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const testWSTurnPolicyRejectionReason = "client policy no longer allows this websocket turn"
+
+func wsTurnPolicyRejectOnSecond(hookCalls *[]int, mu *sync.Mutex) *OpenAIWSIngressHooks {
+	return &OpenAIWSIngressHooks{
+		BeforeTurn: func(turn int) error {
+			mu.Lock()
+			*hookCalls = append(*hookCalls, turn)
+			mu.Unlock()
+			if turn > 1 {
+				return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, testWSTurnPolicyRejectionReason, nil)
+			}
+			return nil
+		},
+	}
+}
+
+func TestOpenAIWSIngressRejectsSubsequentTurnBeforeUpstreamWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.IngressInterTurnIdleTimeoutSeconds = 2
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	upstream := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_policy_turn_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	dialer := &openAIWSCaptureDialer{conn: upstream}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	defer pool.Close()
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          951,
+		Name:        "pooled-turn-policy",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+		Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+	}
+	var hooksMu sync.Mutex
+	var hookCalls []int
+	hooks := wsTurnPolicyRejectOnSecond(&hookCalls, &hooksMu)
+
+	serverErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		readCtx, cancelRead := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancelRead()
+		if readErr != nil {
+			serverErr <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErr <- errors.New("unsupported websocket client message type")
+			return
+		}
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		ginCtx.Request = r.Clone(r.Context())
+		serverErr <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, hooks)
+	}))
+	defer server.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	client, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = client.CloseNow() }()
+
+	writeWSFrame(t, client, `{"type":"response.create","model":"gpt-5.1","stream":false}`)
+	first := readWSFrame(t, client)
+	require.Equal(t, "resp_policy_turn_1", gjson.GetBytes(first, "response.id").String())
+
+	writeWSFrame(t, client, `{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_policy_turn_1"}`)
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, err = client.Read(readCtx)
+	cancelRead()
+	require.Error(t, err, "服务端拒绝第二轮后客户端连接必须结束")
+	// ProxyResponsesWebSocketFromClient 把精确的 policy close 作为 typed error
+	// 交给外层 handler 写帧；本测试 server 直接调用 service 并 CloseNow，因此
+	// 客户端可能只看到 EOF。精确状态码/文案在下方 serverErr 上断言。
+
+	select {
+	case err := <-serverErr:
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, err, &closeErr)
+		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
+		require.Equal(t, testWSTurnPolicyRejectionReason, closeErr.Reason())
+	case <-time.After(3 * time.Second):
+		t.Fatal("pooled ingress policy rejection did not terminate")
+	}
+
+	upstream.mu.Lock()
+	writes := len(upstream.writes)
+	upstream.mu.Unlock()
+	require.Equal(t, 1, writes, "第二轮策略拒绝必须发生在任何上游写入之前")
+	hooksMu.Lock()
+	gotCalls := append([]int(nil), hookCalls...)
+	hooksMu.Unlock()
+	require.Equal(t, []int{1, 2}, gotCalls)
+}
+
+func TestOpenAIWSPassthroughRejectsSubsequentTurnBeforeUpstreamWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_passthrough_policy_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+	var hooksMu sync.Mutex
+	var hookCalls []int
+	hooks := wsTurnPolicyRejectOnSecond(&hookCalls, &hooksMu)
+	server, serverErr := startPassthroughHookRecordingServer(
+		t,
+		controlCtx,
+		newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
+		passthroughLifecycleAccount(),
+		hooks,
+	)
+	defer server.Close()
+	client := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = client.CloseNow() }()
+
+	firstUpstream := requirePassthroughUpstreamWrite(t, upstream, time.Second)
+	require.Equal(t, "response.create", gjson.GetBytes(firstUpstream, "type").String())
+	first, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "resp_passthrough_policy_1", gjson.GetBytes(first, "response.id").String())
+
+	writeWSFrame(t, client, `{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_passthrough_policy_1"}`)
+	_, err = readPassthroughLifecycleFrame(t, client, 3*time.Second)
+	var websocketCloseErr coderws.CloseError
+	require.ErrorAs(t, err, &websocketCloseErr)
+	require.Equal(t, coderws.StatusPolicyViolation, websocketCloseErr.Code)
+	require.Equal(t, testWSTurnPolicyRejectionReason, websocketCloseErr.Reason)
+
+	select {
+	case err := <-serverErr:
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, err, &closeErr)
+		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
+		require.Equal(t, testWSTurnPolicyRejectionReason, closeErr.Reason())
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough policy rejection did not terminate")
+	}
+
+	select {
+	case unexpected := <-upstream.writes:
+		t.Fatalf("第二轮策略拒绝后不应再写上游，got %s", unexpected)
+	case <-time.After(150 * time.Millisecond):
+	}
+	hooksMu.Lock()
+	gotCalls := append([]int(nil), hookCalls...)
+	hooksMu.Unlock()
+	require.Equal(t, []int{1, 2}, gotCalls)
+}
+
+func writeWSFrame(t *testing.T, conn *coderws.Conn, payload string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, conn.Write(ctx, coderws.MessageText, []byte(payload)))
+}
+
+func readWSFrame(t *testing.T, conn *coderws.Conn) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	msgType, payload, err := conn.Read(ctx)
+	require.NoError(t, err)
+	require.Equal(t, coderws.MessageText, msgType)
+	return payload
+}

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -752,6 +752,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, blocked.Message, blocked)
 	}
 	firstClientMessage = updatedFirst
+	if hooks != nil && hooks.BeforeTurn != nil {
+		if err := hooks.BeforeTurn(1); err != nil {
+			return err
+		}
+	}
 
 	// 在 policy filter 之后再提取 service_tier / reasoning_effort 用于
 	// usage 上报：filter
@@ -967,6 +972,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				}
 				if hooks != nil && hooks.BeforeRequest != nil {
 					if err := hooks.BeforeRequest(turnNo, payload, requestModelForThisFrame); err != nil {
+						return payload, nil, err
+					}
+				}
+				if hooks != nil && hooks.BeforeTurn != nil {
+					if err := hooks.BeforeTurn(turnNo); err != nil {
 						return payload, nil, err
 					}
 				}

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -241,6 +241,13 @@ func openAIWSPassthroughRequestModelForFrame(payload []byte) string {
 	return strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 }
 
+func openAIWSPassthroughIsResponseCreateFrame(msgType coderws.MessageType, payload []byte) bool {
+	if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+		return false
+	}
+	return strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create"
+}
+
 func openAIWSPassthroughRequestModelFromSessionFrame(payload []byte) string {
 	if len(payload) == 0 || strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "session.update" {
 		return ""
@@ -453,7 +460,7 @@ func (c *openAIWSPassthroughFirstOutputFrameConn) WriteFrame(ctx context.Context
 		return errOpenAIWSConnClosed
 	}
 	generation := uint64(0)
-	if msgType == coderws.MessageText && strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create" {
+	if openAIWSPassthroughIsResponseCreateFrame(msgType, payload) {
 		generation = c.armDeadline(payload)
 	}
 	if err := c.inner.WriteFrame(ctx, msgType, payload); err != nil {
@@ -929,7 +936,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		// capturedSessionModel 的读写都发生在该 goroutine 内，因此无需
 		// 加锁/原子化。
 		filter: func(msgType coderws.MessageType, payload []byte) (out []byte, blocked *OpenAIFastBlockedError, filterErr error) {
-			if msgType != coderws.MessageText {
+			if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
 				return payload, nil, nil
 			}
 			eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
@@ -1070,8 +1077,12 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			if readErr != nil {
 				return msgType, payload, readErr
 			}
-			if msgType == coderws.MessageText && strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create" {
-				return msgType, payload, nil
+			if openAIWSPassthroughIsResponseCreateFrame(msgType, payload) {
+				// 首包在 handler 读取后已统一按 Text 写入上游；follow-up Binary
+				// JSON response.create 也规范化为 Text，使 relay 的 turn 计时、
+				// request model、usage 和生命周期状态机与 Text 请求完全一致。
+				// 其他 Binary 事件仍保留原 message type 走下方直接透传。
+				return coderws.MessageText, payload, nil
 			}
 			if writeErr := upstreamFrameConn.WriteFrame(readCtx, msgType, payload); writeErr != nil {
 				return msgType, payload, writeErr


### PR DESCRIPTION
## Summary

- freeze the Codex client-policy snapshot once at request ingress and evaluate account compatibility during scheduling
- skip incompatible OpenAI OAuth accounts before slot acquisition, then perform an authoritative repository re-check after slot acquisition and retain a proof-based forwarding guard
- retry another compatible account without consuming an upstream failover attempt or reporting a local policy denial as an account health failure
- preserve sticky and previous-response bindings when they are only incompatible with the current client, while allowing ordinary upstream failover to update sticky state
- make shadow accounts inherit the parent OAuth account restriction and fail closed when the parent cannot be resolved
- version OpenAI scheduler metadata so old Redis payloads missing the Codex restriction fields are treated as cache misses and rebuilt safely
- cover Responses, Chat Completions, Messages, Responses WebSocket, Alpha Search, Embeddings, Images, Count Tokens, Codex Models, Live, and Live Sideband
- keep the existing Anthropic group-level Claude Code restriction model unchanged, while preserving its typed 403 response in Messages and Count Tokens

## Problem

`codex_cli_only` was enforced only after an OpenAI account had already been selected. In a mixed pool, a non-Codex client could therefore land on a restricted account and receive a terminal 403 even when another compatible account was available. Some OpenAI-compatible entrypoints also did not share the same admission lifecycle.

This supersedes #4309 with scheduler-level filtering, authoritative post-slot revalidation, shadow-parent handling, old metadata compatibility, and endpoint-complete coverage.

Closes #3014.

## Behavior

The request identity and global restriction policy are evaluated once at ingress. Because account-specific behavior only differs by the normal restriction and the app-server escape hatch, the request stores two precomputed results and reuses them through candidate filtering, post-slot admission, and the final local guard.

OpenAI API-key accounts are unaffected. Universally compatible official clients keep the existing eager sticky path and do not add a repository read. Non-compatible clients skip restricted OAuth accounts, release any acquired slot, and retry up to a bounded 10 local admission vetoes.

For client-restricted OAuth traffic, the terminal check reads the selected account and any shadow parent from the repository. A repository failure is not misreported as a policy 403 and does not trigger account failover: HTTP returns 503, WebSocket closes with 1013, acquired slots are released, and no upstream request is sent. The forwarding layer accepts only the exact account object granted by that terminal check.

Responses WebSocket follow-up `response.create` frames use the same policy and turn lifecycle for Text and Binary JSON. Binary `response.create` is normalized to Text before entering relay accounting; unrelated Binary frames preserve their original message type.

Old `sched:meta:*` OpenAI payloads do not silently default the new fields to false: a metadata version marker turns old, missing, malformed, or future versions into a cache miss, after which the existing scheduler fallback rebuilds the current payload. Non-OpenAI metadata is unchanged.

No schema migration or frontend change is required.

## Validation

- `go vet ./...`
- `go test ./... -count=1`
- `go test -tags=unit ./... -count=1`
- `go test -tags=integration ./... -run '^$' -count=1`
- `go test -race ./internal/service ./internal/handler -run 'CodexClient|OpenAIClientAdmission|TerminalAdmission|LiveSideband|CreateLiveCall|CountTokens' -count=1`
- targeted passthrough Text/Binary rejection and two-turn lifecycle tests
- GitHub CI, security scan, lint, backend, and frontend checks
