### PR TITLE
feat(openai): record compact capability after successful relay

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -681,6 +681,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
 			}
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
+			if result.CompactRequest && openAIForwardSucceededForScheduling(result) {
+				h.gatewayService.RecordOpenAICompactSuccess(account)
+			}
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), nil)
 		}
@@ -2167,6 +2170,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					scheduleModel = turnRequestedModel
 				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, scheduleModel, openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
+				if result.CompactRequest && openAIForwardSucceededForScheduling(result) {
+					h.gatewayService.RecordOpenAICompactSuccess(account)
+				}
 				inboundEndpoint := GetInboundEndpoint(c)
 				upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account, result)
 				quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)

--- a/backend/internal/service/openai_compact_probe.go
+++ b/backend/internal/service/openai_compact_probe.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -96,6 +97,23 @@ func buildOpenAICompactProbeExtraUpdates(resp *http.Response, body []byte, probe
 	}
 
 	return updates
+}
+
+// RecordOpenAICompactSuccess persists capability learned from a real compact request.
+func (s *OpenAIGatewayService) RecordOpenAICompactSuccess(account *Account) {
+	if s == nil || s.accountRepo == nil || account == nil || !account.IsOpenAI() {
+		return
+	}
+	if supported, ok := account.Extra["openai_compact_supported"].(bool); ok && supported {
+		return
+	}
+
+	updates := buildOpenAICompactProbeExtraUpdates(&http.Response{StatusCode: http.StatusOK}, nil, nil, time.Now())
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.accountRepo.UpdateExtra(ctx, account.ID, updates)
+	}()
 }
 
 func mergeExtraUpdates(base map[string]any, more map[string]any) map[string]any {

--- a/backend/internal/service/openai_compact_probe_test.go
+++ b/backend/internal/service/openai_compact_probe_test.go
@@ -1,11 +1,22 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
 	"time"
 )
+
+type openAICompactSuccessRepo struct {
+	AccountRepository
+	updates chan map[string]any
+}
+
+func (r *openAICompactSuccessRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
+	r.updates <- updates
+	return nil
+}
 
 func TestNormalizeAccountTestMode(t *testing.T) {
 	tests := []struct {
@@ -118,5 +129,43 @@ func TestBuildOpenAICompactProbeExtraUpdates_EmptyFailureBodyFallsBackToHTTPStat
 	}
 	if got := updates["openai_compact_last_error"]; got != "HTTP 503" {
 		t.Fatalf("openai_compact_last_error = %v, want HTTP 503", got)
+	}
+}
+
+func TestRecordOpenAICompactSuccess(t *testing.T) {
+	repo := &openAICompactSuccessRepo{updates: make(chan map[string]any, 1)}
+	account := &Account{ID: 42, Platform: PlatformOpenAI}
+	(&OpenAIGatewayService{accountRepo: repo}).RecordOpenAICompactSuccess(account)
+
+	select {
+	case updates := <-repo.updates:
+		if updates["openai_compact_supported"] != true {
+			t.Fatalf("openai_compact_supported = %v, want true", updates["openai_compact_supported"])
+		}
+		if updates["openai_compact_last_status"] != http.StatusOK {
+			t.Fatalf("openai_compact_last_status = %v, want %d", updates["openai_compact_last_status"], http.StatusOK)
+		}
+		if updates["openai_compact_checked_at"] == "" {
+			t.Fatal("openai_compact_checked_at is empty")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for compact capability update")
+	}
+}
+
+func TestRecordOpenAICompactSuccessSkipsIneligibleAccounts(t *testing.T) {
+	repo := &openAICompactSuccessRepo{updates: make(chan map[string]any, 1)}
+	accounts := []*Account{
+		{ID: 42, Platform: PlatformOpenAI, Extra: map[string]any{"openai_compact_supported": true}},
+		{ID: 43, Platform: PlatformGrok},
+	}
+	for _, account := range accounts {
+		(&OpenAIGatewayService{accountRepo: repo}).RecordOpenAICompactSuccess(account)
+	}
+
+	select {
+	case updates := <-repo.updates:
+		t.Fatalf("unexpected compact capability update: %v", updates)
+	case <-time.After(20 * time.Millisecond):
 	}
 }

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -22,6 +22,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	clearGrokResponsesClientToolMapping(c)
 	clearOpenAIResponsesNamespaceNames(c)
 	startTime := time.Now()
+	compactRequest := isOpenAIResponsesCompactPath(c) ||
+		(openAIResponsesRequestPathSuffix(c) == "" && HasCompactionTriggerInInput(body))
 	// 固定渠道映射后的请求级 canonical body；账号 normalize/strip 不得改写跨 failover hint。
 	canonicalImageIntentBody := body
 
@@ -169,7 +171,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		reasoningEffort := extractOpenAIReasoningEffortFromBody(body, mappedModel)
 		// 国产模型默认 effort 补充：也要用 mappedModel 判定是否是 passback-required 上游。
 		reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, body, mappedModel)
-		return s.forwardOpenAIPassthrough(
+		result, err := s.forwardOpenAIPassthrough(
 			ctx,
 			c,
 			account,
@@ -181,6 +183,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			reqStream,
 			startTime,
 		)
+		if result != nil {
+			result.CompactRequest = compactRequest
+		}
+		return result, err
 	}
 
 	bodyModified := false
@@ -974,6 +980,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			ReasoningEffort: reasoningEffort,
 			Stream:          reqStream,
 			OpenAIWSMode:    false,
+			CompactRequest:  compactRequest,
 			Duration:        time.Since(startTime),
 			FirstTokenMs:    firstTokenMs,
 		}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -247,19 +247,21 @@ type OpenAIForwardResult struct {
 	// UpstreamTerminalEvent is the normalized terminal event observed on an
 	// upstream Responses WebSocket turn. Empty preserves legacy/non-WS success.
 	UpstreamTerminalEvent string
-	ResponseHeaders       http.Header
-	Duration              time.Duration
-	FirstTokenMs          *int
-	ClientDisconnect      bool
-	ImageCount            int
-	ImageSize             string
-	ImageInputSize        string
-	ImageOutputSize       string
-	ImageOutputSizes      []string
-	ImageSizeSource       string
-	ImageSizeBreakdown    map[string]int
-	VideoCount            int
-	VideoResolution       string
+	// CompactRequest reports whether this attempt carried legacy or v2 compact semantics.
+	CompactRequest     bool
+	ResponseHeaders    http.Header
+	Duration           time.Duration
+	FirstTokenMs       *int
+	ClientDisconnect   bool
+	ImageCount         int
+	ImageSize          string
+	ImageInputSize     string
+	ImageOutputSize    string
+	ImageOutputSizes   []string
+	ImageSizeSource    string
+	ImageSizeBreakdown map[string]int
+	VideoCount         int
+	VideoResolution    string
 	// VideoDurationSeconds 是提交时请求的生成时长（xAI 按输出秒数计费），已归一化到 1-15 秒。
 	VideoDurationSeconds int
 	// WebSearchCalls 是 Codex alpha/search 网页搜索调用次数（每次成功请求为 1）。

--- a/backend/internal/service/openai_gpt56_max_test.go
+++ b/backend/internal/service/openai_gpt56_max_test.go
@@ -136,6 +136,7 @@ func TestOpenAIGatewayServiceForwardPreservesGPT56MaxEffort(t *testing.T) {
 	require.Equal(t, "max", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "max", *result.ReasoningEffort)
+	require.False(t, result.CompactRequest)
 }
 
 func TestOpenAIGatewayServiceForwardPreservesMappedGPT56MaxEffort(t *testing.T) {
@@ -179,6 +180,7 @@ func TestOpenAIGatewayServiceForwardPreservesMappedGPT56MaxEffort(t *testing.T) 
 	require.Equal(t, "max", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "max", *result.ReasoningEffort)
+	require.False(t, result.CompactRequest)
 }
 
 func TestOpenAIGatewayServiceForwardOAuthCompactDowngradesMaxEffort(t *testing.T) {
@@ -278,6 +280,7 @@ func TestOpenAIGatewayServiceForwardOAuthRemoteCompactV2PreservesResponsesWire(t
 	require.Contains(t, rec.Body.String(), `"encrypted_content":"summary"`)
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "max", *result.ReasoningEffort)
+	require.True(t, result.CompactRequest)
 }
 
 func TestOpenAIGatewayServiceForwardAPIKeyRemoteCompactV2PreservesResponsesWire(t *testing.T) {
@@ -336,4 +339,5 @@ func TestOpenAIGatewayServiceForwardAPIKeyRemoteCompactV2PreservesResponsesWire(
 	require.Contains(t, rec.Body.String(), `"encrypted_content":"summary"`)
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "max", *result.ReasoningEffort)
+	require.True(t, result.CompactRequest)
 }

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -1020,6 +1020,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					Stream:                reqStream,
 					OpenAIWSMode:          true,
 					UpstreamTerminalEvent: terminalEvent,
+					CompactRequest:        HasCompactionTriggerInInput(payload),
 					ResponseHeaders:       lease.HandshakeHeaders(),
 					Duration:              time.Since(turnStart),
 					FirstTokenMs:          firstTokenMs,

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -759,6 +759,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		Stream:                reqStream,
 		OpenAIWSMode:          true,
 		UpstreamTerminalEvent: upstreamTerminalEvent,
+		CompactRequest:        HasCompactionTriggerInInput(payloadAsJSONBytes(payload)),
 		ResponseHeaders:       lease.HandshakeHeaders(),
 		Duration:              time.Since(startTime),
 		FirstTokenMs:          firstTokenMs,


### PR DESCRIPTION
## Summary

- Record OpenAI Compact capability after a real Compact relay succeeds.
- Cover legacy `/responses/compact` and native remote compaction v2 requests over HTTP and WebSocket turns.
- Update only the account that ultimately succeeds after failover; ordinary Responses requests and failed attempts are not marked as Compact-supported.
- Reuse the existing Compact probe snapshot fields and skip accounts already known to support Compact.

## Verification

- `/usr/local/go/bin/go test ./internal/service ./internal/handler -run "TestRecordOpenAICompactSuccess|TestOpenAIGatewayServiceForward.*Compact|TestOpenAIForwardSucceededForScheduling|TestNormalizeOpenAIResponsesCompactRequest" -count=1`
- `/usr/local/go/bin/go test ./internal/service ./internal/handler -count=1`
- `git diff --check`
