### PR TITLE
fix(prompt-audit): deduplicate latest-turn reviews

### DIFF
--- a/backend/internal/securityaudit/prompt_latest_turn_cache.go
+++ b/backend/internal/securityaudit/prompt_latest_turn_cache.go
@@ -1,0 +1,78 @@
+package securityaudit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	LatestTurnDecisionCacheTTL  = 5 * time.Minute
+	latestTurnDecisionKeyPrefix = "sub2api:prompt_guard:latest_turn:"
+)
+
+type LatestTurnDecisionCache interface {
+	GetLatestTurnDecision(ctx context.Context, key string) (*PromptDecision, error)
+	SetLatestTurnDecision(ctx context.Context, key string, decision *PromptDecision, ttl time.Duration) error
+}
+
+func cacheableLatestTurnDecision(decision *PromptDecision) bool {
+	return decision != nil && decision.AllowNextStage && (decision.Kind == DecisionAllow || decision.Kind == DecisionFlag)
+}
+
+func latestTurnDecisionCacheKey(configVersion int64, promptHash string) string {
+	promptHash = strings.TrimSpace(promptHash)
+	if promptHash == "" {
+		return ""
+	}
+	return latestTurnDecisionKeyPrefix + strconv.FormatInt(configVersion, 10) + ":" + promptHash
+}
+
+func (s *RedisPayloadStore) GetLatestTurnDecision(ctx context.Context, key string) (*PromptDecision, error) {
+	if s == nil || s.client == nil {
+		return nil, fmt.Errorf("latest turn decision cache unavailable")
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, nil
+	}
+	raw, err := s.client.Get(ctx, key).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var decision PromptDecision
+	if err := json.Unmarshal([]byte(raw), &decision); err != nil || !cacheableLatestTurnDecision(&decision) {
+		_ = s.client.Del(ctx, key).Err()
+		if err == nil {
+			err = fmt.Errorf("cached decision does not allow next stage")
+		}
+		return nil, err
+	}
+	return &decision, nil
+}
+
+func (s *RedisPayloadStore) SetLatestTurnDecision(ctx context.Context, key string, decision *PromptDecision, ttl time.Duration) error {
+	if s == nil || s.client == nil {
+		return fmt.Errorf("latest turn decision cache unavailable")
+	}
+	key = strings.TrimSpace(key)
+	if key == "" || !cacheableLatestTurnDecision(decision) {
+		return nil
+	}
+	if ttl <= 0 || ttl > LatestTurnDecisionCacheTTL {
+		ttl = LatestTurnDecisionCacheTTL
+	}
+	payload, err := json.Marshal(decision)
+	if err != nil {
+		return err
+	}
+	return s.client.Set(ctx, key, payload, ttl).Err()
+}

--- a/backend/internal/securityaudit/prompt_latest_turn_cache_test.go
+++ b/backend/internal/securityaudit/prompt_latest_turn_cache_test.go
@@ -1,0 +1,47 @@
+package securityaudit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisPayloadStoreLatestTurnDecisionRoundTripAndTTL(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	store := NewRedisPayloadStore(client)
+	key := latestTurnDecisionCacheKey(7, "prompt-hash")
+	want := &PromptDecision{Kind: DecisionFlag, AllowNextStage: true, Result: &NormalizedResult{Action: ActionWarn, RiskLevel: RiskMedium}}
+
+	require.NoError(t, store.SetLatestTurnDecision(context.Background(), key, want, 2*LatestTurnDecisionCacheTTL))
+	got, err := store.GetLatestTurnDecision(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	ttl, err := client.TTL(context.Background(), key).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, LatestTurnDecisionCacheTTL)
+
+	server.FastForward(LatestTurnDecisionCacheTTL)
+	got, err = store.GetLatestTurnDecision(context.Background(), key)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestRedisPayloadStoreLatestTurnDecisionSkipsNonContinuableResults(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	store := NewRedisPayloadStore(client)
+	key := latestTurnDecisionCacheKey(7, "blocked-turn")
+
+	require.NoError(t, store.SetLatestTurnDecision(context.Background(), key, &PromptDecision{Kind: DecisionBlock}, LatestTurnDecisionCacheTTL))
+	require.Zero(t, client.Exists(context.Background(), key).Val())
+	require.NoError(t, store.SetLatestTurnDecision(context.Background(), key, &PromptDecision{Kind: DecisionBlock, AllowNextStage: true}, LatestTurnDecisionCacheTTL))
+	require.Zero(t, client.Exists(context.Background(), key).Val())
+}

--- a/backend/internal/securityaudit/prompt_logging.go
+++ b/backend/internal/securityaudit/prompt_logging.go
@@ -31,6 +31,8 @@ const (
 	EventGuardBlocked         = "prompt_guard.blocked"
 	EventGuardFailed          = "prompt_guard.failed"
 	EventResultRecordFailed   = "prompt_guard.result_record_failed"
+	EventLatestTurnCacheHit   = "prompt_guard.latest_turn_cache_hit"
+	EventLatestTurnCacheError = "prompt_guard.latest_turn_cache_error"
 	EventEventDeleted         = "prompt_audit.event_deleted"
 	EventEventsDeleted        = "prompt_audit.events_deleted"
 	EventDeletePreviewed      = "prompt_audit.events_delete_previewed"
@@ -44,6 +46,7 @@ var knownLogEvents = map[string]struct{}{
 	EventAuditStarted: {}, EventProcessingReclaimed: {}, EventProcessed: {}, EventProcessFailed: {}, EventFindingRecorded: {},
 	EventChunkStarted: {}, EventChunkCompleted: {}, EventChunkFailed: {}, EventChunksAggregated: {},
 	EventEvaluationStarted: {}, EventGuardAllowed: {}, EventGuardBlocked: {}, EventGuardFailed: {}, EventResultRecordFailed: {},
+	EventLatestTurnCacheHit: {}, EventLatestTurnCacheError: {},
 	EventEventDeleted: {}, EventEventsDeleted: {}, EventDeletePreviewed: {}, EventEventsFilterDeleted: {},
 }
 

--- a/backend/internal/securityaudit/prompt_logging_test.go
+++ b/backend/internal/securityaudit/prompt_logging_test.go
@@ -33,7 +33,7 @@ func TestPromptAuditLogAllowlistAndErrorsDoNotLeakCanarySecrets(t *testing.T) {
 	beforeUnknown := output.Len()
 	LogWarn("prompt_audit.typo_event", map[string]any{"status": "failed"})
 	require.Equal(t, beforeUnknown, output.Len(), "events outside the stable dictionary must not be emitted")
-	require.Len(t, knownLogEvents, 28)
+	require.Len(t, knownLogEvents, 30)
 
 	_, err := NormalizeBaseURL("https://guard.example.test/path?token=" + canary)
 	require.Error(t, err)

--- a/backend/internal/securityaudit/prompt_service.go
+++ b/backend/internal/securityaudit/prompt_service.go
@@ -13,15 +13,16 @@ import (
 )
 
 type PromptService struct {
-	config    ConfigStore
-	repo      *PostgreSQLRepository
-	payload   *RedisPayloadStore
-	enqueuer  *Enqueuer
-	runner    *Runner
-	evaluator *GuardEvaluator
-	scanner   *OpenAICompatibleScanner
-	metrics   *AtomicMetrics
-	clock     Clock
+	config          ConfigStore
+	repo            *PostgreSQLRepository
+	payload         *RedisPayloadStore
+	enqueuer        *Enqueuer
+	runner          *Runner
+	evaluator       *GuardEvaluator
+	latestTurnCache LatestTurnDecisionCache
+	scanner         *OpenAICompatibleScanner
+	metrics         *AtomicMetrics
+	clock           Clock
 
 	lifecycleMu  sync.Mutex
 	cancel       context.CancelFunc
@@ -42,9 +43,13 @@ func NewPromptService(
 	enqueuer := NewEnqueuer(config, repo, payload, metrics)
 	evaluator := NewGuardEvaluator(scanner, repo, metrics)
 	runner := NewRunner(config, repo, payload, scanner, metrics)
+	var latestTurnCache LatestTurnDecisionCache
+	if payload != nil {
+		latestTurnCache = payload
+	}
 	return &PromptService{
 		config: config, repo: repo, payload: payload, scanner: scanner, metrics: metrics,
-		enqueuer: enqueuer, evaluator: evaluator, runner: runner, clock: realClock{},
+		enqueuer: enqueuer, evaluator: evaluator, latestTurnCache: latestTurnCache, runner: runner, clock: realClock{},
 		enqueueSlots: make(chan struct{}, 128), probes: map[string]ProbeResult{},
 	}
 }
@@ -163,7 +168,33 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 	if err != nil {
 		return nil, &GuardError{Code: ErrorCodeInvalidResponse, Cause: err}
 	}
-	return s.evaluator.Evaluate(ctx, cfg, snapshot)
+	cacheKey := ""
+	if cfg.BlockingLatestTurnOnly && snapshot.PromptHash != "" && s.latestTurnCache != nil {
+		cacheKey = latestTurnDecisionCacheKey(cfg.ConfigVersion, snapshot.PromptHash)
+		cached, cacheErr := s.latestTurnCache.GetLatestTurnDecision(ctx, cacheKey)
+		if cacheErr != nil {
+			LogWarn(EventLatestTurnCacheError, mergeLogFields(snapshotLogFields(snapshot), map[string]any{
+				"config_version": cfg.ConfigVersion, "status": "read_failed", "error_code": "cache_read_failed",
+			}))
+		} else if cached != nil {
+			LogInfo(EventLatestTurnCacheHit, mergeLogFields(snapshotLogFields(snapshot), map[string]any{
+				"config_version": cfg.ConfigVersion, "status": "hit",
+			}))
+			return cached, nil
+		}
+	}
+	decision, err := s.evaluator.Evaluate(ctx, cfg, snapshot)
+	if err == nil && decision != nil {
+		if cacheKey != "" && cacheableLatestTurnDecision(decision) {
+			if cacheErr := s.latestTurnCache.SetLatestTurnDecision(ctx, cacheKey, decision, LatestTurnDecisionCacheTTL); cacheErr != nil {
+				LogWarn(EventLatestTurnCacheError, mergeLogFields(snapshotLogFields(snapshot), map[string]any{
+					"config_version": cfg.ConfigVersion, "status": "write_failed", "error_code": "cache_write_failed",
+				}))
+			}
+		}
+		return decision, nil
+	}
+	return decision, err
 }
 
 func (s *PromptService) GetConfig() (PublicConfig, error) { return s.config.Public() }

--- a/backend/internal/securityaudit/prompt_service_test.go
+++ b/backend/internal/securityaudit/prompt_service_test.go
@@ -87,6 +87,56 @@ func TestPromptServiceBlockingLatestTurnOnlyUsesNarrowSnapshot(t *testing.T) {
 	require.Equal(t, []string{"latest user input", "previous output"}, seen)
 }
 
+type recordingLatestTurnCache struct {
+	values map[string]*PromptDecision
+	keys   []string
+}
+
+func (c *recordingLatestTurnCache) GetLatestTurnDecision(_ context.Context, key string) (*PromptDecision, error) {
+	c.keys = append(c.keys, key)
+	return c.values[key], nil
+}
+
+func (c *recordingLatestTurnCache) SetLatestTurnDecision(_ context.Context, key string, decision *PromptDecision, _ time.Duration) error {
+	if c.values == nil {
+		c.values = map[string]*PromptDecision{}
+	}
+	c.values[key] = decision
+	return nil
+}
+
+func TestPromptServiceLatestTurnOnlyReusesDecisionAcrossAssistantUpdates(t *testing.T) {
+	cache := &recordingLatestTurnCache{}
+	metrics := NewAtomicMetrics()
+	config := &fakeConfigStore{active: true, cfg: ActiveConfig{
+		RiskControlEnabled: true, Enabled: true, BlockingEnabled: true, BlockingLatestTurnOnly: true,
+		AllGroups: true, ConfigVersion: 11, Scanners: AllScannerIDs,
+		Endpoints: []ActiveEndpoint{{ID: "guard-1", Enabled: true, TimeoutMS: 1000, InputLimit: 4096}},
+	}}
+	evaluator := newGuardEvaluator(PromptScannerFunc(func(context.Context, ActiveEndpoint, string, []string) (*NormalizedResult, error) {
+		return &NormalizedResult{Decision: EventPass, RiskLevel: RiskLow, Action: ActionAllow, ScannerScores: map[string]float64{}}, nil
+	}), nil, metrics, 2, 2)
+	service := &PromptService{config: config, evaluator: evaluator, latestTurnCache: cache}
+
+	first, err := service.Evaluate(context.Background(), Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"same user turn"},{"role":"assistant","content":"first tool call"},{"role":"tool","content":"first tool result"}]}`)})
+	require.NoError(t, err)
+	second, err := service.Evaluate(context.Background(), Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"same user turn"},{"role":"assistant","content":"second tool call"},{"role":"tool","content":"second tool result"}]}`)})
+	require.NoError(t, err)
+	require.Equal(t, DecisionAllow, first.Kind)
+	require.Equal(t, first, second)
+	require.Equal(t, int64(1), metrics.Snapshot().Total)
+	require.Len(t, cache.values, 1)
+
+	_, err = service.Evaluate(context.Background(), Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"new user turn"},{"role":"assistant","content":"tool call"}]}`)})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), metrics.Snapshot().Total)
+
+	config.cfg.ConfigVersion++
+	_, err = service.Evaluate(context.Background(), Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"same user turn"},{"role":"assistant","content":"third tool call"}]}`)})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), metrics.Snapshot().Total, "config version changes must isolate cached decisions")
+}
+
 func TestPromptServiceRejectsInvalidDeleteConfirmationClaims(t *testing.T) {
 	now := time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC)
 	start, end := now.Add(-time.Hour), now.Add(time.Hour)

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -368,6 +368,24 @@ func TestResponsesOutputTextIncludedInFullAndLatestTurnSnapshots(t *testing.T) {
 	require.NotContains(t, latestTurn.ScanText, "earlier user input")
 }
 
+func TestLatestTurnPromptHashIgnoresSubsequentAssistantAndToolOutput(t *testing.T) {
+	first, err := ExtractBlockingPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"same latest user"},{"role":"assistant","content":"first tool call"},{"role":"tool","content":"first tool result"}]}`)}, true)
+	require.NoError(t, err)
+	second, err := ExtractBlockingPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"previous output"},{"role":"user","content":"same latest user"},{"role":"assistant","content":"second tool call"},{"role":"tool","content":"second tool result"}]}`)}, true)
+	require.NoError(t, err)
+	require.Equal(t, first.ScanText, second.ScanText)
+	require.NotEmpty(t, first.PromptHash)
+	require.Equal(t, first.PromptHash, second.PromptHash)
+}
+
+func TestLatestTurnPromptHashChangesWithAuditedContext(t *testing.T) {
+	first, err := ExtractBlockingPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"first previous output"},{"role":"user","content":"same user"}]}`)}, true)
+	require.NoError(t, err)
+	second, err := ExtractBlockingPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"assistant","content":"second previous output"},{"role":"user","content":"same user"}]}`)}, true)
+	require.NoError(t, err)
+	require.NotEqual(t, first.PromptHash, second.PromptHash)
+}
+
 func TestBlockingPromptSnapshotPreservesFullScopeByDefaultAndWithoutUserInput(t *testing.T) {
 	req := Request{Protocol: "openai_chat_completions", Body: []byte(`{"messages":[{"role":"system","content":"system instruction"},{"role":"user","content":"older user input"},{"role":"assistant","content":"previous output"},{"role":"user","content":"latest user input"}]}`)}
 	full, err := ExtractPromptSnapshot(req)


### PR DESCRIPTION
背景：latest_turn_only模式下，工具调用等ai自行补充上下文的场景，会重复审核 `latest_user + before_assistant` 相同的组合
<img width="3284" height="2146" alt="image" src="https://github.com/user-attachments/assets/c8d2b7d8-5328-4a9d-8bd9-21851d39cb11" />

- 按配置版本和审计提示词哈希缓存审核结果
- 在同一用户轮次的 assistant/tool 更新中复用该决策
- 当 Redis 缓存读写失败时，回退到正常审查


closes #5230