### PR TITLE
fix(openai): keep transient failure streak from resetting on sparse traffic

### DIFF
--- a/backend/internal/service/openai_account_model_transient.go
+++ b/backend/internal/service/openai_account_model_transient.go
@@ -7,7 +7,19 @@ import (
 )
 
 const (
-	openAIModelTransientFailureWindow = time.Minute
+	// openAIModelTransientStreakTTL bounds how long a failure streak survives
+	// without a new failure. It exists only so the map does not keep state for
+	// account+model pairs that stopped being used; a streak is otherwise reset
+	// by recordSuccess alone.
+	//
+	// It must stay well above the cooldowns. Resetting the streak on a short
+	// wall-clock window makes the breaker's sensitivity depend on request rate:
+	// a gateway called less often than the window never reaches streak 2, so a
+	// broken upstream is never cooled down and every request pays a failed
+	// attempt plus a failover before reaching a healthy account. Low-traffic
+	// deployments were hit hardest, which is the opposite of what a breaker
+	// should do.
+	openAIModelTransientStreakTTL     = 30 * time.Minute
 	openAIModelTransientShortCooldown = 10 * time.Second
 	openAIModelTransientLongCooldown  = 45 * time.Second
 	openAIModelTransientDefaultMax    = 4096
@@ -86,7 +98,9 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 	if !exists {
 		s.evictOldestLocked()
 	}
-	if !exists || entry.lastFailure.IsZero() || now.Sub(entry.lastFailure) > openAIModelTransientFailureWindow || now.Before(entry.lastFailure) {
+	// The streak is cleared by recordSuccess. Only drop it here when the entry
+	// is stale beyond the TTL, or when the clock moved backwards.
+	if !exists || entry.lastFailure.IsZero() || now.Sub(entry.lastFailure) > openAIModelTransientStreakTTL || now.Before(entry.lastFailure) {
 		entry.failureStreak = 0
 		entry.blockUntil = time.Time{}
 	}
@@ -139,7 +153,7 @@ func (s *openAIAccountModelTransientState) isBlocked(accountID int64, model stri
 	if !exists {
 		return false
 	}
-	if !entry.lastFailure.IsZero() && now.Sub(entry.lastFailure) > openAIModelTransientFailureWindow {
+	if !entry.lastFailure.IsZero() && now.Sub(entry.lastFailure) > openAIModelTransientStreakTTL {
 		delete(s.entries, key)
 		return false
 	}

--- a/backend/internal/service/openai_account_model_transient_test.go
+++ b/backend/internal/service/openai_account_model_transient_test.go
@@ -80,10 +80,50 @@ func TestOpenAIModelTransient_StaleStreakExpires(t *testing.T) {
 	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
 	state.recordFailure(35, "gpt-5.5", now)
 
-	decision := state.recordFailure(35, "gpt-5.5", now.Add(openAIModelTransientFailureWindow+time.Second))
+	decision := state.recordFailure(35, "gpt-5.5", now.Add(openAIModelTransientStreakTTL+time.Second))
 
 	assert.Equal(t, 1, decision.FailureStreak)
 	assert.Zero(t, decision.Cooldown)
+}
+
+// A streak must not depend on how often the gateway is called. Sparse traffic
+// used to reset the streak between every request, so a broken account+model was
+// never cooled down and each request paid a failed attempt plus a failover.
+func TestOpenAIModelTransient_StreakSurvivesSparseTraffic(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(128)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	gap := 5 * time.Minute
+	require.Greater(t, gap, openAIModelTransientLongCooldown,
+		"the gap must exceed every cooldown, otherwise this passes for the wrong reason")
+
+	first := state.recordFailure(35, "gpt-5.5", now)
+	second := state.recordFailure(35, "gpt-5.5", now.Add(gap))
+	third := state.recordFailure(35, "gpt-5.5", now.Add(2*gap))
+
+	assert.Equal(t, 1, first.FailureStreak)
+	assert.Zero(t, first.Cooldown)
+	assert.Equal(t, 2, second.FailureStreak)
+	assert.Equal(t, openAIModelTransientShortCooldown, second.Cooldown)
+	assert.Equal(t, 3, third.FailureStreak)
+	assert.Equal(t, openAIModelTransientLongCooldown, third.Cooldown)
+	assert.True(t, state.isBlocked(35, "gpt-5.5", now.Add(2*gap+time.Second)))
+}
+
+// A success between two sparse failures still clears the streak, so an account
+// that intermittently works is not pushed into the long cooldown.
+func TestOpenAIModelTransient_SuccessResetsStreakAcrossSparseTraffic(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(128)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	gap := 5 * time.Minute
+
+	state.recordFailure(35, "gpt-5.5", now)
+	state.recordSuccess(35, "gpt-5.5")
+
+	decision := state.recordFailure(35, "gpt-5.5", now.Add(gap))
+
+	assert.Equal(t, 1, decision.FailureStreak)
+	assert.Zero(t, decision.Cooldown)
+	assert.False(t, state.isBlocked(35, "gpt-5.5", now.Add(gap+time.Second)))
 }
 
 func TestOpenAIModelTransient_IgnoresInvalidKeys(t *testing.T) {


### PR DESCRIPTION
## Problem

`openAIAccountModelTransientState` resets an account+model failure streak whenever the gap since the previous failure exceeds `openAIModelTransientFailureWindow` (1 minute). Because the cooldown is `0` at streak 1, `10s` at streak 2 and `45s` at streak 3+, this makes the breaker's sensitivity a function of **request rate** rather than upstream health.

A gateway called less often than once per minute never advances past streak 1, so a consistently broken account is never blocked. Every request re-selects it, pays a full upstream attempt, and only then fails over to a healthy account. The quieter the deployment, the worse it behaves — the opposite of what a breaker should do.

## Evidence

Observed on a low-traffic deployment used intermittently by a Codex client. Two accounts returning `500` and `503` stayed in rotation indefinitely, logging the same line on every request:

```
openai_model_transient_state {"account_id": 95, "model": "gpt-5.6-sol", "failure_streak": 1, "cooldown_ms": 0, "block_scope": "account_model"}
```

A single traced request on `/v1/responses`:

```
18.018  security_audit.gateway_check_start
18.019  security_audit.gateway_check_done      <- 1ms of gateway work
18.562  openai.upstream_failover_switching     <- 543ms wasted on account 95 (500)
18.766  openai.upstream_failover_switching     <- 204ms wasted on account 115 (503)
21.381  http request completed                 <- healthy account, 2615ms
```

~750ms (22%) of every request went to re-probing the same two accounts that had already failed on the previous request. Both status codes are covered by `shouldCooldownOpenAITransientUpstreamError`, so they did reach the breaker — it just never tripped.

## Fix

The streak is already cleared on success: `recordSuccess` deletes the entry, and every OpenAI handler reports the schedule result via `ReportOpenAIAccountScheduleResult`. The time-based reset is therefore not needed to let a recovered account back in.

This keeps a TTL purely to bound the map for account+model pairs that stopped being used, and raises it (30 minutes) well above the cooldowns so it no longer doubles as a streak reset. Renamed to `openAIModelTransientStreakTTL` to reflect that narrower role.

Behaviour change is limited to the sparse-traffic case:
- consecutive failures more than a minute apart now accumulate, as they already did under load
- a success anywhere in between still resets to streak 1 with no cooldown
- entry eviction and the `maxEntries` bound are untouched

## Tests

`TestOpenAIModelTransient_StreakSurvivesSparseTraffic` fails on the previous behaviour (streak stays at 1, cooldown stays 0 across three failures 5 minutes apart) and passes after the change. `TestOpenAIModelTransient_SuccessResetsStreakAcrossSparseTraffic` pins the reset-on-success path so the longer TTL cannot strand a recovered account. `TestOpenAIModelTransient_StaleStreakExpires` still covers TTL expiry.

`go test ./internal/service/ ./internal/handler/` and `go build ./...` pass.
