### PR TITLE
fix(auth-ui): 第三方 OAuth 建号提交前必须持有验证码票据

### DIFF
--- a/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
+++ b/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
@@ -75,7 +75,7 @@
       :data-testid="`${testIdPrefix}-create-account-submit`"
       type="button"
       class="btn btn-primary w-full"
-      :disabled="isSubmitting || !email.trim() || password.length < 6 || (invitationCodeEnabled && !invitationCode.trim())"
+      :disabled="isSubmitting || !email.trim() || password.length < 6 || (invitationCodeEnabled && !invitationCode.trim()) || (turnstileEnabled && !turnstileToken)"
       @click="handleSubmit"
     >
       {{ isSubmitting ? t('common.processing') : t('auth.createAccount') }}
@@ -281,6 +281,14 @@ async function handleSendCode() {
 async function handleSubmit() {
   const trimmedEmail = email.value.trim()
   if (!trimmedEmail || password.value.length < 6) {
+    return
+  }
+
+  // Turnstile 票据一次性：发送验证码已消耗上一枚，reset 后要等新票据回调。
+  // 缺票时不能提交——create-account 端点会校验验证码，空 token 直接被判失败。
+  // 表单的隐式提交（输入框回车）绕得过按钮的 disabled，所以这里必须再挡一次。
+  if (turnstileEnabled.value && !turnstileToken.value) {
+    sendCodeError.value = t('auth.completeVerification')
     return
   }
 

--- a/frontend/src/components/auth/__tests__/PendingOAuthCreateAccountForm.spec.ts
+++ b/frontend/src/components/auth/__tests__/PendingOAuthCreateAccountForm.spec.ts
@@ -328,4 +328,99 @@ describe('PendingOAuthCreateAccountForm', () => {
       turnstile_token: 'turnstile-token'
     })
   })
+
+  it('requires a turnstile token before submitting when turnstile is enabled', async () => {
+    getPublicSettings.mockResolvedValue({
+      turnstile_enabled: true,
+      turnstile_site_key: 'site-key'
+    })
+
+    const wrapper = mount(PendingOAuthCreateAccountForm, {
+      props: {
+        testIdPrefix: 'linuxdo',
+        initialEmail: 'user@example.com',
+        isSubmitting: false
+      },
+      global: {
+        stubs: {
+          TurnstileWidget: {
+            template: '<button data-testid="turnstile-verify" @click="$emit(\'verify\', \'turnstile-token\')">verify</button>',
+            methods: { reset: turnstileReset }
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="linuxdo-create-account-password"]').setValue('secret-123')
+
+    expect(wrapper.get('[data-testid="linuxdo-create-account-submit"]').attributes('disabled')).toBeDefined()
+
+    // 隐式提交（输入框回车）绕过按钮 disabled，仍不能带着空票据发出请求
+    await wrapper.get('form').trigger('submit.prevent')
+    expect(wrapper.emitted('submit')).toBeUndefined()
+
+    await wrapper.get('[data-testid="turnstile-verify"]').trigger('click')
+
+    expect(wrapper.get('[data-testid="linuxdo-create-account-submit"]').attributes('disabled')).toBeUndefined()
+
+    await wrapper.get('[data-testid="linuxdo-create-account-submit"]').trigger('click')
+
+    expect(wrapper.emitted('submit')).toEqual([
+      [
+        {
+          email: 'user@example.com',
+          password: 'secret-123',
+          verifyCode: '',
+          turnstileToken: 'turnstile-token',
+          invitationCode: undefined
+        }
+      ]
+    ])
+  })
+
+  it('blocks submit again after sending a verify code consumes the turnstile proof', async () => {
+    getPublicSettings.mockResolvedValue({
+      turnstile_enabled: true,
+      turnstile_site_key: 'site-key'
+    })
+    sendPendingOAuthVerifyCode.mockResolvedValue({ message: 'sent', countdown: 60 })
+
+    const wrapper = mount(PendingOAuthCreateAccountForm, {
+      props: {
+        testIdPrefix: 'linuxdo',
+        initialEmail: 'user@example.com',
+        isSubmitting: false
+      },
+      global: {
+        stubs: {
+          TurnstileWidget: {
+            template: '<button data-testid="turnstile-verify" @click="$emit(\'verify\', \'turnstile-token\')">verify</button>',
+            methods: { reset: turnstileReset }
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="linuxdo-create-account-password"]').setValue('secret-123')
+    await wrapper.get('[data-testid="turnstile-verify"]').trigger('click')
+    await wrapper.get('[data-testid="linuxdo-create-account-send-code"]').trigger('click')
+    await flushPromises()
+
+    // 发码消耗掉票据并 reset 组件，新票据回调前提交必须保持关闭
+    expect(turnstileReset).toHaveBeenCalled()
+    expect(wrapper.get('[data-testid="linuxdo-create-account-submit"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('form').trigger('submit.prevent')
+    expect(wrapper.emitted('submit')).toBeUndefined()
+
+    // 新票据回调后恢复可提交，且带上新票据
+    await wrapper.get('[data-testid="turnstile-verify"]').trigger('click')
+    await wrapper.get('[data-testid="linuxdo-create-account-submit"]').trigger('click')
+
+    expect(wrapper.emitted('submit')?.[0]?.[0]).toMatchObject({
+      turnstileToken: 'turnstile-token'
+    })
+  })
 })


### PR DESCRIPTION
## 问题

#5261 给 `POST /auth/oauth/pending/create-account` 加了人机验证（`auth_oauth_pending_flow.go:1763`），但共享的建号表单只在**发码按钮**上门控了 Turnstile 票据，**提交按钮**的 disabled 条件里没有它：

```
:disabled="isSubmitting || !email.trim() || password.length < 6 || (invitationCodeEnabled && !invitationCode.trim())"
```

Turnstile 票据是一次性的，所以 `handleSendCode` 在 `finally` 里 `resetTurnstile()` 清空了 token。在控件重新出票之前提交，payload 的条件展开会把 `turnstile_token` 整个省掉，后端拿到空 token 返回 `ErrTurnstileVerificationFailed`（`turnstile_service.go:65-68`）。

- 托管型挑战：约 1 秒自动重新回调，表现为偶发提交失败；
- 需要交互的挑战：`turnstile.reset()` 后必须用户再点一次才出新票据，在那之前提交稳定失败，而按钮一直可点、界面不提示需要重新验证。

另外该端点用的是 `VerifyCaptcha` 而非 `VerifyCaptchaForRegister`，没有「已带邮箱验证码则跳过重复校验」的豁免（对比 `auth_service.go:391-396`），所以发码后提交必须持有一份**新鲜**票据。

## 改动

- 提交按钮的 disabled 条件补上 `(turnstileEnabled && !turnstileToken)`，与同组件发码按钮（第 47 行）及 `EmailVerifyView` 的 pending-OAuth 提交门控口径一致。
- `handleSubmit` 里重复校验一次：输入框回车的隐式表单提交绕得过按钮的 disabled。缺票时走既有的 `auth.completeVerification` 提示通道。

## 影响面

共享组件覆盖 5 个视图：LinuxDo / OIDC / WeChat / DingTalk / DingTalkEmailCompletion。第 6 个调用点 `EmailVerifyView` 自带独立 widget、本来就已门控，未改动。

**不涉及回归：**

- 腾讯天御路径不受影响 —— 两者后端互斥，天御配置下 `turnstile_enabled` 为 false，门控惰性；天御票据本来就由 `handleSubmit` 每次现场取新。
- 未启用验证码时两个开关皆 false，门控惰性。
- 沿用仓库既有的 `turnstileEnabled && !token` 判定，未引入新语义。

## 验证

- `PendingOAuthCreateAccountForm.spec.ts`：11 passed，新增 2 条回归用例
  - 无票据时按钮禁用、隐式提交不触发 emit；拿到票据后恢复并带上票据
  - 发码消耗票据后提交重新关闭，新票据回调后恢复
- 相关 auth 定向套件：14 files / 114 tests 全绿
- `vue-tsc --noEmit`：clean