### PR TITLE
fix(openai): normalize strict Responses stream fields

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -632,3 +632,11 @@ func generateItemID() string {
 	_, _ = rand.Read(b)
 	return "item_" + hex.EncodeToString(b)
 }
+
+// generateMessageItemID returns an OpenAI-style message output item id (msg_…).
+// Strict clients expect message items under response.output to carry this form.
+func generateMessageItemID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return "msg_" + hex.EncodeToString(b)
+}

--- a/backend/internal/pkg/apicompat/responses_stream_event_wire.go
+++ b/backend/internal/pkg/apicompat/responses_stream_event_wire.go
@@ -9,8 +9,8 @@ import "encoding/json"
 // meaningful at 0, a function_call item must always carry call_id/name/arguments
 // (arguments may be ""), a message item must carry content:[] and an output_text
 // part must carry text/annotations/logprobs. Go's `omitempty` drops exactly those
-// zero values, and strict clients (Codex CLI) reject items/deltas whose required
-// fields are missing.
+// zero values, and strict clients (Codex CLI / Grok) reject items/deltas whose
+// required fields are missing.
 //
 // Rather than marshalling with omitempty and patching the JSON afterwards, every
 // streamed event type is constructed explicitly here — the Go analogue of the
@@ -20,7 +20,7 @@ import "encoding/json"
 //
 // Event types not listed fall back to the default struct marshalling, which
 // bounds the blast radius of this method to the streamed item/part/text/tool
-// events.
+// and terminal response events.
 func (e ResponsesStreamEvent) MarshalJSON() ([]byte, error) {
 	switch e.Type {
 	case "response.output_text.delta", "response.output_text.done":
@@ -40,7 +40,7 @@ func (e ResponsesStreamEvent) MarshalJSON() ([]byte, error) {
 		e.putItemID(m)
 		m["output_index"] = e.OutputIndex
 		m["content_index"] = e.ContentIndex
-		m["part"] = outputTextPartWire(e.Part)
+		m["part"] = responsesContentPartWireValue(e.Part)
 		return json.Marshal(m)
 
 	case "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done":
@@ -66,7 +66,11 @@ func (e ResponsesStreamEvent) MarshalJSON() ([]byte, error) {
 	case "response.output_item.added", "response.output_item.done":
 		m := e.wireBase()
 		m["output_index"] = e.OutputIndex
-		m["item"] = responsesItemWire(e.Item)
+		defaultStatus := "in_progress"
+		if e.Type == "response.output_item.done" {
+			defaultStatus = "completed"
+		}
+		m["item"] = responsesOutputItemWireValue(e.Item, defaultStatus)
 		return json.Marshal(m)
 
 	case "response.function_call_arguments.delta", "response.function_call_arguments.done":
@@ -103,9 +107,21 @@ func (e ResponsesStreamEvent) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(m)
 
+	case "response.created", "response.in_progress", "response.completed", "response.done",
+		"response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+		// Terminal/lifecycle events must carry a fully-shaped response.output so
+		// strict clients can deserialize message/output_text items (Grok requires
+		// annotations; Codex requires content arrays and item ids).
+		m := e.wireBase()
+		if e.Response != nil {
+			m["response"] = responsesResponseWire(e.Response, responseItemDefaultStatus(e.Type, e.Response.Status))
+		}
+		if e.Usage != nil {
+			m["usage"] = e.Usage
+		}
+		return json.Marshal(m)
+
 	default:
-		// response.created / completed / done / failed / incomplete and any
-		// event type not shaped above keep the default struct marshalling.
 		type alias ResponsesStreamEvent
 		return json.Marshal(alias(e))
 	}
@@ -129,15 +145,33 @@ func (e ResponsesStreamEvent) putItemID(m map[string]any) {
 // carrying text/annotations/logprobs (matching cc-switch's push_text_delta).
 func outputTextPartWire(part *ResponsesContentPart) map[string]any {
 	text := ""
+	annotations := []json.RawMessage{}
+	logprobs := []json.RawMessage{}
 	if part != nil {
 		text = part.Text
+		if part.Annotations != nil {
+			annotations = part.Annotations
+		}
+		if part.Logprobs != nil {
+			logprobs = part.Logprobs
+		}
 	}
 	return map[string]any{
 		"type":        "output_text",
 		"text":        text,
-		"annotations": []any{},
-		"logprobs":    []any{},
+		"annotations": annotations,
+		"logprobs":    logprobs,
 	}
+}
+
+func responsesContentPartWireValue(part *ResponsesContentPart) any {
+	if part == nil {
+		return map[string]any{}
+	}
+	if part.Type == "" || part.Type == "text" || part.Type == "output_text" {
+		return outputTextPartWire(part)
+	}
+	return part
 }
 
 // summaryTextPartWire renders a reasoning summary part.
@@ -152,20 +186,119 @@ func summaryTextPartWire(part *ResponsesContentPart) map[string]any {
 	}
 }
 
-// responsesItemWire renders an output_item with every field the item's type
-// requires to be present, including the empty arrays/strings that omitempty
-// would otherwise drop. Mirrors cc-switch's response_function_call_item and the
-// message/reasoning item shapes codex expects.
-func responsesItemWire(item *ResponsesOutput) map[string]any {
+// responseItemDefaultStatus picks the default status for output items nested
+// under a lifecycle/terminal response event when the item itself has no status.
+func responseItemDefaultStatus(eventType, responseStatus string) string {
+	switch eventType {
+	case "response.completed", "response.done":
+		return "completed"
+	case "response.incomplete":
+		return "incomplete"
+	case "response.failed", "response.cancelled", "response.canceled":
+		if responseStatus != "" {
+			return responseStatus
+		}
+		return "failed"
+	case "response.created", "response.in_progress":
+		return "in_progress"
+	default:
+		if responseStatus != "" {
+			return responseStatus
+		}
+		return "completed"
+	}
+}
+
+// responsesResponseWire renders a Response object with every nested item/part
+// field strict clients require. response.id is preserved as-is; message items
+// get msg_… ids and completed status when missing; output_text parts always
+// carry annotations/logprobs (even empty).
+func responsesResponseWire(resp *ResponsesResponse, defaultItemStatus string) map[string]any {
+	if resp == nil {
+		return map[string]any{}
+	}
+	object := resp.Object
+	if object == "" {
+		object = "response"
+	}
+	m := map[string]any{
+		"id":     resp.ID,
+		"object": object,
+		"model":  resp.Model,
+		"status": resp.Status,
+		"output": responsesOutputListWire(resp.Output, defaultItemStatus),
+	}
+	if resp.Usage != nil {
+		m["usage"] = resp.Usage
+	}
+	if resp.IncompleteDetails != nil {
+		m["incomplete_details"] = resp.IncompleteDetails
+	}
+	if resp.Error != nil {
+		m["error"] = resp.Error
+	}
+	return m
+}
+
+func responsesOutputListWire(items []ResponsesOutput, defaultStatus string) []any {
+	out := make([]any, 0, len(items))
+	for i := range items {
+		out = append(out, responsesOutputItemWireValue(&items[i], defaultStatus))
+	}
+	return out
+}
+
+func responsesItemUsesStrictWire(itemType string) bool {
+	switch itemType {
+	case "tool_search_call", "message", "function_call", "custom_tool_call", "reasoning":
+		return true
+	default:
+		return false
+	}
+}
+
+// responsesOutputItemWireValue applies the strict builder only to item types it
+// fully models. Other item types retain their default JSON representation so
+// fields such as web_search_call.action are not discarded.
+func responsesOutputItemWireValue(item *ResponsesOutput, defaultStatus string) any {
 	if item == nil {
 		return map[string]any{}
 	}
+	if responsesItemUsesStrictWire(item.Type) {
+		return responsesItemWire(item, defaultStatus)
+	}
+	copyItem := *item
+	if copyItem.Status == "" {
+		copyItem.Status = defaultStatus
+	}
+	return copyItem
+}
+
+// responsesItemWire renders an output_item with every field the item's type
+// requires to be present, including the empty arrays/strings that omitempty
+// would otherwise drop. Mirrors cc-switch's response_function_call_item and the
+// message/reasoning item shapes codex/Grok expect.
+//
+// defaultStatus is applied when item.Status is empty (e.g. "completed" on
+// output_item.done / response.completed, "in_progress" on output_item.added).
+func responsesItemWire(item *ResponsesOutput, defaultStatus string) map[string]any {
+	if item == nil {
+		return map[string]any{}
+	}
+	id := item.ID
+	if id == "" && item.Type == "message" {
+		id = generateMessageItemID()
+	}
 	m := map[string]any{
 		"type": item.Type,
-		"id":   item.ID,
+		"id":   id,
 	}
-	if item.Status != "" {
-		m["status"] = item.Status
+	status := item.Status
+	if status == "" {
+		status = defaultStatus
+	}
+	if status != "" {
+		m["status"] = status
 	}
 	switch item.Type {
 	case "message":
@@ -206,15 +339,30 @@ func responsesItemWire(item *ResponsesOutput) map[string]any {
 }
 
 // messageContentWire renders a message item's content array; always an array
-// (never null), with each output_text part carrying its text.
+// (never null). output_text parts always carry text/annotations/logprobs so
+// strict deserializers (Grok ResponseStreamEvent) accept the payload.
 func messageContentWire(parts []ResponsesContentPart) []map[string]any {
 	out := make([]map[string]any, 0, len(parts))
-	for _, p := range parts {
+	for i := range parts {
+		p := parts[i]
 		typ := p.Type
-		if typ == "" {
+		if typ == "" || typ == "text" {
 			typ = "output_text"
 		}
-		out = append(out, map[string]any{"type": typ, "text": p.Text})
+		if typ == "output_text" {
+			part := p
+			part.Type = "output_text"
+			out = append(out, outputTextPartWire(&part))
+			continue
+		}
+		m := map[string]any{"type": typ}
+		if p.Text != "" {
+			m["text"] = p.Text
+		}
+		if p.ImageURL != "" {
+			m["image_url"] = p.ImageURL
+		}
+		out = append(out, m)
 	}
 	return out
 }

--- a/backend/internal/pkg/apicompat/responses_stream_event_wire_test.go
+++ b/backend/internal/pkg/apicompat/responses_stream_event_wire_test.go
@@ -2,6 +2,7 @@ package apicompat
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,41 @@ func TestWire_MessageItemContentAlwaysArray(t *testing.T) {
 	require.True(t, ok, "content must be an array")
 }
 
+// TestWire_MessageItemFillsIDStatusAndAnnotations guards the Grok/Codex strict
+// shape: message id/status and output_text annotations/logprobs must be present
+// even when emitters omit them.
+func TestWire_MessageItemFillsIDStatusAndAnnotations(t *testing.T) {
+	m := marshalEvent(t, ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type: "message",
+			Role: "assistant",
+			Content: []ResponsesContentPart{
+				{Type: "output_text", Text: "hello"},
+			},
+		},
+	})
+	item, ok := m["item"].(map[string]any)
+	require.True(t, ok, "item must be an object")
+	id, _ := item["id"].(string)
+	require.True(t, strings.HasPrefix(id, "msg_"), "message id must be msg_…, got %q", id)
+	require.Equal(t, "completed", item["status"])
+	content, ok := item["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	part, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "output_text", part["type"])
+	require.Equal(t, "hello", part["text"])
+	require.Contains(t, part, "annotations")
+	require.Contains(t, part, "logprobs")
+	_, ok = part["annotations"].([]any)
+	require.True(t, ok, "annotations must be an array")
+	_, ok = part["logprobs"].([]any)
+	require.True(t, ok, "logprobs must be an array")
+}
+
 // TestWire_ReasoningItemSummaryAlwaysArray guards summary:[] presence.
 func TestWire_ReasoningItemSummaryAlwaysArray(t *testing.T) {
 	m := marshalEvent(t, ResponsesStreamEvent{
@@ -83,7 +119,11 @@ func TestWire_ReasoningItemSummaryAlwaysArray(t *testing.T) {
 func TestWire_ContentPartCarriesAnnotationsLogprobs(t *testing.T) {
 	m := marshalEvent(t, ResponsesStreamEvent{
 		Type: "response.content_part.added", OutputIndex: 0, ContentIndex: 0, ItemID: "msg_1",
-		Part: &ResponsesContentPart{Type: "output_text", Text: ""},
+		Part: &ResponsesContentPart{
+			Type:        "output_text",
+			Text:        "",
+			Annotations: []json.RawMessage{json.RawMessage(`{"type":"url_citation","url":"https://example.com"}`)},
+		},
 	})
 	part, ok := m["part"].(map[string]any)
 	require.True(t, ok, "part must be an object")
@@ -91,6 +131,23 @@ func TestWire_ContentPartCarriesAnnotationsLogprobs(t *testing.T) {
 	require.Contains(t, part, "text")
 	require.Contains(t, part, "annotations")
 	require.Contains(t, part, "logprobs")
+	annotations, ok := part["annotations"].([]any)
+	require.True(t, ok)
+	require.Len(t, annotations, 1)
+	require.Equal(t, "https://example.com", annotations[0].(map[string]any)["url"])
+}
+
+func TestWire_ContentPartPreservesNonOutputTextShape(t *testing.T) {
+	m := marshalEvent(t, ResponsesStreamEvent{
+		Type: "response.content_part.added", OutputIndex: 0, ContentIndex: 0, ItemID: "msg_1",
+		Part: &ResponsesContentPart{Type: "input_image", ImageURL: "data:image/png;base64,abc"},
+	})
+	part, ok := m["part"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "input_image", part["type"])
+	require.Equal(t, "data:image/png;base64,abc", part["image_url"])
+	require.NotContains(t, part, "annotations")
+	require.NotContains(t, part, "logprobs")
 }
 
 // TestWire_ArgumentsDonePresentEvenEmpty guards arguments presence on done.
@@ -122,14 +179,77 @@ func TestWire_CustomToolCallInputIndexPresentAtZero(t *testing.T) {
 	require.NotContains(t, done, "delta")
 }
 
-// TestWire_UnknownEventFallsBackToDefault ensures non-streamed event types keep
-// default marshalling (the response object is preserved).
-func TestWire_UnknownEventFallsBackToDefault(t *testing.T) {
+// TestWire_CompletedCarriesStrictMessageShape ensures response.completed nests
+// a fully-shaped message/output_text (the Grok failure mode: missing annotations).
+func TestWire_CompletedCarriesStrictMessageShape(t *testing.T) {
 	m := marshalEvent(t, ResponsesStreamEvent{
-		Type:     "response.completed",
-		Response: &ResponsesResponse{ID: "resp_1", Object: "response", Status: "completed"},
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			ID:     "resp_1",
+			Object: "response",
+			Model:  "gpt-test",
+			Status: "completed",
+			Output: []ResponsesOutput{{
+				Type: "message",
+				Role: "assistant",
+				Content: []ResponsesContentPart{
+					{Type: "output_text", Text: "你好"},
+				},
+			}},
+		},
 	})
 	require.Contains(t, m, "response")
+	resp, ok := m["response"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "resp_1", resp["id"])
+	output, ok := resp["output"].([]any)
+	require.True(t, ok)
+	require.Len(t, output, 1)
+	item, ok := output[0].(map[string]any)
+	require.True(t, ok)
+	id, _ := item["id"].(string)
+	require.True(t, strings.HasPrefix(id, "msg_"), "got %q", id)
+	require.Equal(t, "completed", item["status"])
+	content, ok := item["content"].([]any)
+	require.True(t, ok)
+	part, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, part, "annotations")
+	require.Contains(t, part, "logprobs")
+	require.Equal(t, "你好", part["text"])
+}
+
+func TestWire_WebSearchActionSurvivesItemAndCompletedEvents(t *testing.T) {
+	item := ResponsesOutput{
+		Type:   "web_search_call",
+		ID:     "ws_1",
+		Status: "completed",
+		Action: &WebSearchAction{Type: "search", Query: "strict wire"},
+	}
+
+	done := marshalEvent(t, ResponsesStreamEvent{
+		Type: "response.output_item.done", OutputIndex: 0, Item: &item,
+	})
+	doneItem, ok := done["item"].(map[string]any)
+	require.True(t, ok)
+	doneAction, ok := doneItem["action"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "search", doneAction["type"])
+	require.Equal(t, "strict wire", doneAction["query"])
+
+	completed := marshalEvent(t, ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			ID: "resp_web", Object: "response", Status: "completed", Output: []ResponsesOutput{item},
+		},
+	})
+	response := completed["response"].(map[string]any)
+	output := response["output"].([]any)
+	completedItem := output[0].(map[string]any)
+	completedAction, ok := completedItem["action"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "search", completedAction["type"])
+	require.Equal(t, "strict wire", completedAction["query"])
 }
 
 func TestResponsesOutputUnmarshal_ToolSearchObjectArguments(t *testing.T) {

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
@@ -454,6 +454,7 @@ type BufferedResponseAccumulator struct {
 	reasoning            strings.Builder
 	funcCalls            []bufferedFuncCall
 	outputIndexToFuncIdx map[int]int
+	messageItemID        string
 }
 
 // NewBufferedResponseAccumulator returns an initialised accumulator.
@@ -469,11 +470,20 @@ func NewBufferedResponseAccumulator() *BufferedResponseAccumulator {
 func (a *BufferedResponseAccumulator) ProcessEvent(event *ResponsesStreamEvent) {
 	switch event.Type {
 	case "response.output_text.delta":
+		if a.messageItemID == "" && event.ItemID != "" {
+			a.messageItemID = event.ItemID
+		}
 		if event.Delta != "" {
 			_, _ = a.text.WriteString(event.Delta)
 		}
 	case "response.output_item.added":
-		if event.Item != nil && (event.Item.Type == "function_call" || event.Item.Type == "custom_tool_call") {
+		if event.Item == nil {
+			return
+		}
+		if event.Item.Type == "message" && a.messageItemID == "" && event.Item.ID != "" {
+			a.messageItemID = event.Item.ID
+		}
+		if event.Item.Type == "function_call" || event.Item.Type == "custom_tool_call" {
 			idx := len(a.funcCalls)
 			a.outputIndexToFuncIdx[event.OutputIndex] = idx
 			a.funcCalls = append(a.funcCalls, bufferedFuncCall{
@@ -516,9 +526,14 @@ func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	}
 
 	if a.text.Len() > 0 {
+		if a.messageItemID == "" {
+			a.messageItemID = generateMessageItemID()
+		}
 		out = append(out, ResponsesOutput{
-			Type: "message",
-			Role: "assistant",
+			Type:   "message",
+			ID:     a.messageItemID,
+			Role:   "assistant",
+			Status: "completed",
 			Content: []ResponsesContentPart{{
 				Type: "output_text",
 				Text: a.text.String(),

--- a/backend/internal/pkg/apicompat/responses_wire_normalize.go
+++ b/backend/internal/pkg/apicompat/responses_wire_normalize.go
@@ -1,0 +1,222 @@
+package apicompat
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ResponsesStrictClientWireNormalizer keeps repairs consistent across all
+// events in one Responses stream. In particular, a missing message id is
+// generated once per output_index and reused by added/done/terminal events.
+type ResponsesStrictClientWireNormalizer struct {
+	messageIDs map[int]string
+}
+
+func NewResponsesStrictClientWireNormalizer() *ResponsesStrictClientWireNormalizer {
+	return &ResponsesStrictClientWireNormalizer{messageIDs: make(map[int]string)}
+}
+
+// NormalizeResponsesStrictClientWireJSON fills missing fields that strict
+// Responses clients (Grok/Codex) require on the wire:
+//
+//   - message items: id (msg_…) and status
+//   - output_text parts: annotations:[] and logprobs:[]
+//
+// Valid existing fields are preserved; missing or invalid required collection
+// fields are repaired. Works for both SSE event payloads (type=response.*) and
+// bare response objects. Streaming callers should reuse one normalizer via
+// Normalize so generated message ids stay stable across events.
+func NormalizeResponsesStrictClientWireJSON(data []byte) ([]byte, bool) {
+	return NewResponsesStrictClientWireNormalizer().Normalize(data)
+}
+
+func (n *ResponsesStrictClientWireNormalizer) Normalize(data []byte) ([]byte, bool) {
+	if len(data) == 0 || !gjson.ValidBytes(data) {
+		return data, false
+	}
+
+	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
+	switch eventType {
+	case "response.output_item.added", "response.output_item.done":
+		defaultStatus := "in_progress"
+		if eventType == "response.output_item.done" {
+			defaultStatus = "completed"
+		}
+		return n.normalizeResponsesItemAtPath(data, "item", defaultStatus, int(gjson.GetBytes(data, "output_index").Int()))
+
+	case "response.content_part.added", "response.content_part.done":
+		return normalizeOutputTextPartAtPath(data, "part")
+
+	case "response.created", "response.in_progress", "response.completed", "response.done",
+		"response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+		defaultStatus := responseItemDefaultStatus(eventType, gjson.GetBytes(data, "response.status").String())
+		return n.normalizeResponsesOutputListAtPath(data, "response.output", defaultStatus)
+
+	default:
+		// Bare non-streaming response body: {"id":"resp_…","object":"response","output":[...]}
+		if gjson.GetBytes(data, "object").String() == "response" || gjson.GetBytes(data, "output").IsArray() {
+			status := gjson.GetBytes(data, "status").String()
+			defaultStatus := "completed"
+			if status != "" {
+				defaultStatus = status
+			}
+			return n.normalizeResponsesOutputListAtPath(data, "output", defaultStatus)
+		}
+		return data, false
+	}
+}
+
+func (n *ResponsesStrictClientWireNormalizer) normalizeResponsesOutputListAtPath(data []byte, path, defaultStatus string) ([]byte, bool) {
+	output := gjson.GetBytes(data, path)
+	if !output.Exists() || !output.IsArray() {
+		return data, false
+	}
+	updated := data
+	changed := false
+	for i := range output.Array() {
+		itemPath := path + "." + strconv.Itoa(i)
+		next, itemChanged := n.normalizeResponsesItemAtPath(updated, itemPath, defaultStatus, i)
+		if itemChanged {
+			updated = next
+			changed = true
+		}
+	}
+	return updated, changed
+}
+
+func (n *ResponsesStrictClientWireNormalizer) normalizeResponsesItemAtPath(data []byte, path, defaultStatus string, outputIndex int) ([]byte, bool) {
+	item := gjson.GetBytes(data, path)
+	if !item.Exists() || !item.IsObject() {
+		return data, false
+	}
+
+	updated := data
+	changed := false
+	itemType := strings.TrimSpace(item.Get("type").String())
+
+	if itemType == "message" {
+		itemID := strings.TrimSpace(item.Get("id").String())
+		if itemID == "" {
+			next, err := sjson.SetBytes(updated, path+".id", n.messageID(outputIndex))
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		} else {
+			n.rememberMessageID(outputIndex, itemID)
+		}
+		if strings.TrimSpace(item.Get("status").String()) == "" && defaultStatus != "" {
+			next, err := sjson.SetBytes(updated, path+".status", defaultStatus)
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		}
+		contentPath := path + ".content"
+		content := gjson.GetBytes(updated, contentPath)
+		if !content.IsArray() {
+			next, err := sjson.SetRawBytes(updated, contentPath, []byte("[]"))
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		} else {
+			for i, part := range content.Array() {
+				partPath := path + ".content." + strconv.Itoa(i)
+				// Re-read type from the current part (original snapshot is fine).
+				partType := strings.TrimSpace(part.Get("type").String())
+				if partType == "" || partType == "text" || partType == "output_text" {
+					if partType == "" || partType == "text" {
+						next, err := sjson.SetBytes(updated, partPath+".type", "output_text")
+						if err == nil {
+							updated = next
+							changed = true
+						}
+					}
+					next, partChanged := normalizeOutputTextPartAtPath(updated, partPath)
+					if partChanged {
+						updated = next
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	return updated, changed
+}
+
+func (n *ResponsesStrictClientWireNormalizer) messageID(outputIndex int) string {
+	if n == nil {
+		return generateMessageItemID()
+	}
+	if n.messageIDs == nil {
+		n.messageIDs = make(map[int]string)
+	}
+	if id := n.messageIDs[outputIndex]; id != "" {
+		return id
+	}
+	id := generateMessageItemID()
+	n.messageIDs[outputIndex] = id
+	return id
+}
+
+func (n *ResponsesStrictClientWireNormalizer) rememberMessageID(outputIndex int, id string) {
+	if n == nil || id == "" {
+		return
+	}
+	if n.messageIDs == nil {
+		n.messageIDs = make(map[int]string)
+	}
+	if n.messageIDs[outputIndex] == "" {
+		n.messageIDs[outputIndex] = id
+	}
+}
+
+func normalizeOutputTextPartAtPath(data []byte, path string) ([]byte, bool) {
+	part := gjson.GetBytes(data, path)
+	if !part.Exists() || !part.IsObject() {
+		return data, false
+	}
+	updated := data
+	changed := false
+
+	partType := strings.TrimSpace(part.Get("type").String())
+	if partType != "" && partType != "text" && partType != "output_text" {
+		return data, false
+	}
+	if partType == "" || partType == "text" {
+		next, err := sjson.SetBytes(updated, path+".type", "output_text")
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+
+	text := part.Get("text")
+	if text.Type != gjson.String {
+		next, err := sjson.SetBytes(updated, path+".text", "")
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	if !part.Get("annotations").IsArray() {
+		next, err := sjson.SetRawBytes(updated, path+".annotations", []byte("[]"))
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	if !part.Get("logprobs").IsArray() {
+		next, err := sjson.SetRawBytes(updated, path+".logprobs", []byte("[]"))
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	return updated, changed
+}

--- a/backend/internal/pkg/apicompat/responses_wire_normalize_test.go
+++ b/backend/internal/pkg/apicompat/responses_wire_normalize_test.go
@@ -1,0 +1,173 @@
+package apicompat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeResponsesStrictClientWireJSON_CompletedMessage(t *testing.T) {
+	// Mirrors the Grok failure payload: message without id/status, output_text
+	// without annotations/logprobs.
+	in := []byte(`{
+		"type":"response.completed",
+		"sequence_number":38,
+		"response":{
+			"id":"resp_03f08335219c85ae016a71d2c1e0a48190867c3b3f1b4e6667",
+			"object":"response",
+			"status":"completed",
+			"output":[{
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"output_text","text":"直接执行"}]
+			}]
+		}
+	}`)
+
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.True(t, changed)
+	require.Equal(t, "resp_03f08335219c85ae016a71d2c1e0a48190867c3b3f1b4e6667", gjson.GetBytes(out, "response.id").String())
+
+	itemID := gjson.GetBytes(out, "response.output.0.id").String()
+	require.True(t, strings.HasPrefix(itemID, "msg_"), "got %q", itemID)
+	require.Equal(t, "completed", gjson.GetBytes(out, "response.output.0.status").String())
+	require.Equal(t, "直接执行", gjson.GetBytes(out, "response.output.0.content.0.text").String())
+	require.True(t, gjson.GetBytes(out, "response.output.0.content.0.annotations").IsArray())
+	require.True(t, gjson.GetBytes(out, "response.output.0.content.0.logprobs").IsArray())
+	require.Len(t, gjson.GetBytes(out, "response.output.0.content.0.annotations").Array(), 0)
+	require.Len(t, gjson.GetBytes(out, "response.output.0.content.0.logprobs").Array(), 0)
+
+	// Idempotent: already-normalized payload must not change.
+	again, changedAgain := NormalizeResponsesStrictClientWireJSON(out)
+	require.False(t, changedAgain)
+	require.JSONEq(t, string(out), string(again))
+}
+
+func TestNormalizeResponsesStrictClientWireJSON_PreservesExistingFields(t *testing.T) {
+	in := []byte(`{
+		"type":"response.completed",
+		"response":{
+			"id":"resp_keep",
+			"status":"completed",
+			"output":[{
+				"type":"message",
+				"id":"msg_existing",
+				"status":"completed",
+				"role":"assistant",
+				"content":[{
+					"type":"output_text",
+					"text":"hi",
+					"annotations":[{"type":"url_citation","url":"https://example.com"}],
+					"logprobs":[{"token":"hi"}]
+				}]
+			}]
+		}
+	}`)
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.False(t, changed)
+	require.Equal(t, "msg_existing", gjson.GetBytes(out, "response.output.0.id").String())
+	require.Equal(t, "https://example.com", gjson.GetBytes(out, "response.output.0.content.0.annotations.0.url").String())
+	require.Equal(t, "hi", gjson.GetBytes(out, "response.output.0.content.0.logprobs.0.token").String())
+}
+
+func TestNormalizeResponsesStrictClientWireJSON_BareResponseBody(t *testing.T) {
+	in := []byte(`{
+		"id":"resp_bare",
+		"object":"response",
+		"status":"completed",
+		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]
+	}`)
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.True(t, changed)
+	require.True(t, strings.HasPrefix(gjson.GetBytes(out, "output.0.id").String(), "msg_"))
+	require.Equal(t, "completed", gjson.GetBytes(out, "output.0.status").String())
+	require.True(t, gjson.GetBytes(out, "output.0.content.0.annotations").IsArray())
+}
+
+func TestNormalizeResponsesStrictClientWireJSON_RepairsInvalidCollections(t *testing.T) {
+	in := []byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{
+			"type":"message",
+			"id":"msg_invalid",
+			"status":"completed",
+			"content":[{
+				"type":"output_text",
+				"text":null,
+				"annotations":null,
+				"logprobs":{"invalid":true}
+			}]
+		}]}
+	}`)
+
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.True(t, changed)
+	require.Equal(t, "", gjson.GetBytes(out, "response.output.0.content.0.text").String())
+	require.True(t, gjson.GetBytes(out, "response.output.0.content.0.annotations").IsArray())
+	require.True(t, gjson.GetBytes(out, "response.output.0.content.0.logprobs").IsArray())
+
+	again, changedAgain := NormalizeResponsesStrictClientWireJSON(out)
+	require.False(t, changedAgain)
+	require.Equal(t, string(out), string(again))
+}
+
+func TestNormalizeResponsesStrictClientWireJSON_RepairsNullMessageContent(t *testing.T) {
+	in := []byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{
+			"type":"message","id":"msg_null_content","status":"completed","content":null
+		}]}
+	}`)
+
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.True(t, changed)
+	require.True(t, gjson.GetBytes(out, "response.output.0.content").IsArray())
+	require.Empty(t, gjson.GetBytes(out, "response.output.0.content").Array())
+}
+
+func TestNormalizeResponsesStrictClientWireJSON_LeavesNonOutputTextPartUnchanged(t *testing.T) {
+	in := []byte(`{
+		"type":"response.content_part.added",
+		"part":{"type":"refusal","refusal":"no","vendor_extension":{"keep":true}}
+	}`)
+
+	out, changed := NormalizeResponsesStrictClientWireJSON(in)
+	require.False(t, changed)
+	require.Equal(t, string(in), string(out))
+}
+
+func TestResponsesStrictClientWireNormalizer_ReusesMessageIDAcrossEvents(t *testing.T) {
+	normalizer := NewResponsesStrictClientWireNormalizer()
+
+	added, changed := normalizer.Normalize([]byte(`{
+		"type":"response.output_item.added",
+		"output_index":0,
+		"item":{"type":"message","role":"assistant"}
+	}`))
+	require.True(t, changed)
+	addedID := gjson.GetBytes(added, "item.id").String()
+	require.True(t, strings.HasPrefix(addedID, "msg_"))
+
+	done, changed := normalizer.Normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":0,
+		"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}
+	}`))
+	require.True(t, changed)
+
+	completed, changed := normalizer.Normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{
+			"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]
+		}]}
+	}`))
+	require.True(t, changed)
+
+	require.Equal(t, addedID, gjson.GetBytes(done, "item.id").String())
+	require.Equal(t, addedID, gjson.GetBytes(completed, "response.output.0.id").String())
+	require.Equal(t, "in_progress", gjson.GetBytes(added, "item.status").String())
+	require.Equal(t, "completed", gjson.GetBytes(done, "item.status").String())
+	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String())
+}

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -295,9 +295,11 @@ func (i *ResponsesInputItem) UnmarshalJSON(data []byte) error {
 
 // ResponsesContentPart is a typed content part in a Responses message.
 type ResponsesContentPart struct {
-	Type     string `json:"type"` // "input_text" | "output_text" | "input_image"
-	Text     string `json:"text,omitempty"`
-	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
+	Type        string            `json:"type"` // "input_text" | "output_text" | "input_image"
+	Text        string            `json:"text,omitempty"`
+	ImageURL    string            `json:"image_url,omitempty"` // data URI for input_image
+	Annotations []json.RawMessage `json:"annotations,omitempty"`
+	Logprobs    []json.RawMessage `json:"logprobs,omitempty"`
 }
 
 // ResponsesTool describes a tool in the Responses API.
@@ -384,26 +386,19 @@ type ResponsesOutput struct {
 	Action *WebSearchAction `json:"action,omitempty"`
 }
 
-// MarshalJSON 处理 tool_search_call 项的线上形态（复用 CallID/Arguments 字段）：
-// execution 固定为 "client"（codex 的必填字段，非 client 的调用会被静默忽略），
-// arguments 是 JSON 对象而非 function_call 语义下的字符串。其余类型走默认结构体
-// 序列化，输出逐字节不变。
+// MarshalJSON 统一输出 Responses output item 的线上形态：
+//   - tool_search_call / message / function_call / custom_tool_call / reasoning
+//     走 responsesItemWire，保证 message 带 id/status、output_text 带
+//     annotations/logprobs 等严格客户端（Codex/Grok）必填字段；
+//   - 其余类型（web_search_call、image_generation_call、compaction 等）保留
+//     默认结构体序列化，避免误丢 opaque 字段。
 func (o ResponsesOutput) MarshalJSON() ([]byte, error) {
+	if responsesItemUsesStrictWire(o.Type) {
+		// 非流式终态默认 completed；调用方若已设 Status 则优先保留。
+		return json.Marshal(responsesItemWire(&o, "completed"))
+	}
 	type responsesOutputAlias ResponsesOutput
-	if o.Type != "tool_search_call" {
-		return json.Marshal(responsesOutputAlias(o))
-	}
-	m := map[string]any{
-		"type":      o.Type,
-		"id":        o.ID,
-		"call_id":   o.CallID,
-		"execution": "client",
-		"arguments": toolSearchCallArgumentsJSON(o.Arguments),
-	}
-	if o.Status != "" {
-		m["status"] = o.Status
-	}
-	return json.Marshal(m)
+	return json.Marshal(responsesOutputAlias(o))
 }
 
 // UnmarshalJSON accepts both the Responses function-call string form and the

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -1113,6 +1114,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	documentScanner := newOpenAISSEJSONDocumentScanner(scanner)
 
 	needModelReplace := strings.TrimSpace(originalModel) != "" && strings.TrimSpace(mappedModel) != "" && strings.TrimSpace(originalModel) != strings.TrimSpace(mappedModel)
+	strictClientWireNormalizer := apicompat.NewResponsesStrictClientWireNormalizer()
 	resultWithUsage := func() *openaiStreamingResultPassthrough {
 		return &openaiStreamingResultPassthrough{
 			usage:            usage,
@@ -1143,6 +1145,11 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				line = "data: " + string(normalizedData)
 			}
 			if normalizedData, normalized := normalizeCompletedImageGenerationStatus(dataBytes); normalized {
+				dataBytes = normalizedData
+				trimmedData = strings.TrimSpace(string(normalizedData))
+				line = "data: " + string(normalizedData)
+			}
+			if normalizedData, normalized := strictClientWireNormalizer.Normalize(dataBytes); normalized {
 				dataBytes = normalizedData
 				trimmedData = strings.TrimSpace(string(normalizedData))
 				line = "data: " + string(normalizedData)
@@ -1347,6 +1354,9 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	if originalModel != "" && mappedModel != "" && originalModel != mappedModel {
 		body = s.replaceModelInResponseBody(body, mappedModel, originalModel)
 	}
+	if normalized, ok := apicompat.NormalizeResponsesStrictClientWireJSON(body); ok {
+		body = normalized
+	}
 	body, err = restoreOpenAIResponsesNamespacePayload(c, body)
 	if err != nil {
 		return nil, fmt.Errorf("restore OpenAI passthrough namespace response: %w", err)
@@ -1386,6 +1396,9 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			}
 		}
 		finalResponse = supplementCompactionItemFromSSE(c, finalResponse, bodyText)
+		if normalized, ok := apicompat.NormalizeResponsesStrictClientWireJSON(finalResponse); ok {
+			finalResponse = normalized
+		}
 		body = finalResponse
 		if originalModel != "" && mappedModel != "" && originalModel != mappedModel {
 			body = s.replaceModelInResponseBody(body, mappedModel, originalModel)

--- a/backend/internal/service/openai_gateway_passthrough_function_args_test.go
+++ b/backend/internal/service/openai_gateway_passthrough_function_args_test.go
@@ -71,6 +71,48 @@ func TestHandleStreamingResponsePassthroughDeduplicatesFunctionCallArguments(t *
 	requireJSONArgument(t, gjson.Get(completed, "response.output.1.arguments").String())
 }
 
+func TestHandleStreamingResponsePassthroughNormalizesStrictMessageShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstreamBody := strings.Join([]string{
+		passthroughSSEData(`{"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}`),
+		passthroughSSEData(`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok","annotations":null,"logprobs":null}]}}`),
+		passthroughSSEData(`{"type":"response.completed","response":{"id":"resp_strict","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}}`),
+		"data: [DONE]\n\n",
+	}, "")
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}
+
+	svc := &OpenAIGatewayService{}
+	result, err := svc.handleStreamingResponsePassthrough(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "gpt-5.4", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	events := collectSSEDataPayloads(t, rec.Body.String())
+	added := findSSEEvent(t, events, "response.output_item.added", "")
+	done := findSSEEvent(t, events, "response.output_item.done", "")
+	completed := findSSEEvent(t, events, "response.completed", "")
+
+	messageID := gjson.Get(added, "item.id").String()
+	require.True(t, strings.HasPrefix(messageID, "msg_"))
+	require.Equal(t, messageID, gjson.Get(done, "item.id").String())
+	require.Equal(t, messageID, gjson.Get(completed, "response.output.0.id").String())
+	require.Equal(t, "in_progress", gjson.Get(added, "item.status").String())
+	require.Equal(t, "completed", gjson.Get(done, "item.status").String())
+	require.Equal(t, "completed", gjson.Get(completed, "response.output.0.status").String())
+	require.True(t, gjson.Get(done, "item.content.0.annotations").IsArray())
+	require.True(t, gjson.Get(done, "item.content.0.logprobs").IsArray())
+	require.True(t, gjson.Get(completed, "response.output.0.content.0.annotations").IsArray())
+	require.True(t, gjson.Get(completed, "response.output.0.content.0.logprobs").IsArray())
+}
+
 func TestForwardResponsesChatCompletionsFallbackKeepsFunctionArgumentsSingle(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -286,6 +286,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 
 	needModelReplace := originalModel != mappedModel
 	streamOutputAccumulator := apicompat.NewBufferedResponseAccumulator()
+	strictClientWireNormalizer := apicompat.NewResponsesStrictClientWireNormalizer()
 	streamImageOutputs := make([]json.RawMessage, 0, 1)
 	streamSeenImages := make(map[string]struct{})
 	resultWithUsage := func() *openaiStreamingResult {
@@ -470,6 +471,14 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				line = "data: " + data
 				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
 			}
+			// Normalize item lifecycle events before accumulation so a generated
+			// message id can be reused when an empty terminal output is rebuilt.
+			if normalizedData, normalized := strictClientWireNormalizer.Normalize(dataBytes); normalized {
+				dataBytes = normalizedData
+				data = string(normalizedData)
+				line = "data: " + data
+				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+			}
 			if imageOutput, ok := extractImageGenerationOutputFromSSEData(dataBytes, streamSeenImages); ok {
 				streamImageOutputs = append(streamImageOutputs, imageOutput)
 			}
@@ -480,6 +489,14 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				}
 			}
 			if normalizedData, normalized := normalizeResponsesStreamingTerminalOutput(dataBytes, streamOutputAccumulator, streamImageOutputs); normalized {
+				dataBytes = normalizedData
+				data = string(normalizedData)
+				line = "data: " + data
+				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+			}
+			// Fill missing message id/status and output_text annotations/logprobs
+			// so strict clients (Grok/Codex) can deserialize response.completed.
+			if normalizedData, normalized := strictClientWireNormalizer.Normalize(dataBytes); normalized {
 				dataBytes = normalizedData
 				data = string(normalizedData)
 				line = "data: " + data
@@ -1153,6 +1170,9 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	if originalModel != mappedModel {
 		body = s.replaceModelInResponseBody(body, mappedModel, originalModel)
 	}
+	if normalized, ok := apicompat.NormalizeResponsesStrictClientWireJSON(body); ok {
+		body = normalized
+	}
 	body, err = restoreGrokResponsesClientToolPayload(c, body)
 	if err != nil {
 		return nil, fmt.Errorf("restore Grok Responses client tool response: %w", err)
@@ -1224,6 +1244,9 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			}
 		}
 		finalResponse = supplementCompactionItemFromSSE(c, finalResponse, bodyText)
+		if normalized, ok := apicompat.NormalizeResponsesStrictClientWireJSON(finalResponse); ok {
+			finalResponse = normalized
+		}
 		body = finalResponse
 		if originalModel != mappedModel {
 			body = s.replaceModelInResponseBody(body, mappedModel, originalModel)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2049,6 +2049,8 @@ func TestOpenAIStreamingNormalizesTerminalOutputFromDeltas(t *testing.T) {
 		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
 			`data: {"type":"response.created","response":{"id":"resp_sdk_parse"}}`,
 			"",
+			`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}`,
+			"",
 			`data: {"type":"response.output_text.delta","delta":"pon"}`,
 			"",
 			`data: {"type":"response.output_text.delta","delta":"g"}`,
@@ -2070,6 +2072,15 @@ func TestOpenAIStreamingNormalizesTerminalOutputFromDeltas(t *testing.T) {
 	require.True(t, output.IsArray())
 	require.Len(t, output.Array(), 1)
 	require.Equal(t, "pong", gjson.GetBytes(terminalPayload, "response.output.0.content.0.text").String())
+	messageID := gjson.GetBytes(terminalPayload, "response.output.0.id").String()
+	require.True(t, strings.HasPrefix(messageID, "msg_"))
+	require.Equal(t, "completed", gjson.GetBytes(terminalPayload, "response.output.0.status").String())
+	require.True(t, gjson.GetBytes(terminalPayload, "response.output.0.content.0.annotations").IsArray())
+	require.True(t, gjson.GetBytes(terminalPayload, "response.output.0.content.0.logprobs").IsArray())
+
+	events := collectSSEDataPayloads(t, rec.Body.String())
+	added := findSSEEvent(t, events, "response.output_item.added", "")
+	require.Equal(t, messageID, gjson.Get(added, "item.id").String())
 }
 
 func TestOpenAIStreamingNormalizesTerminalOutputToEmptyArray(t *testing.T) {


### PR DESCRIPTION
Supersedes #5269. This PR is resubmitted with the commit identity linked to the GitHub account for CLA verification.

## Summary

- Normalize Responses API message and output_text fields required by strict clients.
- Keep message IDs stable across output_item.added, output_item.done, and response.completed.
- Apply the same compatibility normalization to converted and passthrough streaming/non-streaming responses while preserving unknown output item fields.

## Root Cause

Some response.completed payloads serialized output_text parts without annotations or logprobs, and message items without a stable id/status. The passthrough path also bypassed the compatibility serializer. Strict clients such as Grok deserialize these fields as required and failed with missing field annotations.

## Tests

- go test ./internal/pkg/apicompat -count=1
- go test ./internal/service -count=1
- git diff --check