### PR TITLE
fix(apicompat): preserve Codex encrypted reasoning in Anthropic round trips

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -197,6 +197,27 @@ func TestAnthropicToResponses_ThinkingSignatureBecomesReasoning(t *testing.T) {
 	assert.Equal(t, "function_call", items[3].Type)
 }
 
+func TestAnthropicToResponses_CodexThinkingSignatureBecomesReasoning(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.6-sol",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"Hello"`)},
+			{Role: "assistant", Content: json.RawMessage(`[{"type":"thinking","thinking":"plan","signature":"gAAAAAB-codex-encrypted-reasoning"},{"type":"text","text":"Hi!"}]`)},
+			{Role: "user", Content: json.RawMessage(`"Continue"`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 4)
+	assert.Equal(t, "reasoning", items[1].Type)
+	assert.Equal(t, "gAAAAAB-codex-encrypted-reasoning", items[1].EncryptedContent)
+}
+
 func TestAnthropicToResponses_MaxTokensFloor(t *testing.T) {
 	req := &AnthropicRequest{
 		Model:     "gpt-5.2",

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -287,9 +287,10 @@ func anthropicAssistantToResponses(raw json.RawMessage) ([]ResponsesInputItem, e
 			continue
 		}
 		sig := strings.TrimSpace(b.Signature)
-		// Only replay provider ciphertext. Skip GPT/Codex-style gAAAA blobs and
-		// empty placeholders — xAI returns 400 on decrypt for foreign signatures.
-		if sig == "" || strings.HasPrefix(sig, "gAAAA") {
+		// The signature is provider-owned encrypted reasoning. The generic
+		// converter cannot infer its provider from the ciphertext prefix, so
+		// preserve it and let provider-specific retry paths handle decrypt errors.
+		if sig == "" {
 			continue
 		}
 		items = append(items, ResponsesInputItem{

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -999,7 +999,7 @@ func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
 	require.Empty(t, upstream.requests[0].Header.Get("x-codex-turn-state"))
 	requireOpenAIMessagesCodexIdentity(t, upstream.requests[0], codexCLIUserAgent, "codex_cli_rs")
 
-	secondBody := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}],"stream":false}`)
+	secondBody := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"thinking","thinking":"use a tool","signature":"gAAAAAB-codex-encrypted-reasoning"},{"type":"tool_use","id":"toolu_roundtrip","name":"Bash","input":{"command":"pwd"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_roundtrip","content":"/workspace"}]}],"tools":[{"name":"Bash","description":"run shell","input_schema":{"type":"object","properties":{"command":{"type":"string"}}}}],"stream":false}`)
 	secondRec := httptest.NewRecorder()
 	secondCtx, _ := gin.CreateTestContext(secondRec)
 	secondCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(secondBody))
@@ -1014,6 +1014,9 @@ func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
 	requireOpenAIMessagesCodexIdentity(t, upstream.requests[1], codexCLIUserAgent, "codex_cli_rs")
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+	require.Equal(t, "gAAAAAB-codex-encrypted-reasoning", gjson.GetBytes(upstream.bodies[1], `input.#(type=="reasoning").encrypted_content`).String())
+	require.Equal(t, "toolu_roundtrip", gjson.GetBytes(upstream.bodies[1], `input.#(type=="function_call").call_id`).String())
+	require.Equal(t, "toolu_roundtrip", gjson.GetBytes(upstream.bodies[1], `input.#(type=="function_call_output").call_id`).String())
 }
 
 func TestForwardAsAnthropic_OAuthRestoresCodexIdentityHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preserve every non-empty Anthropic thinking signature when converting Messages history to Responses reasoning encrypted content.
- Leave invalid ciphertext recovery to the existing provider-specific Grok strip-and-retry path.
- Add direct conversion and OAuth multi-turn regression coverage, including tool call/result pairing and the absence of previous_response_id.

## Root cause

PR #4591 added a gAAAA prefix filter while improving Grok prompt-cache round trips. The filter lives in the provider-agnostic Anthropic-to-Responses converter, but Codex encrypted reasoning uses the same gAAAA prefix. As a result, Claude Code could receive Codex thinking plus its signature, then have that signature silently removed when it replayed history on the next turn.

The Codex OAuth Messages path uses store=false and manual history replay rather than previous_response_id. Removing reasoning.encrypted_content therefore loses the supported carrier for prior reasoning state.

## Related PRs

- #4986 retries after OpenAI rejects foreign encrypted reasoning, but gAAAA payloads are currently removed before its first upstream attempt.
- #5166 improves Kimi signature round trips but explicitly retains the gAAAA filter, so it does not cover Codex ciphertext.

## Validation

- go test ./internal/pkg/apicompat -count=1
- go test ./internal/service -run TestForwardAsAnthropic_ReusesOAuthCodexTurnState\|TestForwardGrokResponsesRetriesInvalidEncryptedContentOnce -count=1
- git diff --check

No live subscription request was made; the OAuth test exercises ForwardAsAnthropic through a recorded Responses upstream request.