### PR TITLE
feat(frontend): filter API key groups by platform

### DIFF
--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -73,6 +73,8 @@
             />
           </div>
 
+          <slot name="after-search" :search-query="searchQuery" />
+
           <!-- Options list -->
           <div class="select-options" ref="optionsListRef">
             <div
@@ -154,6 +156,7 @@ interface Props {
   id?: string
   ariaLabel?: string
   ariaDescribedby?: string
+  filterOption?: (option: SelectOption | Record<string, unknown>) => boolean
 }
 
 interface Emits {
@@ -276,6 +279,10 @@ const hasValue = computed(
 
 const filteredOptions = computed(() => {
   let opts = props.options as any[]
+  const filterOption = props.filterOption
+  if (filterOption) {
+    opts = opts.filter(filterOption)
+  }
   if (isSearchable.value && searchQuery.value) {
     const query = searchQuery.value.toLowerCase()
     opts = opts.filter((opt) => {

--- a/frontend/src/components/common/__tests__/Select.spec.ts
+++ b/frontend/src/components/common/__tests__/Select.spec.ts
@@ -113,3 +113,44 @@ describe('Select dropdown viewport constraints', () => {
     expect(dropdown?.style.maxWidth).toBe('0px')
   })
 })
+
+describe('Select custom option filtering', () => {
+  it('combines a custom filter with search without losing the selected label', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        modelValue: 'claude',
+        searchable: true,
+        options: [
+          { value: 'gpt', label: 'GPT Standard', platform: 'openai' },
+          { value: 'gpt-mini', label: 'GPT Mini', platform: 'openai' },
+          { value: 'claude', label: 'Claude Standard', platform: 'anthropic' },
+        ],
+        filterOption: (option) => option.platform === 'openai',
+      },
+      slots: {
+        'after-search': '<div data-test="filter-header">Platform filters</div>',
+      },
+    })
+    unmountWrapper = () => wrapper.unmount()
+
+    expect(wrapper.get('.select-value').text()).toBe('Claude Standard')
+
+    await wrapper.get('button').trigger('click')
+    await nextTick()
+
+    expect(document.body.querySelector('[data-test="filter-header"]')?.textContent).toBe(
+      'Platform filters'
+    )
+
+    const searchInput = document.body.querySelector<HTMLInputElement>('.select-search-input')
+    expect(searchInput).not.toBeNull()
+    searchInput!.value = 'mini'
+    searchInput!.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    const labels = Array.from(document.body.querySelectorAll('.select-option-label')).map(
+      (element) => element.textContent
+    )
+    expect(labels).toEqual(['GPT Mini'])
+  })
+})

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -92,6 +92,8 @@ export default {
     noGroup: 'No group',
     searchGroup: 'Search groups...',
     noGroupFound: 'No groups found',
+    allPlatforms: 'All',
+    filterGroupsByPlatform: 'Filter groups by platform',
     created: 'Created',
     copyToClipboard: 'Copy to clipboard',
     copied: 'Copied!',

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -92,6 +92,8 @@ export default {
     noGroup: '无分组',
     searchGroup: '搜索分组...',
     noGroupFound: '未找到匹配的分组',
+    allPlatforms: '全部',
+    filterGroupsByPlatform: '按平台筛选分组',
     created: '创建时间',
     copyToClipboard: '复制到剪贴板',
     copied: '已复制！',

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -472,8 +472,41 @@
             :placeholder="t('keys.selectGroup')"
             :searchable="true"
             :search-placeholder="t('keys.searchGroup')"
+            :filter-option="filterGroupOptionByPlatform"
             data-tour="key-form-group"
           >
+            <template #after-search>
+              <div
+                v-if="groupPlatformFilters.length > 2"
+                class="border-b border-gray-100 px-2 py-2 dark:border-dark-700"
+                role="group"
+                :aria-label="t('keys.filterGroupsByPlatform')"
+              >
+                <div class="flex max-w-full gap-1.5 overflow-x-auto">
+                  <button
+                    v-for="platform in groupPlatformFilters"
+                    :key="platform"
+                    type="button"
+                    :data-test="`group-platform-filter-${platform}`"
+                    :aria-pressed="groupPlatformFilter === platform"
+                    :class="[
+                      'inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                      groupPlatformFilter === platform
+                        ? 'border-primary-200 bg-primary-50 text-primary-700 dark:border-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                        : 'border-transparent bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-dark-700 dark:text-gray-300 dark:hover:bg-dark-600'
+                    ]"
+                    @click.stop="groupPlatformFilter = platform"
+                  >
+                    <PlatformIcon
+                      v-if="platform !== 'all'"
+                      :platform="platform"
+                      size="xs"
+                    />
+                    {{ platform === 'all' ? t('keys.allPlatforms') : platformLabel(platform) }}
+                  </button>
+                </div>
+              </div>
+            </template>
             <template #selected="{ option }">
               <GroupBadge
                 v-if="option"
@@ -1140,11 +1173,13 @@ import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 	import EndpointPopover from '@/components/keys/EndpointPopover.vue'
 	import GroupBadge from '@/components/common/GroupBadge.vue'
 	import GroupOptionItem from '@/components/common/GroupOptionItem.vue'
+	import PlatformIcon from '@/components/common/PlatformIcon.vue'
 	import type { ApiKey, Group, PublicSettings, SubscriptionType, GroupPlatform, UpdateApiKeyRequest } from '@/types'
 import type { Column } from '@/components/common/types'
 import type { BatchApiKeyUsageStats } from '@/api/usage'
 import { formatDateTime } from '@/utils/format'
 import { maskApiKey } from '@/utils/maskApiKey'
+import { platformLabel } from '@/utils/platformColors'
 import {
   buildCcSwitchImportDeeplink,
   type CcSwitchClientType
@@ -1170,6 +1205,17 @@ interface GroupOption {
   subscriptionType: SubscriptionType
   platform: GroupPlatform
 }
+
+type GroupPlatformFilter = GroupPlatform | 'all'
+
+const GROUP_PLATFORM_ORDER: GroupPlatform[] = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'grok',
+  'antigravity',
+  'composite'
+]
 
 const appStore = useAppStore()
 const onboardingStore = useOnboardingStore()
@@ -1423,6 +1469,18 @@ const groupOptions = computed(() =>
     platform: group.platform
   }))
 )
+
+const groupPlatformFilter = ref<GroupPlatformFilter>('all')
+const groupPlatformFilters = computed<GroupPlatformFilter[]>(() => {
+  const availablePlatforms = new Set(groupOptions.value.map((option) => option.platform))
+  return [
+    'all',
+    ...GROUP_PLATFORM_ORDER.filter((platform) => availablePlatforms.has(platform))
+  ]
+})
+
+const filterGroupOptionByPlatform = (option: Record<string, unknown>) =>
+  groupPlatformFilter.value === 'all' || option.platform === groupPlatformFilter.value
 
 // Group dropdown search
 const groupSearchQuery = ref('')
@@ -1787,6 +1845,7 @@ const closeModals = () => {
   showCreateModal.value = false
   showEditModal.value = false
   selectedKey.value = null
+  groupPlatformFilter.value = 'all'
   formData.value = {
     name: '',
     group_id: null,

--- a/frontend/src/views/user/__tests__/KeysView.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.spec.ts
@@ -36,9 +36,11 @@ const messages: Record<string, string> = {
   'common.status': 'Status',
   'keys.apiKey': 'API Key',
   'keys.allGroups': 'All Groups',
+  'keys.allPlatforms': 'All',
   'keys.allStatus': 'All Status',
   'keys.columnSettings': 'Column Settings',
   'keys.createKey': 'Create API Key',
+  'keys.filterGroupsByPlatform': 'Filter groups by platform',
   'keys.created': 'Created',
   'keys.expiresAt': 'Expires',
   'keys.group': 'Group',
@@ -185,11 +187,30 @@ const DataTableStub = {
   `,
 }
 
+const BaseDialogStub = {
+  props: ['show'],
+  template: '<div v-if="show"><slot /><slot name="footer" /></div>',
+}
+
 const SelectStub = {
   name: 'Select',
-  props: ['modelValue', 'options'],
+  props: ['modelValue', 'options', 'filterOption'],
   emits: ['update:modelValue'],
-  template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"></select>',
+  template: `
+    <div>
+      <select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)">
+        <option
+          v-for="option in options.filter((item) => !filterOption || filterOption(item))"
+          :key="option.value"
+          :value="option.value"
+          data-test="select-option"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+      <slot name="after-search" />
+    </div>
+  `,
 }
 
 const SearchInputStub = {
@@ -223,7 +244,7 @@ const mountView = async () => {
         TablePageLayout: TablePageLayoutStub,
         DataTable: DataTableStub,
         Pagination: PaginationStub,
-        BaseDialog: true,
+        BaseDialog: BaseDialogStub,
         ConfirmDialog: true,
         EmptyState: true,
         Select: SelectStub,
@@ -256,7 +277,7 @@ const getButtonByText = (wrapper: VueWrapper, text: string) => {
   return button
 }
 
-describe('user KeysView column settings', () => {
+describe('user KeysView', () => {
   beforeEach(() => {
     localStorage.clear()
 
@@ -437,5 +458,60 @@ describe('user KeysView column settings', () => {
       },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     )
+  })
+
+  it('filters create-key group options by the platforms present in available groups', async () => {
+    getAvailableGroups.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'OpenAI Standard',
+        description: null,
+        platform: 'openai',
+        subscription_type: 'standard',
+        rate_multiplier: 1,
+        peak_rate_enabled: false,
+        peak_start: '',
+        peak_end: '',
+        peak_rate_multiplier: 1,
+      },
+      {
+        id: 20,
+        name: 'Claude Standard',
+        description: null,
+        platform: 'anthropic',
+        subscription_type: 'standard',
+        rate_multiplier: 1,
+        peak_rate_enabled: false,
+        peak_start: '',
+        peak_end: '',
+        peak_rate_multiplier: 1,
+      },
+    ])
+
+    const wrapper = await mountView()
+    await getButtonByText(wrapper, 'Create API Key').trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('[data-test="group-platform-filter-openai"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="group-platform-filter-anthropic"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="group-platform-filter-gemini"]').exists()).toBe(false)
+
+    const groupSelect = wrapper
+      .findAllComponents({ name: 'Select' })
+      .find((select) => select.attributes('data-tour') === 'key-form-group')
+    expect(groupSelect).toBeDefined()
+
+    const optionLabels = () =>
+      groupSelect!.findAll('[data-test="select-option"]').map((option) => option.text())
+
+    expect(optionLabels()).toEqual(['OpenAI Standard', 'Claude Standard'])
+
+    await wrapper.get('[data-test="group-platform-filter-openai"]').trigger('click')
+    await nextTick()
+    expect(optionLabels()).toEqual(['OpenAI Standard'])
+
+    await wrapper.get('[data-test="group-platform-filter-all"]').trigger('click')
+    await nextTick()
+    expect(optionLabels()).toEqual(['OpenAI Standard', 'Claude Standard'])
   })
 })


### PR DESCRIPTION
## Summary

- add an optional custom filter and an after-search slot to the shared Select component
- add platform chips to the API key create/edit group picker
- only show platforms present in the available groups and combine platform filtering with text search
- keep the selected group intact when switching filters and allow horizontal scrolling on narrow screens

No backend or database changes are required.

Closes #5278

## Tests

- `make test-frontend`
- `pnpm vitest run src/components/common/__tests__/Select.spec.ts src/views/user/__tests__/KeysView.spec.ts`
- `pnpm build`
- local browser preview on desktop and a 390px-wide viewport
