### PR TITLE
[codex] suppress unchanged prompt config reload logs

### DIFF
--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -134,14 +134,27 @@ func (m *ConfigManager) Reload(ctx context.Context) error {
 	}
 	now := m.clock.Now()
 	previous := m.snapshot.Load()
+	recovered := m.hasLoadError()
 	m.snapshot.Store(&activeConfigSnapshot{storage: cloneStorageConfig(storage), active: cloneActiveConfig(active), loadedAt: now})
 	m.configUntrusted.Store(false)
 	m.clearLoadError()
 	m.logInvalidTokenEndpoints(previous, active)
-	LogInfo(EventConfigLoaded, map[string]any{
-		"config_version": storage.ConfigVersion, "status": "loaded",
-	})
+	if shouldLogConfigLoaded(previous, active, recovered) {
+		LogInfo(EventConfigLoaded, map[string]any{
+			"config_version": storage.ConfigVersion, "status": "loaded",
+		})
+	}
 	return nil
+}
+
+// shouldLogConfigLoaded keeps successful reloads observable without emitting
+// an INFO entry for every unchanged five-second fallback refresh. A recovery
+// is logged even when the active configuration itself did not change.
+func shouldLogConfigLoaded(previous *activeConfigSnapshot, active ActiveConfig, recovered bool) bool {
+	return previous == nil ||
+		recovered ||
+		previous.active.ConfigVersion != active.ConfigVersion ||
+		previous.active.RiskControlEnabled != active.RiskControlEnabled
 }
 
 // logInvalidTokenEndpoints warns once per change (not on every 5s refresh)
@@ -488,6 +501,15 @@ func (m *ConfigManager) recordLoadError(_ error) {
 	m.lastLoadError = stableErrorMessage("config_load_failed")
 	m.lastErrorAt = &now
 	m.stateMu.Unlock()
+}
+
+func (m *ConfigManager) hasLoadError() bool {
+	if m == nil {
+		return false
+	}
+	m.stateMu.RLock()
+	defer m.stateMu.RUnlock()
+	return m.lastLoadError != ""
 }
 
 func (m *ConfigManager) clearLoadError() {

--- a/backend/internal/securityaudit/prompt_logging_test.go
+++ b/backend/internal/securityaudit/prompt_logging_test.go
@@ -2,7 +2,9 @@ package securityaudit
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -63,4 +65,42 @@ func TestPromptGuardFailureLogUsesCompleteAllowlistedContextAndNoSideEffects(t *
 	require.Equal(t, false, entry["upstream_dispatched"])
 	require.Equal(t, false, entry["billing_preconsumed"])
 	require.EqualValues(t, 25, entry["latency_ms"])
+}
+
+func TestConfigManagerReloadLogsOnlyMaterialChangesAndRecovery(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	values := map[string]string{
+		SettingKeyPromptAuditConfig: "",
+		SettingKeyRiskControl:       "false",
+	}
+	repository := &switchableSettingRepository{staticSettingRepository: staticSettingRepository{values: values}}
+	manager := NewConfigManager(nil, repository, nil, prefixEncryptor{}, testTotpKeyConfig())
+
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 1, bytes.Count(output.Bytes(), []byte(EventConfigLoaded)), "initial load must be observable")
+
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 1, bytes.Count(output.Bytes(), []byte(EventConfigLoaded)), "unchanged fallback refresh must stay silent")
+
+	values[SettingKeyRiskControl] = "true"
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 2, bytes.Count(output.Bytes(), []byte(EventConfigLoaded)), "global risk-control changes must be observable")
+
+	storage := DefaultStorageConfig()
+	storage.ConfigVersion = 2
+	raw, err := json.Marshal(storage)
+	require.NoError(t, err)
+	values[SettingKeyPromptAuditConfig] = string(raw)
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 3, bytes.Count(output.Bytes(), []byte(EventConfigLoaded)), "config version changes must be observable")
+
+	repository.loadErr = errors.New("settings temporarily unavailable")
+	require.Error(t, manager.Reload(context.Background()))
+	repository.loadErr = nil
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 4, bytes.Count(output.Bytes(), []byte(EventConfigLoaded)), "recovery from a load error must be observable")
 }


### PR DESCRIPTION
## Summary

- keep the five-second fallback configuration refresh unchanged
- emit `prompt_guard.config_loaded` only for the initial load, config-version changes, global risk-control changes, or recovery from a load error
- add regression coverage for unchanged refreshes and each observable transition

## Root cause

`ConfigManager.refreshLoop` calls `Reload` every five seconds as a bounded fallback when Redis invalidation is unavailable or missed. `Reload` emitted `prompt_guard.config_loaded` after every successful call, even when the active configuration had not changed.

A production instance emitted 131,208 identical INFO entries in about 7.6 days. They accounted for roughly 66% of the application log.

## Impact

Unchanged fallback refreshes now stay silent while meaningful configuration activation and recovery events remain observable. Runtime refresh, fail-closed behavior, Redis invalidation, and snapshot semantics are unchanged.

## Validation

- `gofmt` on changed Go files
- `git diff --check`
- targeted unit coverage added; CI is expected to run the repository test suite