### PR TITLE
fix(ccswitch): default OpenAI imports to GPT-5.6 Terra

### DIFF
--- a/frontend/src/utils/__tests__/ccswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/ccswitchImport.spec.ts
@@ -13,7 +13,7 @@ function paramsFromDeeplink(deeplink: string): URLSearchParams {
 
 describe('ccswitchImport utils', () => {
   it('defaults OpenAI CC Switch imports to the current Codex model', () => {
-    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.5')
+    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.6-terra')
   })
 
   it('defaults Grok Build imports to the current Grok model', () => {

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,6 +1,6 @@
 import type { GroupPlatform } from '@/types'
 
-export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
+export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.6-terra'
 export const GROK_CC_SWITCH_MODEL = 'grok-4.5'
 
 export type CcSwitchClientType = 'claude' | 'gemini'


### PR DESCRIPTION
## Summary

- update OpenAI/Codex CC Switch imports from GPT-5.5 to GPT-5.6 Terra
- keep Anthropic, Gemini, Antigravity, and Grok import behavior unchanged
- keep the default pinned by the existing CC Switch import test

Terra is the balanced GPT-5.6 variant, so an imported provider is immediately usable with a general-purpose model without adding a model-selection step.

Fixes #5238

## Risk

Narrow frontend-only default-value change. No API, schema, backend scheduling, or UI changes.

## Validation

- `pnpm --dir frontend exec vitest run src/utils/__tests__/ccswitchImport.spec.ts` (10/10)
- `pnpm --dir frontend lint:check`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`

The full frontend suite was also checked against the same base: 206/207 files and 1457/1459 tests passed. The two failures are existing rollback API assertions, and the run also reports existing GroupsView mock rejections; neither affected source or tests in this change.