### PR TITLE
feat(frontend): 在 simple 模式显示用户管理菜单

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -754,7 +754,7 @@ const adminNavItems = computed((): NavItem[] => {
   const baseItems: NavItem[] = [
     { path: '/admin/dashboard', label: t('nav.dashboard'), icon: DashboardIcon },
     { path: '/admin/ops', label: t('nav.ops'), icon: ChartIcon, featureFlag: flagOpsMonitoring },
-    { path: '/admin/users', label: t('nav.users'), icon: UsersIcon, hideInSimpleMode: true },
+    { path: '/admin/users', label: t('nav.users'), icon: UsersIcon },
     { path: '/admin/groups', label: t('nav.groups'), icon: FolderIcon, hideInSimpleMode: true },
     {
       path: '/admin/channels',

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -42,6 +42,15 @@ describe('AppSidebar scroll position persistence', () => {
   })
 })
 
+describe('AppSidebar simple mode navigation', () => {
+  it('keeps admin user management visible', () => {
+    const userManagementItem = componentSource.match(/\{ path: '\/admin\/users'[^}]*\}/)?.[0]
+
+    expect(userManagementItem).toBeDefined()
+    expect(userManagementItem).not.toContain('hideInSimpleMode')
+  })
+})
+
 describe('AppSidebar header styles', () => {
   it('does not clip the version badge dropdown', () => {
     const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n {2}\}/)


### PR DESCRIPTION
## 变更内容

- 在 `RUN_MODE=simple` 下显示管理员侧边栏中的“用户管理”菜单。
- 添加回归测试，确保该菜单不会再被 simple 模式过滤。

## 背景

当前用户管理功能已经可以通过前端路由 `/admin/users` 直接访问，但 simple 模式会隐藏对应的侧边栏菜单入口。

在小团队内部使用场景下，即使采用 simple 模式跳过 SaaS 计费流程，管理员仍需要用户管理功能来维护团队成员，因此需要提供可发现的菜单入口。

## 影响

本次只开放现有菜单入口，不改变管理员权限模型、用户管理路由、后端接口或其他 simple 模式限制。

## 验证

- `corepack pnpm@9.15.9 exec vitest run src/components/layout/__tests__/AppSidebar.spec.ts`
- `corepack pnpm@9.15.9 run lint:check`
- `corepack pnpm@9.15.9 run typecheck`
