### PR TITLE
fix: emit response.failed when compact keepalive commits headers but no SSE payload

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2696,7 +2696,11 @@ func (h *OpenAIGatewayHandler) ensureForwardErrorResponse(c *gin.Context, stream
 		imageKeepalivePaddingOnly = adjustedSize < 0
 		imageKeepaliveResponseWritten = adjustedSize >= 0
 	}
-	if service.IsResponseCommitted(c) || (!compactKeepaliveCommitted && imageKeepaliveResponseWritten) {
+	compactKeepaliveHasMeaningfulOutput := compactKeepaliveCommitted && service.OpenAICompactKeepaliveAdjustedWrittenSize(c) > 0
+	// Compact keepalive may have committed 200 headers without writing a
+	// semantic SSE event. In that case the Responses stream still needs its
+	// protocol-correct terminal response.failed event.
+	if (service.IsResponseCommitted(c) && (!compactKeepaliveCommitted || compactKeepaliveHasMeaningfulOutput)) || (!compactKeepaliveCommitted && imageKeepaliveResponseWritten) {
 		return false
 	}
 	if c.Writer.Written() && !imageKeepalivePaddingOnly {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -334,6 +334,26 @@ func TestOpenAIEnsureForwardErrorResponse_AfterDeltaAppendsSingleValidResponseFa
 	require.Equal(t, 1, errorEvents)
 }
 
+func TestOpenAIEnsureForwardErrorResponse_CompactKeepaliveOnlyWritesResponseFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, EndpointResponses, nil)
+	service.MarkOpenAICompactClientStream(c)
+
+	stop := service.StartOpenAICompactSSEKeepalive(c, 5*time.Millisecond)
+	defer stop()
+	before := service.OpenAICompactKeepaliveAdjustedWrittenSize(c)
+	require.Eventually(t, c.Writer.Written, time.Second, time.Millisecond)
+	require.Equal(t, before, service.OpenAICompactKeepaliveAdjustedWrittenSize(c))
+
+	h := &OpenAIGatewayHandler{}
+	require.True(t, h.ensureForwardErrorResponse(c, false))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "event: response.failed\n")
+	require.NotContains(t, w.Body.String(), "event: error\n")
+}
+
 func TestOpenAIEnsureForwardErrorResponse_ImageJSONKeepaliveWritesSingleJSONFallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## 背景

当 OpenAI Responses 流式请求（`stream: true`）在 compact keepalive 已提交 HTTP 200 headers 但尚未写入任何语义 SSE 事件时，如果上游立即返回 4xx 错误，`ensureForwardErrorResponse` 会因 `IsResponseCommitted(c)` 为 true 而直接返回 false，导致错误被静默吞掉。客户端持有 200 + 空 SSE 流，一直等待直到超时。

Fixes #5289

## 根因

`ensureForwardErrorResponse` 在 line 2699 的判断条件过于宽泛：

```go
if service.IsResponseCommitted(c) || (!compactKeepaliveCommitted && imageKeepaliveResponseWritten) {
    return false
}
```

Compact keepalive 可能仅为心跳目的提交 headers（`MarkResponseCommitted` 被设置），但实际 SSE payload 字节数为 0。此时上游 4xx 错误仍应通过 `response.failed` 事件传达给客户端。

## 改动

区分"headers 已提交"和"有意义的 SSE 输出已写入"：

- 新增 `compactKeepaliveHasMeaningfulOutput` 判断：仅当 compact keepalive 已提交 **且** `OpenAICompactKeepaliveAdjustedWrittenSize(c) > 0` 时，才认为已有语义输出
- 修改条件：当 `IsResponseCommitted(c)` 为 true 时，只有在 compact keepalive 未提交 **或** 已有语义输出时才返回 false
- 保留 image keepalive 语义不变

## 测试

- 新增 `TestOpenAIEnsureForwardErrorResponse_CompactKeepaliveOnlyWritesResponseFailed`：验证 compact keepalive 提交 headers 后仍能写出协议正确的 `response.failed` 事件
- 所有现有 `ensureForwardErrorResponse` 测试通过
- `go vet` 和 `gofmt` 检查通过

## 验证

- `go test ./internal/handler -run TestOpenAIEnsureForwardErrorResponse` 全部通过
- `go test ./internal/handler` 全部通过
- 静态安全扫描：无硬编码密钥、shell 注入、eval/exec、SQL 注入