### PR TITLE
fix(ws): allow Codex prewarm continuation

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_ingress_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_test.go
@@ -551,12 +551,21 @@ func TestNormalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(t *testing.T)
 	t.Parallel()
 
 	normalized, err := normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(
-		[]byte(`{"model":"gpt-5.1","input":[1],"previous_response_id":"resp_x","metadata":{"b":2,"a":1}}`),
+		[]byte(`{"model":"gpt-5.1","input":[1],"previous_response_id":"resp_x","client_metadata":{"request_start_ms":"1"},"stream_options":{"include_usage":true},"generate":false,"metadata":{"b":2,"a":1}}`),
 	)
 	require.NoError(t, err)
 	require.False(t, gjson.GetBytes(normalized, "input").Exists())
 	require.False(t, gjson.GetBytes(normalized, "previous_response_id").Exists())
+	require.False(t, gjson.GetBytes(normalized, "client_metadata").Exists())
+	require.False(t, gjson.GetBytes(normalized, "stream_options").Exists())
+	require.False(t, gjson.GetBytes(normalized, "generate").Exists())
 	require.Equal(t, float64(1), gjson.GetBytes(normalized, "metadata.a").Float())
+
+	normalized, err = normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(
+		[]byte(`{"model":"gpt-5.1","generate":true}`),
+	)
+	require.NoError(t, err)
+	require.True(t, gjson.GetBytes(normalized, "generate").Bool())
 
 	_, err = normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(nil)
 	require.Error(t, err)
@@ -657,6 +666,36 @@ func TestShouldKeepIngressPreviousResponseID(t *testing.T) {
 
 	t.Run("strict_incremental_keep", func(t *testing.T) {
 		keep, reason, err := shouldKeepIngressPreviousResponseID(previousPayload, currentStrictPayload, "resp_turn_1", false)
+		require.NoError(t, err)
+		require.True(t, keep)
+		require.Equal(t, "strict_incremental_ok", reason)
+	})
+
+	t.Run("codex_prewarm_to_business_keep", func(t *testing.T) {
+		prewarmPayload := []byte(`{
+			"type":"response.create",
+			"model":"gpt-5.1",
+			"store":false,
+			"generate":false,
+			"client_metadata":{"x-codex-ws-stream-request-start-ms":"100"},
+			"stream_options":{"include_usage":true},
+			"input":[{"type":"input_text","text":"hello"}]
+		}`)
+		businessPayload := []byte(`{
+			"type":"response.create",
+			"model":"gpt-5.1",
+			"store":false,
+			"client_metadata":{"x-codex-ws-stream-request-start-ms":"200"},
+			"previous_response_id":"resp_prewarm",
+			"input":[{"type":"input_text","text":"hello"}]
+		}`)
+
+		keep, reason, err := shouldKeepIngressPreviousResponseID(
+			prewarmPayload,
+			businessPayload,
+			"resp_prewarm",
+			false,
+		)
 		require.NoError(t, err)
 		require.True(t, keep)
 		require.Equal(t, "strict_incremental_ok", reason)

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -449,6 +449,17 @@ func normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(payload []byte) (
 	}
 	delete(decoded, "input")
 	delete(decoded, "previous_response_id")
+	// Codex changes transport-only metadata for every response.create. These fields
+	// do not alter the context referenced by previous_response_id and are excluded
+	// from Codex's own websocket reuse comparison.
+	delete(decoded, "client_metadata")
+	delete(decoded, "stream_options")
+	// Official Codex prewarms a connection with generate=false, then omits the
+	// field on the business request that continues from the prewarm response.
+	// Only normalize false so a meaningful generate=true change remains visible.
+	if generate, ok := decoded["generate"].(bool); ok && !generate {
+		delete(decoded, "generate")
+	}
 	return json.Marshal(decoded)
 }
 


### PR DESCRIPTION
## Summary

- allow the official Codex WebSocket v2 prewarm (`generate=false`) response to anchor the following business request via `previous_response_id`
- exclude per-request `client_metadata` and transport-only `stream_options` from strict continuation comparison, matching Codex reuse semantics
- keep `generate=true` significant so unrelated semantic changes still fail strict comparison
- add regression coverage for the prewarm-to-business transition

## Problem

Codex first sends a prewarm `response.create` with `generate=false`, then sends the business request on the same WebSocket with the prewarm response ID. It also refreshes `client_metadata` for each request.

The ingress strict comparison currently removes only `input` and `previous_response_id`, so this valid transition is classified as `non_input_changed`. Sub2API then drops `previous_response_id` and replays the full input, defeating incremental continuation. This matches the scenario described in #1569.

## Safety

The normalization is intentionally narrow:

- `generate=false` is treated as the prewarm marker and normalized away
- `generate=true` remains in the comparison
- context-bearing fields such as model, instructions, tools, reasoning, and store remain strict

## Tests

- `go test ./internal/service -run 'TestNormalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID|TestShouldKeepIngressPreviousResponseID' -count=1`\n- `git diff --check`\n\nThe complete `go test ./internal/service -count=1` run reached one unrelated existing live-API comparison failure: `TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI`; the affected and new tests pass.