### PR TITLE
fix(ops): preserve custom range in error lists

### DIFF
--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -114,6 +114,8 @@
         <OpsErrorDetailsModal
           :show="showErrorDetails"
           :time-range="timeRange"
+          :custom-start-time="customStartTime"
+          :custom-end-time="customEndTime"
           :platform="platform"
           :group-id="groupId"
           :error-type="errorDetailsType"

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -5,10 +5,13 @@ import BaseDialog from '@/components/common/BaseDialog.vue'
 import Select from '@/components/common/Select.vue'
 import OpsErrorLogTable from './OpsErrorLogTable.vue'
 import { opsAPI, type OpsErrorLog } from '@/api/admin/ops'
+import { buildOpsErrorTimeParams } from '../utils/opsErrorParams'
 
 interface Props {
   show: boolean
   timeRange: string
+  customStartTime?: string | null
+  customEndTime?: string | null
   platform?: string
   groupId?: number | null
   errorType: 'request' | 'upstream'
@@ -103,11 +106,11 @@ async function fetchErrorLogs() {
     const params: Record<string, any> = {
       page: page.value,
       page_size: pageSize.value,
-      time_range: props.timeRange,
       view: viewMode.value,
       sort_by: sortBy.value,
       sort_order: sortOrder.value
     }
+    Object.assign(params, buildOpsErrorTimeParams(props.timeRange, props.customStartTime, props.customEndTime))
 
     const platform = String(props.platform || '').trim()
     if (platform) params.platform = platform
@@ -160,7 +163,7 @@ watch(
 )
 
 watch(
-  () => [props.timeRange, props.platform, props.groupId] as const,
+  () => [props.timeRange, props.customStartTime, props.customEndTime, props.platform, props.groupId] as const,
   () => {
     if (!props.show) return
     page.value = 1

--- a/frontend/src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts
+++ b/frontend/src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { buildOpsErrorTimeParams } from '../opsErrorParams'
+
+describe('buildOpsErrorTimeParams', () => {
+  it('uses explicit timestamps for a complete custom range', () => {
+    expect(buildOpsErrorTimeParams('custom', '2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z')).toEqual({
+      start_time: '2026-08-01T00:00:00Z',
+      end_time: '2026-08-02T00:00:00Z'
+    })
+  })
+
+  it('preserves predefined ranges and falls back for incomplete custom ranges', () => {
+    expect(buildOpsErrorTimeParams('24h')).toEqual({ time_range: '24h' })
+    expect(buildOpsErrorTimeParams('custom', null, null)).toEqual({ time_range: '1h' })
+  })
+})

--- a/frontend/src/views/admin/ops/utils/opsErrorParams.ts
+++ b/frontend/src/views/admin/ops/utils/opsErrorParams.ts
@@ -1,0 +1,11 @@
+export function buildOpsErrorTimeParams(
+  timeRange: string,
+  customStartTime?: string | null,
+  customEndTime?: string | null
+): Record<string, string> {
+  if (timeRange === 'custom' && customStartTime && customEndTime) {
+    return { start_time: customStartTime, end_time: customEndTime }
+  }
+
+  return { time_range: timeRange === 'custom' ? '1h' : timeRange }
+}


### PR DESCRIPTION
## 问题
错误列表在自定义时间范围下无法持续保留所选范围。

## 根因
错误列表及详情弹窗分别处理时间范围参数，切换或刷新时自定义范围参数未被统一保留。

## 改动
统一错误列表时间范围参数的解析与传递，保留自定义起止时间，并补充对应单元测试。未发现重叠 PR。

## 测试
- `corepack pnpm@9 exec vitest run src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts` 通过（1 个文件 / 2 个测试）
- `corepack pnpm@9 exec vue-tsc --noEmit` 通过
- `corepack pnpm@9 exec eslint src/views/admin/ops/OpsDashboard.vue src/views/admin/ops/components/OpsErrorDetailsModal.vue src/views/admin/ops/utils/opsErrorParams.ts src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts` 通过
- `git diff --check` 通过

Fixes #5312