### PR TITLE
fix(grok): bind video owners for task_id receipts

### DIFF
--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -816,7 +816,7 @@ func extractGrokMediaVideoRequestID(body []byte) string {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return ""
 	}
-	for _, path := range []string{"request_id", "id", "data.request_id", "data.id", "video.request_id", "video.id"} {
+	for _, path := range []string{"request_id", "id", "data.request_id", "data.id", "video.request_id", "video.id", "task_id", "data.task_id", "video.task_id"} {
 		if id := strings.TrimSpace(gjson.GetBytes(body, path).String()); id != "" {
 			return id
 		}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -1216,6 +1216,51 @@ func TestForwardGrokMediaVideoGenerationReturnsUsageAndResponseID(t *testing.T) 
 	require.Equal(t, 10, result.VideoDurationSeconds)
 }
 
+func TestForwardGrokMediaVideoGenerationReturnsTaskIDAsResponseID(t *testing.T) {
+	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"model":"grok-imagine-video","prompt":"waves"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/videos/generations", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	account := &Account{
+		ID:          63,
+		Name:        "grok",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "api-key",
+			"base_url": "https://xai.test/v1",
+		},
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"task_id":"video-task-123"}`)),
+	}}
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+
+	result, err := svc.ForwardGrokMedia(context.Background(), c, account, GrokMediaEndpointVideosGenerations, "", body, "application/json")
+	require.NoError(t, err)
+	require.Equal(t, "video-task-123", result.ResponseID)
+}
+
+func TestExtractGrokMediaVideoRequestIDPreservesExistingPrecedence(t *testing.T) {
+	body := []byte(`{
+		"request_id":"request-id",
+		"id":"id",
+		"task_id":"task-id",
+		"data":{"request_id":"data-request-id","id":"data-id","task_id":"data-task-id"},
+		"video":{"request_id":"video-request-id","id":"video-id","task_id":"video-task-id"}
+	}`)
+
+	require.Equal(t, "request-id", extractGrokMediaVideoRequestID(body))
+}
+
 func TestForwardGrokMediaVideoGenerationPreservesImageToVideoModel(t *testing.T) {
 	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## 问题
兼容的 Grok 视频提交回执可能使用 task_id，导致 ResponseID 为空并跳过现有的 owner binding。

## 根因
提取器仅检查 request_id 和 id 路径。

## 改动
在现有优先级之后增加 task_id、data.task_id 和 video.task_id 作为 fallback 路径，并添加回归测试。

## 测试
- go test -tags=unit ./internal/service -run "^(TestForwardGrokMediaVideoGenerationReturnsUsageAndResponseID|TestForwardGrokMediaVideoGenerationReturnsTaskIDAsResponseID|TestExtractGrokMediaVideoRequestIDPreservesExistingPrecedence)$" -count=1
- go vet -tags=unit ./internal/service
- git diff --check
- 完整 go test -tags=unit ./internal/service 存在一个无关的既有外部 OpenAI 对比测试失败：TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI

Fixes #5314.