### PR TITLE
fix(grok): enforce free rolling quota and bounded failover

### DIFF
--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -382,7 +382,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 					return
 				}
 				switchCount++
-				if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+				if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 					h.handleFailoverExhausted(c, failoverErr, false)
 					return
 				}

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -219,7 +219,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			return
 		}
 		switchCount++
-		if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+		if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 			h.handleFailoverExhausted(c, failoverErr, false)
 			return
 		}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -310,7 +310,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 						return
 					}
 					switchCount++
-					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -632,7 +632,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 						return
 					}
 					switchCount++
-					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}
@@ -1180,7 +1180,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 						return
 					}
 					switchCount++
-					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 						h.handleAnthropicFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}
@@ -1839,7 +1839,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			return false
 		}
 		switchCount++
-		if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+		if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 			closeOpenAIWSFailoverExhausted(wsConn, failoverErr)
 			return false
 		}

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -329,7 +329,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 						return
 					}
 					switchCount++
-					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState) {
+					if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount, &oauth429FailoverState, failoverErr.ResponseBody) {
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}

--- a/backend/internal/pkg/xai/quota.go
+++ b/backend/internal/pkg/xai/quota.go
@@ -7,10 +7,11 @@ import (
 	"time"
 )
 
-const GrokFreeRolling24hTokenLimit int64 = 1_000_000
+const GrokFreeRolling24hTokenLimit int64 = 500_000
 
 var grokFreeRolling24hTokenLimits = map[int64]struct{}{
 	GrokFreeRolling24hTokenLimit: {},
+	1_000_000:                    {}, // Legacy Free limit observed before August 2026.
 	2_000_000:                    {}, // Legacy Free limit observed before July 2026.
 }
 

--- a/backend/internal/pkg/xai/quota_test.go
+++ b/backend/internal/pkg/xai/quota_test.go
@@ -65,7 +65,9 @@ func TestObserveQuotaHeadersRecordsNoHeaderProbe(t *testing.T) {
 func TestIsGrokFreeRolling24hTokenLimit(t *testing.T) {
 	t.Parallel()
 
+	require.Equal(t, int64(500_000), GrokFreeRolling24hTokenLimit)
 	require.True(t, IsGrokFreeRolling24hTokenLimit(GrokFreeRolling24hTokenLimit))
+	require.True(t, IsGrokFreeRolling24hTokenLimit(1_000_000), "legacy snapshots remain classifiable")
 	require.True(t, IsGrokFreeRolling24hTokenLimit(2_000_000), "legacy snapshots remain classifiable")
 	require.False(t, IsGrokFreeRolling24hTokenLimit(3_000_000))
 }

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2170,6 +2170,37 @@ func (r *accountRepository) SetRateLimitedIfLater(ctx context.Context, id int64,
 	return nil
 }
 
+// SetRateLimitedIfInactive atomically starts a new account-level rate-limit
+// generation without extending one that is already active. Local rolling
+// quota checks can run concurrently with stale account snapshots, so repeated
+// checks must not keep moving the same cooldown boundary forward.
+func (r *accountRepository) SetRateLimitedIfInactive(ctx context.Context, id int64, resetAt time.Time) (bool, error) {
+	now := time.Now()
+	updated, err := r.client.Account.Update().
+		Where(
+			dbaccount.IDEQ(id),
+			dbaccount.Or(
+				dbaccount.RateLimitResetAtIsNil(),
+				dbaccount.RateLimitResetAtLTE(now),
+			),
+		).
+		SetRateLimitedAt(now).
+		SetRateLimitResetAt(resetAt).
+		Save(ctx)
+	if err != nil {
+		return false, err
+	}
+	if updated == 0 {
+		r.syncSchedulerAccountSnapshot(ctx, id)
+		return false, nil
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue activated rate limit failed: account=%d err=%v", id, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
+}
+
 // ClearRateLimitIfObserved clears exactly the Grok rate-limit generation seen
 // by a successful request. Matching both timestamps prevents a stale success
 // from erasing a later clear/re-arm generation with an equal or shorter reset.

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -788,8 +788,12 @@ func (s *AccountTestService) testGrokAccountConnection(c *gin.Context, account *
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	var responseBody []byte
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ = io.ReadAll(resp.Body)
+	}
 	now := time.Now()
-	snapshot := parseGrokQuotaSnapshot(resp.Header, resp.StatusCode, now)
+	snapshot := parseGrokQuotaSnapshotWithBody(resp.Header, resp.StatusCode, responseBody, now)
 	if snapshot != nil && s.accountRepo != nil {
 		resetAt, limited := grokRateLimitResetAtForAccount(account, snapshot, now)
 		if limited {
@@ -808,7 +812,6 @@ func (s *AccountTestService) testGrokAccountConnection(c *gin.Context, account *
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusPaymentRequired && s.accountRepo != nil {
 			stateCtx, cancel := openAIAccountStateContext(ctx)
 			defer cancel()
@@ -819,7 +822,7 @@ func (s *AccountTestService) testGrokAccountConnection(c *gin.Context, account *
 				"grok payment required",
 			)
 		}
-		return s.sendErrorAndEnd(c, fmt.Sprintf("Grok Responses API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Grok Responses API returned %d: %s", resp.StatusCode, string(responseBody)))
 	}
 
 	return s.processOpenAIStream(c, resp.Body)

--- a/backend/internal/service/account_test_service_grok_test.go
+++ b/backend/internal/service/account_test_service_grok_test.go
@@ -199,3 +199,35 @@ func TestAccountTestService_Grok429WithoutQuotaHeadersUsesFallback(t *testing.T)
 	require.Equal(t, 1, repo.rateLimitedCalls)
 	require.WithinDuration(t, before.Add(grokRateLimitFallbackCooldown), repo.resetAt, time.Second)
 }
+
+func TestAccountTestService_GrokFreeUsageExhaustionUsesRollingCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := &Account{
+		ID: 17, Name: "grok-oauth-free-exhausted", Platform: PlatformGrok,
+		Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":  "grok-access-token",
+			"refresh_token": "grok-refresh-token",
+			"expires_at":    time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	baseRepo := &mockAccountRepoForGemini{accountsByID: map[int64]*Account{account.ID: account}}
+	repo := &grokAccountTestRateLimitRepo{mockAccountRepoForGemini: baseRepo}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(strings.NewReader(grokFreeUsageExhaustedTestBody)),
+	}}
+	svc := &AccountTestService{
+		accountRepo: repo, grokTokenProvider: NewGrokTokenProvider(repo, nil), httpUpstream: upstream,
+	}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/17/test", nil)
+	before := time.Now()
+
+	err := svc.TestAccountConnection(c, account.ID, "grok", "", AccountTestModeDefault)
+
+	require.Error(t, err)
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustionCooldown), repo.resetAt, time.Second)
+}

--- a/backend/internal/service/account_test_service_grok_test.go
+++ b/backend/internal/service/account_test_service_grok_test.go
@@ -200,7 +200,7 @@ func TestAccountTestService_Grok429WithoutQuotaHeadersUsesFallback(t *testing.T)
 	require.WithinDuration(t, before.Add(grokRateLimitFallbackCooldown), repo.resetAt, time.Second)
 }
 
-func TestAccountTestService_GrokFreeUsageExhaustionUsesRollingCooldown(t *testing.T) {
+func TestAccountTestService_GrokFreeUsageExhaustionUses24HourCooldown(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	account := &Account{
 		ID: 17, Name: "grok-oauth-free-exhausted", Platform: PlatformGrok,

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -229,6 +229,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 	}
 	ctx = s.withWindowCostPrefetch(ctx, accounts)
 	ctx = s.withRPMPrefetch(ctx, accounts)
+	ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	// 提前构建 accountByID（供 Layer 1 和 Layer 1.5 使用）
 	accountByID := make(map[int64]*Account, len(accounts))
@@ -303,7 +304,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 				continue
 			}
 			// 配额检查
-			if !s.isAccountSchedulableForQuota(account) {
+			if !s.isAccountSchedulableForQuota(ctx, account) {
 				continue
 			}
 			// 窗口费用检查（非粘性会话路径）
@@ -348,7 +349,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 							s.isAccountAllowedForPlatform(stickyAccount, platform, useMixed) &&
 							(requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, stickyAccount, requestedModel)) &&
 							s.isAccountSchedulableForModelSelection(ctx, stickyAccount, requestedModel) &&
-							s.isAccountSchedulableForQuota(stickyAccount) &&
+							s.isAccountSchedulableForQuota(ctx, stickyAccount) &&
 							s.isAccountSchedulableForWindowCost(ctx, stickyAccount, true)
 
 						rpmPass := gatePass && s.isAccountSchedulableForRPM(ctx, stickyAccount, true)
@@ -532,7 +533,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 				profitOK := s.isGatewayAccountProfitEligible(ctx, account)
 				modelSupported := requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)
 				modelSchedulable := s.isAccountSchedulableForModelSelection(ctx, account, requestedModel)
-				quotaOK := s.isAccountSchedulableForQuota(account)
+				quotaOK := s.isAccountSchedulableForQuota(ctx, account)
 				windowCostOK := s.isAccountSchedulableForWindowCost(ctx, account, true)
 				rpmOK := s.isAccountSchedulableForRPM(ctx, account, true)
 				schedulable := s.isAccountSchedulableForSelection(account)
@@ -660,7 +661,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			continue
 		}
 		// 配额检查
-		if !s.isAccountSchedulableForQuota(acc) {
+		if !s.isAccountSchedulableForQuota(ctx, acc) {
 			continue
 		}
 		// 窗口费用检查（非粘性会话路径）
@@ -1246,9 +1247,12 @@ func (s *GatewayService) withWindowCostPrefetch(ctx context.Context, accounts []
 	return context.WithValue(ctx, windowCostPrefetchContextKey, costs)
 }
 
-// isAccountSchedulableForQuota 检查账号是否在配额限制内
-// 适用于配置了 quota_limit 的 apikey 和 bedrock 类型账号
-func (s *GatewayService) isAccountSchedulableForQuota(account *Account) bool {
+// isAccountSchedulableForQuota 检查账号是否在配额限制内。
+// 除 API Key/Bedrock 金额配额外，Grok Free OAuth 账号还受本地滚动 24h Token 配额限制。
+func (s *GatewayService) isAccountSchedulableForQuota(ctx context.Context, account *Account) bool {
+	if exhausted, _, known := s.grokFreeRollingQuotaExhausted(ctx, account); known && exhausted {
+		return false
+	}
 	if !account.IsAPIKeyOrBedrock() {
 		return true
 	}
@@ -1798,7 +1802,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
-						if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
+						if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(ctx, account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
 							if s.debugModelRoutingEnabled() {
 								logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] legacy routed sticky hit: group_id=%v model=%s session=%s account=%d", derefGroupID(groupID), requestedModel, shortSessionHash(sessionHash), accountID)
 							}
@@ -1824,6 +1828,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 		// 提前预取窗口费用+RPM 计数，确保 routing 段内的调度检查调用能命中缓存
 		ctx = s.withWindowCostPrefetch(ctx, accounts)
 		ctx = s.withRPMPrefetch(ctx, accounts)
+		ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 		routingSet := make(map[int64]struct{}, len(routingAccountIDs))
 		for _, id := range routingAccountIDs {
@@ -1861,7 +1866,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 			if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
 				continue
 			}
-			if !s.isAccountSchedulableForQuota(acc) {
+			if !s.isAccountSchedulableForQuota(ctx, acc) {
 				continue
 			}
 			if !s.isAccountSchedulableForWindowCost(ctx, acc, false) {
@@ -1920,7 +1925,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
-					if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
+					if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(ctx, account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
 						return account, nil
 					}
 				}
@@ -1944,6 +1949,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 	// 批量预取窗口费用+RPM 计数，避免逐个账号查询（N+1）
 	ctx = s.withWindowCostPrefetch(ctx, accounts)
 	ctx = s.withRPMPrefetch(ctx, accounts)
+	ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	// 3. 按优先级+最久未用选择（考虑模型支持）
 	// needsUpstreamCheck 仅在主选择循环中使用；粘性会话命中时跳过此检查，
@@ -1978,7 +1984,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 		if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
 			continue
 		}
-		if !s.isAccountSchedulableForQuota(acc) {
+		if !s.isAccountSchedulableForQuota(ctx, acc) {
 			continue
 		}
 		if !s.isAccountSchedulableForWindowCost(ctx, acc, false) {
@@ -2062,7 +2068,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
-						if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
+						if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(ctx, account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
 							if account.Platform == nativePlatform || (account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled()) {
 								if s.debugModelRoutingEnabled() {
 									logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] legacy mixed routed sticky hit: group_id=%v model=%s session=%s account=%d", derefGroupID(groupID), requestedModel, shortSessionHash(sessionHash), accountID)
@@ -2086,6 +2092,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 		// 提前预取窗口费用+RPM 计数，确保 routing 段内的调度检查调用能命中缓存
 		ctx = s.withWindowCostPrefetch(ctx, accounts)
 		ctx = s.withRPMPrefetch(ctx, accounts)
+		ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 		routingSet := make(map[int64]struct{}, len(routingAccountIDs))
 		for _, id := range routingAccountIDs {
@@ -2127,7 +2134,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 			if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
 				continue
 			}
-			if !s.isAccountSchedulableForQuota(acc) {
+			if !s.isAccountSchedulableForQuota(ctx, acc) {
 				continue
 			}
 			if !s.isAccountSchedulableForWindowCost(ctx, acc, false) {
@@ -2186,7 +2193,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
-					if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
+					if !clearSticky && s.isGatewayAccountProfitEligible(ctx, account) && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(ctx, account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
 						if account.Platform == nativePlatform || (account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled()) {
 							return account, nil
 						}
@@ -2208,6 +2215,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 	// 批量预取窗口费用+RPM 计数，避免逐个账号查询（N+1）
 	ctx = s.withWindowCostPrefetch(ctx, accounts)
 	ctx = s.withRPMPrefetch(ctx, accounts)
+	ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	// 3. 按优先级+最久未用选择（考虑模型支持和混合调度）
 	// needsUpstreamCheck 仅在主选择循环中使用；粘性会话命中时跳过此检查。
@@ -2245,7 +2253,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 		if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
 			continue
 		}
-		if !s.isAccountSchedulableForQuota(acc) {
+		if !s.isAccountSchedulableForQuota(ctx, acc) {
 			continue
 		}
 		if !s.isAccountSchedulableForWindowCost(ctx, acc, false) {

--- a/backend/internal/service/grok_free_quota_scheduling.go
+++ b/backend/internal/service/grok_free_quota_scheduling.go
@@ -13,6 +13,10 @@ type grokFreeQuotaUsageContextKeyType struct{}
 
 const grokFreeLocalUsageCooldown = 24 * time.Hour
 
+type grokRateLimitActivatingRepository interface {
+	SetRateLimitedIfInactive(ctx context.Context, id int64, resetAt time.Time) (bool, error)
+}
+
 type grokFreeQuotaUsageEntry struct {
 	tokens int64
 	known  bool
@@ -203,5 +207,17 @@ func persistGrokFreeLocalUsageRateLimit(
 	if account.RateLimitResetAt != nil && now.Before(*account.RateLimitResetAt) {
 		return
 	}
-	persistGrokRateLimit(ctx, repo, account, now.Add(grokFreeLocalUsageCooldown))
+	resetAt := now.Add(grokFreeLocalUsageCooldown)
+	if activatingRepo, ok := repo.(grokRateLimitActivatingRepository); ok {
+		stateCtx, cancel := openAIAccountStateContext(ctx)
+		defer cancel()
+		if _, err := activatingRepo.SetRateLimitedIfInactive(stateCtx, account.ID, resetAt); err != nil {
+			slog.Warn("persist_grok_free_local_quota_rate_limit_failed", "account_id", account.ID, "reset_at", resetAt.UTC(), "error", err)
+		}
+		return
+	}
+
+	// Compatibility fallback for non-production repository implementations.
+	// The production repository uses the atomic inactive-only operation above.
+	persistGrokRateLimit(ctx, repo, account, resetAt)
 }

--- a/backend/internal/service/grok_free_quota_scheduling.go
+++ b/backend/internal/service/grok_free_quota_scheduling.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+type grokFreeQuotaUsageContextKeyType struct{}
+
+type grokFreeQuotaUsageEntry struct {
+	tokens int64
+	known  bool
+}
+
+// grokOAuthUsesFreeRollingQuota treats an unclassified Grok OAuth account as
+// Free. Explicit paid evidence always wins, so upgraded accounts are exempt
+// even when an older Free quota snapshot is still present.
+func grokOAuthUsesFreeRollingQuota(account *Account) bool {
+	return account != nil && account.IsGrokOAuth() && !grokOAuthHasExplicitPaidQuota(account)
+}
+
+func grokOAuthHasExplicitPaidQuota(account *Account) bool {
+	if account == nil || !account.IsGrokOAuth() {
+		return false
+	}
+
+	if billing, err := grokBillingSnapshotFromExtra(account.Extra); err == nil && billing != nil {
+		if tier := strings.TrimSpace(billing.Plan); tier != "" &&
+			!isGrokFreeSubscriptionTier(tier) && !isGrokUnknownSubscriptionTier(tier) {
+			return true
+		}
+		if billing.UsagePercent != nil || billing.UsedPercent != nil ||
+			(billing.MonthlyLimitCents != nil && *billing.MonthlyLimitCents > 0) {
+			return true
+		}
+	}
+
+	if snapshot, err := grokQuotaSnapshotFromExtra(account.Extra); err == nil && snapshot != nil {
+		if tier := strings.TrimSpace(snapshot.SubscriptionTier); tier != "" &&
+			!isGrokFreeSubscriptionTier(tier) && !isGrokUnknownSubscriptionTier(tier) {
+			return true
+		}
+	}
+
+	if tier := strings.TrimSpace(account.GetCredential("subscription_tier")); tier != "" &&
+		!isGrokFreeSubscriptionTier(tier) && !isGrokUnknownSubscriptionTier(tier) {
+		return true
+	}
+	return false
+}
+
+// withGrokFreeQuotaUsagePrefetch loads one rolling-window aggregate for all
+// relevant candidates. Unknown entries are retained after a failed query so
+// downstream checks fail open without turning the failure into N+1 queries.
+func withGrokFreeQuotaUsagePrefetch(ctx context.Context, repo UsageLogRepository, accounts []Account, now time.Time) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if repo == nil || len(accounts) == 0 {
+		return ctx
+	}
+
+	entries := make(map[int64]grokFreeQuotaUsageEntry)
+	if existing, ok := ctx.Value(grokFreeQuotaUsageContextKeyType{}).(map[int64]grokFreeQuotaUsageEntry); ok {
+		for accountID, entry := range existing {
+			entries[accountID] = entry
+		}
+	}
+
+	accountIDs := make([]int64, 0, len(accounts))
+	for i := range accounts {
+		account := &accounts[i]
+		if account.ID <= 0 || !grokOAuthUsesFreeRollingQuota(account) {
+			continue
+		}
+		if _, exists := entries[account.ID]; exists {
+			continue
+		}
+		entries[account.ID] = grokFreeQuotaUsageEntry{}
+		accountIDs = append(accountIDs, account.ID)
+	}
+	if len(accountIDs) == 0 {
+		return ctx
+	}
+
+	startTime := now.UTC().Add(-grokFreeQuotaWindow)
+	if batchReader, ok := repo.(accountWindowStatsBatchReader); ok {
+		statsByAccount, err := batchReader.GetAccountWindowStatsBatch(ctx, accountIDs, startTime)
+		if err != nil {
+			slog.Warn("grok_free_quota_batch_query_failed", "accounts", len(accountIDs), "window_start", startTime, "error", err)
+			return context.WithValue(ctx, grokFreeQuotaUsageContextKeyType{}, entries)
+		}
+		for _, accountID := range accountIDs {
+			tokens := int64(0)
+			if stats := statsByAccount[accountID]; stats != nil {
+				tokens = stats.Tokens
+			}
+			entries[accountID] = grokFreeQuotaUsageEntry{tokens: tokens, known: true}
+		}
+		return context.WithValue(ctx, grokFreeQuotaUsageContextKeyType{}, entries)
+	}
+
+	for _, accountID := range accountIDs {
+		stats, err := repo.GetAccountWindowStats(ctx, accountID, startTime)
+		if err != nil {
+			slog.Warn("grok_free_quota_query_failed", "account_id", accountID, "window_start", startTime, "error", err)
+			continue
+		}
+		tokens := int64(0)
+		if stats != nil {
+			tokens = stats.Tokens
+		}
+		entries[accountID] = grokFreeQuotaUsageEntry{tokens: tokens, known: true}
+	}
+	return context.WithValue(ctx, grokFreeQuotaUsageContextKeyType{}, entries)
+}
+
+// grokFreeRollingQuotaExhausted returns known=false when local usage cannot be
+// read. Scheduling deliberately fails open in that case.
+func grokFreeRollingQuotaExhausted(ctx context.Context, repo UsageLogRepository, account *Account, now time.Time) (exhausted bool, tokens int64, known bool) {
+	if !grokOAuthUsesFreeRollingQuota(account) {
+		return false, 0, false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if entries, ok := ctx.Value(grokFreeQuotaUsageContextKeyType{}).(map[int64]grokFreeQuotaUsageEntry); ok {
+		if entry, prefetched := entries[account.ID]; prefetched {
+			if !entry.known {
+				return false, 0, false
+			}
+			return entry.tokens >= xai.GrokFreeRolling24hTokenLimit, entry.tokens, true
+		}
+	}
+
+	if repo == nil || account.ID <= 0 {
+		return false, 0, false
+	}
+	startTime := now.UTC().Add(-grokFreeQuotaWindow)
+	stats, err := repo.GetAccountWindowStats(ctx, account.ID, startTime)
+	if err != nil {
+		slog.Warn("grok_free_quota_query_failed", "account_id", account.ID, "window_start", startTime, "error", err)
+		return false, 0, false
+	}
+	if stats != nil {
+		tokens = stats.Tokens
+	}
+	return tokens >= xai.GrokFreeRolling24hTokenLimit, tokens, true
+}
+
+func (s *OpenAIGatewayService) withGrokFreeQuotaUsagePrefetch(ctx context.Context, accounts []Account) context.Context {
+	if s == nil {
+		return ctx
+	}
+	return withGrokFreeQuotaUsagePrefetch(ctx, s.usageLogRepo, accounts, time.Now())
+}
+
+func (s *OpenAIGatewayService) grokFreeRollingQuotaExhausted(ctx context.Context, account *Account) (bool, int64, bool) {
+	if s == nil {
+		return false, 0, false
+	}
+	return grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, time.Now())
+}
+
+func (s *GatewayService) withGrokFreeQuotaUsagePrefetch(ctx context.Context, accounts []Account) context.Context {
+	if s == nil {
+		return ctx
+	}
+	return withGrokFreeQuotaUsagePrefetch(ctx, s.usageLogRepo, accounts, time.Now())
+}
+
+func (s *GatewayService) grokFreeRollingQuotaExhausted(ctx context.Context, account *Account) (bool, int64, bool) {
+	if s == nil {
+		return false, 0, false
+	}
+	return grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, time.Now())
+}

--- a/backend/internal/service/grok_free_quota_scheduling.go
+++ b/backend/internal/service/grok_free_quota_scheduling.go
@@ -11,6 +11,8 @@ import (
 
 type grokFreeQuotaUsageContextKeyType struct{}
 
+const grokFreeLocalUsageCooldown = 24 * time.Hour
+
 type grokFreeQuotaUsageEntry struct {
 	tokens int64
 	known  bool
@@ -164,7 +166,10 @@ func (s *OpenAIGatewayService) grokFreeRollingQuotaExhausted(ctx context.Context
 	if s == nil {
 		return false, 0, false
 	}
-	return grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, time.Now())
+	now := time.Now()
+	exhausted, tokens, known := grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, now)
+	persistGrokFreeLocalUsageRateLimit(ctx, s.accountRepo, account, now, exhausted, known)
+	return exhausted, tokens, known
 }
 
 func (s *GatewayService) withGrokFreeQuotaUsagePrefetch(ctx context.Context, accounts []Account) context.Context {
@@ -178,5 +183,25 @@ func (s *GatewayService) grokFreeRollingQuotaExhausted(ctx context.Context, acco
 	if s == nil {
 		return false, 0, false
 	}
-	return grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, time.Now())
+	now := time.Now()
+	exhausted, tokens, known := grokFreeRollingQuotaExhausted(ctx, s.usageLogRepo, account, now)
+	persistGrokFreeLocalUsageRateLimit(ctx, s.accountRepo, account, now, exhausted, known)
+	return exhausted, tokens, known
+}
+
+func persistGrokFreeLocalUsageRateLimit(
+	ctx context.Context,
+	repo AccountRepository,
+	account *Account,
+	now time.Time,
+	exhausted bool,
+	known bool,
+) {
+	if !known || !exhausted || repo == nil || account == nil || account.ID <= 0 {
+		return
+	}
+	if account.RateLimitResetAt != nil && now.Before(*account.RateLimitResetAt) {
+		return
+	}
+	persistGrokRateLimit(ctx, repo, account, now.Add(grokFreeLocalUsageCooldown))
 }

--- a/backend/internal/service/grok_free_quota_scheduling_test.go
+++ b/backend/internal/service/grok_free_quota_scheduling_test.go
@@ -26,6 +26,25 @@ type grokFreeQuotaUsageRepoStub struct {
 	singleCalls  int
 }
 
+type grokFreeQuotaAccountRepoStub struct {
+	AccountRepository
+
+	rateLimitedCalls     int
+	lastRateLimitedID    int64
+	lastRateLimitResetAt time.Time
+}
+
+func (r *grokFreeQuotaAccountRepoStub) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
+	r.rateLimitedCalls++
+	r.lastRateLimitedID = id
+	r.lastRateLimitResetAt = resetAt
+	return nil
+}
+
+func (r *grokFreeQuotaAccountRepoStub) SetRateLimitedIfLater(ctx context.Context, id int64, resetAt time.Time) error {
+	return r.SetRateLimited(ctx, id, resetAt)
+}
+
 func (r *grokFreeQuotaUsageRepoStub) GetAccountWindowStatsBatch(_ context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error) {
 	r.batchCalls++
 	r.batchIDs = append([]int64(nil), accountIDs...)
@@ -160,6 +179,111 @@ func TestGrokFreeRollingQuotaPrefetch_BatchFailureFailsOpen(t *testing.T) {
 	require.Zero(t, repo.singleCalls)
 }
 
+func TestPersistGrokFreeLocalUsageRateLimit(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	require.Equal(t, 24*time.Hour, grokFreeLocalUsageCooldown)
+
+	tests := []struct {
+		name      string
+		account   Account
+		exhausted bool
+		known     bool
+		wantCalls int
+	}{
+		{
+			name:      "exhausted free account",
+			account:   schedulableGrokFreeQuotaTestAccount(12, 0),
+			exhausted: true,
+			known:     true,
+			wantCalls: 1,
+		},
+		{
+			name:      "usage below limit",
+			account:   schedulableGrokFreeQuotaTestAccount(13, 0),
+			exhausted: false,
+			known:     true,
+		},
+		{
+			name:      "usage unknown",
+			account:   schedulableGrokFreeQuotaTestAccount(14, 0),
+			exhausted: true,
+			known:     false,
+		},
+		{
+			name: "existing active rate limit",
+			account: func() Account {
+				account := schedulableGrokFreeQuotaTestAccount(15, 0)
+				resetAt := now.Add(time.Hour)
+				account.RateLimitResetAt = &resetAt
+				return account
+			}(),
+			exhausted: true,
+			known:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &grokFreeQuotaAccountRepoStub{}
+			persistGrokFreeLocalUsageRateLimit(context.Background(), repo, &tt.account, now, tt.exhausted, tt.known)
+
+			require.Equal(t, tt.wantCalls, repo.rateLimitedCalls)
+			if tt.wantCalls > 0 {
+				require.Equal(t, tt.account.ID, repo.lastRateLimitedID)
+				require.Equal(t, now.Add(grokFreeLocalUsageCooldown), repo.lastRateLimitResetAt)
+			}
+		})
+	}
+}
+
+func TestGrokFreeRollingQuotaServiceWrappersPersistLocalCooldown(t *testing.T) {
+	account := schedulableGrokFreeQuotaTestAccount(16, 0)
+	usageRepo := &grokFreeQuotaUsageRepoStub{singleResult: map[int64]*usagestats.AccountStats{
+		account.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit},
+	}}
+
+	t.Run("openai gateway", func(t *testing.T) {
+		accountRepo := &grokFreeQuotaAccountRepoStub{}
+		svc := &OpenAIGatewayService{accountRepo: accountRepo, usageLogRepo: usageRepo}
+		before := time.Now()
+
+		exhausted, tokens, known := svc.grokFreeRollingQuotaExhausted(context.Background(), &account)
+
+		require.True(t, known)
+		require.True(t, exhausted)
+		require.Equal(t, xai.GrokFreeRolling24hTokenLimit, tokens)
+		require.Equal(t, 1, accountRepo.rateLimitedCalls)
+		require.WithinDuration(t, before.Add(grokFreeLocalUsageCooldown), accountRepo.lastRateLimitResetAt, time.Second)
+	})
+
+	t.Run("gateway", func(t *testing.T) {
+		accountRepo := &grokFreeQuotaAccountRepoStub{}
+		svc := &GatewayService{accountRepo: accountRepo, usageLogRepo: usageRepo}
+		before := time.Now()
+
+		exhausted, tokens, known := svc.grokFreeRollingQuotaExhausted(context.Background(), &account)
+
+		require.True(t, known)
+		require.True(t, exhausted)
+		require.Equal(t, xai.GrokFreeRolling24hTokenLimit, tokens)
+		require.Equal(t, 1, accountRepo.rateLimitedCalls)
+		require.WithinDuration(t, before.Add(grokFreeLocalUsageCooldown), accountRepo.lastRateLimitResetAt, time.Second)
+	})
+
+	t.Run("paid account remains exempt", func(t *testing.T) {
+		paid := account
+		paid.Credentials = map[string]any{"subscription_tier": "supergrok"}
+		accountRepo := &grokFreeQuotaAccountRepoStub{}
+		svc := &OpenAIGatewayService{accountRepo: accountRepo, usageLogRepo: usageRepo}
+
+		exhausted, _, known := svc.grokFreeRollingQuotaExhausted(context.Background(), &paid)
+
+		require.False(t, known)
+		require.False(t, exhausted)
+		require.Zero(t, accountRepo.rateLimitedCalls)
+	})
+}
+
 func TestOpenAIGatewayService_GrokFreeRollingQuota_LegacyAndStickySkipExhausted(t *testing.T) {
 	resetOpenAIAdvancedSchedulerSettingCacheForTest()
 	exhaustedAccount := schedulableGrokFreeQuotaTestAccount(21, 0)
@@ -181,7 +305,9 @@ func TestOpenAIGatewayService_GrokFreeRollingQuota_LegacyAndStickySkipExhausted(
 		cfg := &config.Config{}
 		cfg.Gateway.Scheduling.LoadBatchEnabled = false
 		return &OpenAIGatewayService{
-			accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+			accountRepo: &grokFreeQuotaAccountRepoStub{
+				AccountRepository: schedulerTestOpenAIAccountRepo{accounts: accounts},
+			},
 			usageLogRepo:       repo,
 			cache:              cache,
 			cfg:                cfg,
@@ -222,7 +348,9 @@ func TestDefaultOpenAIAccountScheduler_GrokFreeRollingQuotaSkipsExhausted(t *tes
 		healthyAccount.ID:   {Tokens: xai.GrokFreeRolling24hTokenLimit - 1},
 	}}
 	svc := &OpenAIGatewayService{
-		accountRepo:  schedulerTestOpenAIAccountRepo{accounts: []Account{exhaustedAccount, healthyAccount}},
+		accountRepo: &grokFreeQuotaAccountRepoStub{
+			AccountRepository: schedulerTestOpenAIAccountRepo{accounts: []Account{exhaustedAccount, healthyAccount}},
+		},
 		usageLogRepo: repo,
 		cfg:          &config.Config{},
 	}

--- a/backend/internal/service/grok_free_quota_scheduling_test.go
+++ b/backend/internal/service/grok_free_quota_scheduling_test.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+type grokFreeQuotaUsageRepoStub struct {
+	UsageLogRepository
+
+	batchResult map[int64]*usagestats.AccountStats
+	batchErr    error
+	batchCalls  int
+	batchIDs    []int64
+	batchStart  time.Time
+
+	singleResult map[int64]*usagestats.AccountStats
+	singleErr    error
+	singleCalls  int
+}
+
+func (r *grokFreeQuotaUsageRepoStub) GetAccountWindowStatsBatch(_ context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error) {
+	r.batchCalls++
+	r.batchIDs = append([]int64(nil), accountIDs...)
+	r.batchStart = startTime
+	if r.batchErr != nil {
+		return nil, r.batchErr
+	}
+	return r.batchResult, nil
+}
+
+func (r *grokFreeQuotaUsageRepoStub) GetAccountWindowStats(_ context.Context, accountID int64, _ time.Time) (*usagestats.AccountStats, error) {
+	r.singleCalls++
+	if r.singleErr != nil {
+		return nil, r.singleErr
+	}
+	if stats := r.singleResult[accountID]; stats != nil {
+		return stats, nil
+	}
+	return &usagestats.AccountStats{}, nil
+}
+
+func schedulableGrokFreeQuotaTestAccount(id int64, priority int) Account {
+	return Account{
+		ID:          id,
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    priority,
+	}
+}
+
+func TestGrokOAuthUsesFreeRollingQuota(t *testing.T) {
+	monthlyLimit := 10.0
+	legacyFreeLimit := int64(2_000_000)
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{name: "nil", account: nil, want: false},
+		{name: "api key", account: &Account{Platform: PlatformGrok, Type: AccountTypeAPIKey}, want: false},
+		{name: "unprobed oauth defaults to free", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}, want: true},
+		{name: "explicit free tier", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Credentials: map[string]any{"subscription_tier": "free"}}, want: true},
+		{name: "paid credential", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Credentials: map[string]any{"subscription_tier": "supergrok"}}, want: false},
+		{name: "paid billing plan", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{grokBillingExtraKey: &xai.BillingSummary{Plan: "SuperGrok"}}}, want: false},
+		{name: "paid monthly allowance", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{grokBillingExtraKey: &xai.BillingSummary{MonthlyLimitCents: &monthlyLimit}}}, want: false},
+		{
+			name: "paid evidence wins over stale free snapshot",
+			account: &Account{
+				Platform:    PlatformGrok,
+				Type:        AccountTypeOAuth,
+				Credentials: map[string]any{"subscription_tier": "supergrok"},
+				Extra: map[string]any{grokQuotaSnapshotExtraKey: &xai.QuotaSnapshot{
+					Tokens: &xai.QuotaWindow{Limit: &legacyFreeLimit},
+				}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, grokOAuthUsesFreeRollingQuota(tt.account))
+		})
+	}
+}
+
+func TestGrokFreeRollingQuotaPrefetch_BoundaryAndRecovery(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	under := schedulableGrokFreeQuotaTestAccount(1, 0)
+	atLimit := schedulableGrokFreeQuotaTestAccount(2, 0)
+	over := schedulableGrokFreeQuotaTestAccount(3, 0)
+	paid := schedulableGrokFreeQuotaTestAccount(4, 0)
+	paid.Credentials = map[string]any{"subscription_tier": "supergrok"}
+	accounts := []Account{under, atLimit, over, paid}
+
+	repo := &grokFreeQuotaUsageRepoStub{batchResult: map[int64]*usagestats.AccountStats{
+		under.ID:   {Tokens: xai.GrokFreeRolling24hTokenLimit - 1},
+		atLimit.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit},
+		over.ID:    {Tokens: xai.GrokFreeRolling24hTokenLimit + 1},
+		paid.ID:    {Tokens: xai.GrokFreeRolling24hTokenLimit * 2},
+	}}
+	ctx := withGrokFreeQuotaUsagePrefetch(context.Background(), repo, accounts, now)
+
+	exhausted, tokens, known := grokFreeRollingQuotaExhausted(ctx, repo, &under, now)
+	require.True(t, known)
+	require.False(t, exhausted)
+	require.Equal(t, xai.GrokFreeRolling24hTokenLimit-1, tokens)
+
+	exhausted, tokens, known = grokFreeRollingQuotaExhausted(ctx, repo, &atLimit, now)
+	require.True(t, known)
+	require.True(t, exhausted)
+	require.Equal(t, xai.GrokFreeRolling24hTokenLimit, tokens)
+
+	exhausted, _, known = grokFreeRollingQuotaExhausted(ctx, repo, &over, now)
+	require.True(t, known)
+	require.True(t, exhausted)
+
+	exhausted, _, known = grokFreeRollingQuotaExhausted(ctx, repo, &paid, now)
+	require.False(t, known)
+	require.False(t, exhausted)
+	require.Equal(t, []int64{under.ID, atLimit.ID, over.ID}, repo.batchIDs)
+	require.Equal(t, now.Add(-24*time.Hour), repo.batchStart)
+	require.Zero(t, repo.singleCalls)
+
+	// A fresh scheduling pass sees the rolling window after old usage falls out
+	// and automatically admits the account again.
+	repo.batchResult[atLimit.ID] = &usagestats.AccountStats{Tokens: xai.GrokFreeRolling24hTokenLimit - 1}
+	recoveredCtx := withGrokFreeQuotaUsagePrefetch(context.Background(), repo, []Account{atLimit}, now.Add(time.Minute))
+	exhausted, tokens, known = grokFreeRollingQuotaExhausted(recoveredCtx, repo, &atLimit, now.Add(time.Minute))
+	require.True(t, known)
+	require.False(t, exhausted)
+	require.Equal(t, xai.GrokFreeRolling24hTokenLimit-1, tokens)
+}
+
+func TestGrokFreeRollingQuotaPrefetch_BatchFailureFailsOpen(t *testing.T) {
+	account := schedulableGrokFreeQuotaTestAccount(11, 0)
+	repo := &grokFreeQuotaUsageRepoStub{
+		batchErr:    errors.New("database unavailable"),
+		singleErr:   errors.New("must not fall back to N+1"),
+		batchResult: map[int64]*usagestats.AccountStats{},
+	}
+	ctx := withGrokFreeQuotaUsagePrefetch(context.Background(), repo, []Account{account}, time.Now())
+
+	exhausted, _, known := grokFreeRollingQuotaExhausted(ctx, repo, &account, time.Now())
+	require.False(t, known)
+	require.False(t, exhausted)
+	require.Equal(t, 1, repo.batchCalls)
+	require.Zero(t, repo.singleCalls)
+}
+
+func TestOpenAIGatewayService_GrokFreeRollingQuota_LegacyAndStickySkipExhausted(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	exhaustedAccount := schedulableGrokFreeQuotaTestAccount(21, 0)
+	healthyAccount := schedulableGrokFreeQuotaTestAccount(22, 1)
+	accounts := []Account{exhaustedAccount, healthyAccount}
+	repo := &grokFreeQuotaUsageRepoStub{
+		batchResult: map[int64]*usagestats.AccountStats{
+			exhaustedAccount.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit},
+			healthyAccount.ID:   {Tokens: xai.GrokFreeRolling24hTokenLimit - 1},
+		},
+		singleResult: map[int64]*usagestats.AccountStats{
+			exhaustedAccount.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit},
+			healthyAccount.ID:   {Tokens: xai.GrokFreeRolling24hTokenLimit - 1},
+		},
+	}
+	groupID := int64(12001)
+
+	newService := func(cache *schedulerTestGatewayCache) *OpenAIGatewayService {
+		cfg := &config.Config{}
+		cfg.Gateway.Scheduling.LoadBatchEnabled = false
+		return &OpenAIGatewayService{
+			accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+			usageLogRepo:       repo,
+			cache:              cache,
+			cfg:                cfg,
+			concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		}
+	}
+
+	t.Run("normal selection", func(t *testing.T) {
+		selection, _, err := newService(&schedulerTestGatewayCache{}).SelectAccountWithSchedulerForCapability(
+			context.Background(), &groupID, "", "", "grok-4.3", nil,
+			OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityChatCompletions,
+			false, false, false, PlatformGrok,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, healthyAccount.ID, selection.Account.ID)
+	})
+
+	t.Run("sticky cannot bypass", func(t *testing.T) {
+		const sessionHash = "grok-quota-sticky"
+		cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{sessionHash: exhaustedAccount.ID}}
+		selection, _, err := newService(cache).SelectAccountWithSchedulerForCapability(
+			context.Background(), &groupID, "", sessionHash, "grok-4.3", nil,
+			OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityChatCompletions,
+			false, false, false, PlatformGrok,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, healthyAccount.ID, selection.Account.ID)
+	})
+}
+
+func TestDefaultOpenAIAccountScheduler_GrokFreeRollingQuotaSkipsExhausted(t *testing.T) {
+	exhaustedAccount := schedulableGrokFreeQuotaTestAccount(31, 0)
+	healthyAccount := schedulableGrokFreeQuotaTestAccount(32, 1)
+	repo := &grokFreeQuotaUsageRepoStub{batchResult: map[int64]*usagestats.AccountStats{
+		exhaustedAccount.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit + 1},
+		healthyAccount.ID:   {Tokens: xai.GrokFreeRolling24hTokenLimit - 1},
+	}}
+	svc := &OpenAIGatewayService{
+		accountRepo:  schedulerTestOpenAIAccountRepo{accounts: []Account{exhaustedAccount, healthyAccount}},
+		usageLogRepo: repo,
+		cfg:          &config.Config{},
+	}
+	scheduler := newDefaultOpenAIAccountScheduler(svc, nil)
+
+	selection, _, err := scheduler.Select(context.Background(), OpenAIAccountScheduleRequest{
+		Platform:           PlatformGrok,
+		RequestedModel:     "grok-4.3",
+		RequiredTransport:  OpenAIUpstreamTransportAny,
+		RequiredCapability: OpenAIEndpointCapabilityChatCompletions,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, healthyAccount.ID, selection.Account.ID)
+	require.Equal(t, 1, repo.batchCalls)
+}
+
+func TestGatewayService_GrokFreeRollingQuotaGate(t *testing.T) {
+	account := schedulableGrokFreeQuotaTestAccount(41, 0)
+	repo := &grokFreeQuotaUsageRepoStub{singleResult: map[int64]*usagestats.AccountStats{
+		account.ID: {Tokens: xai.GrokFreeRolling24hTokenLimit},
+	}}
+	svc := &GatewayService{usageLogRepo: repo}
+
+	require.False(t, svc.isAccountSchedulableForQuota(context.Background(), &account))
+	account.Credentials = map[string]any{"subscription_tier": "supergrok"}
+	require.True(t, svc.isAccountSchedulableForQuota(context.Background(), &account))
+}

--- a/backend/internal/service/grok_free_quota_scheduling_test.go
+++ b/backend/internal/service/grok_free_quota_scheduling_test.go
@@ -32,6 +32,8 @@ type grokFreeQuotaAccountRepoStub struct {
 	rateLimitedCalls     int
 	lastRateLimitedID    int64
 	lastRateLimitResetAt time.Time
+	activationCalls      int
+	active               bool
 }
 
 func (r *grokFreeQuotaAccountRepoStub) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
@@ -43,6 +45,15 @@ func (r *grokFreeQuotaAccountRepoStub) SetRateLimited(_ context.Context, id int6
 
 func (r *grokFreeQuotaAccountRepoStub) SetRateLimitedIfLater(ctx context.Context, id int64, resetAt time.Time) error {
 	return r.SetRateLimited(ctx, id, resetAt)
+}
+
+func (r *grokFreeQuotaAccountRepoStub) SetRateLimitedIfInactive(ctx context.Context, id int64, resetAt time.Time) (bool, error) {
+	r.activationCalls++
+	if r.active {
+		return false, nil
+	}
+	r.active = true
+	return true, r.SetRateLimited(ctx, id, resetAt)
 }
 
 func (r *grokFreeQuotaUsageRepoStub) GetAccountWindowStatsBatch(_ context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error) {
@@ -281,6 +292,26 @@ func TestGrokFreeRollingQuotaServiceWrappersPersistLocalCooldown(t *testing.T) {
 		require.False(t, known)
 		require.False(t, exhausted)
 		require.Zero(t, accountRepo.rateLimitedCalls)
+	})
+
+	t.Run("stale snapshot cannot extend active cooldown", func(t *testing.T) {
+		accountRepo := &grokFreeQuotaAccountRepoStub{}
+		svc := &OpenAIGatewayService{accountRepo: accountRepo, usageLogRepo: usageRepo}
+
+		firstBefore := time.Now()
+		firstExhausted, _, firstKnown := svc.grokFreeRollingQuotaExhausted(context.Background(), &account)
+		firstResetAt := accountRepo.lastRateLimitResetAt
+		time.Sleep(time.Millisecond)
+		secondExhausted, _, secondKnown := svc.grokFreeRollingQuotaExhausted(context.Background(), &account)
+
+		require.True(t, firstKnown)
+		require.True(t, firstExhausted)
+		require.True(t, secondKnown)
+		require.True(t, secondExhausted)
+		require.Equal(t, 2, accountRepo.activationCalls)
+		require.Equal(t, 1, accountRepo.rateLimitedCalls)
+		require.WithinDuration(t, firstBefore.Add(grokFreeLocalUsageCooldown), firstResetAt, time.Second)
+		require.Equal(t, firstResetAt, accountRepo.lastRateLimitResetAt)
 	})
 }
 

--- a/backend/internal/service/grok_free_usage_exhaustion.go
+++ b/backend/internal/service/grok_free_usage_exhaustion.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	grokFreeUsageExhaustedCode      = "subscription:free-usage-exhausted"
-	grokFreeUsageExhaustionCooldown = 2 * time.Hour
+	grokFreeUsageExhaustionCooldown = 24 * time.Hour
 )
 
 var grokFreeUsageTokenPairPattern = regexp.MustCompile(`(?i)tokens?\s*(?:\(actual\s*/\s*limit\))?\s*[:=]?\s*(\d+)\s*/\s*(\d+)`)

--- a/backend/internal/service/grok_free_usage_exhaustion.go
+++ b/backend/internal/service/grok_free_usage_exhaustion.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	grokFreeUsageExhaustedCode      = "subscription:free-usage-exhausted"
+	grokFreeUsageExhaustionCooldown = 2 * time.Hour
+)
+
+var grokFreeUsageTokenPairPattern = regexp.MustCompile(`(?i)tokens?\s*(?:\(actual\s*/\s*limit\))?\s*[:=]?\s*(\d+)\s*/\s*(\d+)`)
+
+type grokFreeUsageExhaustion struct {
+	actual       int64
+	limit        int64
+	hasTokenPair bool
+}
+
+func parseGrokFreeUsageExhaustion(statusCode int, responseBody []byte) (grokFreeUsageExhaustion, bool) {
+	if statusCode != http.StatusTooManyRequests || len(responseBody) == 0 {
+		return grokFreeUsageExhaustion{}, false
+	}
+
+	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "code").String()))
+	message := strings.TrimSpace(gjson.GetBytes(responseBody, "error").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(responseBody, "error.message").String())
+	}
+	combined := strings.ToLower(strings.Join([]string{code, message, string(responseBody)}, " "))
+	canonicalCode := code == grokFreeUsageExhaustedCode || strings.Contains(combined, "free-usage-exhausted")
+	canonicalMessage := strings.Contains(combined, "included free usage") && strings.Contains(combined, "rolling 24-hour")
+	if !canonicalCode && !canonicalMessage {
+		return grokFreeUsageExhaustion{}, false
+	}
+
+	result := grokFreeUsageExhaustion{limit: xai.GrokFreeRolling24hTokenLimit}
+	match := grokFreeUsageTokenPairPattern.FindStringSubmatch(combined)
+	if len(match) != 3 {
+		return result, true
+	}
+	actual, actualErr := strconv.ParseInt(match[1], 10, 64)
+	limit, limitErr := strconv.ParseInt(match[2], 10, 64)
+	if actualErr != nil || limitErr != nil || actual < 0 || limit <= 0 {
+		return result, true
+	}
+	result.actual = actual
+	result.limit = limit
+	result.hasTokenPair = true
+	return result, true
+}
+
+func isGrokFreeUsageExhausted(statusCode int, responseBody []byte) bool {
+	_, exhausted := parseGrokFreeUsageExhaustion(statusCode, responseBody)
+	return exhausted
+}
+
+func parseGrokQuotaSnapshotWithBody(headers http.Header, statusCode int, responseBody []byte, now time.Time) *xai.QuotaSnapshot {
+	snapshot := parseGrokQuotaSnapshot(headers, statusCode, now)
+	exhaustion, exhausted := parseGrokFreeUsageExhaustion(statusCode, responseBody)
+	if !exhausted {
+		return snapshot
+	}
+	if snapshot == nil {
+		snapshot = &xai.QuotaSnapshot{}
+	}
+
+	resetAt := now.Add(grokFreeUsageExhaustionCooldown)
+	if observedResetAt, limited := grokRateLimitResetAt(snapshot, now); limited && observedResetAt.After(resetAt) {
+		resetAt = observedResetAt
+	}
+	limit := exhaustion.limit
+	if !exhaustion.hasTokenPair && snapshot.Tokens != nil && snapshot.Tokens.Limit != nil && *snapshot.Tokens.Limit > 0 {
+		limit = *snapshot.Tokens.Limit
+	}
+	remaining := int64(0)
+	resetUnix := resetAt.Unix()
+	snapshot.Tokens = &xai.QuotaWindow{
+		Limit:     &limit,
+		Remaining: &remaining,
+		ResetUnix: &resetUnix,
+		ResetAt:   resetAt.UTC().Format(time.RFC3339),
+	}
+	if strings.TrimSpace(snapshot.SubscriptionTier) == "" {
+		snapshot.SubscriptionTier = "free"
+	}
+	snapshot.StatusCode = statusCode
+	snapshot.ObservationSource = "upstream_error_body"
+	snapshot.UpdatedAt = now.UTC().Format(time.RFC3339)
+	return snapshot
+}

--- a/backend/internal/service/grok_free_usage_exhaustion_test.go
+++ b/backend/internal/service/grok_free_usage_exhaustion_test.go
@@ -29,7 +29,7 @@ func TestParseGrokFreeUsageExhaustionRejectsGeneric429(t *testing.T) {
 	require.False(t, exhausted)
 }
 
-func TestParseGrokQuotaSnapshotWithBodyUsesRollingCooldown(t *testing.T) {
+func TestParseGrokQuotaSnapshotWithBodyUses24HourCooldown(t *testing.T) {
 	now := time.Date(2026, time.August, 6, 3, 0, 0, 0, time.UTC)
 	snapshot := parseGrokQuotaSnapshotWithBody(nil, http.StatusTooManyRequests, []byte(grokFreeUsageExhaustedTestBody), now)
 
@@ -42,5 +42,5 @@ func TestParseGrokQuotaSnapshotWithBodyUsesRollingCooldown(t *testing.T) {
 	require.NotNil(t, snapshot.Tokens.ResetUnix)
 	require.EqualValues(t, xai.GrokFreeRolling24hTokenLimit, *snapshot.Tokens.Limit)
 	require.Zero(t, *snapshot.Tokens.Remaining)
-	require.Equal(t, now.Add(grokFreeUsageExhaustionCooldown).Unix(), *snapshot.Tokens.ResetUnix)
+	require.Equal(t, now.Add(24*time.Hour).Unix(), *snapshot.Tokens.ResetUnix)
 }

--- a/backend/internal/service/grok_free_usage_exhaustion_test.go
+++ b/backend/internal/service/grok_free_usage_exhaustion_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+const grokFreeUsageExhaustedTestBody = `{"code":"subscription:free-usage-exhausted","error":"You've used all the included free usage for model grok-4.5 for now. Usage resets over a rolling 24-hour window - tokens (actual/limit): 880175/500000."}`
+
+func TestParseGrokFreeUsageExhaustion(t *testing.T) {
+	result, exhausted := parseGrokFreeUsageExhaustion(http.StatusTooManyRequests, []byte(grokFreeUsageExhaustedTestBody))
+
+	require.True(t, exhausted)
+	require.True(t, result.hasTokenPair)
+	require.EqualValues(t, 880_175, result.actual)
+	require.EqualValues(t, xai.GrokFreeRolling24hTokenLimit, result.limit)
+}
+
+func TestParseGrokFreeUsageExhaustionRejectsGeneric429(t *testing.T) {
+	_, exhausted := parseGrokFreeUsageExhaustion(
+		http.StatusTooManyRequests,
+		[]byte(`{"error":{"message":"rate limit exceeded"}}`),
+	)
+
+	require.False(t, exhausted)
+}
+
+func TestParseGrokQuotaSnapshotWithBodyUsesRollingCooldown(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 3, 0, 0, 0, time.UTC)
+	snapshot := parseGrokQuotaSnapshotWithBody(nil, http.StatusTooManyRequests, []byte(grokFreeUsageExhaustedTestBody), now)
+
+	require.NotNil(t, snapshot)
+	require.Equal(t, "free", snapshot.SubscriptionTier)
+	require.Equal(t, "upstream_error_body", snapshot.ObservationSource)
+	require.NotNil(t, snapshot.Tokens)
+	require.NotNil(t, snapshot.Tokens.Limit)
+	require.NotNil(t, snapshot.Tokens.Remaining)
+	require.NotNil(t, snapshot.Tokens.ResetUnix)
+	require.EqualValues(t, xai.GrokFreeRolling24hTokenLimit, *snapshot.Tokens.Limit)
+	require.Zero(t, *snapshot.Tokens.Remaining)
+	require.Equal(t, now.Add(grokFreeUsageExhaustionCooldown).Unix(), *snapshot.Tokens.ResetUnix)
+}

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -19,8 +19,8 @@ const (
 )
 
 // OpenAIOAuth429FailoverState tracks the request-local follow-up budget after
-// the first Grok OAuth 429. Once that 429 occurs, exactly one different account
-// may be attempted; any failure from that follow-up account ends failover.
+// a generic Grok OAuth 429. Confirmed Free quota exhaustion is account-scoped
+// and may continue through the handler's normal bounded failover chain.
 type OpenAIOAuth429FailoverState struct {
 	grokOAuth429FollowupPending bool
 }
@@ -335,8 +335,11 @@ func (s *OpenAIGatewayService) isOpenAIOAuth429Storm() bool {
 	return s.openaiOAuth429WindowCount.Load() >= openAIOAuth429StormThreshold
 }
 
-func (s *OpenAIGatewayService) ShouldStopOpenAIOAuth429Failover(account *Account, statusCode int, failedSwitches int, state *OpenAIOAuth429FailoverState) bool {
+func (s *OpenAIGatewayService) ShouldStopOpenAIOAuth429Failover(account *Account, statusCode int, failedSwitches int, state *OpenAIOAuth429FailoverState, responseBody []byte) bool {
 	if failedSwitches < openAIOAuth429StormMaxAccountSwitches {
+		return false
+	}
+	if isGrokOAuthAccount(account) && isGrokFreeUsageExhausted(statusCode, responseBody) {
 		return false
 	}
 	if state != nil && state.grokOAuth429FollowupPending {

--- a/backend/internal/service/openai_account_runtime_block_fastpath_test.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath_test.go
@@ -404,16 +404,16 @@ func TestShouldStopOpenAIOAuth429Failover_OnlyDuringStorm(t *testing.T) {
 	apiKeyAccount := &Account{ID: 43, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 	var state OpenAIOAuth429FailoverState
 
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state, nil))
 
 	for i := 0; i < openAIOAuth429StormThreshold; i++ {
 		svc.recordOpenAIOAuth429()
 	}
 
-	require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state))
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusTooManyRequests, 1, &state))
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 1, &state))
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 0, &state))
+	require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state, nil))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusTooManyRequests, 1, &state, nil))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 1, &state, nil))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 0, &state, nil))
 }
 
 func TestShouldStopOpenAIOAuth429Failover_TracksOneGrokFollowupAttempt(t *testing.T) {
@@ -423,24 +423,44 @@ func TestShouldStopOpenAIOAuth429Failover_TracksOneGrokFollowupAttempt(t *testin
 
 	t.Run("429 then 500 stops after one followup", func(t *testing.T) {
 		var state OpenAIOAuth429FailoverState
-		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state))
-		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 2, &state))
+		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state, nil))
+		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 2, &state, nil))
 	})
 
 	t.Run("500 then 429 still allows one followup", func(t *testing.T) {
 		var state OpenAIOAuth429FailoverState
-		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 1, &state))
-		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 2, &state))
-		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusBadGateway, 3, &state))
+		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 1, &state, nil))
+		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 2, &state, nil))
+		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusBadGateway, 3, &state, nil))
 	})
 
 	t.Run("OAuth 429 then API-key failure consumes the same followup", func(t *testing.T) {
 		var state OpenAIOAuth429FailoverState
-		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state))
-		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusInternalServerError, 2, &state))
+		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 1, &state, nil))
+		require.True(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusInternalServerError, 2, &state, nil))
 	})
 
 	var state OpenAIOAuth429FailoverState
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 0, &state))
-	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusTooManyRequests, 2, &state))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 0, &state, nil))
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusTooManyRequests, 2, &state, nil))
+}
+
+func TestShouldStopOpenAIOAuth429Failover_FreeUsageUsesNormalFailoverBudget(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{ID: 46, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	var state OpenAIOAuth429FailoverState
+	body := []byte(grokFreeUsageExhaustedTestBody)
+
+	for failedSwitches := 1; failedSwitches <= 10; failedSwitches++ {
+		require.False(t, svc.ShouldStopOpenAIOAuth429Failover(
+			account,
+			http.StatusTooManyRequests,
+			failedSwitches,
+			&state,
+			body,
+		))
+	}
+
+	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusTooManyRequests, 11, &state, nil))
+	require.True(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusBadGateway, 12, &state, nil))
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1330,6 +1330,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	if len(accounts) == 0 {
 		return nil, 0, 0, 0, noAvailableOpenAISelectionError(req.RequestedModel, false, openAISelectionFilterStats{}.summary(""))
 	}
+	ctx = s.service.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	// require_privacy_set: 获取分组信息
 	var schedGroup *Group
@@ -1692,6 +1693,18 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx con
 			reason += "_" + decision.window
 		}
 		return false, reason
+	}
+	if paused, decision := shouldAutoPauseGrokAccountByQuota(account); paused {
+		reason := "quota_auto_pause"
+		if decision.window != "" {
+			reason += "_" + decision.window
+		}
+		return false, reason
+	}
+	if s != nil && s.service != nil {
+		if exhausted, _, known := s.service.grokFreeRollingQuotaExhausted(ctx, account); known && exhausted {
+			return false, "quota_auto_pause_24h"
+		}
 	}
 	// 母账号健康联动：影子账号的凭据来自母账号，母账号不可调度时影子也不应被选中。
 	// Parent-health gate: shadow borrows the parent's credentials; an unschedulable

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -1355,7 +1355,7 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		return
 	}
 	now := time.Now()
-	s.updateGrokUsageSnapshot(ctx, account, parseGrokQuotaSnapshot(headers, statusCode, now))
+	s.updateGrokUsageSnapshot(ctx, account, parseGrokQuotaSnapshotWithBody(headers, statusCode, responseBody, now))
 	if statusCode == http.StatusForbidden && s.applyGrokForbiddenPolicy(ctx, account, responseBody) {
 		return
 	}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2692,7 +2692,7 @@ func TestHandleGrokAccountUpstreamError429UsesFallbackReset(t *testing.T) {
 	require.Zero(t, repo.tempUnschedCalls)
 }
 
-func TestHandleGrokAccountUpstreamErrorFreeUsageExhaustionUsesRollingCooldown(t *testing.T) {
+func TestHandleGrokAccountUpstreamErrorFreeUsageExhaustionUses24HourCooldown(t *testing.T) {
 	account := &Account{ID: 631, Platform: PlatformGrok, Type: AccountTypeOAuth}
 	repo := &grokQuotaAccountRepo{}
 	svc := &OpenAIGatewayService{accountRepo: repo}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2692,6 +2692,31 @@ func TestHandleGrokAccountUpstreamError429UsesFallbackReset(t *testing.T) {
 	require.Zero(t, repo.tempUnschedCalls)
 }
 
+func TestHandleGrokAccountUpstreamErrorFreeUsageExhaustionUsesRollingCooldown(t *testing.T) {
+	account := &Account{ID: 631, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	repo := &grokQuotaAccountRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	before := time.Now()
+
+	svc.handleGrokAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		nil,
+		[]byte(grokFreeUsageExhaustedTestBody),
+	)
+
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustionCooldown), repo.lastRateLimitResetAt, time.Second)
+	require.Equal(t, 1, repo.updateCalls)
+	snapshot, ok := repo.updates[account.ID][grokQuotaSnapshotExtraKey].(*xai.QuotaSnapshot)
+	require.True(t, ok)
+	require.NotNil(t, snapshot.Tokens)
+	require.EqualValues(t, xai.GrokFreeRolling24hTokenLimit, *snapshot.Tokens.Limit)
+	require.Zero(t, *snapshot.Tokens.Remaining)
+}
+
 func TestGrokRateLimitResetAtForAccountEscalatesRepeated429s(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	retryAfter := 45

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -308,6 +308,22 @@ func isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *A
 	return true
 }
 
+func (s *OpenAIGatewayService) isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
+	if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
+		return false
+	}
+	if exhausted, tokens, known := s.grokFreeRollingQuotaExhausted(ctx, account); known && exhausted {
+		slog.Debug("grok_account_auto_paused_by_local_quota",
+			"account_id", account.ID,
+			"window", "24h",
+			"limit", xai.GrokFreeRolling24hTokenLimit,
+			"tokens", tokens,
+		)
+		return false
+	}
+	return true
+}
+
 type openAIQuotaAutoPauseDecision struct {
 	window      string
 	threshold   float64
@@ -656,6 +672,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 	if err != nil {
 		return nil, fmt.Errorf("query accounts failed: %w", err)
 	}
+	ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	// 3. 按优先级 + LRU 选择最佳账号
 	// Select by priority + LRU
@@ -718,7 +735,7 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 
 	// 验证账号是否可用于当前请求
 	// Verify account is usable for current request
-	if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
+	if !s.isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
@@ -908,6 +925,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if len(accounts) == 0 {
 		return nil, ErrNoAvailableAccounts
 	}
+	ctx = s.withGrokFreeQuotaUsagePrefetch(ctx, accounts)
 
 	isExcluded := func(accountID int64) bool {
 		if excludedIDs == nil {
@@ -927,7 +945,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 				if clearSticky {
 					_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 				}
-				if !clearSticky && isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
+				if !clearSticky && s.isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
 					account = s.recheckSelectedOpenAIAccountFromDB(ctx, account, groupID, platform, requestedModel, requireCompact, requiredCapability)
 					if account == nil {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
@@ -990,7 +1008,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		// Scheduler snapshots can be temporarily stale (bucket rebuild is throttled);
 		// re-check schedulability here so recently rate-limited/overloaded accounts
 		// are not selected again before the bucket is rebuilt.
-		if !isOpenAICompatibleAccountEligibleForRequest(ctx, acc, platform, requestedModel, false, requiredCapability) {
+		if !s.isOpenAICompatibleAccountEligibleForRequest(ctx, acc, platform, requestedModel, false, requiredCapability) {
 			continue
 		}
 		if !parentHealthyForShadow(acc, parentLookupL2) {
@@ -1244,7 +1262,7 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.
 		fresh = current
 	}
 
-	if !isOpenAICompatibleAccountEligibleForRequest(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
+	if !s.isOpenAICompatibleAccountEligibleForRequest(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
@@ -1279,7 +1297,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 	}
 	platform = normalizeOpenAICompatiblePlatform(platform)
 	if s.schedulerSnapshot == nil || s.accountRepo == nil {
-		if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
+		if !s.isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
 			return nil
 		}
 		if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
@@ -1298,7 +1316,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 	if !s.openAIAccountMatchesSchedulingGroup(latest, groupID) {
 		return nil
 	}
-	if !isOpenAICompatibleAccountEligibleForRequest(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
+	if !s.isOpenAICompatibleAccountEligibleForRequest(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -790,12 +790,12 @@ describe('AccountUsageCell', () => {
 
   it.each([
     { tokens: 0, expected: 0, compact: '0' },
-    { tokens: 500_000, expected: 50, compact: '500.0K' },
-    { tokens: 1_000_000, expected: 100, compact: '1.0M' },
-    { tokens: 1_100_000, expected: 100, compact: '1.1M' }
-  ])('Grok Free derives its 1M quota from local tokens: $tokens -> $expected%', async ({ tokens, expected, compact }) => {
+    { tokens: 250_000, expected: 50, compact: '250.0K' },
+    { tokens: 500_000, expected: 100, compact: '500.0K' },
+    { tokens: 550_000, expected: 100, compact: '550.0K' }
+  ])('Grok Free derives its 0.5M quota from local tokens: $tokens -> $expected%', async ({ tokens, expected, compact }) => {
     getUsage.mockResolvedValue({
-      grok_free_token_limit: 1_000_000,
+      grok_free_token_limit: 500_000,
       grok_billing: {
         period_type: 'weekly',
         usage_percent: null,
@@ -809,7 +809,7 @@ describe('AccountUsageCell', () => {
         user_cost: 0
       },
       grok_request_quota: { limit: 100, remaining: 100 },
-      grok_token_quota: { limit: 1_000_000, remaining: 1_000_000 }
+      grok_token_quota: { limit: 500_000, remaining: 500_000 }
     })
 
     const wrapper = mount(AccountUsageCell, {
@@ -839,7 +839,7 @@ describe('AccountUsageCell', () => {
 
   it('Grok Free uses rolling 24h usage instead of today-only usage', async () => {
     getUsage.mockResolvedValue({
-      grok_free_token_limit: 1_000_000,
+      grok_free_token_limit: 500_000,
       grok_billing: { period_type: 'weekly', usage_percent: null, plan: '' },
       grok_local_usage: {
         requests: 2,
@@ -849,7 +849,7 @@ describe('AccountUsageCell', () => {
       },
       grok_local_usage_24h: {
         requests: 12,
-        tokens: 750_000,
+        tokens: 375_000,
         cost: 0,
         standard_cost: 0
       }
@@ -880,7 +880,7 @@ describe('AccountUsageCell', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('24h|75|admin.accounts.usageWindow.grokFreeQuota24hHint')
-    expect(wrapper.text()).toContain('750.0K')
+    expect(wrapper.text()).toContain('375.0K')
     expect(wrapper.text()).not.toContain('7d|')
     expect(wrapper.text()).not.toContain('200.0K')
     expect(wrapper.text()).not.toContain('250.0K')
@@ -888,7 +888,7 @@ describe('AccountUsageCell', () => {
 
   it('Grok Free does not substitute today stats when rolling 24h usage is unavailable', async () => {
     getUsage.mockResolvedValue({
-      grok_free_token_limit: 1_000_000,
+      grok_free_token_limit: 500_000,
       grok_billing: { period_type: 'weekly', usage_percent: null, plan: '' },
       grok_local_usage: {
         requests: 1,
@@ -1009,13 +1009,13 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).not.toContain('2M|')
   })
 
-  it('Grok credential Free tier keeps the 1M fallback when billing is unavailable', async () => {
+  it('Grok credential Free tier keeps the 0.5M fallback when billing is unavailable', async () => {
     getUsage.mockResolvedValue({
-      grok_free_token_limit: 1_000_000,
+      grok_free_token_limit: 500_000,
       subscription_tier: 'FREE',
       grok_local_usage_24h: {
         requests: 3,
-        tokens: 1_000_000,
+        tokens: 500_000,
         cost: 0,
         standard_cost: 0
       }
@@ -1254,7 +1254,7 @@ describe('AccountUsageCell', () => {
 
   it('Grok Free manual probes merge rolling 24h usage', async () => {
     getUsage.mockResolvedValue({
-      grok_free_token_limit: 1_000_000,
+      grok_free_token_limit: 500_000,
       subscription_tier: 'FREE',
       grok_quota_snapshot_state: 'no_headers'
     })
@@ -1275,7 +1275,7 @@ describe('AccountUsageCell', () => {
             template: `<button class="probe" @click="$emit('probed', {
               source: 'hybrid_probe',
               billing: { period_type: 'weekly', usage_percent: null, plan: '' },
-              local_usage_24h: { requests: 12, tokens: 750000, cost: 0, standard_cost: 0 },
+              local_usage_24h: { requests: 12, tokens: 375000, cost: 0, standard_cost: 0 },
               headers_observed: false,
               reset_supported: false,
               fetched_at: 1
@@ -1289,7 +1289,7 @@ describe('AccountUsageCell', () => {
     await wrapper.get('.probe').trigger('click')
 
     expect(wrapper.text()).toContain('24h|75')
-    expect(wrapper.text()).toContain('750.0K')
+    expect(wrapper.text()).toContain('375.0K')
     expect(wrapper.text()).not.toContain('7d|')
   })
 


### PR DESCRIPTION
## Summary

- Update the observed Grok Free rolling 24-hour token limit to 500,000 while retaining legacy limit recognition.
- Exclude exhausted Grok Free OAuth accounts during scheduling using one prefetched rolling-window aggregate.
- Detect subscription:free-usage-exhausted from 429 response bodies, persist a zero-remaining quota snapshot, and place the account in cooldown.
- Continue bounded account failover for confirmed per-account Free quota exhaustion while preserving the existing generic 429 storm guard.
- Apply the same response-body classification when an administrator tests a Grok account.

## Problem

Grok Free exhaustion can be returned without rate-limit headers. Local usage logs also cannot account for tokens consumed before import or by another client. As a result, an exhausted account could remain schedulable, receive only a short fallback cooldown, and stop failover after one follow-up account.

The canonical response is account-scoped:

    subscription:free-usage-exhausted
    Usage resets over a rolling 24-hour window - tokens (actual/limit): .../500000

## Behavior

- Confirmed Free exhaustion records limit=500000, remaining=0, and an upstream_error_body observation.
- The account receives an 24-hour cooldown before being probed by normal traffic again.
- Confirmed exhaustion may continue through the configured account-switch budget.
- Generic Grok/OpenAI 429 responses retain the existing conservative follow-up and storm behavior.
- Successful recovery continues to clear only the observed cooldown generation.

## Verification

    go vet ./...
    go test ./internal/service -run 'Test(ParseGrokFreeUsageExhaustion|ParseGrokQuotaSnapshotWithBody|AccountTestService_GrokFreeUsageExhaustion|HandleGrokAccountUpstreamErrorFreeUsageExhaustion|ShouldStopOpenAIOAuth429Failover|GrokFree)' -count=1
    go test ./internal/service ./internal/handler -count=1 -skip TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig
    pnpm test:run -- src/components/account/__tests__/AccountUsageCell.spec.ts

## Related Issue

Fixes #5132