### PR TITLE
fix(openai): persist quota snapshots at auto-pause thresholds

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -678,7 +678,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if result != nil {
 			// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
 			if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
-				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
+				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account, result.ResponseHeaders)
 			}
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
 		} else {
@@ -2162,7 +2162,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				)
 				// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
 				if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
-					h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, result.ResponseHeaders)
+					h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(ctx, account, result.ResponseHeaders)
 				}
 				scheduleModel := turnUpstreamModel
 				if scheduleModel == "" {

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -364,7 +364,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		if result != nil {
 			// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
 			if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
-				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
+				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account, result.ResponseHeaders)
 			}
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(requestModel), true, result.FirstTokenMs)
 		} else {

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -108,7 +108,7 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 	}
 
 	if !account.IsShadow() {
-		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, resp.Header)
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
 	}
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	contentType := resp.Header.Get("Content-Type")
@@ -193,7 +193,7 @@ func (s *OpenAIGatewayService) forwardAlphaSearchViaResponsesWebSearch(
 	}
 
 	if !account.IsShadow() {
-		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, resp.Header)
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
 	}
 	alphaRespBody, err := openAIAlphaSearchResponseFromResponsesSSE(respBody)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -301,6 +301,11 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 		return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)
 	}
+	// Capture quota state before the response body is drained. This matters for
+	// long-running streams that cross an auto-pause threshold in their headers.
+	if account.Type == AccountTypeOAuth && !account.IsShadow() {
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
+	}
 
 	// 9. Handle normal response
 	var result *OpenAIForwardResult
@@ -329,14 +334,6 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		if responsesReq.Reasoning != nil && responsesReq.Reasoning.Effort != "" {
 			re := responsesReq.Reasoning.Effort
 			result.ReasoningEffort = &re
-		}
-	}
-
-	// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
-	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if handleErr == nil && account.Type == AccountTypeOAuth && !account.IsShadow() {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -918,6 +918,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			return s.handleErrorResponse(ctx, resp, c, account, body, billingModel)
 		}
 		defer func() { _ = resp.Body.Close() }()
+		// Quota headers are available before a streaming body is drained. Persist a
+		// threshold-crossing snapshot now so later requests cannot keep selecting the
+		// account for the lifetime of a long stream.
+		if account.Type == AccountTypeOAuth && !account.IsShadow() {
+			s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
+		}
 
 		serviceTier := extractOpenAIServiceTierFromBody(body)
 		// 上游接受后只保留计费需要的标量，避免响应处理期间继续保活完整 input/tools map。
@@ -950,14 +956,6 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			imageOutputSizes = nonStreamResult.imageOutputSizes
 		}
 		s.bindHTTPResponseAccount(ctx, c, account, responseID)
-
-		// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
-		// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-		if account.Type == AccountTypeOAuth && !account.IsShadow() {
-			if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-				s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-			}
-		}
 
 		if usage == nil {
 			usage = &OpenAIUsage{}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -443,6 +443,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.Platform == PlatformGrok && account.Type == AccountTypeOAuth && !account.IsShadow() {
 		s.updateGrokUsageFromResponse(ctx, account, resp.Header, resp.StatusCode)
 	}
+	if account.Type == AccountTypeOAuth && !account.IsShadow() && account.Platform != PlatformGrok {
+		// Process quota headers before draining the always-streaming upstream body.
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
+	}
 
 	if account.Type == AccountTypeOAuth && promptCacheKey != "" {
 		if turnState := strings.TrimSpace(resp.Header.Get("x-codex-turn-state")); turnState != "" {
@@ -485,14 +489,6 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		if responsesReq.Reasoning != nil && responsesReq.Reasoning.Effort != "" {
 			re := responsesReq.Reasoning.Effort
 			result.ReasoningEffort = &re
-		}
-	}
-
-	// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
-	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if handleErr == nil && account.Type == AccountTypeOAuth && !account.IsShadow() && account.Platform != PlatformGrok {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -235,6 +235,11 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		return nil, s.handleErrorResponsePassthrough(ctx, resp, c, account, body, probeBody)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// Capture quota state as soon as the upstream headers arrive. Waiting for the
+	// body would leave the account schedulable throughout a long streaming response.
+	if !account.IsShadow() {
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account, resp.Header)
+	}
 
 	serviceTier := extractOpenAIServiceTierFromBody(body)
 
@@ -264,13 +269,6 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageOutputSizes = result.imageOutputSizes
 	}
 	s.bindHTTPResponseAccount(ctx, c, account, responseID)
-
-	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if !account.IsShadow() {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-		}
-	}
 
 	if usage == nil {
 		usage = &OpenAIUsage{}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -62,7 +62,8 @@ const (
 	// 官方身份时整体回退到本常量，因此它必须跟随官方 CLI 的当前发布版本，
 	// 落后多个版本会让这些请求稳定落在被优先丢弃的一侧。
 	codexCLIVersion = "0.146.0"
-	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
+	// 普通 Codex 限额快照不需要每个成功请求都立即落库；达到自动暂停阈值的
+	// 快照会绕过该节流并同步刷新调度缓存。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 	// 配额自动暂停时，超过该时长仍未刷新的 used% 快照视为陈旧，不再据此暂停账号。
 	// 被暂停的账号收不到流量，其快照永远不会从上游响应头刷新；该兜底让账号在快照
@@ -351,15 +352,67 @@ type openAIWSRetryMetrics struct {
 }
 
 type accountWriteThrottle struct {
-	minInterval time.Duration
-	mu          sync.Mutex
-	lastByID    map[int64]time.Time
+	minInterval      time.Duration
+	mu               sync.Mutex
+	lastByID         map[int64]time.Time
+	criticalLastByID map[int64]time.Time
+}
+
+type accountWriteLockEntry struct {
+	orderMu sync.Mutex
+	writeMu sync.Mutex
+	refs    int
+}
+
+type accountWriteLockMap struct {
+	mu    sync.Mutex
+	locks map[int64]*accountWriteLockEntry
+}
+
+// LockIfAllowed orders the throttle decision and write-lock acquisition for one
+// account. This prevents an older write that already passed throttling from being
+// overtaken by a newer critical write before it has claimed the write lock.
+func (m *accountWriteLockMap) LockIfAllowed(id int64, allow func() bool) (func(), bool) {
+	m.mu.Lock()
+	if m.locks == nil {
+		m.locks = make(map[int64]*accountWriteLockEntry)
+	}
+	entry := m.locks[id]
+	if entry == nil {
+		entry = &accountWriteLockEntry{}
+		m.locks[id] = entry
+	}
+	entry.refs++
+	m.mu.Unlock()
+
+	entry.orderMu.Lock()
+	if allow != nil && !allow() {
+		entry.orderMu.Unlock()
+		m.release(id, entry)
+		return nil, false
+	}
+	entry.writeMu.Lock()
+	entry.orderMu.Unlock()
+	return func() {
+		entry.writeMu.Unlock()
+		m.release(id, entry)
+	}, true
+}
+
+func (m *accountWriteLockMap) release(id int64, entry *accountWriteLockEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry.refs--
+	if entry.refs == 0 && m.locks[id] == entry {
+		delete(m.locks, id)
+	}
 }
 
 func newAccountWriteThrottle(minInterval time.Duration) *accountWriteThrottle {
 	return &accountWriteThrottle{
-		minInterval: minInterval,
-		lastByID:    make(map[int64]time.Time),
+		minInterval:      minInterval,
+		lastByID:         make(map[int64]time.Time),
+		criticalLastByID: make(map[int64]time.Time),
 	}
 }
 
@@ -375,17 +428,60 @@ func (t *accountWriteThrottle) Allow(id int64, now time.Time) bool {
 		return false
 	}
 	t.lastByID[id] = now
-
-	if len(t.lastByID) > 4096 {
-		cutoff := now.Add(-4 * t.minInterval)
-		for accountID, writtenAt := range t.lastByID {
-			if writtenAt.Before(cutoff) {
-				delete(t.lastByID, accountID)
-			}
-		}
-	}
+	t.pruneLocked(now)
 
 	return true
+}
+
+// AllowCritical lets one threshold-crossing write bypass a recent ordinary write.
+// Further critical writes are deduplicated for the same interval so a burst of
+// already in-flight responses cannot fan out into an unbounded number of DB writes.
+func (t *accountWriteThrottle) AllowCritical(id int64, now time.Time) bool {
+	if t == nil || id <= 0 || t.minInterval <= 0 {
+		return true
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if last, ok := t.criticalLastByID[id]; ok && now.Sub(last) < t.minInterval {
+		return false
+	}
+	t.criticalLastByID[id] = now
+	t.lastByID[id] = now
+	t.pruneLocked(now)
+	return true
+}
+
+func (t *accountWriteThrottle) CancelCritical(id int64, allowedAt time.Time) {
+	if t == nil || id <= 0 || t.minInterval <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if last, ok := t.criticalLastByID[id]; ok && last.Equal(allowedAt) {
+		delete(t.criticalLastByID, id)
+	}
+	if last, ok := t.lastByID[id]; ok && last.Equal(allowedAt) {
+		delete(t.lastByID, id)
+	}
+}
+
+func (t *accountWriteThrottle) pruneLocked(now time.Time) {
+	if len(t.lastByID) <= 4096 && len(t.criticalLastByID) <= 4096 {
+		return
+	}
+	cutoff := now.Add(-4 * t.minInterval)
+	for accountID, writtenAt := range t.lastByID {
+		if writtenAt.Before(cutoff) {
+			delete(t.lastByID, accountID)
+		}
+	}
+	for accountID, writtenAt := range t.criticalLastByID {
+		if writtenAt.Before(cutoff) {
+			delete(t.criticalLastByID, accountID)
+		}
+	}
 }
 
 var defaultOpenAICodexSnapshotPersistThrottle = newAccountWriteThrottle(openAICodexSnapshotPersistMinInterval)
@@ -451,6 +547,7 @@ type OpenAIGatewayService struct {
 	openaiWSRetryMetrics                openAIWSRetryMetrics
 	responseHeaderFilter                *responseheaders.CompiledHeaderFilter
 	codexSnapshotThrottle               *accountWriteThrottle
+	codexSnapshotWriteLocks             accountWriteLockMap
 	codexModelsManifestCache            codexModelsManifestCache
 	openaiCompatSessionResponses        sync.Map
 	openaiCompatAnthropicDigestSessions sync.Map

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2818,7 +2818,7 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 	headers.Set("x-codex-primary-reset-after-seconds", "600")
 	headers.Set("x-codex-secondary-reset-after-seconds", "86400")
 
-	svc.UpdateCodexUsageSnapshotFromHeaders(context.Background(), 123, headers)
+	svc.UpdateCodexUsageSnapshotFromHeaders(context.Background(), &Account{ID: 123}, headers)
 
 	select {
 	case updates := <-repo.updateExtraCalls:

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -826,17 +827,18 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 	return updates
 }
 
-// updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field
-// updateCodexUsageSnapshot 把 /responses 的 x-codex-* 全局头快照写入账号 codex_* Extra。
-// ⚠️ 调用方必须排除 spark 影子账号(account.IsShadow()):影子的 codex_* 仅由 QueryUsage
-// (/wham/usage bengalfox 道)更新,不能被全局头口径污染(外审第7轮 P1)。本函数仅持 accountID,
-// 无法在此自检影子,故守卫前置到各调用点。
-func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot) {
+// updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field.
+// Callers must continue excluding spark shadow accounts: their codex_* fields are
+// refreshed only through the dimension-specific /wham/usage query.
+func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, account *Account, snapshot *OpenAICodexUsageSnapshot) {
 	if snapshot == nil {
 		return
 	}
-	if s == nil || s.accountRepo == nil {
+	if s == nil || s.accountRepo == nil || account == nil || account.ID <= 0 {
 		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	now := time.Now()
@@ -844,22 +846,70 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 	if len(updates) == 0 {
 		return
 	}
-	if !s.getCodexSnapshotThrottle().Allow(accountID, now) {
+
+	throttle := s.getCodexSnapshotThrottle()
+	if s.codexSnapshotReachesAutoPauseThreshold(ctx, account, updates) {
+		unlockWrite, allowed := s.codexSnapshotWriteLocks.LockIfAllowed(account.ID, func() bool {
+			return throttle.AllowCritical(account.ID, now)
+		})
+		if !allowed {
+			return
+		}
+		defer unlockWrite()
+		persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := s.accountRepo.UpdateExtra(persistCtx, account.ID, updates); err != nil {
+			throttle.CancelCritical(account.ID, now)
+			slog.Warn("openai_codex_auto_pause_snapshot_persist_failed", "account_id", account.ID, "error", err)
+		}
+		return
+	}
+	accountID := account.ID
+	unlockWrite, allowed := s.codexSnapshotWriteLocks.LockIfAllowed(accountID, func() bool {
+		return throttle.Allow(accountID, now)
+	})
+	if !allowed {
 		return
 	}
 
 	go func() {
+		defer unlockWrite()
 		updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
+		if err := s.accountRepo.UpdateExtra(updateCtx, accountID, updates); err != nil {
+			slog.Warn("openai_codex_snapshot_persist_failed", "account_id", accountID, "error", err)
+		}
 	}()
 }
 
-func (s *OpenAIGatewayService) UpdateCodexUsageSnapshotFromHeaders(ctx context.Context, accountID int64, headers http.Header) {
-	if accountID <= 0 || headers == nil {
+func (s *OpenAIGatewayService) codexSnapshotReachesAutoPauseThreshold(ctx context.Context, account *Account, updates map[string]any) bool {
+	if account == nil || !account.IsOpenAI() || len(updates) == 0 {
+		return false
+	}
+	_, has5h := updates["codex_5h_used_percent"]
+	_, has7d := updates["codex_7d_used_percent"]
+	if !has5h && !has7d {
+		return false
+	}
+
+	mergedExtra := make(map[string]any, len(account.Extra)+len(updates))
+	for key, value := range account.Extra {
+		mergedExtra[key] = value
+	}
+	for key, value := range updates {
+		mergedExtra[key] = value
+	}
+	accountSnapshot := *account
+	accountSnapshot.Extra = mergedExtra
+	paused, _ := shouldAutoPauseOpenAIAccountByQuota(s.withOpenAIQuotaAutoPauseContext(ctx), &accountSnapshot)
+	return paused
+}
+
+func (s *OpenAIGatewayService) UpdateCodexUsageSnapshotFromHeaders(ctx context.Context, account *Account, headers http.Header) {
+	if account == nil || account.ID <= 0 || headers == nil {
 		return
 	}
 	if snapshot := ParseCodexRateLimitHeaders(headers); snapshot != nil {
-		s.updateCodexUsageSnapshot(ctx, accountID, snapshot)
+		s.updateCodexUsageSnapshot(ctx, account, snapshot)
 	}
 }

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -1,15 +1,18 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
@@ -28,6 +31,39 @@ type openAICodexSnapshotAsyncRepo struct {
 	updateExtraCh chan map[string]any
 	rateLimitCh   chan time.Time
 }
+
+type orderedOpenAICodexSnapshotRepo struct {
+	stubOpenAIAccountRepo
+	firstStarted chan struct{}
+	releaseFirst chan struct{}
+	mu           sync.Mutex
+	calls        int
+	used5hWrites []float64
+}
+
+type blockingCodexQuotaBody struct {
+	payload     []byte
+	readStarted chan struct{}
+	release     <-chan struct{}
+	offset      int
+	started     bool
+}
+
+func (b *blockingCodexQuotaBody) Read(dst []byte) (int, error) {
+	if !b.started {
+		b.started = true
+		close(b.readStarted)
+		<-b.release
+	}
+	if b.offset >= len(b.payload) {
+		return 0, io.EOF
+	}
+	n := copy(dst, b.payload[b.offset:])
+	b.offset += n
+	return n, nil
+}
+
+func (b *blockingCodexQuotaBody) Close() error { return nil }
 
 type openAICodexExtraListRepo struct {
 	stubOpenAIAccountRepo
@@ -63,6 +99,22 @@ func (r *openAICodexSnapshotAsyncRepo) UpdateExtra(_ context.Context, _ int64, u
 		}
 		r.updateExtraCh <- copied
 	}
+	return nil
+}
+
+func (r *orderedOpenAICodexSnapshotRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+	if call == 1 {
+		close(r.firstStarted)
+		<-r.releaseFirst
+	}
+	used5h, _ := updates["codex_5h_used_percent"].(float64)
+	r.mu.Lock()
+	r.used5hWrites = append(r.used5hWrites, used5h)
+	r.mu.Unlock()
 	return nil
 }
 
@@ -408,7 +460,7 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ExhaustedSnapshotDoesNotS
 		SecondaryResetAfterSeconds: ptrIntWS(1200),
 		SecondaryWindowMinutes:     ptrIntWS(300),
 	}
-	svc.updateCodexUsageSnapshot(context.Background(), 601, snapshot)
+	svc.updateCodexUsageSnapshot(context.Background(), &Account{ID: 601}, snapshot)
 
 	select {
 	case updates := <-repo.updateExtraCh:
@@ -438,7 +490,7 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_NonExhaustedSnapshotDoesN
 		SecondaryResetAfterSeconds: ptrIntWS(1200),
 		SecondaryWindowMinutes:     ptrIntWS(300),
 	}
-	svc.updateCodexUsageSnapshot(context.Background(), 602, snapshot)
+	svc.updateCodexUsageSnapshot(context.Background(), &Account{ID: 602}, snapshot)
 
 	select {
 	case <-repo.updateExtraCh:
@@ -470,8 +522,9 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThrottlesExtraWrites(t *t
 		SecondaryWindowMinutes:     ptrIntWS(300),
 	}
 
-	svc.updateCodexUsageSnapshot(context.Background(), 777, snapshot)
-	svc.updateCodexUsageSnapshot(context.Background(), 777, snapshot)
+	account := &Account{ID: 777}
+	svc.updateCodexUsageSnapshot(context.Background(), account, snapshot)
+	svc.updateCodexUsageSnapshot(context.Background(), account, snapshot)
 
 	select {
 	case <-repo.updateExtraCh:
@@ -483,6 +536,310 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThrottlesExtraWrites(t *t
 	case updates := <-repo.updateExtraCh:
 		t.Fatalf("unexpected second codex snapshot write: %v", updates)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThresholdCrossingBypassesThrottle(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		extra     map[string]any
+		accountID int64
+	}{
+		{
+			name:      "account threshold",
+			ctx:       context.Background(),
+			extra:     map[string]any{"auto_pause_5h_threshold": 0.95},
+			accountID: 778,
+		},
+		{
+			name:      "global threshold",
+			ctx:       withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold5h: 0.95}),
+			accountID: 779,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &openAICodexSnapshotAsyncRepo{updateExtraCh: make(chan map[string]any, 2)}
+			svc := &OpenAIGatewayService{
+				accountRepo:           repo,
+				codexSnapshotThrottle: newAccountWriteThrottle(time.Hour),
+			}
+			account := &Account{
+				ID:       tt.accountID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra:    tt.extra,
+			}
+			snapshot := func(used5h float64) *OpenAICodexUsageSnapshot {
+				return &OpenAICodexUsageSnapshot{
+					PrimaryUsedPercent:         ptrFloat64WS(used5h),
+					PrimaryResetAfterSeconds:   ptrIntWS(3600),
+					PrimaryWindowMinutes:       ptrIntWS(300),
+					SecondaryUsedPercent:       ptrFloat64WS(20),
+					SecondaryResetAfterSeconds: ptrIntWS(86400),
+					SecondaryWindowMinutes:     ptrIntWS(10080),
+				}
+			}
+
+			svc.updateCodexUsageSnapshot(tt.ctx, account, snapshot(94))
+			select {
+			case updates := <-repo.updateExtraCh:
+				require.Equal(t, 94.0, updates["codex_5h_used_percent"])
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for the pre-threshold snapshot")
+			}
+
+			// The 95% observation is inside the ordinary one-hour throttle window,
+			// but it must be persisted synchronously because it pauses scheduling.
+			svc.updateCodexUsageSnapshot(tt.ctx, account, snapshot(95))
+			select {
+			case updates := <-repo.updateExtraCh:
+				require.Equal(t, 95.0, updates["codex_5h_used_percent"])
+			default:
+				t.Fatal("threshold-crossing snapshot was not persisted synchronously")
+			}
+
+			// Already in-flight responses above the threshold are deduplicated.
+			svc.updateCodexUsageSnapshot(tt.ctx, account, snapshot(96))
+			select {
+			case updates := <-repo.updateExtraCh:
+				t.Fatalf("unexpected duplicate critical snapshot write: %v", updates)
+			case <-time.After(200 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThresholdWriteCannotBeOverwrittenByOlderAsyncWrite(t *testing.T) {
+	repo := &orderedOpenAICodexSnapshotRepo{
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:           repo,
+		codexSnapshotThrottle: newAccountWriteThrottle(time.Hour),
+	}
+	account := &Account{
+		ID:       780,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"auto_pause_5h_threshold": 0.95},
+	}
+	snapshot := func(used5h float64) *OpenAICodexUsageSnapshot {
+		return &OpenAICodexUsageSnapshot{
+			PrimaryUsedPercent:         ptrFloat64WS(used5h),
+			PrimaryResetAfterSeconds:   ptrIntWS(3600),
+			PrimaryWindowMinutes:       ptrIntWS(300),
+			SecondaryUsedPercent:       ptrFloat64WS(20),
+			SecondaryResetAfterSeconds: ptrIntWS(86400),
+			SecondaryWindowMinutes:     ptrIntWS(10080),
+		}
+	}
+
+	svc.updateCodexUsageSnapshot(context.Background(), account, snapshot(94))
+	select {
+	case <-repo.firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("older async snapshot did not start")
+	}
+
+	criticalDone := make(chan struct{})
+	go func() {
+		svc.updateCodexUsageSnapshot(context.Background(), account, snapshot(95))
+		close(criticalDone)
+	}()
+	select {
+	case <-criticalDone:
+		t.Fatal("critical write returned before the older snapshot finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(repo.releaseFirst)
+	select {
+	case <-criticalDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("critical snapshot write did not finish")
+	}
+
+	repo.mu.Lock()
+	writes := append([]float64(nil), repo.used5hWrites...)
+	repo.mu.Unlock()
+	require.Equal(t, []float64{94, 95}, writes)
+}
+
+func TestAccountWriteLockMap_ThrottleDecisionCannotBeOvertaken(t *testing.T) {
+	var locks accountWriteLockMap
+	firstDecisionStarted := make(chan struct{})
+	releaseFirstDecision := make(chan struct{})
+	firstAcquired := make(chan struct{})
+	releaseFirstWrite := make(chan struct{})
+	secondDecisionStarted := make(chan struct{})
+	secondAcquired := make(chan struct{})
+
+	go func() {
+		unlock, allowed := locks.LockIfAllowed(1, func() bool {
+			close(firstDecisionStarted)
+			<-releaseFirstDecision
+			return true
+		})
+		if !allowed {
+			return
+		}
+		close(firstAcquired)
+		<-releaseFirstWrite
+		unlock()
+	}()
+	<-firstDecisionStarted
+
+	go func() {
+		unlock, allowed := locks.LockIfAllowed(1, func() bool {
+			close(secondDecisionStarted)
+			return true
+		})
+		if !allowed {
+			return
+		}
+		close(secondAcquired)
+		unlock()
+	}()
+
+	select {
+	case <-secondDecisionStarted:
+		t.Fatal("newer decision overtook the older decision before it claimed write order")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirstDecision)
+	select {
+	case <-firstAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("older write did not acquire its ordered lock")
+	}
+	select {
+	case <-secondDecisionStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("newer throttle decision did not run after the older write was ordered")
+	}
+	select {
+	case <-secondAcquired:
+		t.Fatal("newer write acquired before the older write completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirstWrite)
+	select {
+	case <-secondAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("newer write did not acquire after the older write completed")
+	}
+}
+
+func TestAccountWriteLockMap_DeniedWriteDoesNotWaitForActiveWrite(t *testing.T) {
+	var locks accountWriteLockMap
+	unlockFirst, allowed := locks.LockIfAllowed(1, func() bool { return true })
+	require.True(t, allowed)
+	defer unlockFirst()
+
+	type deniedResult struct {
+		unlock  func()
+		allowed bool
+	}
+	deniedDone := make(chan deniedResult, 1)
+	go func() {
+		unlock, secondAllowed := locks.LockIfAllowed(1, func() bool { return false })
+		deniedDone <- deniedResult{unlock: unlock, allowed: secondAllowed}
+	}()
+
+	select {
+	case result := <-deniedDone:
+		require.False(t, result.allowed)
+		require.Nil(t, result.unlock)
+	case <-time.After(2 * time.Second):
+		t.Fatal("throttled write waited for an unrelated active database write")
+	}
+}
+
+func TestOpenAIGatewayService_ForwardPersistsThresholdSnapshotBeforeStreamingBodyCompletes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	requestBody := []byte(`{"model":"gpt-5.4","stream":true,"input":"hello"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	releaseBody := make(chan struct{})
+	upstreamBody := &blockingCodexQuotaBody{
+		payload:     []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_quota\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"),
+		readStarted: make(chan struct{}),
+		release:     releaseBody,
+	}
+	headers := http.Header{"Content-Type": []string{"text/event-stream"}}
+	headers.Set("x-codex-primary-used-percent", "95")
+	headers.Set("x-codex-primary-reset-after-seconds", "3600")
+	headers.Set("x-codex-primary-window-minutes", "300")
+	headers.Set("x-codex-secondary-used-percent", "20")
+	headers.Set("x-codex-secondary-reset-after-seconds", "86400")
+	headers.Set("x-codex-secondary-window-minutes", "10080")
+
+	repo := &openAICodexSnapshotAsyncRepo{updateExtraCh: make(chan map[string]any, 1)}
+	svc := &OpenAIGatewayService{
+		cfg:                   &config.Config{},
+		accountRepo:           repo,
+		httpUpstream:          &httpUpstreamRecorder{resp: &http.Response{StatusCode: http.StatusOK, Header: headers, Body: upstreamBody}},
+		codexSnapshotThrottle: newAccountWriteThrottle(time.Hour),
+	}
+	account := &Account{
+		ID:          781,
+		Name:        "quota-stream-test",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-account"},
+		Extra: map[string]any{
+			"openai_passthrough":      true,
+			"auto_pause_5h_threshold": 0.95,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	resultCh := make(chan *OpenAIForwardResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := svc.Forward(context.Background(), c, account, requestBody)
+		resultCh <- result
+		errCh <- err
+	}()
+
+	select {
+	case <-upstreamBody.readStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("streaming body read did not start")
+	}
+	select {
+	case updates := <-repo.updateExtraCh:
+		require.Equal(t, 95.0, updates["codex_5h_used_percent"])
+	default:
+		t.Fatal("quota threshold snapshot was not persisted before streaming body read")
+	}
+	select {
+	case <-resultCh:
+		t.Fatal("forward returned before the blocked streaming body was released")
+	default:
+	}
+
+	close(releaseBody)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("forward did not finish after releasing the streaming body")
+	}
+	select {
+	case result := <-resultCh:
+		require.NotNil(t, result)
+	case <-time.After(2 * time.Second):
+		t.Fatal("forward result was not returned")
 	}
 }
 


### PR DESCRIPTION
## 问题

OpenAI OAuth 账号配置 5h/7d 自动暂停阈值（例如 95%）后，成功响应已经返回阈值用量时，账号仍可能继续被调度，直到 100% 的 429 路径才写入最新快照并触发限流。

## 根因

- 成功响应的 Codex 快照在检查阈值前先经过 30 秒写入节流。若 94% 快照刚占用节流窗口，随后的 95% 快照会被直接丢弃。
- Responses、passthrough、Chat Completions 和 Messages 路径在完整消费响应体后才保存响应头。长流期间调度器看不到已到达的阈值信号。
- 普通快照异步写入；若旧写入晚于关键写入完成，账号用量可能倒退。

429 路径本身同步保存快照，因此最终可见状态往往直接从阈值前值跳到 100%。

## 改动

- 快照更新接收完整账号，并复用现有账号级/全局自动暂停逻辑判断新快照是否达到阈值。
- 达到阈值的快照绕过普通节流，在 5 秒上限内同步调用 `UpdateExtra`；同一节流窗口内的重复关键写入仍会去重。
- 将节流判断和按账号写入顺序绑定，防止旧异步写入越过新的关键写入；已被节流的普通请求不会等待正在进行的数据库写入。
- 在成功响应头到达后、消费响应体前采集快照，覆盖 Responses、passthrough、Chat Completions 和 Messages。
- 保持 spark shadow 只由 `/wham/usage` 刷新，并保留 Grok 的专用用量更新路径。

## 影响面

- 无数据库 schema、配置或 API 变更。
- 未达到阈值的快照仍按原行为异步写入并保持 30 秒节流。
- 只有达到自动暂停阈值的请求会等待关键快照持久化，最长 5 秒；这是为了让后续调度在请求返回前看到暂停信号。
- 本 PR 保证单进程内写入顺序；跨实例的数据库单调写入保护见 #5321。

## 验证

- `cd backend && make test-unit`
- `cd backend && make test-integration`
- `cd backend && golangci-lint run ./...`（0 issues）
- `cd backend && make build`
- `cd backend && go test -race ./internal/service -run "Test(AccountWriteLockMap|OpenAIGatewayService_(UpdateCodexUsageSnapshot|ForwardPersistsThresholdSnapshot)|OpenAIUpdateCodexUsageSnapshotFromHeaders)" -count=1`
- `make test-frontend`（8 files / 132 tests）
- 上游 deployment shell tests 全部通过
- `cd backend && govulncheck ./...`（0 reachable vulnerabilities）

新增回归测试覆盖：94% 后的 95% 节流绕过、账号级和全局阈值、旧异步写入顺序、节流判断竞态，以及响应体阻塞时的提前持久化。