### PR TITLE
fix(openai): prevent stale quota snapshot overwrites

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -64,9 +64,10 @@ var schedulerNeutralExtraKeyPrefixes = []string{
 }
 
 var schedulerNeutralExtraKeys = map[string]struct{}{
-	"codex_usage_updated_at":     {},
-	"grok_billing_snapshot":      {},
-	"session_window_utilization": {},
+	"codex_usage_updated_at":                           {},
+	service.OpenAICodexUsageObservedAtUnixNanoExtraKey: {},
+	"grok_billing_snapshot":                            {},
+	"session_window_utilization":                       {},
 }
 
 const postgresParameterBatchSize = 50000
@@ -2552,10 +2553,16 @@ func (r *accountRepository) UpdateExtra(ctx context.Context, id int64, updates m
 	if clearProbeSnapshot {
 		extraExpression = "(" + extraExpression + ") - 'upstream_billing_probe'"
 	}
+	args := []any{string(payload), id}
+	if observedAt, ok := updates[service.OpenAICodexUsageObservedAtUnixNanoExtraKey].(int64); ok && observedAt > 0 {
+		key := service.OpenAICodexUsageObservedAtUnixNanoExtraKey
+		extraExpression = "CASE WHEN COALESCE(CASE WHEN jsonb_typeof(COALESCE(extra, '{}'::jsonb)->'" + key + "') = 'number' THEN (extra->>'" + key + "')::numeric END, 0) <= $3::numeric THEN " + extraExpression + " ELSE COALESCE(extra, '{}'::jsonb) END"
+		args = append(args, observedAt)
+	}
 	result, err := client.ExecContext(
 		ctx,
 		"UPDATE accounts SET extra = "+extraExpression+", updated_at = NOW() WHERE id = $2 AND deleted_at IS NULL",
-		string(payload), id,
+		args...,
 	)
 
 	if err != nil {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -1521,6 +1521,40 @@ func (s *AccountRepoSuite) TestUpdateExtra_ExhaustedCodexSnapshotSyncsSchedulerC
 	s.Require().Equal(100.0, cacheRecorder.setAccounts[0].Extra["codex_7d_used_percent"])
 }
 
+func (s *AccountRepoSuite) TestUpdateExtra_OlderCodexSnapshotCannotOverwriteNewerObservation() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name:     "acc-extra-codex-monotonic",
+		Platform: service.PlatformOpenAI,
+		Type:     service.AccountTypeOAuth,
+		Extra:    map[string]any{},
+	})
+	const newer = int64(1771236000200000000)
+	const older = int64(1771236000100000000)
+
+	s.Require().NoError(s.repo.UpdateExtra(s.ctx, account.ID, map[string]any{
+		"codex_5h_used_percent":                            95.0,
+		service.OpenAICodexUsageObservedAtUnixNanoExtraKey: newer,
+	}))
+	s.Require().NoError(s.repo.UpdateExtra(s.ctx, account.ID, map[string]any{
+		"codex_5h_used_percent":                            94.0,
+		service.OpenAICodexUsageObservedAtUnixNanoExtraKey: older,
+	}))
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Equal(95.0, got.Extra["codex_5h_used_percent"])
+
+	var storedObservedAt string
+	s.Require().NoError(scanSingleRow(
+		s.ctx,
+		s.repo.sql,
+		"SELECT extra ->> $1 FROM accounts WHERE id = $2",
+		[]any{service.OpenAICodexUsageObservedAtUnixNanoExtraKey, account.ID},
+		&storedObservedAt,
+	))
+	s.Require().Equal("1771236000200000000", storedObservedAt)
+}
+
 func (s *AccountRepoSuite) TestUpdateExtra_SchedulerRelevantStillEnqueuesOutbox() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:     "acc-extra-mixed",

--- a/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
+++ b/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
@@ -285,6 +285,29 @@ func TestUpdateExtraNilProbeRemovesKeyInsteadOfWritingJSONNull(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUpdateExtraCodexSnapshotUsesMonotonicObservationGuard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	client := dbent.NewClient(dbent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	t.Cleanup(func() { _ = client.Close() })
+
+	const observedAt = int64(1771236000123456789)
+	mock.ExpectExec(`(?s)UPDATE accounts SET extra = CASE WHEN .*codex_usage_observed_at_unix_nano.* <= \$3::numeric THEN .* ELSE .* END, updated_at = NOW\(\) WHERE id = \$2`).
+		WithArgs(sqlmock.AnyArg(), int64(29), observedAt).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	repo := newAccountRepositoryWithSQL(client, db, nil)
+
+	err = repo.UpdateExtra(context.Background(), 29, map[string]any{
+		"codex_5h_used_percent":                            95.0,
+		"codex_usage_updated_at":                           "2026-02-16T10:00:00Z",
+		service.OpenAICodexUsageObservedAtUnixNanoExtraKey: observedAt,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBulkUpdateNilProbeRemovesKeyInsteadOfWritingJSONNull(t *testing.T) {
 	exec := &recordingSQLExecutor{result: rowsAffectedResult(1)}
 	repo := newAccountRepositoryWithSQL(nil, exec, nil)

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -151,6 +151,7 @@ func duplicateAccountExtra(value map[string]any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	delete(cloned, OpenAICodexUsageObservedAtUnixNanoExtraKey)
 	for key := range duplicateAccountDiscardedExtraKeys {
 		delete(cloned, key)
 	}

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -96,11 +96,26 @@ func TestBuildCodexUsageExtraUpdates_UsesSnapshotUpdatedAt(t *testing.T) {
 	if got := updates["codex_usage_updated_at"]; got != "2026-02-16T10:00:00Z" {
 		t.Fatalf("codex_usage_updated_at = %v, want %s", got, "2026-02-16T10:00:00Z")
 	}
+	if got := updates[OpenAICodexUsageObservedAtUnixNanoExtraKey]; got != time.Date(2026, 2, 16, 10, 0, 0, 0, time.UTC).UnixNano() {
+		t.Fatalf("%s = %v, want snapshot observation time", OpenAICodexUsageObservedAtUnixNanoExtraKey, got)
+	}
 	if got := updates["codex_5h_reset_at"]; got != "2026-02-16T11:00:00Z" {
 		t.Fatalf("codex_5h_reset_at = %v, want %s", got, "2026-02-16T11:00:00Z")
 	}
 	if got := updates["codex_7d_reset_at"]; got != "2026-02-17T10:00:00Z" {
 		t.Fatalf("codex_7d_reset_at = %v, want %s", got, "2026-02-17T10:00:00Z")
+	}
+}
+
+func TestBuildCodexUsageExtraUpdates_PreservesObservationNanoseconds(t *testing.T) {
+	snapshot := &OpenAICodexUsageSnapshot{
+		UpdatedAt: "2026-02-16T10:00:00.123456789Z",
+	}
+	want := time.Date(2026, 2, 16, 10, 0, 0, 123456789, time.UTC).UnixNano()
+
+	updates := buildCodexUsageExtraUpdates(snapshot, time.Time{})
+	if got := updates[OpenAICodexUsageObservedAtUnixNanoExtraKey]; got != want {
+		t.Fatalf("%s = %v, want %d", OpenAICodexUsageObservedAtUnixNanoExtraKey, got, want)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -18,6 +18,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// OpenAICodexUsageObservedAtUnixNanoExtraKey orders concurrent quota snapshot
+// writes across gateway instances so an older observation cannot win last.
+const OpenAICodexUsageObservedAtUnixNanoExtraKey = "codex_usage_observed_at_unix_nano"
+
 // OpenAIRecordUsageInput input for recording usage
 type OpenAIRecordUsageInput struct {
 	Result             *OpenAIForwardResult
@@ -733,7 +737,7 @@ func ParseCodexRateLimitHeaders(headers http.Header) *OpenAICodexUsageSnapshot {
 		return nil
 	}
 
-	snapshot.UpdatedAt = time.Now().Format(time.RFC3339)
+	snapshot.UpdatedAt = time.Now().Format(time.RFC3339Nano)
 	return snapshot
 }
 
@@ -794,6 +798,9 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
 	}
 	updates["codex_usage_updated_at"] = baseTime.Format(time.RFC3339)
+	if !baseTime.IsZero() {
+		updates[OpenAICodexUsageObservedAtUnixNanoExtraKey] = baseTime.UnixNano()
+	}
 
 	// 归一化到 5h/7d 规范字段
 	if normalized := snapshot.Normalize(); normalized != nil {


### PR DESCRIPTION
## 问题

多个 gateway 实例或并发请求可能为同一 OpenAI 账号写入不同时间采集的 Codex 用量快照。当前 `UpdateExtra` 使用无条件 JSONB 合并，最后提交的写入获胜，因此较旧的 94% 快照可能覆盖已经保存的 95% 快照，使自动暂停状态倒退。

## 根因

`codex_usage_updated_at` 主要用于展示和陈旧快照判断，当前只保存到秒，且 repository 合并时不比较观测顺序。应用内锁也无法覆盖不同进程或不同节点。

## 改动

- 响应头快照使用 `RFC3339Nano` 记录采集时间。
- `buildCodexUsageExtraUpdates` 写入内部键 `codex_usage_observed_at_unix_nano`，同时保留现有秒级 `codex_usage_updated_at` 契约。
- `accountRepository.UpdateExtra` 在更新携带该 `int64` 键时，以 PostgreSQL `numeric` 原子比较数据库中的观测序号；仅当新序号不早于当前值时合并 JSONB。
- 缺失或非数字旧值按 0 处理，兼容既有账号数据，无需迁移。
- 将内部观测键标记为调度中性，并在复制账号时丢弃，避免复制瞬态状态。

## 影响面

- 无数据库 schema、migration 或外部 API 变更；只新增一个账号 `Extra` 内部键。
- 普通 `UpdateExtra` 调用不携带该键时，SQL 行为保持不变。
- 本 PR 与 #5320 独立；#5320 处理阈值节流和响应头采集时机，本 PR 只处理数据库写入顺序。
- 排序依据实例墙钟，部署环境仍应保持 NTP 同步。
- 滚动升级期间，尚未升级的旧实例不会携带观测键，因此完整保护在所有 gateway 实例升级后生效。

## 验证

- `cd backend && make test-unit`
- `cd backend && make test-integration`
- `cd backend && golangci-lint run ./...`（0 issues）
- `cd backend && make build`
- `cd backend && go test -tags=integration ./internal/repository -run "TestAccountRepoSuite/TestUpdateExtra_OlderCodexSnapshotCannotOverwriteNewerObservation$" -count=1 -v`
- `make test-frontend`（8 files / 132 tests）
- 上游 deployment shell tests 全部通过
- `cd backend && govulncheck ./...`（0 reachable vulnerabilities）
- frontend production audit exceptions validated

真实 PostgreSQL 回归用例先写入观测时间较新的 95%，再写入较旧的 94%，最终确认数据库仍保留 95% 和较新的精确观测序号。