### PR TITLE
fix(admin): keep row action menus within viewport

### DIFF
--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -4,8 +4,14 @@
       <!-- Backdrop: click anywhere outside to close -->
       <div class="fixed inset-0 z-[9998]" @click="emit('close')"></div>
       <div
-        class="action-menu-content fixed z-[9999] w-52 overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-black/5 dark:bg-dark-800"
-        :style="{ top: position.top + 'px', left: position.left + 'px' }"
+        class="action-menu-content fixed z-[9999] overflow-y-auto rounded-xl bg-white shadow-lg ring-1 ring-black/5 dark:bg-dark-800"
+        :style="{
+          top: position.top === null ? undefined : position.top + 'px',
+          bottom: position.bottom === null ? undefined : position.bottom + 'px',
+          left: position.left + 'px',
+          width: position.width + 'px',
+          maxHeight: position.maxHeight + 'px'
+        }"
         @click.stop
       >
         <div class="py-1">
@@ -66,8 +72,9 @@ import { computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import type { Account } from '@/types'
+import type { FloatingPanelPosition } from '@/utils/floatingPanel'
 
-const props = defineProps<{ show: boolean; account: Account | null; position: { top: number; left: number } | null }>()
+const props = defineProps<{ show: boolean; account: Account | null; position: FloatingPanelPosition | null }>()
 const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'duplicate', 'reauth', 'refresh-token', 'recover-state', 'reset-quota', 'set-privacy', 'create-spark-shadow'])
 const { t } = useI18n()
 const canDuplicate = computed(() => {

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
@@ -42,13 +42,31 @@ function makeAccount(overrides: Partial<Account>): Account {
   }
 }
 
-const position = { top: 100, left: 100 }
+const position = { top: null, bottom: 104, left: 100, width: 208, maxHeight: 320 }
 
 // AccountActionMenu uses <Teleport to="body">; content is rendered in document.body, not in wrapper.
 const getBodyText = () => document.body.textContent ?? ''
 const getBodyButtons = () => Array.from(document.body.querySelectorAll('button'))
 
 describe('AccountActionMenu — spark shadow 按钮可见性', () => {
+  it('applies viewport-bounded position and scroll height', () => {
+    const account = makeAccount({ platform: 'openai', type: 'oauth', parent_account_id: null })
+    const wrapper = mount(AccountActionMenu, {
+      props: { show: true, account, position },
+      attachTo: document.body,
+    })
+
+    const menu = document.body.querySelector<HTMLElement>('.action-menu-content')
+    expect(menu).not.toBeNull()
+    expect(menu?.style.top).toBe('')
+    expect(menu?.style.bottom).toBe('104px')
+    expect(menu?.style.width).toBe('208px')
+    expect(menu?.style.maxHeight).toBe('320px')
+    expect(menu?.classList.contains('overflow-y-auto')).toBe(true)
+
+    wrapper.unmount()
+  })
+
   it('普通账号显示「复制账号」按钮', () => {
     const account = makeAccount({ platform: 'anthropic', type: 'apikey', parent_account_id: null })
     const wrapper = mount(AccountActionMenu, {

--- a/frontend/src/utils/__tests__/floatingPanel.spec.ts
+++ b/frontend/src/utils/__tests__/floatingPanel.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getFloatingPanelPosition } from '@/utils/floatingPanel'
+import { getFloatingActionMenuPosition, getFloatingPanelPosition } from '@/utils/floatingPanel'
 
 describe('getFloatingPanelPosition', () => {
   it('移动端使用视口安全边距，不再从靠左按钮向屏幕外展开', () => {
@@ -39,5 +39,40 @@ describe('getFloatingPanelPosition', () => {
     expect(position.top).toBeNull()
     expect(position.bottom).toBe(108)
     expect(position.maxHeight).toBe(560)
+  })
+
+  it('行内操作菜单在末行向上展开并保持视口安全边距', () => {
+    const position = getFloatingActionMenuPosition(
+      { top: 700, right: 1200, bottom: 740 },
+      1280,
+      800,
+      192
+    )
+
+    expect(position).toEqual({
+      top: null,
+      bottom: 104,
+      left: 1008,
+      width: 192,
+      maxHeight: 640
+    })
+  })
+
+  it('行内操作菜单在上下空间都不足时限制高度供内部滚动', () => {
+    const position = getFloatingActionMenuPosition(
+      { top: 100, right: 172, bottom: 140 },
+      180,
+      240,
+      208
+    )
+
+    expect(position).toEqual({
+      top: 144,
+      bottom: null,
+      left: 8,
+      width: 164,
+      maxHeight: 88
+    })
+    expect(position.top! + position.maxHeight).toBeLessThanOrEqual(240 - 8)
   })
 })

--- a/frontend/src/utils/floatingPanel.ts
+++ b/frontend/src/utils/floatingPanel.ts
@@ -15,6 +15,11 @@ export interface FloatingPanelOptions {
   minComfortableHeight?: number
 }
 
+const ACTION_MENU_VIEWPORT_PADDING = 8
+const ACTION_MENU_GAP = 4
+const ACTION_MENU_MAX_HEIGHT_RATIO = 0.8
+const ACTION_MENU_COMFORTABLE_HEIGHT = 320
+
 /**
  * 计算挂载到 body 的浮层位置，避免触发按钮靠近视口边缘时浮层被挤到屏幕外。
  */
@@ -54,3 +59,25 @@ export const getFloatingPanelPosition = (
     maxHeight
   }
 }
+
+/**
+ * 计算行内操作菜单的位置。菜单始终限制在视口可用高度内；当任一方向
+ * 都无法完整容纳菜单时，由调用方通过 maxHeight 提供内部滚动。
+ */
+export const getFloatingActionMenuPosition = (
+  triggerRect: Pick<DOMRect, 'top' | 'right' | 'bottom'>,
+  viewportWidth: number,
+  viewportHeight: number,
+  maxWidth: number
+): FloatingPanelPosition => getFloatingPanelPosition(
+  triggerRect,
+  viewportWidth,
+  viewportHeight,
+  {
+    viewportPadding: ACTION_MENU_VIEWPORT_PADDING,
+    gap: ACTION_MENU_GAP,
+    maxWidth,
+    maxHeightRatio: ACTION_MENU_MAX_HEIGHT_RATIO,
+    minComfortableHeight: ACTION_MENU_COMFORTABLE_HEIGHT
+  }
+)

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -525,7 +525,7 @@ import { formatDateTime, formatRelativeTime } from '@/utils/format'
 import { proxyExpiryBadgeClass, proxyExpiryLabelKey } from '@/utils/proxyExpiry'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { sanitizeUrl } from '@/utils/url'
-import { getFloatingPanelPosition } from '@/utils/floatingPanel'
+import { getFloatingActionMenuPosition, getFloatingPanelPosition, type FloatingPanelPosition } from '@/utils/floatingPanel'
 import { formatMultiplier } from '@/utils/formatters'
 import type { Account, AccountPlatform, AccountSchedulerGroupScore, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel, UpstreamBillingProbeSnapshot } from '@/types'
 
@@ -603,7 +603,7 @@ const showSchedulePanel = ref(false)
 const scheduleAcc = ref<Account | null>(null)
 const scheduleModelOptions = ref<SelectOption[]>([])
 const togglingSchedulable = ref<number | null>(null)
-const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
+const menu = reactive<{show:boolean, acc:Account|null, pos:FloatingPanelPosition|null}>({ show: false, acc: null, pos: null })
 const exportingData = ref(false)
 const probingUpstreamBilling = reactive(new Set<number>())
 const upstreamBillingProbeGloballyEnabled = ref<boolean | undefined>(undefined)
@@ -1478,50 +1478,18 @@ const openMenu = (a: Account, e: MouseEvent) => {
   menu.acc = a
 
   const target = e.currentTarget as HTMLElement
-  if (target) {
-    const rect = target.getBoundingClientRect()
-    const menuWidth = 200
-    const menuHeight = 240
-    const padding = 8
-    const viewportWidth = window.innerWidth
-    const viewportHeight = window.innerHeight
-
-    let left: number
-    let top: number
-
-    if (viewportWidth < 768) {
-      // 居中显示,水平位置
-      left = Math.max(padding, Math.min(
-        rect.left + rect.width / 2 - menuWidth / 2,
-        viewportWidth - menuWidth - padding
-      ))
-
-      // 优先显示在按钮下方
-      top = rect.bottom + 4
-
-      // 如果下方空间不够,显示在上方
-      if (top + menuHeight > viewportHeight - padding) {
-        top = rect.top - menuHeight - 4
-        // 如果上方也不够,就贴在视口顶部
-        if (top < padding) {
-          top = padding
-        }
-      }
-    } else {
-      left = Math.max(padding, Math.min(
-        e.clientX - menuWidth,
-        viewportWidth - menuWidth - padding
-      ))
-      top = e.clientY
-      if (top + menuHeight > viewportHeight - padding) {
-        top = viewportHeight - menuHeight - padding
-      }
-    }
-
-    menu.pos = { top, left }
-  } else {
-    menu.pos = { top: e.clientY, left: e.clientX - 200 }
+  if (!target) {
+    menu.show = false
+    menu.pos = null
+    return
   }
+
+  menu.pos = getFloatingActionMenuPosition(
+    target.getBoundingClientRect(),
+    document.documentElement.clientWidth || window.innerWidth,
+    window.innerHeight,
+    208
+  )
 
   menu.show = true
 }

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -666,8 +666,14 @@
     <Teleport to="body">
       <div
         v-if="activeMenuId !== null && menuPosition"
-        class="action-menu-content fixed z-[9999] w-48 overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-black/5 dark:bg-dark-800 dark:ring-white/10"
-        :style="{ top: menuPosition.top + 'px', left: menuPosition.left + 'px' }"
+        class="action-menu-content fixed z-[9999] overflow-y-auto rounded-xl bg-white shadow-lg ring-1 ring-black/5 dark:bg-dark-800 dark:ring-white/10"
+        :style="{
+          top: menuPosition.top === null ? undefined : menuPosition.top + 'px',
+          bottom: menuPosition.bottom === null ? undefined : menuPosition.bottom + 'px',
+          left: menuPosition.left + 'px',
+          width: menuPosition.width + 'px',
+          maxHeight: menuPosition.maxHeight + 'px'
+        }"
       >
         <div class="py-1">
           <template v-for="user in users" :key="user.id">
@@ -778,6 +784,7 @@ import { useAppStore } from '@/stores/app'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { useTableSelection } from '@/composables/useTableSelection'
 import { formatDateTime } from '@/utils/format'
+import { getFloatingActionMenuPosition, type FloatingPanelPosition } from '@/utils/floatingPanel'
 import Icon from '@/components/icons/Icon.vue'
 
 const { t } = useI18n()
@@ -1428,7 +1435,7 @@ const refreshCurrentPageSecondaryData = () => {
 
 // Action Menu State
 const activeMenuId = ref<number | null>(null)
-const menuPosition = ref<{ top: number; left: number } | null>(null)
+const menuPosition = ref<FloatingPanelPosition | null>(null)
 
 const openActionMenu = (user: AdminUser, e: MouseEvent) => {
   if (activeMenuId.value === user.id) {
@@ -1441,44 +1448,12 @@ const openActionMenu = (user: AdminUser, e: MouseEvent) => {
     }
 
     const rect = target.getBoundingClientRect()
-    const menuWidth = 200
-    const menuHeight = 240
-    const padding = 8
-    const viewportWidth = window.innerWidth
-    const viewportHeight = window.innerHeight
-
-    let left, top
-
-    if (viewportWidth < 768) {
-      // 居中显示,水平位置
-      left = Math.max(padding, Math.min(
-        rect.left + rect.width / 2 - menuWidth / 2,
-        viewportWidth - menuWidth - padding
-      ))
-
-      // 优先显示在按钮下方
-      top = rect.bottom + 4
-
-      // 如果下方空间不够,显示在上方
-      if (top + menuHeight > viewportHeight - padding) {
-        top = rect.top - menuHeight - 4
-        // 如果上方也不够,就贴在视口顶部
-        if (top < padding) {
-          top = padding
-        }
-      }
-    } else {
-      left = Math.max(padding, Math.min(
-        e.clientX - menuWidth,
-        viewportWidth - menuWidth - padding
-      ))
-      top = e.clientY
-      if (top + menuHeight > viewportHeight - padding) {
-        top = viewportHeight - menuHeight - padding
-      }
-    }
-
-    menuPosition.value = { top, left }
+    menuPosition.value = getFloatingActionMenuPosition(
+      rect,
+      document.documentElement.clientWidth || window.innerWidth,
+      window.innerHeight,
+      192
+    )
     activeMenuId.value = user.id
   }
 }

--- a/frontend/src/views/admin/__tests__/UsersView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsersView.spec.ts
@@ -98,6 +98,7 @@ const DataTableStub = {
       </template>
       <div v-for="row in data" :key="row.id">
         <slot name="cell-last_used_at" :value="row.last_used_at" :row="row" />
+        <slot name="cell-actions" :value="row.actions" :row="row" />
       </div>
     </div>
   `
@@ -118,6 +119,9 @@ const BulkEditUserModalStub = {
     </div>
   `
 }
+
+const originalInnerWidth = window.innerWidth
+const originalInnerHeight = window.innerHeight
 
 describe('admin UsersView', () => {
   beforeEach(() => {
@@ -145,6 +149,9 @@ describe('admin UsersView', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight })
   })
 
   it('shows active, used, and created activity columns in order and requests last_used_at sort', async () => {
@@ -292,6 +299,77 @@ describe('admin UsersView', () => {
       }),
       expect.any(Object)
     )
+  })
+
+  it('opens the last-row action menu upward within the viewport', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      if ((this as HTMLElement).classList.contains('action-menu-trigger')) {
+        return {
+          x: 1160,
+          y: 700,
+          top: 700,
+          right: 1200,
+          bottom: 740,
+          left: 1160,
+          width: 40,
+          height: 40,
+          toJSON: () => ({})
+        } as DOMRect
+      }
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => ({})
+      } as DOMRect
+    })
+
+    const wrapper = mount(UsersView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          TablePageLayout: {
+            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+          },
+          DataTable: DataTableStub,
+          Pagination: true,
+          ConfirmDialog: true,
+          EmptyState: true,
+          GroupBadge: true,
+          Select: true,
+          UserAttributesConfigModal: true,
+          UserConcurrencyCell: true,
+          UserCreateModal: true,
+          UserEditModal: true,
+          BulkEditUserModal: BulkEditUserModalStub,
+          UserPlatformQuotaModal: true,
+          UserApiKeysModal: true,
+          UserAllowedGroupsModal: true,
+          UserBalanceModal: true,
+          UserBalanceHistoryModal: true,
+          GroupReplaceModal: true,
+          Icon: true,
+          Teleport: true
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.get('.action-menu-trigger').trigger('click')
+
+    const menu = wrapper.get<HTMLElement>('.action-menu-content')
+    expect(menu.element.style.top).toBe('')
+    expect(menu.element.style.bottom).toBe('104px')
+    expect(menu.element.style.width).toBe('192px')
+    expect(menu.element.style.maxHeight).toBe('640px')
+    expect(menu.classes()).toContain('overflow-y-auto')
   })
 
   it('keeps selected user IDs across pages and clears them after a successful bulk update', async () => {


### PR DESCRIPTION
## Summary

- position admin row action menus according to the available viewport space
- open the user and account action menus upward near the bottom edge
- constrain menu height and allow internal scrolling when neither direction has enough space
- add focused positioning and component coverage

## Verification

- 21 focused Vitest tests passed
- vue-tsc --noEmit passed
- ESLint passed for all changed files
- npm run build passed
- Playwright verified both real admin pages against a local Vite server with mocked APIs; all non-localhost requests were blocked
