### PR TITLE
fix(openai): fail over HTTP 200 response.failed on non-streaming paths

### DIFF
--- a/backend/internal/service/openai_compact_stream_bridge_test.go
+++ b/backend/internal/service/openai_compact_stream_bridge_test.go
@@ -318,7 +318,7 @@ func TestHandlePassthroughSSEToJSON_CompactRawOutputItemDoneRepairsEmptyTerminal
 		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -512,7 +512,7 @@ func TestHandleNonStreamingResponsePassthrough_CompactClientStreamBridgesToSSE(t
 		}`)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -254,7 +254,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	} else {
-		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, account, reqModel, upstreamPassthroughModel)
 		if err != nil {
 			return nil, err
 		}
@@ -1000,6 +1000,49 @@ func (s *OpenAIGatewayService) recordOpenAIStreamUpstreamError(
 	return message
 }
 
+// nonStreamingFailedEventFailover 判定 stream=false 场景下、承载于 HTTP 200 SSE 的
+// response.failed 终止事件应当切号，还是直接把错误回写给客户端。
+//
+// 同一个上游 capacity/限流错误此前在两条路径上行为不一致：流式路径经
+// openAIStreamFailedEventShouldFailover 判定后返回 UpstreamFailoverError 切号；
+// 而 stream=false 的 SSE→JSON 转换路径直接 writeOpenAINonStreamingProtocolError
+// 回写 502，池内还有可调度账号也不会切，并把上游原始文案暴露给最终用户。
+//
+// 这条路径上的响应体已被 ReadUpstreamResponseBody 完整缓冲，判定发生在任何
+// 语义响应写出之前，因此重放是安全的。与流式路径一致，本函数只拒绝已经写过
+// 语义响应的场景（IsResponseCommitted）；能否真正换号由 handler 仲裁——它用
+// OpenAICompactKeepaliveAdjustedWrittenSize 扣除 compact 心跳注释字节后，
+// 再判断 Forward 期间是否已写出响应（#3887）。
+//
+// 返回 nil 表示不切号，调用方继续走原有的错误回写逻辑。
+func (s *OpenAIGatewayService) nonStreamingFailedEventFailover(
+	c *gin.Context,
+	account *Account,
+	passthrough bool,
+	resp *http.Response,
+	payload []byte,
+	message string,
+) *UpstreamFailoverError {
+	if account == nil || resp == nil || c == nil {
+		return nil
+	}
+	if IsResponseCommitted(c) {
+		return nil
+	}
+	if !openAIStreamFailedEventShouldFailover(payload, message) {
+		return nil
+	}
+	return s.newOpenAIStreamFailoverError(
+		c,
+		account,
+		passthrough,
+		resp.Header.Get("x-request-id"),
+		payload,
+		message,
+		resp.Header,
+	)
+}
+
 func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 	c *gin.Context,
 	account *Account,
@@ -1309,6 +1352,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 ) (*openaiNonStreamingResultPassthrough, error) {
@@ -1322,7 +1366,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	// stream=false was requested. Without this conversion the client would
 	// receive raw SSE text or a terminal event with empty output.
 	if isEventStreamResponse(resp.Header) {
-		return s.handlePassthroughSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handlePassthroughSSEToJSON(resp, c, account, body, originalModel, mappedModel)
 	}
 
 	usage := &OpenAIUsage{}
@@ -1367,7 +1411,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 // response for the passthrough path. It mirrors handleSSEToJSON while
 // preserving passthrough payloads, except compact-only model remapping may
 // rewrite model fields back to the original requested model.
-func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel string, mappedModel string) (*openaiNonStreamingResultPassthrough, error) {
+func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, account *Account, body []byte, originalModel string, mappedModel string) (*openaiNonStreamingResultPassthrough, error) {
 	bodyText := string(body)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
@@ -1403,6 +1447,10 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			msg := extractOpenAISSEErrorMessage(terminalPayload)
 			if msg == "" {
 				msg = "Upstream compact response failed"
+			}
+			// 与流式 passthrough 路径采用同一套判定，见 nonStreamingFailedEventFailover。
+			if failoverErr := s.nonStreamingFailedEventFailover(c, account, true, resp, terminalPayload, msg); failoverErr != nil {
+				return nil, failoverErr
 			}
 			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
 		}

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1115,7 +1115,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	// Some OpenAI-compatible upstreams (including other sub2api instances)
 	// may return SSE even when stream=false was requested.
 	if isEventStreamResponse(resp.Header) {
-		return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handleSSEToJSON(resp, c, account, body, originalModel, mappedModel)
 	}
 	// bodyLooksLikeSSE is a line-level heuristic: real SSE framing requires
 	// "data:"/"event:" field names at the very start of a physical line. A
@@ -1131,7 +1131,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	// positives on JSON responses that coincidentally contain "data:" or
 	// "event:" in their text content.
 	if account.Type == AccountTypeOAuth && bodyLooksLikeSSE {
-		return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+		return s.handleSSEToJSON(resp, c, account, body, originalModel, mappedModel)
 	}
 	if account != nil && account.IsGrok() && isOpenAIResponsesCompactPath(c) {
 		body, err = convertGrokResponseToOpenAICompact(body)
@@ -1143,7 +1143,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	usageValue, usageOK := extractOpenAIUsageFromJSONBytes(body)
 	if !usageOK {
 		if bodyLooksLikeSSE {
-			return s.handleSSEToJSON(resp, c, body, originalModel, mappedModel)
+			return s.handleSSEToJSON(resp, c, account, body, originalModel, mappedModel)
 		}
 		return nil, fmt.Errorf("parse response: invalid json response")
 	}
@@ -1204,7 +1204,7 @@ func bodyHasSSEFraming(body []byte) bool {
 	return false
 }
 
-func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
+func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, account *Account, body []byte, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
 	bodyText := string(body)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
@@ -1245,6 +1245,11 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			msg := extractOpenAISSEErrorMessage(terminalPayload)
 			if msg == "" {
 				msg = "Upstream compact response failed"
+			}
+			// 与流式路径采用同一套判定：临时性上游错误（模型容量不足、限流等）
+			// 必须切号，而不是把上游文案当成最终错误直接返回给客户端。
+			if failoverErr := s.nonStreamingFailedEventFailover(c, account, false, resp, terminalPayload, msg); failoverErr != nil {
+				return nil, failoverErr
 			}
 			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
 		}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -3380,7 +3380,7 @@ func TestHandleSSEToJSON_CompletedEventReturnsJSON(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, body, "gpt-4o", "gpt-4o")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 7, usage.InputTokens)
@@ -3473,7 +3473,7 @@ func TestHandleSSEToJSON_ReconstructsImageGenerationOutputItemDone(t *testing.T)
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-5.4", "gpt-5.4")
+	usage, err := svc.handleSSEToJSON(resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, body, "gpt-5.4", "gpt-5.4")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 4, usage.ImageOutputTokens)
@@ -3500,7 +3500,7 @@ func TestHandleSSEToJSON_NoFinalResponseKeepsSSEBody(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, body, "gpt-4o", "gpt-4o")
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, 0, usage.InputTokens)
@@ -3508,7 +3508,12 @@ func TestHandleSSEToJSON_NoFinalResponseKeepsSSEBody(t *testing.T) {
 	require.Contains(t, rec.Body.String(), `data: {"type":"response.in_progress"`)
 }
 
-func TestHandleSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
+// 未被分类为不可重试的 response.failed 走与流式路径相同的判定
+// （openAIStreamFailedEventShouldFailover 对未知错误默认倾向切号），
+// 因此这里返回 UpstreamFailoverError 而不是直接回写 502。
+// 明确不可重试的错误仍然回写协议错误，见
+// TestNonStreamingSSEToJSONInvalidRequestFailedStillWritesError。
+func TestHandleSSEToJSON_ResponseFailedUnclassifiedReturnsFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -3524,12 +3529,12 @@ func TestHandleSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
 		`data: [DONE]`,
 	}, "\n"))
 
-	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-4o", "gpt-4o")
+	usage, err := svc.handleSSEToJSON(resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, body, "gpt-4o", "gpt-4o")
 	require.Nil(t, usage)
-	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code)
-	require.Contains(t, rec.Body.String(), "upstream rejected request")
-	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Empty(t, rec.Body.String(), "切号前不得向下游写入任何字节")
 }
 
 func TestOpenAICompatSSEFrameParserResetsEventTypeAtFrameBoundary(t *testing.T) {

--- a/backend/internal/service/openai_non_streaming_failed_event_failover_test.go
+++ b/backend/internal/service/openai_non_streaming_failed_event_failover_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// stream=false 时上游仍可能返回 SSE，容量错误经 HTTP 200 的 response.failed
+// 终止事件回传。此前该路径直接写 502，池内还有可调度账号也不会切号；
+// 而完全相同的上游错误在流式路径上是会切号的
+// （TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover）。
+const nonStreamingCapacityFailedSSE = `event: response.created
+data: {"type":"response.created","response":{"id":"resp_1"}}
+
+event: response.failed
+data: {"type":"response.failed","error":{"message":"Selected model is at capacity. Please try a different model.","type":"invalid_request_error"}}
+
+`
+
+func newNonStreamingFailoverTestService() *OpenAIGatewayService {
+	return &OpenAIGatewayService{cfg: &config.Config{
+		Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+	}}
+}
+
+func newNonStreamingFailoverTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	return c, rec
+}
+
+func newCapacityFailedSSEResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"X-Request-Id": []string{"rid-nonstream-capacity"},
+		},
+		Body: io.NopCloser(strings.NewReader(nonStreamingCapacityFailedSSE)),
+	}
+}
+
+func TestNonStreamingSSEToJSONCapacityFailedReturnsFailover(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	c, rec := newNonStreamingFailoverTestContext()
+
+	_, err := svc.handleNonStreamingResponse(
+		context.Background(),
+		newCapacityFailedSSEResponse(),
+		c,
+		&Account{ID: 7, Type: AccountTypeOAuth},
+		"gpt-5.5",
+		"gpt-5.5",
+	)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr),
+		"容量错误必须触发切号，实际错误: %v", err)
+	require.Empty(t, rec.Body.String(),
+		"切号前不得向下游写入任何字节，否则无法安全重放")
+	require.NotContains(t, rec.Body.String(), "at capacity",
+		"上游原始容量文案不应暴露给最终用户")
+}
+
+func TestNonStreamingPassthroughSSEToJSONCapacityFailedReturnsFailover(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	c, rec := newNonStreamingFailoverTestContext()
+
+	_, err := svc.handleNonStreamingResponsePassthrough(
+		context.Background(),
+		newCapacityFailedSSEResponse(),
+		c,
+		&Account{ID: 7, Type: AccountTypeOAuth},
+		"gpt-5.5",
+		"gpt-5.5",
+	)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr),
+		"透传路径的容量错误同样必须触发切号，实际错误: %v", err)
+	require.Empty(t, rec.Body.String())
+}
+
+// 用户参数错误不是临时故障，必须原样回写而不是浪费一次切号。
+func TestNonStreamingSSEToJSONInvalidRequestFailedStillWritesError(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	c, rec := newNonStreamingFailoverTestContext()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.failed",
+			`data: {"type":"response.failed","error":{"message":"Invalid value for 'temperature'","type":"invalid_request_error"}}`,
+			"",
+		}, "\n"))),
+	}
+
+	_, err := svc.handleNonStreamingResponse(
+		context.Background(), resp, c,
+		&Account{ID: 7, Type: AccountTypeOAuth}, "gpt-5.5", "gpt-5.5",
+	)
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "参数错误不应触发切号")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), "upstream_error")
+}
+
+// 上下文超限同样不可重放到别的账号——换号也一样超限。
+func TestNonStreamingSSEToJSONContextWindowFailedStillWritesError(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	c, rec := newNonStreamingFailoverTestContext()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.failed",
+			`data: {"type":"response.failed","error":{"message":"Your input exceeds the context window of this model.","type":"invalid_request_error"}}`,
+			"",
+		}, "\n"))),
+	}
+
+	_, err := svc.handleNonStreamingResponse(
+		context.Background(), resp, c,
+		&Account{ID: 7, Type: AccountTypeOAuth}, "gpt-5.5", "gpt-5.5",
+	)
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "上下文超限换号也无法解决，不应切号")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// 响应已提交（例如 body-signal compact 心跳已写出 200 响应头）时禁止切号：
+// 下游已经收到字节，重放会产生重复输出。
+func TestNonStreamingSSEToJSONSkipsFailoverAfterResponseCommitted(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	c, rec := newNonStreamingFailoverTestContext()
+	MarkResponseCommitted(c)
+
+	_, err := svc.handleNonStreamingResponse(
+		context.Background(),
+		newCapacityFailedSSEResponse(),
+		c,
+		&Account{ID: 7, Type: AccountTypeOAuth},
+		"gpt-5.5",
+		"gpt-5.5",
+	)
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr),
+		"响应已提交后必须沿用原有错误回写路径，不得切号")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// 判定函数本身的边界：account/resp 缺失或响应已写出时一律不切号。
+func TestNonStreamingFailedEventFailoverGuards(t *testing.T) {
+	svc := newNonStreamingFailoverTestService()
+	payload := []byte(`{"type":"response.failed","error":{"message":"Selected model is at capacity. Please try a different model.","type":"invalid_request_error"}}`)
+	msg := "Selected model is at capacity. Please try a different model."
+	resp := newCapacityFailedSSEResponse()
+
+	t.Run("nil_account", func(t *testing.T) {
+		c, _ := newNonStreamingFailoverTestContext()
+		require.Nil(t, svc.nonStreamingFailedEventFailover(c, nil, false, resp, payload, msg))
+	})
+
+	t.Run("nil_response", func(t *testing.T) {
+		c, _ := newNonStreamingFailoverTestContext()
+		require.Nil(t, svc.nonStreamingFailedEventFailover(c, &Account{ID: 1}, false, nil, payload, msg))
+	})
+
+	t.Run("nil_context", func(t *testing.T) {
+		require.Nil(t, svc.nonStreamingFailedEventFailover(nil, &Account{ID: 1}, false, resp, payload, msg))
+	})
+
+	t.Run("response_committed", func(t *testing.T) {
+		c, _ := newNonStreamingFailoverTestContext()
+		MarkResponseCommitted(c)
+		require.Nil(t, svc.nonStreamingFailedEventFailover(c, &Account{ID: 1}, false, resp, payload, msg))
+	})
+
+	t.Run("clean_context_failovers", func(t *testing.T) {
+		c, _ := newNonStreamingFailoverTestContext()
+		require.NotNil(t, svc.nonStreamingFailedEventFailover(c, &Account{ID: 1}, false, resp, payload, msg))
+	})
+}

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -665,7 +665,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceNonStreamingResponse(t *
 	setOpenAIResponsesNamespaceNames(c, names)
 
 	result, err := (&OpenAIGatewayService{cfg: &config.Config{}}).handleNonStreamingResponsePassthrough(
-		context.Background(), resp, c, "gpt-5.5", "",
+		context.Background(), resp, c, &Account{ID: 1, Type: AccountTypeOAuth}, "gpt-5.5", "",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)


### PR DESCRIPTION
Fixes #5281

## 问题

`stream=false` 时上游仍可能返回 SSE（其他 sub2api 实例、部分 OpenAI 兼容上游），容量/限流错误经 HTTP 200 的 `response.failed` 终止事件回传。同一个上游错误在两条路径上行为不一致：

**流式路径** — `openai_gateway_response_handling.go:450` 经 `openAIStreamFailedEventShouldFailover` 判定后返回 `UpstreamFailoverError`，正常切到下一个可调度账号。已有测试 `TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover` 覆盖。

**stream=false 的 SSE→JSON 转换路径** — `handleSSEToJSON` / `handlePassthroughSSEToJSON` 从不调用该判定：

```go
terminalType, terminalPayload, terminalOK := extractOpenAISSETerminalEvent(bodyText)
if terminalOK && terminalType == "response.failed" {
    msg := extractOpenAISSEErrorMessage(terminalPayload)
    if msg == "" {
        msg = "Upstream compact response failed"
    }
    return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)  // ← 固定 502
}
```

池内还有可调度账号也不会切，并把上游原始文案直接暴露给最终用户：

```json
{"error":{"type":"upstream_error","message":"Selected model is at capacity. Please try a different model."}}
```

## 改动

新增 `nonStreamingFailedEventFailover`，在两条非流式路径上复用流式路径的**同一套分类**：可重试的上游错误返回 `UpstreamFailoverError`，明确不可重试的错误（参数错误、上下文超限等）仍然回写协议错误。

**为什么这里重放总是安全的**：响应体已被 `ReadUpstreamResponseBody` 完整缓冲，判定发生在任何语义响应写出之前。

**谁来仲裁能否真正换号**：handler。它用 `OpenAICompactKeepaliveAdjustedWrittenSize` 扣除 body-signal compact 心跳的注释字节后，再判断 Forward 期间是否已写出响应（#3887 已建立的口径）。service 侧只额外拒绝 `IsResponseCommitted` 的场景，不重复实现心跳判定——避免与 handler 的口径分叉。

签名变更：`handleSSEToJSON` / `handlePassthroughSSEToJSON` / `handleNonStreamingResponsePassthrough` 增加 `account *Account` 参数（`newOpenAIStreamFailoverError` 需要它记录 ops 上游错误事件并判定 `RetryableOnSameAccount`）。两个调用方作用域内本来就有 `account`。

## ⚠️ 行为变更（请重点看这一条）

`openAIStreamFailedEventShouldFailover` 对**未被分类为不可重试**的错误默认倾向切号。因此无 `type`/`code` 的泛化 `response.failed` 在非流式路径上从「回写 502」变为「切号」。

这正是与流式路径对齐的结果——同一个事件，同一个判定。但它确实翻转了一个既有测试的预期，故显式说明：

`TestHandleSSEToJSON_ResponseFailedReturnsProtocolError` → 更名为 `TestHandleSSEToJSON_ResponseFailedUnclassifiedReturnsFailover`，断言从「502 + body 含上游文案」改为「返回 UpstreamFailoverError + 未写出任何字节」。该测试原本的场景（`{"message":"upstream rejected request"}`，无 type/code）在流式路径上本来就会切号。

「response.failed 必须回写协议错误」这一契约没有丢，由新增的 `TestNonStreamingSSEToJSONInvalidRequestFailedStillWritesError` 与 `...ContextWindowFailedStillWritesError` 接管。

如果维护者认为泛化错误在非流式路径上应保持 502，吾可以把判定收窄为「仅正向识别为临时错误（capacity / 429 / transient）才切号」，这样既修复 issue 报告的场景，也完全不动既有测试——请告知取舍。

## 测试

`backend/internal/service/openai_non_streaming_failed_event_failover_test.go`

- `TestNonStreamingSSEToJSONCapacityFailedReturnsFailover` — issue 原始场景，断言切号且**未向下游写出任何字节**、容量文案不外泄
- `TestNonStreamingPassthroughSSEToJSONCapacityFailedReturnsFailover` — 透传路径同上
- `TestNonStreamingSSEToJSONInvalidRequestFailedStillWritesError` — 参数错误不切号，仍回写 502
- `TestNonStreamingSSEToJSONContextWindowFailedStillWritesError` — 上下文超限换号也无解，不切号
- `TestNonStreamingSSEToJSONSkipsFailoverAfterResponseCommitted` — 响应已提交后禁止切号
- `TestNonStreamingFailedEventFailoverGuards` — nil account / nil resp / nil ctx / 已提交 / 干净上下文

```
ok  github.com/Wei-Shaw/sub2api/internal/service   98.898s   （全包回归）
```

## 未包含

issue 的第 1 点（错误透传规则先于 failover 执行，配置透传关键词会隐式禁用切号）**没有改**。

那是一个策略问题而非一致性缺陷：管理员显式为某个关键词配置了透传，先执行透传规则可以理解为尊重该配置。改动它会翻转管理员的既有意图，且需要在规则里新增「允许/禁止 failover」的语义字段——建议单独评估。本 PR 只修「同一事件在流式与非流式两条路径上判定不一致」这一点。

需要说明的是，非流式路径此前**完全不应用**错误透传规则，本 PR 也没有引入它，因此不存在透传配置被本 PR 破坏的情况。