### PR TITLE
feat(frontend): 首页补齐全部已支持平台展示

### DIFF
--- a/frontend/src/i18n/locales/en/landing.ts
+++ b/frontend/src/i18n/locales/en/landing.ts
@@ -101,6 +101,10 @@ export default {
       claude: 'Claude',
       gemini: 'Gemini',
       antigravity: 'Antigravity',
+      grok: 'Grok',
+      kimi: 'Kimi',
+      zhipu: 'Zhipu GLM',
+      deepseek: 'DeepSeek',
       more: 'More'
     },
     // CTA section

--- a/frontend/src/i18n/locales/zh/landing.ts
+++ b/frontend/src/i18n/locales/zh/landing.ts
@@ -101,6 +101,10 @@ export default {
       claude: 'Claude',
       gemini: 'Gemini',
       antigravity: 'Antigravity',
+      grok: 'Grok',
+      kimi: 'Kimi',
+      zhipu: 'Zhipu GLM',
+      deepseek: 'DeepSeek',
       more: '更多'
     },
     // CTA 区块

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -442,6 +442,66 @@
               >{{ t('home.providers.supported') }}</span
             >
           </div>
+          <!-- Grok / xAI - Supported -->
+          <div
+            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
+          >
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-zinc-700 to-zinc-950"
+            >
+              <span class="text-xs font-bold text-white">X</span>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.grok') }}</span>
+            <span
+              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+              >{{ t('home.providers.supported') }}</span
+            >
+          </div>
+          <!-- Kimi - Supported -->
+          <div
+            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
+          >
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-pink-400 to-pink-500"
+            >
+              <span class="text-xs font-bold text-white">K</span>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.kimi') }}</span>
+            <span
+              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+              >{{ t('home.providers.supported') }}</span
+            >
+          </div>
+          <!-- Zhipu GLM - Supported -->
+          <div
+            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
+          >
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-400 to-indigo-500"
+            >
+              <span class="text-xs font-bold text-white">Z</span>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.zhipu') }}</span>
+            <span
+              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+              >{{ t('home.providers.supported') }}</span
+            >
+          </div>
+          <!-- DeepSeek - Supported -->
+          <div
+            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
+          >
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-teal-400 to-teal-500"
+            >
+              <span class="text-xs font-bold text-white">D</span>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.deepseek') }}</span>
+            <span
+              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+              >{{ t('home.providers.supported') }}</span
+            >
+          </div>
           <!-- More - Coming Soon -->
           <div
             class="flex items-center gap-2 rounded-xl border border-gray-200/50 bg-white/40 px-5 py-3 opacity-60 backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/40"

--- a/frontend/src/views/__tests__/HomeView.compact.spec.ts
+++ b/frontend/src/views/__tests__/HomeView.compact.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import HomeView from '../HomeView.vue'
+import enLanding from '@/i18n/locales/en/landing'
+import zhLanding from '@/i18n/locales/zh/landing'
 
 const { appStore, authStore } = vi.hoisted(() => ({
   appStore: {
@@ -66,16 +68,18 @@ function modelPlazaDestination(wrapper: ReturnType<typeof mountHome>) {
     ?.props('to')
 }
 
+function resetHomeState() {
+  authStore.isAuthenticated = false
+  authStore.isAdmin = false
+  authStore.user = null
+  authStore.checkAuth.mockClear()
+  appStore.fetchPublicSettings.mockClear()
+  localStorage.clear()
+  vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList)
+}
+
 describe('HomeView compact mode', () => {
-  beforeEach(() => {
-    authStore.isAuthenticated = false
-    authStore.isAdmin = false
-    authStore.user = null
-    authStore.checkAuth.mockClear()
-    appStore.fetchPublicSettings.mockClear()
-    localStorage.clear()
-    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList)
-  })
+  beforeEach(resetHomeState)
 
   it('renders custom HTML ahead of compact mode', () => {
     const wrapper = mountHome({
@@ -180,5 +184,37 @@ describe('HomeView compact mode', () => {
     })
 
     expect(modelPlazaDestination(wrapper)).toBeUndefined()
+  })
+})
+
+describe('HomeView supported providers', () => {
+  beforeEach(resetHomeState)
+
+  it('renders all concrete providers and retains the coming-soon card', () => {
+    const text = mountHome().text()
+
+    expect(text).toContain('home.providers.claude')
+    expect(text).toContain('GPT')
+    expect(text).toContain('home.providers.gemini')
+    expect(text).toContain('home.providers.antigravity')
+    expect(text).toContain('home.providers.grok')
+    expect(text).toContain('home.providers.kimi')
+    expect(text).toContain('home.providers.zhipu')
+    expect(text).toContain('home.providers.deepseek')
+    expect(text.match(/home\.providers\.supported/g)).toHaveLength(8)
+    expect(text).toContain('home.providers.more')
+    expect(text).toContain('home.providers.soon')
+  })
+
+  it('defines every added provider label for all supported landing locales', () => {
+    const expectedLabels = {
+      grok: 'Grok',
+      kimi: 'Kimi',
+      zhipu: 'Zhipu GLM',
+      deepseek: 'DeepSeek',
+    }
+
+    expect(zhLanding.home.providers).toMatchObject(expectedLabels)
+    expect(enLanding.home.providers).toMatchObject(expectedLabels)
   })
 })


### PR DESCRIPTION
## 背景

后端 `AllPlatforms()` 与前端 `CONCRETE_PLATFORM_OPTIONS` 已统一支持 8 个一级上游平台，但公开首页仍只展示 Claude、GPT、Gemini、Antigravity，导致首页能力展示与实际支持范围不一致。

## 改动

- 首页按正式平台顺序展示 Claude、GPT、Gemini、Antigravity、Grok、Kimi、Zhipu GLM、DeepSeek。
- Grok、Kimi、Zhipu GLM、DeepSeek 沿用全站平台品牌色，并继续保留“更多 / 即将推出”占位卡。
- 补齐中英文 `home.providers.grok/kimi/zhipu/deepseek` 文案。
- 新增首页回归测试，断言 8 个正式平台、8 个“已支持”状态及占位卡。
- 不将 `composite`、Bedrock、Vertex 等聚合分组或接入方式混入一级平台展示。

## 页面截图

### PC（1440 × 900）

![首页全部平台 PC 验收截图](https://raw.githubusercontent.com/creamtea47/sub2api/2656cc3b4b929028126b23cd2f176864f924e207/pr-5335-all-providers-desktop.png)

### 手机（390 × 1100）

![首页全部平台手机验收截图](https://raw.githubusercontent.com/creamtea47/sub2api/2656cc3b4b929028126b23cd2f176864f924e207/pr-5335-all-providers-mobile.png)

## 验证

- `pnpm test:run -- src/views/__tests__/HomeView.compact.spec.ts`（15/15 通过）
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm build`
- `git diff --check main...HEAD`
- 本地生产构建实页验收：PC 与手机视口下 8 个平台和占位卡均完整显示，无截断或重叠。

## 影响范围

- 仅修改默认公开首页、落地页中英文文案及对应前端测试，共 4 个文件。
- 保留主线最新的 Model Plaza 导航与鉴权测试。
- 自定义 `home_content`、紧凑首页模式及后端 API、数据库、部署配置均不受影响。