### PR TITLE
feat(accounts): add configurable token counting mode for OpenAI API keys

### DIFF
--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -23,6 +23,11 @@ const (
 	openAIInputTokensFallbackMinimum      = 1
 )
 
+const (
+	openAIAPICountTokensModeCredentialKey = "openai_count_tokens_mode"
+	openAIAPICountTokensModeLocal         = "local"
+)
+
 type openAIInputTokensCountRequest struct {
 	Model        string                    `json:"model"`
 	Instructions string                    `json:"instructions,omitempty"`
@@ -72,8 +77,9 @@ func EstimateGrokCountTokens(body []byte) (int, error) {
 	return estimated, nil
 }
 
-// ForwardCountTokensAsAnthropic bridges Anthropic /v1/messages/count_tokens to
-// OpenAI POST /v1/responses/input_tokens and returns Anthropic-compatible output.
+// ForwardCountTokensAsAnthropic returns an Anthropic-compatible token count.
+// OpenAI API Key accounts may estimate locally; all other accounts use
+// OpenAI POST /v1/responses/input_tokens with the existing OAuth fallback.
 func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 	ctx context.Context,
 	c *gin.Context,
@@ -90,6 +96,25 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 	if err != nil {
 		writeAnthropicCountTokensError(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return err
+	}
+
+	if account.Type == AccountTypeAPIKey &&
+		strings.EqualFold(strings.TrimSpace(account.GetCredential(openAIAPICountTokensModeCredentialKey)), openAIAPICountTokensModeLocal) {
+		estimated, estimateErr := estimateOpenAIInputTokens(prepared.Request)
+		if estimateErr != nil {
+			writeAnthropicCountTokensError(c, http.StatusInternalServerError, "api_error", "Failed to estimate input tokens")
+			return fmt.Errorf("estimate openai input tokens locally: %w", estimateErr)
+		}
+		if estimated < openAIInputTokensFallbackMinimum {
+			estimated = openAIInputTokensFallbackMinimum
+		}
+		logger.L().Debug("openai count_tokens: using local tiktoken estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+		)
+		c.JSON(http.StatusOK, gin.H{"input_tokens": estimated})
+		return nil
 	}
 
 	upstreamBody, err := marshalOpenAIUpstreamJSON(prepared.Request)

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -85,6 +85,39 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesI
 	require.False(t, gjson.GetBytes(upstream.lastBody, "messages").Exists())
 }
 
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyCanEstimateLocally(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"claude-sonnet-4-5","system":"You are helpful.","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:       102,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":                             "sk-test",
+			"base_url":                            "http://upstream.example",
+			openAIAPICountTokensModeCredentialKey: openAIAPICountTokensModeLocal,
+		},
+	}
+
+	prepared, err := prepareOpenAIInputTokensCountRequest(body, account, "gpt-5.3-codex")
+	require.NoError(t, err)
+	expected, err := estimateOpenAIInputTokens(prepared.Request)
+	require.NoError(t, err)
+
+	err = svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "gpt-5.3-codex")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"input_tokens":`+strconv.Itoa(expected)+`}`, rec.Body.String())
+	require.Nil(t, upstream.lastReq, "local mode must not call the upstream input_tokens endpoint")
+}
+
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPlatformEndpointUnsupported(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1157,6 +1157,27 @@
           <p v-if="apiKeyHint" class="input-hint">{{ apiKeyHint }}</p>
         </div>
 
+        <div
+          v-if="form.platform === 'openai'"
+          class="flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-dark-600"
+        >
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.countTokensMode') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.countTokensModeDesc') }}
+            </p>
+          </div>
+          <select
+            v-model="openAICountTokensMode"
+            class="input w-52 text-sm"
+            data-testid="openai-count-tokens-mode-select"
+            :aria-label="t('admin.accounts.openai.countTokensMode')"
+          >
+            <option value="remote">{{ t('admin.accounts.openai.countTokensModeRemote') }}</option>
+            <option value="local">{{ t('admin.accounts.openai.countTokensModeLocal') }}</option>
+          </select>
+        </div>
+
         <!-- 上游倍率自动探测：全部 API-key 平台可用（所在区块已限定 apikey 类型） -->
         <div
           class="flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-dark-600"
@@ -3732,6 +3753,7 @@ const addMethod = ref<AddMethod>('oauth') // For oauth-based: 'oauth' or 'setup-
 const apiKeyBaseUrl = ref('https://api.anthropic.com')
 const apiKeyValue = ref('')
 const upstreamBillingAutoProbeEnabled = ref(true)
+const openAICountTokensMode = ref<'remote' | 'local'>('remote')
 
 const syncPreviewCredentials = computed(() => {
   if (!apiKeyValue.value) return undefined
@@ -4671,6 +4693,7 @@ const resetForm = () => {
   apiKeyBaseUrl.value = 'https://api.anthropic.com'
   apiKeyValue.value = ''
   upstreamBillingAutoProbeEnabled.value = true
+  openAICountTokensMode.value = 'remote'
   editQuotaLimit.value = null
   editQuotaDailyLimit.value = null
   editQuotaWeeklyLimit.value = null
@@ -5134,6 +5157,9 @@ const handleSubmit = async () => {
     const compactModelMapping = buildOpenAICompactModelMapping()
     if (compactModelMapping) {
       credentials.compact_model_mapping = compactModelMapping
+    }
+    if (openAICountTokensMode.value === 'local') {
+      credentials.openai_count_tokens_mode = 'local'
     }
   }
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -78,6 +78,27 @@
           <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
         </div>
 
+        <div
+          v-if="account.platform === 'openai'"
+          class="flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-dark-600"
+        >
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.countTokensMode') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.countTokensModeDesc') }}
+            </p>
+          </div>
+          <select
+            v-model="openAICountTokensMode"
+            class="input w-52 text-sm"
+            data-testid="openai-count-tokens-mode-select"
+            :aria-label="t('admin.accounts.openai.countTokensMode')"
+          >
+            <option value="remote">{{ t('admin.accounts.openai.countTokensModeRemote') }}</option>
+            <option value="local">{{ t('admin.accounts.openai.countTokensModeLocal') }}</option>
+          </select>
+        </div>
+
         <!-- Model Restriction Section (不适用于 Antigravity) -->
         <div v-if="account.platform !== 'antigravity'" class="border-t border-gray-200 pt-4 dark:border-dark-600">
           <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
@@ -2777,6 +2798,7 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+const openAICountTokensMode = ref<'remote' | 'local'>('remote')
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -3367,6 +3389,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
+  openAICountTokensMode.value = 'remote'
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -3555,6 +3578,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
             ? 'https://api.x.ai/v1'
             : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
+    openAICountTokensMode.value =
+      credentials.openai_count_tokens_mode === 'local' ? 'local' : 'remote'
 
     // Load model mappings and detect mode
     loadModelRestrictionFromMapping(credentials.model_mapping as Record<string, unknown> | undefined)
@@ -4191,6 +4216,11 @@ const handleSubmit = async () => {
           newCredentials.compact_model_mapping = compactModelMapping
         } else {
           delete newCredentials.compact_model_mapping
+        }
+        if (openAICountTokensMode.value === 'local') {
+          newCredentials.openai_count_tokens_mode = 'local'
+        } else {
+          delete newCredentials.openai_count_tokens_mode
         }
       }
 

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -188,6 +188,22 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(createAccountMock.mock.calls[0]?.[0]?.upstream_billing_probe_enabled).toBe(true)
   })
 
+  it('stores local token counting for OpenAI API key accounts', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI account')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('[data-testid="openai-count-tokens-mode-select"]').setValue('local')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]?.credentials?.openai_count_tokens_mode).toBe(
+      'local'
+    )
+  })
+
   it('waits for the initial upstream billing probe before refreshing the account list', async () => {
     let resolveProbe: (() => void) | undefined
     probeUpstreamBillingMock.mockImplementationOnce(

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -639,6 +639,29 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_responses_supported).toBe(false)
   })
 
+  it('loads and clears local token counting for OpenAI API key accounts', async () => {
+    const account = buildAccount()
+    account.credentials.openai_count_tokens_mode = 'local'
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const select = wrapper.get<HTMLSelectElement>(
+      '[data-testid="openai-count-tokens-mode-select"]'
+    )
+    expect(select.element.value).toBe('local')
+
+    await select.setValue('remote')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials).not.toHaveProperty(
+      'openai_count_tokens_mode'
+    )
+  })
+
   it('submits the account upstream billing auto-probe setting', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -498,6 +498,11 @@ export default {
       openai: {
         baseUrlHint: 'Leave default for official OpenAI API',
         apiKeyHint: 'Your OpenAI API Key',
+        countTokensMode: 'Token counting mode',
+        countTokensModeDesc:
+          'Remote mode calls the account upstream /v1/responses/input_tokens endpoint. Local mode estimates with Sub2API’s built-in tokenizer without calling upstream.',
+        countTokensModeRemote: 'Remote exact count',
+        countTokensModeLocal: 'Local estimate',
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -569,6 +569,10 @@ export default {
       openai: {
         baseUrlHint: '留空使用官方 OpenAI API',
         apiKeyHint: '您的 OpenAI API Key',
+        countTokensMode: 'Token 计算方式',
+        countTokensModeDesc: '远程模式调用账号上游的 /v1/responses/input_tokens；本地模式使用 Sub2API 内置 tokenizer 估算，不请求上游。',
+        countTokensModeRemote: '远程精确计算',
+        countTokensModeLocal: '本地估算',
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',


### PR DESCRIPTION
## Summary

- add a per-account token counting mode for OpenAI API Key accounts
- keep remote `/v1/responses/input_tokens` counting as the backward-compatible default
- allow local tiktoken estimation without credentials or an upstream HTTP request
- expose and persist the option in both create and edit account dialogs

## Configuration

Local mode is stored as `credentials.openai_count_tokens_mode = "local"`. The default remote mode omits the key, so existing accounts retain their current behavior without migration.

## Verification

- `go test ./internal/service ./internal/handler`
- `pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.spec.ts src/components/account/__tests__/EditAccountModal.spec.ts`
- `pnpm exec eslint` on all changed frontend files
- `pnpm run build`
- browser smoke test of OpenAI API Key account creation and the mode selector