### PR TITLE
fix: avoid cooling OAuth accounts for HTML count token errors

### DIFF
--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -345,10 +345,24 @@ func isOpenAIOAuthInputTokensUnsupported(statusCode int, body []byte) bool {
 		return true
 	}
 
+	// OAuth's platform endpoint can be blocked by an upstream proxy before it
+	// reaches the API and return an HTML 403 page without a structured error.
+	// Treat that endpoint-level response like the other unsupported cases so
+	// count_tokens remains a local, non-health-affecting convenience request.
+	if statusCode == http.StatusForbidden && isHTMLResponse(body) {
+		return true
+	}
+
 	return strings.Contains(msg, "input_tokens") &&
 		(strings.Contains(msg, "not found") ||
 			strings.Contains(msg, "not supported") ||
 			strings.Contains(msg, "unsupported"))
+}
+
+func isHTMLResponse(body []byte) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(string(body)))
+	return strings.HasPrefix(trimmed, "<!doctype html") ||
+		strings.HasPrefix(trimmed, "<html")
 }
 
 func estimateOpenAIInputTokens(req openAIInputTokensCountRequest) (int, error) {

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -124,6 +124,11 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPl
 			body:       `{"error":{"type":"invalid_request_error","code":"missing_scope","message":"Missing scopes: api.responses.write"}}`,
 		},
 		{
+			name:       "403_html_proxy_page",
+			statusCode: http.StatusForbidden,
+			body:       "<!doctype html><html><body>Forbidden</body></html>",
+		},
+		{
 			name:       "404_input_tokens_unsupported",
 			statusCode: http.StatusNotFound,
 			body:       `{"error":{"type":"invalid_request_error","message":"The /v1/responses/input_tokens endpoint was not found"}}`,


### PR DESCRIPTION
## 问题

OAuth 账户调用 count_tokens 时，上游代理可能返回 HTML 格式的 403 页面。该错误会被当作账户健康问题处理，导致账户进入冷却。

## 根因

现有逻辑只识别结构化的平台端点不支持错误，没有识别代理在请求到达 API 前返回的 HTML 403 响应。

## 改动

将 HTML 格式的 403 响应视为 OAuth input_tokens 平台端点不可用，并回退到本地 token 估算，避免影响账户健康状态。

## 测试

- targeted count_tokens tests passed
- repeated 10 times passed
- go vet ./internal/service passed
- git diff --check passed
- full package test has an existing external-dependent failure in TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI because it calls the OpenAI API

Fixes #5331