### PR TITLE
修复antigravity作为OpenClaw提供商进行使用时的大面积请求错误`INVALID_ARGUMENT`.

### DIFF
--- a/backend/internal/service/antigravity_gateway_gemini.go
+++ b/backend/internal/service/antigravity_gateway_gemini.go
@@ -121,6 +121,9 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 	if err != nil {
 		return nil, s.writeGoogleError(c, http.StatusBadRequest, "Invalid request body")
 	}
+	if injectedBody, err = normalizeGeminiRequestForAntigravity(injectedBody); err != nil {
+		return nil, s.writeGoogleError(c, http.StatusBadRequest, "Invalid request body")
+	}
 
 	// 清理 Schema
 	if cleanedBody, err := cleanGeminiRequest(injectedBody); err == nil {

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -652,6 +652,7 @@ func normalizeGeminiRequestForAntigravity(body []byte) ([]byte, error) {
 	}
 	return normalized, nil
 }
+
 // wrapV1InternalRequest 包装请求为 v1internal 格式
 func (s *AntigravityGatewayService) wrapV1InternalRequest(projectID, model string, originalBody []byte) ([]byte, error) {
 	var request any

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -606,40 +606,58 @@ func injectIdentityPatchToGeminiRequest(body []byte) ([]byte, error) {
 	return json.Marshal(request)
 }
 
-// normalizeGeminiRequestForAntigravity 将 Gemini 原生请求中客户端常用的
-// google_search 字段转换为 Antigravity v1internal 上游使用的 googleSearch。
+// normalizeGeminiRequestForAntigravity 将 Gemini 原生请求规范化为
+// Antigravity v1internal 上游接受的格式。
 //
 // Gemini AI Studio 与 Antigravity v1internal 对 Google Search 工具的 JSON
 // 字段命名并不一致。原生 Gemini 客户端可能发送 snake_case，而
 // Antigravity 的内部请求模型只接受 camelCase；不转换时上游会返回
-// INVALID_ARGUMENT。
+// INVALID_ARGUMENT。此外，Gemini 原生接口允许单轮 contents 省略 role，
+// 而 v1internal 要求显式的 user/model role。
 func normalizeGeminiRequestForAntigravity(body []byte) ([]byte, error) {
 	var request map[string]any
 	if err := json.Unmarshal(body, &request); err != nil {
 		return nil, err
 	}
 
-	tools, ok := request["tools"].([]any)
-	if !ok || len(tools) == 0 {
-		return body, nil
+	modified := false
+	if contents, ok := request["contents"].([]any); ok {
+		for _, rawContent := range contents {
+			content, ok := rawContent.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			role, hasRole := content["role"]
+			if !hasRole || role == nil {
+				content["role"] = "user"
+				modified = true
+				continue
+			}
+			if roleString, ok := role.(string); ok && strings.TrimSpace(roleString) == "" {
+				content["role"] = "user"
+				modified = true
+			}
+		}
 	}
 
-	modified := false
-	for _, rawTool := range tools {
-		tool, ok := rawTool.(map[string]any)
-		if !ok {
-			continue
-		}
+	if tools, ok := request["tools"].([]any); ok {
+		for _, rawTool := range tools {
+			tool, ok := rawTool.(map[string]any)
+			if !ok {
+				continue
+			}
 
-		googleSearch, ok := tool["google_search"]
-		if !ok {
-			continue
+			googleSearch, ok := tool["google_search"]
+			if !ok {
+				continue
+			}
+			if _, hasCamelCase := tool["googleSearch"]; !hasCamelCase {
+				tool["googleSearch"] = googleSearch
+			}
+			delete(tool, "google_search")
+			modified = true
 		}
-		if _, hasCamelCase := tool["googleSearch"]; !hasCamelCase {
-			tool["googleSearch"] = googleSearch
-		}
-		delete(tool, "google_search")
-		modified = true
 	}
 
 	if !modified {

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -606,6 +606,52 @@ func injectIdentityPatchToGeminiRequest(body []byte) ([]byte, error) {
 	return json.Marshal(request)
 }
 
+// normalizeGeminiRequestForAntigravity 将 Gemini 原生请求中客户端常用的
+// google_search 字段转换为 Antigravity v1internal 上游使用的 googleSearch。
+//
+// Gemini AI Studio 与 Antigravity v1internal 对 Google Search 工具的 JSON
+// 字段命名并不一致。原生 Gemini 客户端可能发送 snake_case，而
+// Antigravity 的内部请求模型只接受 camelCase；不转换时上游会返回
+// INVALID_ARGUMENT。
+func normalizeGeminiRequestForAntigravity(body []byte) ([]byte, error) {
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, err
+	}
+
+	tools, ok := request["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		return body, nil
+	}
+
+	modified := false
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		googleSearch, ok := tool["google_search"]
+		if !ok {
+			continue
+		}
+		if _, hasCamelCase := tool["googleSearch"]; !hasCamelCase {
+			tool["googleSearch"] = googleSearch
+		}
+		delete(tool, "google_search")
+		modified = true
+	}
+
+	if !modified {
+		return body, nil
+	}
+
+	normalized, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
 // wrapV1InternalRequest 包装请求为 v1internal 格式
 func (s *AntigravityGatewayService) wrapV1InternalRequest(projectID, model string, originalBody []byte) ([]byte, error) {
 	var request any

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // antigravityFailingWriter 模拟客户端断开连接的 gin.ResponseWriter
@@ -333,6 +334,56 @@ func TestAntigravityGatewayService_ForwardGemini_UsesConfiguredProjectFallback(t
 	var wrapped map[string]any
 	require.NoError(t, json.Unmarshal(upstream.requestBodies[0], &wrapped))
 	require.Equal(t, "configured-project", wrapped["project"])
+}
+
+func TestAntigravityGatewayService_ForwardGemini_NormalizesGoogleSearchTool(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	writer := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(writer)
+
+	body := []byte(`{
+		"contents":[{"parts":[{"text":"AI"}]}],
+		"tools":[{"google_search":{}}]
+	}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/antigravity/v1beta/models/gemini-2.5-flash:generateContent", bytes.NewReader(body))
+
+	upstreamBody := []byte("data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1}}}\n\n")
+	upstream := &queuedHTTPUpstreamStub{
+		responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(bytes.NewReader(upstreamBody)),
+		}},
+	}
+	svc := &AntigravityGatewayService{
+		settingService: NewSettingService(&antigravitySettingRepoStub{}, &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}),
+		tokenProvider:  &AntigravityTokenProvider{},
+		httpUpstream:   upstream,
+	}
+
+	account := &Account{
+		ID:          103,
+		Name:        "acc-google-search",
+		Platform:    PlatformAntigravity,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-google-search",
+			"model_mapping": map[string]any{
+				"gemini-2.5-flash": "gemini-2.5-flash",
+			},
+		},
+	}
+
+	result, err := svc.ForwardGemini(context.Background(), c, account, "gemini-2.5-flash", "generateContent", false, body, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requestBodies, 1)
+
+	require.True(t, gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.googleSearch").Exists())
+	require.False(t, gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.google_search").Exists())
 }
 
 func TestAntigravityGatewayService_ForwardGemini_MissingProjectReturnsLocalError(t *testing.T) {

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -281,6 +281,42 @@ func TestResolveAntigravityProjectID(t *testing.T) {
 	}
 }
 
+func TestNormalizeGeminiRequestForAntigravity(t *testing.T) {
+	t.Run("normalizes captured native request", func(t *testing.T) {
+		body := []byte(`{
+			"contents":[{"parts":[{"text":"AI"}]}],
+			"tools":[{"google_search":{}}]
+		}`)
+
+		normalized, err := normalizeGeminiRequestForAntigravity(body)
+		require.NoError(t, err)
+		require.Equal(t, "user", gjson.GetBytes(normalized, "contents.0.role").String())
+		require.True(t, gjson.GetBytes(normalized, "tools.0.googleSearch").Exists())
+		require.False(t, gjson.GetBytes(normalized, "tools.0.google_search").Exists())
+	})
+
+	t.Run("adds missing role without tools", func(t *testing.T) {
+		body := []byte(`{"contents":[{"parts":[{"text":"hello"}]}]}`)
+
+		normalized, err := normalizeGeminiRequestForAntigravity(body)
+		require.NoError(t, err)
+		require.Equal(t, "user", gjson.GetBytes(normalized, "contents.0.role").String())
+	})
+
+	t.Run("preserves explicit roles", func(t *testing.T) {
+		body := []byte(`{
+			"contents":[
+				{"role":"user","parts":[{"text":"hello"}]},
+				{"role":"model","parts":[{"text":"hi"}]}
+			]
+		}`)
+
+		normalized, err := normalizeGeminiRequestForAntigravity(body)
+		require.NoError(t, err)
+		require.Equal(t, body, normalized)
+	})
+}
+
 func TestAntigravityGatewayService_ForwardGemini_UsesConfiguredProjectFallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	writer := httptest.NewRecorder()
@@ -336,7 +372,7 @@ func TestAntigravityGatewayService_ForwardGemini_UsesConfiguredProjectFallback(t
 	require.Equal(t, "configured-project", wrapped["project"])
 }
 
-func TestAntigravityGatewayService_ForwardGemini_NormalizesGoogleSearchTool(t *testing.T) {
+func TestAntigravityGatewayService_ForwardGemini_NormalizesCapturedNativeRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	writer := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(writer)
@@ -382,6 +418,7 @@ func TestAntigravityGatewayService_ForwardGemini_NormalizesGoogleSearchTool(t *t
 	require.NotNil(t, result)
 	require.Len(t, upstream.requestBodies, 1)
 
+	require.Equal(t, "user", gjson.GetBytes(upstream.requestBodies[0], "request.contents.0.role").String())
 	require.True(t, gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.googleSearch").Exists())
 	require.False(t, gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.google_search").Exists())
 }


### PR DESCRIPTION
问题：

OpenClaw 发出的标准 Gemini 请求包含：

"tools": [{"google_search": {}}]

Sub2API 转发到 Antigravity v1internal 时未转换字段名,导致上游无法识别并返回 400 INVALID_ARGUMENT.

修复：

- 在 backend/internal/service/antigravity_gateway_gemini.go:124 转发前增加工具字段规范化.
- 将 google_search 转换为 Antigravity 内部协议要求的 googleSearch.
- 已存在 googleSearch 时保留并删除重复的蛇形字段.
- 增加回归测试,验证实际发送给上游的请求字段正确.

额外说明:

OpenClaw 发出的 "google_search": {} 是标准 Gemini REST 格式,Google 官方示例也是这样写的.官方文档 (https://ai.google.dev/gemini-api/docs/generate-content/google-search?hl=en) 
`/antigravity/v1beta` 是 Sub2API 的兼容层,转发到 Antigravity v1internal 时需要转换为内部使用的 googleSearch. 因此不应让 OpenClaw 改成 Antigravity 私有字段,否则可能破坏标准 Gemini API 兼容性.OpenClaw 社区也将 google_search 作为 Gemini 原生工具格式.OpenClaw issue (https://github.com/openclaw/openclaw/issues/17925)

所以当前 Sub2API 中的转换修复是合理的.
