### PR TITLE
fix(openai-ws): exclude terminal events from TTFT

### DIFF
--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -953,7 +953,10 @@ func shouldParseUsage(eventType string) bool {
 }
 
 func isTokenEvent(eventType string) bool {
-	return strings.HasSuffix(strings.TrimSpace(eventType), ".delta")
+	eventType = strings.TrimSpace(eventType)
+	return strings.HasSuffix(eventType, ".delta") ||
+		eventType == "response.output_text.done" ||
+		eventType == "response.function_call_arguments.done"
 }
 
 func minDuration(a, b time.Duration) time.Duration {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -953,23 +953,7 @@ func shouldParseUsage(eventType string) bool {
 }
 
 func isTokenEvent(eventType string) bool {
-	if eventType == "" {
-		return false
-	}
-	switch eventType {
-	case "response.created", "response.in_progress", "response.output_item.added", "response.output_item.done":
-		return false
-	}
-	if strings.Contains(eventType, ".delta") {
-		return true
-	}
-	if strings.HasPrefix(eventType, "response.output_text") {
-		return true
-	}
-	if strings.HasPrefix(eventType, "response.output") {
-		return true
-	}
-	return eventType == "response.completed" || eventType == "response.done"
+	return strings.HasSuffix(strings.TrimSpace(eventType), ".delta")
 }
 
 func minDuration(a, b time.Duration) time.Duration {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
@@ -409,9 +409,12 @@ func TestIsTokenEventCoverageBranches(t *testing.T) {
 	require.True(t, isTokenEvent("response.output_audio.delta"))
 	require.True(t, isTokenEvent("response.function_call_arguments.delta"))
 	require.True(t, isTokenEvent("response.reasoning_summary_text.delta"))
+	require.True(t, isTokenEvent("response.output_text.done"))
+	require.True(t, isTokenEvent("response.function_call_arguments.done"))
 	require.False(t, isTokenEvent("response.output"))
-	require.False(t, isTokenEvent("response.output_text.done"))
 	require.False(t, isTokenEvent("response.output_audio.done"))
+	require.False(t, isTokenEvent("response.content_part.done"))
+	require.False(t, isTokenEvent("response.output_item.done"))
 	require.False(t, isTokenEvent("response.output_text.annotation.added"))
 	require.False(t, isTokenEvent("response.done"))
 }

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
@@ -246,7 +246,7 @@ func TestHelperFunctionsCoverage(t *testing.T) {
 
 	require.True(t, isTokenEvent("response.output_text.delta"))
 	require.True(t, isTokenEvent("response.output_audio.delta"))
-	require.True(t, isTokenEvent("response.completed"))
+	require.False(t, isTokenEvent("response.completed"))
 	require.False(t, isTokenEvent(""))
 	require.False(t, isTokenEvent("response.created"))
 
@@ -407,8 +407,29 @@ func TestIsTokenEventCoverageBranches(t *testing.T) {
 	require.False(t, isTokenEvent("response.in_progress"))
 	require.False(t, isTokenEvent("response.output_item.added"))
 	require.True(t, isTokenEvent("response.output_audio.delta"))
-	require.True(t, isTokenEvent("response.output"))
-	require.True(t, isTokenEvent("response.done"))
+	require.True(t, isTokenEvent("response.function_call_arguments.delta"))
+	require.True(t, isTokenEvent("response.reasoning_summary_text.delta"))
+	require.False(t, isTokenEvent("response.output"))
+	require.False(t, isTokenEvent("response.output_text.done"))
+	require.False(t, isTokenEvent("response.output_audio.done"))
+	require.False(t, isTokenEvent("response.output_text.annotation.added"))
+	require.False(t, isTokenEvent("response.done"))
+}
+
+func TestTerminalAndTokenEventSetsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	for _, eventType := range []string{
+		"response.completed",
+		"response.done",
+		"response.failed",
+		"response.incomplete",
+		"response.cancelled",
+		"response.canceled",
+	} {
+		require.True(t, isTerminalEvent(eventType), eventType)
+		require.False(t, isTokenEvent(eventType), eventType)
+	}
 }
 
 func TestShouldParseUsageTerminalEvents(t *testing.T) {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -202,7 +202,7 @@ func TestRelay_BasicRelayAndUsage(t *testing.T) {
 	require.Equal(t, 7, result.Usage.InputTokens)
 	require.Equal(t, 3, result.Usage.OutputTokens)
 	require.Equal(t, 2, result.Usage.CacheReadInputTokens)
-	require.NotNil(t, result.FirstTokenMs)
+	require.Nil(t, result.FirstTokenMs)
 	require.Equal(t, int64(1), result.ClientToUpstreamFrames)
 	require.Equal(t, int64(1), result.UpstreamToClientFrames)
 	require.Equal(t, int64(0), result.DroppedDownstreamFrames)
@@ -863,6 +863,64 @@ func (c *errorOnWriteFrameConn) WriteFrame(_ context.Context, _ coderws.MessageT
 
 func (c *errorOnWriteFrameConn) Close() error {
 	return nil
+}
+
+func TestRelay_NoDeltaTerminalSequence_FirstTokenMsNil(t *testing.T) {
+	t.Parallel()
+
+	for _, terminalEvent := range []string{"response.completed", "response.done"} {
+		terminalEvent := terminalEvent
+		t.Run(terminalEvent, func(t *testing.T) {
+			t.Parallel()
+
+			clientConn := newPassthroughTestFrameConn(nil, false)
+			upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"response.created","response":{"id":"resp_no_delta"}}`),
+				},
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"response.in_progress","response":{"id":"resp_no_delta"}}`),
+				},
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"response.output_text.done","response_id":"resp_no_delta","text":""}`),
+				},
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"response.content_part.done","response_id":"resp_no_delta"}`),
+				},
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"response.output_item.done","response_id":"resp_no_delta"}`),
+				},
+				{
+					msgType: coderws.MessageText,
+					payload: []byte(`{"type":"` + terminalEvent + `","response":{"id":"resp_no_delta","usage":{"input_tokens":2,"output_tokens":0}}}`),
+				},
+			}, true)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			var turn RelayTurnResult
+			result, relayExit := Relay(
+				ctx,
+				clientConn,
+				upstreamConn,
+				[]byte(`{"type":"response.create","model":"gpt-5.3-codex","input":[]}`),
+				RelayOptions{OnTurnComplete: func(current RelayTurnResult) { turn = current }},
+			)
+
+			require.Nil(t, relayExit)
+			require.Equal(t, terminalEvent, turn.TerminalEventType)
+			require.Nil(t, turn.FirstTokenMs)
+			require.Equal(t, terminalEvent, result.TerminalEventType)
+			require.Nil(t, result.FirstTokenMs)
+			require.Equal(t, int64(6), result.UpstreamToClientFrames)
+		})
+	}
 }
 
 func TestRelay_OnTurnComplete_RealOpenAIStream_FirstTokenMs(t *testing.T) {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -865,7 +865,7 @@ func (c *errorOnWriteFrameConn) Close() error {
 	return nil
 }
 
-func TestRelay_NoDeltaTerminalSequence_FirstTokenMsNil(t *testing.T) {
+func TestRelay_NoSemanticOutputTerminalSequence_FirstTokenMsNil(t *testing.T) {
 	t.Parallel()
 
 	for _, terminalEvent := range []string{"response.completed", "response.done"} {
@@ -877,27 +877,23 @@ func TestRelay_NoDeltaTerminalSequence_FirstTokenMsNil(t *testing.T) {
 			upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
 				{
 					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"response.created","response":{"id":"resp_no_delta"}}`),
+					payload: []byte(`{"type":"response.created","response":{"id":"resp_no_output"}}`),
 				},
 				{
 					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"response.in_progress","response":{"id":"resp_no_delta"}}`),
+					payload: []byte(`{"type":"response.in_progress","response":{"id":"resp_no_output"}}`),
 				},
 				{
 					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"response.output_text.done","response_id":"resp_no_delta","text":""}`),
+					payload: []byte(`{"type":"response.content_part.done","response_id":"resp_no_output"}`),
 				},
 				{
 					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"response.content_part.done","response_id":"resp_no_delta"}`),
+					payload: []byte(`{"type":"response.output_item.done","response_id":"resp_no_output"}`),
 				},
 				{
 					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"response.output_item.done","response_id":"resp_no_delta"}`),
-				},
-				{
-					msgType: coderws.MessageText,
-					payload: []byte(`{"type":"` + terminalEvent + `","response":{"id":"resp_no_delta","usage":{"input_tokens":2,"output_tokens":0}}}`),
+					payload: []byte(`{"type":"` + terminalEvent + `","response":{"id":"resp_no_output","usage":{"input_tokens":2,"output_tokens":0}}}`),
 				},
 			}, true)
 
@@ -918,7 +914,61 @@ func TestRelay_NoDeltaTerminalSequence_FirstTokenMsNil(t *testing.T) {
 			require.Nil(t, turn.FirstTokenMs)
 			require.Equal(t, terminalEvent, result.TerminalEventType)
 			require.Nil(t, result.FirstTokenMs)
-			require.Equal(t, int64(6), result.UpstreamToClientFrames)
+			require.Equal(t, int64(5), result.UpstreamToClientFrames)
+		})
+	}
+}
+
+func TestRelay_NoDeltaOutputDoneEvent_RecordsFirstTokenBeforeTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		donePayload string
+	}{
+		{
+			name:        "output text done",
+			donePayload: `{"type":"response.output_text.done","response_id":"resp_done","text":"hello"}`,
+		},
+		{
+			name:        "function call arguments done",
+			donePayload: `{"type":"response.function_call_arguments.done","response_id":"resp_done","arguments":"{\"city\":\"Paris\"}"}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientConn := newPassthroughTestFrameConn(nil, false)
+			upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+				{msgType: coderws.MessageText, payload: []byte(`{"type":"response.created","response":{"id":"resp_done"}}`)},
+				{msgType: coderws.MessageText, payload: []byte(tt.donePayload)},
+				{msgType: coderws.MessageText, payload: []byte(`{"type":"response.completed","response":{"id":"resp_done","usage":{"input_tokens":2,"output_tokens":1}}}`)},
+			}, true)
+
+			base := time.Unix(0, 0)
+			var nowTick atomic.Int64
+			nowFn := func() time.Time {
+				return base.Add(time.Duration(nowTick.Add(1)) * 10 * time.Millisecond)
+			}
+			var turn RelayTurnResult
+			result, relayExit := Relay(
+				context.Background(),
+				clientConn,
+				upstreamConn,
+				[]byte(`{"type":"response.create","model":"gpt-5.3-codex","input":[]}`),
+				RelayOptions{
+					Now:            nowFn,
+					OnTurnComplete: func(current RelayTurnResult) { turn = current },
+				},
+			)
+
+			require.Nil(t, relayExit)
+			require.NotNil(t, turn.FirstTokenMs)
+			require.Less(t, int64(*turn.FirstTokenMs), turn.Duration.Milliseconds())
+			require.NotNil(t, result.FirstTokenMs)
+			require.Less(t, int64(*result.FirstTokenMs), result.Duration.Milliseconds())
 		})
 	}
 }


### PR DESCRIPTION
## 问题

WS v2 passthrough 中的 terminal/non-delta 事件会污染 `first_token_ms`，导致没有实际 delta 的 turn 也被记录首 token 时间。

## 根因

`isTokenEvent` 的宽泛 fallback 会接受 `completed`、`done` 以及其他 `response.output*` 生命周期事件，并错误地将它们视为 token 事件。

## 改动

- 仅将 `.delta` 事件分类为 token 事件
- 对无 delta 的 turn 保持 `first_token_ms` 为 nil
- 增加回归测试，覆盖互斥的 terminal 事件集合和 lifecycle done 序列

## 验证

- `go test ./internal/service/openai_ws_v2 -count=1`
- `go test -race ./internal/service/openai_ws_v2 -run Test(TerminalAndTokenEventSetsAreDisjoint|Relay_NoDeltaTerminalSequence_FirstTokenMsNil|Relay_OnTurnComplete_RealOpenAIStream_FirstTokenMs)$ -count=10`
- `go vet ./internal/service/openai_ws_v2`
- `gofmt -l backend/internal/service/openai_ws_v2/passthrough_relay.go backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go backend/internal/service/openai_ws_v2/passthrough_relay_test.go`（无输出）
- `git diff --check`

Fixes #5340.