### PR TITLE
fix(gemini): use short cooldown for Vertex service account 429s

### DIFF
--- a/backend/internal/service/gemini_error_policy_test.go
+++ b/backend/internal/service/gemini_error_policy_test.go
@@ -489,6 +489,41 @@ func TestHandleGeminiUpstreamError_GoogleOneCapacityExhaustedUsesTierCooldown(t 
 	require.True(t, repo.lastRateLimitReset.Before(after.Add(5*time.Minute).Add(2*time.Second)))
 }
 
+func TestHandleGeminiUpstreamError_VertexServiceAccountUsesShortCooldown(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo: repo,
+	}
+
+	account := &Account{
+		ID:       812,
+		Platform: PlatformGemini,
+		Type:     AccountTypeServiceAccount,
+		Credentials: map[string]any{
+			"tier_id": "vertex",
+		},
+	}
+	// Vertex QPM 429 body: no quotaResetDelay, no "per day" wording.
+	body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.Equal(t, int64(812), repo.lastRateLimitID)
+	// Unknown tier → geminiCooldownForTier default 5 minutes (not PST midnight).
+	require.WithinDuration(t, before.Add(5*time.Minute), repo.lastRateLimitReset, 2*time.Second)
+	require.True(t, repo.lastRateLimitReset.After(before))
+	require.True(t, repo.lastRateLimitReset.Before(after.Add(5*time.Minute).Add(2*time.Second)))
+
+	// Sanity: must NOT be locked until next PST midnight (often many hours away).
+	pstMidnight := geminiDailyResetTime(before)
+	require.True(t, repo.lastRateLimitReset.Before(before.Add(30*time.Minute)),
+		"Vertex SA cooldown should be minutes-scale, got reset_at=%v (pst midnight would be %v)",
+		repo.lastRateLimitReset, pstMidnight)
+}
+
 type geminiErrorPolicyRepo struct {
 	mockAccountRepoForGemini
 	setErrorCalls            int

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2953,6 +2953,13 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 			} else {
 				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Google One OAuth, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(ra).Truncate(time.Second))
 			}
+		} else if account.IsVertexServiceAccount() {
+			// Vertex service accounts are billed per-use and have no daily quota reset;
+			// their 429 is a per-minute rate limit and should cool down in minutes.
+			// Use geminiCooldownForTier only: GeminiCooldown maps empty oauth_type to aistudio_free (30m).
+			cooldown := geminiCooldownForTier(tierID)
+			ra = time.Now().Add(cooldown)
+			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Vertex service account, tier=%s) rate limited, cooldown=%v", account.ID, tierID, time.Until(ra).Truncate(time.Second))
 		} else {
 			// API Key / AI Studio OAuth: PST 午夜
 			if ts := nextGeminiDailyResetUnix(); ts != nil {


### PR DESCRIPTION
## Summary

Vertex AI service accounts are treated like AI Studio API keys when a 429 comes back. If the response body has no `quotaResetDelay` and no "per day" wording, `handleGeminiUpstreamError` falls through to `nextGeminiDailyResetUnix()` and locks the account **until the next America/Los_Angeles midnight** — often 10+ hours away.

Vertex is billed per-use and has no daily-quota-reset model on this path. Those 429s are QPM-style rate limits and should cool down in minutes.

## Root cause

In `handleGeminiUpstreamError` (`backend/internal/service/gemini_messages_compat_service.go`):

- `IsGeminiCodeAssist()` / `GeminiOAuthType()` only apply to `type=oauth`, so a `service_account` never reaches the short-cooldown branch
- `ParseGeminiRateLimitResetTime` correctly returns `nil` for Vertex's `RESOURCE_EXHAUSTED` body
- The `else` branch then applies the API Key / AI Studio daily-quota model

The production log line is self-contradictory — it reports `API Key/AI Studio` while `type=service_account`:

```
[Gemini 429] Account N (API Key/AI Studio, type=service_account) rate limited,
             reset at PST midnight (2026-08-07 15:00:00 +0800 CST)
```

In our deployment three Vertex service accounts were locked out within 9 minutes and stayed unusable for the rest of the day, even though the upstream limit only needed a few minutes of backoff.

## Fix

- Detect `account.IsVertexServiceAccount()` before the API Key / AI Studio branch
- Apply `geminiCooldownForTier(tierID)` — unknown tier falls back to the existing 5 minute default
- Deliberately **not** using `rateLimitService.GeminiCooldown`: service accounts have no `oauth_type`, so `geminiQuotaTierKeyForAccount` maps them to `aistudio_free` (30m)
- `ParseGeminiRateLimitResetTime` left unchanged — it is shared by other platforms and its behaviour here is already correct

```
if Code Assist || google_one   -> tier cooldown            (unchanged)
else if IsVertexServiceAccount -> geminiCooldownForTier    (new, ~5m)
else                           -> PST midnight             (unchanged)
```

## Test plan

- [x] `go build ./...` in `backend/`
- [x] `go test -count=1 -tags=unit ./internal/service/ -run 'TestHandleGeminiUpstreamError_|TestParseGeminiRateLimitResetTime'` — all pass
- [x] New unit test `TestHandleGeminiUpstreamError_VertexServiceAccountUsesShortCooldown` feeds a real Vertex 429 body and asserts a minutes-scale cooldown
- [x] Mutation check — reverting the production change turns the new test red with a clear signal:

```
Error: Max difference between ... allowed is 2s, but difference was -12h34m18s
```

## Non-goals

- Does not change AI Studio API Key or AI Studio OAuth daily-reset behaviour (`type=apikey` / `type=oauth` still take the original branch)
- Does not add a dedicated `vertex` tier to the quota precheck — `canonicalGeminiTierID` still treats `tier_id=vertex` as unknown, which is pre-existing and on a different code path
- Anthropic-on-Vertex service accounts do not go through this handler and are unaffected

---

## 中文摘要

Vertex 的 `service_account` 遇到 429 时被当成 AI Studio API Key，锁到次日太平洋午夜（十几个小时）。实际上 Vertex 按量计费、没有日配额概念，其 429 属于 QPM 限速，退避几分钟即可。

本 PR 在 API Key 分支之前识别 `IsVertexServiceAccount()`，改用 `geminiCooldownForTier`（未知 tier 默认 5 分钟）。API Key / AI Studio 路径行为完全不变。
