### PR TITLE
fix(security): block OAuth account takeover via pending exchange

### DIFF
--- a/backend/internal/handler/auth_oauth_pending_flow.go
+++ b/backend/internal/handler/auth_oauth_pending_flow.go
@@ -1998,6 +1998,21 @@ func (h *AuthHandler) ExchangePendingOAuthCompletion(c *gin.Context) {
 		response.Success(c, payload)
 		return
 	}
+	// ─── 安全修复（账号接管 0day）────────────────────────────────────────────
+	// 非终态 session（如 choose_account_action_required）的 TargetUserID 可能来自
+	// 攻击者提交的他人邮箱：createPendingOAuthAccount / SendPendingOAuthVerifyCode
+	// 发现邮箱已存在时会把本 session 指向该邮箱用户，全程无密码、无邮箱验证码、
+	// 无账号所有权证明。若此时带着 adoption decision 继续执行，下方的
+	// applyPendingOAuthAdoption 会把本 OAuth identity 直接绑定到 TargetUserID，
+	// 攻击者随后再次 OAuth 登录即被系统识别为受害者本人（完整账号接管）。
+	// 只有两类 session 允许在此处执行 adoption/binding：
+	//   1. canIssueTokenPair == true —— 登录终态，identity 已安全绑定该用户；
+	//   2. intent == bind_current_user —— 已登录用户主动发起绑定（绑定目标来自登录态 cookie）。
+	// 其余状态一律只返回 payload，不绑定、不消费 session。
+	if !canIssueTokenPair && !strings.EqualFold(strings.TrimSpace(session.Intent), oauthIntentBindCurrentUser) {
+		response.Success(c, payload)
+		return
+	}
 	if !adoptionDecision.hasDecision() {
 		adoptionRequired, _ := payload["adoption_required"].(bool)
 		if adoptionRequired {

--- a/backend/internal/handler/auth_oauth_pending_flow_test.go
+++ b/backend/internal/handler/auth_oauth_pending_flow_test.go
@@ -910,6 +910,92 @@ func TestExchangePendingOAuthCompletionRejectsDisabledTargetUser(t *testing.T) {
 	require.Nil(t, storedSession.ConsumedAt)
 }
 
+func TestExchangePendingOAuthCompletionChoiceStateDoesNotBindIdentity(t *testing.T) {
+	// 回归测试：复刻"补邮箱/创建账户"路径的账号接管 0day。
+	// 攻击者用自己的 OAuth 账号登录后，在 create-account 步骤提交受害者邮箱，
+	// 后端发现邮箱已存在会把 pending session 转入 choice 状态并指向受害者
+	// （TargetUserID=受害者、无密码/验证码证明）。此时带 adoption decision 调
+	// exchange 绝不能把 OAuth identity 绑定到受害者账号。
+	handler, client := newOAuthPendingFlowTestHandler(t, false)
+	ctx := context.Background()
+
+	victim, err := client.User.Create().
+		SetEmail("victim@example.com").
+		SetUsername("victim-user").
+		SetPasswordHash("hash").
+		SetRole(service.RoleUser).
+		SetStatus(service.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	session, err := client.PendingAuthSession.Create().
+		SetSessionToken("choice-state-attack-session-token").
+		SetIntent("login").
+		SetProviderType("linuxdo").
+		SetProviderKey("linuxdo").
+		SetProviderSubject("attacker-subject-123").
+		SetTargetUserID(victim.ID).
+		SetResolvedEmail(victim.Email).
+		SetBrowserSessionKey("choice-state-attack-browser-session-key").
+		SetUpstreamIdentityClaims(map[string]any{
+			"username":               "attacker_linuxdo_user",
+			"suggested_display_name": "Attacker Display Name",
+			"suggested_avatar_url":   "https://cdn.example/attacker.png",
+		}).
+		SetLocalFlowState(map[string]any{
+			oauthCompletionResponseKey: map[string]any{
+				"step":                      oauthPendingChoiceStep,
+				"adoption_required":         true,
+				"force_email_on_signup":     true,
+				"email_binding_required":    true,
+				"existing_account_bindable": true,
+				"email":                     victim.Email,
+				"resolved_email":            victim.Email,
+				"redirect":                  "/dashboard",
+			},
+		}).
+		SetExpiresAt(time.Now().UTC().Add(10 * time.Minute)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	body := bytes.NewBufferString(`{"adopt_display_name":true,"adopt_avatar":true}`)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/oauth/pending/exchange", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: oauthPendingSessionCookieName, Value: encodeCookieValue(session.SessionToken)})
+	req.AddCookie(&http.Cookie{Name: oauthPendingBrowserCookieName, Value: encodeCookieValue("choice-state-attack-browser-session-key")})
+	ginCtx.Request = req
+
+	handler.ExchangePendingOAuthCompletion(ginCtx)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	data := decodeJSONResponseData(t, recorder)
+	require.NotContains(t, data, "access_token")
+	require.Equal(t, oauthPendingChoiceStep, data["step"])
+
+	// 攻击者的 OAuth identity 绝不能绑定到受害者账号
+	identityCount, err := client.AuthIdentity.Query().
+		Where(
+			authidentity.ProviderTypeEQ("linuxdo"),
+			authidentity.ProviderKeyEQ("linuxdo"),
+			authidentity.ProviderSubjectEQ("attacker-subject-123"),
+		).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, identityCount)
+
+	// 受害者资料不得被 adoption 篡改
+	storedVictim, err := client.User.Get(ctx, victim.ID)
+	require.NoError(t, err)
+	require.Equal(t, "victim-user", storedVictim.Username)
+
+	// session 不得被消费（攻击者无法进入下一环）
+	storedSession, err := client.PendingAuthSession.Get(ctx, session.ID)
+	require.NoError(t, err)
+	require.Nil(t, storedSession.ConsumedAt)
+}
+
 func TestNormalizePendingOAuthCompletionResponseScrubsLegacyTokenPayload(t *testing.T) {
 	payload := normalizePendingOAuthCompletionResponse(map[string]any{
 		"access_token":  "legacy-access-token",


### PR DESCRIPTION
## Summary

Fixes a **critical account-takeover vulnerability (0day)** in the pending OAuth flow: an attacker who only knows a victim's email address can bind their own LinuxDo / OIDC / WeChat / DingTalk identity to the victim's account and log in as them.

## Attack chain

1. Attacker logs in with their own OAuth account (`intent=login`) and lands on the email-completion step.
2. Attacker submits the **victim's email** via `POST /auth/oauth/pending/create-account` with an arbitrary password. Because the email already exists, the handler transitions the pending session into the choice state with `TargetUserID = victim`, `existing_account_bindable = true` — **no password, no email verification code, no captcha, no proof of ownership** is ever checked on this path (the captcha check is skipped when the email exists).
3. Attacker calls `POST /auth/oauth/pending/exchange` with an adoption decision (`adopt_display_name` / `adopt_avatar` — pure booleans unrelated to account ownership). `ExchangePendingOAuthCompletion` only guarded against `email_completion` / `bind_login_required` steps, so the request falls through to `applyPendingOAuthAdoption` → `applyPendingOAuthBinding`, and `shouldBindPendingOAuthIdentity` returns `true` unconditionally for `intent=login`.
4. The attacker's OAuth identity is now bound to the victim's account. On the next OAuth login, `findOAuthIdentityUser` resolves the attacker to the victim and the exchange endpoint issues the **victim's token pair**.

## Fix

`ExchangePendingOAuthCompletion` now only performs adoption/binding for:

1. **Terminal login sessions** (`canIssueTokenPair == true`) — the identity was already safely bound to that user during a completed login;
2. **`bind_current_user` sessions** — initiated by an authenticated user whose binding target comes from the login-session cookie.

Every other state (including `choose_account_action_required`) returns the payload **without binding the identity and without consuming the session**, so the attacker cannot proceed to the next step either.

## Testing

- New regression test `TestExchangePendingOAuthCompletionChoiceStateDoesNotBindIdentity` reproduces the exact attack (choice-state session + adoption decision → identity not bound, session not consumed, no token issued).
- All existing `TestExchangePendingOAuthCompletion*`, `TestCreateOIDCOAuthAccount*`, `TestSendPendingOAuthVerifyCode*`, and the full `internal/handler` package tests pass.

## Recommendation for follow-up (not included)

Defense in depth: when `create-account` / `send-verify-code` discovers an existing email, the session should transition to a **password/2FA-required** state (`bind_login_required` semantics) instead of a choice state that implies bindability. Please also audit existing `auth_identities` rows for bindings whose upstream email does not match the owning user.
