### PR TITLE
fix: fail over Anthropic transport errors

### DIFF
--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -114,29 +114,9 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			if !errors.Is(err, context.Canceled) {
-				scheduleOllamaCloudUsageActivity(s.deferredService, account)
-			}
-			safeErr := sanitizeUpstreamErrorMessage(err.Error())
-			setOpsUpstreamError(c, 0, safeErr, "")
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: 0,
-				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-				Passthrough:        true,
-				Kind:               "request_error",
-				Message:            safeErr,
-			})
-			c.JSON(http.StatusBadGateway, gin.H{
-				"type": "error",
-				"error": gin.H{
-					"type":    "upstream_error",
-					"message": "Upstream request failed",
-				},
-			})
-			return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+			return nil, s.handleGatewayUpstreamTransportError(
+				ctx, c, account, upstreamReq.URL.String(), err, true,
+			)
 		}
 
 		// 透传分支禁止 400 请求体降级重试（该重试会改写请求体）

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -380,30 +380,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			// Transport attempt left local validation; count Ollama Cloud activity.
-			if !errors.Is(err, context.Canceled) {
-				scheduleOllamaCloudUsageActivity(s.deferredService, account)
-			}
-			// Ensure the client receives an error response (handlers assume Forward writes on non-failover errors).
-			safeErr := sanitizeUpstreamErrorMessage(err.Error())
-			setOpsUpstreamError(c, 0, safeErr, "")
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: 0,
-				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-				Kind:               "request_error",
-				Message:            safeErr,
-			})
-			c.JSON(http.StatusBadGateway, gin.H{
-				"type": "error",
-				"error": gin.H{
-					"type":    "upstream_error",
-					"message": "Upstream request failed",
-				},
-			})
-			return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+			return nil, s.handleGatewayUpstreamTransportError(
+				ctx, c, account, upstreamReq.URL.String(), err, false,
+			)
 		}
 
 		// 优先检测thinking block签名错误（400）并重试一次

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -131,18 +131,9 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()
 		}
-		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		writeGatewayCCError(c, http.StatusBadGateway, "server_error", "Upstream request failed")
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+		return nil, s.handleGatewayUpstreamTransportError(
+			ctx, c, account, upstreamReq.URL.String(), err, false,
+		)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -136,18 +136,9 @@ func (s *GatewayService) ForwardAsResponses(
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()
 		}
-		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		writeResponsesError(c, http.StatusBadGateway, "server_error", "Upstream request failed")
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+		return nil, s.handleGatewayUpstreamTransportError(
+			ctx, c, account, upstreamReq.URL.String(), err, false,
+		)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/gateway_upstream_transport_error.go
+++ b/backend/internal/service/gateway_upstream_transport_error.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+const gatewayTransportErrorStateUpdateTimeout = 5 * time.Second
+
+// Keep the legacy Anthropic-shaped 502 payload until the failover loop is
+// exhausted. The handler owns the actual client response during failover.
+var gatewayTransportFailoverBody = []byte(`{"type":"error","error":{"type":"upstream_error","message":"Upstream request failed"}}`)
+
+// handleGatewayUpstreamTransportError converts a failed HTTP round-trip into
+// the failover error understood by the gateway handlers. A transport error has
+// no upstream HTTP status, so writing 502 here would bypass account failover.
+func (s *GatewayService) handleGatewayUpstreamTransportError(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	upstreamURL string,
+	err error,
+	passthrough bool,
+) error {
+	if err == nil {
+		return nil
+	}
+
+	safeErr := sanitizeUpstreamErrorMessage(err.Error())
+	setOpsUpstreamError(c, 0, safeErr, "")
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: 0,
+		UpstreamURL:        safeUpstreamURL(upstreamURL),
+		Passthrough:        passthrough,
+		Kind:               "request_error",
+		Message:            safeErr,
+	})
+
+	// The client is gone. Retrying another account would only create work and
+	// could incorrectly quarantine a healthy account.
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	if s != nil {
+		scheduleOllamaCloudUsageActivity(s.deferredService, account)
+	}
+
+	if classifyUpstreamTransportError(err).Persistent {
+		s.tempUnscheduleGatewayTransportError(ctx, account, safeErr)
+	}
+
+	return &UpstreamFailoverError{
+		StatusCode:        http.StatusBadGateway,
+		ResponseBody:      gatewayTransportFailoverBody,
+		NextAccountAction: NextAccountRetry,
+	}
+}
+
+// tempUnscheduleGatewayTransportError persists a durable network/proxy fault
+// and updates the selected account object immediately for the current process.
+// The repository also refreshes the scheduler snapshot after the DB write.
+func (s *GatewayService) tempUnscheduleGatewayTransportError(ctx context.Context, account *Account, safeErr string) {
+	if s == nil || account == nil {
+		return
+	}
+
+	until := time.Now().Add(upstreamTransportErrorTempUnschedDuration)
+	reason := "upstream transport error (proxy/network): " + safeErr
+	account.TempUnschedulableUntil = &until
+	account.TempUnschedulableReason = reason
+
+	if s.accountRepo == nil {
+		logger.L().With(zap.String("component", "service.gateway")).Warn(
+			"gateway.account_temp_unscheduled_transport_memory_only",
+			zap.Int64("account_id", account.ID),
+			zap.String("account_name", account.Name),
+			zap.String("platform", account.Platform),
+			zap.Time("until", until),
+			zap.String("reason", reason),
+		)
+		return
+	}
+
+	baseCtx := context.Background()
+	if ctx != nil {
+		baseCtx = context.WithoutCancel(ctx)
+	}
+	stateCtx, cancel := context.WithTimeout(baseCtx, gatewayTransportErrorStateUpdateTimeout)
+	defer cancel()
+	if err := s.accountRepo.SetTempUnschedulable(stateCtx, account.ID, until, reason); err != nil {
+		logger.L().With(zap.String("component", "service.gateway")).Warn(
+			"gateway.account_temp_unscheduled_transport_failed",
+			zap.Int64("account_id", account.ID),
+			zap.Error(err),
+		)
+		return
+	}
+
+	logger.L().With(zap.String("component", "service.gateway")).Warn(
+		"gateway.account_temp_unscheduled_transport",
+		zap.Int64("account_id", account.ID),
+		zap.String("account_name", account.Name),
+		zap.String("platform", account.Platform),
+		zap.Time("until", until),
+		zap.String("reason", reason),
+	)
+}

--- a/backend/internal/service/gateway_upstream_transport_error_test.go
+++ b/backend/internal/service/gateway_upstream_transport_error_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type gatewayTransportAccountRepoStub struct {
+	AccountRepository
+	tempUnschedCalls []gatewayTempUnschedCall
+}
+
+type gatewayTempUnschedCall struct {
+	accountID int64
+	until     time.Time
+	reason    string
+}
+
+func (r *gatewayTransportAccountRepoStub) SetTempUnschedulable(_ context.Context, id int64, until time.Time, reason string) error {
+	r.tempUnschedCalls = append(r.tempUnschedCalls, gatewayTempUnschedCall{accountID: id, until: until, reason: reason})
+	return nil
+}
+
+func newGatewayTransportErrTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	return c, rec
+}
+
+func TestHandleGatewayUpstreamTransportError_PersistentFailsOverAndUnschedules(t *testing.T) {
+	repo := &gatewayTransportAccountRepoStub{}
+	svc := &GatewayService{accountRepo: repo}
+	account := &Account{ID: 4627, Name: "local-llm-down", Platform: PlatformAnthropic}
+	c, rec := newGatewayTransportErrTestContext()
+
+	before := time.Now()
+	err := svc.handleGatewayUpstreamTransportError(
+		context.Background(),
+		c,
+		account,
+		"http://127.0.0.1:30001/v1/messages",
+		errors.New(`dial tcp 127.0.0.1:30001: connect: connection refused`),
+		true,
+	)
+	after := time.Now()
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.JSONEq(t, string(gatewayTransportFailoverBody), string(failoverErr.ResponseBody))
+	require.Len(t, repo.tempUnschedCalls, 1)
+	require.Equal(t, int64(4627), repo.tempUnschedCalls[0].accountID)
+	require.Contains(t, repo.tempUnschedCalls[0].reason, "connection refused")
+	require.True(t, repo.tempUnschedCalls[0].until.After(before.Add(upstreamTransportErrorTempUnschedDuration-time.Second)))
+	require.True(t, repo.tempUnschedCalls[0].until.Before(after.Add(upstreamTransportErrorTempUnschedDuration+time.Second)))
+	require.NotNil(t, account.TempUnschedulableUntil)
+	require.Equal(t, repo.tempUnschedCalls[0].reason, account.TempUnschedulableReason)
+	require.Equal(t, 0, rec.Body.Len(), "the handler must own the response during failover")
+}
+
+func TestHandleGatewayUpstreamTransportError_TransientFailsOverWithoutUnscheduling(t *testing.T) {
+	repo := &gatewayTransportAccountRepoStub{}
+	svc := &GatewayService{accountRepo: repo}
+	account := &Account{ID: 99, Name: "local-llm-flaky", Platform: PlatformAnthropic}
+	c, rec := newGatewayTransportErrTestContext()
+
+	err := svc.handleGatewayUpstreamTransportError(
+		context.Background(),
+		c,
+		account,
+		"http://127.0.0.1:30001/v1/messages",
+		errors.New(`Post "http://127.0.0.1:30001/v1/messages": context deadline exceeded`),
+		false,
+	)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Empty(t, repo.tempUnschedCalls)
+	require.Nil(t, account.TempUnschedulableUntil)
+	require.Equal(t, 0, rec.Body.Len())
+}
+
+func TestHandleGatewayUpstreamTransportError_ContextCanceledDoesNotFailOver(t *testing.T) {
+	repo := &gatewayTransportAccountRepoStub{}
+	svc := &GatewayService{accountRepo: repo}
+	account := &Account{ID: 77, Name: "local-llm-healthy", Platform: PlatformAnthropic}
+	c, rec := newGatewayTransportErrTestContext()
+
+	err := svc.handleGatewayUpstreamTransportError(context.Background(), c, account, "http://127.0.0.1:30001", context.Canceled, false)
+
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, repo.tempUnschedCalls)
+	require.Nil(t, account.TempUnschedulableUntil)
+	require.Equal(t, 0, rec.Body.Len())
+}

--- a/backend/internal/service/openai_upstream_transport_error.go
+++ b/backend/internal/service/openai_upstream_transport_error.go
@@ -14,9 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// openAITransportErrorTempUnschedDuration is how long an account is temporarily
+// upstreamTransportErrorTempUnschedDuration is how long an account is temporarily
 // unscheduled after a durable transport failure (matches tokenRefreshTempUnschedDuration).
-const openAITransportErrorTempUnschedDuration = 10 * time.Minute
+const upstreamTransportErrorTempUnschedDuration = 10 * time.Minute
 
 // openAITransportFailoverBody is the OpenAI-format error body attached to the
 // failover error for a transport-level failure. Kept identical to the legacy
@@ -24,10 +24,10 @@ const openAITransportErrorTempUnschedDuration = 10 * time.Minute
 // ultimately exhausted.
 var openAITransportFailoverBody = []byte(`{"error":{"type":"upstream_error","message":"Upstream request failed"}}`)
 
-// openAITransportErrorClass describes how to react to a transport-level upstream
+// upstreamTransportErrorClass describes how to react to a transport-level upstream
 // failure — i.e. the HTTP round-trip never completed (proxy / DNS / TCP / TLS
 // error, no HTTP status code received).
-type openAITransportErrorClass struct {
+type upstreamTransportErrorClass struct {
 	// Persistent marks failures where retrying the same proxy/account is
 	// pointless: expired or rejected proxy credentials, a dead proxy endpoint,
 	// or DNS/routing failure. Such accounts should be temporarily unscheduled
@@ -35,12 +35,12 @@ type openAITransportErrorClass struct {
 	Persistent bool
 }
 
-// openAIPersistentTransportErrorMarkers are substrings (matched case-insensitively
+// persistentUpstreamTransportErrorMarkers are substrings (matched case-insensitively
 // against the raw transport error) that indicate a durable proxy/network fault.
 // Matched signals are intentionally specific failure *reasons*, not the operation
 // (e.g. we match "connection refused", not "proxyconnect") so that a transient
 // failure of the same operation (a proxy timeout) is NOT misclassified as durable.
-var openAIPersistentTransportErrorMarkers = []string{
+var persistentUpstreamTransportErrorMarkers = []string{
 	"authentication failed",         // SOCKS5 RFC1929 / proxy credentials rejected (expired account)
 	"proxy authentication required", // HTTP proxy 407
 	"connection refused",            // proxy/upstream endpoint down
@@ -49,7 +49,7 @@ var openAIPersistentTransportErrorMarkers = []string{
 	"no such host", // DNS resolution failure (bad/expired proxy hostname)
 }
 
-// classifyOpenAITransportError decides whether a transport-level upstream error
+// classifyUpstreamTransportError decides whether a transport-level upstream error
 // is durable (Persistent — evict the account + alert) or a transient blip
 // (fail over to a healthy account but keep this one schedulable).
 //
@@ -65,30 +65,30 @@ var openAIPersistentTransportErrorMarkers = []string{
 //     The network-layer string markers ("connection refused", "no route to host",
 //     "network is unreachable", "no such host") are kept as a cross-platform safety
 //     net even though the typed checks should cover them on modern Go+Linux.
-func classifyOpenAITransportError(err error) openAITransportErrorClass {
+func classifyUpstreamTransportError(err error) upstreamTransportErrorClass {
 	if err == nil {
-		return openAITransportErrorClass{}
+		return upstreamTransportErrorClass{}
 	}
 
 	// — Typed checks (preferred) ——————————————————————————————————————————————
 	if errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.EHOSTUNREACH) ||
 		errors.Is(err, syscall.ENETUNREACH) {
-		return openAITransportErrorClass{Persistent: true}
+		return upstreamTransportErrorClass{Persistent: true}
 	}
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
-		return openAITransportErrorClass{Persistent: true}
+		return upstreamTransportErrorClass{Persistent: true}
 	}
 
 	// — String-marker fallback ————————————————————————————————————————————————
 	msg := strings.ToLower(err.Error())
-	for _, marker := range openAIPersistentTransportErrorMarkers {
+	for _, marker := range persistentUpstreamTransportErrorMarkers {
 		if strings.Contains(msg, marker) {
-			return openAITransportErrorClass{Persistent: true}
+			return upstreamTransportErrorClass{Persistent: true}
 		}
 	}
-	return openAITransportErrorClass{}
+	return upstreamTransportErrorClass{}
 }
 
 // handleOpenAIUpstreamTransportError handles a transport-level upstream failure
@@ -129,7 +129,7 @@ func (s *OpenAIGatewayService) handleOpenAIUpstreamTransportError(ctx context.Co
 		scheduleOllamaCloudUsageActivity(s.deferredService, account)
 	}
 
-	if classifyOpenAITransportError(err).Persistent {
+	if classifyUpstreamTransportError(err).Persistent {
 		s.tempUnscheduleOpenAITransportError(ctx, account, safeErr)
 	}
 
@@ -154,7 +154,7 @@ func (s *OpenAIGatewayService) tempUnscheduleOpenAITransportError(ctx context.Co
 	if s == nil || account == nil {
 		return
 	}
-	until := time.Now().Add(openAITransportErrorTempUnschedDuration)
+	until := time.Now().Add(upstreamTransportErrorTempUnschedDuration)
 	reason := "upstream transport error (proxy/network): " + safeErr
 
 	// Immediate in-memory block (honoured by the scheduler at selection time),

--- a/backend/internal/service/openai_upstream_transport_error_handle_test.go
+++ b/backend/internal/service/openai_upstream_transport_error_handle_test.go
@@ -77,8 +77,8 @@ func TestHandleOpenAIUpstreamTransportError_PersistentEvictsAndFailsOver(t *test
 	require.Len(t, repo.tempUnschedCalls, 1)
 	require.Equal(t, int64(4627), repo.tempUnschedCalls[0].accountID)
 	require.Contains(t, repo.tempUnschedCalls[0].reason, "authentication failed")
-	require.True(t, repo.tempUnschedCalls[0].until.After(before.Add(openAITransportErrorTempUnschedDuration-time.Second)))
-	require.True(t, repo.tempUnschedCalls[0].until.Before(after.Add(openAITransportErrorTempUnschedDuration+time.Second)))
+	require.True(t, repo.tempUnschedCalls[0].until.After(before.Add(upstreamTransportErrorTempUnschedDuration-time.Second)))
+	require.True(t, repo.tempUnschedCalls[0].until.Before(after.Add(upstreamTransportErrorTempUnschedDuration+time.Second)))
 
 	// Immediate in-memory effect so subsequent requests skip it before DB/cache catches up.
 	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))

--- a/backend/internal/service/openai_upstream_transport_error_test.go
+++ b/backend/internal/service/openai_upstream_transport_error_test.go
@@ -76,9 +76,9 @@ func TestClassifyOpenAITransportError(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyOpenAITransportError(tc.err).Persistent
+			got := classifyUpstreamTransportError(tc.err).Persistent
 			if got != tc.persistent {
-				t.Fatalf("classifyOpenAITransportError(%q).Persistent = %v, want %v", errString(tc.err), got, tc.persistent)
+				t.Fatalf("classifyUpstreamTransportError(%q).Persistent = %v, want %v", errString(tc.err), got, tc.persistent)
 			}
 		})
 	}


### PR DESCRIPTION
Routes Anthropic transport-level upstream failures through account failover. Persistent connection, proxy, and network failures are temporarily unscheduled; transient timeouts and resets fail over without eviction. Added focused tests and verified the Docker build.