### PR TITLE
fix(grok): 内容违规的 permission-denied 403 不再误判为账号失效并耗尽号池

### DIFF
--- a/backend/internal/service/grok_upstream_errors.go
+++ b/backend/internal/service/grok_upstream_errors.go
@@ -105,6 +105,11 @@ func isGrokContentPolicyCode(value string) bool {
 	}
 }
 
+// isGrokAccountAccessCode matches codes that unambiguously describe the
+// account itself. "permission_denied" is deliberately absent: xAI reuses that
+// code for both entitlement denials ("Access to the chat endpoint is denied")
+// and request-scoped safety refusals ("Content violates usage guidelines."),
+// so like "policy_violation" the accompanying message decides instead.
 func isGrokAccountAccessCode(value string) bool {
 	switch normalizeGrokErrorMarker(value) {
 	case "account_suspended",
@@ -114,8 +119,7 @@ func isGrokAccountAccessCode(value string) bool {
 		"subscription_required",
 		"entitlement_required",
 		"not_entitled",
-		"plan_required",
-		"permission_denied":
+		"plan_required":
 		return true
 	default:
 		return false
@@ -171,6 +175,7 @@ func grokContentPolicyMessage(value string) bool {
 		"prompt violates policy",
 		"input violates content policy",
 		"input violates policy",
+		"violates usage guidelines",
 	} {
 		if strings.Contains(lower, phrase) {
 			return true

--- a/backend/internal/service/grok_upstream_errors_test.go
+++ b/backend/internal/service/grok_upstream_errors_test.go
@@ -84,6 +84,24 @@ func TestIsGrokContentPolicyRejection(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "permission denied with usage guidelines refusal",
+			status: http.StatusForbidden,
+			body:   `{"code":"permission-denied","error":"Content violates usage guidelines. "}`,
+			want:   true,
+		},
+		{
+			name:   "permission denied entitlement message keeps account path",
+			status: http.StatusForbidden,
+			body:   `{"code":"permission-denied","error":"Access to the chat endpoint is denied"}`,
+			want:   false,
+		},
+		{
+			name:   "structured account code overrides usage guidelines phrase",
+			status: http.StatusForbidden,
+			body:   `{"error":{"code":"account_suspended","message":"Content violates usage guidelines."}}`,
+			want:   false,
+		},
+		{
 			name:   "wrong status",
 			status: http.StatusBadRequest,
 			body:   `{"error":{"code":"new_sensitive"}}`,
@@ -120,6 +138,38 @@ func TestGrokContentPolicy403DoesNotMutateOrFailover(t *testing.T) {
 	got := svc.failoverOpenAIUpstreamHTTPError(context.Background(), c, account, resp, body, "text is sensitive", "grok-4.5")
 	require.Nil(t, got)
 	require.Zero(t, repo.tempUnschedCalls)
+}
+
+func TestGrokPermissionDeniedContentRefusalDoesNotMutateOrFailover(t *testing.T) {
+	repo := &grokQuotaAccountRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	account := &Account{ID: 4785, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	body := []byte(`{"code":"permission-denied","error":"Content violates usage guidelines. "}`)
+
+	svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusForbidden, nil, body)
+
+	require.Zero(t, repo.tempUnschedCalls)
+	require.Zero(t, repo.rateLimitedCalls)
+	require.Zero(t, repo.updateCalls)
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.False(t, svc.shouldFailoverGrokUpstreamError(http.StatusForbidden, body))
+}
+
+func TestGrokPermissionDeniedEntitlementKeepsDefaultCooldown(t *testing.T) {
+	repo := &grokQuotaAccountRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	account := &Account{ID: 4786, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	body := []byte(`{"code":"permission-denied","error":"Access to the chat endpoint is denied"}`)
+	before := time.Now()
+
+	svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusForbidden, nil, body)
+
+	require.Equal(t, 1, repo.tempUnschedCalls)
+	require.Equal(t, "grok access or entitlement denied", repo.lastTempUnschedReason)
+	require.Greater(t, repo.lastTempUnschedUntil, before.Add(29*time.Minute))
+	require.Less(t, repo.lastTempUnschedUntil, before.Add(31*time.Minute))
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.True(t, svc.shouldFailoverGrokUpstreamError(http.StatusForbidden, body))
 }
 
 func TestGrokNonFailoverDoesNotApplyGenericTempUnschedulablePolicy(t *testing.T) {


### PR DESCRIPTION
## 问题

Fixes #4785

xAI 对「内容违反使用规范」的请求级拒绝返回：

```json
403 {"code":"permission-denied","error":"Content violates usage guidelines. "}
```

但 `isGrokContentPolicyRejection` 会把它误判为账号级问题，走 failover + 临时停止调度：

1. `grok_upstream_errors.go` 中 `permission_denied` 在 `isGrokAccountAccessCode` 的无条件否决清单里——结构化 marker 一命中就直接排除内容政策分类；
2. 同时 `"violates usage guidelines"` 不在 `grokContentPolicyMessage` 片语清单中，即使没被否决也接不住。

后果：同一条违规 prompt 被逐号重试，每个被轮到的账号吃 30 分钟 `grok access or entitlement denied` 冷却，整个号池被一条内容违规请求耗尽。

## 根因：xAI 对 `permission-denied` 是双义复用

同一个 code 同时用于：

- **账号/权益拒绝**（#4525 场景）：`"Access to the chat endpoint is denied"`
- **请求级内容拒绝**（本 issue）：`"Content violates usage guidelines. "`

因此 code 本身不足以定性。仓库内已有同款先例：`policy_violation` 不在任何 code 清单中，由 message 决定分类（见既有测试 `ambiguous policy violation code is not enough` / `policy violation with request scoped message`）。

## 修复

沿用该先例，把 `permission_denied` 也降为「双义 code、由 message 决定」：

- `isGrokAccountAccessCode` 移除 `permission_denied`（补注释说明双义原因）；无歧义的账号 code（`account_suspended` / `subscription_required` 等）与账号片语否决逻辑不变
- `grokContentPolicyMessage` 片语清单新增 `"violates usage guidelines"`

行为影响面收敛为：**仅当** body 的 message 命中内容政策片语时，`permission_denied` 案例才改判内容拒绝（不 failover、不冷却、403 原样返回）；`"Access to the chat endpoint is denied"` 等权益拒绝的 message 不含内容片语，仍走原账号冷却路径，行为零变化（有回归测试钉住）。

## 测试

新增 5 个测试（`-tags unit`）：

- 表驱动 3 例：issue 原文 body（含尾随空格）→ 判内容拒绝；`permission-denied` + entitlement message → 保持账号路径；**优先序冲突锁**：`account_suspended` 码 + `"Content violates usage guidelines."` message → 仍判账号路径（钉住「结构化账号标记优先于内容片语」的检查顺序，防未来重排把停权账号误判成内容拒绝）
- 行为级 2 例：仿 `TestGrokContentPolicy403DoesNotMutateOrFailover`，用 #4785 body 断言零 `tempUnsched` / 零 `rateLimited` / 零 update / 不进入 runtime block / 不 failover；entitlement message 则仍吃 30 分钟默认冷却 + runtime block + 保留 failover（双向都上锁）

已验证红→绿：未修复代码上 `permission_denied_with_usage_guidelines_refusal` 失败（复现 bug），修复后 16 个分类案例 + 全部 Grok 行为测试通过，改动文件 gofmt 干净。

## 查重与已知限制

- 查重：`gh search prs` 按 issue 编号与关键词搜索，无其他 PR 处理 #4785；merged PR #4540 修的是 CLI chat endpoint 的 entitlement fallback（transport 层、exact-match `permission_denied` 下划线 + chat-endpoint 前缀），与本修复零交互
- 已知限制（既有行为、不在本 PR 范围）：此类扁平 body（顶层字符串 `error` 键）不被 `extractUpstreamErrorMessage` 解析，客户端收到的 403 文案是通用的 "Request blocked by upstream content policy" 而非 xAI 原文；不影响路由/冷却/failover 正确性

🤖 Generated with [Claude Code](https://claude.com/claude-code)
