### PR TITLE
fix(billing): 渠道定价对带后缀的模型名不再被官方兜底价覆盖

### DIFF
--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -85,7 +85,7 @@ func (r *ModelPricingResolver) Resolve(ctx context.Context, input PricingInput) 
 
 	var chPricing *ChannelModelPricing
 	if input.GroupID != nil && r.channelService != nil {
-		chPricing = r.channelService.GetChannelModelPricing(ctx, *input.GroupID, input.Model)
+		chPricing = r.lookupChannelPricingNormalized(ctx, *input.GroupID, input.Model)
 		if chPricing != nil {
 			mode := chPricing.BillingMode
 			if mode == "" {
@@ -177,9 +177,33 @@ func (r *ModelPricingResolver) resolveBasePricing(model string) (*ModelPricing, 
 	return pricing, PricingSourceLiteLLM
 }
 
+// lookupChannelPricingNormalized 查找渠道定价：先用字面模型名做精确/通配匹配，
+// 未命中时用与官方兜底价一致的归一化模型名再查一次。
+//
+// 官方兜底价对 OpenAI/Codex 族会把 gpt-5.6-luna-high 这类变体名归一化到基名
+// （billing_service.go 的 normalizeKnownOpenAICodexModel 分支），而渠道定价此前
+// 只认字面名。两者不对称导致：管理员只配基名、请求模型带 effort 后缀时，渠道定价
+// 未命中而官方兜底命中，计费候选循环首个成功即返回，渠道定价永远轮不到（issue #5256）。
+//
+// 字面名优先，保证管理员对具体变体的显式配价不被基名覆盖；非 OpenAI 模型
+// normalizeKnownOpenAICodexModel 返回空串，此处天然 no-op。
+func (r *ModelPricingResolver) lookupChannelPricingNormalized(ctx context.Context, groupID int64, model string) *ChannelModelPricing {
+	if r.channelService == nil {
+		return nil
+	}
+	if pricing := r.channelService.GetChannelModelPricing(ctx, groupID, model); pricing != nil {
+		return pricing
+	}
+	normalized := normalizeKnownOpenAICodexModel(model)
+	if normalized == "" || strings.EqualFold(normalized, strings.TrimSpace(model)) {
+		return nil
+	}
+	return r.channelService.GetChannelModelPricing(ctx, groupID, normalized)
+}
+
 // applyChannelOverrides 应用渠道定价覆盖
 func (r *ModelPricingResolver) applyChannelOverrides(ctx context.Context, groupID int64, model string, resolved *ResolvedPricing) {
-	chPricing := r.channelService.GetChannelModelPricing(ctx, groupID, model)
+	chPricing := r.lookupChannelPricingNormalized(ctx, groupID, model)
 	if chPricing == nil {
 		return
 	}

--- a/backend/internal/service/model_pricing_resolver_channel_normalized_test.go
+++ b/backend/internal/service/model_pricing_resolver_channel_normalized_test.go
@@ -1,0 +1,162 @@
+//go:build unit
+
+package service
+
+// issue #5256 回归测试：使用记录的费用统计没有按照渠道定价的价格进行计算。
+//
+// 场景：管理员在渠道定价把 gpt-5.6-luna 的输入价从官方 $0.2/M 调成 $0.4/M。
+// 当请求模型带 effort 后缀（gpt-5.6-luna-high）而渠道只配了基名时，渠道定价查找
+// 用字面名未命中，官方兜底价却会把后缀名归一化到 gpt-5.6-luna 并命中静态价
+// （pricing_service.go 的 gpt-5.6-luna 前缀分支），计费候选循环首个成功即返回
+// → 落库的是官方 0.2 而不是渠道 0.4。
+//
+// 测试走与生产一致的 populateChannelCache → OpenAIGatewayService.RecordUsage 路径，
+// 断言落库 UsageLog 的 InputCost。
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// 1M 输入 token 下，渠道价与官方兜底价的期望费用（USD）
+	channelPricingExpectedChannelCost  = 0.4
+	channelPricingExpectedOfficialCost = 0.2
+	// 用于验证「不相关的渠道配置不会被误命中」的对照价
+	channelPricingUnrelatedCost = 0.9
+)
+
+// tokenPricingForModels 构造 token 计费模式的渠道定价；inputPerMillion 单位为 USD/1M token。
+func tokenPricingForModels(models []string, inputPerMillion float64) ChannelModelPricing {
+	return ChannelModelPricing{
+		Platform:        PlatformOpenAI,
+		Models:          models,
+		BillingMode:     BillingModeToken,
+		InputPrice:      float64Ptr(inputPerMillion / 1e6),
+		OutputPrice:     float64Ptr(2.4e-6),
+		CacheWritePrice: float64Ptr(0.5e-6),
+		CacheReadPrice:  float64Ptr(0.04e-6),
+	}
+}
+
+func newChannelServiceWithPricings(groupID int64, pricings []ChannelModelPricing) *ChannelService {
+	ch := Channel{
+		ID:           1,
+		Name:         "codex-channel",
+		Status:       StatusActive,
+		ModelPricing: pricings,
+		GroupIDs:     []int64{groupID},
+	}
+	cs := &ChannelService{}
+	cs.cache.Store(populateChannelCache([]Channel{ch}, map[int64]string{groupID: PlatformOpenAI}))
+	return cs
+}
+
+// recordUsageWithChannelPricing 用给定的渠道定价跑一次 RecordUsage，返回落库的 UsageLog。
+func recordUsageWithChannelPricing(t *testing.T, requestedModel string, subscriptionGroup bool, pricings []ChannelModelPricing) *UsageLog {
+	t.Helper()
+	const groupID = int64(777)
+
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+	cs := newChannelServiceWithPricings(groupID, pricings)
+	svc.channelService = cs
+	svc.resolver = NewModelPricingResolver(cs, svc.billingService)
+
+	group := &Group{
+		ID:             groupID,
+		Platform:       PlatformOpenAI,
+		RateMultiplier: 1,
+	}
+	if subscriptionGroup {
+		group.SubscriptionType = SubscriptionTypeSubscription
+	}
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:    "resp_luna_5256",
+			Model:        requestedModel,
+			BillingModel: requestedModel,
+			Usage: OpenAIUsage{
+				InputTokens:  1_000_000,
+				OutputTokens: 0,
+			},
+			Duration: time.Second,
+		},
+		ChannelUsageFields: ChannelUsageFields{
+			OriginalModel:      requestedModel,
+			ChannelMappedModel: requestedModel,
+		},
+		APIKey: &APIKey{
+			ID:      1,
+			GroupID: i64p(groupID),
+			Group:   group,
+		},
+		User:    &User{ID: 1},
+		Account: &Account{ID: 1, Platform: PlatformOpenAI},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	return usageRepo.lastLog
+}
+
+// 基线：请求模型与渠道定价 key 完全一致 → 按渠道价计。
+func TestChannelPricing_ExactModelMatch(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna", false, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.6-luna"}, channelPricingExpectedChannelCost),
+	})
+	require.InDelta(t, channelPricingExpectedChannelCost, log.InputCost, 1e-9)
+}
+
+// issue #5256 主回归：请求模型带 effort 后缀、渠道只配基名（无通配符）→ 仍应按渠道价计。
+// 修复前此处得到 0.2（官方兜底价）。
+func TestChannelPricing_SuffixedModelUsesNormalizedChannelPricing(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna-high", false, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.6-luna"}, channelPricingExpectedChannelCost),
+	})
+	require.InDelta(t, channelPricingExpectedChannelCost, log.InputCost, 1e-9,
+		"suffixed request model should fall back to the normalized channel pricing; got %v (%v = official fallback)",
+		log.InputCost, channelPricingExpectedOfficialCost)
+}
+
+// 同一根因的另一种变体名：上游返回带日期后缀的模型名
+// （isCodexDateSuffix，如 gpt-5.6-luna-2026-08-01），渠道只配基名 → 仍应按渠道价计。
+func TestChannelPricing_DateSuffixedModelUsesNormalizedChannelPricing(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna-2026-08-01", false, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.6-luna"}, channelPricingExpectedChannelCost),
+	})
+	require.InDelta(t, channelPricingExpectedChannelCost, log.InputCost, 1e-9,
+		"date-suffixed request model should fall back to the normalized channel pricing; got %v", log.InputCost)
+}
+
+// 精确匹配优先：同时配了变体名与基名时，请求变体名必须命中变体的显式配价，
+// 不能被归一化后的基名覆盖。
+func TestChannelPricing_ExactVariantWinsOverNormalizedBaseName(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna-high", false, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.6-luna-high"}, channelPricingUnrelatedCost),
+		tokenPricingForModels([]string{"gpt-5.6-luna"}, channelPricingExpectedChannelCost),
+	})
+	require.InDelta(t, channelPricingUnrelatedCost, log.InputCost, 1e-9,
+		"explicit per-variant channel pricing must win over the normalized base name")
+}
+
+// 订阅型分组走同一条渠道定价解析路径。
+func TestChannelPricing_SuffixedModelSubscriptionGroup(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna-high", true, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.6-luna"}, channelPricingExpectedChannelCost),
+	})
+	require.InDelta(t, channelPricingExpectedChannelCost, log.InputCost, 1e-9)
+}
+
+// 反向保护：渠道只配了不相关的模型时，归一化查找不得误命中该配置，
+// 应落回官方兜底价。
+func TestChannelPricing_UnrelatedChannelModelNotMatched(t *testing.T) {
+	log := recordUsageWithChannelPricing(t, "gpt-5.6-luna-high", false, []ChannelModelPricing{
+		tokenPricingForModels([]string{"gpt-5.4"}, channelPricingUnrelatedCost),
+	})
+	require.InDelta(t, channelPricingExpectedOfficialCost, log.InputCost, 1e-9,
+		"normalized lookup must not match an unrelated channel pricing entry")
+}


### PR DESCRIPTION
## 问题

Fixes #5256。

管理员在「渠道定价」里给模型配了自定义价格，使用记录的费用却仍按官方价计算。报告者提到「我记得之前调整一些渠道定价是生效的，不知道从何开始失效了」——这确实是一次回归。

触发条件：**实际计费的模型名是变体名，而管理员在渠道定价里只配了基名（且没用通配符）**。变体名在本项目里是被显式支持的合法形态，`isKnownCodexModelSuffix`（`openai_codex_transform.go:620`）列了两类：

- effort 后缀：`gpt-5.6-luna-high` / `-xhigh` / `-medium` / `-low` / `-minimal` / `-none`
- 日期后缀：`gpt-5.6-luna-2026-08-01`（`isCodexDateSuffix`）

## 根因

渠道定价查找与官方兜底价的「模型名归一化」不对称，叠加计费候选循环首个成功即返回：

1. `openai_gateway_usage.go:447-467` `calculateOpenAIRecordUsageCost` 遍历计费候选，**第一个不报错的即 return**。候选顺序由 `usageBillingModelCandidates`（`openai_model_alias.go:155`）生成：字面名 → 拼写归一名 → `normalizeKnownOpenAICodexModel` 基名。
2. `model_pricing_resolver.go:66-107` `Resolve()` 只拿**字面**模型名查渠道定价；`channel_service.go:412-429` `lookupPricingAcrossPlatforms` 只做精确匹配 + 通配符（`normalizeChannelPricingModelName` 仅对 `claude-` 前缀替换 `.`，对 OpenAI 族等同 no-op）。
3. 官方兜底价这边却会**激进归一化**：`billing_service.go:780` 走 `normalizeKnownOpenAICodexModel`；`pricing_service.go:965-969` 对 `gpt-5.6-luna` 前缀直接返回静态价 `2e-07`（$0.2/M）。

于是：首个候选（变体名）渠道未命中 → 官方兜底命中并「成功」→ **循环立即 return，带归一化基名的第二个候选（本可命中渠道定价）永远轮不到**。

回归引入点应是为 5.6 族加静态 prefix 兜底价的那批改动（`383f61d0` / `de28eba3`）：在此之前变体名走不到静态兜底，渠道定价才有机会在后续候选里生效——这与报告者说的「之前是生效的」吻合。

## 修复

`model_pricing_resolver.go` 抽出 `lookupChannelPricingNormalized`，统一 `Resolve()` 顶部与 `applyChannelOverrides` 两个查找点：字面名先查，未命中时用**与官方兜底同一个** `normalizeKnownOpenAICodexModel` 的归一化名再查一次。

三点取舍：

- **字面名优先**：管理员若对具体变体（如 `gpt-5.6-luna-high`）配了显式价格，不会被基名覆盖。
- **修在 resolver 层而非 OpenAI 计费循环层**：`Resolve()` 是各平台共用的定价入口，修在这里让所有走渠道定价的路径一致受益，也不必在循环里塞特例。
- **非 OpenAI 模型天然 no-op**：`normalizeKnownOpenAICodexModel` 对非 GPT/Codex 名返回空串，此时直接返回 nil，行为与修复前完全一致。

## 测试

新增 `model_pricing_resolver_channel_normalized_test.go`（`//go:build unit`，与它复用 stub 的 `gateway_record_usage_test.go` 同 tag），走与生产一致的 `populateChannelCache` → `OpenAIGatewayService.RecordUsage` 路径，断言落库的 `UsageLog.InputCost`。渠道价设 $0.4/M，官方兜底 $0.2/M，输入 1M token：

| 测试 | 场景 | 期望 |
|------|------|------|
| `ExactModelMatch` | 请求名与渠道定价 key 完全一致 | 0.4 |
| `SuffixedModelUsesNormalizedChannelPricing` | 请求 `gpt-5.6-luna-high`，渠道只配基名 | 0.4（**修复前 0.2**） |
| `DateSuffixedModelUsesNormalizedChannelPricing` | 请求 `gpt-5.6-luna-2026-08-01`，渠道只配基名 | 0.4（**修复前 0.2**） |
| `ExactVariantWinsOverNormalizedBaseName` | 变体名与基名都配了价 | 变体名的显式价，不被基名覆盖 |
| `SuffixedModelSubscriptionGroup` | 订阅型分组同场景 | 0.4（**修复前 0.2**） |
| `UnrelatedChannelModelNotMatched` | 渠道只配了不相关模型（`gpt-5.4`） | 0.2，归一化查找不误命中 |

**红灯**（`golang:1.26` 容器内，只保留新测试、把 `model_pricing_resolver.go` 还原成本 PR 之前的版本）：

```
--- PASS: TestChannelPricing_ExactModelMatch (0.00s)
--- FAIL: TestChannelPricing_SuffixedModelUsesNormalizedChannelPricing (0.00s)
        Error: Max difference between 0.4 and 0.19999999999999998 allowed is 1e-09, but difference was 0.20000000000000004
--- FAIL: TestChannelPricing_DateSuffixedModelUsesNormalizedChannelPricing (0.00s)
        Error: Max difference between 0.4 and 0.19999999999999998 allowed is 1e-09, but difference was 0.20000000000000004
--- PASS: TestChannelPricing_ExactVariantWinsOverNormalizedBaseName (0.00s)
--- FAIL: TestChannelPricing_SuffixedModelSubscriptionGroup (0.00s)
        Error: Max difference between 0.4 and 0.19999999999999998 allowed is 1e-09, but difference was 0.20000000000000004
--- PASS: TestChannelPricing_UnrelatedChannelModelNotMatched (0.00s)
FAIL    github.com/Wei-Shaw/sub2api/internal/service     0.032s
```

三个失败的实测值正是官方兜底价 0.2；三个保护性用例在修复前后都通过，说明它们覆盖的是不受本次改动影响的既有行为。

**绿灯**：

```
$ go test -tags unit ./internal/service/ -count=1
ok      github.com/Wei-Shaw/sub2api/internal/service     150.479s

$ go test -tags=unit ./... -count=1     # 与 make test-unit 一致
GOTEST_EXIT=0  FAIL_LINES=0  OK_PACKAGES=52
```

`gofmt -l` 对两个改动文件输出为空，`go vet -tags unit ./internal/service/` 通过。

## 查重与已知限制

- 已检索仓库 open PR，没有其他 PR 在修这个问题。
- **诚实保留**：issue 未提供版本号与具体的渠道定价配置，无法 100% 证明报告者命中的就是这条路径。但缺陷本身已由上述单测确证存在，且与他描述的现象（配了渠道价、仍按官方 0.2 计、以前生效过）完全吻合。
- **给报告者的即时 workaround**（不必等本 PR 合并）：在渠道定价里把模型名写成通配形式 `gpt-5.6-luna*`，即可让所有变体名立刻命中自定义价格（`expandPricingToCache` 对以 `*` 结尾的模型名按前缀匹配）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
