### PR TITLE
feat(gateway): log upstream requests and responses

### DIFF
--- a/backend/internal/pkg/gatewaydebug/logger.go
+++ b/backend/internal/pkg/gatewaydebug/logger.go
@@ -1,0 +1,88 @@
+package gatewaydebug
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	EnvName         = "SUB2API_DEBUG_GATEWAY_BODY"
+	defaultFilename = "gateway_debug.log"
+)
+
+type Logger struct {
+	writer   io.Writer
+	mu       sync.Mutex
+	sequence atomic.Uint64
+}
+
+var (
+	defaultOnce   sync.Once
+	defaultLogger *Logger
+)
+
+func Default() *Logger {
+	defaultOnce.Do(func() {
+		path := strings.TrimSpace(os.Getenv(EnvName))
+		if path == "" {
+			return
+		}
+		if isTruthy(path) {
+			path = defaultFilename
+		}
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			path = filepath.Join(path, defaultFilename)
+		}
+		if dir := filepath.Dir(path); dir != "." {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				slog.Error("failed to create gateway debug log directory", "dir", dir, "error", err)
+				return
+			}
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			slog.Error("failed to open gateway debug log file", "path", path, "error", err)
+			return
+		}
+		defaultLogger = New(file)
+		slog.Info("gateway debug logging enabled", "path", path)
+	})
+	return defaultLogger
+}
+
+func New(writer io.Writer) *Logger {
+	if writer == nil {
+		return nil
+	}
+	return &Logger{writer: writer}
+}
+
+func (l *Logger) NextID() uint64 {
+	if l == nil {
+		return 0
+	}
+	return l.sequence.Add(1)
+}
+
+func (l *Logger) Write(write func(io.Writer)) {
+	if l == nil || l.writer == nil || write == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	write(l.writer)
+}
+
+func isTruthy(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gatewaydebug"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
@@ -145,9 +146,10 @@ type openAIHTTP2FallbackState struct {
 // 7. 代理变更时清空旧连接池，避免复用错误代理
 // 8. 账号并发数与连接池上限对应（账号隔离策略下）
 type httpUpstreamService struct {
-	cfg     *config.Config                  // 全局配置
-	mu      sync.RWMutex                    // 保护 clients map 的读写锁
-	clients map[string]*upstreamClientEntry // 客户端缓存池，key 由隔离策略决定
+	cfg         *config.Config                  // 全局配置
+	mu          sync.RWMutex                    // 保护 clients map 的读写锁
+	clients     map[string]*upstreamClientEntry // 客户端缓存池，key 由隔离策略决定
+	debugLogger *gatewaydebug.Logger
 	// OpenAI 走 HTTP/HTTPS 代理时的 H2->H1 回退状态（key=标准化 proxyKey）
 	openAIHTTP2Fallbacks sync.Map
 }
@@ -162,8 +164,9 @@ type httpUpstreamService struct {
 //   - service.HTTPUpstream 接口实现
 func NewHTTPUpstream(cfg *config.Config) service.HTTPUpstream {
 	return &httpUpstreamService{
-		cfg:     cfg,
-		clients: make(map[string]*upstreamClientEntry),
+		cfg:         cfg,
+		clients:     make(map[string]*upstreamClientEntry),
+		debugLogger: gatewaydebug.Default(),
 	}
 }
 
@@ -202,8 +205,10 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 	// 执行请求
 	client := httpClientForUpstreamRequest(entry.client, req)
 	client = httpClientWithGrokAccessDeniedFallback(client)
+	debugTrace := s.beginUpstreamDebugTrace(req, proxyURL, accountID, profile)
 	resp, err := servertiming.Do(client, req)
 	if err != nil {
+		debugTrace.logTransportError(err)
 		s.recordOpenAIHTTP2Failure(profile, entry.protocolMode, entry.proxyKey, err)
 		// 请求失败，立即减少计数
 		atomic.AddInt64(&entry.inFlight, -1)
@@ -214,6 +219,8 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 
 	// 如果上游返回了压缩内容，解压后再交给业务层
 	decompressResponseBody(resp)
+	debugTrace.logResponse(resp)
+	resp.Body = debugTrace.wrapResponseBody(resp.Body)
 
 	// 包装响应体，在关闭时自动减少计数并更新时间戳
 	// 这确保了流式响应（如 SSE）在完全读取前不会被淘汰
@@ -266,8 +273,10 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 
 	client := httpClientForUpstreamRequest(entry.client, req)
 	client = httpClientWithGrokAccessDeniedFallback(client)
+	debugTrace := s.beginUpstreamDebugTrace(req, proxyURL, accountID, upstreamProfile)
 	resp, err := servertiming.Do(client, req)
 	if err != nil {
+		debugTrace.logTransportError(err)
 		atomic.AddInt64(&entry.inFlight, -1)
 		atomic.StoreInt64(&entry.lastUsed, time.Now().UnixNano())
 		slog.Debug("tls_fingerprint_request_failed", "account_id", accountID, "error", err)
@@ -275,6 +284,8 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 	}
 
 	decompressResponseBody(resp)
+	debugTrace.logResponse(resp)
+	resp.Body = debugTrace.wrapResponseBody(resp.Body)
 
 	resp.Body = wrapTrackedBody(resp.Body, func() {
 		atomic.AddInt64(&entry.inFlight, -1)

--- a/backend/internal/repository/http_upstream_debug.go
+++ b/backend/internal/repository/http_upstream_debug.go
@@ -1,0 +1,266 @@
+package repository
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gatewaydebug"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+type upstreamDebugTrace struct {
+	logger        *gatewaydebug.Logger
+	id            uint64
+	requestBytes  atomic.Int64
+	responseBytes atomic.Int64
+}
+
+type upstreamDebugBody struct {
+	io.ReadCloser
+	onChunk func([]byte)
+	onDone  func(string, error)
+	once    sync.Once
+}
+
+func (s *httpUpstreamService) beginUpstreamDebugTrace(
+	req *http.Request,
+	proxyURL string,
+	accountID int64,
+	profile service.HTTPUpstreamProfile,
+) *upstreamDebugTrace {
+	if s == nil || s.debugLogger == nil || req == nil {
+		return nil
+	}
+	trace := &upstreamDebugTrace{
+		logger: s.debugLogger,
+		id:     s.debugLogger.NextID(),
+	}
+
+	var bodyCopy io.ReadCloser
+	if req.Body != nil && req.GetBody != nil {
+		bodyCopy, _ = req.GetBody()
+	}
+	trace.logger.Write(func(writer io.Writer) {
+		fmt.Fprintf(writer, "\n========== [%s] UPSTREAM_REQUEST id=%d ==========\n", debugTimestamp(), trace.id)
+		fmt.Fprintln(writer, "--- context ---")
+		fmt.Fprintf(writer, "  account_id: %d\n", accountID)
+		fmt.Fprintf(writer, "  profile: %s\n", profile)
+		fmt.Fprintf(writer, "  proxy: %s\n", sanitizeDebugURL(proxyURL))
+		fmt.Fprintln(writer, "--- request ---")
+		fmt.Fprintf(writer, "  method: %s\n", req.Method)
+		fmt.Fprintf(writer, "  url: %s\n", sanitizeDebugURL(req.URL.String()))
+		if req.Host != "" {
+			fmt.Fprintf(writer, "  host: %s\n", req.Host)
+		}
+		fmt.Fprintf(writer, "  content_length: %d\n", req.ContentLength)
+		writeDebugHeaders(writer, req.Header)
+		fmt.Fprintln(writer, "--- body ---")
+		switch {
+		case req.Body == nil:
+			fmt.Fprintln(writer, "  (empty)")
+			fmt.Fprintf(writer, "========== UPSTREAM_REQUEST_END id=%d bytes=0 ==========\n", trace.id)
+		case bodyCopy != nil:
+			written, copyErr := io.Copy(writer, bodyCopy)
+			trace.requestBytes.Store(written)
+			_ = bodyCopy.Close()
+			fmt.Fprintln(writer)
+			if copyErr != nil {
+				fmt.Fprintf(writer, "========== UPSTREAM_REQUEST_END id=%d bytes=%d error=%q ==========\n", trace.id, written, copyErr.Error())
+			} else {
+				fmt.Fprintf(writer, "========== UPSTREAM_REQUEST_END id=%d bytes=%d ==========\n", trace.id, written)
+			}
+		default:
+			fmt.Fprintf(writer, "  (streamed below with id=%d)\n", trace.id)
+		}
+	})
+
+	if req.Body != nil && bodyCopy == nil {
+		req.Body = &upstreamDebugBody{
+			ReadCloser: req.Body,
+			onChunk: func(chunk []byte) {
+				trace.logBodyChunk("UPSTREAM_REQUEST_BODY_CHUNK", &trace.requestBytes, chunk)
+			},
+			onDone: func(reason string, err error) {
+				trace.logBodyEnd("UPSTREAM_REQUEST_END", trace.requestBytes.Load(), reason, err)
+			},
+		}
+	}
+	return trace
+}
+
+func (t *upstreamDebugTrace) logTransportError(err error) {
+	if t == nil || t.logger == nil || err == nil {
+		return
+	}
+	t.logger.Write(func(writer io.Writer) {
+		fmt.Fprintf(writer, "\n========== [%s] UPSTREAM_TRANSPORT_ERROR id=%d ==========\n", debugTimestamp(), t.id)
+		fmt.Fprintf(writer, "  error: %s\n", err.Error())
+	})
+}
+
+func (t *upstreamDebugTrace) logResponse(resp *http.Response) {
+	if t == nil || t.logger == nil || resp == nil {
+		return
+	}
+	t.logger.Write(func(writer io.Writer) {
+		fmt.Fprintf(writer, "\n========== [%s] UPSTREAM_RESPONSE id=%d ==========\n", debugTimestamp(), t.id)
+		fmt.Fprintln(writer, "--- response ---")
+		fmt.Fprintf(writer, "  status: %s\n", resp.Status)
+		fmt.Fprintf(writer, "  status_code: %d\n", resp.StatusCode)
+		fmt.Fprintf(writer, "  content_length: %d\n", resp.ContentLength)
+		writeDebugHeaders(writer, resp.Header)
+		fmt.Fprintln(writer, "--- body ---")
+		if resp.Body == nil {
+			fmt.Fprintln(writer, "  (empty)")
+			fmt.Fprintf(writer, "========== UPSTREAM_RESPONSE_END id=%d bytes=0 ==========\n", t.id)
+		} else {
+			fmt.Fprintf(writer, "  (streamed below with id=%d)\n", t.id)
+		}
+	})
+}
+
+func (t *upstreamDebugTrace) wrapResponseBody(body io.ReadCloser) io.ReadCloser {
+	if t == nil || t.logger == nil || body == nil {
+		return body
+	}
+	return &upstreamDebugBody{
+		ReadCloser: body,
+		onChunk: func(chunk []byte) {
+			t.logBodyChunk("UPSTREAM_RESPONSE_BODY_CHUNK", &t.responseBytes, chunk)
+		},
+		onDone: func(reason string, err error) {
+			t.logBodyEnd("UPSTREAM_RESPONSE_END", t.responseBytes.Load(), reason, err)
+		},
+	}
+}
+
+func (t *upstreamDebugTrace) logBodyChunk(tag string, total *atomic.Int64, chunk []byte) {
+	if t == nil || t.logger == nil || len(chunk) == 0 {
+		return
+	}
+	total.Add(int64(len(chunk)))
+	t.logger.Write(func(writer io.Writer) {
+		fmt.Fprintf(writer, "\n---------- [%s] %s id=%d bytes=%d ----------\n", debugTimestamp(), tag, t.id, len(chunk))
+		_, _ = writer.Write(chunk)
+		fmt.Fprintln(writer)
+	})
+}
+
+func (t *upstreamDebugTrace) logBodyEnd(tag string, total int64, reason string, err error) {
+	if t == nil || t.logger == nil {
+		return
+	}
+	t.logger.Write(func(writer io.Writer) {
+		fmt.Fprintf(writer, "========== [%s] %s id=%d bytes=%d reason=%s", debugTimestamp(), tag, t.id, total, reason)
+		if err != nil {
+			fmt.Fprintf(writer, " error=%q", err.Error())
+		}
+		fmt.Fprintln(writer, " ==========")
+	})
+}
+
+func (b *upstreamDebugBody) Read(buffer []byte) (int, error) {
+	read, err := b.ReadCloser.Read(buffer)
+	if read > 0 && b.onChunk != nil {
+		b.onChunk(buffer[:read])
+	}
+	if err != nil {
+		reason := "read_error"
+		var doneErr error
+		if err == io.EOF {
+			reason = "eof"
+		} else {
+			doneErr = err
+		}
+		b.finish(reason, doneErr)
+	}
+	return read, err
+}
+
+func (b *upstreamDebugBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.finish("closed", err)
+	return err
+}
+
+func (b *upstreamDebugBody) finish(reason string, err error) {
+	if b == nil || b.onDone == nil {
+		return
+	}
+	b.once.Do(func() {
+		b.onDone(reason, err)
+	})
+}
+
+func writeDebugHeaders(writer io.Writer, headers http.Header) {
+	fmt.Fprintln(writer, "--- headers ---")
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		for _, value := range headers[key] {
+			fmt.Fprintf(writer, "  %s: %s\n", key, safeDebugHeaderValue(key, value))
+		}
+	}
+}
+
+func safeDebugHeaderValue(key string, value string) string {
+	if !isSensitiveDebugName(key) {
+		return strings.TrimSpace(value)
+	}
+	if strings.EqualFold(strings.TrimSpace(key), "authorization") && strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "bearer ") {
+		return "Bearer [redacted]"
+	}
+	return "[redacted]"
+}
+
+func sanitizeDebugURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return "direct"
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "[invalid-url]"
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("[redacted]")
+	}
+	query := parsed.Query()
+	for key := range query {
+		if isSensitiveDebugName(key) {
+			query.Set(key, "[redacted]")
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func isSensitiveDebugName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	switch normalized {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie", "api-key", "apikey", "key", "x-api-key", "x-goog-api-key", "password", "passwd":
+		return true
+	}
+	return strings.Contains(normalized, "access_token") ||
+		strings.Contains(normalized, "access-token") ||
+		strings.Contains(normalized, "client_secret") ||
+		strings.Contains(normalized, "client-secret") ||
+		strings.Contains(normalized, "signature") ||
+		strings.HasSuffix(normalized, "_token") ||
+		strings.HasSuffix(normalized, "-token") ||
+		strings.HasSuffix(normalized, "_key") ||
+		strings.HasSuffix(normalized, "-key")
+}
+
+func debugTimestamp() string {
+	return time.Now().Format("2006-01-02 15:04:05.000")
+}

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -16,11 +16,93 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gatewaydebug"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func TestHTTPUpstreamDebugLogsRequestAndResponseWithoutConsumingBodies(t *testing.T) {
+	const (
+		requestBody    = `{"model":"gpt-image-1","prompt":"draw a lighthouse"}`
+		responseBody   = `{"created":123,"data":[{"b64_json":"image-data"}]}`
+		authorization  = "Bearer request-secret"
+		requestAPIKey  = "request-api-secret"
+		responseToken  = "response-token-secret"
+		queryAPIKey    = "query-api-secret"
+		visibleTraceID = "trace-visible"
+	)
+
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Response-Token", responseToken)
+		w.WriteHeader(http.StatusCreated)
+		_, err = io.WriteString(w, responseBody)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/images/generations?api_key="+queryAPIKey+"&trace="+visibleTraceID, strings.NewReader(requestBody))
+	require.NoError(t, err)
+	request.Header.Set("Authorization", authorization)
+	request.Header.Set("X-Api-Key", requestAPIKey)
+	request.Header.Set("X-Trace-ID", visibleTraceID)
+
+	var debugLog bytes.Buffer
+	upstream := NewHTTPUpstream(nil).(*httpUpstreamService)
+	upstream.debugLogger = gatewaydebug.New(&debugLog)
+	response, err := upstream.Do(request, "", 42, 1)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Equal(t, requestBody, receivedBody)
+	require.Equal(t, responseBody, string(body))
+	logText := debugLog.String()
+	require.Contains(t, logText, "UPSTREAM_REQUEST id=1")
+	require.Contains(t, logText, "UPSTREAM_RESPONSE id=1")
+	require.Contains(t, logText, requestBody)
+	require.Contains(t, logText, responseBody)
+	require.Contains(t, logText, visibleTraceID)
+	require.Contains(t, logText, "Bearer [redacted]")
+	require.NotContains(t, logText, "request-secret")
+	require.NotContains(t, logText, requestAPIKey)
+	require.NotContains(t, logText, responseToken)
+	require.NotContains(t, logText, queryAPIKey)
+}
+
+func TestHTTPUpstreamDebugLogsRequestBodyWithoutGetBody(t *testing.T) {
+	const requestBody = "streamed-request-body"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+	request.Body = io.NopCloser(strings.NewReader(requestBody))
+	request.ContentLength = int64(len(requestBody))
+	require.Nil(t, request.GetBody)
+
+	var debugLog bytes.Buffer
+	upstream := NewHTTPUpstream(nil).(*httpUpstreamService)
+	upstream.debugLogger = gatewaydebug.New(&debugLog)
+	response, err := upstream.Do(request, "", 7, 1)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Contains(t, debugLog.String(), requestBody)
+	require.Contains(t, debugLog.String(), "UPSTREAM_REQUEST_END id=1")
+}
 
 func TestHTTPUpstreamDoCanDisableRedirectsPerRequest(t *testing.T) {
 	var redirectedCalls atomic.Int64

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -19,6 +19,7 @@ import (
 	"unsafe"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gatewaydebug"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/cespare/xxhash/v2"
@@ -58,7 +59,6 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 	defaultModelsListCacheTTL              = 15 * time.Second
 	postUsageBillingTimeout                = 15 * time.Second
 	claudeCodeNoopDeltaKeepaliveMinVersion = "2.1.193"
-	debugGatewayBodyEnv                    = "SUB2API_DEBUG_GATEWAY_BODY"
 	// 上游错误体只需要提取错误 JSON/日志摘要，默认 512KiB 避免错误风暴叠加大请求体。
 	gatewayUpstreamErrorBodyReadLimit int64 = 512 << 10
 )
@@ -734,7 +734,7 @@ type GatewayService struct {
 	channelService        *ChannelService
 	resolver              *ModelPricingResolver
 	compositeResolver     *CompositeRouteResolver
-	debugGatewayBodyFile  atomic.Pointer[os.File] // non-nil when SUB2API_DEBUG_GATEWAY_BODY is set
+	debugGatewayLogger    *gatewaydebug.Logger
 	tlsFPProfileService   *TLSFingerprintProfileService
 	balanceNotifyService  *BalanceNotifyService
 	userPlatformQuotaRepo UserPlatformQuotaRepository
@@ -817,9 +817,7 @@ func NewGatewayService(
 	)
 	svc.debugModelRouting.Store(parseDebugEnvBool(os.Getenv("SUB2API_DEBUG_MODEL_ROUTING")))
 	svc.debugClaudeMimic.Store(parseDebugEnvBool(os.Getenv("SUB2API_DEBUG_CLAUDE_MIMIC")))
-	if path := strings.TrimSpace(os.Getenv(debugGatewayBodyEnv)); path != "" {
-		svc.initDebugGatewayBodyFile(path)
-	}
+	svc.debugGatewayLogger = gatewaydebug.Default()
 	return svc
 }
 
@@ -1365,40 +1363,6 @@ func (s *GatewayService) InvalidateAvailableModelsCache(groupID *int64, platform
 	}
 }
 
-const debugGatewayBodyDefaultFilename = "gateway_debug.log"
-
-// initDebugGatewayBodyFile 初始化网关调试日志文件。
-//
-//   - "1"/"true" 等布尔值 → 当前目录下 gateway_debug.log
-//   - 已有目录路径        → 该目录下 gateway_debug.log
-//   - 其他               → 视为完整文件路径
-func (s *GatewayService) initDebugGatewayBodyFile(path string) {
-	if parseDebugEnvBool(path) {
-		path = debugGatewayBodyDefaultFilename
-	}
-
-	// 如果 path 指向一个已存在的目录，自动追加默认文件名
-	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		path = filepath.Join(path, debugGatewayBodyDefaultFilename)
-	}
-
-	// 确保父目录存在
-	if dir := filepath.Dir(path); dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			slog.Error("failed to create gateway debug log directory", "dir", dir, "error", err)
-			return
-		}
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		slog.Error("failed to open gateway debug log file", "path", path, "error", err)
-		return
-	}
-	s.debugGatewayBodyFile.Store(f)
-	slog.Info("gateway debug logging enabled", "path", path)
-}
-
 // debugLogGatewaySnapshot 将网关请求的完整快照（headers + body）写入独立的调试日志文件，
 // 用于对比客户端原始请求和上游转发请求。
 //
@@ -1409,8 +1373,7 @@ func (s *GatewayService) initDebugGatewayBodyFile(path string) {
 //
 // tag: "CLIENT_ORIGINAL" 或 "UPSTREAM_FORWARD"
 func (s *GatewayService) debugLogGatewaySnapshot(tag string, headers http.Header, body []byte, extra map[string]string) {
-	f := s.debugGatewayBodyFile.Load()
-	if f == nil {
+	if s.debugGatewayLogger == nil {
 		return
 	}
 
@@ -1453,6 +1416,7 @@ func (s *GatewayService) debugLogGatewaySnapshot(tag string, headers http.Header
 		}
 	}
 
-	// 写入文件（调试用，并发写入可能交错但不影响可读性）
-	_, _ = f.WriteString(buf.String())
+	s.debugGatewayLogger.Write(func(writer io.Writer) {
+		_, _ = io.WriteString(writer, buf.String())
+	})
 }


### PR DESCRIPTION
## Summary

- share a concurrency-safe gateway debug logger between gateway snapshots and HTTP upstream requests
- log redacted upstream request/response metadata and streamed bodies without consuming them

## Testing

- `GOCACHE=/tmp/sub2api-go-build go test ./internal/repository ./internal/service ./internal/pkg/gatewaydebug`