### PR TITLE
fix(ent): make GroupQuery clone nil-safe

### DIFF
--- a/backend/ent/group_query.go
+++ b/backend/ent/group_query.go
@@ -439,9 +439,17 @@ func (_q *GroupQuery) Clone() *GroupQuery {
 	if _q == nil {
 		return nil
 	}
+	var ctx *QueryContext
+	if _q.ctx != nil {
+		ctx = _q.ctx.Clone()
+	}
+	var selector *sql.Selector
+	if _q.sql != nil {
+		selector = _q.sql.Clone()
+	}
 	return &GroupQuery{
 		config:                _q.config,
-		ctx:                   _q.ctx.Clone(),
+		ctx:                   ctx,
 		order:                 append([]group.OrderOption{}, _q.order...),
 		inters:                append([]Interceptor{}, _q.inters...),
 		predicates:            append([]predicate.Group{}, _q.predicates...),
@@ -454,7 +462,7 @@ func (_q *GroupQuery) Clone() *GroupQuery {
 		withAccountGroups:     _q.withAccountGroups.Clone(),
 		withUserAllowedGroups: _q.withUserAllowedGroups.Clone(),
 		// clone intermediate query.
-		sql:  _q.sql.Clone(),
+		sql:  selector,
 		path: _q.path,
 	}
 }

--- a/backend/ent/group_query_test.go
+++ b/backend/ent/group_query_test.go
@@ -1,0 +1,42 @@
+package ent
+
+import (
+	"testing"
+
+	"entgo.io/ent/dialect/sql"
+)
+
+func TestGroupQueryCloneUninitialized(t *testing.T) {
+	query := (&GroupQuery{}).Clone()
+	if query == nil {
+		t.Fatal("Clone returned nil for a non-nil query")
+	}
+	if query.ctx != nil {
+		t.Fatal("Clone initialized a nil query context")
+	}
+	if query.sql != nil {
+		t.Fatal("Clone initialized a nil SQL selector")
+	}
+}
+
+func TestGroupQueryClonePreservesContext(t *testing.T) {
+	ctx := &QueryContext{}
+	query := (&GroupQuery{ctx: ctx}).Clone()
+	if query == nil || query.ctx == nil {
+		t.Fatal("Clone did not preserve an initialized query context")
+	}
+	if query.ctx == ctx {
+		t.Fatal("Clone reused the original query context")
+	}
+}
+
+func TestGroupQueryClonePreservesSQLSelector(t *testing.T) {
+	selector := sql.Select("id").From(sql.Table("groups"))
+	query := (&GroupQuery{sql: selector}).Clone()
+	if query == nil || query.sql == nil {
+		t.Fatal("Clone did not preserve an initialized SQL selector")
+	}
+	if query.sql == selector {
+		t.Fatal("Clone reused the original SQL selector")
+	}
+}


### PR DESCRIPTION
## 问题

`GroupQuery.Clone` 在查询上下文或 SQL selector 尚未初始化时会发生空指针异常。

## 根因

克隆逻辑无条件调用 `_q.ctx.Clone()` 和 `_q.sql.Clone()`，未处理这两个字段为 `nil` 的情况。

## 改动

为查询上下文和 SQL selector 增加 nil-safe 克隆，并添加覆盖未初始化及已初始化字段的回归测试。未发现重叠 PR。

## 测试

- `cd backend && go test ./ent -run TestGroupQueryClone -count=1` (passed)
- `cd backend && go vet ./ent` (passed)
- `git diff --check` (passed)

Fixes #5360.