### PR TITLE
docs: add sub2api-lark-quota to ecosystem projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Community projects that extend or integrate with Sub2API:
 |---------|-------------|----------|
 | ~~[Sub2ApiPay](https://github.com/touwaeriol/sub2apipay)~~ | ~~Self-service payment system~~ | **Now Built-in** — Payment is now integrated into Sub2API, no separate deployment needed. See [Payment Configuration Guide](docs/PAYMENT.md) |
 | [sub2api-mobile](https://github.com/ckken/sub2api-mobile) | Mobile admin console | Cross-platform app (iOS/Android/Web) for user management, account management, monitoring dashboard, and multi-backend switching; built with Expo + React Native |
+| [sub2api-lark-quota](https://github.com/XlSerena/sub2api-lark-quota) | Feishu/Lark approval auto-deposit | Bot top-up → approval → Admin API `balance` add; email-based user mapping; optional Bitable ledger |
 
 ## Tech Stack
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -193,6 +193,7 @@ Sub2API 是一个 AI API 网关平台，用于分发和管理 AI 产品订阅的
 |------|------|------|
 | ~~[Sub2ApiPay](https://github.com/touwaeriol/sub2apipay)~~ | ~~自助支付系统~~ | **已内置** — 支付功能已集成到 Sub2API 中，无需独立部署。详见 [支付配置指南](docs/PAYMENT_CN.md) |
 | [sub2api-mobile](https://github.com/ckken/sub2api-mobile) | 移动端管理控制台 | 跨平台应用（iOS/Android/Web），支持用户管理、账号管理、监控看板、多后端切换；基于 Expo + React Native 构建 |
+| [sub2api-lark-quota](https://github.com/XlSerena/sub2api-lark-quota) | 飞书审批自动加余额 | 机器人提额 → 飞书审批通过 → 调用 Admin API `balance` 自动 Deposit；按企业邮箱映射用户；可选多维表格流水 |
 
 ## 技术栈
 


### PR DESCRIPTION
## Summary
- Add [sub2api-lark-quota](https://github.com/XlSerena/sub2api-lark-quota) to the ecosystem table (CN + EN README).
- Peripheral Next.js service: Feishu/Lark bot + approval → Sub2API Admin `POST /api/v1/admin/users/:id/balance`.
- Does not modify Sub2API core; uses documented Admin Payment Integration API.

## Test plan
- [ ] Links resolve
- [ ] Table renders in README preview

Made with [Cursor](https://cursor.com)