### PR TITLE
fix(openai-raw,#5370): OpenAI 直转路径补齐 message id，修复 zen 上游 400 missing field id

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -11,10 +11,41 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
+
+// ensureChatMessagesIDs 为 OpenAI Chat Completions 请求的每条 message 补齐
+// 顶层 id 字段（缺失时）。
+//
+// 为什么需要：opencode 官方 zen 网关（opencode.ai/zen/v1）的 serde 结构要求
+// message 必须带 id（opencode 客户端自身发送的消息始终带 id）。第三方客户端
+// （opencode 之外经 sub2api 转发的流量，尤其多模态 content 数组消息）不带 id
+// 会被拒为 400 "missing field `id`"。
+//
+// 对标准 OpenAI / DeepSeek 等上游无害：官方实现忽略消息的未知字段，id 是
+// 只读回显字段。
+func ensureChatMessagesIDs(body []byte) ([]byte, error) {
+	count := gjson.GetBytes(body, "messages.#").Int()
+	if count <= 0 {
+		return body, nil
+	}
+	out := body
+	for i := int64(0); i < count; i++ {
+		path := fmt.Sprintf("messages.%d.id", i)
+		if gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, err := sjson.SetBytes(out, path, "msg_"+strings.ReplaceAll(uuid.NewString(), "-", ""))
+		if err != nil {
+			return body, err
+		}
+		out = next
+	}
+	return out, nil
+}
 
 // openaiCCRawAllowedHeaders 是 CC 直转路径专用的客户端 header 透传白名单。
 //
@@ -92,6 +123,18 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	}
 	if normalizedBody, normalized := NormalizeGLMOpenAIReasoningEffort(upstreamBody, upstreamModel); normalized {
 		upstreamBody = normalizedBody
+	}
+
+	// 3b. 补齐 message id：部分上游（如 opencode zen 网关）serde 要求消息带 id。
+	// 标准 OpenAI 兼容上游忽略未知字段，补 id 无副作用。
+	if updated, err := ensureChatMessagesIDs(upstreamBody); err != nil {
+		logger.L().Warn("openai chat_completions raw: failed to ensure message ids, forwarding as-is",
+			zap.Int64("account_id", account.ID),
+			zap.String("upstream_model", upstreamModel),
+			zap.Error(err),
+		)
+	} else {
+		upstreamBody = updated
 	}
 
 	// 4. Apply OpenAI fast policy on the CC body

--- a/backend/internal/service/openai_gateway_chat_completions_raw_msgid_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_msgid_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestEnsureChatMessagesIDs(t *testing.T) {
+	t.Parallel()
+
+	// 输入：3 条消息，中间一条已带 id，首尾缺 id（含一条多模态 content）
+	body := []byte(`{
+		"model": "deepseek-v4-flash",
+		"messages": [
+			{"role": "user", "content": "q1"},
+			{"role": "assistant", "content": "a1", "id": "keep-this-id"},
+			{"role": "user", "content": [
+				{"type": "text", "text": "看这张图"},
+				{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+			]}
+		]
+	}`)
+
+	out, err := ensureChatMessagesIDs(body)
+	if err != nil {
+		t.Fatalf("ensureChatMessagesIDs error: %v", err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+
+	// 已有 id 的消息保留原值
+	if got := gjson.GetBytes(out, "messages.1.id").String(); got != "keep-this-id" {
+		t.Fatalf("expected existing id preserved, got %q", got)
+	}
+
+	// 缺 id 的消息补齐
+	for i := 0; i < 3; i++ {
+		id := gjson.GetBytes(out, "messages."+string(rune('0'+i))+".id").String()
+		if id == "" {
+			t.Fatalf("messages[%d] missing id", i)
+		}
+	}
+
+	// 无 messages 的 body 原样返回
+	plain := []byte(`{"model":"x"}`)
+	out2, err := ensureChatMessagesIDs(plain)
+	if err != nil {
+		t.Fatalf("ensureChatMessagesIDs plain error: %v", err)
+	}
+	if string(out2) != string(plain) {
+		t.Fatalf("plain body changed: %s", out2)
+	}
+
+	// 空 messages 原样返回
+	empty := []byte(`{"messages":[]}`)
+	out3, err := ensureChatMessagesIDs(empty)
+	if err != nil {
+		t.Fatalf("ensureChatMessagesIDs empty error: %v", err)
+	}
+	if string(out3) != string(empty) {
+		t.Fatalf("empty body changed: %s", out3)
+	}
+}


### PR DESCRIPTION
## 问题

opencode 贴图请求 deepseek-v4-flash（渠道上游 https://opencode.ai/zen/v1）时返回 400：

```
[invalid_request_error] Failed to deserialize the JSON body into the target type:
messages[4]: missing field 'id' at line 1 column 193226
```

## 根因（已线上实证）

1. deepseek-v4-flash = openai apikey 账号池，upstream = opencode.ai/zen/v1（容器 s2a-api 日志 forward_failed account_id=29 实锤）
2. forwardAsRawChatCompletions 原样转发 body，不做消息改写
3. zen 网关 serde 结构要求每条 message 带顶层 id；opencode 客户端自带 id，第三方客户端不带
4. 带图（多模态 content）消息 100% 触发；文本消息未触发

## 修复

forwardAsRawChatCompletions 转发前对 messages 逐条补齐顶层 id（缺失时）。
标准 OpenAI/DeepSeek 等上游忽略消息未知字段，无副作用。

## Test

go test -tags=unit ./internal/service/ -run TestEnsureChatMessagesIDs
（补齐缺失 id / 保留已有 id / 无 messages 与空数组原样返回）

ref #5370