### PR TITLE
fix(admin): enable image generation permission for Composite groups

### DIFF
--- a/frontend/src/views/admin/__tests__/groupsImagePricing.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsImagePricing.spec.ts
@@ -27,6 +27,11 @@ describe("groups image pricing platform support", () => {
     expect(supportsImagePricingPlatform("anthropic")).toBe(false);
   });
 
+  it("includes Composite groups in image pricing controls", () => {
+    expect(supportsImagePricingPlatform("composite")).toBe(true);
+    expect(imagePricingPlatforms.has("composite")).toBe(true);
+  });
+
   it("keeps image and video pricing copy separate", () => {
     expect(imagePricingI18nKey("grok", "title")).toBe(
       "admin.groups.imagePricing.title",

--- a/frontend/src/views/admin/groupsImagePricing.ts
+++ b/frontend/src/views/admin/groupsImagePricing.ts
@@ -1,5 +1,6 @@
 export const imagePricingPlatforms = new Set([
   "antigravity",
+  "composite",
   "gemini",
   "grok",
   "openai",


### PR DESCRIPTION
## 问题

Composite 分组已正确配置图片模型和目标平台账号，但图片生成请求仍返回 403：

```json
{
  "error": {
    "type": "permission_error",
    "message": "Image generation is not enabled for this group"
  }
}
```

后台创建或编辑 Composite 分组时，没有显示允许当前分组生图开关，因此 `allow_image_generation` 始终保持默认值 `false`。

## 根因

`frontend/src/views/admin/groupsImagePricing.ts` 中的 `imagePricingPlatforms` 集合仅包含 `antigravity`、`gemini`、`grok`、`openai`，未包含 `composite`。

`GroupsView.vue` 通过 `supportsImagePricingPlatform(createForm.platform)` 控制图片生成计费配置区块的显示，导致 Composite 分组无法看到该开关。

后端 `group_handler.go` 的 `CreateGroupRequest` 和 `UpdateGroupRequest` 均已支持 `allow_image_generation` 字段，且 `Platform` 字段的 `oneof` 验证已包含 `composite`。

## 改动

- 在 `imagePricingPlatforms` 集合中添加 `"composite"`
- 添加测试用例验证 Composite 平台被正确包含

## 验证

- 后端已支持 Composite 平台的 `allow_image_generation` 字段
- 前端 i18n 键 `admin.groups.imagePricing.*` 是平台无关的，无需额外翻译
- 修改范围小、局部、向后兼容

Fixes #5369