### PR TITLE
fix(ops): 系统日志落库失败后退避重试，避免拖垮数据库连接池

### DIFF
--- a/backend/internal/service/ops_system_log_sink.go
+++ b/backend/internal/service/ops_system_log_sink.go
@@ -34,6 +34,10 @@ type OpsSystemLogSink struct {
 	batchSize     int
 	flushInterval time.Duration
 
+	// 连续写入失败后的退避参数。构造后只读，测试可在 Start 前覆盖。
+	flushBackoff    time.Duration
+	flushBackoffMax time.Duration
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -48,20 +52,52 @@ type OpsSystemLogSink struct {
 
 const maxSystemLogHostLength = 255
 
+const (
+	// 首次写入失败后暂停落库的时长，之后逐次翻倍到上限。
+	defaultOpsSystemLogFlushBackoff = 2 * time.Second
+	// 退避上限。日志是尽力而为的观测数据，不值得为它无限期占用连接池。
+	defaultOpsSystemLogFlushBackoffMax = 60 * time.Second
+)
+
 func NewOpsSystemLogSink(opsRepo OpsRepository) *OpsSystemLogSink {
 	ctx, cancel := context.WithCancel(context.Background())
 	rawHost, err := os.Hostname()
 	s := &OpsSystemLogSink{
-		opsRepo:       opsRepo,
-		host:          normalizeSystemLogHost(rawHost, err),
-		queue:         make(chan *logger.LogEvent, 5000),
-		batchSize:     200,
-		flushInterval: time.Second,
-		ctx:           ctx,
-		cancel:        cancel,
+		opsRepo:         opsRepo,
+		host:            normalizeSystemLogHost(rawHost, err),
+		queue:           make(chan *logger.LogEvent, 5000),
+		batchSize:       200,
+		flushInterval:   time.Second,
+		flushBackoff:    defaultOpsSystemLogFlushBackoff,
+		flushBackoffMax: defaultOpsSystemLogFlushBackoffMax,
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 	s.lastError.Store("")
 	return s
+}
+
+// flushBackoffFor 返回第 failures 次连续失败后的退避时长（指数退避，封顶）。
+func (s *OpsSystemLogSink) flushBackoffFor(failures int) time.Duration {
+	base := s.flushBackoff
+	if base <= 0 {
+		base = defaultOpsSystemLogFlushBackoff
+	}
+	maxBackoff := s.flushBackoffMax
+	if maxBackoff <= 0 {
+		maxBackoff = defaultOpsSystemLogFlushBackoffMax
+	}
+	if maxBackoff < base {
+		maxBackoff = base
+	}
+	backoff := base
+	for i := 1; i < failures && backoff < maxBackoff; i++ {
+		backoff *= 2
+	}
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	return backoff
 }
 
 func normalizeSystemLogHost(host string, err error) string {
@@ -146,20 +182,37 @@ func (s *OpsSystemLogSink) run() {
 	defer ticker.Stop()
 
 	batch := make([]*logger.LogEvent, 0, s.batchSize)
+	// 仅在本 goroutine 内读写，无需加锁。
+	failures := 0
+	var suppressedUntil time.Time
 	flush := func(baseCtx context.Context) {
 		if len(batch) == 0 {
+			return
+		}
+		now := time.Now()
+		if now.Before(suppressedUntil) {
+			// 退避窗口内直接丢弃本批：日志是尽力而为的观测数据，继续攒批只会把
+			// 压力转移到内存，而每次重试都会再占用并取消一条池内连接。
+			atomic.AddUint64(&s.droppedCount, uint64(len(batch)))
+			batch = batch[:0]
 			return
 		}
 		started := time.Now()
 		inserted, err := s.flushBatch(baseCtx, batch)
 		delay := time.Since(started)
 		if err != nil {
+			failures++
+			backoff := s.flushBackoffFor(failures)
+			suppressedUntil = time.Now().Add(backoff)
 			atomic.AddUint64(&s.writeFailed, uint64(len(batch)))
 			s.lastError.Store(err.Error())
-			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"ops system log sink flush failed\" err=%v batch=%d\n",
-				time.Now().Format(time.RFC3339Nano), err, len(batch),
+			// 每个退避窗口至多一条，避免数据库故障期间刷屏。
+			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"ops system log sink flush failed\" err=%v batch=%d failures=%d backoff=%s\n",
+				time.Now().Format(time.RFC3339Nano), err, len(batch), failures, backoff,
 			)
 		} else {
+			failures = 0
+			suppressedUntil = time.Time{}
 			atomic.AddUint64(&s.writtenCount, uint64(inserted))
 			atomic.AddUint64(&s.totalDelayNs, uint64(delay.Nanoseconds()))
 			s.lastError.Store("")

--- a/backend/internal/service/ops_system_log_sink_backoff_test.go
+++ b/backend/internal/service/ops_system_log_sink_backoff_test.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+func opsSystemLogBackoffEvent() *logger.LogEvent {
+	return &logger.LogEvent{
+		Time:      time.Now().UTC(),
+		Level:     "warn",
+		Component: "app",
+		Message:   "boom",
+		Fields:    map[string]any{},
+	}
+}
+
+// pumpOpsSystemLogEvents 持续投递日志事件，模拟故障期间业务侧不断产生 WARN/ERROR。
+func pumpOpsSystemLogEvents(t *testing.T, sink *OpsSystemLogSink) {
+	t.Helper()
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sink.WriteLogEvent(opsSystemLogBackoffEvent())
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		<-done
+	})
+}
+
+func waitForOpsSystemLogCondition(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestOpsSystemLogSinkFlushBackoffFor(t *testing.T) {
+	sink := &OpsSystemLogSink{flushBackoff: time.Second, flushBackoffMax: 8 * time.Second}
+
+	cases := []struct {
+		name     string
+		failures int
+		want     time.Duration
+	}{
+		{"first_failure", 1, time.Second},
+		{"second_failure", 2, 2 * time.Second},
+		{"third_failure", 3, 4 * time.Second},
+		{"fourth_failure", 4, 8 * time.Second},
+		{"capped", 9, 8 * time.Second},
+		{"large_streak_does_not_overflow", 1000, 8 * time.Second},
+		{"zero_streak_uses_base", 0, time.Second},
+		{"negative_streak_uses_base", -1, time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sink.flushBackoffFor(tc.failures); got != tc.want {
+				t.Fatalf("flushBackoffFor(%d) = %s, want %s", tc.failures, got, tc.want)
+			}
+		})
+	}
+}
+
+// 未显式配置时回落到默认值；max 小于 base 时以 base 为准，不产生比基准还短的退避。
+func TestOpsSystemLogSinkFlushBackoffForFallbacks(t *testing.T) {
+	zero := &OpsSystemLogSink{}
+	if got := zero.flushBackoffFor(1); got != defaultOpsSystemLogFlushBackoff {
+		t.Fatalf("zero-value base = %s, want %s", got, defaultOpsSystemLogFlushBackoff)
+	}
+	if got := zero.flushBackoffFor(100); got != defaultOpsSystemLogFlushBackoffMax {
+		t.Fatalf("zero-value cap = %s, want %s", got, defaultOpsSystemLogFlushBackoffMax)
+	}
+
+	inverted := &OpsSystemLogSink{flushBackoff: 5 * time.Second, flushBackoffMax: time.Second}
+	if got := inverted.flushBackoffFor(3); got != 5*time.Second {
+		t.Fatalf("inverted bounds = %s, want 5s", got)
+	}
+}
+
+// issue #5265：写入失败后如果按 flushInterval 继续每秒重试，每一轮都会占用并取消
+// 一条池内连接（远程 PG 上 COPY 取消会让连接协议失步而被销毁），小连接池会被日志
+// 通道长期占满，业务侧最终报 Billing 503。失败后必须退避。
+func TestOpsSystemLogSinkSuppressesRetriesDuringBackoff(t *testing.T) {
+	var calls int64
+	repo := &opsRepoMock{
+		BatchInsertSystemLogsFn: func(_ context.Context, _ []*OpsInsertSystemLogInput) (int64, error) {
+			atomic.AddInt64(&calls, 1)
+			return 0, errors.New("db unavailable")
+		},
+	}
+
+	sink := NewOpsSystemLogSink(repo)
+	sink.batchSize = 1
+	sink.flushInterval = 5 * time.Millisecond
+	sink.flushBackoff = 800 * time.Millisecond
+	sink.flushBackoffMax = 800 * time.Millisecond
+	sink.Start()
+	defer sink.Stop()
+	pumpOpsSystemLogEvents(t, sink)
+
+	if !waitForOpsSystemLogCondition(t, 2*time.Second, func() bool { return atomic.LoadInt64(&calls) >= 1 }) {
+		t.Fatalf("first flush never happened")
+	}
+
+	// 退避窗口内不得再打上游：修复前 5ms 的 flushInterval 会在这 300ms 里打出上百次。
+	time.Sleep(300 * time.Millisecond)
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("upstream calls during backoff = %d, want 1", got)
+	}
+
+	// 被抑制的批次记为 dropped，而不是 write_failed —— 没有尝试过就不算写失败。
+	health := sink.Health()
+	if health.DroppedCount == 0 {
+		t.Fatalf("dropped_count should grow while flushing is suppressed")
+	}
+	if health.WriteFailed == 0 || health.LastError == "" {
+		t.Fatalf("failed flush should still surface in health: %+v", health)
+	}
+}
+
+// 退避到期后必须自动恢复，不能变成永久停写。
+func TestOpsSystemLogSinkResumesAfterBackoffWindow(t *testing.T) {
+	var calls int64
+	repo := &opsRepoMock{
+		BatchInsertSystemLogsFn: func(_ context.Context, _ []*OpsInsertSystemLogInput) (int64, error) {
+			atomic.AddInt64(&calls, 1)
+			return 0, errors.New("db unavailable")
+		},
+	}
+
+	sink := NewOpsSystemLogSink(repo)
+	sink.batchSize = 1
+	sink.flushInterval = 5 * time.Millisecond
+	sink.flushBackoff = 150 * time.Millisecond
+	sink.flushBackoffMax = 150 * time.Millisecond
+	sink.Start()
+	defer sink.Stop()
+	pumpOpsSystemLogEvents(t, sink)
+
+	if !waitForOpsSystemLogCondition(t, 3*time.Second, func() bool { return atomic.LoadInt64(&calls) >= 3 }) {
+		t.Fatalf("sink did not resume flushing after backoff, calls=%d", atomic.LoadInt64(&calls))
+	}
+}
+
+// 一次成功必须清空失败计数与抑制窗口，否则短暂抖动后写入速率无法恢复。
+func TestOpsSystemLogSinkSuccessClearsSuppression(t *testing.T) {
+	var calls int64
+	repo := &opsRepoMock{
+		BatchInsertSystemLogsFn: func(_ context.Context, inputs []*OpsInsertSystemLogInput) (int64, error) {
+			if atomic.AddInt64(&calls, 1) == 1 {
+				return 0, errors.New("db unavailable")
+			}
+			return int64(len(inputs)), nil
+		},
+	}
+
+	sink := NewOpsSystemLogSink(repo)
+	sink.batchSize = 1
+	sink.flushInterval = 5 * time.Millisecond
+	sink.flushBackoff = 150 * time.Millisecond
+	sink.flushBackoffMax = 150 * time.Millisecond
+	sink.Start()
+	defer sink.Stop()
+	pumpOpsSystemLogEvents(t, sink)
+
+	// 第 2 次调用（恢复后的首次成功）之后不应再有抑制：调用次数需要快速爬升。
+	if !waitForOpsSystemLogCondition(t, 3*time.Second, func() bool { return atomic.LoadInt64(&calls) >= 2 }) {
+		t.Fatalf("sink never retried after the first failure")
+	}
+	recovered := atomic.LoadInt64(&calls)
+	time.Sleep(200 * time.Millisecond)
+	if got := atomic.LoadInt64(&calls) - recovered; got < 3 {
+		t.Fatalf("calls after recovery = %d in 200ms, want >=3 (suppression not cleared)", got)
+	}
+	if sink.Health().WrittenCount == 0 {
+		t.Fatalf("written_count should grow after recovery")
+	}
+}
+
+// 健康路径不受影响：一直成功就永远不进入退避。
+func TestOpsSystemLogSinkHealthyPathNeverSuppressed(t *testing.T) {
+	var calls int64
+	repo := &opsRepoMock{
+		BatchInsertSystemLogsFn: func(_ context.Context, inputs []*OpsInsertSystemLogInput) (int64, error) {
+			atomic.AddInt64(&calls, 1)
+			return int64(len(inputs)), nil
+		},
+	}
+
+	sink := NewOpsSystemLogSink(repo)
+	sink.batchSize = 1
+	sink.flushInterval = 5 * time.Millisecond
+	sink.flushBackoff = time.Hour
+	sink.flushBackoffMax = time.Hour
+	sink.Start()
+	defer sink.Stop()
+	pumpOpsSystemLogEvents(t, sink)
+
+	if !waitForOpsSystemLogCondition(t, 3*time.Second, func() bool { return atomic.LoadInt64(&calls) >= 10 }) {
+		t.Fatalf("healthy sink should keep flushing, calls=%d", atomic.LoadInt64(&calls))
+	}
+	if got := sink.Health().DroppedCount; got != 0 {
+		t.Fatalf("healthy sink dropped_count = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## 背景

Fixes #5265

`OpsSystemLogSink` 的 flush 没有任何失败退避。`run()` 里 ticker 每 `flushInterval`（1 秒）触发一次，每次 `flushBatch` 都用固定 5 秒超时打一批 `COPY ops_system_logs FROM STDIN`；失败之后什么都不做，下一个 tick 立刻再来一次。

在远程 PostgreSQL（TLS，建连 + 握手抖动到 1~2 秒）上，这条循环会退化成持续的「占用一条池内连接 → 5 秒超时 → 发 cancel → 连接被服务端 FATAL 终止 → 重建」。issue 里的现场数据正好对得上：

```
ERROR: unexpected message type 0x58 during COPY from stdin
FATAL: terminating connection because protocol synchronization was lost
LOG:   PID ... in cancel request did not match any process     × 3921
```

`0x58` 是 `X`（Terminate），即 lib/pq 在 COPY 数据流中途关闭了连接。3921 次 cancel 请求也说明这是持续重试而不是偶发。当 `max_open: 4` 时，尽力而为的日志写入会长期占满连接池，业务侧最终在账号调度之前就报 `BILLING_SERVICE_ERROR` / 503。

## 改动

`backend/internal/service/ops_system_log_sink.go`，只动 flush 的失败处理：

- 新增 `flushBackoff` / `flushBackoffMax` 两个字段（默认 2s 起、翻倍、封顶 60s），以及纯函数 `flushBackoffFor(failures)` 计算退避时长。
- `run()` 里维护 `failures` 和 `suppressedUntil` 两个局部变量（只在 sink 自己的 goroutine 内读写，不需要加锁）。
- 处在退避窗口内时，直接丢弃当前批次并计入 `dropped_count`，**不触达数据库**。继续攒批只会把压力挪到内存，而每次重试都会再占用并取消一条池内连接。
- 任意一次成功立即把 `failures` 清零、抑制窗口清空。
- 失败时的 stderr 日志随退避天然收敛成每个窗口至多一条，并补上 `failures=` 和 `backoff=`，方便运维判断当前处于第几级退避。

## 兼容性说明

- **健康路径完全不变**：只要写入成功就永远不会进入退避，`flushInterval` / `batchSize` / 队列容量都没动。
- **计数语义**：被抑制而未尝试的批次记为 `dropped_count`（和队列满时丢弃同一口径），不记为 `write_failed_count` —— 没尝试过就不算写失败。真正失败的那一批仍然照旧计入 `write_failed_count` 并写 `last_error`，`/ops` 健康接口的字段没有增减。
- **不会永久停写**：退避封顶 60 秒，数据库恢复后下一个窗口就会自动恢复写入。
- **关停路径**：`Stop()` 的 `drainAndFlush` 同样遵守抑制窗口。数据库已经不可用时，这会让关停快速返回而不是每批再耗 5 秒；数据库健康时不存在抑制窗口，排空行为不变。
- 没有新增配置项，没有改数据库 schema，没有改前端。

## 本次未包含（说明理由）

issue 里一共提了 6 个方向，这个 PR 只做第 5 条（降低日志故障对业务的影响），其余几条都不适合塞进同一个 PR：

- **没有改 lib/pq COPY 的连接处理**（issue 第 2 条：独立连接 / 超时后显式关闭底层连接 / 改用普通 INSERT / 远程模式禁用 COPY）。这几种做法都会改变 `BatchInsertSystemLogs` 的写入方式，取舍需要作者定方向；而且只要退避住了，COPY 取消的频率本身就从「每秒一次」降到「每个退避窗口至多一次」。
- **没有把超时、批量大小、flush 间隔、是否用 COPY 做成配置项**（issue 第 4 条）。那是配置面 + 文档 + 默认值的产品决策。
- **没有改 `_ = stmt.Close()` / `_ = tx.Rollback()` 的清理错误处理**（issue 第 3 条）。`database/sql` 在驱动返回 `ErrBadConn` 时本来就会丢弃连接，是否要额外显式标记连接不可复用，属于 repository 层的独立议题。
- **没有给日志加独立连接池**。同上，属于架构决策。

如果作者希望其中某条也一起做，我可以另开 PR。

## 测试

新增 `backend/internal/service/ops_system_log_sink_backoff_test.go`，6 个测试函数：

- `flushBackoffFor` 的 8 个子用例：1/2/3/4 次失败的翻倍序列、封顶、1000 次连续失败不溢出、失败数为 0 和负数时回落到基准
- 边界回落：字段为零值时用默认常量；`max < base` 时以 `base` 为准，不会退出比基准更短的退避
- **退避期间不重试**：持续投递事件，首次失败后 300ms 内上游调用次数必须恒为 1（修复前 5ms 的 flushInterval 会在同一段时间里打出上百次），同时断言 `dropped_count` 增长而 `write_failed_count` / `last_error` 仍然正常上报
- **退避到期自动恢复**：不会退化成永久停写
- **一次成功清空抑制**：恢复后 200ms 内调用次数快速爬升，`written_count` 增长
- **健康路径不受影响**：一直成功时即使把退避设成 1 小时也不会进入抑制，`dropped_count` 保持 0

本地运行：

```bash
go build ./...
go test -tags=unit ./internal/service/ -run TestOpsSystemLogSink -count=1 -v
go test -tags=unit -race ./internal/service/ -run TestOpsSystemLogSink -count=3
go test -tags=unit ./internal/service/ -count=1
go test -tags=integration ./... -count=1
go vet ./internal/service/
gofmt -l internal/service/ops_system_log_sink.go internal/service/ops_system_log_sink_backoff_test.go
```

全部通过（含 `-race`，`failures` / `suppressedUntil` 只在 sink 自己的 goroutine 内读写）。golangci-lint v2.9 本地装不上（v2.9.0 自身用 go1.25 构建，低于本仓库 go.mod 的 1.26.5，启动即报错），这一项交给 CI。
