### PR TITLE
feat(openai): query and cache real subscription expiry

### DIFF
--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -18,16 +20,21 @@ import (
 
 // OpenAIOAuthHandler handles OpenAI OAuth-related operations
 type OpenAIOAuthHandler struct {
-	openaiOAuthService *service.OpenAIOAuthService
-	adminService       service.AdminService
-	quotaService       openAIQuotaService
-	rateLimitService   openAIAccountStateRecoverer
+	openaiOAuthService        *service.OpenAIOAuthService
+	adminService              service.AdminService
+	quotaService              openAIQuotaService
+	subscriptionExpiryService openAISubscriptionExpiryService
+	rateLimitService          openAIAccountStateRecoverer
 }
 
 type openAIQuotaService interface {
 	QueryUsage(ctx context.Context, accountID int64) (*service.OpenAIQuotaUsage, error)
 	CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *service.OpenAIRateLimitResetCredits) error
 	ResetCredit(ctx context.Context, accountID int64) (*service.OpenAIQuotaResetResult, error)
+}
+
+type openAISubscriptionExpiryService interface {
+	QuerySubscriptionExpiry(ctx context.Context, accountID int64) (*service.OpenAISubscriptionExpiryResult, error)
 }
 
 type openAIAccountStateRecoverer interface {
@@ -97,6 +104,7 @@ func NewOpenAIOAuthHandler(
 	// `== nil` capability guards below and panic instead of returning 400.
 	if quotaService != nil {
 		h.quotaService = quotaService
+		h.subscriptionExpiryService = quotaService
 	}
 	if rateLimitService != nil {
 		h.rateLimitService = rateLimitService
@@ -535,6 +543,130 @@ func (h *OpenAIOAuthHandler) RefreshQuota(c *gin.Context) {
 	}
 	refreshResponse.CachePersisted = true
 	response.Success(c, refreshResponse)
+}
+
+// QuerySubscriptionExpiry queries and caches the real ChatGPT subscription
+// expiry for one OpenAI OAuth account. The cache is updated only by this
+// explicit POST action; accounts.expires_at is used only as the response's
+// manual effective fallback when upstream proves unavailable.
+// POST /api/v1/admin/openai/accounts/:id/subscription-expiry/query
+func (h *OpenAIOAuthHandler) QuerySubscriptionExpiry(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	if h.subscriptionExpiryService == nil {
+		response.BadRequest(c, "openai subscription expiry service is not enabled")
+		return
+	}
+
+	result, err := h.subscriptionExpiryService.QuerySubscriptionExpiry(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if result == nil {
+		response.Error(c, http.StatusInternalServerError, "openai subscription expiry query returned an empty result")
+		return
+	}
+	response.Success(c, result)
+}
+
+const (
+	openAISubscriptionExpiryBatchLimit       = 100
+	openAISubscriptionExpiryBatchConcurrency = 4
+)
+
+type openAISubscriptionExpiryBatchRequest struct {
+	AccountIDs []int64 `json:"account_ids"`
+}
+
+type openAISubscriptionExpiryBatchItem struct {
+	AccountID          int64                                     `json:"account_id"`
+	Snapshot           *service.OpenAISubscriptionExpirySnapshot `json:"snapshot,omitempty"`
+	EffectiveExpiresAt string                                    `json:"effective_expires_at,omitempty"`
+	EffectiveSource    string                                    `json:"effective_source,omitempty"`
+	Error              string                                    `json:"error,omitempty"`
+}
+
+type openAISubscriptionExpiryBatchResponse struct {
+	Results []openAISubscriptionExpiryBatchItem `json:"results"`
+}
+
+// QuerySubscriptionExpiryBatch performs bounded, explicitly requested
+// subscription lookups. One failed account is represented in its result item;
+// it does not fail the rest of the batch.
+// POST /api/v1/admin/openai/accounts/subscription-expiry/query
+func (h *OpenAIOAuthHandler) QuerySubscriptionExpiryBatch(c *gin.Context) {
+	if h.subscriptionExpiryService == nil {
+		response.BadRequest(c, "openai subscription expiry service is not enabled")
+		return
+	}
+
+	var req openAISubscriptionExpiryBatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	accountIDs := make([]int64, 0, len(req.AccountIDs))
+	seen := make(map[int64]struct{}, len(req.AccountIDs))
+	for _, accountID := range req.AccountIDs {
+		if _, ok := seen[accountID]; ok {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		accountIDs = append(accountIDs, accountID)
+	}
+	if len(accountIDs) == 0 {
+		response.BadRequest(c, "account_ids must contain at least one account ID")
+		return
+	}
+	if len(accountIDs) > openAISubscriptionExpiryBatchLimit {
+		response.BadRequest(c, "account_ids must contain no more than 100 unique account IDs")
+		return
+	}
+
+	items := make([]openAISubscriptionExpiryBatchItem, len(accountIDs))
+	sem := make(chan struct{}, openAISubscriptionExpiryBatchConcurrency)
+	var wg sync.WaitGroup
+	for i, accountID := range accountIDs {
+		items[i].AccountID = accountID
+		wg.Add(1)
+		go func(index int, id int64) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result, err := h.subscriptionExpiryService.QuerySubscriptionExpiry(c.Request.Context(), id)
+			if err != nil {
+				items[index].Error = openAISubscriptionExpiryBatchError(err)
+				return
+			}
+			if result == nil {
+				items[index].Error = "openai subscription expiry query returned an empty result"
+				return
+			}
+			snapshot := result.Snapshot
+			items[index].Snapshot = &snapshot
+			items[index].EffectiveExpiresAt = result.EffectiveExpiresAt
+			items[index].EffectiveSource = result.EffectiveSource
+		}(i, accountID)
+	}
+	wg.Wait()
+
+	response.Success(c, openAISubscriptionExpiryBatchResponse{Results: items})
+}
+
+func openAISubscriptionExpiryBatchError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if message := infraerrors.Message(err); message != "" {
+		return message
+	}
+	return "openai subscription expiry query failed"
 }
 
 // CreateShadowRequest is the request body for CreateShadow.

--- a/backend/internal/handler/admin/openai_oauth_handler_subscription_expiry_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_subscription_expiry_test.go
@@ -1,0 +1,212 @@
+//go:build unit
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+type subscriptionExpiryHandlerStub struct {
+	mu        sync.Mutex
+	results   map[int64]*service.OpenAISubscriptionExpiryResult
+	errors    map[int64]error
+	calls     []int64
+	active    int
+	maxActive int
+	started   chan struct{}
+	release   <-chan struct{}
+}
+
+func (s *subscriptionExpiryHandlerStub) QuerySubscriptionExpiry(_ context.Context, accountID int64) (*service.OpenAISubscriptionExpiryResult, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, accountID)
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.active--
+		s.mu.Unlock()
+	}()
+
+	if s.started != nil {
+		s.started <- struct{}{}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	if err := s.errors[accountID]; err != nil {
+		return nil, err
+	}
+	return s.results[accountID], nil
+}
+
+func newSubscriptionExpiryHandlerResult(accountID int64) *service.OpenAISubscriptionExpiryResult {
+	return &service.OpenAISubscriptionExpiryResult{
+		AccountID: accountID,
+		Snapshot: service.OpenAISubscriptionExpirySnapshot{
+			Status:    service.OpenAISubscriptionExpiryStatusAvailable,
+			ExpiresAt: "2026-08-08T07:23:45Z",
+			CheckedAt: "2026-08-07T06:17:00Z",
+			Source:    service.OpenAISubscriptionExpirySourceSubscriptions,
+			PlanType:  "plus",
+			WillRenew: false,
+		},
+		EffectiveExpiresAt: "2026-08-08T07:23:45Z",
+		EffectiveSource:    service.OpenAISubscriptionExpiryEffectiveSourceUpstream,
+	}
+}
+
+func TestQuerySubscriptionExpiryHandler_ReturnsSingleResultContract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &subscriptionExpiryHandlerStub{
+		results: map[int64]*service.OpenAISubscriptionExpiryResult{7: newSubscriptionExpiryHandlerResult(7)},
+		errors:  map[int64]error{},
+	}
+	h := &OpenAIOAuthHandler{subscriptionExpiryService: stub}
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/:id/subscription-expiry/query", h.QuerySubscriptionExpiry)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/admin/openai/accounts/7/subscription-expiry/query", nil))
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var envelope struct {
+		Data service.OpenAISubscriptionExpiryResult `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &envelope))
+	require.Equal(t, int64(7), envelope.Data.AccountID)
+	require.Equal(t, service.OpenAISubscriptionExpiryStatusAvailable, envelope.Data.Snapshot.Status)
+	require.Equal(t, "2026-08-08T07:23:45Z", envelope.Data.EffectiveExpiresAt)
+	require.Equal(t, service.OpenAISubscriptionExpiryEffectiveSourceUpstream, envelope.Data.EffectiveSource)
+}
+
+func TestQuerySubscriptionExpiryBatchHandler_DeduplicatesAndKeepsPerAccountErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &subscriptionExpiryHandlerStub{
+		results: map[int64]*service.OpenAISubscriptionExpiryResult{1: newSubscriptionExpiryHandlerResult(1)},
+		errors:  map[int64]error{2: errors.New("account query failed")},
+	}
+	h := &OpenAIOAuthHandler{subscriptionExpiryService: stub}
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/subscription-expiry/query", h.QuerySubscriptionExpiryBatch)
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/openai/accounts/subscription-expiry/query", strings.NewReader(`{"account_ids":[1,1,2]}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var envelope struct {
+		Data struct {
+			Results []struct {
+				AccountID int64 `json:"account_id"`
+				Snapshot  *struct {
+					Status string `json:"status"`
+				} `json:"snapshot"`
+				Error string `json:"error"`
+			} `json:"results"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &envelope))
+	require.Len(t, envelope.Data.Results, 2)
+	require.Equal(t, int64(1), envelope.Data.Results[0].AccountID)
+	require.Equal(t, service.OpenAISubscriptionExpiryStatusAvailable, envelope.Data.Results[0].Snapshot.Status)
+	require.Equal(t, int64(2), envelope.Data.Results[1].AccountID)
+	require.Nil(t, envelope.Data.Results[1].Snapshot)
+	require.NotEmpty(t, envelope.Data.Results[1].Error)
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	require.ElementsMatch(t, []int64{1, 2}, stub.calls)
+}
+
+func TestQuerySubscriptionExpiryBatchHandlerCapsConcurrencyAtFour(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	release := make(chan struct{})
+	stub := &subscriptionExpiryHandlerStub{
+		results: make(map[int64]*service.OpenAISubscriptionExpiryResult),
+		errors:  make(map[int64]error),
+		started: make(chan struct{}, 5),
+		release: release,
+	}
+	for id := int64(1); id <= 5; id++ {
+		stub.results[id] = newSubscriptionExpiryHandlerResult(id)
+	}
+	h := &OpenAIOAuthHandler{subscriptionExpiryService: stub}
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/subscription-expiry/query", h.QuerySubscriptionExpiryBatch)
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/openai/accounts/subscription-expiry/query", strings.NewReader(`{"account_ids":[1,2,3,4,5]}`))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(recorder, req)
+	}()
+
+	for i := 0; i < 4; i++ {
+		select {
+		case <-stub.started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for a batch worker")
+		}
+	}
+	select {
+	case <-stub.started:
+		t.Fatal("batch started more than four account queries")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for batch response")
+	}
+	require.Equal(t, http.StatusOK, recorder.Code)
+	stub.mu.Lock()
+	maxActive := stub.maxActive
+	stub.mu.Unlock()
+	require.LessOrEqual(t, maxActive, 4)
+}
+
+func TestQuerySubscriptionExpiryHandler_NilCapabilityGuard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewOpenAIOAuthHandler(nil, newStubAdminService(), nil, nil)
+	require.Nil(t, h.subscriptionExpiryService)
+
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/:id/subscription-expiry/query", h.QuerySubscriptionExpiry)
+	router.POST("/api/v1/admin/openai/accounts/subscription-expiry/query", h.QuerySubscriptionExpiryBatch)
+
+	for _, tc := range []struct {
+		path string
+		body string
+	}{
+		{path: "/api/v1/admin/openai/accounts/7/subscription-expiry/query"},
+		{path: "/api/v1/admin/openai/accounts/subscription-expiry/query", body: `{"account_ids":[7]}`},
+	} {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code, tc.path)
+	}
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -442,6 +442,8 @@ func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		openai.GET("/accounts/:id/quota", h.Admin.OpenAIOAuth.QueryQuota)
 		openai.POST("/accounts/:id/quota/refresh", h.Admin.OpenAIOAuth.RefreshQuota)
 		openai.POST("/accounts/:id/reset-quota", h.Admin.OpenAIOAuth.ResetQuota)
+		openai.POST("/accounts/:id/subscription-expiry/query", h.Admin.OpenAIOAuth.QuerySubscriptionExpiry)
+		openai.POST("/accounts/subscription-expiry/query", h.Admin.OpenAIOAuth.QuerySubscriptionExpiryBatch)
 	}
 }
 

--- a/backend/internal/service/openai_subscription_expiry.go
+++ b/backend/internal/service/openai_subscription_expiry.go
@@ -1,0 +1,301 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/imroc/req/v3"
+)
+
+const (
+	// OpenAISubscriptionExpirySnapshotKey is intentionally separate from
+	// credentials.subscription_expires_at. OAuth refreshes may rewrite the
+	// credentials map, but an explicit admin query must remain a stable row
+	// snapshot until the next explicit query.
+	OpenAISubscriptionExpirySnapshotKey = "openai_subscription_expiry_snapshot"
+
+	OpenAISubscriptionExpiryStatusAvailable   = "available"
+	OpenAISubscriptionExpiryStatusUnavailable = "unavailable"
+
+	OpenAISubscriptionExpirySourceSubscriptions = "subscriptions"
+	OpenAISubscriptionExpirySourceAccountsCheck = "accounts_check"
+	OpenAISubscriptionExpirySourceUnavailable   = "unavailable"
+
+	OpenAISubscriptionExpiryEffectiveSourceUpstream = "upstream"
+	OpenAISubscriptionExpiryEffectiveSourceManual   = "manual"
+	OpenAISubscriptionExpiryEffectiveSourceNone     = "none"
+
+	openAISubscriptionExpiryUpstreamTimeout = 20 * time.Second
+)
+
+// OpenAISubscriptionExpirySnapshot is the result of one explicit upstream
+// subscription-expiry query. CheckedAt, and any non-empty expiry, are RFC3339
+// timestamps in UTC. WillRenew is deliberately not omitempty so false remains
+// distinguishable from a missing field in the persisted JSON object.
+type OpenAISubscriptionExpirySnapshot struct {
+	Status    string `json:"status"`
+	ExpiresAt string `json:"expires_at"`
+	CheckedAt string `json:"checked_at"`
+	Source    string `json:"source"`
+	PlanType  string `json:"plan_type"`
+	WillRenew bool   `json:"will_renew"`
+}
+
+// OpenAISubscriptionExpiryResult is returned after a single explicit query.
+// Snapshot is always present on a successful result, including an
+// unavailable snapshot. EffectiveExpiresAt may come from accounts.expires_at
+// when the upstream query proved that no real expiry was available.
+type OpenAISubscriptionExpiryResult struct {
+	AccountID          int64                            `json:"account_id"`
+	Snapshot           OpenAISubscriptionExpirySnapshot `json:"snapshot"`
+	EffectiveExpiresAt string                           `json:"effective_expires_at,omitempty"`
+	EffectiveSource    string                           `json:"effective_source"`
+}
+
+type openAISubscriptionResponse struct {
+	PlanType    string `json:"plan_type"`
+	ActiveUntil string `json:"active_until"`
+	WillRenew   *bool  `json:"will_renew"`
+}
+
+type openAIAccountsCheckResponse struct {
+	Accounts map[string]map[string]any `json:"accounts"`
+}
+
+type openAIAccountsCheckResult struct {
+	ExpiresAt string
+	PlanType  string
+	WillRenew *bool
+}
+
+// QuerySubscriptionExpiry performs one user-triggered subscription lookup
+// for accountID and persists the resulting snapshot on that same account row.
+// Spark shadows resolve credentials and proxy through their parent in
+// prepareUpstreamCall, but the manual effective-expiry fallback and cache write
+// deliberately use the clicked row.
+func (s *OpenAIQuotaService) QuerySubscriptionExpiry(ctx context.Context, accountID int64) (*OpenAISubscriptionExpiryResult, error) {
+	if s == nil || s.accountRepo == nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_SUBSCRIPTION_EXPIRY_NOT_CONFIGURED", "openai subscription expiry service is not configured")
+	}
+
+	clickedAccount, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil || clickedAccount == nil {
+		return nil, infraerrors.New(http.StatusNotFound, "OPENAI_SUBSCRIPTION_EXPIRY_ACCOUNT_NOT_FOUND", "account not found")
+	}
+	if clickedAccount.Platform != PlatformOpenAI {
+		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_SUBSCRIPTION_EXPIRY_INVALID_PLATFORM", "account is not an OpenAI account")
+	}
+	if clickedAccount.Type != AccountTypeOAuth {
+		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_SUBSCRIPTION_EXPIRY_INVALID_TYPE", "account is not an OAuth account")
+	}
+
+	// prepareUpstreamCall performs the canonical shadow resolution, token
+	// acquisition, account-id validation, and proxy lookup used by quota calls.
+	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(accessToken) == "" {
+		// Agent-identity accounts intentionally do not carry an OAuth bearer
+		// token. This endpoint is only for OpenAI OAuth subscription accounts.
+		return nil, infraerrors.New(http.StatusBadGateway, "OPENAI_SUBSCRIPTION_EXPIRY_TOKEN_UNAVAILABLE", "openai OAuth access token is unavailable")
+	}
+
+	client, err := s.privacyClientFactory(proxyURL)
+	if err != nil {
+		return nil, infraerrors.New(http.StatusBadGateway, "OPENAI_SUBSCRIPTION_EXPIRY_CLIENT_ERROR", "failed to build upstream client")
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, openAISubscriptionExpiryUpstreamTimeout)
+	defer cancel()
+	headers := buildCodexCommonHeaders(accessToken, chatGPTAccountID, fedRAMP)
+	headers["Origin"] = "https://chatgpt.com"
+	headers["Referer"] = "https://chatgpt.com/"
+	headers["Accept"] = "application/json"
+
+	subscription, subscriptionsOK := queryOpenAISubscription(callCtx, client, headers, chatGPTAccountID)
+	if subscriptionsOK {
+		if expiresAt := normalizeOpenAIExpiry(subscription.ActiveUntil); expiresAt != "" {
+			return s.persistSubscriptionExpiryResult(ctx, accountID, clickedAccount, OpenAISubscriptionExpirySnapshot{
+				Status:    OpenAISubscriptionExpiryStatusAvailable,
+				ExpiresAt: expiresAt,
+				CheckedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				Source:    OpenAISubscriptionExpirySourceSubscriptions,
+				PlanType:  strings.TrimSpace(subscription.PlanType),
+				WillRenew: boolValue(subscription.WillRenew),
+			})
+		}
+	}
+
+	// active_until is absent (or the subscriptions endpoint failed), so use
+	// accounts/check as the compatibility source. A successful, parseable
+	// envelope with no entitlement expiry is enough to establish unavailable;
+	// a failed/malformed fallback is not and must preserve the old cache.
+	accountCheck, accountsCheckOK := queryOpenAIAccountsCheck(callCtx, client, headers)
+	if !accountsCheckOK {
+		if subscriptionsOK && strings.TrimSpace(subscription.ActiveUntil) == "" {
+			return s.persistSubscriptionExpiryResult(ctx, accountID, clickedAccount, OpenAISubscriptionExpirySnapshot{
+				Status:    OpenAISubscriptionExpiryStatusUnavailable,
+				CheckedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				Source:    OpenAISubscriptionExpirySourceUnavailable,
+				PlanType:  strings.TrimSpace(subscription.PlanType),
+				WillRenew: boolValue(subscription.WillRenew),
+			})
+		}
+		if !subscriptionsOK {
+			slog.Warn("openai_subscription_expiry_upstream_failed", "account_id", accountID)
+		}
+		return nil, infraerrors.New(http.StatusBadGateway, "OPENAI_SUBSCRIPTION_EXPIRY_UPSTREAM_ERROR", "failed to obtain a trusted subscription expiry from upstream")
+	}
+
+	planType := strings.TrimSpace(subscription.PlanType)
+	willRenew := boolValue(subscription.WillRenew)
+	if planType == "" {
+		planType = strings.TrimSpace(accountCheck.PlanType)
+	}
+	if subscription.WillRenew == nil {
+		willRenew = boolValue(accountCheck.WillRenew)
+	}
+
+	expiresAt := normalizeOpenAIExpiry(accountCheck.ExpiresAt)
+	source := OpenAISubscriptionExpirySourceUnavailable
+	status := OpenAISubscriptionExpiryStatusUnavailable
+	if expiresAt != "" {
+		source = OpenAISubscriptionExpirySourceAccountsCheck
+		status = OpenAISubscriptionExpiryStatusAvailable
+	}
+
+	return s.persistSubscriptionExpiryResult(ctx, accountID, clickedAccount, OpenAISubscriptionExpirySnapshot{
+		Status:    status,
+		ExpiresAt: expiresAt,
+		CheckedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Source:    source,
+		PlanType:  planType,
+		WillRenew: willRenew,
+	})
+}
+
+func queryOpenAISubscription(ctx context.Context, client *req.Client, headers map[string]string, accountID string) (openAISubscriptionResponse, bool) {
+	var payload openAISubscriptionResponse
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeaders(headers).
+		SetSuccessResult(&payload).
+		SetQueryParam("account_id", accountID).
+		Get(chatGPTSubscriptionsURL)
+	if err != nil {
+		slog.Debug("openai_subscription_expiry_subscriptions_request_error", "error", err)
+		return openAISubscriptionResponse{}, false
+	}
+	if !resp.IsSuccessState() {
+		slog.Debug("openai_subscription_expiry_subscriptions_failed", "status", resp.StatusCode)
+		return openAISubscriptionResponse{}, false
+	}
+	return payload, true
+}
+
+func queryOpenAIAccountsCheck(ctx context.Context, client *req.Client, headers map[string]string) (openAIAccountsCheckResult, bool) {
+	var payload openAIAccountsCheckResponse
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeaders(headers).
+		SetSuccessResult(&payload).
+		Get(chatGPTAccountsCheckURL)
+	if err != nil {
+		slog.Debug("openai_subscription_expiry_accounts_check_request_error", "error", err)
+		return openAIAccountsCheckResult{}, false
+	}
+	if !resp.IsSuccessState() {
+		slog.Debug("openai_subscription_expiry_accounts_check_failed", "status", resp.StatusCode)
+		return openAIAccountsCheckResult{}, false
+	}
+	if payload.Accounts == nil {
+		return openAIAccountsCheckResult{}, false
+	}
+
+	account, ok := payload.Accounts[strings.TrimSpace(headers["chatgpt-account-id"])]
+	if !ok {
+		// A legacy response may contain exactly one account while omitting the
+		// organization key used by the credential. It is safe to use that one
+		// candidate. Multiple unmatched accounts are not a trusted "unavailable"
+		// result because we cannot tell which workspace belongs to this row.
+		if len(payload.Accounts) != 1 {
+			return openAIAccountsCheckResult{}, false
+		}
+		for _, candidate := range payload.Accounts {
+			account = candidate
+		}
+	}
+
+	return openAIAccountsCheckResult{
+		ExpiresAt: extractEntitlementExpiresAt(account),
+		PlanType:  extractPlanType(account),
+		WillRenew: extractWillRenew(account),
+	}, true
+}
+
+func (s *OpenAIQuotaService) persistSubscriptionExpiryResult(ctx context.Context, accountID int64, clickedAccount *Account, snapshot OpenAISubscriptionExpirySnapshot) (*OpenAISubscriptionExpiryResult, error) {
+	if err := s.accountRepo.UpdateExtra(ctx, accountID, map[string]any{
+		OpenAISubscriptionExpirySnapshotKey: snapshot,
+	}); err != nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_SUBSCRIPTION_EXPIRY_CACHE_WRITE_FAILED", "failed to cache subscription expiry snapshot").WithCause(err)
+	}
+
+	result := &OpenAISubscriptionExpiryResult{
+		AccountID:       accountID,
+		Snapshot:        snapshot,
+		EffectiveSource: OpenAISubscriptionExpiryEffectiveSourceNone,
+	}
+	if snapshot.Status == OpenAISubscriptionExpiryStatusAvailable && snapshot.ExpiresAt != "" {
+		result.EffectiveExpiresAt = snapshot.ExpiresAt
+		result.EffectiveSource = OpenAISubscriptionExpiryEffectiveSourceUpstream
+	} else if clickedAccount != nil && clickedAccount.ExpiresAt != nil {
+		result.EffectiveExpiresAt = clickedAccount.ExpiresAt.UTC().Format(time.RFC3339Nano)
+		result.EffectiveSource = OpenAISubscriptionExpiryEffectiveSourceManual
+	}
+	return result, nil
+}
+
+func normalizeOpenAIExpiry(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func extractWillRenew(account map[string]any) *bool {
+	if account == nil {
+		return nil
+	}
+	for _, candidate := range []map[string]any{
+		account,
+		mapValue(account, "account"),
+		mapValue(account, "entitlement"),
+	} {
+		if candidate == nil {
+			continue
+		}
+		if value, ok := candidate["will_renew"].(bool); ok {
+			return &value
+		}
+	}
+	return nil
+}
+
+func mapValue(values map[string]any, key string) map[string]any {
+	value, _ := values[key].(map[string]any)
+	return value
+}

--- a/backend/internal/service/openai_subscription_expiry_test.go
+++ b/backend/internal/service/openai_subscription_expiry_test.go
@@ -1,0 +1,303 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/imroc/req/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func newSubscriptionExpiryTestAccount(id int64, chatGPTAccountID string) *Account {
+	return &Account{
+		ID:       id,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":       "test-access-token",
+			"chatgpt_account_id": chatGPTAccountID,
+			"expires_at":         time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+func newSubscriptionExpiryTestService(repo *stubQuotaAccountRepo, server *httptest.Server) *OpenAIQuotaService {
+	return NewOpenAIQuotaService(
+		repo,
+		nil,
+		&OpenAITokenProvider{},
+		newQuotaRedirectingFactory(server),
+	)
+}
+
+func TestQuerySubscriptionExpiry_SubscriptionsSuccess(t *testing.T) {
+	const accountID = int64(41)
+	const chatGPTAccountID = "chatgpt-account-41"
+	const wantExpiresAt = "2026-08-08T07:23:45Z"
+
+	var subscriptionCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/subscriptions", r.URL.Path)
+		require.Equal(t, chatGPTAccountID, r.URL.Query().Get("account_id"))
+		require.Equal(t, "Bearer test-access-token", r.Header.Get("Authorization"))
+		subscriptionCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plan_type":    "plus",
+			"active_until": wantExpiresAt,
+			"will_renew":   false,
+		})
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{accountID: account}}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, accountID, result.AccountID)
+	require.Equal(t, OpenAISubscriptionExpiryStatusAvailable, result.Snapshot.Status)
+	require.Equal(t, wantExpiresAt, result.Snapshot.ExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpirySourceSubscriptions, result.Snapshot.Source)
+	require.Equal(t, "plus", result.Snapshot.PlanType)
+	require.False(t, result.Snapshot.WillRenew)
+	require.Equal(t, wantExpiresAt, result.EffectiveExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpiryEffectiveSourceUpstream, result.EffectiveSource)
+	require.Len(t, repo.extraUpdates, 1)
+	require.Equal(t, result.Snapshot, repo.extraUpdates[accountID][OpenAISubscriptionExpirySnapshotKey])
+	require.Equal(t, 1, subscriptionCalls)
+}
+
+func TestQuerySubscriptionExpiry_SubscriptionsWithoutActiveUntilFallsBackToAccountsCheck(t *testing.T) {
+	const accountID = int64(42)
+	const chatGPTAccountID = "chatgpt-account-42"
+	const wantExpiresAt = "2026-09-01T10:20:30+00:00"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/subscriptions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"plan_type":    "plus",
+				"active_until": "",
+				"will_renew":   true,
+			})
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accounts": map[string]any{
+					chatGPTAccountID: map[string]any{
+						"account":     map[string]any{"plan_type": "plus"},
+						"entitlement": map[string]any{"expires_at": wantExpiresAt},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{accountID: account}}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, OpenAISubscriptionExpiryStatusAvailable, result.Snapshot.Status)
+	require.Equal(t, "2026-09-01T10:20:30Z", result.Snapshot.ExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpirySourceAccountsCheck, result.Snapshot.Source)
+	require.Equal(t, "plus", result.Snapshot.PlanType)
+	require.True(t, result.Snapshot.WillRenew)
+	require.Equal(t, OpenAISubscriptionExpiryEffectiveSourceUpstream, result.EffectiveSource)
+}
+
+func TestQuerySubscriptionExpiry_NoRealValueCachesUnavailableAndUsesManualEffectiveExpiry(t *testing.T) {
+	const accountID = int64(43)
+	const chatGPTAccountID = "chatgpt-account-43"
+	manualExpiry := time.Date(2027, time.March, 4, 5, 6, 7, 0, time.FixedZone("CST", 8*60*60))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/subscriptions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"plan_type":    "free",
+				"active_until": "",
+				"will_renew":   false,
+			})
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accounts": map[string]any{
+					chatGPTAccountID: map[string]any{
+						"account": map[string]any{"plan_type": "free"},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	account.ExpiresAt = &manualExpiry
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{accountID: account}}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, OpenAISubscriptionExpiryStatusUnavailable, result.Snapshot.Status)
+	require.Empty(t, result.Snapshot.ExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpirySourceUnavailable, result.Snapshot.Source)
+	require.False(t, result.Snapshot.WillRenew)
+	require.Equal(t, manualExpiry.UTC().Format(time.RFC3339Nano), result.EffectiveExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpiryEffectiveSourceManual, result.EffectiveSource)
+	require.Equal(t, result.Snapshot, repo.extraUpdates[accountID][OpenAISubscriptionExpirySnapshotKey])
+}
+
+func TestQuerySubscriptionExpiry_SubscriptionsEmptyActiveUntilIsTrustedWhenAccountsCheckFails(t *testing.T) {
+	const accountID = int64(46)
+	const chatGPTAccountID = "chatgpt-account-46"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/subscriptions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"plan_type":    "free",
+				"active_until": "",
+				"will_renew":   false,
+			})
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			w.WriteHeader(http.StatusBadGateway)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{accountID: account}}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, OpenAISubscriptionExpiryStatusUnavailable, result.Snapshot.Status)
+	require.Empty(t, result.Snapshot.ExpiresAt)
+	require.Equal(t, OpenAISubscriptionExpirySourceUnavailable, result.Snapshot.Source)
+	require.Equal(t, "free", result.Snapshot.PlanType)
+	require.False(t, result.Snapshot.WillRenew)
+	require.Equal(t, result.Snapshot, repo.extraUpdates[accountID][OpenAISubscriptionExpirySnapshotKey])
+}
+
+func TestQuerySubscriptionExpiry_BothUpstreamEndpointsFailPreservesOldCache(t *testing.T) {
+	const accountID = int64(44)
+	const chatGPTAccountID = "chatgpt-account-44"
+	oldSnapshot := OpenAISubscriptionExpirySnapshot{
+		Status:    OpenAISubscriptionExpiryStatusAvailable,
+		ExpiresAt: "2026-01-01T00:00:00Z",
+		CheckedAt: "2025-12-01T00:00:00Z",
+		Source:    OpenAISubscriptionExpirySourceSubscriptions,
+		PlanType:  "plus",
+		WillRenew: true,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	repo := &stubQuotaAccountRepo{
+		accounts:     map[int64]*Account{accountID: account},
+		extraUpdates: map[int64]map[string]any{accountID: {OpenAISubscriptionExpirySnapshotKey: oldSnapshot}},
+	}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Equal(t, oldSnapshot, repo.extraUpdates[accountID][OpenAISubscriptionExpirySnapshotKey])
+}
+
+func TestQuerySubscriptionExpiry_UnmatchedMultiAccountFallbackPreservesOldCache(t *testing.T) {
+	const accountID = int64(47)
+	const chatGPTAccountID = "target-chatgpt-account"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/subscriptions":
+			w.WriteHeader(http.StatusBadGateway)
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accounts": map[string]any{
+					"other-one": map[string]any{"entitlement": map[string]any{"expires_at": "2027-01-01T00:00:00Z"}},
+					"other-two": map[string]any{"entitlement": map[string]any{"expires_at": "2027-02-01T00:00:00Z"}},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	account := newSubscriptionExpiryTestAccount(accountID, chatGPTAccountID)
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{accountID: account}}
+	result, err := newSubscriptionExpiryTestService(repo, server).QuerySubscriptionExpiry(context.Background(), accountID)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Empty(t, repo.extraUpdates)
+}
+
+func TestQuerySubscriptionExpiry_ShadowUsesParentCredentialsAndProxyButCachesShadowRow(t *testing.T) {
+	const shadowID = int64(45)
+	const chatGPTAccountID = "parent-chatgpt-account"
+	parentID := int64(145)
+
+	parent := newSubscriptionExpiryTestAccount(parentID, chatGPTAccountID)
+	proxyID := int64(9)
+	parent.ProxyID = &proxyID
+	parent.Proxy = &Proxy{Protocol: "http", Host: "proxy.example", Port: 8080}
+	parentExpiry := time.Date(2027, time.June, 7, 8, 9, 10, 0, time.UTC)
+	parent.ExpiresAt = &parentExpiry
+	shadow := &Account{
+		ID:              shadowID,
+		Platform:        PlatformOpenAI,
+		Type:            AccountTypeOAuth,
+		ParentAccountID: &parentID,
+		QuotaDimension:  QuotaDimensionSpark,
+	}
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{shadowID: shadow, parentID: parent}}
+
+	var seenProxyURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/subscriptions", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plan_type":    "plus",
+			"active_until": "2027-07-08T09:10:11Z",
+			"will_renew":   true,
+		})
+	}))
+	defer server.Close()
+
+	factory := func(proxyURL string) (*req.Client, error) {
+		seenProxyURL = proxyURL
+		return newQuotaRedirectingFactory(server)(proxyURL)
+	}
+	service := NewOpenAIQuotaService(repo, nil, &OpenAITokenProvider{}, factory)
+	result, err := service.QuerySubscriptionExpiry(context.Background(), shadowID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "http://proxy.example:8080", seenProxyURL)
+	require.Contains(t, repo.extraUpdates, shadowID)
+	require.NotContains(t, repo.extraUpdates, parentID)
+	require.Equal(t, result.Snapshot, repo.extraUpdates[shadowID][OpenAISubscriptionExpirySnapshotKey])
+}

--- a/frontend/src/api/__tests__/admin.accounts.subscriptionExpiry.spec.ts
+++ b/frontend/src/api/__tests__/admin.accounts.subscriptionExpiry.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }))
+
+vi.mock('@/api/client', () => ({
+  apiClient: { post }
+}))
+
+import {
+  queryOpenAISubscriptionExpiry,
+  queryOpenAISubscriptionExpiryBatch
+} from '@/api/admin/accounts'
+
+describe('admin account OpenAI subscription expiry API', () => {
+  beforeEach(() => post.mockReset())
+
+  it('uses explicit mutating endpoints for single and batch cache refreshes', async () => {
+    const result = {
+      account_id: 41,
+      snapshot: {
+        status: 'available' as const,
+        expires_at: '2026-08-08T07:23:45Z',
+        checked_at: '2026-08-07T06:17:00Z',
+        source: 'subscriptions'
+      }
+    }
+    post.mockResolvedValueOnce({ data: result })
+    post.mockResolvedValueOnce({ data: { results: [result] } })
+
+    await expect(queryOpenAISubscriptionExpiry(41)).resolves.toEqual(result)
+    await expect(queryOpenAISubscriptionExpiryBatch([41])).resolves.toEqual([result])
+
+    expect(post).toHaveBeenNthCalledWith(
+      1,
+      '/admin/openai/accounts/41/subscription-expiry/query'
+    )
+    expect(post).toHaveBeenNthCalledWith(
+      2,
+      '/admin/openai/accounts/subscription-expiry/query',
+      { account_ids: [41] },
+      { timeout: 120_000 }
+    )
+  })
+})

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -780,6 +780,43 @@ export async function batchRefresh(accountIds: number[]): Promise<BatchOperation
   return data
 }
 
+export interface OpenAISubscriptionExpirySnapshot {
+  status: 'available' | 'unavailable'
+  expires_at?: string
+  checked_at: string
+  source?: string
+  plan_type?: string
+  will_renew?: boolean
+}
+
+export interface OpenAISubscriptionExpiryResult {
+  account_id: number
+  snapshot?: OpenAISubscriptionExpirySnapshot
+  effective_expires_at?: string
+  effective_source?: 'upstream' | 'manual' | 'none'
+  error?: string
+}
+
+/** Explicitly query and cache one OpenAI account's real subscription expiry. */
+export async function queryOpenAISubscriptionExpiry(id: number): Promise<OpenAISubscriptionExpiryResult> {
+  const { data } = await apiClient.post<OpenAISubscriptionExpiryResult>(
+    `/admin/openai/accounts/${id}/subscription-expiry/query`
+  )
+  return data
+}
+
+/** Explicitly query and cache multiple OpenAI accounts with server-side bounded concurrency. */
+export async function queryOpenAISubscriptionExpiryBatch(
+  accountIds: number[]
+): Promise<OpenAISubscriptionExpiryResult[]> {
+  const { data } = await apiClient.post<{ results: OpenAISubscriptionExpiryResult[] }>(
+    '/admin/openai/accounts/subscription-expiry/query',
+    { account_ids: accountIds },
+    { timeout: 120_000 }
+  )
+  return data.results
+}
+
 /**
  * Set privacy for an Antigravity OAuth account
  * @param id - Account ID
@@ -1027,6 +1064,8 @@ export const accountsAPI = {
   batchDelete,
   batchClearError,
   batchRefresh,
+  queryOpenAISubscriptionExpiry,
+  queryOpenAISubscriptionExpiryBatch,
   setPrivacy,
   revertProxyFallback,
   refreshOpenAIQuota,

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -47,6 +47,13 @@
         <button @click="$emit('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
         <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
         <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
+        <button
+          class="btn btn-secondary btn-sm"
+          :disabled="subscriptionExpiryLoading"
+          @click="$emit('query-subscription-expiry')"
+        >
+          {{ subscriptionExpiryLoading ? t('admin.accounts.subscriptionExpiryQuerying') : t('admin.accounts.bulkActions.querySubscriptionExpiry') }}
+        </button>
         <button @click="$emit('probe-upstream-billing')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.probeUpstreamBilling') }}</button>
         <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
         <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
@@ -67,6 +74,7 @@ defineProps<{
   totalResults: number
   selectingAll: boolean
   allResultsSelected: boolean
+  subscriptionExpiryLoading?: boolean
 }>()
 
 defineEmits([
@@ -79,6 +87,7 @@ defineEmits([
   'toggle-schedulable',
   'reset-status',
   'refresh-token',
+  'query-subscription-expiry',
   'probe-upstream-billing'
 ])
 

--- a/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
@@ -47,4 +47,24 @@ describe('AccountBulkActionsBar', () => {
     await button!.trigger('click')
     expect(wrapper.emitted('probe-upstream-billing')).toHaveLength(1)
   })
+
+  it('queries subscription expiry only after the batch button is clicked', async () => {
+    const wrapper = mount(AccountBulkActionsBar, {
+      props: {
+        selectedIds: [41, 42],
+        totalResults: 2,
+        selectingAll: false,
+        allResultsSelected: true
+      }
+    })
+
+    expect(wrapper.emitted('query-subscription-expiry')).toBeUndefined()
+    const button = wrapper.findAll('button').find(item =>
+      item.text().includes('admin.accounts.bulkActions.querySubscriptionExpiry')
+    )
+
+    expect(button).toBeDefined()
+    await button!.trigger('click')
+    expect(wrapper.emitted('query-subscription-expiry')).toHaveLength(1)
+  })
 })

--- a/frontend/src/components/common/PlatformTypeBadge.vue
+++ b/frontend/src/components/common/PlatformTypeBadge.vue
@@ -57,9 +57,23 @@
         <span>{{ privacyBadge.label }}</span>
       </span>
     </div>
-    <!-- Row 3: Subscription expiration (non-free paid accounts only) -->
-    <div v-if="expiresLabel" class="text-[10px] leading-tight text-gray-400 dark:text-gray-500 pl-0.5" :title="subscriptionExpiresAt">
-      {{ expiresLabel }}
+    <!-- Row 3: Cached subscription expiration and explicit refresh action -->
+    <div
+      v-if="expiresLabel || subscriptionExpiryQueryable"
+      class="flex items-center gap-1 pl-0.5 text-[10px] leading-tight text-gray-400 dark:text-gray-500"
+      :title="expiryTitle"
+    >
+      <span>{{ expiresLabel || emptyExpiryLabel }}</span>
+      <button
+        v-if="subscriptionExpiryQueryable"
+        type="button"
+        class="rounded px-1 py-0.5 font-medium text-primary-600 hover:bg-primary-50 disabled:cursor-wait disabled:opacity-60 dark:text-primary-400 dark:hover:bg-primary-900/30"
+        :disabled="subscriptionExpiryLoading"
+        data-testid="query-subscription-expiry"
+        @click.stop="emit('query-subscription-expiry')"
+      >
+        {{ subscriptionExpiryLoading ? t('admin.accounts.subscriptionExpiryQuerying') : t('admin.accounts.subscriptionExpiryQuery') }}
+      </button>
     </div>
   </div>
 </template>
@@ -71,6 +85,7 @@ import type { AccountPlatform, AccountType } from '@/types'
 import GrokFreeIcon from './GrokFreeIcon.vue'
 import PlatformIcon from './PlatformIcon.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { formatDateTimeToMinute } from '@/utils/format'
 
 const { t } = useI18n()
 
@@ -81,9 +96,16 @@ interface Props {
   planType?: string
   privacyMode?: string
   subscriptionExpiresAt?: string
+  subscriptionExpirySource?: 'upstream' | 'legacy' | 'manual' | 'none'
+  subscriptionExpiryCheckedAt?: string
+  subscriptionExpiryQueryable?: boolean
+  subscriptionExpiryLoading?: boolean
 }
 
 const props = defineProps<Props>()
+const emit = defineEmits<{
+  'query-subscription-expiry': []
+}>()
 
 const platformLabel = computed(() => {
   if (props.platform === 'anthropic') return 'Anthropic'
@@ -232,20 +254,36 @@ const planBadgeClass = computed(() => {
   return typeClass.value
 })
 
-// Subscription expiration label (non-free only)
 const expiresLabel = computed(() => {
-  if (!props.subscriptionExpiresAt || !props.planType) return ''
-  if (normalizedPlanType.value === 'free' || normalizedPlanType.value === 'basic') return ''
-  try {
-    const d = new Date(props.subscriptionExpiresAt)
-    if (isNaN(d.getTime())) return ''
-    const yyyy = d.getFullYear()
-    const mm = String(d.getMonth() + 1).padStart(2, '0')
-    const dd = String(d.getDate()).padStart(2, '0')
-    return `${t('admin.accounts.subscriptionExpires')} ${yyyy}-${mm}-${dd}`
-  } catch {
+  if (!props.subscriptionExpiryQueryable && (normalizedPlanType.value === 'free' || normalizedPlanType.value === 'basic')) {
     return ''
   }
+  const formatted = formatDateTimeToMinute(props.subscriptionExpiresAt)
+  if (!formatted) return ''
+  const sourceKey = ({
+    upstream: 'admin.accounts.subscriptionExpirySourceUpstream',
+    legacy: 'admin.accounts.subscriptionExpirySourceLegacy',
+    manual: 'admin.accounts.subscriptionExpirySourceManual'
+  } as Record<string, string>)[props.subscriptionExpirySource || '']
+  const source = sourceKey ? ` · ${t(sourceKey)}` : ''
+  return `${t('admin.accounts.subscriptionExpires')} ${formatted}${source}`
+})
+
+const emptyExpiryLabel = computed(() =>
+  props.subscriptionExpiryCheckedAt
+    ? t('admin.accounts.subscriptionExpiryUnavailable')
+    : t('admin.accounts.subscriptionExpiryNotQueried')
+)
+
+const expiryTitle = computed(() => {
+  const parts: string[] = []
+  if (props.subscriptionExpiresAt) parts.push(props.subscriptionExpiresAt)
+  if (props.subscriptionExpiryCheckedAt) {
+    parts.push(t('admin.accounts.subscriptionExpiryCheckedAt', {
+      time: formatDateTimeToMinute(props.subscriptionExpiryCheckedAt)
+    }))
+  }
+  return parts.join(' · ')
 })
 
 // Privacy badge — shows different states for OpenAI/Antigravity OAuth privacy setting

--- a/frontend/src/components/common/__tests__/PlatformTypeBadge.grok.spec.ts
+++ b/frontend/src/components/common/__tests__/PlatformTypeBadge.grok.spec.ts
@@ -107,4 +107,25 @@ describe('PlatformTypeBadge OpenAI authentication modes', () => {
     await wrapper.setProps({ authMode: undefined })
     expect(wrapper.text()).toContain('OAuth')
   })
+
+  it('shows minute-level source metadata and emits only on an explicit query click', async () => {
+    const wrapper = mount(PlatformTypeBadge, {
+      props: {
+        platform: 'openai',
+        type: 'oauth',
+        planType: 'plus',
+        subscriptionExpiresAt: '2026-08-08T07:23:45Z',
+        subscriptionExpirySource: 'upstream',
+        subscriptionExpiryCheckedAt: '2026-08-07T06:17:00Z',
+        subscriptionExpiryQueryable: true,
+      },
+    })
+
+    expect(wrapper.text()).toContain('admin.accounts.subscriptionExpires')
+    expect(wrapper.text()).toContain('admin.accounts.subscriptionExpirySourceUpstream')
+    expect(wrapper.emitted('query-subscription-expiry')).toBeUndefined()
+
+    await wrapper.get('[data-testid="query-subscription-expiry"]').trigger('click')
+    expect(wrapper.emitted('query-subscription-expiry')).toHaveLength(1)
+  })
 })

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -274,6 +274,18 @@ export default {
       setPrivacy: 'Set Privacy',
       subscriptionAbnormal: 'Abnormal',
       subscriptionExpires: 'Expires',
+      subscriptionExpiryQuery: 'Query',
+      subscriptionExpiryQuerying: 'Querying…',
+      subscriptionExpiryNotQueried: 'Real expiry not queried',
+      subscriptionExpiryUnavailable: 'Upstream returned no real expiry',
+      subscriptionExpirySourceUpstream: 'Real',
+      subscriptionExpirySourceLegacy: 'Stored real',
+      subscriptionExpirySourceManual: 'Manual',
+      subscriptionExpiryCheckedAt: 'Queried at {time}',
+      subscriptionExpiryQuerySuccess: 'Subscription expiry updated for account #{id}',
+      subscriptionExpiryQueryFailed: 'Failed to query the real subscription expiry',
+      subscriptionExpiryBatchCompleted: 'Queried subscription expiry for {count} account(s)',
+      subscriptionExpiryBatchPartial: 'Subscription expiry query partially completed: {success} succeeded, {failed} failed',
       // Capacity status tooltips
       capacity: {
         windowCost: {
@@ -415,6 +427,7 @@ export default {
         disableScheduling: 'Disable Scheduling',
         resetStatus: 'Reset Status',
         refreshToken: 'Refresh Token',
+        querySubscriptionExpiry: 'Query Subscription Expiry',
         probeUpstreamBilling: 'Probe Upstream Rate',
         resetStatusSuccess: 'Successfully reset {count} account(s) status',
         refreshTokenSuccess: 'Successfully refreshed {count} account(s) token',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -222,6 +222,18 @@ export default {
       setPrivacy: '设置隐私',
       subscriptionAbnormal: '异常',
       subscriptionExpires: '到期',
+      subscriptionExpiryQuery: '查询',
+      subscriptionExpiryQuerying: '查询中…',
+      subscriptionExpiryNotQueried: '尚未查询真实到期',
+      subscriptionExpiryUnavailable: '上游未返回真实到期',
+      subscriptionExpirySourceUpstream: '真实',
+      subscriptionExpirySourceLegacy: '已存真实',
+      subscriptionExpirySourceManual: '手填',
+      subscriptionExpiryCheckedAt: '查询于 {time}',
+      subscriptionExpiryQuerySuccess: '账号 #{id} 的订阅到期已更新',
+      subscriptionExpiryQueryFailed: '查询真实订阅到期失败',
+      subscriptionExpiryBatchCompleted: '已查询 {count} 个账号的订阅到期',
+      subscriptionExpiryBatchPartial: '订阅到期查询部分完成：成功 {success} 个，失败 {failed} 个',
       // 容量状态提示
       capacity: {
         windowCost: {
@@ -494,6 +506,7 @@ export default {
         disableScheduling: '批量停止调度',
         resetStatus: '批量重置状态',
         refreshToken: '批量刷新令牌',
+        querySubscriptionExpiry: '查询订阅到期',
         probeUpstreamBilling: '探测上游倍率',
         resetStatusSuccess: '已成功重置 {count} 个账号状态',
         refreshTokenSuccess: '已成功刷新 {count} 个账号令牌',

--- a/frontend/src/utils/__tests__/openaiSubscriptionExpiry.spec.ts
+++ b/frontend/src/utils/__tests__/openaiSubscriptionExpiry.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { Account } from '@/types'
+import {
+  getOpenAISubscriptionExpiryDisplay,
+  OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY
+} from '../openaiSubscriptionExpiry'
+
+const account = (overrides: Partial<Account> = {}): Account => ({
+  id: 41,
+  name: 'account',
+  platform: 'openai',
+  type: 'oauth',
+  proxy_id: null,
+  concurrency: 1,
+  priority: 1,
+  status: 'active',
+  error_message: null,
+  last_used_at: null,
+  expires_at: 1_786_078_800,
+  auto_pause_on_expired: false,
+  created_at: '2026-08-01T00:00:00Z',
+  updated_at: '2026-08-01T00:00:00Z',
+  schedulable: true,
+  rate_limited_at: null,
+  rate_limit_reset_at: null,
+  overload_until: null,
+  temp_unschedulable_until: null,
+  temp_unschedulable_reason: null,
+  session_window_start: null,
+  session_window_end: null,
+  session_window_status: null,
+  ...overrides
+})
+
+describe('getOpenAISubscriptionExpiryDisplay', () => {
+  it('prefers the explicitly queried upstream snapshot over manual expiry', () => {
+    const result = getOpenAISubscriptionExpiryDisplay(account({
+      extra: {
+        [OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY]: {
+          status: 'available',
+          expires_at: '2026-08-08T07:23:45Z',
+          checked_at: '2026-08-07T06:17:00Z',
+          source: 'subscriptions'
+        }
+      }
+    }))
+
+    expect(result).toMatchObject({
+      expiresAt: '2026-08-08T07:23:45Z',
+      source: 'upstream',
+      checkedAt: '2026-08-07T06:17:00Z'
+    })
+  })
+
+  it('falls back to the operator-entered expiry after a trusted unavailable result', () => {
+    const result = getOpenAISubscriptionExpiryDisplay(account({
+      credentials: { subscription_expires_at: '2027-01-01T00:00:00Z' },
+      extra: {
+        [OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY]: {
+          status: 'unavailable',
+          checked_at: '2026-08-07T06:17:00Z',
+          source: 'accounts_check'
+        }
+      }
+    }))
+
+    expect(result.source).toBe('manual')
+    expect(result.expiresAt).toBe(new Date(1_786_078_800 * 1000).toISOString())
+  })
+
+  it('keeps showing a legacy real expiry until the first explicit query', () => {
+    expect(getOpenAISubscriptionExpiryDisplay(account({
+      credentials: { subscription_expires_at: '2026-08-08T07:23:45Z' }
+    }))).toEqual({
+      expiresAt: '2026-08-08T07:23:45Z',
+      source: 'legacy'
+    })
+  })
+})

--- a/frontend/src/utils/openaiSubscriptionExpiry.ts
+++ b/frontend/src/utils/openaiSubscriptionExpiry.ts
@@ -1,0 +1,89 @@
+import type { Account } from '@/types'
+
+export const OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY = 'openai_subscription_expiry_snapshot'
+
+export type OpenAISubscriptionExpirySnapshotStatus = 'available' | 'unavailable'
+export type OpenAISubscriptionExpiryDisplaySource = 'upstream' | 'legacy' | 'manual' | 'none'
+
+export interface OpenAISubscriptionExpirySnapshot {
+  status: OpenAISubscriptionExpirySnapshotStatus
+  expires_at?: string
+  checked_at: string
+  source?: string
+  plan_type?: string
+  will_renew?: boolean
+}
+export interface OpenAISubscriptionExpiryDisplay {
+  expiresAt?: string
+  source: OpenAISubscriptionExpiryDisplaySource
+  checkedAt?: string
+  snapshot?: OpenAISubscriptionExpirySnapshot
+}
+
+const validDateString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string' || value.trim() === '') return undefined
+  return Number.isNaN(new Date(value).getTime()) ? undefined : value
+}
+
+export const readOpenAISubscriptionExpirySnapshot = (
+  account: Account
+): OpenAISubscriptionExpirySnapshot | undefined => {
+  const value = account.extra?.[OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY]
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+  const raw = value as Record<string, unknown>
+  if (raw.status !== 'available' && raw.status !== 'unavailable') return undefined
+  const checkedAt = validDateString(raw.checked_at)
+  if (!checkedAt) return undefined
+
+  return {
+    status: raw.status,
+    checked_at: checkedAt,
+    ...(validDateString(raw.expires_at) ? { expires_at: raw.expires_at as string } : {}),
+    ...(typeof raw.source === 'string' ? { source: raw.source } : {}),
+    ...(typeof raw.plan_type === 'string' ? { plan_type: raw.plan_type } : {}),
+    ...(typeof raw.will_renew === 'boolean' ? { will_renew: raw.will_renew } : {})
+  }
+}
+
+const manualExpiry = (account: Account): string | undefined => {
+  if (typeof account.expires_at !== 'number' || !Number.isFinite(account.expires_at) || account.expires_at <= 0) {
+    return undefined
+  }
+  return new Date(account.expires_at * 1000).toISOString()
+}
+
+const legacyUpstreamExpiry = (account: Account): string | undefined =>
+  validDateString(account.credentials?.subscription_expires_at) ??
+  validDateString(account.parent_subscription_expires_at)
+
+export const getOpenAISubscriptionExpiryDisplay = (
+  account: Account
+): OpenAISubscriptionExpiryDisplay => {
+  const snapshot = readOpenAISubscriptionExpirySnapshot(account)
+  if (snapshot) {
+    if (snapshot.status === 'available' && snapshot.expires_at) {
+      return {
+        expiresAt: snapshot.expires_at,
+        source: 'upstream',
+        checkedAt: snapshot.checked_at,
+        snapshot
+      }
+    }
+    const fallback = manualExpiry(account)
+    return {
+      ...(fallback ? { expiresAt: fallback } : {}),
+      source: fallback ? 'manual' : 'none',
+      checkedAt: snapshot.checked_at,
+      snapshot
+    }
+  }
+
+  const legacy = legacyUpstreamExpiry(account)
+  if (legacy) return { expiresAt: legacy, source: 'legacy' }
+
+  const fallback = manualExpiry(account)
+  return fallback
+    ? { expiresAt: fallback, source: 'manual' }
+    : { source: 'none' }
+}

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -180,9 +180,11 @@
           :total-results="pagination.total"
           :selecting-all="selectingAllResults"
           :all-results-selected="allResultsSelected"
+          :subscription-expiry-loading="subscriptionExpiryBatchLoading"
           @delete="handleBulkDelete"
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
+          @query-subscription-expiry="handleBulkQuerySubscriptionExpiry"
           @probe-upstream-billing="handleBulkProbeUpstreamBilling"
           @edit-selected="openBulkEditSelected"
           @edit-filtered="openBulkEditFiltered"
@@ -262,7 +264,12 @@
                   :auth-mode="getOpenAIAuthMode(row)"
                   :plan-type="getAccountPlanType(row)"
                   :privacy-mode="row.extra?.privacy_mode || row.parent_privacy_mode"
-                  :subscription-expires-at="row.credentials?.subscription_expires_at || row.parent_subscription_expires_at" />
+                  :subscription-expires-at="getOpenAISubscriptionExpiryDisplay(row).expiresAt"
+                  :subscription-expiry-source="getOpenAISubscriptionExpiryDisplay(row).source"
+                  :subscription-expiry-checked-at="getOpenAISubscriptionExpiryDisplay(row).checkedAt"
+                  :subscription-expiry-queryable="row.platform === 'openai' && row.type === 'oauth'"
+                  :subscription-expiry-loading="queryingSubscriptionExpiry.has(row.id)"
+                  @query-subscription-expiry="handleQuerySubscriptionExpiry(row)" />
                 <span
                   v-if="getAntigravityTierLabel(row)"
                   :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', getAntigravityTierClass(row)]"
@@ -532,6 +539,11 @@ import { extractApiErrorMessage } from '@/utils/apiError'
 import { sanitizeUrl } from '@/utils/url'
 import { getFloatingPanelPosition } from '@/utils/floatingPanel'
 import { formatMultiplier } from '@/utils/formatters'
+import {
+  getOpenAISubscriptionExpiryDisplay,
+  OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY,
+  type OpenAISubscriptionExpirySnapshot
+} from '@/utils/openaiSubscriptionExpiry'
 import type { Account, AccountPlatform, AccountSchedulerGroupScore, AccountType, AccountUsageInfo, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel, UpstreamBillingProbeSnapshot } from '@/types'
 
 const { t } = useI18n()
@@ -611,6 +623,8 @@ const togglingSchedulable = ref<number | null>(null)
 const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
 const exportingData = ref(false)
 const probingUpstreamBilling = reactive(new Set<number>())
+const queryingSubscriptionExpiry = reactive(new Set<number>())
+const subscriptionExpiryBatchLoading = ref(false)
 const upstreamBillingProbeGloballyEnabled = ref<boolean | undefined>(undefined)
 const upstreamBillingNow = ref(Date.now())
 let lastUpstreamBillingSortRefreshMinute = -1
@@ -1753,6 +1767,48 @@ const handleBulkRefreshToken = async () => {
     appStore.showError(String(error))
   }
 }
+const patchSubscriptionExpirySnapshot = (
+  accountID: number,
+  snapshot: OpenAISubscriptionExpirySnapshot
+) => {
+  const account = accounts.value.find(item => item.id === accountID)
+  if (!account) return
+  patchAccountInList({
+    ...account,
+    extra: {
+      ...account.extra,
+      [OPENAI_SUBSCRIPTION_EXPIRY_SNAPSHOT_KEY]: snapshot
+    }
+  })
+}
+const handleBulkQuerySubscriptionExpiry = async () => {
+  const accountIDs = [...selIds.value]
+  if (accountIDs.length === 0 || subscriptionExpiryBatchLoading.value) return
+
+  subscriptionExpiryBatchLoading.value = true
+  accountIDs.forEach(id => queryingSubscriptionExpiry.add(id))
+  try {
+    const results = await adminAPI.accounts.queryOpenAISubscriptionExpiryBatch(accountIDs)
+    results.forEach(result => {
+      if (result.snapshot) patchSubscriptionExpirySnapshot(result.account_id, result.snapshot)
+    })
+    const failed = results.filter(result => result.error || !result.snapshot).length
+    if (failed > 0) {
+      appStore.showError(t('admin.accounts.subscriptionExpiryBatchPartial', {
+        success: results.length - failed,
+        failed
+      }))
+    } else {
+      appStore.showSuccess(t('admin.accounts.subscriptionExpiryBatchCompleted', { count: results.length }))
+    }
+  } catch (error) {
+    console.error('Failed to query subscription expiry in batch:', error)
+    appStore.showError(extractApiErrorMessage(error, t('admin.accounts.subscriptionExpiryQueryFailed')))
+  } finally {
+    accountIDs.forEach(id => queryingSubscriptionExpiry.delete(id))
+    subscriptionExpiryBatchLoading.value = false
+  }
+}
 const handleBulkProbeUpstreamBilling = async () => {
   const accountIDs = [...selIds.value]
   if (accountIDs.length === 0) {
@@ -2093,6 +2149,24 @@ const handleProbeUpstreamBilling = async (account: Account) => {
     appStore.showError(extractApiErrorMessage(error, t('admin.accounts.upstreamBilling.probeFailed')))
   } finally {
     probingUpstreamBilling.delete(account.id)
+  }
+}
+const handleQuerySubscriptionExpiry = async (account: Account) => {
+  if (queryingSubscriptionExpiry.has(account.id)) return
+  queryingSubscriptionExpiry.add(account.id)
+  try {
+    const result = await adminAPI.accounts.queryOpenAISubscriptionExpiry(account.id)
+    if (!result.snapshot) {
+      appStore.showError(t('admin.accounts.subscriptionExpiryQueryFailed'))
+      return
+    }
+    patchSubscriptionExpirySnapshot(account.id, result.snapshot)
+    appStore.showSuccess(t('admin.accounts.subscriptionExpiryQuerySuccess', { id: account.id }))
+  } catch (error) {
+    console.error('Failed to query subscription expiry:', error)
+    appStore.showError(extractApiErrorMessage(error, t('admin.accounts.subscriptionExpiryQueryFailed')))
+  } finally {
+    queryingSubscriptionExpiry.delete(account.id)
   }
 }
 const handleAccountUpdated = (updatedAccount: Account) => {


### PR DESCRIPTION
# Query and cache real OpenAI subscription expiry

## Summary

- Add explicit admin APIs to query one or multiple OpenAI OAuth accounts for their upstream subscription expiry
- Prefer `active_until` from the ChatGPT subscriptions response, with the account-check response as a fallback
- Cache the query result separately in `extra.openai_subscription_expiry_snapshot` without overwriting the operator-managed account expiry
- Show the effective expiry to minute precision, including whether it came from upstream, legacy credentials, or the manual account value
- Add row-level and bulk query actions to the accounts page

The existing top-level `accounts.expires_at` value is operator-managed, so it can differ from the actual ChatGPT subscription state. This PR adds an explicit refresh path that records both the upstream value and when it was checked, while preserving the manual value as the final fallback.

The query flow:

- requests `/backend-api/subscriptions?account_id=<account_id>` first
- falls back to the account-check response when the subscriptions response does not provide `active_until`
- treats a successful upstream response without an expiry as a trusted "unavailable" result
- preserves the previous cached snapshot when all upstream attempts fail or when a multi-workspace fallback cannot be matched safely
- uses a Spark shadow account's parent credentials and proxy, but stores the snapshot on the selected shadow row

The feature does not query upstream automatically while loading the accounts list. A snapshot changes only after an administrator clicks the single-account or bulk action.

## Related issues

- #4736
- #3445
- #1744
- #5459
- #1005

## API

- `POST /api/v1/admin/openai/accounts/:id/subscription-expiry/query`
- `POST /api/v1/admin/openai/accounts/subscription-expiry/query`

The batch endpoint deduplicates account IDs, accepts at most 100 unique IDs, limits upstream concurrency to 4, and reports per-account errors without failing the entire batch.

## Testing

```bash
cd backend
go test ./internal/service -run '^TestQuerySubscriptionExpiry' -count=1
go test -tags unit ./internal/handler/admin -run '^TestQuerySubscriptionExpiry' -count=1
go test ./internal/server/routes -run '^$' -count=1

cd frontend
pnpm exec vitest run \
  src/api/__tests__/admin.accounts.subscriptionExpiry.spec.ts \
  src/utils/__tests__/openaiSubscriptionExpiry.spec.ts \
  src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts \
  src/components/common/__tests__/PlatformTypeBadge.grok.spec.ts
pnpm typecheck
pnpm build
```

## Notes

- This PR is limited to OpenAI OAuth subscription-expiry lookup and display
- It does not replace or mutate the manually configured account expiry
- Cached upstream state is kept independent from token-refresh metadata


