### PR TITLE
feat(openai-opencode,#5379): 提炼 OpenCodeProvider——zen 端点档次适配 + CreditsError 账号级处置

### DIFF
--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -100,6 +100,14 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	if account != nil && account.Platform == PlatformGrok {
 		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 	}
+	// opencode/zen 上游的账号级错误（CreditsError: No payment method /
+	// Insufficient balance）在此识别并停用账号，避免通用路径把账号级问题
+	// 当普通 401/403 处理、失效账号继续参与调度耗尽 failover 配额。
+	if account != nil && account.IsOpenCodeUpstream() {
+		if s.handleOpenCodeAccountUpstreamError(ctx, account, resp.StatusCode, respBody) {
+			shouldFailover = true
+		}
+	}
 	if !shouldFailover {
 		return nil
 	}

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -94,6 +94,20 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		upstreamBody = normalizedBody
 	}
 
+	// 3b. opencode/zen 上游适配：free 档次（/zen/v1）serde 要求 message 带
+	// 顶层 id，转发前补齐缺失 id；go 档次（/zen/go/v1）标准兼容，原样通过。
+	if account.IsOpenCodeUpstream() {
+		prepared, prepErr := OpenCodePrepareUpstreamBody(account, upstreamBody)
+		if prepErr != nil {
+			logger.L().Warn("opencode prepare upstream body failed",
+				zap.Int64("account_id", account.ID),
+				zap.Error(prepErr),
+			)
+		} else {
+			upstreamBody = prepared
+		}
+	}
+
 	// 4. Apply OpenAI fast policy on the CC body
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, upstreamBody)
 	if policyErr != nil {

--- a/backend/internal/service/openai_opencode_errors.go
+++ b/backend/internal/service/openai_opencode_errors.go
@@ -1,0 +1,82 @@
+package service
+
+// opencode zen 上游的账号级错误语义（2026-08-07 实测）：
+//   - 401 CreditsError "No payment method ..."：账号未绑定支付方式，
+//     属永久性账号问题，充值/绑卡前不可用 -> 停用账号，避免 failover 反复打它
+//   - 401 CreditsError "Insufficient balance ..."：余额耗尽，充值前不可用
+//     -> 停用账号
+//
+// 通用路径把两者映射成 generic 502/401 且不处置账号状态，导致失效账号
+// 持续参与调度并耗尽 failover 配额。本模块在 opencode 上游分支识别并处置。
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	openCodeCreditsErrorType            = "CreditsError"
+	openCodeCreditsNoPaymentMethod      = "No payment method"
+	openCodeCreditsInsufficientBalance  = "Insufficient balance"
+	openCodeBlockReasonNoPaymentMethod  = "opencode_no_payment_method"
+	openCodeBlockReasonInsufficientBal  = "opencode_insufficient_balance"
+)
+
+// parseOpenCodeCreditsError 从 zen 错误响应体提取 CreditsError 类型与消息。
+// 响应形状: {"type":"error","error":{"type":"CreditsError","message":"..."}}
+func parseOpenCodeCreditsError(body []byte) (typ, message string) {
+	typ = gjson.GetBytes(body, "error.type").String()
+	if typ == "" {
+		typ = gjson.GetBytes(body, "type").String()
+	}
+	if typ != openCodeCreditsErrorType {
+		return "", ""
+	}
+	return typ, gjson.GetBytes(body, "error.message").String()
+}
+
+// handleOpenCodeAccountUpstreamError 处置 opencode 上游的账号级错误。
+// 命中 CreditsError 时按语义停用账号并返回 true（调用方跳过通用账号处置）；
+// 未命中返回 false（继续走通用 failover 路径）。
+func (s *OpenAIGatewayService) handleOpenCodeAccountUpstreamError(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	responseBody []byte,
+) bool {
+	if s == nil || account == nil || !account.IsOpenCodeUpstream() {
+		return false
+	}
+	if statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden {
+		return false
+	}
+	typ, msg := parseOpenCodeCreditsError(responseBody)
+	if typ != openCodeCreditsErrorType {
+		return false
+	}
+	switch {
+	case strings.Contains(msg, openCodeCreditsNoPaymentMethod):
+		slog.Warn("opencode_account_no_payment_method",
+			"account_id", account.ID,
+			"account_name", account.Name,
+			"reason", openCodeBlockReasonNoPaymentMethod,
+		)
+		s.BlockAccountScheduling(account, time.Time{}, openCodeBlockReasonNoPaymentMethod)
+		return true
+	case strings.Contains(msg, openCodeCreditsInsufficientBalance):
+		slog.Warn("opencode_account_insufficient_balance",
+			"account_id", account.ID,
+			"account_name", account.Name,
+			"reason", openCodeBlockReasonInsufficientBal,
+		)
+		s.BlockAccountScheduling(account, time.Time{}, openCodeBlockReasonInsufficientBal)
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/openai_opencode_gateway.go
+++ b/backend/internal/service/openai_opencode_gateway.go
@@ -1,0 +1,79 @@
+package service
+
+// opencode zen 网关（opencode.ai/zen/*）provider 适配。
+//
+// opencode 官方网关有两个端点，行为不同（2026-08-07 实证）：
+//   - /zen/v1（免费/普通端点）：serde 结构要求每条 message 带顶层 id，
+//     OpenAI 标准消息不带 id 会 400 "missing field `id`"（带图/多模态消息
+//     100% 触发）
+//   - /zen/go/v1（Go 计划付费端点）：标准 OpenAI 兼容，无 id 要求
+//
+// 账号以 base_url 声明端点；本模块按档次做转发前适配。账号仍是通用
+// openai/apikey 账号（extra 无需新字段），识别完全靠 base_url。
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// openCodeUpstreamHost 是 opencode zen 网关的域名片段，用于识别上游归属。
+const openCodeUpstreamHost = "opencode.ai/zen/"
+
+// IsOpenCodeUpstream 判定账号上游是否为 opencode zen 网关。
+func (a *Account) IsOpenCodeUpstream() bool {
+	return a != nil && strings.Contains(a.GetOpenAIBaseURL(), openCodeUpstreamHost)
+}
+
+// OpenCodePlan 返回 opencode 账号档次：go（Go 计划付费端点 /zen/go/）或
+// free（免费/普通端点 /zen/）。非 opencode 上游返回空字符串。
+func (a *Account) OpenCodePlan() string {
+	if a == nil {
+		return ""
+	}
+	base := a.GetOpenAIBaseURL()
+	switch {
+	case strings.Contains(base, "/zen/go/"):
+		return "go"
+	case strings.Contains(base, "/zen/"):
+		return "free"
+	default:
+		return ""
+	}
+}
+
+// OpenCodePrepareUpstreamBody 按账号档次准备发往 opencode 上游的请求体。
+// free 档次（/zen/v1）serde 要求 message 带顶层 id，补齐缺失 id；
+// go 档次（/zen/go/v1）标准 OpenAI 兼容，原样返回。
+func OpenCodePrepareUpstreamBody(account *Account, body []byte) ([]byte, error) {
+	if account == nil || !account.IsOpenCodeUpstream() || account.OpenCodePlan() == "go" {
+		return body, nil
+	}
+	return ensureChatMessagesIDs(body)
+}
+
+// ensureChatMessagesIDs 为 OpenAI Chat Completions 请求的每条 message 补齐
+// 顶层 id 字段（缺失时）。标准 OpenAI / DeepSeek 等上游忽略消息未知字段，
+// 补 id 无副作用；opencode /zen/v1 端点要求 id 必填。
+func ensureChatMessagesIDs(body []byte) ([]byte, error) {
+	count := gjson.GetBytes(body, "messages.#").Int()
+	if count <= 0 {
+		return body, nil
+	}
+	out := body
+	for i := int64(0); i < count; i++ {
+		path := fmt.Sprintf("messages.%d.id", i)
+		if gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, err := sjson.SetBytes(out, path, "msg_"+strings.ReplaceAll(uuid.NewString(), "-", ""))
+		if err != nil {
+			return body, err
+		}
+		out = next
+	}
+	return out, nil
+}

--- a/backend/internal/service/openai_opencode_gateway_test.go
+++ b/backend/internal/service/openai_opencode_gateway_test.go
@@ -1,0 +1,181 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestIsOpenCodeUpstream(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{"zen/go 付费端点", "https://opencode.ai/zen/go/v1", true},
+		{"zen/v1 免费端点", "https://opencode.ai/zen/v1", true},
+		{"deepseek 官方", "https://api.deepseek.com", false},
+		{"openai 官方", "https://api.openai.com/v1", false},
+		{"空 base", "", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+			if tc.baseURL != "" {
+				a.Credentials = map[string]any{"base_url": tc.baseURL}
+			}
+			if got := a.IsOpenCodeUpstream(); got != tc.want {
+				t.Fatalf("IsOpenCodeUpstream()=%v, want %v (base=%q)", got, tc.want, tc.baseURL)
+			}
+		})
+	}
+}
+
+func TestOpenCodePlan(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"go 计划", "https://opencode.ai/zen/go/v1", "go"},
+		{"免费端点", "https://opencode.ai/zen/v1", "free"},
+		{"非 opencode", "https://api.deepseek.com", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+			a.Credentials = map[string]any{"base_url": tc.baseURL}
+			if got := a.OpenCodePlan(); got != tc.want {
+				t.Fatalf("OpenCodePlan()=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenCodePrepareUpstreamBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"a1","id":"keep"}]}`)
+
+	t.Run("free 档次补齐 id", func(t *testing.T) {
+		t.Parallel()
+		a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		a.Credentials = map[string]any{"base_url": "https://opencode.ai/zen/v1"}
+		out, err := OpenCodePrepareUpstreamBody(a, body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !json.Valid(out) {
+			t.Fatalf("invalid json: %s", out)
+		}
+		// 已有 id 保留
+		if got := gjson.GetBytes(out, "messages.1.id").String(); got != "keep" {
+			t.Fatalf("existing id not preserved: %q", got)
+		}
+		// 缺失 id 补齐
+		if got := gjson.GetBytes(out, "messages.0.id").String(); got == "" {
+			t.Fatalf("missing id not filled")
+		}
+	})
+
+	t.Run("go 档次原样", func(t *testing.T) {
+		t.Parallel()
+		a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		a.Credentials = map[string]any{"base_url": "https://opencode.ai/zen/go/v1"}
+		out, err := OpenCodePrepareUpstreamBody(a, body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if string(out) != string(body) {
+			t.Fatalf("go tier body changed: %s", out)
+		}
+	})
+
+	t.Run("非 opencode 原样", func(t *testing.T) {
+		t.Parallel()
+		a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		a.Credentials = map[string]any{"base_url": "https://api.deepseek.com"}
+		out, err := OpenCodePrepareUpstreamBody(a, body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if string(out) != string(body) {
+			t.Fatalf("non-opencode body changed: %s", out)
+		}
+	})
+
+	t.Run("无 messages 原样", func(t *testing.T) {
+		t.Parallel()
+		a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		a.Credentials = map[string]any{"base_url": "https://opencode.ai/zen/v1"}
+		plain := []byte(`{"model":"x"}`)
+		out, err := OpenCodePrepareUpstreamBody(a, plain)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if string(out) != string(plain) {
+			t.Fatalf("plain body changed: %s", out)
+		}
+	})
+}
+
+func TestParseOpenCodeCreditsError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"no payment method",
+			`{"type":"error","error":{"type":"CreditsError","message":"No payment method. Add a payment method here: https://opencode.ai/workspace/x/billing"}}`,
+			openCodeCreditsNoPaymentMethod,
+		},
+		{
+			"insufficient balance",
+			`{"type":"error","error":{"type":"CreditsError","message":"Insufficient balance. Manage your billing here: https://opencode.ai/workspace/x/billing"}}`,
+			openCodeCreditsInsufficientBalance,
+		},
+		{"非 CreditsError", `{"error":{"type":"invalid_request_error","message":"bad"}}`, ""},
+		{"空 body", `{}`, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			typ, msg := parseOpenCodeCreditsError([]byte(tc.body))
+			if typ != openCodeCreditsErrorType && typ != "" {
+				t.Fatalf("unexpected type %q", typ)
+			}
+			if tc.want != "" && !containsOpenCodeCreditMessage(msg, tc.want) {
+				t.Fatalf("message %q does not contain %q", msg, tc.want)
+			}
+			if tc.want == "" && (typ != "" || msg != "") {
+				t.Fatalf("expected no match, got type=%q msg=%q", typ, msg)
+			}
+		})
+	}
+}
+
+func containsOpenCodeCreditMessage(msg, sub string) bool {
+	return len(msg) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(msg); i++ {
+			if msg[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}


### PR DESCRIPTION
## 背景

opencode zen 网关（opencode.ai/zen/*）作为上游时，通用 openai apikey 路径暴露两个适配缺陷（2026-08-07 实证）：

1. **双端点差异**：/zen/v1（免费端点）serde 要求 message 带顶层 id，带图消息 100% 触发 400 missing field id；/zen/go/v1（Go 计划付费端点）标准 OpenAI 兼容无此要求
2. **CreditsError 无语义**：No payment method / Insufficient balance 被通用路径映射成 generic 502，失效账号不处置、持续参与调度耗尽 failover 配额

## 方案（标准版，用户拍板）

沿用现有 apikey 账号模型，识别完全靠 base_url（无新字段）：

- `openai_opencode_gateway.go`：`IsOpenCodeUpstream` / `OpenCodePlan`（base_url 含 opencode.ai/zen/）；free 档次转发前补 message id（ensureChatMessagesIDs），go 档次原样
- `openai_opencode_errors.go`：CreditsError 识别，No payment method 与 Insufficient balance 均停用账号（BlockAccountScheduling），挂载到 failoverOpenAIUpstreamHTTPError 的 opencode 分支
- raw 直转路径 3b 挂载 OpenCodePrepareUpstreamBody

## 测试

go test -tags=unit ./internal/service/ -run 'TestIsOpenCodeUpstream|TestOpenCodePlan|TestOpenCodePrepareUpstreamBody|TestParseOpenCodeCreditsError' 全 pass；全量 service 单测 ok（176s）

## 后续 TODO（独立跟踪）

models.dev 模型 ID 标准化（网关返回的 zen 模型 ID 需映射到 models.dev 标准 ID）——见 issue #5379 评论。

ref #5379