### PR TITLE
fix(risk-control): 风控后端异常时阻断提示词请求

### DIFF
--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -831,7 +831,14 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 			"endpoint", input.Endpoint,
 			"protocol", input.Protocol,
 			"error", err)
-		return allow, nil
+		return &ContentModerationDecision{
+			Allowed:    false,
+			Blocked:    true,
+			Flagged:    false,
+			Message:    "风控系统暂时不可用，请稍后重试",
+			StatusCode: http.StatusInternalServerError,
+			Action:     ContentModerationActionError,
+		}, nil
 	}
 	if !runtimeSnapshot.riskControlEnabled {
 		slog.Info("content_moderation.skip_feature_disabled",

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -19,6 +19,7 @@ import (
 
 type contentModerationTestSettingRepo struct {
 	values map[string]string
+	err    error
 }
 
 func (r *contentModerationTestSettingRepo) Get(ctx context.Context, key string) (*Setting, error) {
@@ -44,6 +45,9 @@ func (r *contentModerationTestSettingRepo) Set(ctx context.Context, key, value s
 }
 
 func (r *contentModerationTestSettingRepo) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
 	out := map[string]string{}
 	for _, key := range keys {
 		if value, ok := r.values[key]; ok {
@@ -51,6 +55,23 @@ func (r *contentModerationTestSettingRepo) GetMultiple(ctx context.Context, keys
 		}
 	}
 	return out, nil
+}
+
+func TestContentModerationCheck_LoadRuntimeSnapshotFailureBlocks(t *testing.T) {
+	svc := &ContentModerationService{
+		settingRepo: &contentModerationTestSettingRepo{err: fmt.Errorf("settings unavailable")},
+		repo:        &contentModerationTestRepo{},
+	}
+
+	decision, err := svc.Check(context.Background(), ContentModerationCheckInput{UserID: 1})
+
+	require.NoError(t, err)
+	require.False(t, decision.Allowed)
+	require.True(t, decision.Blocked)
+	require.False(t, decision.Flagged)
+	require.Equal(t, ContentModerationActionError, decision.Action)
+	require.Equal(t, "风控系统暂时不可用，请稍后重试", decision.Message)
+	require.Equal(t, http.StatusInternalServerError, decision.StatusCode)
 }
 
 func (r *contentModerationTestSettingRepo) SetMultiple(ctx context.Context, settings map[string]string) error {


### PR DESCRIPTION
## 背景

当风控中心后端异常（配置加载失败）时，当前实现会 fail-open，允许提示词通过。这与前置拦截的设计意图相悖——前置拦截的核心价值在于风控后端异常时阻止请求，而非放行。

Fixes #5388

## 根因

`content_moderation.go` 第 825-834 行的 `Check` 函数在 `loadRuntimeSnapshot` 失败时返回 `allow=true`（fail-open）。

## 改动

- 将 `loadRuntimeSnapshot` 失败时的错误处理从返回 allow 改为返回 block
- 返回的 `ContentModerationDecision` 包含：
  - `Allowed: false`
  - `Blocked: true`
  - `Flagged: false`（系统错误，非违规）
  - `Action: ContentModerationActionError`
  - `Message: "风控系统暂时不可用，请稍后重试"`
  - `StatusCode: 500`
- 添加回归测试 `TestContentModerationCheck_LoadRuntimeSnapshotFailureBlocks`

## 测试

- 新增测试验证 `loadRuntimeSnapshot` 失败时返回 block
- 所有 ContentModeration 相关测试通过