### PR TITLE
fix(openai): 图像能力丢失时冷却 image 调度，不再反复选中坏号

### DIFF
--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -133,6 +133,17 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		return false
 	}
 
+	// Self-built images requests always carry a matching image_generation tool, so a
+	// "tool choice not found in 'tools'" 400 means upstream revoked this account's
+	// image capability. Gated on the self-built marker: passthrough clients control
+	// their own tools/tool_choice and could otherwise poison a healthy account.
+	if isOpenAIImagesSelfBuiltRequest(ctx) && isOpenAIImageCapabilityLossError(statusCode, responseBody) {
+		if s != nil && s.rateLimitService != nil {
+			_ = s.rateLimitService.HandleOpenAIImageCapabilityLoss(stateCtx, account, statusCode, responseBody)
+		}
+		return false
+	}
+
 	if s == nil || account == nil {
 		return false
 	}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -328,6 +328,26 @@ func openAIImageUploadToDataURL(upload OpenAIImagesUpload) (string, error) {
 	return "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(upload.Data), nil
 }
 
+// openAIImagesSelfBuiltRequestContextKey marks a request whose upstream body was
+// fully constructed by buildOpenAIImagesResponsesRequest, i.e. tool_choice and the
+// matching image_generation tool are always both present and never client-controlled.
+type openAIImagesSelfBuiltRequestContextKey struct{}
+
+func withOpenAIImagesSelfBuiltRequest(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, openAIImagesSelfBuiltRequestContextKey{}, true)
+}
+
+func isOpenAIImagesSelfBuiltRequest(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	selfBuilt, _ := ctx.Value(openAIImagesSelfBuiltRequestContextKey{}).(bool)
+	return selfBuilt
+}
+
 func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel string) ([]byte, error) {
 	if parsed == nil {
 		return nil, fmt.Errorf("parsed images request is required")
@@ -1775,6 +1795,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 	if err != nil {
 		return nil, err
 	}
+	upstreamCtx = withOpenAIImagesSelfBuiltRequest(upstreamCtx)
 	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, parsed.StickySessionSeed(), false)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -75,6 +75,8 @@ const (
 const (
 	openAIImageRateLimitDefaultCooldown = time.Minute
 	openAIImageRateLimitReason          = "openai_image_rate_limited"
+	openAIImageCapabilityLossCooldown   = 30 * time.Minute
+	openAIImageCapabilityLossReason     = "openai_image_capability_lost"
 )
 
 var openAIImageTryAgainPattern = regexp.MustCompile(`(?i)try again in\s+([0-9]+(?:\.[0-9]+)?)\s*(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes)`)
@@ -2188,6 +2190,44 @@ func (s *RateLimitService) HandleOpenAIImageRateLimit(ctx context.Context, accou
 	}
 	slog.Info("openai_image_rate_limited", "account_id", account.ID, "scope", openAIImageGenerationRateLimitKey, "reset_at", resetAt, "reset_in", time.Until(resetAt).Truncate(time.Second))
 	return true
+}
+
+func (s *RateLimitService) HandleOpenAIImageCapabilityLoss(ctx context.Context, account *Account, statusCode int, responseBody []byte) bool {
+	if s == nil || account == nil || s.accountRepo == nil {
+		return false
+	}
+	if account.Platform != PlatformOpenAI {
+		return false
+	}
+	if !account.ShouldHandleErrorCode(statusCode) {
+		slog.Info("openai_image_capability_loss_skipped_by_error_code_policy", "account_id", account.ID, "status_code", statusCode)
+		return false
+	}
+	if !isOpenAIImageCapabilityLossError(statusCode, responseBody) {
+		return false
+	}
+
+	resetAt := time.Now().Add(openAIImageCapabilityLossCooldown)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, openAIImageGenerationRateLimitKey, resetAt, openAIImageCapabilityLossReason); err != nil {
+		slog.Warn("openai_image_capability_loss_set_model_rate_limit_failed", "account_id", account.ID, "scope", openAIImageGenerationRateLimitKey, "error", err)
+		return true
+	}
+	slog.Info("openai_image_capability_lost", "account_id", account.ID, "scope", openAIImageGenerationRateLimitKey, "reset_at", resetAt, "reset_in", time.Until(resetAt).Truncate(time.Second))
+	return true
+}
+
+// isOpenAIImageCapabilityLossError reports whether upstream rejected the
+// image_generation tool choice that sub2api itself put into the request body.
+// Only meaningful for self-built images requests, where tools always carries a
+// matching image_generation entry — upstream saying otherwise means the account
+// lost the capability.
+func isOpenAIImageCapabilityLossError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest || len(body) == 0 {
+		return false
+	}
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "image_generation") &&
+		strings.Contains(lower, "not found in 'tools' parameter")
 }
 
 func isOpenAIImageRateLimitError(statusCode int, body []byte) bool {

--- a/backend/internal/service/ratelimit_service_openai_image_test.go
+++ b/backend/internal/service/ratelimit_service_openai_image_test.go
@@ -169,3 +169,120 @@ func TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability(t *t
 	require.Equal(t, openAIImagesOAuthUnavailableReason, call.reason)
 	require.WithinDuration(t, before.Add(openAIImagesOAuthUnavailableCooldown), call.resetAt, time.Second)
 }
+
+func TestOpenAIGatewayServiceForwardImages_CapabilityLossCoolsImageScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &modelNotFoundAccountRepoStub{}
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat"}`)
+	errorBody := `{"error":{"message":"Tool choice 'image_generation' not found in 'tools' parameter.","param":"tool_choice","type":"invalid_request_error"}}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{
+		rateLimitService: &RateLimitService{accountRepo: repo},
+		httpUpstream: &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"X-Request-Id": []string{"req_img_capability_lost"}},
+				Body:       io.NopCloser(strings.NewReader(errorBody)),
+			},
+		},
+	}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	account := &Account{
+		ID:       205,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	before := time.Now()
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, account.ID, call.accountID)
+	require.Equal(t, openAIImageGenerationRateLimitKey, call.scope)
+	require.Equal(t, openAIImageCapabilityLossReason, call.reason)
+	require.WithinDuration(t, before.Add(openAIImageCapabilityLossCooldown), call.resetAt, time.Second)
+}
+
+func TestOpenAIGatewayServiceHandleUpstreamError_PassthroughCapabilityLossDoesNotCool(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &OpenAIGatewayService{rateLimitService: &RateLimitService{accountRepo: repo}}
+	account := &Account{ID: 206, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(`{"error":{"message":"Tool choice 'image_generation' not found in 'tools' parameter.","param":"tool_choice","type":"invalid_request_error"}}`)
+
+	disabled := svc.handleOpenAIAccountUpstreamError(context.Background(), account, http.StatusBadRequest, http.Header{}, body, "gpt-5.5")
+
+	require.False(t, disabled)
+	require.Empty(t, repo.modelRateLimitCalls)
+	_, wholeAccountBlocked := svc.openaiAccountRuntimeBlockUntil.Load(account.ID)
+	require.False(t, wholeAccountBlocked)
+}
+
+func TestRateLimitServiceHandleOpenAIImageCapabilityLoss_IgnoresGenericBadRequest(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := &Account{ID: 207, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(`{"error":{"message":"Invalid type for input[0].arguments"}}`)
+
+	handled := svc.HandleOpenAIImageCapabilityLoss(context.Background(), account, http.StatusBadRequest, body)
+
+	require.False(t, handled)
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
+func TestRateLimitServiceHandleOpenAIImageCapabilityLoss_RespectsPlatformAndErrorCodePolicy(t *testing.T) {
+	body := []byte(`{"error":{"message":"Tool choice 'image_generation' not found in 'tools' parameter.","param":"tool_choice","type":"invalid_request_error"}}`)
+
+	t.Run("non_openai_platform", func(t *testing.T) {
+		repo := &modelNotFoundAccountRepoStub{}
+		svc := &RateLimitService{accountRepo: repo}
+		account := &Account{ID: 208, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+		handled := svc.HandleOpenAIImageCapabilityLoss(context.Background(), account, http.StatusBadRequest, body)
+
+		require.False(t, handled)
+		require.Empty(t, repo.modelRateLimitCalls)
+	})
+
+	t.Run("custom_error_code_policy_excludes_400", func(t *testing.T) {
+		repo := &modelNotFoundAccountRepoStub{}
+		svc := &RateLimitService{accountRepo: repo}
+		account := &Account{
+			ID:       209,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"custom_error_codes_enabled": true,
+				"custom_error_codes":         []any{float64(http.StatusTooManyRequests)},
+			},
+		}
+
+		require.False(t, account.ShouldHandleErrorCode(http.StatusBadRequest))
+		handled := svc.HandleOpenAIImageCapabilityLoss(context.Background(), account, http.StatusBadRequest, body)
+
+		require.False(t, handled)
+		require.Empty(t, repo.modelRateLimitCalls)
+	})
+}
+
+func TestIsOpenAIImageCapabilityLossError(t *testing.T) {
+	capabilityLossBody := []byte(`{"error":{"message":"Tool choice 'image_generation' not found in 'tools' parameter.","param":"tool_choice","type":"invalid_request_error"}}`)
+	genericBadRequestBody := []byte(`{"error":{"message":"Invalid type for input[0].arguments"}}`)
+
+	require.True(t, isOpenAIImageCapabilityLossError(http.StatusBadRequest, capabilityLossBody))
+	require.False(t, isOpenAIImageCapabilityLossError(http.StatusBadRequest, genericBadRequestBody))
+	require.False(t, isOpenAIImageCapabilityLossError(http.StatusTooManyRequests, capabilityLossBody))
+}


### PR DESCRIPTION
## 问题

Fixes #4466

OAuth 账号被上游收走 `image_generation` 能力后，`/v1/images/*` 会稳定返回同一句 400：

```json
{"error":{"message":"Tool choice 'image_generation' not found in 'tools' parameter.","param":"tool_choice","type":"invalid_request_error"}}
```

但网关不做任何处置，坏号持续被排程选中（报告者实测连续 17 次同 body 400、窗口内 0 成功、持续 3.5 小时，直到人工停调度）。issue 报的是 v0.1.157，当前 main 行为一致。

## 根因

- `internal/service/ratelimit_service.go` 的 `case 400:` 是**白名单式**，只认 `organization has been disabled`、Anthropic `credit balance`、`identity verification is required` 三句，并明确注释「其他 400 错误（如参数问题）不处理，不禁用账号」。
- 唯一能兜任意 400 的 `tryTempUnschedulable` 要求 `account.IsTempUnschedulableEnabled()`，OAuth 账号默认没开这个开关。

两条路都不命中 ⇒ `shouldDisable` 恒为 false，且没有任何 model 作用域冷却 ⇒ 坏号恒可被选中。

## 修复

**收窄到 sub2api 自建 body 的 images 管线**，而不是在共用错误入口做全局签名匹配。

`buildOpenAIImagesResponsesRequest` 产出的 body **必定同时带** `tool_choice: {"type":"image_generation"}` 与匹配的 `image_generation` tool（该函数硬编 tool_choice、并总是写入 tools 数组）。因此这条路上出现该 400，只可能是上游收走了这颗账号的能力。

实现：

1. `forwardOpenAIImagesOAuth` 在 body 构造成功后，于 `upstreamCtx` 上打一个自建标记（`withOpenAIImagesSelfBuiltRequest`）。该 ctx 覆盖此函数下游全部三个错误分支（`handleFailoverSideEffects` / `handleOpenAIImagesErrorResponse` / `handleOpenAIImagesOAuthResponseError`）。
2. `handleOpenAIAccountUpstreamError` 读标记，仅在标记为真时把该 400 判为能力丢失。
3. 处置对齐既有同族先例 `HandleOpenAIImageRateLimit`：对 `openai:image_generation` 作用域下 `SetModelRateLimit` 冷却 **30 分钟**（与语义最接近的 `upstreamModelNotFoundCooldown` 一致），**不禁用整颗账号**——上游收的是 image 能力，账号对文本请求依然健康。

### 为什么不采用 issue 建议①（在 400 白名单加全局签名匹配）

`handleOpenAIAccountUpstreamError` 是共用入口，同时服务 passthrough 路径（`openai_gateway_passthrough.go`），那里的请求 body 由客户端自由填写。客户端只要送一个「`tool_choice` 指 `image_generation`、但 `tools` 不带」的请求，上游就返回**一字不差的同一句 400** —— 全局签名匹配等于任何一个 API 用户都能用一句话废掉一颗健康账号。

这不是理论推演：本 PR 的测试 #2 就是钉死这个边界的，撤掉 ctx 闸门后它会实测失败（见下方红→绿证明第 2 段）。

### 关于 issue 建议②（连续 N 次 400 且零成功熔断）

本 PR 不做。跨请求状态 + 需要配置项 + 前后端 i18n，面积远超一个 bug fix，且与本修复正交。留待另议。

## 影响面收敛

- 标记只在 `forwardOpenAIImagesOAuth` 一处写入，`forwardOpenAIImagesAPIKey` 与其余 12 个 `handleOpenAIAccountUpstreamError` 生产调用点均不受影响。
- 未改动 `case 400:` 白名单，既有 400 语义零变更。
- 新判断式要求 `statusCode == 400` 且 body 同时含 `image_generation` 与 `not found in 'tools' parameter`，一般参数型 400 不误伤。
- 沿用 `HandleOpenAIImageRateLimit` 的两道前置闸（`Platform != PlatformOpenAI` / `ShouldHandleErrorCode`）。
- 即使签名判断有偏差，最坏后果是 30 分钟的 image-only 冷却，不会杀账号。

## 测试

新增 5 个测试（`ratelimit_service_openai_image_test.go`，既有测试未改动，仅追加）：

| 测试 | 覆盖 |
|------|------|
| `TestOpenAIGatewayServiceForwardImages_CapabilityLossCoolsImageScope` | **端到端**走 `ForwardImages` OAuth 路径，验证 scope / reason / 30 分钟 resetAt |
| `TestOpenAIGatewayServiceHandleUpstreamError_PassthroughCapabilityLossDoesNotCool` | **同一份 body** 走无标记路径 → 不冷却、不禁用（防毒杀） |
| `TestRateLimitServiceHandleOpenAIImageCapabilityLoss_IgnoresGenericBadRequest` | 一般参数型 400 不误伤 |
| `TestRateLimitServiceHandleOpenAIImageCapabilityLoss_RespectsPlatformAndErrorCodePolicy` | 非 OpenAI 平台 / 自定义错误码策略排除 400 |
| `TestIsOpenAIImageCapabilityLossError` | 纯签名判断正反例（含 429 同句话不命中） |

### 红→绿证明（三段定向注入，逐条对应本 PR 宣称的不变式）

| 注入 | 期望 | 实测 |
|------|------|------|
| 撤掉 `handleOpenAIAccountUpstreamError` 里的挂钩 | 端到端测试失败 | ✅ `"[]" should have 1 item(s), but has 0`（坏号完全没被冷却，复现 issue 症状） |
| 只拆掉 ctx 闸门（＝退化成建议①的全局匹配） | 防毒杀测试失败 | ✅ `Should be empty, but was [{206 openai:image_generation ... openai_image_capability_lost}]`（passthrough 请求真的冷却了健康账号） |
| 撤掉 `forwardOpenAIImagesOAuth` 的标记写入 | 端到端测试失败 | ✅ `"[]" should have 1 item(s), but has 0` |

三段还原后 5/5 全绿。

### 其他验证

- `go test -tags=unit ./internal/service/ -count=1` → `ok 147.755s`
- `go test -tags=unit ./... -count=1` → exit 0，0 个 FAIL，51 个包 ok
- `go build ./...` → exit 0
- `gofmt -l`（4 个改动文件）→ 空
- `go vet -tags unit ./internal/service/` → exit 0

（Go 1.26.5，与 `go.mod` 一致）

## 查重与已知限制

- 查重：`repo:Wei-Shaw/sub2api is:pr 4466 in:body` 无命中；issue 自 2026-07-17 开启至今 0 comment、无 assignee。
- 已知限制：冷却时长 30 分钟为固定值（对齐 `upstreamModelNotFoundCooldown`），未做成配置项；若维护者希望可配置，可另开 PR 照 429 冷却配置化的既有范式补。
- 本 PR 未接触 `/v1/images/generations` 以外的自建 body 路径 —— 已排查全部 13 个 `handleOpenAIAccountUpstreamError` 生产调用点，只有 images OAuth 管线会自建带 `image_generation` tool_choice 的 body（`openai_codex_transform.go` 的 `normalizeOpenAIResponsesImageOnlyModel` 虽也补 `tool_choice`，但它同时保证 tools 数组内有对应 tool，不会产生本类 400）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
