### PR TITLE
fix(apicompat): Responses→Anthropic 转换不再发出上游会拒收的 content block

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic_invalid_blocks_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_invalid_blocks_test.go
@@ -1,0 +1,207 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// anthropicInboundBlockTypes 是 Anthropic Messages 请求体里合法的 content block
+// 类型。转换结果只能落在这个集合内——发出集合外的类型，上游一律回
+// 400 "Request body format invalid"（见 issue #5329）。
+var anthropicInboundBlockTypes = map[string]bool{
+	"text":              true,
+	"image":             true,
+	"document":          true,
+	"tool_use":          true,
+	"tool_result":       true,
+	"thinking":          true,
+	"redacted_thinking": true,
+}
+
+func responsesToAnthropicMessages(t *testing.T, input string) []AnthropicMessage {
+	t.Helper()
+	var req ResponsesRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"model":"glm-5.2","input":`+input+`}`), &req))
+	out, err := ResponsesToAnthropicRequest(&req)
+	require.NoError(t, err)
+	return out.Messages
+}
+
+// requireAnthropicMessagesAreSendable 断言消息序列不含 Anthropic 会拒收的形态：
+// 未知 block 类型、空内容消息、纯空白 text 块。
+func requireAnthropicMessagesAreSendable(t *testing.T, messages []AnthropicMessage) {
+	t.Helper()
+	for i, m := range messages {
+		raw := strings.TrimSpace(string(m.Content))
+		require.NotContains(t, []string{"", "null", `""`, "[]"}, raw,
+			"messages[%d] 内容为空，Anthropic 拒收空内容消息", i)
+
+		var s string
+		if err := json.Unmarshal(m.Content, &s); err == nil {
+			require.NotEmpty(t, strings.TrimSpace(s), "messages[%d] 字符串内容不能全为空白", i)
+			continue
+		}
+		blocks := parseContentBlocks(m.Content)
+		require.NotEmpty(t, blocks, "messages[%d] 解析不出任何 block", i)
+		for j, b := range blocks {
+			require.True(t, anthropicInboundBlockTypes[b.Type],
+				"messages[%d].content[%d] 是 Anthropic 不认识的 block 类型 %q", i, j, b.Type)
+			if b.Type == "text" {
+				require.NotEmpty(t, strings.TrimSpace(b.Text),
+					"messages[%d].content[%d] 是空白 text 块，Anthropic 拒收", i, j)
+			}
+		}
+	}
+}
+
+// issue #5329：工具执行后的下一轮，Codex 会把 reasoning item 一起回放。
+// 该 item 带 content 数组时，reasoning_text 块以前会被原样塞进 Anthropic 请求体。
+func TestResponsesToAnthropic_ReasoningItemWithContentIsDropped(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"run a shell command"}]},
+		{"type":"reasoning","id":"rs_1","summary":[],"content":[{"type":"reasoning_text","text":"let me think"}]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Len(t, messages, 1)
+	require.NotContains(t, string(messages[0].Content), "reasoning_text")
+	require.NotContains(t, string(messages[0].Content), "let me think")
+}
+
+// Codex 的常见 reasoning 形态（只有 summary + encrypted_content）本来就会被丢弃，
+// 这条守卫确保行为没有被改变。
+func TestResponsesToAnthropic_ReasoningItemSummaryOnlyStillDropped(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+		{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"s"}],"encrypted_content":"gAAAA"}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Len(t, messages, 1)
+	require.NotContains(t, string(messages[0].Content), "gAAAA")
+}
+
+// 未知 item type 的 content 以前会被逐字透传，把 Responses 专有分片带进上游请求。
+func TestResponsesToAnthropic_UnknownItemTypeContentIsSanitized(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"web_search_call","id":"ws_1","content":[{"type":"web_search_result","text":"payload"}]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Empty(t, messages, "整条内容都无法映射时不应发出消息")
+}
+
+// 未知 item type 里夹带的可识别文本仍然保留，不做无谓丢弃。
+func TestResponsesToAnthropic_UnknownItemTypeKeepsRecognizableText(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"some_future_item","content":[
+			{"type":"input_text","text":"keep me"},
+			{"type":"reasoning_text","text":"drop me"}
+		]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Len(t, messages, 1)
+	require.Contains(t, string(messages[0].Content), "keep me")
+	require.NotContains(t, string(messages[0].Content), "drop me")
+}
+
+// user 消息的分片全部不可识别时，以前会退化成 content:""，Anthropic 拒收空内容消息。
+func TestResponsesToAnthropic_UserMessageWithOnlyUnknownPartsIsDropped(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"message","role":"user","content":[{"type":"input_file","file_id":"file_1"}]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Empty(t, messages)
+}
+
+// assistant 侧同理：以前会退化成单个空 text 块，Anthropic 同样拒收。
+func TestResponsesToAnthropic_AssistantMessageWithOnlyUnknownPartsIsDropped(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+		{"type":"message","role":"assistant","content":[{"type":"refusal","refusal":"no"}]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+	require.Len(t, messages, 1)
+	require.Equal(t, "user", messages[0].Role)
+}
+
+// 完整的 Codex 工具续接回放：tool_use / tool_result 配对必须保持不变，
+// 同时整个序列满足可发送不变式。
+func TestResponsesToAnthropic_CodexToolRoundStaysIntactAndSendable(t *testing.T) {
+	messages := responsesToAnthropicMessages(t, `[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"run ls"}]},
+		{"type":"reasoning","id":"rs_1","summary":[],"content":[{"type":"reasoning_text","text":"plan"}],"encrypted_content":"gAAAA"},
+		{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{\"cmd\":\"ls\"}"},
+		{"type":"function_call_output","call_id":"call_1","output":"file1"},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+	]`)
+
+	requireAnthropicMessagesAreSendable(t, messages)
+
+	var sawToolUse, sawToolResult bool
+	for _, m := range messages {
+		for _, b := range parseContentBlocks(m.Content) {
+			switch b.Type {
+			case "tool_use":
+				sawToolUse = true
+				require.Equal(t, "call_1", b.ID)
+				require.Equal(t, "shell", b.Name)
+			case "tool_result":
+				sawToolResult = true
+				require.Equal(t, "call_1", b.ToolUseID)
+			}
+		}
+	}
+	require.True(t, sawToolUse, "function_call 必须转成 tool_use")
+	require.True(t, sawToolResult, "function_call_output 必须转成 tool_result")
+	require.NotContains(t, string(mustMarshal(t, messages)), "reasoning_text")
+	require.NotContains(t, string(mustMarshal(t, messages)), "gAAAA")
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func TestAnthropicContentIsEmpty(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{``, true},
+		{`""`, true},
+		{`null`, true},
+		{`[]`, true},
+		{`  []  `, true},
+		{`"hi"`, false},
+		{`[{"type":"text","text":"hi"}]`, false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, anthropicContentIsEmpty(json.RawMessage(tc.raw)), "raw=%q", tc.raw)
+	}
+}
+
+func TestAnthropicContentIsOnlyBlankText(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{`[{"type":"text","text":""}]`, true},
+		{`[{"type":"text","text":"   "}]`, true},
+		{`[{"type":"text","text":""},{"type":"text","text":" "}]`, true},
+		{`[{"type":"text","text":"hi"}]`, false},
+		{`[{"type":"text","text":""},{"type":"image","source":{}}]`, false},
+		{`[]`, false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, anthropicContentIsOnlyBlankText(json.RawMessage(tc.raw)), "raw=%q", tc.raw)
+	}
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -164,10 +164,23 @@ func convertResponsesInputToAnthropic(instructions string, inputRaw json.RawMess
 				Content: blockJSON,
 			})
 
+		case item.Type == "reasoning":
+			// Anthropic 无法摄入 OpenAI 的 reasoning：encrypted_content 是不透明的，
+			// 而 thinking 块的重放需要 Anthropic 自己签发的 signature，无法伪造。
+			// Codex 常见形态（只带 summary + encrypted_content）本来就会被丢弃，
+			// 这里让带 content 数组的形态保持同样行为——否则 reasoning_text 块会被
+			// 原样塞进 Anthropic 请求体，上游直接回 400。
+
 		case item.Role == "user":
 			content, err := convertResponsesUserToAnthropicContent(item.Content)
 			if err != nil {
 				return nil, nil, err
+			}
+			// 内容里只有网关不认识的分片时，sanitize 会得到空串。Anthropic 拒收
+			// 空内容消息（"all messages must have non-empty content"），整条丢掉
+			// 比发一条必然 400 的消息更可用。
+			if anthropicContentIsEmpty(content) {
+				continue
 			}
 			messages = append(messages, AnthropicMessage{
 				Role:    "user",
@@ -179,19 +192,35 @@ func convertResponsesInputToAnthropic(instructions string, inputRaw json.RawMess
 			if err != nil {
 				return nil, nil, err
 			}
+			// 同上：分片全不认识时会退化成单个空 text 块，而 Anthropic 拒收
+			// 空文本块（"text content blocks must contain non-whitespace text"）。
+			if anthropicContentIsEmpty(content) || anthropicContentIsOnlyBlankText(content) {
+				continue
+			}
 			messages = append(messages, AnthropicMessage{
 				Role:    "assistant",
 				Content: content,
 			})
 
 		default:
-			// Unknown role/type — attempt as user message
-			if item.Content != nil {
-				messages = append(messages, AnthropicMessage{
-					Role:    "user",
-					Content: item.Content,
-				})
+			// 未知 role/type —— 尽量当作 user 消息保留其中的文本/图片。
+			// 必须走与真实 user 消息同一套白名单转换：直接透传 item.Content 会把
+			// Responses 专有的分片类型（reasoning_text、web_search_call 的载荷等）
+			// 原样发给 Anthropic，上游只会回 400 把整轮打挂。
+			if item.Content == nil {
+				continue
 			}
+			content, err := convertResponsesUserToAnthropicContent(item.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			if anthropicContentIsEmpty(content) {
+				continue
+			}
+			messages = append(messages, AnthropicMessage{
+				Role:    "user",
+				Content: content,
+			})
 		}
 	}
 
@@ -393,6 +422,32 @@ func extractTextFromContent(raw json.RawMessage) string {
 
 // convertResponsesUserToAnthropicContent converts a Responses user message
 // content field into Anthropic content blocks JSON.
+// anthropicContentIsEmpty 判断转换结果是否为"空内容"。
+// convertResponsesUserToAnthropicContent 在没有任何可识别分片时返回 JSON 空串，
+// 而 Anthropic 拒收空内容消息。
+func anthropicContentIsEmpty(content json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(content))
+	switch trimmed {
+	case "", "null", `""`, "[]":
+		return true
+	}
+	return false
+}
+
+// anthropicContentIsOnlyBlankText 判断内容是否只由空白 text 块组成。
+func anthropicContentIsOnlyBlankText(content json.RawMessage) bool {
+	blocks := parseContentBlocks(content)
+	if len(blocks) == 0 {
+		return false
+	}
+	for _, b := range blocks {
+		if b.Type != "text" || strings.TrimSpace(b.Text) != "" {
+			return false
+		}
+	}
+	return true
+}
+
 func convertResponsesUserToAnthropicContent(raw json.RawMessage) (json.RawMessage, error) {
 	if len(raw) == 0 {
 		return json.Marshal("") // empty string content


### PR DESCRIPTION
## 背景

Fixes #5329

issue 报的是 Codex `/v1/responses` → Anthropic `/v1/messages`（阿里云 GLM-5.2）时，普通对话和第一次工具调用正常，但**工具执行完成后的下一轮**开始固定返回 `400 Request body format invalid`，而且此后同一会话里发普通消息也一直失败。报告者列了一串怀疑点但拿不到脱敏后的实际请求体，无法定位。

我把 Codex 形态的多轮请求体喂进 `ResponsesToAnthropicRequest` 实测了一遍，找到了确定的原因。

## 根因

`convertResponsesInputToAnthropic` 的 `default` 分支把未知 item 的 `content` **逐字透传**成 Anthropic user 消息：

```go
default:
    // Unknown role/type — attempt as user message
    if item.Content != nil {
        messages = append(messages, AnthropicMessage{Role: "user", Content: item.Content})
    }
```

`type=reasoning` 正好落进这个分支。Codex 在工具执行后回放的 reasoning item 带 `content` 数组时，转换结果是：

```json
{"role":"user","content":[
  {"text":"run a shell command","type":"text"},
  {"type":"reasoning_text","text":"let me think"}     ← Anthropic 不认识
]}
```

`reasoning_text` 不是合法的 Anthropic content block，上游直接拒收整个请求体。而 reasoning item 会一直留在会话历史里被回放，所以**一旦出现就每轮都失败**——正好对上 issue 描述的"第一轮正常，工具执行后开始固定 400，之后普通消息也一直错"。

顺着这条线还测出同类的另外两处（都会产出 Anthropic 拒收的形态）：

| 输入形态 | 修复前的转换结果 | 上游反应 |
|:--|:--|:--|
| `reasoning` 带 `content` 数组 | 混入 `reasoning_text` 块 | 未知 block 类型 → 400 |
| 未知 item type 带 `content` | 原样透传该数组 | 未知 block 类型 → 400 |
| user 消息分片全不可识别 | `{"role":"user","content":""}` | 空内容消息 → 400 |
| assistant 消息分片全不可识别 | `[{"type":"text","text":""}]` | 空白 text 块 → 400 |

后两条来自 `convertResponsesUserToAnthropicContent` / `convertResponsesAssistantToAnthropicContent` 的白名单在没命中任何分片时的兜底返回值，调用方没做空值判断。

## 改动

只动 `backend/internal/pkg/apicompat/responses_to_anthropic_request.go`：

- **`type=reasoning` 显式跳过**。Anthropic 无法摄入 OpenAI 的 reasoning：`encrypted_content` 是不透明的，`thinking` 块的重放又需要 Anthropic 自己签发的 `signature`，网关伪造不出来。Codex 的常见形态（只有 `summary` + `encrypted_content`，没有 `content`）本来就会被丢弃，这次让带 `content` 的形态保持同样行为，而不是走 default 逐字透传。
- **`default` 分支改走 `convertResponsesUserToAnthropicContent`**，也就是真实 user 消息用的同一套白名单转换：`input_text`/`text`/`input_image` 保留，其余分片丢弃。未知 item 里夹带的可识别文本仍然会保留，不做无谓丢弃。
- **user / assistant 分支在转换结果为空内容或纯空白文本时跳过该消息**，不再发出必然被拒的空消息。新增两个小判定 `anthropicContentIsEmpty` / `anthropicContentIsOnlyBlankText`。

## 兼容性说明

- **正常 Codex 工具续接完全不受影响**：`function_call` → `tool_use`、`function_call_output` → `tool_result` 的转换和 `normalizeAnthropicToolPairing` 的配对修复都没有改动，测试里有完整回放的断言。
- **只有原本就会被上游拒收的形态才改变行为**。可识别的文本/图片一律保留。
- reasoning 的丢弃不是新行为：Codex 的主流形态本来就在丢，这次只是让带 `content` 的变体一致。
- 没有改响应侧转换，没有改工具 schema 转换，没有改 system/instructions 合并。

## 本次未包含（说明理由）

- **没有把 OpenAI reasoning 转成 Anthropic `thinking` 块**。`thinking` 的多轮重放要求携带 Anthropic 签发的 `signature`，从 Responses 侧拿不到；伪造只会换一个 400。
- **没有加 issue 里建议的"脱敏调试选项查看转换后请求体"**。那是新的运维能力（要定脱敏范围、开关位置、权限），属于产品决策，不适合夹带在缺陷修复里。
- **没有扩到 `/v1/chat/completions` 入站桥接**。那条路的 `normalizeChatMessages` 是独立实现，报告的是 Responses 入站，先不扩大范围。

## 测试

新增 `responses_to_anthropic_invalid_blocks_test.go`：

核心是一个可复用的不变式断言 `requireAnthropicMessagesAreSendable`——遍历转换结果，要求每个 block 的类型落在 Anthropic 合法集合内（`text`/`image`/`document`/`tool_use`/`tool_result`/`thinking`/`redacted_thinking`），且没有空内容消息、没有空白 text 块。9 个用例：

- `ReasoningItemWithContentIsDropped` —— issue 的直接复现形态，断言 `reasoning_text` 与其文本都不出现在结果里
- `ReasoningItemSummaryOnlyStillDropped` —— 守卫 Codex 主流形态行为不变，`encrypted_content` 不泄漏
- `UnknownItemTypeContentIsSanitized` —— 未知 item 的载荷不再逐字透传
- `UnknownItemTypeKeepsRecognizableText` —— 未知 item 里的 `input_text` 仍然保留，只丢不可识别的分片
- `UserMessageWithOnlyUnknownPartsIsDropped` / `AssistantMessageWithOnlyUnknownPartsIsDropped` —— 不再产出空内容消息
- `CodexToolRoundStaysIntactAndSendable` —— 完整工具续接回放，断言 `tool_use`/`tool_result` 的 id、name 配对不变，同时满足可发送不变式
- `TestAnthropicContentIsEmpty` / `TestAnthropicContentIsOnlyBlankText` —— 两个判定的边界表

本地运行：

```bash
go build ./...
go test -tags=unit ./internal/pkg/apicompat/ -count=1
go test -tags=unit ./internal/pkg/... ./internal/service/ -count=1
go test -tags=unit ./internal/handler/ -count=1
go test -tags=integration ./... -count=1
go vet ./internal/pkg/apicompat/
gofmt -l internal/pkg/apicompat/
```

全部通过，`apicompat` 既有的 Responses→Anthropic 测试（tool_use、parallel tool、read tool、instructions、cache_creation、cc chain、tool pairing）无一被翻转。golangci-lint v2.9 本地装不上（v2.9.0 自身用 go1.25 构建，低于本仓库 go.mod 的 1.26.5，启动即报错），这一项交给 CI。
