### PR TITLE
fix(openai): inject retryable detail into empty ws error events

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_error_detail_test.go
+++ b/backend/internal/service/openai_ws_forwarder_error_detail_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestEnsureOpenAIWSErrorEventClientDetail(t *testing.T) {
+	t.Run("injects retryable detail into empty error object", func(t *testing.T) {
+		message := []byte(`{"type":"error","error":{}}`)
+		updated, changed := ensureOpenAIWSErrorEventClientDetail(message)
+		if !changed {
+			t.Fatalf("expected empty error event to be rewritten")
+		}
+		if got := gjson.GetBytes(updated, "error.code").String(); got != openAICapacityShedRetryableClientCode {
+			t.Fatalf("error.code = %q, want %q", got, openAICapacityShedRetryableClientCode)
+		}
+		if got := gjson.GetBytes(updated, "error.message").String(); !strings.Contains(got, "You can retry your request") {
+			t.Fatalf("error.message = %q, want retry guidance", got)
+		}
+		if got := gjson.GetBytes(updated, "type").String(); got != "error" {
+			t.Fatalf("event type mutated to %q", got)
+		}
+	})
+
+	t.Run("injects when error object is missing entirely", func(t *testing.T) {
+		message := []byte(`{"type":"error"}`)
+		updated, changed := ensureOpenAIWSErrorEventClientDetail(message)
+		if !changed {
+			t.Fatalf("expected error event without error object to be rewritten")
+		}
+		if got := gjson.GetBytes(updated, "error.message").String(); got == "" {
+			t.Fatalf("expected injected error.message")
+		}
+	})
+
+	t.Run("keeps upstream detail verbatim", func(t *testing.T) {
+		message := []byte(`{"type":"error","error":{"code":"rate_limit_exceeded","message":"slow down"}}`)
+		updated, changed := ensureOpenAIWSErrorEventClientDetail(message)
+		if changed {
+			t.Fatalf("expected populated error event to pass through unchanged")
+		}
+		if string(updated) != string(message) {
+			t.Fatalf("payload mutated: %s", updated)
+		}
+	})
+
+	t.Run("keeps events with only a type populated", func(t *testing.T) {
+		message := []byte(`{"type":"error","error":{"type":"server_error"}}`)
+		if _, changed := ensureOpenAIWSErrorEventClientDetail(message); changed {
+			t.Fatalf("expected error event with populated type to pass through unchanged")
+		}
+	})
+
+	t.Run("leaves invalid json untouched", func(t *testing.T) {
+		message := []byte(`not-json`)
+		updated, changed := ensureOpenAIWSErrorEventClientDetail(message)
+		if changed || string(updated) != "not-json" {
+			t.Fatalf("expected invalid payload to pass through unchanged")
+		}
+	})
+}

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -966,6 +966,17 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 
 			if !clientDisconnected {
+				if eventType == "error" {
+					if updated, changed := ensureOpenAIWSErrorEventClientDetail(upstreamMessage); changed {
+						upstreamMessage = updated
+						logOpenAIWSModeInfo(
+							"ingress_error_event_detail_injected account_id=%d turn=%d conn_id=%s",
+							account.ID,
+							turn,
+							truncateOpenAIWSLogValue(lease.ConnID(), openAIWSIDValueMaxLen),
+						)
+					}
+				}
 				if needModelReplace && len(mappedModelBytes) > 0 && openAIWSEventMayContainModel(eventType) && bytes.Contains(upstreamMessage, mappedModelBytes) {
 					upstreamMessage = replaceOpenAIWSMessageModel(upstreamMessage, mappedModel, originalModel)
 				}

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -195,6 +195,39 @@ func payloadAsJSONBytes(payload map[string]any) []byte {
 	return body
 }
 
+// openAIWSEmptyErrorClientMessage is injected into upstream `error` events that
+// carry no code/type/message before they are forwarded to a client. The phrase
+// "You can retry your request" mirrors OpenAI's own transient-failure wording so
+// downstream retry classifiers treat the failure as retryable.
+const openAIWSEmptyErrorClientMessage = "Upstream provider returned an error without details. You can retry your request."
+
+// ensureOpenAIWSErrorEventClientDetail rewrites an upstream `error` event whose
+// error object has no code/type/message before forwarding it to a client.
+// Strict SDK clients (e.g. openai-node) stringify the empty error object into
+// the literal message "{}", which no downstream retry classifier can recognize,
+// so a transient upstream failure terminates the client session instead of
+// being retried. Like sanitizeOpenAICapacityShedErrorCodeForClient, this only
+// changes the client-facing copy: monitoring, account-state and failover
+// decisions all run on the original payload.
+func ensureOpenAIWSErrorEventClientDetail(message []byte) ([]byte, bool) {
+	code, errType, errMsg := parseOpenAIWSErrorEventFields(message)
+	if code != "" || errType != "" || errMsg != "" {
+		return message, false
+	}
+	if !gjson.ValidBytes(message) {
+		return message, false
+	}
+	updated, err := sjson.SetBytes(message, "error", map[string]any{
+		"code":    openAICapacityShedRetryableClientCode,
+		"type":    "server_error",
+		"message": openAIWSEmptyErrorClientMessage,
+	})
+	if err != nil {
+		return message, false
+	}
+	return updated, true
+}
+
 func isOpenAIWSTerminalEvent(eventType string) bool {
 	switch strings.TrimSpace(eventType) {
 	case "response.completed", "response.done", "response.failed", "response.incomplete", "response.cancelled", "response.canceled":

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -634,7 +634,17 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 			setOpsUpstreamError(c, statusCode, errMsg, "")
 			if reqStream && !clientDisconnected {
 				flushBufferedStreamEvents("error_event")
-				emitStreamMessage(message, true)
+				clientMessage := message
+				if updated, changed := ensureOpenAIWSErrorEventClientDetail(message); changed {
+					clientMessage = updated
+					logOpenAIWSModeInfo(
+						"error_event_detail_injected account_id=%d conn_id=%s idx=%d",
+						account.ID,
+						connID,
+						eventCount,
+					)
+				}
+				emitStreamMessage(clientMessage, true)
 			}
 			if !reqStream {
 				c.JSON(statusCode, gin.H{


### PR DESCRIPTION
## 问题

OpenAI WS 上游在部分瞬时失败时推送的 `error` 事件错误体是空的（`{"type":"error","error":{}}`），真实错误文案只出现在其后的 `response.failed` 终止帧里。v2 ws→SSE 桥（`emitStreamMessage` 仅写 `data:` 行）与 ws ingress 都将空信封原样转发。

严格的 SDK 客户端（如 openai-node）在收到首个 `error` 事件时立即抛异常终止读流——异常消息是对空 error 对象的 `JSON.stringify`，即字面量 **`"{}"`**：

- 客户端**永远读不到**后面携带真实文案的 `response.failed`
- `"{}"` 无法命中任何下游重试分类器 → 本可重试的瞬时失败直接终止会话
- 服务端同样解析不出细节（`parseOpenAIWSErrorEventFields` 读嵌套 `error.*` 也是空），ops 错误日志无记录，问题不可观测

实测场景：high-reasoning 长请求 ~45s 后上游失败，客户端侧只见 `"{}"`，agent 会话静默无回答；同一错误当文案完整到达时（HTTP 直连路径），客户端重试分类器正常识别并重试成功。

## 修复

仅当 `error` 事件的 error 对象完全没有 code/type/message 时，改写**发给客户端的副本**：注入 `code=server_error` + OpenAI 同款重试文案（"You can retry your request"）。与既有 `sanitizeOpenAICapacityShedErrorCodeForClient` 同一思路：

- 上游带任何细节的事件**原样透传**，不覆盖
- 监控、账号状态、failover 判定仍基于原始 payload
- v2 桥与 ingress 两条客户端路径同步生效，注入时打日志（`error_event_detail_injected`）

## 测试

- 新增 `openai_ws_forwarder_error_detail_test.go`（空对象注入 / 缺 error 键注入 / 有细节透传 / 仅 type 透传 / 非法 JSON 不动）
- `go test ./internal/service/ -run OpenAIWS` 全绿