### PR TITLE
fix(openai): 非流式生图脱钩上游 context，客户端断开不再导致图已出却不扣费

### DIFF
--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -601,7 +601,12 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 	if err != nil {
 		return nil, err
 	}
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
+	// 生图是长耗时、上游侧已产生实际成本的操作：客户端中途断开不应连带取消上游请求。
+	// detachStreamUpstreamContext 在非流式时原样返回请求 context，于是客户端一断开
+	// 就把已经在出图的上游调用打断成 context canceled，网关记 502、不扣费，而上游那边
+	// 图已经生成并计费。同一端点的 OAuth 分支 forwardOpenAIImagesOAuth 以及 Grok 媒体
+	// 路径本来就无条件脱钩，这里对齐；上游侧仍由 ResponseHeaderTimeout 兜底。
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 	defer releaseUpstreamCtx()
 
 	token, _, err := s.GetAccessToken(upstreamCtx, account)

--- a/backend/internal/service/openai_images_upstream_context_test.go
+++ b/backend/internal/service/openai_images_upstream_context_test.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+func newOpenAIImagesTestContext(t *testing.T, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	return c, rec
+}
+
+func newOpenAIImagesTestService(upstream HTTPUpstream) *OpenAIGatewayService {
+	return &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg: &config.Config{
+			Security: config.SecurityConfig{
+				URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+			},
+		},
+	}
+}
+
+func newOpenAIImagesAPIKeyAccount() *Account {
+	return &Account{
+		ID:       31,
+		Name:     "openai-apikey-images",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.openai.com/v1",
+		},
+	}
+}
+
+func openAIImagesJSONResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Request-Id": []string{"req_img_ctx"},
+		},
+		Body: io.NopCloser(strings.NewReader(
+			`{"created":1710000000,"data":[{"b64_json":"aGVsbG8="}],"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}`,
+		)),
+	}
+}
+
+// issue #5411：生图是长耗时、上游侧已经产生实际成本的操作。客户端中途断开时，
+// 如果连带取消上游请求，就会出现「上游已出图并计费、网关记 502 context canceled、
+// 用户不扣费」。非流式路径以前走 detachStreamUpstreamContext(ctx, false)，
+// 该函数在非流式时原样返回请求 context，因此不脱钩。
+func TestForwardOpenAIImagesAPIKey_NonStreamDetachesUpstreamContext(t *testing.T) {
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","response_format":"b64_json"}`)
+	c, _ := newOpenAIImagesTestContext(t, body)
+
+	recorder := &httpUpstreamRecorder{resp: openAIImagesJSONResponse()}
+	svc := newOpenAIImagesTestService(recorder)
+
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	require.False(t, parsed.Stream, "本用例覆盖非流式生图")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 客户端已断开
+
+	result, err := svc.ForwardImages(ctx, c, newOpenAIImagesAPIKeyAccount(), body, parsed, "")
+
+	require.NoError(t, err, "客户端断开不应把已在出图的上游调用打断成 context canceled")
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount, "图片已产出，必须带回结果供计费")
+
+	require.NotNil(t, recorder.lastReq)
+	require.NoError(t, recorder.lastReq.Context().Err(),
+		"交给上游的请求 context 必须已脱钩，不随客户端断开取消")
+}
+
+// 流式路径本来就脱钩，这条守卫防止对齐时把它改坏。
+func TestForwardOpenAIImagesAPIKey_StreamKeepsDetachedUpstreamContext(t *testing.T) {
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"b64_json"}`)
+	c, _ := newOpenAIImagesTestContext(t, body)
+
+	recorder := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"X-Request-Id": []string{"req_img_ctx_stream"},
+		},
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000000}}\n\n" +
+				"data: {\"type\":\"response.image_generation_call.completed\",\"result\":\"aGVsbG8=\"}\n\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}}\n\n",
+		)),
+	}}
+	svc := newOpenAIImagesTestService(recorder)
+
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	require.True(t, parsed.Stream)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _ = svc.ForwardImages(ctx, c, newOpenAIImagesAPIKeyAccount(), body, parsed, "")
+
+	require.NotNil(t, recorder.lastReq)
+	require.NoError(t, recorder.lastReq.Context().Err(),
+		"流式路径原本就脱钩，不能被改回随客户端取消")
+}
+
+// 两个 detach 辅助函数的语义差异是本次修复的根据，锁死它们防止被悄悄改动。
+func TestDetachUpstreamContextSemantics(t *testing.T) {
+	t.Run("detachUpstreamContext_always_detaches", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		detached, release := detachUpstreamContext(ctx)
+		defer release()
+		require.NoError(t, detached.Err())
+	})
+
+	t.Run("detachStreamUpstreamContext_keeps_cancel_when_not_streaming", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		same, release := detachStreamUpstreamContext(ctx, false)
+		defer release()
+		require.ErrorIs(t, same.Err(), context.Canceled,
+			"非流式时该函数原样返回请求 context —— 生图路径不能用它")
+	})
+
+	t.Run("detachStreamUpstreamContext_detaches_when_streaming", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		detached, release := detachStreamUpstreamContext(ctx, true)
+		defer release()
+		require.NoError(t, detached.Err())
+	})
+}


### PR DESCRIPTION
## 背景

Fixes #5411

报告的现象是：`/v1/images/generations` 偶尔出现「上游实际已完成生图 → Sub2API 记录 502 `context canceled` → 本次请求不扣费」。

## 根因

`forwardOpenAIImagesAPIKey`（`openai_images.go:604`）取上游 context 用的是：

```go
upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
```

而这个函数在**非流式**时原样返回请求 context（`gateway_usage_billing.go:484-492`）：

```go
func detachStreamUpstreamContext(ctx context.Context, stream bool) (context.Context, context.CancelFunc) {
	if ctx == nil { return context.Background(), func() {} }
	if !stream { return ctx, func() {} }        // ← 非流式不脱钩
	return context.WithoutCancel(ctx), func() {}
}
```

于是客户端中途断开会连带取消已经在出图的上游调用，链路是：

```
客户端断开 → requestCtx 取消 → 上游读取返回 context canceled
→ forwardOpenAIImagesAPIKey 返回 (nil, err)
→ handler 里 result != nil && result.ImageCount > 0 这个兜底命中不了
→ 走通用错误分支，记 502，直接 return，不提交用量记录
→ 不扣费
```

而上游那边图已经生成、也已经按它自己的口径计费了。

生图和普通非流式 chat 不是一类操作：单次要几十秒，且上游一旦开始就产生了实际成本，提前取消省不下上游开销，只会把已经付过钱的产出丢掉。仓库里还专门为这条路径做了 JSON keepalive 心跳（`StartOpenAIImagesJSONKeepalive`），本身就说明它长到容易被中途掐断。

## 这是一处孤立的不一致

把 OpenAI 网关侧所有转发点的取 context 方式列出来对比：

| 转发点 | 取 context 方式 |
|:--|:--|
| `openai_images_responses.go:1690`（**同一端点的 OAuth 分支**） | `detachUpstreamContext` |
| `grok_media.go:377` / `:471`（Grok 媒体，同属生成类） | `detachUpstreamContext` |
| `openai_gateway_forward.go:801` | `detachUpstreamContext` |
| `openai_gateway_passthrough.go:197` | `detachUpstreamContext` |
| `openai_gateway_chat_completions.go:258` | `detachUpstreamContext` |
| `openai_gateway_messages.go:305` / `:359` | `detachUpstreamContext` |
| `openai_gateway_cc_pipeline.go:181` | `detachUpstreamContext` |
| `openai_gateway_grok.go:93` / `:892` | `detachUpstreamContext` |
| `openai_gateway_grok_chat_bridge.go:588` | `detachUpstreamContext` |
| `openai_embeddings.go:63` | `detachUpstreamContext` |
| `openai_ws_http_bridge.go:190` | `detachUpstreamContext` |
| **`openai_images.go:604`** | **`detachStreamUpstreamContext`** ← 唯一例外 |

`detachStreamUpstreamContext` 的其余使用者全部在 Anthropic 侧的 `GatewayService`（`gateway_forward.go`、`gateway_anthropic_passthrough.go`、`gateway_forward_as_*.go`），那边的条件脱钩是有意为之。OpenAI 生图路径引用到它应该是个疏漏。

## 改动

`openai_images.go` 一行，加注释：

```go
upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
```

## 兼容性说明

- **流式生图行为完全不变**：原本 `detachStreamUpstreamContext(ctx, true)` 就是 `context.WithoutCancel`，改后等价。测试里有守卫。
- **OAuth 生图不受影响**，它本来就是 `detachUpstreamContext`。
- **不会无界挂起**：上游侧仍由 transport 的 `ResponseHeaderTimeout`（默认 300s，`http_upstream.go:57`）兜底，与 OAuth 分支现有的保护完全一致。
- 客户端断开后写响应会失败，但那是无害的；关键是结果能带回来供 `RecordUsage` 计费。
- 没有改计费口径、没有改 failover 判定、没有改调度状态。

## 本次未包含（说明理由）

- **没有给上游 body 读取加独立的整体超时**。当前 detach 之后 body 读取只受 `ResponseHeaderTimeout` 和读取大小上限约束，但这与 OAuth 分支、Grok 媒体路径的现状完全相同，属于这一类转发的既有设计；单独给生图加超时会引入一个新的可配置量，应由作者定方向。
- **没有改非流式分支 `return nil, err` 丢弃 imageCount 的写法**。流式分支有 `if streamCount > 0 { return 带图结果, err }` 的保护而非流式没有，看起来不对称；但核对下来两个非流式 handler（`handleOpenAIImagesNonStreamingResponse`、`handleOpenAIImagesOAuthNonStreamingResponse`）都是「先出错、后写客户端」，不存在写完再报错的路径，所以那条兜底目前不可达。改它属于防御性重构，不夹带进缺陷修复。

## 测试

新增 `openai_images_upstream_context_test.go`，4 个用例：

- `NonStreamDetachesUpstreamContext` —— 传入**已取消**的 ctx 调用 `ForwardImages`，断言不返回错误、`result.ImageCount == 1`（结果能带回去计费）、且交给上游的 `lastReq.Context().Err()` 为 nil。**回滚本次改动后该用例失败**（`Received unexpected error: context canceled`）。
- `StreamKeepsDetachedUpstreamContext` —— 守卫流式路径原本的脱钩行为不被改坏。
- `TestDetachUpstreamContextSemantics` 的 3 个子用例 —— 锁死两个 detach 辅助函数的语义差异（本次修复的依据），防止被悄悄改动。

本地运行：

```bash
go build ./...
go test -tags=unit ./internal/service/ -run 'TestForwardOpenAIImagesAPIKey|TestDetachUpstreamContextSemantics' -count=1 -v
go test -tags=unit ./internal/service/ -count=1
go test -tags=unit ./internal/handler/ ./internal/pkg/... -count=1
go test -tags=integration ./... -count=1
go vet ./internal/service/
gofmt -l internal/service/
```

全部通过。golangci-lint v2.9 本地装不上（v2.9.0 自身用 go1.25 构建，低于本仓库 go.mod 的 1.26.5，启动即报错），这一项交给 CI。
