### PR TITLE
feat(admin): add inline priority editing and persist account filters

### DIFF
--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -96,6 +96,10 @@ export default {
       schedulableEnabled: 'Scheduling enabled',
       schedulableDisabled: 'Scheduling disabled',
       failedToToggleSchedulable: 'Failed to toggle scheduling status',
+      priorityQuickEditLabel: 'Edit priority for {name}',
+      priorityQuickEditHint: 'Press Enter or blur to save priority',
+      priorityInvalid: 'Enter an integer priority greater than or equal to 1',
+      priorityUpdateFailed: 'Failed to update priority',
       groupCountTotal: '{count} groups total',
       platforms: {
         anthropic: 'Anthropic',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -94,6 +94,10 @@ export default {
       schedulableEnabled: '调度已开启',
       schedulableDisabled: '调度已关闭',
       failedToToggleSchedulable: '切换调度状态失败',
+      priorityQuickEditLabel: '修改 {name} 的优先级',
+      priorityQuickEditHint: '回车或失焦保存优先级',
+      priorityInvalid: '优先级必须是大于等于 1 的整数',
+      priorityUpdateFailed: '更新优先级失败',
       groupCountTotal: '共 {count} 个分组',
       columns: {
         name: '名称',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -373,8 +373,31 @@
               @probe="handleProbeUpstreamBilling(row)"
             />
           </template>
-          <template #cell-priority="{ value }">
-            <span class="text-sm text-gray-700 dark:text-gray-300">{{ value }}</span>
+          <template #cell-priority="{ row }">
+            <div class="inline-flex w-28 items-center gap-1.5" @click.stop>
+              <input
+                :value="getPriorityDraft(row)"
+                type="number"
+                min="1"
+                step="1"
+                inputmode="numeric"
+                class="h-8 w-16 rounded-md border border-gray-300 bg-white px-2 text-sm font-mono text-gray-700 transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-200 dark:disabled:bg-dark-700"
+                :disabled="isPrioritySaving(row.id)"
+                :aria-label="t('admin.accounts.priorityQuickEditLabel', { name: row.name })"
+                :title="t('admin.accounts.priorityQuickEditHint')"
+                data-test="account-priority-input"
+                @input="setPriorityDraft(row, ($event.target as HTMLInputElement).value)"
+                @blur="commitPriorityDraft(row)"
+                @keydown.enter.prevent="commitPriorityDraft(row)"
+                @keydown.esc.prevent="resetPriorityDraft(row)"
+              />
+              <Icon
+                v-if="isPrioritySaving(row.id)"
+                name="refresh"
+                size="xs"
+                class="animate-spin text-primary-500"
+              />
+            </div>
           </template>
           <template #header-scheduler_score="{ column }">
             <div class="flex items-center">
@@ -605,6 +628,8 @@ const scheduleModelOptions = ref<SelectOption[]>([])
 const togglingSchedulable = ref<number | null>(null)
 const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
 const exportingData = ref(false)
+const priorityDrafts = reactive<Record<number, string>>({})
+const savingPriorityIds = ref<Set<number>>(new Set())
 const probingUpstreamBilling = reactive(new Set<number>())
 const upstreamBillingProbeGloballyEnabled = ref<boolean | undefined>(undefined)
 const upstreamBillingNow = ref(Date.now())
@@ -629,15 +654,24 @@ const accountToolsDropdownStyle = computed(() => ({
   width: `${accountToolsDropdownPosition.width}px`
 }))
 const hiddenColumns = reactive<Set<string>>(new Set())
-const DEFAULT_HIDDEN_COLUMNS = ['today_stats', 'proxy', 'notes', 'priority', 'scheduler_score', 'rate_multiplier']
+const DEFAULT_HIDDEN_COLUMNS = ['today_stats', 'proxy', 'notes', 'scheduler_score', 'rate_multiplier']
 const HIDDEN_COLUMNS_KEY = 'account-hidden-columns'
 // One-time migration: hide scheduler score for existing admins too, because showing it opt-ins to heavy backend scoring.
 const HIDDEN_COLUMNS_VERSION_KEY = 'account-hidden-columns-version'
 const HIDDEN_COLUMNS_CURRENT_VERSION = 'scheduler-score-hidden-by-default'
 
 // Sorting settings
+const ACCOUNT_FILTERS_STORAGE_KEY = 'account-table-filters'
 const ACCOUNT_SORT_STORAGE_KEY = 'account-table-sort'
 type AccountSortOrder = 'asc' | 'desc'
+type AccountListFilterValues = {
+  platform: string
+  type: string
+  status: string
+  privacy_mode: string
+  group: string
+  search: string
+}
 type AccountSortState = {
   sort_by: string
   sort_order: AccountSortOrder
@@ -654,6 +688,56 @@ const ACCOUNT_SORTABLE_KEYS = new Set([
   'created_at',
   'expires_at'
 ])
+const sanitizePersistedAccountFilter = (value: unknown): string => {
+  return typeof value === 'string' ? value : ''
+}
+
+const getRouteSearchFilter = (): string | null => {
+  if (typeof window === 'undefined') return null
+  return new URLSearchParams(window.location.search).get('search')
+}
+
+const loadInitialAccountFilters = (): AccountListFilterValues => {
+  const routeSearch = getRouteSearchFilter()
+  const fallback: AccountListFilterValues = {
+    platform: '',
+    type: '',
+    status: '',
+    privacy_mode: '',
+    group: '',
+    search: routeSearch ?? ''
+  }
+
+  if (typeof window === 'undefined') return fallback
+
+  try {
+    const raw = window.localStorage.getItem(ACCOUNT_FILTERS_STORAGE_KEY)
+    if (!raw) return fallback
+
+    const parsed = JSON.parse(raw) as Partial<Record<keyof AccountListFilterValues, unknown>>
+    return {
+      platform: sanitizePersistedAccountFilter(parsed.platform),
+      type: sanitizePersistedAccountFilter(parsed.type),
+      status: sanitizePersistedAccountFilter(parsed.status),
+      privacy_mode: sanitizePersistedAccountFilter(parsed.privacy_mode),
+      group: sanitizePersistedAccountFilter(parsed.group),
+      search: routeSearch ?? sanitizePersistedAccountFilter(parsed.search)
+    }
+  } catch (error) {
+    console.error('Failed to load saved account filters:', error)
+    return fallback
+  }
+}
+
+const saveAccountFiltersToStorage = (filters: AccountListFilterValues) => {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(ACCOUNT_FILTERS_STORAGE_KEY, JSON.stringify(filters))
+  } catch (error) {
+    console.error('Failed to save account filters:', error)
+  }
+}
 const loadInitialAccountSortState = (): AccountSortState => {
   const fallback: AccountSortState = { sort_by: 'name', sort_order: 'asc' }
   try {
@@ -916,12 +1000,7 @@ const {
 } = useTableLoader<Account, any>({
   fetchFn: adminAPI.accounts.list,
   initialParams: {
-    platform: '',
-    type: '',
-    status: '',
-    privacy_mode: '',
-    group: '',
-    search: '',
+    ...loadInitialAccountFilters(),
     include_scheduler_score: shouldIncludeSchedulerScore() ? '1' : '0',
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
@@ -1041,6 +1120,20 @@ const debouncedReload = () => {
   pendingTodayStatsRefresh.value = true
   baseDebouncedReload()
 }
+
+watch(
+  () => ({
+    platform: params.platform,
+    type: params.type,
+    status: params.status,
+    privacy_mode: params.privacy_mode,
+    group: params.group,
+    search: params.search
+  }),
+  (filters) => {
+    saveAccountFiltersToStorage(filters)
+  }
+)
 
 const handlePageChange = (page: number) => {
   syncAccountListDerivedParams()
@@ -1927,6 +2020,51 @@ const handleProbeUpstreamBilling = async (account: Account) => {
 const handleAccountUpdated = (updatedAccount: Account) => {
   patchAccountInList(updatedAccount)
   enterAutoRefreshSilentWindow()
+}
+const getPriorityDraft = (account: Account) => priorityDrafts[account.id] ?? String(account.priority)
+const setPriorityDraft = (account: Account, value: string) => {
+  priorityDrafts[account.id] = value
+}
+const resetPriorityDraft = (account: Account) => {
+  delete priorityDrafts[account.id]
+}
+const parsePriorityDraft = (value: string) => {
+  const priority = Number(value.trim())
+  return Number.isInteger(priority) && priority >= 1 ? priority : null
+}
+const setPrioritySaving = (accountId: number, saving: boolean) => {
+  const next = new Set(savingPriorityIds.value)
+  if (saving) next.add(accountId)
+  else next.delete(accountId)
+  savingPriorityIds.value = next
+}
+const isPrioritySaving = (accountId: number) => savingPriorityIds.value.has(accountId)
+const commitPriorityDraft = async (account: Account) => {
+  if (isPrioritySaving(account.id)) return
+
+  const priority = parsePriorityDraft(getPriorityDraft(account))
+  if (priority === null) {
+    resetPriorityDraft(account)
+    appStore.showError(t('admin.accounts.priorityInvalid'))
+    return
+  }
+  if (priority === account.priority) {
+    resetPriorityDraft(account)
+    return
+  }
+
+  setPrioritySaving(account.id, true)
+  try {
+    const updated = await adminAPI.accounts.update(account.id, { priority })
+    patchAccountInList(updated)
+    resetPriorityDraft(updated)
+    enterAutoRefreshSilentWindow()
+  } catch (error) {
+    resetPriorityDraft(account)
+    appStore.showError(extractApiErrorMessage(error, t('admin.accounts.priorityUpdateFailed')))
+  } finally {
+    setPrioritySaving(account.id, false)
+  }
 }
 const formatExportTimestamp = () => {
   const now = new Date()

--- a/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
@@ -12,6 +12,7 @@ const {
   getAllGroups,
   probeUpstreamBilling,
   probeUpstreamBillingBatch,
+  updateAccount,
   showError,
   showSuccess
 } = vi.hoisted(() => ({
@@ -23,6 +24,7 @@ const {
   getAllGroups: vi.fn(),
   probeUpstreamBilling: vi.fn(),
   probeUpstreamBillingBatch: vi.fn(),
+  updateAccount: vi.fn(),
   showError: vi.fn(),
   showSuccess: vi.fn()
 }))
@@ -39,6 +41,7 @@ vi.mock('@/api/admin', () => ({
       batchRefresh: vi.fn(),
       probeUpstreamBilling,
       probeUpstreamBillingBatch,
+      update: updateAccount,
       toggleSchedulable: vi.fn()
     },
     proxies: {
@@ -82,6 +85,7 @@ const DataTableStub = {
       <div v-for="row in data" :key="row.id">
         <div data-test="select-row"><slot name="cell-select" :row="row" /></div>
         <slot name="cell-created_at" :value="row.created_at" :row="row" />
+        <slot name="cell-priority" :value="row.priority" :row="row" />
         <div data-test="account-rate"><slot name="cell-rate_multiplier" :row="row" /></div>
       </div>
     </div>
@@ -121,6 +125,72 @@ const BulkEditAccountModalStub = {
   template: '<div data-test="bulk-edit-modal" :data-show="String(show)" :data-target-mode="target?.mode ?? \'\'"></div>'
 }
 
+const InteractiveAccountTableFiltersStub = {
+  emits: ['update:filters', 'change', 'update:searchQuery'],
+  template: `
+    <div>
+      <button data-test="set-platform-filter" @click="$emit('update:filters', { platform: 'openai' }); $emit('change')">set platform</button>
+      <button data-test="set-search-filter" @click="$emit('update:searchQuery', 'saved-account')">set search</button>
+    </div>
+  `
+}
+
+const baseStubs = {
+  AppLayout: { template: '<div><slot /></div>' },
+  TablePageLayout: {
+    template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+  },
+  DataTable: DataTableStub,
+  Pagination: true,
+  ConfirmDialog: true,
+  AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
+  AccountTableFilters: { template: '<div></div>' },
+  AccountBulkActionsBar: AccountBulkActionsBarStub,
+  AccountActionMenu: true,
+  ImportDataModal: true,
+  ReAuthAccountModal: true,
+  AccountTestModal: true,
+  AccountStatsModal: true,
+  ScheduledTestsPanel: true,
+  SyncFromCrsModal: true,
+  TempUnschedStatusModal: true,
+  ErrorPassthroughRulesModal: true,
+  TLSFingerprintProfilesModal: true,
+  TotpStepUpDialog: true,
+  CreateAccountModal: true,
+  EditAccountModal: true,
+  BulkEditAccountModal: BulkEditAccountModalStub,
+  PlatformTypeBadge: true,
+  AccountCapacityCell: true,
+  AccountStatusIndicator: true,
+  AccountTodayStatsCell: true,
+  AccountGroupsCell: true,
+  AccountUsageCell: true,
+  Icon: true
+}
+
+const mountAccountsView = (stubs: Record<string, unknown> = {}) => mount(AccountsView, {
+  global: {
+    stubs: {
+      ...baseStubs,
+      ...stubs
+    }
+  }
+})
+
+const buildAccount = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  name: 'test-account',
+  platform: 'anthropic',
+  type: 'oauth',
+  status: 'active',
+  schedulable: true,
+  priority: 10,
+  created_at: '2026-08-08T10:00:00Z',
+  updated_at: '2026-08-08T10:00:00Z',
+  ...overrides
+})
+
 describe('admin AccountsView bulk edit scope', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -133,8 +203,10 @@ describe('admin AccountsView bulk edit scope', () => {
     getAllGroups.mockReset()
     probeUpstreamBilling.mockReset()
     probeUpstreamBillingBatch.mockReset()
+    updateAccount.mockReset()
     showError.mockReset()
     showSuccess.mockReset()
+    window.history.replaceState({}, '', '/')
 
     listAccounts.mockResolvedValue({
       items: [],
@@ -268,6 +340,144 @@ describe('admin AccountsView bulk edit scope', () => {
       label: 'admin.accounts.columns.createdAt',
       sortable: true
     })
+  })
+
+  it('updates priority from the inline editor', async () => {
+    const account = buildAccount()
+    listAccounts.mockResolvedValue({ items: [account], total: 1, page: 1, page_size: 20, pages: 1 })
+    updateAccount.mockResolvedValue({ ...account, priority: 20 })
+    const wrapper = mountAccountsView()
+
+    await flushPromises()
+    const input = wrapper.get('[data-test="account-priority-input"]')
+    await input.setValue('20')
+    await input.trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(updateAccount).toHaveBeenCalledWith(1, { priority: 20 })
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('updates priority when the inline editor loses focus', async () => {
+    const account = buildAccount()
+    listAccounts.mockResolvedValue({ items: [account], total: 1, page: 1, page_size: 20, pages: 1 })
+    updateAccount.mockResolvedValue({ ...account, priority: 15 })
+    const wrapper = mountAccountsView()
+
+    await flushPromises()
+    const input = wrapper.get('[data-test="account-priority-input"]')
+    await input.setValue('15')
+    await input.trigger('blur')
+    await flushPromises()
+
+    expect(updateAccount).toHaveBeenCalledWith(1, { priority: 15 })
+  })
+
+  it('discards the inline priority draft on Escape', async () => {
+    const account = buildAccount()
+    listAccounts.mockResolvedValue({ items: [account], total: 1, page: 1, page_size: 20, pages: 1 })
+    const wrapper = mountAccountsView()
+
+    await flushPromises()
+    const input = wrapper.get('[data-test="account-priority-input"]')
+    await input.setValue('20')
+    await input.trigger('keydown', { key: 'Escape' })
+    await flushPromises()
+
+    expect(updateAccount).not.toHaveBeenCalled()
+    expect((input.element as HTMLInputElement).value).toBe('10')
+  })
+
+  it('rejects an invalid inline priority without sending a request', async () => {
+    const account = buildAccount()
+    listAccounts.mockResolvedValue({ items: [account], total: 1, page: 1, page_size: 20, pages: 1 })
+    const wrapper = mountAccountsView()
+
+    await flushPromises()
+    const input = wrapper.get('[data-test="account-priority-input"]')
+    await input.setValue('0')
+    await input.trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(updateAccount).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledWith('admin.accounts.priorityInvalid')
+  })
+
+  it('restores the server priority and reports an API update failure', async () => {
+    const account = buildAccount()
+    listAccounts.mockResolvedValue({ items: [account], total: 1, page: 1, page_size: 20, pages: 1 })
+    updateAccount.mockRejectedValue({})
+    const wrapper = mountAccountsView()
+
+    await flushPromises()
+    const input = wrapper.get('[data-test="account-priority-input"]')
+    await input.setValue('20')
+    await input.trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(updateAccount).toHaveBeenCalledWith(1, { priority: 20 })
+    expect(showError).toHaveBeenCalledWith('admin.accounts.priorityUpdateFailed')
+    expect((input.element as HTMLInputElement).value).toBe('10')
+  })
+
+  it('restores saved account filters and lets the URL search override storage', async () => {
+    localStorage.setItem('account-table-filters', JSON.stringify({
+      platform: 'openai',
+      type: 'oauth',
+      status: 'active',
+      privacy_mode: 'enabled',
+      group: '7',
+      search: 'saved-search'
+    }))
+    window.history.replaceState({}, '', '/admin/accounts?search=route-search')
+
+    mountAccountsView()
+    await flushPromises()
+
+    const requestFilters = listAccounts.mock.calls[0]?.[2]
+    expect(requestFilters).toMatchObject({
+      platform: 'openai',
+      type: 'oauth',
+      status: 'active',
+      privacy_mode: 'enabled',
+      group: '7',
+      search: 'route-search'
+    })
+  })
+
+  it('falls back to empty filters when saved browser state is corrupted', async () => {
+    localStorage.setItem('account-table-filters', '{invalid-json')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mountAccountsView()
+    await flushPromises()
+
+    expect(listAccounts.mock.calls[0]?.[2]).toMatchObject({
+      platform: '',
+      type: '',
+      status: '',
+      privacy_mode: '',
+      group: '',
+      search: ''
+    })
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('persists changed account filters in localStorage', async () => {
+    const wrapper = mountAccountsView({ AccountTableFilters: InteractiveAccountTableFiltersStub })
+    await flushPromises()
+
+    await wrapper.get('[data-test="set-platform-filter"]').trigger('click')
+    await wrapper.get('[data-test="set-search-filter"]').trigger('click')
+    await flushPromises()
+
+    expect(JSON.parse(localStorage.getItem('account-table-filters') || '{}')).toMatchObject({
+      platform: 'openai',
+      search: 'saved-account'
+    })
+    await new Promise(resolve => setTimeout(resolve, 350))
+    wrapper.unmount()
   })
 
   it('passes the loaded global probe state to every upstream billing cell', async () => {


### PR DESCRIPTION
## Summary

- add an inline account priority editor with integer validation, save-on-Enter/blur, Escape reset, saving state, and API error feedback
- persist account search and filter values in browser local storage while keeping the URL search parameter authoritative
- show the priority column by default and add English/Chinese UI messages

## Tests

- pnpm exec vitest run for all five AccountsView spec files: 34 tests passed
- pnpm exec eslint for all changed frontend files
- pnpm typecheck
- pnpm build