### PR TITLE
fix(gemini): 原生生图按上游实际回吐的图片张数计费，修复自定义模型名下生图记 $0

### DIFF
--- a/backend/internal/service/gemini_image_output_accounting.go
+++ b/backend/internal/service/gemini_image_output_accounting.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+// geminiImageOutputCounterKey 是请求级内联图片计数器挂在 gin.Context 上的键。
+const geminiImageOutputCounterKey = "gemini_image_output_counter"
+
+// geminiImageOutputCounter 记录一次转发里 Gemini 上游真正回吐的内联图片数量。
+//
+// 取「单个 payload 内的最大值」而不是累加：Gemini 兼容上游的 SSE 分片可能是
+// 累积式的（同一份内容在后续 chunk 里重复整段回来——本文件同目录的
+// computeGeminiTextDelta 就是为此存在的），逐 chunk 累加会把同一张图算很多次。
+// 计费上宁可少算不可多算，所以用 max 兜底：
+//   - 非流式：整份响应体只观测一次，max 即真实张数；
+//   - 累积式流：最后一个 chunk 含全部图片，max 仍是真实张数；
+//   - 增量式流且多图分散在不同 chunk：会低估到 1，与改动前的模型名启发式同值，
+//     不构成回退。
+type geminiImageOutputCounter struct {
+	count int
+}
+
+// beginGeminiImageOutputObservation 在每次 Forward 开头重置计数器。
+// failover 会拿同一个 gin.Context 重跑转发，不重置就会把上一个账号的图数带进来。
+func beginGeminiImageOutputObservation(c *gin.Context) *geminiImageOutputCounter {
+	if c == nil {
+		return nil
+	}
+	counter := &geminiImageOutputCounter{}
+	c.Set(geminiImageOutputCounterKey, counter)
+	return counter
+}
+
+func geminiImageOutputCounterFromContext(c *gin.Context) *geminiImageOutputCounter {
+	if c == nil {
+		return nil
+	}
+	value, ok := c.Get(geminiImageOutputCounterKey)
+	if !ok {
+		return nil
+	}
+	counter, _ := value.(*geminiImageOutputCounter)
+	return counter
+}
+
+// observeGeminiImageOutputs 观测一段上游响应（整份或单个 chunk）里的内联图片。
+// 调用点与 upstreamResponseModelObserver.ObserveGemini 一一对应——那里拿得到
+// 解包后的上游响应体，这里需要的是同一份字节。
+func observeGeminiImageOutputs(c *gin.Context, payload []byte) {
+	counter := geminiImageOutputCounterFromContext(c)
+	if counter == nil {
+		return
+	}
+	if count := countGeminiInlineImageOutputs(payload); count > counter.count {
+		counter.count = count
+	}
+}
+
+func observedGeminiImageOutputs(c *gin.Context) int {
+	counter := geminiImageOutputCounterFromContext(c)
+	if counter == nil {
+		return 0
+	}
+	return counter.count
+}
+
+// resolveGeminiImageCount 决定本次请求按几张图计费。
+//
+// 优先用上游真正返回的内联图片数：走 GeminiMessagesCompatService 的账号多是
+// API Key + 自定义模型映射，客户端请求名和上游模型名都可能是站长自取的别名
+// （issue #5358 里的 nana-banana-2），isImageGenerationModel 的白名单必然判不出，
+// 于是 ImageCount=0，calculateRecordUsageCost 整条按次计费分支不触发，
+// 生图请求全部记 $0。
+//
+// 只有响应里数不出图时（例如上游用 fileData 引用而非 inlineData 回图，或聚合
+// 函数丢掉了图片 part）才退回既有的模型名启发式，保证老行为不回退；这里额外
+// 也认映射后的上游模型名，与 shouldSkipCodexPlanGatedImageModelCooldown 对
+// requestedModel / modelKey 双取的口径一致。
+func resolveGeminiImageCount(c *gin.Context, originalModel, mappedModel string) int {
+	if observed := observedGeminiImageOutputs(c); observed > 0 {
+		return observed
+	}
+	if isImageGenerationModel(originalModel) || isImageGenerationModel(mappedModel) {
+		return 1
+	}
+	return 0
+}
+
+// countGeminiInlineImageOutputs 统计一段 Gemini 响应 JSON 里的内联图片 part。
+// Gemini REST 回 camelCase 的 inlineData，官方 SDK 与部分中转会回 snake_case
+// 的 inline_data，两种都要认。
+func countGeminiInlineImageOutputs(payload []byte) int {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return 0
+	}
+	count := 0
+	gjson.GetBytes(payload, "candidates").ForEach(func(_, candidate gjson.Result) bool {
+		candidate.Get("content.parts").ForEach(func(_, part gjson.Result) bool {
+			if geminiPartIsInlineImage(part) {
+				count++
+			}
+			return true
+		})
+		return true
+	})
+	return count
+}
+
+func geminiPartIsInlineImage(part gjson.Result) bool {
+	inline := part.Get("inlineData")
+	if !inline.Exists() {
+		inline = part.Get("inline_data")
+	}
+	if !inline.Exists() {
+		return false
+	}
+
+	mimeType := inline.Get("mimeType")
+	if !mimeType.Exists() {
+		mimeType = inline.Get("mime_type")
+	}
+	if !isGeminiInlineImageMIMEType(strings.ToLower(strings.TrimSpace(mimeType.String()))) {
+		return false
+	}
+
+	// 只认真的带上了 base64 数据的 part，空壳 part 不计费。
+	return strings.TrimSpace(inline.Get("data").String()) != ""
+}

--- a/backend/internal/service/gemini_image_output_accounting_test.go
+++ b/backend/internal/service/gemini_image_output_accounting_test.go
@@ -1,0 +1,204 @@
+//go:build unit
+
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const geminiTestPNG = "iVBORw0KGgoAAAANSUhEUg=="
+
+func newGeminiImageTestContext(t *testing.T) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost,
+		"/v1beta/models/nana-banana-2:generateContent", strings.NewReader("{}"))
+	return c
+}
+
+func geminiImageResponse(parts string) string {
+	return `{"candidates":[{"content":{"role":"model","parts":[` + parts + `]},"finishReason":"STOP"}]}`
+}
+
+func TestCountGeminiInlineImageOutputs(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    int
+	}{
+		{
+			name:    "camelCase inlineData",
+			payload: geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}}`),
+			want:    1,
+		},
+		{
+			// 官方 SDK 与部分中转把字段回成 snake_case。
+			name:    "snake_case inline_data",
+			payload: geminiImageResponse(`{"inline_data":{"mime_type":"image/png","data":"` + geminiTestPNG + `"}}`),
+			want:    1,
+		},
+		{
+			name: "text and image mixed",
+			payload: geminiImageResponse(`{"text":"here you go"},` +
+				`{"inlineData":{"mimeType":"image/jpeg","data":"` + geminiTestPNG + `"}}`),
+			want: 1,
+		},
+		{
+			name: "multiple images",
+			payload: geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}},` +
+				`{"inlineData":{"mimeType":"image/webp","data":"` + geminiTestPNG + `"}}`),
+			want: 2,
+		},
+		{
+			name:    "uppercase mime type",
+			payload: geminiImageResponse(`{"inlineData":{"mimeType":"IMAGE/PNG","data":"` + geminiTestPNG + `"}}`),
+			want:    1,
+		},
+		{
+			name:    "text only",
+			payload: geminiImageResponse(`{"text":"no image here"}`),
+			want:    0,
+		},
+		{
+			// 非图片的内联附件（例如音频）不能按图片计费。
+			name:    "non image mime type",
+			payload: geminiImageResponse(`{"inlineData":{"mimeType":"audio/mpeg","data":"` + geminiTestPNG + `"}}`),
+			want:    0,
+		},
+		{
+			name:    "empty data is not billable",
+			payload: geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":""}}`),
+			want:    0,
+		},
+		{name: "empty payload", payload: "", want: 0},
+		{name: "invalid json", payload: "not-json", want: 0},
+		{name: "error response", payload: `{"error":{"code":429,"message":"quota"}}`, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, countGeminiInlineImageOutputs([]byte(tc.payload)))
+		})
+	}
+}
+
+// 累积式 SSE 会把同一张图在后续 chunk 里整段重发，逐 chunk 累加会重复计费。
+// 计数器取单个 payload 内的最大值，正是为了挡住这一点。
+func TestObserveGeminiImageOutputs_CumulativeChunksDoNotDoubleCount(t *testing.T) {
+	c := newGeminiImageTestContext(t)
+	beginGeminiImageOutputObservation(c)
+
+	oneImage := geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}}`)
+	for range 4 {
+		observeGeminiImageOutputs(c, []byte(oneImage))
+	}
+
+	require.Equal(t, 1, observedGeminiImageOutputs(c))
+}
+
+func TestObserveGeminiImageOutputs_KeepsLargestChunk(t *testing.T) {
+	c := newGeminiImageTestContext(t)
+	beginGeminiImageOutputObservation(c)
+
+	observeGeminiImageOutputs(c, []byte(geminiImageResponse(`{"text":"working"}`)))
+	observeGeminiImageOutputs(c, []byte(geminiImageResponse(
+		`{"inlineData":{"mimeType":"image/png","data":"`+geminiTestPNG+`"}},`+
+			`{"inlineData":{"mimeType":"image/png","data":"`+geminiTestPNG+`"}}`)))
+	// 收尾 chunk 只带 usageMetadata，不能把已数到的张数抹掉。
+	observeGeminiImageOutputs(c, []byte(`{"usageMetadata":{"promptTokenCount":9}}`))
+
+	require.Equal(t, 2, observedGeminiImageOutputs(c))
+}
+
+// failover 会拿同一个 gin.Context 重跑 Forward，计数器必须按次重置，
+// 否则失败账号已经回吐的图会被叠加到成功账号的账单上。
+func TestBeginGeminiImageOutputObservation_ResetsPerForward(t *testing.T) {
+	c := newGeminiImageTestContext(t)
+	oneImage := []byte(geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}}`))
+
+	beginGeminiImageOutputObservation(c)
+	observeGeminiImageOutputs(c, oneImage)
+	require.Equal(t, 1, observedGeminiImageOutputs(c))
+
+	beginGeminiImageOutputObservation(c)
+	require.Equal(t, 0, observedGeminiImageOutputs(c))
+	observeGeminiImageOutputs(c, oneImage)
+	require.Equal(t, 1, observedGeminiImageOutputs(c))
+}
+
+// issue #5358：自定义模型名（客户端名与上游映射名都不在白名单里）走 Gemini 原生
+// generateContent 生图，改动前 ImageCount 恒为 0，calculateRecordUsageCost 的按次
+// 计费分支整条不触发，四次生图全部记 $0。
+func TestResolveGeminiImageCount(t *testing.T) {
+	oneImage := []byte(geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}}`))
+	textOnly := []byte(geminiImageResponse(`{"text":"hello"}`))
+
+	t.Run("custom model name bills by observed images", func(t *testing.T) {
+		c := newGeminiImageTestContext(t)
+		beginGeminiImageOutputObservation(c)
+		observeGeminiImageOutputs(c, oneImage)
+
+		require.False(t, isImageGenerationModel("nana-banana-2"), "前置条件：白名单判不出自定义名")
+		require.Equal(t, 1, resolveGeminiImageCount(c, "nana-banana-2", "nana-banana-2"))
+	})
+
+	t.Run("falls back to requested model name", func(t *testing.T) {
+		c := newGeminiImageTestContext(t)
+		beginGeminiImageOutputObservation(c)
+		observeGeminiImageOutputs(c, textOnly)
+
+		require.Equal(t, 1, resolveGeminiImageCount(c, "gemini-3-pro-image-preview", "gemini-3-pro-image-preview"))
+	})
+
+	t.Run("falls back to mapped upstream model name", func(t *testing.T) {
+		c := newGeminiImageTestContext(t)
+		beginGeminiImageOutputObservation(c)
+		observeGeminiImageOutputs(c, textOnly)
+
+		require.Equal(t, 1, resolveGeminiImageCount(c, "my-image-alias", "gemini-2.5-flash-image"))
+	})
+
+	t.Run("text model stays unbilled", func(t *testing.T) {
+		c := newGeminiImageTestContext(t)
+		beginGeminiImageOutputObservation(c)
+		observeGeminiImageOutputs(c, textOnly)
+
+		require.Equal(t, 0, resolveGeminiImageCount(c, "gemini-2.5-pro", "gemini-2.5-pro"))
+	})
+
+	t.Run("no counter on context degrades to name heuristic", func(t *testing.T) {
+		c := newGeminiImageTestContext(t)
+		require.Equal(t, 0, resolveGeminiImageCount(c, "nana-banana-2", "nana-banana-2"))
+		require.Equal(t, 1, resolveGeminiImageCount(c, "gemini-3-pro-image", "gemini-3-pro-image"))
+	})
+}
+
+// 端到端守住接线：/v1beta/models/{model}:generateContent 的非流式响应体
+// 必须真的喂进计数器，否则上面的单测全绿而线上依然记 $0。
+func TestHandleNativeNonStreamingResponse_FeedsImageCounter(t *testing.T) {
+	c := newGeminiImageTestContext(t)
+	beginGeminiImageOutputObservation(c)
+
+	body := geminiImageResponse(`{"inlineData":{"mimeType":"image/png","data":"` + geminiTestPNG + `"}}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	svc := &GeminiMessagesCompatService{}
+	usage, err := svc.handleNativeNonStreamingResponse(c, resp, false)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	require.Equal(t, 1, observedGeminiImageOutputs(c))
+	require.Equal(t, 1, resolveGeminiImageCount(c, "nana-banana-2", "nana-banana-2"))
+}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -582,6 +582,7 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 
 func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	beginGeminiImageOutputObservation(c)
 	startTime := time.Now()
 
 	var req struct {
@@ -1074,6 +1075,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			}
 			collectedBytes, _ := json.Marshal(collected)
 			upstreamResponseModelObserverFromContext(c).ObserveGemini(collectedBytes)
+			observeGeminiImageOutputs(c, collectedBytes)
 			claudeResp, usageObj2 := convertGeminiToClaudeMessage(collected, originalModel, collectedBytes, false)
 			c.JSON(http.StatusOK, claudeResp)
 			usage = usageObj2
@@ -1089,12 +1091,9 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	}
 
 	// 图片生成计费
-	imageCount := 0
 	imageInputSize := s.extractImageInputSize(body)
 	imageSize := normalizeOpenAIImageSizeTier(imageInputSize)
-	if isImageGenerationModel(originalModel) {
-		imageCount = 1
-	}
+	imageCount := resolveGeminiImageCount(c, originalModel, mappedModel)
 
 	return &ForwardResult{
 		RequestID:                     requestID,
@@ -1122,6 +1121,7 @@ func isGeminiSignatureRelatedError(respBody []byte) bool {
 
 func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.Context, account *Account, originalModel string, action string, stream bool, body []byte) (*ForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	beginGeminiImageOutputObservation(c)
 	startTime := time.Now()
 
 	if strings.TrimSpace(originalModel) == "" {
@@ -1609,6 +1609,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 			}
 			b, _ := json.Marshal(collected)
 			upstreamResponseModelObserverFromContext(c).ObserveGemini(b)
+			observeGeminiImageOutputs(c, b)
 			c.Data(http.StatusOK, "application/json", b)
 			usage = usageObj
 		} else {
@@ -1625,12 +1626,9 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	}
 
 	// 图片生成计费
-	imageCount := 0
 	imageInputSize := s.extractImageInputSize(body)
 	imageSize := normalizeOpenAIImageSizeTier(imageInputSize)
-	if isImageGenerationModel(originalModel) {
-		imageCount = 1
-	}
+	imageCount := resolveGeminiImageCount(c, originalModel, mappedModel)
 
 	return &ForwardResult{
 		RequestID:                     requestID,
@@ -2012,6 +2010,7 @@ func (s *GeminiMessagesCompatService) handleNonStreamingResponse(c *gin.Context,
 		observer = beginUpstreamResponseModelObservation(c)
 	}
 	observer.ObserveGemini(unwrappedBody)
+	observeGeminiImageOutputs(c, unwrappedBody)
 
 	var geminiResp map[string]any
 	if err := json.Unmarshal(unwrappedBody, &geminiResp); err != nil {
@@ -2100,6 +2099,7 @@ func (s *GeminiMessagesCompatService) handleStreamingResponse(c *gin.Context, re
 			observer = beginUpstreamResponseModelObservation(c)
 		}
 		observer.ObserveGemini(unwrappedBytes)
+		observeGeminiImageOutputs(c, unwrappedBytes)
 
 		var geminiResp map[string]any
 		if err := json.Unmarshal(unwrappedBytes, &geminiResp); err != nil {
@@ -2606,6 +2606,7 @@ func (s *GeminiMessagesCompatService) handleNativeNonStreamingResponse(c *gin.Co
 		observer = beginUpstreamResponseModelObservation(c)
 	}
 	observer.ObserveGemini(respBody)
+	observeGeminiImageOutputs(c, respBody)
 
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
@@ -2689,6 +2690,7 @@ func (s *GeminiMessagesCompatService) handleNativeStreamingResponse(c *gin.Conte
 						usage = u
 					}
 					observer.ObserveGemini(rawBytes)
+					observeGeminiImageOutputs(c, rawBytes)
 
 					if firstTokenMs == nil {
 						ms := int(time.Since(startTime).Milliseconds())


### PR DESCRIPTION
Fixes #5358

## 问题

`/v1beta/models/{model}:generateContent` 走 Gemini 原生协议生图，账单全是 $0——按量、独立（按次）两种计费都不生效。报告人贴的用量表里，4 次 `nana-banana-2` 请求各耗时 33~44 秒（图确实出了），费用列全部 `$0.000000`，计费模式停在「按量」；同一张表里 `/v1/images/generations` 的 `gpt-image-2` 正常显示「按次(图片) 1张 (1K) $1.200000`。

## 根因

`GeminiMessagesCompatService.Forward` / `ForwardNative` 收尾处的图片计费判定只看客户端请求名：

```go
imageCount := 0
if isImageGenerationModel(originalModel) {
    imageCount = 1
}
```

而 `isImageGenerationModel`（`antigravity_gateway_streaming.go:1212`）是按 Google 官方模型名精确/前缀匹配写死的白名单，且**故意**不放行自定义名——`antigravity_image_test.go:32` 就断言：

```go
require.False(t, isImageGenerationModel("my-gemini-3-pro-image-test"))
require.False(t, isImageGenerationModel("custom-gemini-2.5-flash-image-wrapper"))
```

这个口径对 Antigravity 是对的（模型名由 Google 下发，固定）。但 `GeminiMessagesCompatService` 服务的主要是 **API Key + 自定义模型映射**的账号：`ForwardNative` 自己就有 `mappedModel = account.GetMappedModel(originalModel)`，客户端请求名和映射后的上游名都可能是站长自取的别名（issue 里的 `nana-banana-2`）。白名单必然判不出 → `ImageCount = 0` → `gateway_usage_billing.go:809` 的

```go
if result.ImageCount > 0 {
    ...
    return s.calculateImageCost(...)
}
```

整条按次计费分支不触发，回落到 token 计费；而这类上游又常常不回 `usageMetadata`（截图里 TOKEN 是 ↓0 ↑0），于是两种模式都算出 $0。

**同类路径怎么做的**——这正是本 PR 的依据：

| 路径 | 图片张数来源 | 文件 |
|---|---|---|
| OpenAI Responses passthrough | 数响应体里的图片输出 | `openai_gateway_passthrough.go:1457` `countOpenAIResponseImageOutputsFromJSONBytes(body)` |
| OpenAI Responses 响应处理 | 同上 | `openai_gateway_response_handling.go:1195` |
| Grok 媒体 | 同上 | `grok_media.go:800` |
| `/v1/images/*` | 数响应体 | `openai_images.go:1169` |
| **Gemini 原生 / 兼容** | **只猜模型名，恒为 1 或 0** | `gemini_messages_compat_service.go:1095 / 1631` |

只有 Gemini 这条不看响应体。

## 改动

新增 `gemini_image_output_accounting.go`：请求级内联图片计数器，挂在 `gin.Context` 上，取数点与既有的 `upstreamResponseModelObserver.ObserveGemini` 完全重合（那 6 处拿到的就是解包后的上游响应体），计费时优先用真实张数，数不出来才退回原有模型名启发式。

三个刻意的设计选择：

1. **取「单个 payload 内的最大值」而不是累加。** Gemini 兼容上游的 SSE 分片可能是累积式的（同一份内容在后续 chunk 里整段重发）——本仓库的 `computeGeminiTextDelta` 就是为此存在的。逐 chunk 累加会把同一张图算很多次，计费上宁可少算不可多算。max 的效果：非流式整份响应只观测一次，结果就是真实张数；累积式流最后一个 chunk 含全部图片，结果仍是真实张数；增量式流且多图分散在不同 chunk 会低估到 1，**与改动前的模型名启发式同值，不构成回退**。

2. **每次 `Forward` 开头重置计数器。** failover 会拿同一个 `gin.Context` 重跑转发（`gemini_v1beta_handler.go` 的 `FailoverContinue` → `continue`），不重置就会把失败账号已回吐的图叠加到成功账号的账单上。

3. **兜底判定同时认映射后的上游模型名。** 与 #5391 里 `shouldSkipCodexPlanGatedImageModelCooldown` 同时取 `requestedModel` / `modelKey` 的口径一致。

字段兼容：`inlineData`（Gemini REST camelCase）与 `inline_data`（官方 SDK / 部分中转 snake_case）都认；只统计带 base64 数据且 MIME 为图片的 part，空壳 part 与 `audio/mpeg` 这类非图片附件不计费。

**未改动的范围（有意为之）**：`AntigravityGatewayService.ForwardGemini` 的同名判定保持不变——那条路径的模型名由 Google 下发、恒在白名单内，不存在本问题，且 `antigravity_image_test.go` 已经把「自定义名不算图片模型」锁成断言。

## 验证

```
go build ./...                                      OK
go vet -tags unit ./internal/service/               OK
gofmt -l （本 PR 三个文件）                          干净
go test -tags unit ./internal/service/              ok  146.5s
go test -tags unit ./internal/handler/... ./internal/pkg/...   全部 ok
```

新增 20 个用例（`gemini_image_output_accounting_test.go`），包括 camelCase/snake_case 字段、多图、大小写 MIME、非图片 MIME、空 data、非法 JSON、错误响应体，以及三条不变式：累积式 chunk 不重复计数、收尾 usage-only chunk 不抹掉已数到的张数、failover 重置。最后一条 `TestHandleNativeNonStreamingResponse_FeedsImageCounter` 端到端守住接线本身。

**回滚验证**（确认测试真的绑在修复上，而不是自说自话）：

- `git stash` 掉 `gemini_messages_compat_service.go` 的接线 → `TestHandleNativeNonStreamingResponse_FeedsImageCounter` FAIL（expected 1, actual 0）
- 把 `resolveGeminiImageCount` 改回旧的 `isImageGenerationModel(originalModel)` 判定 → `custom_model_name_bills_by_observed_images`、`falls_back_to_mapped_upstream_model_name` 与端到端用例 FAIL

golangci-lint v2.9 无法在本地运行（它自身 go.mod 锁 toolchain go1.25，低于本仓库的 go 1.26.5，加载配置即报错），这一项留给 CI。
