### PR TITLE
feat(admin): add per-account fallback-only OpenAI session stickiness

### DIFF
--- a/backend/ent/account.go
+++ b/backend/ent/account.go
@@ -81,6 +81,8 @@ type Account struct {
 	ParentAccountID *int64 `json:"parent_account_id,omitempty"`
 	// 'global' (default) or 'spark' (shadow reads codex_bengalfox).
 	QuotaDimension account.QuotaDimension `json:"quota_dimension,omitempty"`
+	// OpenaiSessionStickyMode holds the value of the "openai_session_sticky_mode" field.
+	OpenaiSessionStickyMode account.OpenaiSessionStickyMode `json:"openai_session_sticky_mode,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AccountQuery when eager-loading is set.
 	Edges        AccountEdges `json:"edges"`
@@ -177,7 +179,7 @@ func (*Account) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case account.FieldID, account.FieldProxyID, account.FieldProxyFallbackOriginID, account.FieldConcurrency, account.FieldLoadFactor, account.FieldPriority, account.FieldParentAccountID:
 			values[i] = new(sql.NullInt64)
-		case account.FieldName, account.FieldNotes, account.FieldPlatform, account.FieldType, account.FieldStatus, account.FieldErrorMessage, account.FieldTempUnschedulableReason, account.FieldSessionWindowStatus, account.FieldQuotaDimension:
+		case account.FieldName, account.FieldNotes, account.FieldPlatform, account.FieldType, account.FieldStatus, account.FieldErrorMessage, account.FieldTempUnschedulableReason, account.FieldSessionWindowStatus, account.FieldQuotaDimension, account.FieldOpenaiSessionStickyMode:
 			values[i] = new(sql.NullString)
 		case account.FieldCreatedAt, account.FieldUpdatedAt, account.FieldDeletedAt, account.FieldLastUsedAt, account.FieldExpiresAt, account.FieldRateLimitedAt, account.FieldRateLimitResetAt, account.FieldOverloadUntil, account.FieldTempUnschedulableUntil, account.FieldSessionWindowStart, account.FieldSessionWindowEnd:
 			values[i] = new(sql.NullTime)
@@ -409,6 +411,12 @@ func (_m *Account) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.QuotaDimension = account.QuotaDimension(value.String)
 			}
+		case account.FieldOpenaiSessionStickyMode:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field openai_session_sticky_mode", values[i])
+			} else if value.Valid {
+				_m.OpenaiSessionStickyMode = account.OpenaiSessionStickyMode(value.String)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -601,6 +609,9 @@ func (_m *Account) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("quota_dimension=")
 	builder.WriteString(fmt.Sprintf("%v", _m.QuotaDimension))
+	builder.WriteString(", ")
+	builder.WriteString("openai_session_sticky_mode=")
+	builder.WriteString(fmt.Sprintf("%v", _m.OpenaiSessionStickyMode))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/account/account.go
+++ b/backend/ent/account/account.go
@@ -78,6 +78,8 @@ const (
 	FieldParentAccountID = "parent_account_id"
 	// FieldQuotaDimension holds the string denoting the quota_dimension field in the database.
 	FieldQuotaDimension = "quota_dimension"
+	// FieldOpenaiSessionStickyMode holds the string denoting the openai_session_sticky_mode field in the database.
+	FieldOpenaiSessionStickyMode = "openai_session_sticky_mode"
 	// EdgeGroups holds the string denoting the groups edge name in mutations.
 	EdgeGroups = "groups"
 	// EdgeProxy holds the string denoting the proxy edge name in mutations.
@@ -162,6 +164,7 @@ var Columns = []string{
 	FieldSessionWindowStatus,
 	FieldParentAccountID,
 	FieldQuotaDimension,
+	FieldOpenaiSessionStickyMode,
 }
 
 var (
@@ -208,6 +211,8 @@ var (
 	DefaultConcurrency int
 	// DefaultPriority holds the default value on creation for the "priority" field.
 	DefaultPriority int
+	// DefaultOpenaiSessionStickyMode holds the default value on creation for the "openai_session_sticky_mode" field.
+	DefaultOpenaiSessionStickyMode OpenaiSessionStickyMode
 	// DefaultRateMultiplier holds the default value on creation for the "rate_multiplier" field.
 	DefaultRateMultiplier float64
 	// DefaultStatus holds the default value on creation for the "status" field.
@@ -236,6 +241,27 @@ const (
 
 func (qd QuotaDimension) String() string {
 	return string(qd)
+}
+
+// OpenaiSessionStickyMode defines the type for the "openai_session_sticky_mode" enum field.
+type OpenaiSessionStickyMode string
+
+const (
+	OpenaiSessionStickyModeNormal       OpenaiSessionStickyMode = "normal"
+	OpenaiSessionStickyModeFallbackOnly OpenaiSessionStickyMode = "fallback_only"
+)
+
+func (m OpenaiSessionStickyMode) String() string {
+	return string(m)
+}
+
+func OpenaiSessionStickyModeValidator(m OpenaiSessionStickyMode) error {
+	switch m {
+	case OpenaiSessionStickyModeNormal, OpenaiSessionStickyModeFallbackOnly:
+		return nil
+	default:
+		return fmt.Errorf("account: invalid enum value for openai_session_sticky_mode field: %q", m)
+	}
 }
 
 // QuotaDimensionValidator is a validator for the "quota_dimension" field enum values. It is called by the builders before save.

--- a/backend/ent/account_create.go
+++ b/backend/ent/account_create.go
@@ -419,6 +419,20 @@ func (_c *AccountCreate) SetNillableQuotaDimension(v *account.QuotaDimension) *A
 	return _c
 }
 
+// SetOpenaiSessionStickyMode sets the "openai_session_sticky_mode" field.
+func (_c *AccountCreate) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountCreate {
+	_c.mutation.SetOpenaiSessionStickyMode(v)
+	return _c
+}
+
+// SetNillableOpenaiSessionStickyMode sets the field if the given value is not nil.
+func (_c *AccountCreate) SetNillableOpenaiSessionStickyMode(v *account.OpenaiSessionStickyMode) *AccountCreate {
+	if v != nil {
+		_c.SetOpenaiSessionStickyMode(*v)
+	}
+	return _c
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (_c *AccountCreate) AddGroupIDs(ids ...int64) *AccountCreate {
 	_c.mutation.AddGroupIDs(ids...)
@@ -581,6 +595,10 @@ func (_c *AccountCreate) defaults() error {
 		v := account.DefaultQuotaDimension
 		_c.mutation.SetQuotaDimension(v)
 	}
+	if _, ok := _c.mutation.OpenaiSessionStickyMode(); !ok {
+		v := account.DefaultOpenaiSessionStickyMode
+		_c.mutation.SetOpenaiSessionStickyMode(v)
+	}
 	return nil
 }
 
@@ -656,6 +674,11 @@ func (_c *AccountCreate) check() error {
 	if v, ok := _c.mutation.QuotaDimension(); ok {
 		if err := account.QuotaDimensionValidator(v); err != nil {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
 		}
 	}
 	return nil
@@ -800,6 +823,10 @@ func (_c *AccountCreate) createSpec() (*Account, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
 		_node.QuotaDimension = value
+	}
+	if value, ok := _c.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
+		_node.OpenaiSessionStickyMode = value
 	}
 	if nodes := _c.mutation.GroupsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1425,6 +1452,16 @@ func (u *AccountUpsert) SetQuotaDimension(v account.QuotaDimension) *AccountUpse
 	return u
 }
 
+func (u *AccountUpsert) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsert {
+	u.Set(account.FieldOpenaiSessionStickyMode, v)
+	return u
+}
+
+func (u *AccountUpsert) UpdateOpenaiSessionStickyMode() *AccountUpsert {
+	u.SetExcluded(account.FieldOpenaiSessionStickyMode)
+	return u
+}
+
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.
 func (u *AccountUpsert) UpdateQuotaDimension() *AccountUpsert {
 	u.SetExcluded(account.FieldQuotaDimension)
@@ -2041,6 +2078,14 @@ func (u *AccountUpsertOne) SetQuotaDimension(v account.QuotaDimension) *AccountU
 	return u.Update(func(s *AccountUpsert) {
 		s.SetQuotaDimension(v)
 	})
+}
+
+func (u *AccountUpsertOne) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) { s.SetOpenaiSessionStickyMode(v) })
+}
+
+func (u *AccountUpsertOne) UpdateOpenaiSessionStickyMode() *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) { s.UpdateOpenaiSessionStickyMode() })
 }
 
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.
@@ -2826,6 +2871,14 @@ func (u *AccountUpsertBulk) SetQuotaDimension(v account.QuotaDimension) *Account
 	return u.Update(func(s *AccountUpsert) {
 		s.SetQuotaDimension(v)
 	})
+}
+
+func (u *AccountUpsertBulk) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) { s.SetOpenaiSessionStickyMode(v) })
+}
+
+func (u *AccountUpsertBulk) UpdateOpenaiSessionStickyMode() *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) { s.UpdateOpenaiSessionStickyMode() })
 }
 
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.

--- a/backend/ent/account_update.go
+++ b/backend/ent/account_update.go
@@ -556,6 +556,11 @@ func (_u *AccountUpdate) SetQuotaDimension(v account.QuotaDimension) *AccountUpd
 	return _u
 }
 
+func (_u *AccountUpdate) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpdate {
+	_u.mutation.SetOpenaiSessionStickyMode(v)
+	return _u
+}
+
 // SetNillableQuotaDimension sets the "quota_dimension" field if the given value is not nil.
 func (_u *AccountUpdate) SetNillableQuotaDimension(v *account.QuotaDimension) *AccountUpdate {
 	if v != nil {
@@ -787,6 +792,11 @@ func (_u *AccountUpdate) check() error {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -945,6 +955,9 @@ func (_u *AccountUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1696,6 +1709,11 @@ func (_u *AccountUpdateOne) SetQuotaDimension(v account.QuotaDimension) *Account
 	return _u
 }
 
+func (_u *AccountUpdateOne) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpdateOne {
+	_u.mutation.SetOpenaiSessionStickyMode(v)
+	return _u
+}
+
 // SetNillableQuotaDimension sets the "quota_dimension" field if the given value is not nil.
 func (_u *AccountUpdateOne) SetNillableQuotaDimension(v *account.QuotaDimension) *AccountUpdateOne {
 	if v != nil {
@@ -1940,6 +1958,11 @@ func (_u *AccountUpdateOne) check() error {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -2115,6 +2138,9 @@ func (_u *AccountUpdateOne) sqlSave(ctx context.Context) (_node *Account, err er
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -127,6 +127,7 @@ var (
 		{Name: "quota_dimension", Type: field.TypeEnum, Enums: []string{"global", "spark"}, Default: "global"},
 		{Name: "proxy_id", Type: field.TypeInt64, Nullable: true},
 		{Name: "parent_account_id", Type: field.TypeInt64, Nullable: true},
+		{Name: "openai_session_sticky_mode", Type: field.TypeEnum, Enums: []string{"normal", "fallback_only"}, Default: "normal"},
 	}
 	// AccountsTable holds the schema information for the "accounts" table.
 	AccountsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -2319,6 +2319,7 @@ type AccountMutation struct {
 	session_window_end          *time.Time
 	session_window_status       *string
 	quota_dimension             *account.QuotaDimension
+	openai_session_sticky_mode  *account.OpenaiSessionStickyMode
 	clearedFields               map[string]struct{}
 	groups                      map[int64]struct{}
 	removedgroups               map[int64]struct{}
@@ -3085,6 +3086,39 @@ func (m *AccountMutation) AddedPriority() (r int, exists bool) {
 func (m *AccountMutation) ResetPriority() {
 	m.priority = nil
 	m.addpriority = nil
+}
+
+// SetOpenaiSessionStickyMode sets the "openai_session_sticky_mode" field.
+func (m *AccountMutation) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) {
+	m.openai_session_sticky_mode = &v
+}
+
+// OpenaiSessionStickyMode returns the value of the field in the mutation.
+func (m *AccountMutation) OpenaiSessionStickyMode() (r account.OpenaiSessionStickyMode, exists bool) {
+	if m.openai_session_sticky_mode == nil {
+		return r, false
+	}
+	return *m.openai_session_sticky_mode, true
+}
+
+// OldOpenaiSessionStickyMode returns the old field value.
+func (m *AccountMutation) OldOpenaiSessionStickyMode(ctx context.Context) (account.OpenaiSessionStickyMode, error) {
+	if !m.op.Is(OpUpdateOne) {
+		return "", errors.New("OldOpenaiSessionStickyMode is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return "", errors.New("OldOpenaiSessionStickyMode requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return "", fmt.Errorf("querying old value for OldOpenaiSessionStickyMode: %w", err)
+	}
+	return oldValue.OpenaiSessionStickyMode, nil
+}
+
+// ResetOpenaiSessionStickyMode resets changes to the field.
+func (m *AccountMutation) ResetOpenaiSessionStickyMode() {
+	m.openai_session_sticky_mode = nil
 }
 
 // SetRateMultiplier sets the "rate_multiplier" field.
@@ -4232,6 +4266,9 @@ func (m *AccountMutation) Fields() []string {
 	if m.quota_dimension != nil {
 		fields = append(fields, account.FieldQuotaDimension)
 	}
+	if m.openai_session_sticky_mode != nil {
+		fields = append(fields, account.FieldOpenaiSessionStickyMode)
+	}
 	return fields
 }
 
@@ -4302,6 +4339,8 @@ func (m *AccountMutation) Field(name string) (ent.Value, bool) {
 		return m.ParentAccountID()
 	case account.FieldQuotaDimension:
 		return m.QuotaDimension()
+	case account.FieldOpenaiSessionStickyMode:
+		return m.OpenaiSessionStickyMode()
 	}
 	return nil, false
 }
@@ -4373,6 +4412,8 @@ func (m *AccountMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldParentAccountID(ctx)
 	case account.FieldQuotaDimension:
 		return m.OldQuotaDimension(ctx)
+	case account.FieldOpenaiSessionStickyMode:
+		return m.OldOpenaiSessionStickyMode(ctx)
 	}
 	return nil, fmt.Errorf("unknown Account field %s", name)
 }
@@ -4598,6 +4639,13 @@ func (m *AccountMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetQuotaDimension(v)
+		return nil
+	case account.FieldOpenaiSessionStickyMode:
+		v, ok := value.(account.OpenaiSessionStickyMode)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOpenaiSessionStickyMode(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)
@@ -4908,6 +4956,9 @@ func (m *AccountMutation) ResetField(name string) error {
 		return nil
 	case account.FieldQuotaDimension:
 		m.ResetQuotaDimension()
+		return nil
+	case account.FieldOpenaiSessionStickyMode:
+		m.ResetOpenaiSessionStickyMode()
 		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -256,6 +256,9 @@ func init() {
 	accountDescSessionWindowStatus := accountFields[25].Descriptor()
 	// account.SessionWindowStatusValidator is a validator for the "session_window_status" field. It is called by the builders before save.
 	account.SessionWindowStatusValidator = accountDescSessionWindowStatus.Validators[0].(func(string) error)
+	// accountDescOpenaiSessionStickyMode is the enum sticky policy field.
+	accountDescOpenaiSessionStickyMode := accountFields[28].Descriptor()
+	account.DefaultOpenaiSessionStickyMode = account.OpenaiSessionStickyMode(accountDescOpenaiSessionStickyMode.Default.(string))
 	accountgroupFields := schema.AccountGroup{}.Fields()
 	_ = accountgroupFields
 	// accountgroupDescPriority is the schema descriptor for priority field.

--- a/backend/ent/schema/account.go
+++ b/backend/ent/schema/account.go
@@ -201,6 +201,10 @@ func (Account) Fields() []ent.Field {
 			Comment("Parent account id for a linked spark shadow (NULL = normal)."),
 		field.Enum("quota_dimension").Values("global", "spark").Default("global").
 			Comment("'global' (default) or 'spark' (shadow reads codex_bengalfox)."),
+		field.Enum("openai_session_sticky_mode").
+			Values("normal", "fallback_only").
+			Default("normal").
+			Comment("OpenAI session_hash sticky policy; fallback_only yields to ready higher-priority accounts."),
 	}
 }
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -141,6 +141,7 @@ type UpdateAccountRequest struct {
 	ProxyID                 *int64         `json:"proxy_id"`
 	Concurrency             *int           `json:"concurrency"`
 	Priority                *int           `json:"priority"`
+	OpenAISessionStickyMode *string        `json:"openai_session_sticky_mode"`
 	RateMultiplier          *float64       `json:"rate_multiplier"`
 	LoadFactor              *int           `json:"load_factor"`
 	Status                  string         `json:"status" binding:"omitempty,oneof=active inactive error"`
@@ -975,23 +976,24 @@ func (h *AccountHandler) Update(c *gin.Context) {
 	skipCheck := req.ConfirmMixedChannelRisk != nil && *req.ConfirmMixedChannelRisk
 
 	account, err := h.adminService.UpdateAccount(c.Request.Context(), accountID, &service.UpdateAccountInput{
-		Name:                  req.Name,
-		Notes:                 req.Notes,
-		Type:                  req.Type,
-		Credentials:           req.Credentials,
-		Extra:                 req.Extra,
-		ProxyID:               req.ProxyID,
-		Concurrency:           req.Concurrency, // 指针类型，nil 表示未提供
-		Priority:              req.Priority,    // 指针类型，nil 表示未提供
-		RateMultiplier:        req.RateMultiplier,
-		LoadFactor:            req.LoadFactor,
-		Status:                req.Status,
-		GroupIDs:              req.GroupIDs,
-		ExpiresAt:             req.ExpiresAt,
-		AutoPauseOnExpired:    req.AutoPauseOnExpired,
-		ProbeEnabled:          req.ProbeEnabled,
-		RateSyncEnabled:       req.RateSyncEnabled,
-		SkipMixedChannelCheck: skipCheck,
+		Name:                    req.Name,
+		Notes:                   req.Notes,
+		Type:                    req.Type,
+		Credentials:             req.Credentials,
+		Extra:                   req.Extra,
+		ProxyID:                 req.ProxyID,
+		Concurrency:             req.Concurrency, // 指针类型，nil 表示未提供
+		Priority:                req.Priority,    // 指针类型，nil 表示未提供
+		OpenAISessionStickyMode: req.OpenAISessionStickyMode,
+		RateMultiplier:          req.RateMultiplier,
+		LoadFactor:              req.LoadFactor,
+		Status:                  req.Status,
+		GroupIDs:                req.GroupIDs,
+		ExpiresAt:               req.ExpiresAt,
+		AutoPauseOnExpired:      req.AutoPauseOnExpired,
+		ProbeEnabled:            req.ProbeEnabled,
+		RateSyncEnabled:         req.RateSyncEnabled,
+		SkipMixedChannelCheck:   skipCheck,
 	})
 	if err != nil {
 		// 检查是否为混合渠道错误

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -244,6 +244,7 @@ func AccountFromServiceShallow(a *service.Account) *Account {
 		Concurrency:             a.Concurrency,
 		LoadFactor:              a.LoadFactor,
 		Priority:                a.Priority,
+		OpenAISessionStickyMode: a.OpenAISessionStickyModeOrDefault(),
 		RateMultiplier:          a.BillingRateMultiplier(),
 		Status:                  a.Status,
 		ErrorMessage:            a.ErrorMessage,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -203,6 +203,7 @@ type Account struct {
 	Concurrency             int                            `json:"concurrency"`
 	LoadFactor              *int                           `json:"load_factor,omitempty"`
 	Priority                int                            `json:"priority"`
+	OpenAISessionStickyMode string                         `json:"openai_session_sticky_mode"`
 	RateMultiplier          float64                        `json:"rate_multiplier"`
 	Status                  string                         `json:"status"`
 	ErrorMessage            string                         `json:"error_message"`

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -113,6 +113,7 @@ func createAccountRecord(ctx context.Context, client *dbent.Client, account *ser
 		SetExtra(normalizeJSONMap(account.Extra)).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
+		SetOpenaiSessionStickyMode(dbaccount.OpenaiSessionStickyMode(account.OpenAISessionStickyModeOrDefault())).
 		SetStatus(account.Status).
 		SetErrorMessage(account.ErrorMessage).
 		SetSchedulable(account.Schedulable).
@@ -502,6 +503,7 @@ func (r *accountRepository) updateLockedAccount(
 		SetExtra(extra).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
+		SetOpenaiSessionStickyMode(dbaccount.OpenaiSessionStickyMode(account.OpenAISessionStickyModeOrDefault())).
 		SetStatus(account.Status).
 		SetErrorMessage(account.ErrorMessage).
 		SetSchedulable(schedulable).
@@ -3339,6 +3341,7 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 		ProxyFallbackOriginID:   m.ProxyFallbackOriginID,
 		Concurrency:             m.Concurrency,
 		Priority:                m.Priority,
+		OpenAISessionStickyMode: string(m.OpenaiSessionStickyMode),
 		RateMultiplier:          &rateMultiplier,
 		LoadFactor:              m.LoadFactor,
 		Status:                  m.Status,

--- a/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
+++ b/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
@@ -478,6 +478,6 @@ func updatedAccountRows(id int64, extra string) *sqlmock.Rows {
 		id, now, now, nil, "test", nil, service.PlatformOpenAI, service.AccountTypeAPIKey,
 		[]byte(`{"api_key":"sk-test"}`), []byte(extra), nil, nil, 1, nil, 1, 1.0,
 		service.StatusActive, nil, nil, nil, false, true, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, service.QuotaDimensionGlobal,
+		nil, nil, nil, service.QuotaDimensionGlobal, "normal",
 	)
 }

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -871,6 +871,7 @@ func buildSchedulerMetadataAccount(account service.Account) service.Account {
 		Concurrency:             account.Concurrency,
 		LoadFactor:              account.LoadFactor,
 		Priority:                account.Priority,
+		OpenAISessionStickyMode: account.OpenAISessionStickyModeOrDefault(),
 		RateMultiplier:          account.RateMultiplier,
 		Status:                  account.Status,
 		LastUsedAt:              account.LastUsedAt,

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -325,6 +325,18 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestBuildSchedulerMetadataAccount_PreservesOpenAISessionStickyMode(t *testing.T) {
+	account := service.Account{
+		ID:                      45,
+		Platform:                service.PlatformOpenAI,
+		OpenAISessionStickyMode: service.OpenAISessionStickyModeFallbackOnly,
+	}
+
+	got := buildSchedulerMetadataAccount(account)
+
+	require.Equal(t, service.OpenAISessionStickyModeFallbackOnly, got.OpenAISessionStickyMode)
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsGrokMediaEligibility(t *testing.T) {
 	t.Run("explicit override", func(t *testing.T) {
 		account := service.Account{

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -31,6 +31,10 @@ type Account struct {
 	ProxyFallbackOriginName *string // 仅展示用
 	Concurrency             int
 	Priority                int
+	// OpenAISessionStickyMode controls whether an OpenAI account can retain a
+	// session_hash binding while a strictly higher-priority account is ready.
+	// Empty values are treated as normal for legacy in-memory/cache records.
+	OpenAISessionStickyMode string
 	// RateMultiplier 账号计费倍率（>=0，允许 0 表示该账号计费为 0）。
 	// 使用指针用于兼容旧版本调度缓存（Redis）中缺字段的情况：nil 表示按 1.0 处理。
 	RateMultiplier     *float64
@@ -79,6 +83,33 @@ type Account struct {
 	headerOverrideCacheRawPtr         uintptr
 	headerOverrideCacheRawLen         int
 	headerOverrideCacheRawSig         uint64
+}
+
+const (
+	OpenAISessionStickyModeNormal       = "normal"
+	OpenAISessionStickyModeFallbackOnly = "fallback_only"
+)
+
+func normalizeOpenAISessionStickyMode(mode string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", OpenAISessionStickyModeNormal:
+		return OpenAISessionStickyModeNormal, true
+	case OpenAISessionStickyModeFallbackOnly:
+		return OpenAISessionStickyModeFallbackOnly, true
+	default:
+		return "", false
+	}
+}
+
+func (a *Account) OpenAISessionStickyModeOrDefault() string {
+	if a == nil {
+		return OpenAISessionStickyModeNormal
+	}
+	mode, ok := normalizeOpenAISessionStickyMode(a.OpenAISessionStickyMode)
+	if !ok {
+		return OpenAISessionStickyModeNormal
+	}
+	return mode
 }
 
 type OpenAIEndpointCapability string

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -461,17 +461,18 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 	delete(accountExtra, OllamaCloudUsageAutoRefreshExtraKey)
 	delete(accountExtra, OllamaCloudUsageSnapshotExtraKey)
 	account := &Account{
-		Name:        input.Name,
-		Notes:       normalizeAccountNotes(input.Notes),
-		Platform:    input.Platform,
-		Type:        input.Type,
-		Credentials: input.Credentials,
-		Extra:       accountExtra,
-		ProxyID:     input.ProxyID,
-		Concurrency: normalizeAccountConcurrency(input.Platform, input.Type, input.Concurrency),
-		Priority:    input.Priority,
-		Status:      StatusActive,
-		Schedulable: true,
+		Name:                    input.Name,
+		Notes:                   normalizeAccountNotes(input.Notes),
+		Platform:                input.Platform,
+		Type:                    input.Type,
+		Credentials:             input.Credentials,
+		Extra:                   accountExtra,
+		ProxyID:                 input.ProxyID,
+		Concurrency:             normalizeAccountConcurrency(input.Platform, input.Type, input.Concurrency),
+		Priority:                input.Priority,
+		OpenAISessionStickyMode: OpenAISessionStickyModeNormal,
+		Status:                  StatusActive,
+		Schedulable:             true,
 	}
 	if input.ProbeEnabled != nil && *input.ProbeEnabled {
 		if !isUpstreamBillingProbeAccount(account) {
@@ -599,6 +600,13 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	account, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+	if input.OpenAISessionStickyMode != nil {
+		mode, ok := normalizeOpenAISessionStickyMode(*input.OpenAISessionStickyMode)
+		if !ok {
+			return nil, infraerrors.BadRequest("INVALID_OPENAI_SESSION_STICKY_MODE", "openai_session_sticky_mode must be normal or fallback_only")
+		}
+		account.OpenAISessionStickyMode = mode
 	}
 	var normalizedExtra map[string]any
 	if input.Extra != nil {

--- a/backend/internal/service/admin_account_sticky_mode_test.go
+++ b/backend/internal/service/admin_account_sticky_mode_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAccountStickyModeOmittedPreservesExistingValue(t *testing.T) {
+	accountID := int64(93001)
+	mode := OpenAISessionStickyModeFallbackOnly
+	repo := &updateAccountCredsRepoStub{account: &Account{
+		ID:                      accountID,
+		Name:                    "fallback",
+		Platform:                PlatformOpenAI,
+		Type:                    AccountTypeOAuth,
+		Status:                  StatusActive,
+		OpenAISessionStickyMode: mode,
+	}}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(context.Background(), accountID, &UpdateAccountInput{Name: "renamed"})
+
+	require.NoError(t, err)
+	require.Equal(t, "renamed", updated.Name)
+	require.Equal(t, mode, repo.account.OpenAISessionStickyMode)
+}
+
+func TestUpdateAccountStickyModeRejectsUnknownValue(t *testing.T) {
+	accountID := int64(93002)
+	repo := &updateAccountCredsRepoStub{account: &Account{
+		ID:       accountID,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+	}}
+	unknown := "sometimes"
+
+	_, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(context.Background(), accountID, &UpdateAccountInput{OpenAISessionStickyMode: &unknown})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "openai_session_sticky_mode")
+	require.Zero(t, repo.updateCalls)
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -370,23 +370,24 @@ type ShadowOptions struct {
 }
 
 type UpdateAccountInput struct {
-	Name                  string
-	Notes                 *string
-	Type                  string // Account type: oauth, setup-token, apikey
-	Credentials           map[string]any
-	Extra                 map[string]any
-	ProxyID               *int64
-	Concurrency           *int     // 使用指针区分"未提供"和"设置为0"
-	Priority              *int     // 使用指针区分"未提供"和"设置为0"
-	RateMultiplier        *float64 // 账号计费倍率（>=0，允许 0）
-	LoadFactor            *int
-	Status                string
-	GroupIDs              *[]int64
-	ExpiresAt             *int64
-	AutoPauseOnExpired    *bool
-	ProbeEnabled          *bool
-	RateSyncEnabled       *bool
-	SkipMixedChannelCheck bool // 跳过混合渠道检查（用户已确认风险）
+	Name                    string
+	Notes                   *string
+	Type                    string // Account type: oauth, setup-token, apikey
+	Credentials             map[string]any
+	Extra                   map[string]any
+	ProxyID                 *int64
+	Concurrency             *int     // 使用指针区分"未提供"和"设置为0"
+	Priority                *int     // 使用指针区分"未提供"和"设置为0"
+	OpenAISessionStickyMode *string  // nil 表示不修改；仅影响 OpenAI session_hash sticky
+	RateMultiplier          *float64 // 账号计费倍率（>=0，允许 0）
+	LoadFactor              *int
+	Status                  string
+	GroupIDs                *[]int64
+	ExpiresAt               *int64
+	AutoPauseOnExpired      *bool
+	ProbeEnabled            *bool
+	RateSyncEnabled         *bool
+	SkipMixedChannelCheck   bool // 跳过混合渠道检查（用户已确认风险）
 }
 
 // BulkUpdateAccountsInput describes the payload for bulk updating accounts.

--- a/backend/internal/service/concurrency_service.go
+++ b/backend/internal/service/concurrency_service.go
@@ -769,3 +769,12 @@ func (s *ConcurrencyService) GetAccountConcurrencyBatch(ctx context.Context, acc
 
 	return s.cache.GetAccountConcurrencyBatch(redisCtx, accountIDs)
 }
+
+// GetAccountConcurrency returns the current active slot count for one account.
+func (s *ConcurrencyService) GetAccountConcurrency(ctx context.Context, accountID int64) (int, error) {
+	counts, err := s.GetAccountConcurrencyBatch(ctx, []int64{accountID})
+	if err != nil {
+		return 0, err
+	}
+	return counts[accountID], nil
+}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -412,6 +412,34 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 
+	if req.StickyAccountID > 0 && strings.TrimSpace(req.SessionHash) != "" && s.service != nil {
+		sticky, stickyErr := s.service.getSchedulableAccount(ctx, req.StickyAccountID)
+		if stickyErr == nil && sticky != nil && sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly {
+			selection, acquireErr := s.service.selectFallbackOnlyWithHigherPriorityAcquisition(
+				ctx,
+				req.GroupID,
+				req.Platform,
+				req.SessionHash,
+				req.StickyAccountID,
+				req.RequestedModel,
+				req.ExcludedIDs,
+				req.RequireCompact,
+				req.RequiredCapability,
+				req.RequiredImageCapability,
+				req.RequiredTransport,
+			)
+			if acquireErr != nil {
+				return nil, decision, acquireErr
+			}
+			if selection != nil {
+				decision.Layer = openAIAccountScheduleLayerLoadBalance
+				decision.SelectedAccountID = selection.Account.ID
+				decision.SelectedAccountType = selection.Account.Type
+				return selection, decision, nil
+			}
+		}
+	}
+
 	if !req.StickyWeighted {
 		selection, escapedSticky, err := s.selectBySessionHash(ctx, req)
 		if err != nil {
@@ -426,6 +454,16 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 		if escapedSticky {
 			req.PreserveStickyBinding = true
+			stickyAccountID := req.StickyAccountID
+			if stickyAccountID <= 0 {
+				stickyAccountID, _ = s.service.getStickySessionAccountID(ctx, req.GroupID, strings.TrimSpace(req.SessionHash))
+			}
+			if stickyAccountID > 0 {
+				sticky, stickyErr := s.service.getSchedulableAccount(ctx, stickyAccountID)
+				if stickyErr == nil && sticky != nil && sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly {
+					req.PreserveStickyBinding = false
+				}
+			}
 		}
 	}
 
@@ -498,6 +536,10 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 	if account == nil || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
+	}
+	if s.service.shouldEscapeFallbackOnlySticky(ctx, req.GroupID, req.Platform, sessionHash, account, req.RequestedModel, req.ExcludedIDs, req.RequireCompact, req.RequiredCapability, req.RequiredTransport) {
+		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
+		return nil, true, nil
 	}
 	escapeCfg := s.service.openAIStickyEscapeConfig()
 	if reason, errorRate, ttft, shouldEscape := s.shouldEscapeStickyAccount(accountID, escapeCfg); shouldEscape {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -87,6 +87,7 @@ type schedulerTestConcurrencyCache struct {
 	loadBatchErr    error
 	loadMap         map[int64]*AccountLoadInfo
 	acquireResults  map[int64]bool
+	acquireErrors   map[int64]error
 	waitCounts      map[int64]int
 	skipDefaultLoad bool
 	acquiredIDs     *[]int64
@@ -96,6 +97,11 @@ type schedulerTestConcurrencyCache struct {
 func (c schedulerTestConcurrencyCache) AcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
 	if c.acquiredIDs != nil {
 		*c.acquiredIDs = append(*c.acquiredIDs, accountID)
+	}
+	if c.acquireErrors != nil {
+		if err, ok := c.acquireErrors[accountID]; ok {
+			return false, err
+		}
 	}
 	if c.acquireResults != nil {
 		if result, ok := c.acquireResults[accountID]; ok {
@@ -144,6 +150,27 @@ func (c schedulerTestConcurrencyCache) GetAccountWaitingCount(ctx context.Contex
 		}
 	}
 	return 0, nil
+}
+
+func (c schedulerTestConcurrencyCache) GetAccountConcurrency(ctx context.Context, accountID int64) (int, error) {
+	if c.loadMap != nil {
+		if load, ok := c.loadMap[accountID]; ok && load != nil {
+			return load.CurrentConcurrency, nil
+		}
+	}
+	return 0, nil
+}
+
+func (c schedulerTestConcurrencyCache) GetAccountConcurrencyBatch(ctx context.Context, accountIDs []int64) (map[int64]int, error) {
+	result := make(map[int64]int, len(accountIDs))
+	for _, accountID := range accountIDs {
+		current, err := c.GetAccountConcurrency(ctx, accountID)
+		if err != nil {
+			return nil, err
+		}
+		result[accountID] = current
+	}
+	return result, nil
 }
 
 type schedulerTestGatewayCache struct {

--- a/backend/internal/service/openai_fallback_sticky_test.go
+++ b/backend/internal/service/openai_fallback_sticky_test.go
@@ -1,0 +1,388 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func fallbackStickyTestAccounts(groupID int64) []Account {
+	return []Account{
+		{
+			ID:                      91001,
+			Platform:                PlatformOpenAI,
+			Type:                    AccountTypeOAuth,
+			Status:                  StatusActive,
+			Schedulable:             true,
+			Concurrency:             1,
+			Priority:                200,
+			GroupIDs:                []int64{groupID},
+			Credentials:             map[string]any{"model_mapping": map[string]any{"gpt-ready": "gpt-ready"}},
+			Extra:                   map[string]any{"openai_oauth_responses_websockets_v2_enabled": true},
+			OpenAISessionStickyMode: OpenAISessionStickyModeFallbackOnly,
+		},
+		{
+			ID:                      91002,
+			Platform:                PlatformOpenAI,
+			Type:                    AccountTypeOAuth,
+			Status:                  StatusActive,
+			Schedulable:             true,
+			Concurrency:             1,
+			Priority:                1,
+			GroupIDs:                []int64{groupID},
+			Credentials:             map[string]any{"model_mapping": map[string]any{"gpt-ready": "gpt-ready"}},
+			OpenAISessionStickyMode: OpenAISessionStickyModeNormal,
+		},
+	}
+}
+
+func fallbackStickyTestAccountsWithTwoPrimaries(groupID int64) []Account {
+	accounts := fallbackStickyTestAccounts(groupID)
+	secondPrimary := accounts[1]
+	secondPrimary.ID = 91003
+	secondPrimary.Priority = 2
+	return append(accounts, secondPrimary)
+}
+
+func TestFallbackOnlyStickyEscapesToImmediatelyAvailableHigherPriorityAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9101)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:fallback-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "fallback-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[1].ID, selected.ID)
+	require.Equal(t, accounts[1].ID, cache.sessionBindings["openai:fallback-session"])
+}
+
+func TestNormalStickyKeepsExistingAccountEvenWhenHigherPriorityAccountIsAvailable(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9102)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[0].OpenAISessionStickyMode = OpenAISessionStickyModeNormal
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:normal-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "normal-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyKeepsAccountWhenHigherPriorityCandidateCannotServeRequest(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9103)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[1].Credentials = map[string]any{"model_mapping": map[string]any{"other-model": "other-model"}}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:unsupported-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "unsupported-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyKeepsAccountWhenHigherPrioritySlotIsFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9104)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:full-session": accounts[0].ID}}
+	concurrency := schedulerTestConcurrencyCache{loadMap: map[int64]*AccountLoadInfo{
+		accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: accounts[1].Concurrency, LoadRate: 100},
+	}}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "full-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyRecoversWhenHigherPrioritySlotIsTakenAfterProbe(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9105)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "racy-session", "gpt-ready", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyRecoversAfterAllHigherPrioritySlotsRaceFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9109)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:multi-racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+			accounts[2].ID: {AccountID: accounts[2].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "multi-racy-session", "gpt-ready", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:multi-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyEscapesInAdvancedScheduler(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9106)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-session": accounts[0].ID}}
+	cfg := &config.Config{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[1].ID, selection.Account.ID)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerRecoversWhenHigherPrioritySlotIsTakenAfterProbe(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9107)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-racy-session": accounts[0].ID}}
+	concurrency := schedulerTestConcurrencyCache{
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-racy-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:advanced-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerRecoversAfterAllHigherPrioritySlotsRaceFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9110)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-multi-racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+			accounts[2].ID: {AccountID: accounts[2].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 2
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-multi-racy-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:advanced-multi-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerSkipsImageIncompatibleHigherPriorityAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9111)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[1].Type = AccountTypeSetupToken
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:image-capability-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	svc := &OpenAIGatewayService{
+		accountRepo:      schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:            cache,
+		cfg:              &config.Config{},
+		rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{
+			acquiredIDs: &acquiredIDs,
+		}),
+	}
+
+	selection, _, err := svc.SelectAccountWithSchedulerForImages(ctx, &groupID, "image-capability-session", "gpt-ready", nil, OpenAIImagesCapabilityBasic)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.Equal(t, []int64{accounts[0].ID}, acquiredIDs)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerContinuesAfterHigherPriorityAcquireError(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9112)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:acquire-error-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		acquireErrors: map[int64]error{
+			accounts[1].ID: errors.New("temporary acquire failure"),
+		},
+		acquireResults: map[int64]bool{
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "acquire-error-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyEscapesWeightedAdvancedScheduler(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9108)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:weighted-session": accounts[0].ID}}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 2
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 1
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true", "true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "weighted-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[1].ID, selection.Account.ID)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -740,11 +740,170 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
+	if s.shouldEscapeFallbackOnlySticky(ctx, groupID, platform, sessionHash, account, requestedModel, excludedIDs, requireCompact, requiredCapability, OpenAIUpstreamTransportAny) {
+		return nil
+	}
 
 	// 刷新会话 TTL 并返回账号
 	// Refresh session TTL and return account
 	_ = s.refreshStickySessionTTL(ctx, groupID, sessionHash, openaiStickySessionTTL)
 	return account
+}
+
+// shouldEscapeFallbackOnlySticky reports whether a fallback-only sticky account
+// should yield to a strictly higher-priority account that can serve this request
+// immediately. The check is deliberately read-only: the eventual selection path
+// owns slot acquisition and sticky rebinding.
+func (s *OpenAIGatewayService) shouldEscapeFallbackOnlySticky(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	sessionHash string,
+	sticky *Account,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	requiredTransport OpenAIUpstreamTransport,
+) bool {
+	if sticky == nil || sticky.OpenAISessionStickyModeOrDefault() != OpenAISessionStickyModeFallbackOnly {
+		return false
+	}
+	if strings.TrimSpace(sessionHash) == "" {
+		return false
+	}
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	if err != nil {
+		return false
+	}
+	for i := range accounts {
+		candidate := &accounts[i]
+		if candidate.ID == sticky.ID || candidate.Priority >= sticky.Priority {
+			continue
+		}
+		if excludedIDs != nil {
+			if _, excluded := excludedIDs[candidate.ID]; excluded {
+				continue
+			}
+		}
+		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, candidate, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) {
+			continue
+		}
+		if groupID != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID) &&
+			s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+			continue
+		}
+		if !s.hasImmediatelyAvailableAccountSlot(ctx, fresh) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// selectFallbackOnlyWithHigherPriorityAcquisition atomically walks every
+// eligible higher-priority account before returning to the sticky fallback.
+// This closes the gap between a read-only capacity probe and slot acquisition.
+func (s *OpenAIGatewayService) selectFallbackOnlyWithHigherPriorityAcquisition(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	sessionHash string,
+	stickyAccountID int64,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	requiredImageCapability OpenAIImagesCapability,
+	requiredTransport OpenAIUpstreamTransport,
+) (*AccountSelectionResult, error) {
+	if stickyAccountID <= 0 {
+		return nil, nil
+	}
+	if _, excluded := excludedIDs[stickyAccountID]; excluded {
+		return nil, nil
+	}
+	sticky, err := s.getSchedulableAccount(ctx, stickyAccountID)
+	if err != nil || sticky == nil || sticky.OpenAISessionStickyModeOrDefault() != OpenAISessionStickyModeFallbackOnly {
+		return nil, err
+	}
+	sticky = s.recheckSelectedOpenAIAccountFromDB(ctx, sticky, groupID, platform, requestedModel, requireCompact, requiredCapability)
+	if sticky == nil || !s.openAIAccountMatchesSchedulingGroup(sticky, groupID) ||
+		!s.isOpenAIAccountTransportCompatible(sticky, requiredTransport) ||
+		!accountSupportsOpenAICapabilities(sticky, requiredCapability, requiredImageCapability) {
+		return nil, nil
+	}
+
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]*Account, 0, len(accounts)+1)
+	for i := range accounts {
+		candidate := &accounts[i]
+		if candidate.ID == sticky.ID || candidate.Priority >= sticky.Priority {
+			continue
+		}
+		if _, excluded := excludedIDs[candidate.ID]; excluded {
+			continue
+		}
+		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, candidate, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) ||
+			!accountSupportsOpenAICapabilities(fresh, requiredCapability, requiredImageCapability) {
+			continue
+		}
+		if groupID != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID) &&
+			s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+			continue
+		}
+		candidates = append(candidates, fresh)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return s.isBetterAccount(candidates[i], candidates[j])
+	})
+	candidates = append(candidates, sticky)
+
+	for _, candidate := range candidates {
+		fresh := s.recheckSelectedOpenAIAccountFromDB(ctx, candidate, groupID, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.openAIAccountMatchesSchedulingGroup(fresh, groupID) ||
+			!s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) ||
+			!accountSupportsOpenAICapabilities(fresh, requiredCapability, requiredImageCapability) {
+			continue
+		}
+		result, acquireErr := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
+		if acquireErr != nil {
+			if fresh.ID != sticky.ID {
+				continue
+			}
+			_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, sticky.ID, openaiStickySessionTTL)
+			return nil, acquireErr
+		}
+		if result == nil || !result.Acquired {
+			continue
+		}
+		if sessionHash != "" && !gatewayProfitControlGateActive(ctx) {
+			_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
+		}
+		return s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
+	}
+
+	_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, sticky.ID, openaiStickySessionTTL)
+	cfg := s.schedulingConfig()
+	return s.newSelectionResult(ctx, sticky, false, nil, &AccountWaitPlan{
+		AccountID:      sticky.ID,
+		MaxConcurrency: sticky.Concurrency,
+		Timeout:        cfg.StickySessionWaitTimeout,
+		MaxWaiting:     cfg.StickySessionMaxWaiting,
+	})
+}
+
+func (s *OpenAIGatewayService) hasImmediatelyAvailableAccountSlot(ctx context.Context, account *Account) bool {
+	if account == nil || s.concurrencyService == nil || account.Concurrency <= 0 {
+		return true
+	}
+	current, err := s.concurrencyService.GetAccountConcurrency(ctx, account.ID)
+	return err == nil && current < account.Concurrency
 }
 
 // selectBestAccount 从候选账号中选择最佳账号（优先级 + LRU）。
@@ -874,6 +1033,30 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			stickyAccountID = accountID
 		}
 	}
+	stickyFallbackOnly := false
+	if stickyAccountID > 0 {
+		if sticky, stickyErr := s.getSchedulableAccount(ctx, stickyAccountID); stickyErr == nil && sticky != nil {
+			stickyFallbackOnly = sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly
+		}
+	}
+	if stickyFallbackOnly && stickyAccountID > 0 && strings.TrimSpace(sessionHash) != "" {
+		selection, acquireErr := s.selectFallbackOnlyWithHigherPriorityAcquisition(
+			ctx,
+			groupID,
+			platform,
+			sessionHash,
+			stickyAccountID,
+			requestedModel,
+			excludedIDs,
+			requireCompact,
+			requiredCapability,
+			"",
+			OpenAIUpstreamTransportAny,
+		)
+		if acquireErr != nil || selection != nil {
+			return selection, acquireErr
+		}
+	}
 	if s.concurrencyService == nil || !cfg.LoadBatchEnabled {
 		account, err := s.selectAccountForModelWithExclusions(ctx, groupID, platform, sessionHash, requestedModel, excludedIDs, requireCompact, stickyAccountID, requiredCapability, preferLowUpstreamRate)
 		if err != nil {
@@ -940,6 +1123,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
+					} else if s.shouldEscapeFallbackOnlySticky(ctx, groupID, platform, sessionHash, account, requestedModel, excludedIDs, requireCompact, requiredCapability, OpenAIUpstreamTransportAny) {
 					} else {
 						result, err := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 						if err == nil && result != nil && result.Acquired {

--- a/backend/migrations/194_add_openai_account_session_sticky_mode.sql
+++ b/backend/migrations/194_add_openai_account_session_sticky_mode.sql
@@ -1,0 +1,21 @@
+-- Keep existing accounts on the historical sticky behavior while allowing an
+-- explicitly configured OpenAI fallback account to yield session_hash affinity.
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS openai_session_sticky_mode VARCHAR(32) NOT NULL DEFAULT 'normal';
+
+UPDATE accounts
+SET openai_session_sticky_mode = 'normal'
+WHERE openai_session_sticky_mode IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'accounts_openai_session_sticky_mode_check'
+    ) THEN
+        ALTER TABLE accounts
+            ADD CONSTRAINT accounts_openai_session_sticky_mode_check
+            CHECK (openai_session_sticky_mode IN ('normal', 'fallback_only'));
+    END IF;
+END $$;

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -19,6 +19,7 @@ import type {
   CodexSessionImportRequest,
   CodexSessionImportResult,
   OpenAICodexPATCreateRequest,
+  OpenAISessionStickyMode,
   CheckMixedChannelRequest,
   CheckMixedChannelResponse,
   UpstreamBillingProbeResult,
@@ -26,6 +27,12 @@ import type {
   OllamaCloudUsageSettings,
   OllamaCloudUsageState
 } from '@/types'
+
+export const OPENAI_SESSION_STICKY_MODES = ['normal', 'fallback_only'] as const
+
+export function isOpenAISessionStickyMode(value: unknown): value is OpenAISessionStickyMode {
+  return OPENAI_SESSION_STICKY_MODES.includes(value as OpenAISessionStickyMode)
+}
 
 /**
  * List all accounts with pagination

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1516,6 +1516,36 @@
         </div>
       </div>
 
+      <!-- OpenAI session sticky policy (account-level; create and bulk edit intentionally omit it) -->
+      <div
+        v-if="account?.platform === 'openai'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+        data-testid="openai-session-sticky-policy"
+      >
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.sessionStickyMode') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.sessionStickyModeDesc') }}
+            </p>
+            <p
+              v-if="openAISessionStickyMode === null"
+              class="mt-2 text-xs text-red-600 dark:text-red-400"
+              data-testid="openai-session-sticky-mode-missing"
+            >
+              {{ t('admin.accounts.openai.sessionStickyModeMissing') }}
+            </p>
+          </div>
+          <div v-if="openAISessionStickyMode !== null" class="w-56 shrink-0">
+            <Select
+              v-model="openAISessionStickyMode"
+              data-testid="openai-session-sticky-mode"
+              :options="openAISessionStickyModeOptions"
+            />
+          </div>
+        </div>
+      </div>
+
       <!-- OpenAI Codex namespace 工具摊平（兼容开关，仅 OAuth） -->
       <div
         v-if="account?.platform === 'openai' && account?.type === 'oauth'"
@@ -2663,6 +2693,7 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import { adminAPI } from '@/api/admin'
+import { isOpenAISessionStickyMode } from '@/api/admin/accounts'
 import { useQuotaNotifyState } from '@/composables/useQuotaNotifyState'
 import type {
   Account,
@@ -2672,6 +2703,7 @@ import type {
   OpenAICompactMode,
   OpenAIResponsesMode,
   OpenAIEndpointCapability,
+  OpenAISessionStickyMode,
   OllamaCloudUsageState
 } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
@@ -2916,6 +2948,7 @@ const openAILongContextBillingEnabled = ref(false)
 const editPlanType = ref<string>('')
 const openAICompactMode = ref<OpenAICompactMode>('auto')
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
+const openAISessionStickyMode = ref<OpenAISessionStickyMode | null>(null)
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
@@ -3049,6 +3082,16 @@ const openAIResponsesModeOptions = computed(() => [
   { value: 'auto', label: t('admin.accounts.openai.responsesModeAuto') },
   { value: 'force_responses', label: t('admin.accounts.openai.responsesModeForceResponses') },
   { value: 'force_chat_completions', label: t('admin.accounts.openai.responsesModeForceChatCompletions') }
+])
+const openAISessionStickyModeOptions = computed(() => [
+  {
+    value: 'normal' as const,
+    label: t('admin.accounts.openai.sessionStickyModeNormal')
+  },
+  {
+    value: 'fallback_only' as const,
+    label: t('admin.accounts.openai.sessionStickyModeFallbackOnly')
+  }
 ])
 const openAITextEndpointCapabilityLabel = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
@@ -3367,6 +3410,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
+  openAISessionStickyMode.value = null
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -3429,6 +3473,11 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     if (compactMappings && typeof compactMappings === 'object') {
       openAICompactModelMappings.value = Object.entries(compactMappings).map(([from, to]) => ({ from, to }))
     }
+  }
+  if (newAccount.platform === 'openai') {
+    openAISessionStickyMode.value = isOpenAISessionStickyMode(newAccount.openai_session_sticky_mode)
+      ? newAccount.openai_session_sticky_mode
+      : null
   }
   if (newAccount.platform === 'anthropic' && newAccount.type === 'apikey') {
     anthropicPassthroughEnabled.value = extra?.anthropic_passthrough === true
@@ -4095,6 +4144,17 @@ const submitUpdateAccount = async (accountID: number, updatePayload: Record<stri
   submitting.value = true
   try {
     const updatedAccount = await adminAPI.accounts.update(accountID, withAntigravityConfirmFlag(updatePayload))
+    if (props.account?.platform === 'openai') {
+      const requestedMode = updatePayload.openai_session_sticky_mode
+      if (
+        !isOpenAISessionStickyMode(requestedMode) ||
+        !isOpenAISessionStickyMode(updatedAccount.openai_session_sticky_mode) ||
+        updatedAccount.openai_session_sticky_mode !== requestedMode
+      ) {
+        appStore.showError(t('admin.accounts.openai.sessionStickyModeRoundTripFailed'))
+        return
+      }
+    }
     appStore.showSuccess(t('admin.accounts.accountUpdated'))
     emit('updated', updatedAccount)
     handleClose()
@@ -4126,6 +4186,13 @@ const handleSubmit = async () => {
 
   const updatePayload: Record<string, unknown> = { ...form }
   try {
+    if (props.account.platform === 'openai') {
+      if (!isOpenAISessionStickyMode(openAISessionStickyMode.value)) {
+        appStore.showError(t('admin.accounts.openai.sessionStickyModeMissing'))
+        return
+      }
+      updatePayload.openai_session_sticky_mode = openAISessionStickyMode.value
+    }
     // 后端期望 proxy_id: 0 表示清除代理，而不是 null
     if (updatePayload.proxy_id === null) {
       updatePayload.proxy_id = 0

--- a/frontend/src/components/account/__tests__/EditAccountModal.grokUpstream.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.grokUpstream.spec.ts
@@ -40,9 +40,13 @@ vi.mock('@/api/admin', () => ({
   }
 }))
 
-vi.mock('@/api/admin/accounts', () => ({
-  getAntigravityDefaultModelMapping: vi.fn()
-}))
+vi.mock('@/api/admin/accounts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/admin/accounts')>()
+  return {
+    ...actual,
+    getAntigravityDefaultModelMapping: vi.fn()
+  }
+})
 
 vi.mock('vue-i18n', async () => {
   const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -2,18 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
 
-const { updateAccountMock, checkMixedChannelRiskMock, authIsSimpleMode } = vi.hoisted(() => ({
+const { updateAccountMock, checkMixedChannelRiskMock, authIsSimpleMode, appStoreMock } = vi.hoisted(() => ({
   updateAccountMock: vi.fn(),
   checkMixedChannelRiskMock: vi.fn(),
-  authIsSimpleMode: { value: true }
-}))
-
-vi.mock('@/stores/app', () => ({
-  useAppStore: () => ({
+  authIsSimpleMode: { value: true },
+  appStoreMock: {
     showError: vi.fn(),
     showSuccess: vi.fn(),
     showInfo: vi.fn()
-  })
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => appStoreMock
 }))
 
 vi.mock('@/stores/auth', () => ({
@@ -41,7 +42,8 @@ vi.mock('@/api/admin', () => ({
 }))
 
 vi.mock('@/api/admin/accounts', () => ({
-  getAntigravityDefaultModelMapping: vi.fn()
+  getAntigravityDefaultModelMapping: vi.fn(),
+  isOpenAISessionStickyMode: (value: unknown) => value === 'normal' || value === 'fallback_only'
 }))
 
 vi.mock('vue-i18n', async () => {
@@ -160,6 +162,7 @@ function buildAccount() {
     priority: 1,
     rate_multiplier: 1,
     status: 'active',
+    openai_session_sticky_mode: 'normal',
     group_ids: [],
     expires_at: null,
     auto_pause_on_expired: false
@@ -314,6 +317,74 @@ function mountModal(account = buildAccount()) {
 describe('EditAccountModal', () => {
   beforeEach(() => {
     authIsSimpleMode.value = true
+    appStoreMock.showError.mockReset()
+    appStoreMock.showSuccess.mockReset()
+    appStoreMock.showInfo.mockReset()
+  })
+
+  it('shows and submits the OpenAI session sticky mode for the current account only', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue({ ...account, openai_session_sticky_mode: 'fallback_only' })
+
+    const wrapper = mountModal(account)
+    const modeSelect = wrapper.get<HTMLSelectElement>('[data-testid="openai-session-sticky-mode"]')
+
+    expect(modeSelect.element.value).toBe('normal')
+    await modeSelect.setValue('fallback_only')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock.mock.calls[0]?.[1]?.openai_session_sticky_mode).toBe('fallback_only')
+  })
+
+  it('does not render or submit the OpenAI session sticky mode for non-OpenAI accounts', async () => {
+    const account = buildVertexAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    expect(wrapper.find('[data-testid="openai-session-sticky-mode"]').exists()).toBe(false)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock.mock.calls[0]?.[1]).not.toHaveProperty('openai_session_sticky_mode')
+  })
+
+  it('fails visibly when the OpenAI sticky mode is missing from the server response', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue({ ...account, openai_session_sticky_mode: undefined })
+
+    const wrapper = mountModal(account)
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(appStoreMock.showError).toHaveBeenCalledWith(
+      'admin.accounts.openai.sessionStickyModeRoundTripFailed'
+    )
+    expect(wrapper.emitted('updated')).toBeUndefined()
+  })
+
+  it('fails visibly before saving when an OpenAI account has no sticky mode field', async () => {
+    const account = { ...buildAccount(), openai_session_sticky_mode: undefined }
+    updateAccountMock.mockReset()
+
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="openai-session-sticky-mode"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="openai-session-sticky-mode-missing"]').exists()).toBe(true)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).not.toHaveBeenCalled()
+    expect(appStoreMock.showError).toHaveBeenCalledWith(
+      'admin.accounts.openai.sessionStickyModeMissing'
+    )
   })
 
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -501,6 +501,13 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        sessionStickyMode: 'Session sticky policy',
+        sessionStickyModeDesc:
+          'Only affects OpenAI session_hash affinity. Normal affinity reuses this account; fallback-only affinity yields to a higher-priority account that supports the request and has an immediate slot. previous_response_id remains bound to its original account.',
+        sessionStickyModeNormal: 'Normal sticky',
+        sessionStickyModeFallbackOnly: 'Sticky only as fallback',
+        sessionStickyModeMissing: 'The server did not return this account session sticky policy, so it cannot be saved safely. Upgrade the backend first.',
+        sessionStickyModeRoundTripFailed: 'The server did not confirm the session sticky policy. The save was rejected; refresh the account and try again.',
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -572,6 +572,13 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        sessionStickyMode: '会话粘性策略',
+        sessionStickyModeDesc:
+          '此设置只影响 OpenAI 的 session_hash。正常粘性会继续使用当前账号。仅作保底时，只要有优先级更高且能立即处理请求的账号，就会自动切换过去。previous_response_id 仍固定使用原账号，避免上下文失效。',
+        sessionStickyModeNormal: '正常粘性',
+        sessionStickyModeFallbackOnly: '仅作保底时粘性',
+        sessionStickyModeMissing: '服务端未返回该账号的会话粘性策略，无法安全保存。请先升级后端。',
+        sessionStickyModeRoundTripFailed: '服务端未确认会话粘性策略，保存失败。请刷新账号后重试。',
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1114,6 +1114,8 @@ export interface Account {
   scheduler_scores?: AccountSchedulerGroupScore[] | null
   priority: number
   rate_multiplier?: number // Account billing multiplier (>=0, 0 means free)
+  // OpenAI account-level session_hash sticky policy; legacy responses may omit it and are rejected by the editor.
+  openai_session_sticky_mode?: OpenAISessionStickyMode
   status: 'active' | 'inactive' | 'error'
   error_message: string | null
   last_used_at: string | null
@@ -1351,6 +1353,7 @@ export interface CodexUsageSnapshot {
 export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'
 export type OpenAIResponsesMode = 'auto' | 'force_responses' | 'force_chat_completions'
 export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings'
+export type OpenAISessionStickyMode = 'normal' | 'fallback_only'
 
 export interface OpenAICompactState {
   openai_compact_mode?: OpenAICompactMode
@@ -1395,6 +1398,7 @@ export interface UpdateAccountRequest {
   load_factor?: number | null
   priority?: number
   rate_multiplier?: number // Account billing multiplier (>=0, 0 means free)
+  openai_session_sticky_mode?: OpenAISessionStickyMode
   schedulable?: boolean
   status?: 'active' | 'inactive' | 'error'
   group_ids?: number[]


### PR DESCRIPTION
## Summary

- add a per-account `openai_session_sticky_mode` enum with `normal` and `fallback_only`, defaulting existing accounts to `normal`;
- expose the setting through the admin account API and OpenAI account edit form with omission-preserving updates and strict value validation;
- make `fallback_only` session-hash selection atomically try all compatible higher-priority accounts before acquiring or waiting on the original fallback;
- apply the behavior to legacy, advanced, and weighted advanced scheduling while preserving hard `previous_response_id` affinity.

## Scheduling contract

A `fallback_only` sticky account yields only to a strictly higher-priority account that supports the requested model, endpoint, image capability, transport, and compact mode and can immediately acquire a concurrency slot. Candidate acquisition races and transient candidate acquisition errors continue through the remaining higher-priority candidates. If none can acquire, the original fallback is acquired or returned with its sticky wait plan.

## Validation

- `go test -tags=unit ./...` (105 packages, 8523 tests)
- `pnpm typecheck`
- `pnpm test:run src/components/account/__tests__/EditAccountModal.spec.ts src/components/account/__tests__/EditAccountModal.grokUpstream.spec.ts` (54 tests)
- `pnpm run build`
- local deployment smoke test with a synthetic session identifier confirmed selection returned to an available higher-priority account

Closes #5431
