### PR TITLE
fix: show image pricing controls for composite groups

### DIFF
--- a/frontend/src/views/admin/__tests__/groupsImagePricing.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsImagePricing.spec.ts
@@ -23,6 +23,11 @@ describe("groups image pricing platform support", () => {
     expect(supportsVideoPricingPlatform("openai")).toBe(false);
   });
 
+  it("includes composite groups so their image generation stays configurable", () => {
+    expect(supportsImagePricingPlatform("composite")).toBe(true);
+    expect(imagePricingPlatforms.has("composite")).toBe(true);
+  });
+
   it("keeps non-media group platforms out of the image pricing controls", () => {
     expect(supportsImagePricingPlatform("anthropic")).toBe(false);
   });

--- a/frontend/src/views/admin/groupsImagePricing.ts
+++ b/frontend/src/views/admin/groupsImagePricing.ts
@@ -1,5 +1,10 @@
+// Composite groups dispatch to the concrete platforms below, and the backend gate
+// (GroupAllowsImageGeneration) is platform-agnostic, so they can serve image
+// generation too. Without this entry the whole image pricing block is hidden and
+// allow_image_generation can only be toggled through the admin API.
 export const imagePricingPlatforms = new Set([
   "antigravity",
+  "composite",
   "gemini",
   "grok",
   "openai",


### PR DESCRIPTION
## Problem

Composite groups cannot have image generation configured from the admin console.

`imagePricingPlatforms` in `frontend/src/views/admin/groupsImagePricing.ts` lists `antigravity`, `gemini`, `grok` and `openai`, but not `composite`. Both the create and edit group forms wrap the entire image pricing block in `v-if="supportsImagePricingPlatform(...)"` (`GroupsView.vue:866` and `GroupsView.vue:2573`), so for a composite group the *Allow image generation* checkbox, the independent-multiplier toggle and the 1k/2k/4k price fields are never rendered.

## Why composite should be included

The backend has no such restriction:

- `GroupAllowsImageGeneration` (`backend/internal/service/image_generation_intent.go:35`) only reads the flag; it is platform-agnostic.
- `POST /v1/images/generations` is registered with the `compositeTarget` middleware (`backend/internal/server/routes/gateway.go:332`), so composite groups do dispatch image requests to their concrete platforms.

The result is that `allow_image_generation` is honoured at request time for composite groups but can only be toggled through the admin API (`PUT /api/v1/admin/groups/:id`), never from the console.

## Change

Add `composite` to `imagePricingPlatforms`, plus a unit test.

Batch image generation is deliberately untouched and stays Gemini-only, enforced in both places it already was:

- the group form normaliser (`GroupsView.vue`, `platform !== "gemini"` clears the flag)
- `admin_group.go:667` on write and `batch_image_public.go:993` at runtime

## Testing

`npx vitest run src/views/admin/__tests__/` — 26 files, 156 tests passed.