### PR TITLE
docs: sync Go 1.26.5 / golangci-lint v2.9 versions with CI

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -34,8 +34,8 @@
 ### 开发工具
 
 ```bash
-# golangci-lint v2.7
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7
+# golangci-lint（CI 用 v2.9，本地建议装同一版以免版本差异带来的噪音）
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9
 
 # pnpm (前端包管理)
 npm install -g pnpm
@@ -47,13 +47,13 @@ npm install -g pnpm
 
 | Workflow | 触发条件 | 检查内容 |
 |----------|----------|----------|
-| **backend-ci.yml** | push, pull_request | 单元测试 + 集成测试 + golangci-lint v2.7 |
+| **backend-ci.yml** | push, pull_request | 单元测试 + 集成测试 + golangci-lint v2.9 |
 | **security-scan.yml** | push, pull_request, 每周一 | govulncheck + gosec + pnpm audit |
 | **release.yml** | tag `v*` | 构建发布（PR 不触发） |
 
 ### CI 要求
 
-- Go 版本必须是 **1.25.7**
+- Go 版本必须是 **1.26.5**：三个 workflow 都用 `go-version-file: backend/go.mod` 取版本，随后硬断言 `go version | grep -q 'go1.26.5'`。升级 Go 时要同时改 `backend/go.mod` 和 `backend-ci.yml`（两处）、`release.yml`、`security-scan.yml` 里的这句断言，否则 CI 会在版本校验步骤直接失败。
 - 前端使用 `pnpm install --frozen-lockfile`，必须提交 `pnpm-lock.yaml`
 
 ### 本地测试命令

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.25.7-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -196,7 +196,7 @@ Community projects that extend or integrate with Sub2API:
 
 | Component | Technology |
 |-----------|------------|
-| Backend | Go 1.25.7, Gin, Ent |
+| Backend | Go 1.26.5, Gin, Ent |
 | Frontend | Vue 3.4+, Vite 5+, TailwindCSS |
 | Database | PostgreSQL 15+ |
 | Cache/Queue | Redis 7+ |

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.25.7-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -198,7 +198,7 @@ Sub2API 是一个 AI API 网关平台，用于分发和管理 AI 产品订阅的
 
 | 组件 | 技术 |
 |------|------|
-| 后端 | Go 1.25.7, Gin, Ent |
+| 后端 | Go 1.26.5, Gin, Ent |
 | 前端 | Vue 3.4+, Vite 5+, TailwindCSS |
 | 数据库 | PostgreSQL 15+ |
 | 缓存/队列 | Redis 7+ |

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.25.7-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -197,7 +197,7 @@ Sub2API を拡張・統合するコミュニティプロジェクト:
 
 | コンポーネント | 技術 |
 |-----------|------------|
-| バックエンド | Go 1.25.7, Gin, Ent |
+| バックエンド | Go 1.26.5, Gin, Ent |
 | フロントエンド | Vue 3.4+, Vite 5+, TailwindCSS |
 | データベース | PostgreSQL 15+ |
 | キャッシュ/キュー | Redis 7+ |


### PR DESCRIPTION
## Summary

`DEV_GUIDE.md` and the three READMEs still advertise **Go 1.25.7** and **golangci-lint v2.7**, but CI has since moved past both. This updates the ten stale references so the docs match what the workflows actually enforce.

## Why it matters

Two concrete ways the current docs mislead a new contributor:

- **golangci-lint**: `DEV_GUIDE.md` tells you to `go install ...@v2.7`, while `.github/workflows/backend-ci.yml` pins `version: v2.9`. You get a different finding set locally than CI reports, which reads as flaky CI rather than a version skew.
- **Go**: `backend/go.mod` declares `go 1.26.5`. All three workflows resolve the toolchain with `go-version-file: backend/go.mod` and then hard-assert it:

  ```
  go version | grep -q 'go1.26.5'
  ```

  So "Go 版本必须是 **1.25.7**" names a version the workflow's own assertion step rejects.

## Changes

| File | Change |
|---|---|
| `DEV_GUIDE.md` | golangci-lint v2.7 → v2.9 (install cmd + workflow table); Go 1.25.7 → 1.26.5 |
| `README.md` / `README_CN.md` / `README_JA.md` | Go badge + tech-stack table 1.25.7 → 1.26.5 |

I also noted in the CI section which files carry the Go version assertion (`backend/go.mod`, plus `backend-ci.yml` ×2, `release.yml`, `security-scan.yml`), since a bump that misses one fails in the version-check step with no obvious pointer to the culprit.

Verified with `git grep` that no other tracked file still references `1.25.7` or `@v2.7`.

## Test plan

Docs only — no code, no workflow, no dependency changes. Version numbers were read from `backend/go.mod` and `.github/workflows/backend-ci.yml` at `main` rather than assumed.