### PR TITLE
fix(openai): correct WS TTFT and compress OAuth requests

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -1034,7 +1034,12 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	}
 	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
 
-	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
+	upstreamBody, compressed, err := compressOpenAIOAuthCodexRequestBody(account, body)
+	if err != nil {
+		return nil, fmt.Errorf("compress OpenAI OAuth request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(upstreamBody))
 	if err != nil {
 		return nil, err
 	}
@@ -1132,6 +1137,9 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 
 	// 账号级请求头覆写（仅 openai api_key 账号启用时生效；OAuth 路径 no-op）
 	account.ApplyHeaderOverrides(req.Header)
+	if compressed {
+		req.Header.Set("content-encoding", "zstd")
+	}
 	setOpenAICodexRoutingHintFromBody(req.Header, account, body)
 	logOpenAIRoutingDiagnosticsFromBody(ctx, account, "http", req.Header, body, "not_applicable")
 

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -356,7 +356,12 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	}
 	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	upstreamBody, compressed, err := compressOpenAIOAuthCodexRequestBody(account, body)
+	if err != nil {
+		return nil, fmt.Errorf("compress OpenAI OAuth request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(upstreamBody))
 	if err != nil {
 		return nil, err
 	}
@@ -459,6 +464,9 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 
 	// 账号级请求头覆写（仅 openai api_key 账号启用时生效；OAuth 路径 no-op）
 	account.ApplyHeaderOverrides(req.Header)
+	if compressed {
+		req.Header.Set("content-encoding", "zstd")
+	}
 	setOpenAICodexRoutingHintFromBody(req.Header, account, body)
 	logOpenAIRoutingDiagnosticsFromBody(ctx, account, "http_passthrough", req.Header, body, "not_applicable")
 

--- a/backend/internal/service/openai_oauth_body_compression.go
+++ b/backend/internal/service/openai_oauth_body_compression.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// compressOpenAIOAuthCodexRequestBody encodes requests to the official
+// ChatGPT Codex backend. API-key accounts may target arbitrary compatible
+// upstreams, so their bodies must remain uncompressed.
+func compressOpenAIOAuthCodexRequestBody(account *Account, body []byte) ([]byte, bool, error) {
+	if account == nil || account.Type != AccountTypeOAuth {
+		return body, false, nil
+	}
+
+	encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(3)))
+	if err != nil {
+		return nil, false, fmt.Errorf("create zstd encoder: %w", err)
+	}
+	defer encoder.Close()
+
+	return encoder.EncodeAll(body, nil), true, nil
+}

--- a/backend/internal/service/openai_oauth_body_compression_test.go
+++ b/backend/internal/service/openai_oauth_body_compression_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIHTTPBuildersCompressOnlyOAuthRequestBodies(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-codex","input":[{"role":"user","content":"compress this final request body"}]}`)
+	svc := &OpenAIGatewayService{cfg: &config.Config{
+		Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		},
+	}}
+	oauthAccount := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "test-account",
+		},
+	}
+	apiKeyAccount := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-api-key",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		compressed bool
+		build      func(*gin.Context) (*http.Request, error)
+	}{
+		{
+			name:       "ordinary OAuth",
+			compressed: true,
+			build: func(c *gin.Context) (*http.Request, error) {
+				return svc.buildUpstreamRequest(context.Background(), c, oauthAccount, body, "oauth-token", false, "", true)
+			},
+		},
+		{
+			name:       "OAuth passthrough",
+			compressed: true,
+			build: func(c *gin.Context) (*http.Request, error) {
+				return svc.buildUpstreamRequestOpenAIPassthrough(context.Background(), c, oauthAccount, body, "oauth-token")
+			},
+		},
+		{
+			name: "ordinary API key",
+			build: func(c *gin.Context) (*http.Request, error) {
+				return svc.buildUpstreamRequest(context.Background(), c, apiKeyAccount, body, "api-key-token", false, "", true)
+			},
+		},
+		{
+			name: "API key passthrough",
+			build: func(c *gin.Context) (*http.Request, error) {
+				return svc.buildUpstreamRequestOpenAIPassthrough(context.Background(), c, apiKeyAccount, body, "api-key-token")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+
+			req, err := tt.build(c)
+			require.NoError(t, err)
+			defer req.Body.Close()
+
+			encodedBody, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			require.Equal(t, int64(len(encodedBody)), req.ContentLength)
+
+			if !tt.compressed {
+				require.Empty(t, req.Header.Get("content-encoding"))
+				require.Equal(t, body, encodedBody)
+				return
+			}
+
+			require.Equal(t, "zstd", req.Header.Get("content-encoding"))
+			decoder, err := zstd.NewReader(nil)
+			require.NoError(t, err)
+			decompressedBody, err := decoder.DecodeAll(encodedBody, nil)
+			decoder.Close()
+			require.NoError(t, err)
+			require.Equal(t, body, decompressedBody)
+		})
+	}
+}

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -67,11 +68,29 @@ func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID 
 	u.lastReq = req
 	u.lastProxyURL = proxyURL
 	if req != nil && req.Body != nil {
-		b, _ := io.ReadAll(req.Body)
-		u.lastBody = b
-		u.bodies = append(u.bodies, append([]byte(nil), b...))
+		rawBody, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body := rawBody
+		if strings.EqualFold(strings.TrimSpace(req.Header.Get("content-encoding")), "zstd") {
+			decoder, err := zstd.NewReader(nil)
+			if err != nil {
+				return nil, fmt.Errorf("create test zstd decoder: %w", err)
+			}
+			body, err = decoder.DecodeAll(rawBody, nil)
+			decoder.Close()
+			if err != nil {
+				return nil, fmt.Errorf("decode test zstd request body: %w", err)
+			}
+		}
+
+		// The recorder exposes the semantic body after transport decoding while
+		// retaining the raw request (including Content-Encoding) for header tests.
+		u.lastBody = body
+		u.bodies = append(u.bodies, append([]byte(nil), body...))
 		_ = req.Body.Close()
-		req.Body = io.NopCloser(bytes.NewReader(b))
+		req.Body = io.NopCloser(bytes.NewReader(rawBody))
 	}
 	u.requests = append(u.requests, req)
 	if u.err != nil {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -1039,7 +1039,7 @@ func isTokenEvent(eventType string) bool {
 	if strings.HasPrefix(eventType, "response.output") {
 		return true
 	}
-	return eventType == "response.completed" || eventType == "response.done"
+	return false
 }
 
 func minDuration(a, b time.Duration) time.Duration {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
@@ -246,7 +246,7 @@ func TestHelperFunctionsCoverage(t *testing.T) {
 
 	require.True(t, isTokenEvent("response.output_text.delta"))
 	require.True(t, isTokenEvent("response.output_audio.delta"))
-	require.True(t, isTokenEvent("response.completed"))
+	require.False(t, isTokenEvent("response.completed"))
 	require.False(t, isTokenEvent(""))
 	require.False(t, isTokenEvent("response.created"))
 
@@ -408,7 +408,70 @@ func TestIsTokenEventCoverageBranches(t *testing.T) {
 	require.False(t, isTokenEvent("response.output_item.added"))
 	require.True(t, isTokenEvent("response.output_audio.delta"))
 	require.True(t, isTokenEvent("response.output"))
-	require.True(t, isTokenEvent("response.done"))
+	require.False(t, isTokenEvent("response.done"))
+}
+
+func TestObserveUpstreamMessage_TerminalEventDoesNotSetFirstToken(t *testing.T) {
+	t.Parallel()
+
+	state := &relayState{}
+	startAt := time.Unix(0, 0)
+	now := startAt
+	nowFn := func() time.Time {
+		now = now.Add(5 * time.Millisecond)
+		return now
+	}
+
+	observed := observeUpstreamMessage(
+		state,
+		[]byte(`{"type":"response.completed","response":{"id":"resp_terminal","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		startAt,
+		nowFn,
+		nil,
+	)
+
+	require.True(t, observed.terminal)
+	require.Nil(t, state.firstTokenMs)
+	require.Nil(t, observed.firstToken)
+}
+
+func TestObserveUpstreamMessage_DeltaSetsFirstTokenBeforeTerminalEvent(t *testing.T) {
+	t.Parallel()
+
+	state := &relayState{}
+	startAt := time.Unix(0, 0)
+	now := startAt
+	nowFn := func() time.Time {
+		now = now.Add(5 * time.Millisecond)
+		return now
+	}
+
+	observeUpstreamMessage(
+		state,
+		[]byte(`{"type":"response.created","response":{"id":"resp_delta"}}`),
+		startAt,
+		nowFn,
+		nil,
+	)
+	observeUpstreamMessage(
+		state,
+		[]byte(`{"type":"response.output_text.delta","response_id":"resp_delta","delta":"hello"}`),
+		startAt,
+		nowFn,
+		nil,
+	)
+	observed := observeUpstreamMessage(
+		state,
+		[]byte(`{"type":"response.completed","response":{"id":"resp_delta","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		startAt,
+		nowFn,
+		nil,
+	)
+
+	require.NotNil(t, state.firstTokenMs)
+	require.Equal(t, 10, *state.firstTokenMs)
+	require.NotNil(t, observed.firstToken)
+	require.Equal(t, 5, *observed.firstToken)
 }
 
 func TestShouldParseUsageTerminalEvents(t *testing.T) {

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -202,7 +202,7 @@ func TestRelay_BasicRelayAndUsage(t *testing.T) {
 	require.Equal(t, 7, result.Usage.InputTokens)
 	require.Equal(t, 3, result.Usage.OutputTokens)
 	require.Equal(t, 2, result.Usage.CacheReadInputTokens)
-	require.NotNil(t, result.FirstTokenMs)
+	require.Nil(t, result.FirstTokenMs)
 	require.Equal(t, int64(1), result.ClientToUpstreamFrames)
 	require.Equal(t, int64(1), result.UpstreamToClientFrames)
 	require.Equal(t, int64(0), result.DroppedDownstreamFrames)


### PR DESCRIPTION
## Summary
- Do not treat `response.completed` or `response.done` WebSocket events as first-token events, while preserving terminal usage parsing and completion tracking.
- Compress final OpenAI OAuth Responses request bodies with zstd level 3 in both ordinary and automatic passthrough HTTP builders.
- Keep API-key/custom upstream requests uncompressed, and cover the compressed wire body plus post-decompression semantics in tests.

## Verification
- `go test ./internal/service -run '^TestOpenAIHTTPBuildersCompressOnlyOAuthRequestBodies$' -count=1`
- `go test ./internal/service/openai_ws_v2 -count=1`
- Targeted OAuth forwarding regressions for compact, chat completions, images, and Anthropic compatibility.
- `go test ./internal/service -count=1` reaches one unrelated, pre-existing content moderation runtime-cache failure: `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` (also reproduces by itself); all affected OpenAI/OAuth checks pass.

Fixes #5340
Fixes #5176