### PR TITLE
fix(pricing): codex-auto-review 费率以内置兜底值为准，防止远程价格仓库旧值覆盖

### DIFF
--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -22,8 +22,16 @@ import (
 )
 
 var (
-	openAIModelDatePattern     = regexp.MustCompile(`-\d{8}$`)
-	openAIModelBasePattern     = regexp.MustCompile(`^(gpt-\d+(?:\.\d+)?)(?:-|$)`)
+	openAIModelDatePattern = regexp.MustCompile(`-\d{8}$`)
+	openAIModelBasePattern = regexp.MustCompile(`^(gpt-\d+(?:\.\d+)?)(?:-|$)`)
+
+	// internalPricingModels 是计费费率由本仓库维护、不受远程价格仓库覆盖的模型。
+	// codex-auto-review 是 Codex 内部专用模型，LiteLLM 上游无对应条目，远程价格仓库
+	// 未同步其费率时若以远程值为准，会回退为旧费率（见 v0.1.170 的费率调整）。
+	internalPricingModels = map[string]bool{
+		"codex-auto-review": true,
+	}
+
 	openAIGPT54FallbackPricing = &LiteLLMModelPricing{
 		InputCostPerToken:               2.5e-06, // $2.5 per MTok
 		OutputCostPerToken:              1.5e-05, // $15 per MTok
@@ -567,6 +575,13 @@ func (s *PricingService) mergeFallbackPricingData(data map[string]*LiteLLMModelP
 	}
 	merged := 0
 	for modelName, pricing := range fallbackData {
+		if internalPricingModels[modelName] {
+			// 内部专用模型（如 codex-auto-review）费率以本仓库内置值为准，
+			// 覆盖远程同步值，防止远程价格仓库未同步时按旧费率计费。
+			data[modelName] = pricing
+			merged++
+			continue
+		}
 		if _, ok := data[modelName]; ok {
 			continue
 		}

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -378,6 +378,40 @@ func TestPricingService_MergesFallbackOnlyModels(t *testing.T) {
 	require.InDelta(t, 0.034, merged["gemini-3.1-flash-lite-image"].OutputCostPerImage, 1e-12)
 }
 
+func TestMergeFallbackPricingOverridesInternalModelWithStaleRemoteRate(t *testing.T) {
+	svc := &PricingService{cfg: &config.Config{}}
+	svc.cfg.Pricing.FallbackFile = filepath.Join("..", "..", "resources", "model-pricing", "model_prices_and_context_window.json")
+
+	// 模拟远程价格仓库尚未同步 v0.1.170 费率调整：仍为旧费率 5e-06/3e-05/5e-07
+	remoteData, err := svc.parsePricingData([]byte(`{
+		"codex-auto-review": {
+			"input_cost_per_token": 0.000005,
+			"output_cost_per_token": 0.00003,
+			"cache_read_input_token_cost": 0.0000005,
+			"litellm_provider": "openai",
+			"mode": "chat"
+		},
+		"remote-model": {
+			"input_cost_per_token": 0.000002,
+			"litellm_provider": "test",
+			"mode": "chat"
+		}
+	}`))
+	require.NoError(t, err)
+
+	merged := svc.mergeFallbackPricingData(remoteData)
+
+	// 内置兜底值必须覆盖远程旧费率
+	got := merged["codex-auto-review"]
+	require.NotNil(t, got)
+	require.InDelta(t, 0.2e-6, got.InputCostPerToken, 1e-12)
+	require.InDelta(t, 1.2e-6, got.OutputCostPerToken, 1e-12)
+	require.InDelta(t, 0.02e-6, got.CacheReadInputTokenCost, 1e-12)
+
+	// 非内部模型仍以远程值为准，不受影响
+	require.InDelta(t, 0.000002, merged["remote-model"].InputCostPerToken, 1e-12)
+}
+
 func TestGetModelPricing_Gpt53CodexSparkUsesGpt51CodexPricing(t *testing.T) {
 	sparkPricing := &LiteLLMModelPricing{InputCostPerToken: 1}
 	gpt53Pricing := &LiteLLMModelPricing{InputCostPerToken: 9}


### PR DESCRIPTION
## 问题

升级到 v0.1.170/v0.1.171/v0.1.173 后，codex-auto-review 仍按旧费率 $5/$30/$0.5 (per 1M tokens) 计费，v0.1.170 调整的新费率 $0.20/$1.20/$0.02 从未生效。 Fixes #5139 #5263 

## 背景

运行时计费费率来自 Wei-Shaw/model-price-repo main 分支下载的 JSON，而非二进制内置文件。v0.1.170 仅更新了内置兜底文件，价格仓库未同步，导致新费率永远被旧值覆盖（内置文件只在远程"没有"该模型时才合并，而远程有该条目）。

## 证据链

1. v0.1.170 发布说明明确写了「更新 Codex Auto-review 模型计费费率」
2. 内置文件 diff：v0.1.169 → v0.1.170，该模型费率由 5e-06/3e-05/5e-07 改为 2e-07/1.2e-06/2e-08
3. pricing_service_test.go 的 TestDefaultPricingUsesCurrentCodexAutoReviewBaseRates 断言新费率 0.2e-6/1.2e-6/0.02e-6
4. model-price-repo 近 5 次 commit（含最新 sync）该条目始终为 5e-06
5. litellm 上游无此模型条目（Codex 内部模型），自动 sync 不会带出此改动
6. 实测：账单 CSV 中 codex-auto-review 记录全部按 5e-06/3e-05/5e-07 计费，与新旧费率换算均精确吻合

## 修复

codex-auto-review 是 Codex 内部专用模型，LiteLLM 上游无此条目，费率由本仓库维护（与 gpt-5.6-luna 等静态兜底价同一设计）。将此类模型纳入 internalPricingModels 集合，mergeFallbackPricingData 合并时以内置兜底值**覆盖**远程值，而非仅在远程缺失时补充。

修复生效路径：启动加载本地文件、远程下载、定时同步三条路径都经过 mergeFallbackPricingData，因此无论远程仓库是否同步，计费都会使用内置正确费率。后续 GetModelPricing 精确匹配到合并后的值，账单与后台显示同步修正。

## 测试

- 新增 TestMergeFallbackPricingOverridesInternalModelWithStaleRemoteRate：模拟远程仍为旧费率时，合并后必须为内置新费率，且非内部模型仍以远程值为准不受影响
- TestDefaultPricingUsesCurrentCodexAutoReviewBaseRates 继续通过
- go test ./internal/service/：4944 个测试全部通过