### PR TITLE
feat: auto-cooldown slow first-token accounts in Go code

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1002,6 +1002,14 @@ type GatewayConfig struct {
 	// Gemini 账户切换最大次数（Gemini 平台单独配置，因 API 限制更严格）
 	MaxAccountSwitchesGemini int `mapstructure:"max_account_switches_gemini"`
 
+	// SlowFirstTokenCooldownMs: 首 Token 延迟超过此阈值（毫秒）时自动冷却该上游账号。
+	// 0 表示禁用此功能。该冷却在请求完成、failover 循环全部结束后触发，
+	// 不影响当前请求，仅保护后续请求不再选择该慢速账号。
+	SlowFirstTokenCooldownMs int `mapstructure:"slow_first_token_cooldown_ms"`
+	// SlowFirstTokenCooldownSeconds: 慢速首 Token 冷却时长（秒）。
+	// 仅在 SlowFirstTokenCooldownMs > 0 时生效，默认 60 秒。
+	SlowFirstTokenCooldownSeconds int `mapstructure:"slow_first_token_cooldown_seconds"`
+
 	// Antigravity 429 fallback 限流时间（分钟），解析重置时间失败时使用
 	AntigravityFallbackCooldownMinutes int `mapstructure:"antigravity_fallback_cooldown_minutes"`
 
@@ -2235,6 +2243,8 @@ func setDefaults() {
 	viper.SetDefault("gateway.failover_on_400", false)
 	viper.SetDefault("gateway.max_account_switches", 10)
 	viper.SetDefault("gateway.max_account_switches_gemini", 3)
+	viper.SetDefault("gateway.slow_first_token_cooldown_ms", 0)
+	viper.SetDefault("gateway.slow_first_token_cooldown_seconds", 60)
 	viper.SetDefault("gateway.force_codex_cli", false)
 	viper.SetDefault("gateway.disable_codex_identity_enforcement", false)
 	viper.SetDefault("gateway.disable_codex_originator_normalization", false)

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -345,6 +345,10 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), true, nil)
 		}
+		// 首 Token 慢响应自动冷却：仅影响后续请求的调度
+		if result != nil {
+			h.gatewayService.MaybeCooldownSlowFirstToken(c.Request.Context(), account.ID, result.FirstTokenMs)
+		}
 
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -684,6 +684,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), nil)
 		}
+		// 首 Token 慢响应自动冷却：仅影响后续请求的调度
+		if result != nil {
+			h.gatewayService.MaybeCooldownSlowFirstToken(c.Request.Context(), account.ID, result.FirstTokenMs)
+		}
 
 		// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 		userAgent := c.GetHeader("User-Agent")
@@ -1213,6 +1217,10 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), true, nil)
+		}
+		// 首 Token 慢响应自动冷却：仅影响后续请求的调度
+		if result != nil {
+			h.gatewayService.MaybeCooldownSlowFirstToken(c.Request.Context(), account.ID, result.FirstTokenMs)
 		}
 
 		userAgent := c.GetHeader("User-Agent")

--- a/backend/internal/service/slow_first_token_cooldown.go
+++ b/backend/internal/service/slow_first_token_cooldown.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// MaybeCooldownSlowFirstToken 在请求完成后检查首 Token 延迟是否超过阈值，
+// 若超过则自动将该账号置入临时冷却（temp_unschedulable），保护后续请求
+// 不再选择该慢速账号。
+//
+// 调用时机：failover 循环结束、请求已成功返回、尚未提交使用记录之前。
+// 该冷却不影响当前请求，仅影响后续调度。
+//
+// 与外部脚本 slow-account-kicker.sh 的语义一致，
+// 但从轮询改为事件驱动（请求完成即判断），延迟更低。
+func (s *OpenAIGatewayService) MaybeCooldownSlowFirstToken(ctx context.Context, accountID int64, firstTokenMs *int) {
+	if s.cfg == nil {
+		return
+	}
+	thresholdMs := s.cfg.Gateway.SlowFirstTokenCooldownMs
+	if thresholdMs <= 0 {
+		return
+	}
+	if firstTokenMs == nil {
+		return
+	}
+	if *firstTokenMs <= thresholdMs {
+		return
+	}
+
+	cooldownSeconds := s.cfg.Gateway.SlowFirstTokenCooldownSeconds
+	if cooldownSeconds <= 0 {
+		cooldownSeconds = 60
+	}
+
+	until := time.Now().Add(time.Duration(cooldownSeconds) * time.Second)
+	reason := fmt.Sprintf("Auto-cooled: first_token_ms=%d > threshold=%dms", *firstTokenMs, thresholdMs)
+
+	bgCtx := context.Background()
+	if err := s.accountRepo.SetTempUnschedulable(bgCtx, accountID, until, reason); err != nil {
+		logger.L().With(
+			zap.String("component", "service.slow_first_token_cooldown"),
+			zap.Int64("account_id", accountID),
+		).Warn("slow_first_token_cooldown.set_temp_unschedulable_failed", zap.Error(err))
+		return
+	}
+
+	logger.L().With(
+		zap.String("component", "service.slow_first_token_cooldown"),
+		zap.Int64("account_id", accountID),
+		zap.Int("first_token_ms", *firstTokenMs),
+		zap.Int("threshold_ms", thresholdMs),
+		zap.Int("cooldown_seconds", cooldownSeconds),
+		zap.Time("until", until),
+	).Info("slow_first_token_cooldown.applied")
+}


### PR DESCRIPTION
Replace external shell script polling with event-driven cooldown:
- Check first_token_ms after failover loop completes
- Auto SetTempUnschedulable for accounts exceeding threshold
- Default disabled (threshold=0), enable via config/env

Config: gateway.slow_first_token_cooldown_ms / _seconds