### PR TITLE
security: harden credential storage and authentication state

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -73,8 +73,15 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	billingCacheService := service.ProvideBillingCacheService(billingCache, userRepository, userSubscriptionRepository, apiKeyRepository, userRPMCache, userGroupRateRepository, configConfig, serviceUserPlatformQuotaRepository)
 	apiKeyCache := repository.NewAPIKeyCache(redisClient)
 	concurrencyCache := repository.ProvideConcurrencyCache(redisClient, configConfig)
-	schedulerCache := repository.ProvideSchedulerCache(redisClient, configConfig)
-	accountRepository := repository.NewAccountRepository(client, db, schedulerCache)
+	credentialCipher, err := repository.NewCredentialCipher(configConfig)
+	if err != nil {
+		return nil, err
+	}
+	schedulerCache, err := repository.ProvideSchedulerCache(redisClient, configConfig, credentialCipher)
+	if err != nil {
+		return nil, err
+	}
+	accountRepository := repository.NewAccountRepository(client, db, schedulerCache, credentialCipher)
 	concurrencyService := service.ProvideConcurrencyService(concurrencyCache, accountRepository, configConfig)
 	apiKeyService := service.ProvideAPIKeyService(apiKeyRepository, userRepository, groupRepository, userSubscriptionRepository, userGroupRateRepository, apiKeyCache, configConfig, billingCacheService, concurrencyService)
 	apiKeyAuthCacheInvalidator := service.ProvideAPIKeyAuthCacheInvalidator(apiKeyService)
@@ -115,7 +122,10 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tempUnschedCache := repository.NewTempUnschedCache(redisClient)
 	timeoutCounterCache := repository.NewTimeoutCounterCache(redisClient)
 	openAI403CounterCache := repository.NewOpenAI403CounterCache(redisClient)
-	geminiTokenCache := repository.NewGeminiTokenCache(redisClient)
+	geminiTokenCache, err := repository.ProvideGeminiTokenCache(redisClient, credentialCipher)
+	if err != nil {
+		return nil, err
+	}
 	compositeTokenCacheInvalidator := service.NewCompositeTokenCacheInvalidator(geminiTokenCache)
 	rateLimitService := service.ProvideRateLimitService(accountRepository, usageLogRepository, configConfig, geminiQuotaService, tempUnschedCache, timeoutCounterCache, openAI403CounterCache, settingService, compositeTokenCacheInvalidator)
 	identityCache := repository.NewIdentityCache(redisClient)
@@ -186,7 +196,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	dashboardAggregationService := service.ProvideDashboardAggregationService(dashboardAggregationRepository, timingWheelService, leaderLockCache, db, configConfig)
 	dashboardHandler := admin.NewDashboardHandler(dashboardService, dashboardAggregationService)
 	adminGroupRepository := repository.NewAdminGroupRepository(client, db)
-	adminAccountRepository := repository.NewAdminAccountRepository(client, db, schedulerCache)
+	adminAccountRepository := repository.NewAdminAccountRepository(client, db, schedulerCache, credentialCipher)
 	proxyExitInfoProber := repository.NewProxyExitInfoProber(configConfig)
 	proxyLatencyCache := repository.NewProxyLatencyCache(redisClient)
 	adminService := service.NewAdminService(userRepository, adminGroupRepository, adminAccountRepository, proxyRepository, apiKeyRepository, redeemCodeRepository, userGroupRateRepository, userRPMCache, billingCacheService, proxyExitInfoProber, proxyLatencyCache, apiKeyAuthCacheInvalidator, client, settingService, subscriptionService, userSubscriptionRepository, privacyClientFactory, openAIGatewayService, affiliateService, compositeModelRouteRepository, compositeRouteResolver)

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1797,6 +1797,7 @@ var (
 		{Name: "balance_notify_extra_emails", Type: field.TypeString, Default: "[]", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "total_recharged", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "rpm_limit", Type: field.TypeInt, Default: 0},
+		{Name: "token_version", Type: field.TypeInt64, Default: 0},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/backend/ent/schema/user.go
+++ b/backend/ent/schema/user.go
@@ -115,6 +115,12 @@ func (User) Fields() []ent.Field {
 		// 用户级每分钟请求数上限（0 = 不限制）。仅当所在分组未设置 rpm_limit 时作为兜底生效。
 		field.Int("rpm_limit").
 			Default(0),
+
+		// token_version is a persistent security stamp for JWT and refresh-token
+		// revocation. It is advanced atomically whenever all sessions must be
+		// invalidated or a password credential changes.
+		field.Int64("token_version").
+			Default(0),
 	}
 }
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/zeromicro/go-zero v1.9.4
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.53.0
-	golang.org/x/image v0.41.0
+	golang.org/x/image v0.43.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -250,8 +250,6 @@ github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:E
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
-github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=
@@ -312,8 +310,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -350,8 +346,6 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -386,8 +380,6 @@ github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEv
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -423,8 +415,6 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=
@@ -555,8 +545,8 @@ golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsi
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
-golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
-golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
+golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -32,7 +32,7 @@ const (
 
 // DefaultCSPPolicy is the default Content-Security-Policy with nonce support
 // __CSP_NONCE__ will be replaced with actual nonce at request time by the SecurityHeaders middleware
-const DefaultCSPPolicy = "default-src 'self'; worker-src 'self' blob:; script-src 'self' __CSP_NONCE__ https://challenges.cloudflare.com https://*.alicdn.com https://static.cloudflareinsights.com https://turing.captcha.qcloud.com https://turing.captcha.gtimg.com https://ca.turing.captcha.qcloud.com https://global.turing.captcha.gtimg.com https://www.tycaptcha.com https://cloudcache.tencentcs.com https://*.stripe.com https://static.airwallex.com https://checkout.airwallex.com https://static-demo.airwallex.com https://checkout-demo.airwallex.com; style-src 'self' 'unsafe-inline' https://*.captcha.gtimg.com https://fonts.googleapis.com https://*.alicdn.com https://static.airwallex.com https://checkout.airwallex.com https://static-demo.airwallex.com https://checkout-demo.airwallex.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://turing.captcha.qcloud.com https://www.tycaptcha.com https://rce.tencentrio.com https:; frame-src https://challenges.cloudflare.com https://turing.captcha.qcloud.com https://ca.turing.captcha.qcloud.com https://www.tycaptcha.com https://*.stripe.com https://checkout.airwallex.com https://checkout-demo.airwallex.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+const DefaultCSPPolicy = "default-src 'self'; object-src 'none'; worker-src 'self' blob:; script-src 'self' __CSP_NONCE__ https://challenges.cloudflare.com https://*.alicdn.com https://static.cloudflareinsights.com https://turing.captcha.qcloud.com https://turing.captcha.gtimg.com https://ca.turing.captcha.qcloud.com https://global.turing.captcha.gtimg.com https://www.tycaptcha.com https://cloudcache.tencentcs.com https://*.stripe.com https://static.airwallex.com https://checkout.airwallex.com https://static-demo.airwallex.com https://checkout-demo.airwallex.com; style-src 'self' 'unsafe-inline' https://*.captcha.gtimg.com https://fonts.googleapis.com https://*.alicdn.com https://static.airwallex.com https://checkout.airwallex.com https://static-demo.airwallex.com https://checkout-demo.airwallex.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://turing.captcha.qcloud.com https://www.tycaptcha.com https://rce.tencentrio.com https:; frame-src https://challenges.cloudflare.com https://turing.captcha.qcloud.com https://ca.turing.captcha.qcloud.com https://www.tycaptcha.com https://*.stripe.com https://checkout.airwallex.com https://checkout-demo.airwallex.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
 // UMQ（用户消息队列）模式常量
 const (
@@ -73,6 +73,7 @@ type Config struct {
 	Ops                     OpsConfig                     `mapstructure:"ops"`
 	JWT                     JWTConfig                     `mapstructure:"jwt"`
 	Totp                    TotpConfig                    `mapstructure:"totp"`
+	CredentialEncryption    CredentialEncryptionConfig    `mapstructure:"credential_encryption"`
 	WebAuthn                WebAuthnConfig                `mapstructure:"webauthn"`
 	LinuxDo                 LinuxDoConnectConfig          `mapstructure:"linuxdo_connect"`
 	WeChat                  WeChatConnectConfig           `mapstructure:"wechat_connect"`
@@ -1567,6 +1568,15 @@ type TotpConfig struct {
 	EncryptionKeyConfigured bool `mapstructure:"-"`
 }
 
+// CredentialEncryptionConfig controls authenticated encryption for
+// accounts.credentials and scheduler-cache credential payloads. Unlike the
+// development-only TOTP fallback, this key is never generated automatically:
+// losing it would make provider credentials unrecoverable.
+type CredentialEncryptionConfig struct {
+	Key   string `mapstructure:"key"`
+	KeyID string `mapstructure:"key_id"`
+}
+
 type TurnstileConfig struct {
 	Required bool `mapstructure:"required"`
 }
@@ -1750,6 +1760,8 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 	if cfg.Server.Mode == "" {
 		cfg.Server.Mode = "debug"
 	}
+	cfg.CredentialEncryption.Key = strings.TrimSpace(cfg.CredentialEncryption.Key)
+	cfg.CredentialEncryption.KeyID = strings.TrimSpace(cfg.CredentialEncryption.KeyID)
 	cfg.Server.FrontendURL = strings.TrimSpace(cfg.Server.FrontendURL)
 	cfg.JWT.Secret = strings.TrimSpace(cfg.JWT.Secret)
 	cfg.LinuxDo.ClientID = strings.TrimSpace(cfg.LinuxDo.ClientID)
@@ -2177,6 +2189,10 @@ func setDefaults() {
 	// TOTP
 	viper.SetDefault("totp.encryption_key", "")
 
+	// Account provider credential encryption (fixed deployment key; no fallback).
+	viper.SetDefault("credential_encryption.key", "")
+	viper.SetDefault("credential_encryption.key_id", "primary")
+
 	// Default
 	// Admin credentials are created via the setup flow (web wizard / CLI / AUTO_SETUP).
 	// Do not ship fixed defaults here to avoid insecure "known credentials" in production.
@@ -2596,6 +2612,25 @@ func (c *Config) Validate() error {
 	// 选择 bytes 而不是 rune 计数，确保二进制/随机串的长度语义更接近“熵”而非“字符数”。
 	if len([]byte(jwtSecret)) < 32 {
 		return fmt.Errorf("jwt.secret must be at least 32 bytes")
+	}
+	credentialKey := strings.TrimSpace(c.CredentialEncryption.Key)
+	if credentialKey == "" {
+		if strings.EqualFold(strings.TrimSpace(c.Server.Mode), "release") {
+			return fmt.Errorf("credential_encryption.key is required in release mode (set CREDENTIAL_ENCRYPTION_KEY to 64 hexadecimal characters)")
+		}
+	} else {
+		decoded, err := hex.DecodeString(credentialKey)
+		if err != nil || len(decoded) != 32 {
+			return fmt.Errorf("credential_encryption.key must be 64 hexadecimal characters (32 bytes)")
+		}
+	}
+	keyID := strings.TrimSpace(c.CredentialEncryption.KeyID)
+	if keyID == "" {
+		keyID = "primary"
+		c.CredentialEncryption.KeyID = keyID
+	}
+	if !validCredentialEncryptionKeyID(keyID) {
+		return fmt.Errorf("credential_encryption.key_id must be 1-64 characters using only letters, digits, dot, underscore, or hyphen")
 	}
 	switch c.Log.Level {
 	case "debug", "info", "warn", "error":
@@ -3593,6 +3628,19 @@ func normalizeStringSlice(values []string) []string {
 		normalized = append(normalized, trimmed)
 	}
 	return normalized
+}
+
+func validCredentialEncryptionKeyID(value string) bool {
+	if len(value) == 0 || len(value) > 64 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func isWeakJWTSecret(secret string) bool {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	original, existed := os.LookupEnv("CREDENTIAL_ENCRYPTION_KEY")
+	if !existed || strings.TrimSpace(original) == "" {
+		_ = os.Setenv("CREDENTIAL_ENCRYPTION_KEY", strings.Repeat("a", 64))
+	}
+	code := m.Run()
+	if existed {
+		_ = os.Setenv("CREDENTIAL_ENCRYPTION_KEY", original)
+	} else {
+		_ = os.Unsetenv("CREDENTIAL_ENCRYPTION_KEY")
+	}
+	os.Exit(code)
+}
+
 func resetViperWithJWTSecret(t *testing.T) {
 	t.Helper()
 	viper.Reset()
@@ -21,6 +35,28 @@ func resetViperWithJWTSecret(t *testing.T) {
 	t.Setenv("CONFIG_FILE", "")
 	t.Setenv("DATA_DIR", "")
 	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	t.Setenv("CREDENTIAL_ENCRYPTION_KEY", strings.Repeat("a", 64))
+}
+
+func TestCredentialEncryptionKeyReleaseModeValidation(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("SERVER_MODE", "release")
+	t.Setenv("CREDENTIAL_ENCRYPTION_KEY", "")
+	_, err := Load()
+	require.ErrorContains(t, err, "credential_encryption.key is required in release mode")
+
+	resetViperWithJWTSecret(t)
+	t.Setenv("SERVER_MODE", "release")
+	t.Setenv("CREDENTIAL_ENCRYPTION_KEY", "abcd")
+	_, err = Load()
+	require.ErrorContains(t, err, "64 hexadecimal characters")
+
+	resetViperWithJWTSecret(t)
+	t.Setenv("SERVER_MODE", "release")
+	t.Setenv("CREDENTIAL_ENCRYPTION_KEY_ID", "primary-2026")
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, "primary-2026", cfg.CredentialEncryption.KeyID)
 }
 
 func TestLoadServerTimingConfig(t *testing.T) {

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -312,20 +312,14 @@ func (h *AuthHandler) Login2FA(c *gin.Context) {
 	// Get the login session
 	session, err := h.totpService.GetLoginSession(c.Request.Context(), req.TempToken)
 	if err != nil || session == nil {
-		tokenPrefix := ""
-		if len(req.TempToken) >= 8 {
-			tokenPrefix = req.TempToken[:8]
-		}
 		slog.Debug("login_2fa_session_invalid",
-			"temp_token_prefix", tokenPrefix,
 			"error", err)
 		response.BadRequest(c, "Invalid or expired 2FA session")
 		return
 	}
 
 	slog.Debug("login_2fa_session_found",
-		"user_id", session.UserID,
-		"email", session.Email)
+		"user_id", session.UserID)
 
 	// Verify the TOTP code
 	if err := h.totpService.VerifyCode(c.Request.Context(), session.UserID, req.TotpCode); err != nil {
@@ -336,7 +330,26 @@ func (h *AuthHandler) Login2FA(c *gin.Context) {
 		return
 	}
 
-	// Get the user (before session deletion so we can check backend mode)
+	// Claim the temporary session before any login side effect or token mint.
+	// Every concurrent caller may validate the same time-window TOTP code, but
+	// Redis atomically returns the session to exactly one of them.
+	consumedSession, err := h.totpService.ConsumeLoginSession(c.Request.Context(), req.TempToken)
+	if err != nil {
+		slog.Debug("login_2fa_session_consume_failed",
+			"user_id", session.UserID,
+			"error", err)
+		response.InternalError(c, "Failed to consume 2FA session")
+		return
+	}
+	if consumedSession == nil || consumedSession.UserID != session.UserID {
+		slog.Debug("login_2fa_session_already_consumed",
+			"user_id", session.UserID)
+		response.BadRequest(c, "Invalid or expired 2FA session")
+		return
+	}
+	session = consumedSession
+
+	// Get the user only after the one-time session has been claimed.
 	user, err := h.userService.GetByID(c.Request.Context(), session.UserID)
 	if err != nil {
 		response.ErrorFrom(c, err)
@@ -408,9 +421,6 @@ func (h *AuthHandler) Login2FA(c *gin.Context) {
 			return
 		}
 	}
-
-	// Delete the login session (only after all checks pass)
-	_ = h.totpService.DeleteLoginSession(c.Request.Context(), req.TempToken)
 
 	if session.PendingOAuthBind == nil {
 		h.authService.RecordSuccessfulLogin(c.Request.Context(), user.ID)

--- a/backend/internal/handler/auth_login_2fa_atomic_test.go
+++ b/backend/internal/handler/auth_login_2fa_atomic_test.go
@@ -1,0 +1,140 @@
+//go:build unit
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/pquerna/otp/totp"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/repository"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type failingConsumeTotpCache struct {
+	service.TotpCache
+}
+
+func (failingConsumeTotpCache) ConsumeLoginSession(context.Context, string) (*service.TotpLoginSession, error) {
+	return nil, errors.New("fake redis consume failure")
+}
+
+type login2FAResult struct {
+	status int
+	body   []byte
+}
+
+func newAtomicLogin2FATestHandler(t *testing.T, cache service.TotpCache) (*AuthHandler, string, string) {
+	t.Helper()
+	handler, client := newOAuthPendingFlowTestHandlerWithDependencies(t, oauthPendingFlowTestHandlerOptions{
+		settingValues: map[string]string{service.SettingKeyTotpEnabled: "true"},
+		totpCache:     cache,
+		totpEncryptor: oauthPendingFlowTotpEncryptorStub{},
+	})
+
+	const secret = "JBSWY3DPEHPK3PXP"
+	passwordHash, err := handler.authService.HashPassword("fake-local-password")
+	require.NoError(t, err)
+	user, err := client.User.Create().
+		SetEmail("atomic-login@example.test").
+		SetUsername("atomic-login-user").
+		SetPasswordHash(passwordHash).
+		SetRole(service.RoleUser).
+		SetStatus(service.StatusActive).
+		SetTotpEnabled(true).
+		SetTotpSecretEncrypted(secret).
+		SetTotpEnabledAt(time.Now().UTC()).
+		Save(context.Background())
+	require.NoError(t, err)
+
+	tempToken, err := handler.totpService.CreateLoginSession(context.Background(), user.ID, user.Email)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, time.Now().UTC())
+	require.NoError(t, err)
+	return handler, tempToken, code
+}
+
+func invokeLogin2FA(handler *AuthHandler, tempToken, code string) login2FAResult {
+	body, _ := json.Marshal(Login2FARequest{TempToken: tempToken, TotpCode: code})
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login/2fa", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	ginContext.Request = request
+	handler.Login2FA(ginContext)
+	return login2FAResult{status: recorder.Code, body: recorder.Body.Bytes()}
+}
+
+func responseContainsTokenPair(t *testing.T, body []byte) bool {
+	t.Helper()
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	accessToken, accessOK := envelope.Data["access_token"].(string)
+	refreshToken, refreshOK := envelope.Data["refresh_token"].(string)
+	return accessOK && refreshOK && accessToken != "" && refreshToken != ""
+}
+
+func TestLogin2FASameTempTokenAndCode32ConcurrentRequestsIssueExactlyOneTokenPair(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { require.NoError(t, redisClient.Close()) })
+	cache := repository.NewTotpCache(redisClient)
+	handler, tempToken, code := newAtomicLogin2FATestHandler(t, cache)
+
+	const callers = 32
+	start := make(chan struct{})
+	results := make(chan login2FAResult, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- invokeLogin2FA(handler, tempToken, code)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	tokenPairs := 0
+	for result := range results {
+		if responseContainsTokenPair(t, result.body) {
+			tokenPairs++
+			require.Equal(t, http.StatusOK, result.status)
+		} else {
+			require.NotEqual(t, http.StatusOK, result.status)
+		}
+	}
+	require.Equal(t, 1, tokenPairs)
+
+	remaining, err := cache.GetLoginSession(context.Background(), tempToken)
+	require.NoError(t, err)
+	require.Nil(t, remaining)
+}
+
+func TestLogin2FAConsumeStorageErrorIssuesNoTokenPair(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { require.NoError(t, redisClient.Close()) })
+	cache := failingConsumeTotpCache{TotpCache: repository.NewTotpCache(redisClient)}
+	handler, tempToken, code := newAtomicLogin2FATestHandler(t, cache)
+
+	result := invokeLogin2FA(handler, tempToken, code)
+	require.Equal(t, http.StatusInternalServerError, result.status)
+	require.False(t, responseContainsTokenPair(t, result.body))
+}

--- a/backend/internal/handler/auth_oauth_pending_flow_test.go
+++ b/backend/internal/handler/auth_oauth_pending_flow_test.go
@@ -2869,6 +2869,10 @@ func (s *oauthPendingFlowRefreshTokenCacheStub) GetRefreshToken(context.Context,
 	return nil, service.ErrRefreshTokenNotFound
 }
 
+func (s *oauthPendingFlowRefreshTokenCacheStub) ConsumeRefreshToken(context.Context, string) (*service.RefreshTokenData, error) {
+	return nil, service.ErrRefreshTokenNotFound
+}
+
 func (s *oauthPendingFlowRefreshTokenCacheStub) DeleteRefreshToken(context.Context, string) error {
 	return nil
 }
@@ -3551,6 +3555,15 @@ func (s *oauthPendingFlowTotpCacheStub) SetLoginSession(_ context.Context, tempT
 	return nil
 }
 
+func (s *oauthPendingFlowTotpCacheStub) ConsumeLoginSession(_ context.Context, tempToken string) (*service.TotpLoginSession, error) {
+	if s == nil || s.loginSessions == nil {
+		return nil, nil
+	}
+	session := s.loginSessions[tempToken]
+	delete(s.loginSessions, tempToken)
+	return session, nil
+}
+
 func (s *oauthPendingFlowTotpCacheStub) DeleteLoginSession(_ context.Context, tempToken string) error {
 	delete(s.loginSessions, tempToken)
 	return nil
@@ -3576,11 +3589,11 @@ func (s *oauthPendingFlowTotpCacheStub) ClearVerifyAttempts(_ context.Context, u
 	return nil
 }
 
-func (s *oauthPendingFlowTotpCacheStub) SetStepUpGrant(_ context.Context, _ int64, _ string, _ time.Duration) error {
+func (s *oauthPendingFlowTotpCacheStub) SetStepUpGrant(_ context.Context, _ int64, _, _ string, _ time.Duration) error {
 	return nil
 }
 
-func (s *oauthPendingFlowTotpCacheStub) HasStepUpGrant(_ context.Context, _ int64, _ string) (bool, error) {
+func (s *oauthPendingFlowTotpCacheStub) HasStepUpGrant(_ context.Context, _ int64, _, _ string) (bool, error) {
 	return false, nil
 }
 

--- a/backend/internal/handler/auth_session_revocation_test.go
+++ b/backend/internal/handler/auth_session_revocation_test.go
@@ -3,6 +3,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,6 +38,8 @@ func TestAuthHandlerRevokeAllSessionsInvalidatesAccessTokens(t *testing.T) {
 	}
 	authService := service.NewAuthService(nil, repo, nil, refreshTokenCache, cfg, nil, nil, nil, nil, nil, nil, nil, nil)
 	handler := &AuthHandler{authService: authService}
+	oldAccessToken, err := authService.GenerateToken(context.Background(), repo.user)
+	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -47,11 +50,33 @@ func TestAuthHandlerRevokeAllSessionsInvalidatesAccessTokens(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, []int64{29}, refreshTokenCache.revokedUserIDs)
-	// users 表没有 token_version 列（见 resolvedTokenVersion：JWT 里的值由
-	// email+password_hash 指纹推导），所以自增 TokenVersion 只停留在内存里。
-	// 此前紧跟其后的整行 Update 不写任何有效数据，却会用旧快照覆盖并发写入的列，
-	// 已移除。会话撤销由上面的 refresh session 清理承担。
-	require.Equal(t, int64(7), repo.user.TokenVersion)
+	require.Equal(t, int64(8), repo.user.TokenVersion)
+
+	// Exercise the real middleware surface: the stateless token still has a
+	// valid signature, but its durable security stamp is now stale.
+	userService := service.NewUserService(repo, nil, nil, nil)
+	router := gin.New()
+	router.GET(
+		"/protected",
+		gin.HandlerFunc(middleware2.NewJWTAuthMiddleware(authService, userService, nil, nil)),
+		func(c *gin.Context) { c.Status(http.StatusNoContent) },
+	)
+	oldRecorder := httptest.NewRecorder()
+	oldRequest := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	oldRequest.Header.Set("Authorization", "Bearer "+oldAccessToken)
+	router.ServeHTTP(oldRecorder, oldRequest)
+	require.Equal(t, http.StatusUnauthorized, oldRecorder.Code)
+
+	// A fresh login issued after the increment carries the new stamp and works.
+	freshUser, err := repo.GetByID(context.Background(), 29)
+	require.NoError(t, err)
+	freshAccessToken, err := authService.GenerateToken(context.Background(), freshUser)
+	require.NoError(t, err)
+	freshRecorder := httptest.NewRecorder()
+	freshRequest := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	freshRequest.Header.Set("Authorization", "Bearer "+freshAccessToken)
+	router.ServeHTTP(freshRecorder, freshRequest)
+	require.Equal(t, http.StatusNoContent, freshRecorder.Code)
 
 	var resp struct {
 		Code int `json:"code"`

--- a/backend/internal/handler/auth_wechat_oauth_test.go
+++ b/backend/internal/handler/auth_wechat_oauth_test.go
@@ -1466,6 +1466,10 @@ func (s *wechatOAuthRefreshTokenCacheStub) GetRefreshToken(context.Context, stri
 	return nil, service.ErrRefreshTokenNotFound
 }
 
+func (s *wechatOAuthRefreshTokenCacheStub) ConsumeRefreshToken(context.Context, string) (*service.RefreshTokenData, error) {
+	return nil, service.ErrRefreshTokenNotFound
+}
+
 func (s *wechatOAuthRefreshTokenCacheStub) DeleteRefreshToken(context.Context, string) error {
 	return nil
 }

--- a/backend/internal/handler/user_handler_test.go
+++ b/backend/internal/handler/user_handler_test.go
@@ -33,6 +33,14 @@ func (s *userHandlerRepoStub) GetByID(context.Context, int64) (*service.User, er
 	cloned := *s.user
 	return &cloned, nil
 }
+func (s *userHandlerRepoStub) GetTokenVersion(context.Context, int64) (int64, error) {
+	return s.user.TokenVersion, nil
+}
+func (s *userHandlerRepoStub) IncrementTokenVersion(context.Context, int64) (int64, error) {
+	s.user.TokenVersion++
+	s.user.TokenVersionResolved = true
+	return s.user.TokenVersion, nil
+}
 func (s *userHandlerRepoStub) GetByEmail(context.Context, string) (*service.User, error) {
 	cloned := *s.user
 	return &cloned, nil
@@ -426,6 +434,10 @@ func (s *userHandlerRefreshTokenCacheStub) GetRefreshToken(context.Context, stri
 	return nil, service.ErrRefreshTokenNotFound
 }
 
+func (s *userHandlerRefreshTokenCacheStub) ConsumeRefreshToken(context.Context, string) (*service.RefreshTokenData, error) {
+	return nil, service.ErrRefreshTokenNotFound
+}
+
 func (s *userHandlerRefreshTokenCacheStub) DeleteRefreshToken(context.Context, string) error {
 	return nil
 }
@@ -664,11 +676,7 @@ func TestUserHandlerUnbindIdentityRevokesAllUserSessionsWhenAuthServiceConfigure
 
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, []int64{23}, refreshTokenCache.revokedUserIDs)
-	// 撤销依赖的是 refresh session 清理，而不是 token_version：users 表没有这一列
-	// （见 resolvedTokenVersion，实际值由 email+password_hash 指纹推导），
-	// 所以此前"自增 TokenVersion 再整行写回"不持久化任何东西，
-	// 却会用旧快照覆盖并发写入的列。这里断言用户行未被改写。
-	require.Equal(t, int64(4), repo.user.TokenVersion)
+	require.Equal(t, int64(5), repo.user.TokenVersion)
 }
 
 func TestUserHandlerUnbindIdentityDoesNotRevokeSessionsWhenNothingWasUnbound(t *testing.T) {

--- a/backend/internal/repository/account_credentials_crypto.go
+++ b/backend/internal/repository/account_credentials_crypto.go
@@ -1,0 +1,613 @@
+package repository
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+const (
+	credentialEnvelopeKey       = "__sub2api_credential_envelope"
+	credentialFingerprintKey    = "__sub2api_credential_fingerprint"
+	credentialAPIKeyIndexKey    = "__sub2api_api_key_index"
+	credentialOllamaBaseURLKey  = "__sub2api_ollama_cloud_base_url"
+	credentialHasRefreshKey     = "__sub2api_has_refresh_token"
+	credentialEnvelopeVersion   = 1
+	credentialEnvelopeAlgorithm = "AES-256-GCM"
+	credentialCacheSecretPrefix = "sub2api-secret:v1:"
+	oauthTokenCacheSecretScope  = "sub2api/redis/oauth-token"
+	schedulerProxySecretScope   = "sub2api/redis/scheduler-proxy-password"
+
+	credentialMigrationAdvisoryLockID int64 = 694208311321144028
+)
+
+var (
+	errCredentialEnvelopeInvalid  = errors.New("account credential envelope is invalid")
+	errCacheSecretEnvelopeInvalid = errors.New("cache secret envelope is invalid")
+)
+
+// CredentialCipher encrypts complete account credential documents. The only
+// values left beside the envelope are authenticated, non-secret lookup
+// projections needed by existing PostgreSQL scheduling queries.
+type CredentialCipher struct {
+	keyID              string
+	aead               cipher.AEAD
+	oauthTokenAEAD     cipher.AEAD
+	schedulerProxyAEAD cipher.AEAD
+	indexKey           [sha256.Size]byte
+}
+
+type credentialEnvelope struct {
+	Version    int    `json:"version"`
+	KeyID      string `json:"key_id"`
+	Algorithm  string `json:"algorithm"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type credentialAAD struct {
+	Scope         string `json:"scope"`
+	Version       int    `json:"version"`
+	KeyID         string `json:"key_id"`
+	Algorithm     string `json:"algorithm"`
+	AccountID     int64  `json:"account_id"`
+	Platform      string `json:"platform"`
+	Fingerprint   string `json:"fingerprint"`
+	APIKeyIndex   string `json:"api_key_index,omitempty"`
+	OllamaBaseURL bool   `json:"ollama_cloud_base_url"`
+	HasRefresh    bool   `json:"has_refresh_token"`
+}
+
+type cacheSecretAAD struct {
+	Scope     string `json:"scope"`
+	Version   int    `json:"version"`
+	KeyID     string `json:"key_id"`
+	Algorithm string `json:"algorithm"`
+	Context   string `json:"context"`
+}
+
+// NewCredentialCipher constructs the production account-credential cipher.
+// A nil cipher is returned only for non-release development configurations
+// that intentionally omit credential_encryption.key.
+func NewCredentialCipher(cfg *config.Config) (*CredentialCipher, error) {
+	if cfg == nil {
+		return nil, errors.New("credential encryption config is required")
+	}
+	keyHex := strings.TrimSpace(cfg.CredentialEncryption.Key)
+	if keyHex == "" {
+		if strings.EqualFold(strings.TrimSpace(cfg.Server.Mode), "release") {
+			return nil, errors.New("credential_encryption.key is required in release mode")
+		}
+		return nil, nil
+	}
+	master, err := hex.DecodeString(keyHex)
+	if err != nil || len(master) != 32 {
+		return nil, errors.New("credential_encryption.key must be 64 hexadecimal characters (32 bytes)")
+	}
+	keyID := strings.TrimSpace(cfg.CredentialEncryption.KeyID)
+	if keyID == "" {
+		keyID = "primary"
+	}
+	aeadKey := deriveCredentialSubkey(master, "sub2api/account-credentials/aead/v1")
+	indexKey := deriveCredentialSubkey(master, "sub2api/account-credentials/index/v1")
+	oauthTokenKey := deriveCredentialSubkey(master, "sub2api/redis-oauth-token/aead/v1")
+	schedulerProxyKey := deriveCredentialSubkey(master, "sub2api/redis-scheduler-proxy-password/aead/v1")
+	aead, err := newCredentialAEAD(aeadKey)
+	if err != nil {
+		return nil, fmt.Errorf("create account credential cipher: %w", err)
+	}
+	oauthTokenAEAD, err := newCredentialAEAD(oauthTokenKey)
+	if err != nil {
+		return nil, fmt.Errorf("create OAuth token cache cipher: %w", err)
+	}
+	schedulerProxyAEAD, err := newCredentialAEAD(schedulerProxyKey)
+	if err != nil {
+		return nil, fmt.Errorf("create scheduler proxy cipher: %w", err)
+	}
+	return &CredentialCipher{
+		keyID:              keyID,
+		aead:               aead,
+		oauthTokenAEAD:     oauthTokenAEAD,
+		schedulerProxyAEAD: schedulerProxyAEAD,
+		indexKey:           indexKey,
+	}, nil
+}
+
+func newCredentialAEAD(key [sha256.Size]byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func deriveCredentialSubkey(master []byte, label string) [sha256.Size]byte {
+	mac := hmac.New(sha256.New, master)
+	_, _ = mac.Write([]byte(label))
+	var out [sha256.Size]byte
+	copy(out[:], mac.Sum(nil))
+	return out
+}
+
+func (c *CredentialCipher) EncryptOAuthTokenCache(cacheKey, token string) (string, error) {
+	if c == nil || c.oauthTokenAEAD == nil {
+		return token, nil
+	}
+	if strings.TrimSpace(cacheKey) == "" {
+		return "", errors.New("OAuth token cache encryption requires a cache key")
+	}
+	return c.encryptCacheSecret(c.oauthTokenAEAD, oauthTokenCacheSecretScope, cacheKey, token)
+}
+
+func (c *CredentialCipher) DecryptOAuthTokenCache(cacheKey, storage string) (token string, legacy bool, err error) {
+	if c == nil || c.oauthTokenAEAD == nil {
+		return storage, true, nil
+	}
+	if strings.TrimSpace(cacheKey) == "" {
+		return "", false, errors.New("OAuth token cache decryption requires a cache key")
+	}
+	return c.decryptCacheSecret(c.oauthTokenAEAD, oauthTokenCacheSecretScope, cacheKey, storage)
+}
+
+func (c *CredentialCipher) EncryptSchedulerProxyPassword(accountID int64, platform string, proxyID int64, password string) (string, error) {
+	if c == nil || c.schedulerProxyAEAD == nil {
+		return password, nil
+	}
+	contextValue, err := schedulerProxySecretContext(accountID, platform, proxyID)
+	if err != nil {
+		return "", err
+	}
+	return c.encryptCacheSecret(c.schedulerProxyAEAD, schedulerProxySecretScope, contextValue, password)
+}
+
+func (c *CredentialCipher) DecryptSchedulerProxyPassword(accountID int64, platform string, proxyID int64, storage string) (password string, legacy bool, err error) {
+	if c == nil || c.schedulerProxyAEAD == nil {
+		return storage, true, nil
+	}
+	contextValue, err := schedulerProxySecretContext(accountID, platform, proxyID)
+	if err != nil {
+		return "", false, err
+	}
+	return c.decryptCacheSecret(c.schedulerProxyAEAD, schedulerProxySecretScope, contextValue, storage)
+}
+
+func schedulerProxySecretContext(accountID int64, platform string, proxyID int64) (string, error) {
+	if accountID <= 0 || proxyID <= 0 || strings.TrimSpace(platform) == "" {
+		return "", errors.New("scheduler proxy encryption requires positive account/proxy IDs and platform")
+	}
+	encoded, err := json.Marshal(struct {
+		AccountID int64  `json:"account_id"`
+		Platform  string `json:"platform"`
+		ProxyID   int64  `json:"proxy_id"`
+	}{AccountID: accountID, Platform: platform, ProxyID: proxyID})
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func (c *CredentialCipher) encryptCacheSecret(aead cipher.AEAD, scope, contextValue, plaintext string) (string, error) {
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generate cache secret nonce: %w", err)
+	}
+	aad, err := c.marshalCacheSecretAAD(scope, contextValue)
+	if err != nil {
+		return "", err
+	}
+	envelope := credentialEnvelope{
+		Version:    credentialEnvelopeVersion,
+		KeyID:      c.keyID,
+		Algorithm:  credentialEnvelopeAlgorithm,
+		Nonce:      base64.RawURLEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawURLEncoding.EncodeToString(aead.Seal(nil, nonce, []byte(plaintext), aad)),
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("encode cache secret envelope: %w", err)
+	}
+	return credentialCacheSecretPrefix + base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func (c *CredentialCipher) decryptCacheSecret(aead cipher.AEAD, scope, contextValue, storage string) (plaintext string, legacy bool, err error) {
+	if !strings.HasPrefix(storage, credentialCacheSecretPrefix) {
+		return storage, true, nil
+	}
+	encoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(storage, credentialCacheSecretPrefix))
+	if err != nil {
+		return "", false, fmt.Errorf("%w: invalid encoding", errCacheSecretEnvelopeInvalid)
+	}
+	var envelope credentialEnvelope
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&envelope); err != nil {
+		return "", false, fmt.Errorf("%w: decode envelope", errCacheSecretEnvelopeInvalid)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return "", false, fmt.Errorf("%w: trailing envelope data", errCacheSecretEnvelopeInvalid)
+	}
+	canonicalEnvelope, err := json.Marshal(envelope)
+	if err != nil || !bytes.Equal(encoded, canonicalEnvelope) {
+		return "", false, fmt.Errorf("%w: non-canonical envelope", errCacheSecretEnvelopeInvalid)
+	}
+	if envelope.Version != credentialEnvelopeVersion || envelope.KeyID != c.keyID || envelope.Algorithm != credentialEnvelopeAlgorithm {
+		return "", false, fmt.Errorf("%w: unsupported version, key ID, or algorithm", errCacheSecretEnvelopeInvalid)
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(envelope.Nonce)
+	if err != nil || len(nonce) != aead.NonceSize() {
+		return "", false, fmt.Errorf("%w: invalid nonce", errCacheSecretEnvelopeInvalid)
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(envelope.Ciphertext)
+	if err != nil || len(ciphertext) < aead.Overhead() {
+		return "", false, fmt.Errorf("%w: invalid ciphertext", errCacheSecretEnvelopeInvalid)
+	}
+	aad, err := c.marshalCacheSecretAAD(scope, contextValue)
+	if err != nil {
+		return "", false, err
+	}
+	opened, err := aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: authentication failed", errCacheSecretEnvelopeInvalid)
+	}
+	return string(opened), false, nil
+}
+
+func (c *CredentialCipher) marshalCacheSecretAAD(scope, contextValue string) ([]byte, error) {
+	return json.Marshal(cacheSecretAAD{
+		Scope:     scope,
+		Version:   credentialEnvelopeVersion,
+		KeyID:     c.keyID,
+		Algorithm: credentialEnvelopeAlgorithm,
+		Context:   contextValue,
+	})
+}
+
+// Encrypt returns a JSONB-safe envelope. Credentials themselves never appear
+// outside the AEAD ciphertext.
+func (c *CredentialCipher) Encrypt(accountID int64, platform string, credentials map[string]any) (map[string]any, error) {
+	if c == nil || c.aead == nil {
+		return cloneCredentialMap(credentials)
+	}
+	if accountID <= 0 || strings.TrimSpace(platform) == "" {
+		return nil, errors.New("account credential encryption requires a positive account ID and platform")
+	}
+	plaintext, err := canonicalCredentialJSON(credentials)
+	if err != nil {
+		return nil, err
+	}
+	fingerprint := c.fingerprintBytes(plaintext)
+	apiKeyIndex := ""
+	if apiKey, ok := credentials["api_key"].(string); ok && apiKey != "" {
+		apiKeyIndex = c.APIKeyIndex(apiKey)
+	}
+	baseURL, _ := credentials["base_url"].(string)
+	ollamaBaseURL := isOllamaCloudBaseURL(baseURL)
+	hasRefresh := false
+	if refresh, ok := credentials["refresh_token"].(string); ok && strings.TrimSpace(refresh) != "" {
+		hasRefresh = true
+	}
+	aad, err := c.marshalAAD(accountID, platform, fingerprint, apiKeyIndex, ollamaBaseURL, hasRefresh)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate account credential nonce: %w", err)
+	}
+	ciphertext := c.aead.Seal(nil, nonce, plaintext, aad)
+	storage := map[string]any{
+		credentialEnvelopeKey: credentialEnvelope{
+			Version:    credentialEnvelopeVersion,
+			KeyID:      c.keyID,
+			Algorithm:  credentialEnvelopeAlgorithm,
+			Nonce:      base64.RawURLEncoding.EncodeToString(nonce),
+			Ciphertext: base64.RawURLEncoding.EncodeToString(ciphertext),
+		},
+		credentialFingerprintKey:   fingerprint,
+		credentialHasRefreshKey:    hasRefresh,
+		credentialOllamaBaseURLKey: ollamaBaseURL,
+	}
+	if apiKeyIndex != "" {
+		storage[credentialAPIKeyIndexKey] = apiKeyIndex
+	}
+	return storage, nil
+}
+
+// Decrypt supports legacy plaintext maps during the startup migration window.
+// Once an envelope marker is present, all failures are fatal; malformed or
+// partial metadata is never reinterpreted as plaintext.
+func (c *CredentialCipher) Decrypt(accountID int64, platform string, storage map[string]any) (credentials map[string]any, legacy bool, err error) {
+	if c == nil || c.aead == nil {
+		cloned, cloneErr := cloneCredentialMap(storage)
+		return cloned, true, cloneErr
+	}
+	rawEnvelope, hasEnvelope := storage[credentialEnvelopeKey]
+	if !hasEnvelope {
+		for _, reserved := range []string{
+			credentialFingerprintKey,
+			credentialAPIKeyIndexKey,
+			credentialOllamaBaseURLKey,
+			credentialHasRefreshKey,
+		} {
+			if _, exists := storage[reserved]; exists {
+				return nil, false, fmt.Errorf("%w: partial reserved metadata", errCredentialEnvelopeInvalid)
+			}
+		}
+		cloned, cloneErr := cloneCredentialMap(storage)
+		return cloned, true, cloneErr
+	}
+	allowedStorageKeys := map[string]struct{}{
+		credentialEnvelopeKey:      {},
+		credentialFingerprintKey:   {},
+		credentialAPIKeyIndexKey:   {},
+		credentialOllamaBaseURLKey: {},
+		credentialHasRefreshKey:    {},
+	}
+	for key := range storage {
+		if _, allowed := allowedStorageKeys[key]; !allowed {
+			return nil, false, fmt.Errorf("%w: unexpected top-level field %q", errCredentialEnvelopeInvalid, key)
+		}
+	}
+	if accountID <= 0 || strings.TrimSpace(platform) == "" {
+		return nil, false, fmt.Errorf("%w: missing record context", errCredentialEnvelopeInvalid)
+	}
+	envelopeJSON, err := json.Marshal(rawEnvelope)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: encode envelope", errCredentialEnvelopeInvalid)
+	}
+	var envelope credentialEnvelope
+	decoder := json.NewDecoder(bytes.NewReader(envelopeJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, false, fmt.Errorf("%w: decode envelope", errCredentialEnvelopeInvalid)
+	}
+	if envelope.Version != credentialEnvelopeVersion || envelope.KeyID != c.keyID || envelope.Algorithm != credentialEnvelopeAlgorithm {
+		return nil, false, fmt.Errorf("%w: unsupported version, key ID, or algorithm", errCredentialEnvelopeInvalid)
+	}
+	fingerprint, ok := storage[credentialFingerprintKey].(string)
+	if !ok || !validCredentialHMAC(fingerprint) {
+		return nil, false, fmt.Errorf("%w: missing fingerprint", errCredentialEnvelopeInvalid)
+	}
+	apiKeyIndex := ""
+	if rawAPIKeyIndex, exists := storage[credentialAPIKeyIndexKey]; exists {
+		var valid bool
+		apiKeyIndex, valid = rawAPIKeyIndex.(string)
+		if !valid || !validCredentialHMAC(apiKeyIndex) {
+			return nil, false, fmt.Errorf("%w: invalid API-key index", errCredentialEnvelopeInvalid)
+		}
+	}
+	ollamaBaseURL, ok := storage[credentialOllamaBaseURLKey].(bool)
+	if !ok {
+		return nil, false, fmt.Errorf("%w: invalid Ollama base URL projection", errCredentialEnvelopeInvalid)
+	}
+	hasRefresh, ok := storage[credentialHasRefreshKey].(bool)
+	if !ok {
+		return nil, false, fmt.Errorf("%w: invalid refresh-token projection", errCredentialEnvelopeInvalid)
+	}
+	aad, err := c.marshalAAD(accountID, platform, fingerprint, apiKeyIndex, ollamaBaseURL, hasRefresh)
+	if err != nil {
+		return nil, false, err
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(envelope.Nonce)
+	if err != nil || len(nonce) != c.aead.NonceSize() {
+		return nil, false, fmt.Errorf("%w: invalid nonce", errCredentialEnvelopeInvalid)
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(envelope.Ciphertext)
+	if err != nil || len(ciphertext) < c.aead.Overhead() {
+		return nil, false, fmt.Errorf("%w: invalid ciphertext", errCredentialEnvelopeInvalid)
+	}
+	plaintext, err := c.aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: authentication failed", errCredentialEnvelopeInvalid)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(plaintext, &decoded); err != nil || decoded == nil {
+		return nil, false, fmt.Errorf("%w: decrypted document is not an object", errCredentialEnvelopeInvalid)
+	}
+	if !hmac.Equal([]byte(fingerprint), []byte(c.fingerprintBytes(plaintext))) {
+		return nil, false, fmt.Errorf("%w: fingerprint mismatch", errCredentialEnvelopeInvalid)
+	}
+	return decoded, false, nil
+}
+
+func (c *CredentialCipher) Fingerprint(credentials map[string]any) (string, error) {
+	if c == nil {
+		return "", nil
+	}
+	plaintext, err := canonicalCredentialJSON(credentials)
+	if err != nil {
+		return "", err
+	}
+	return c.fingerprintBytes(plaintext), nil
+}
+
+func (c *CredentialCipher) fingerprintBytes(plaintext []byte) string {
+	mac := hmac.New(sha256.New, c.indexKey[:])
+	_, _ = mac.Write([]byte("credential-document\x00"))
+	_, _ = mac.Write(plaintext)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (c *CredentialCipher) APIKeyIndex(apiKey string) string {
+	if c == nil {
+		return apiKey
+	}
+	mac := hmac.New(sha256.New, c.indexKey[:])
+	_, _ = mac.Write([]byte("api-key\x00"))
+	_, _ = mac.Write([]byte(apiKey))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func validCredentialHMAC(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}
+
+func (c *CredentialCipher) marshalAAD(accountID int64, platform, fingerprint, apiKeyIndex string, ollamaBaseURL, hasRefresh bool) ([]byte, error) {
+	return json.Marshal(credentialAAD{
+		Scope:         "sub2api/accounts/credentials",
+		Version:       credentialEnvelopeVersion,
+		KeyID:         c.keyID,
+		Algorithm:     credentialEnvelopeAlgorithm,
+		AccountID:     accountID,
+		Platform:      platform,
+		Fingerprint:   fingerprint,
+		APIKeyIndex:   apiKeyIndex,
+		OllamaBaseURL: ollamaBaseURL,
+		HasRefresh:    hasRefresh,
+	})
+}
+
+func isOllamaCloudBaseURL(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "?#") {
+		return false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Opaque != "" || !strings.EqualFold(parsed.Scheme, "https") || parsed.User != nil || parsed.ForceQuery || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawFragment != "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "ollama.com" && host != "www.ollama.com" {
+		return false
+	}
+	authority := strings.ToLower(parsed.Host)
+	if authority != host && authority != host+":443" {
+		return false
+	}
+	if parsed.RawPath != "" {
+		return false
+	}
+	return parsed.Path == "" || parsed.Path == "/v1"
+}
+
+func canonicalCredentialJSON(credentials map[string]any) ([]byte, error) {
+	if credentials == nil {
+		credentials = map[string]any{}
+	}
+	encoded, err := json.Marshal(credentials)
+	if err != nil {
+		return nil, fmt.Errorf("encode account credentials: %w", err)
+	}
+	return encoded, nil
+}
+
+func cloneCredentialMap(credentials map[string]any) (map[string]any, error) {
+	encoded, err := canonicalCredentialJSON(credentials)
+	if err != nil {
+		return nil, err
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		return nil, fmt.Errorf("clone account credentials: %w", err)
+	}
+	return cloned, nil
+}
+
+func hasCredentialEnvelope(storage map[string]any) bool {
+	if storage == nil {
+		return false
+	}
+	_, ok := storage[credentialEnvelopeKey]
+	return ok
+}
+
+// migrateLegacyAccountCredentials atomically validates every existing
+// envelope and encrypts every legacy plaintext row before the server starts.
+// The transaction-scoped advisory lock serializes concurrent replica starts.
+func migrateLegacyAccountCredentials(ctx context.Context, db *sql.DB, credentialCipher *CredentialCipher) error {
+	if credentialCipher == nil || db == nil {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin account credential migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", credentialMigrationAdvisoryLockID); err != nil {
+		return fmt.Errorf("lock account credential migration: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, platform, credentials
+		FROM accounts
+		ORDER BY id
+		FOR UPDATE
+	`)
+	if err != nil {
+		return fmt.Errorf("scan account credentials for migration: %w", err)
+	}
+	type row struct {
+		id       int64
+		platform string
+		storage  map[string]any
+		raw      []byte
+	}
+	var pending []row
+	for rows.Next() {
+		var item row
+		if err := rows.Scan(&item.id, &item.platform, &item.raw); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan account credential row: %w", err)
+		}
+		if err := json.Unmarshal(item.raw, &item.storage); err != nil || item.storage == nil {
+			_ = rows.Close()
+			return fmt.Errorf("account %d has invalid credential JSON", item.id)
+		}
+		_, legacy, err := credentialCipher.Decrypt(item.id, item.platform, item.storage)
+		if err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("validate encrypted credentials for account %d: %w", item.id, err)
+		}
+		if legacy {
+			pending = append(pending, item)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate account credential rows: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close account credential rows: %w", err)
+	}
+	for _, item := range pending {
+		storage, err := credentialCipher.Encrypt(item.id, item.platform, item.storage)
+		if err != nil {
+			return fmt.Errorf("encrypt legacy credentials for account %d: %w", item.id, err)
+		}
+		encoded, err := json.Marshal(storage)
+		if err != nil {
+			return fmt.Errorf("encode encrypted credentials for account %d: %w", item.id, err)
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE accounts
+			SET credentials = $1::jsonb
+			WHERE id = $2 AND credentials = $3::jsonb
+		`, string(encoded), item.id, string(item.raw))
+		if err != nil {
+			return fmt.Errorf("migrate credentials for account %d: %w", item.id, err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil || affected != 1 {
+			return fmt.Errorf("migrate credentials for account %d: concurrent change detected", item.id)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit account credential migration: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/repository/account_credentials_crypto_test.go
+++ b/backend/internal/repository/account_credentials_crypto_test.go
@@ -1,0 +1,245 @@
+package repository
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func testCredentialCipher(t *testing.T, keyByte string, keyID string) *CredentialCipher {
+	t.Helper()
+	cipher, err := NewCredentialCipher(&config.Config{
+		Server: config.ServerConfig{Mode: "release"},
+		CredentialEncryption: config.CredentialEncryptionConfig{
+			Key:   strings.Repeat(keyByte, 64),
+			KeyID: keyID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cipher)
+	return cipher
+}
+
+func TestCredentialCipherRoundTripUsesRandomNonceAndNoPlaintext(t *testing.T) {
+	cipher := testCredentialCipher(t, "a", "primary-2026")
+	credentials := map[string]any{
+		"access_token":  "secret-access-token",
+		"refresh_token": "secret-refresh-token",
+		"api_key":       "secret-api-key",
+		"base_url":      "https://api.example.test/v1",
+		"model_mapping": map[string]any{"alias": "model"},
+	}
+	first, err := cipher.Encrypt(42, "openai", credentials)
+	require.NoError(t, err)
+	second, err := cipher.Encrypt(42, "openai", credentials)
+	require.NoError(t, err)
+	require.NotEqual(t, first[credentialEnvelopeKey], second[credentialEnvelopeKey])
+
+	storedJSON, err := json.Marshal(first)
+	require.NoError(t, err)
+	for _, secret := range []string{"secret-access-token", "secret-refresh-token", "secret-api-key", "model"} {
+		require.NotContains(t, string(storedJSON), secret)
+	}
+	require.NotContains(t, string(storedJSON), "api.example.test")
+	require.Contains(t, string(storedJSON), "primary-2026")
+	require.Contains(t, string(storedJSON), credentialEnvelopeAlgorithm)
+
+	decoded, legacy, err := cipher.Decrypt(42, "openai", first)
+	require.NoError(t, err)
+	require.False(t, legacy)
+	require.Equal(t, credentials, decoded)
+}
+
+func TestOllamaBaseURLProjectionNeverStoresURLSecrets(t *testing.T) {
+	require.True(t, isOllamaCloudBaseURL("HTTPS://WWW.OLLAMA.COM:443/v1"))
+	require.False(t, isOllamaCloudBaseURL("https://token@ollama.com/v1"))
+	require.False(t, isOllamaCloudBaseURL("https://ollama.com/v1?"))
+	require.False(t, isOllamaCloudBaseURL("https://ollama.com/v1?api_key=secret"))
+	require.False(t, isOllamaCloudBaseURL("https://ollama.com/v1#secret"))
+}
+
+func TestSchedulerCacheCredentialPayloadIsEncryptedAndAADBound(t *testing.T) {
+	cipher := testCredentialCipher(t, "f", "primary")
+	account := service.Account{
+		ID:       99,
+		Platform: service.PlatformOpenAI,
+		Type:     service.AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "cache-access-secret",
+			"api_key":      "cache-api-secret",
+		},
+		Proxy: &service.Proxy{
+			ID:       77,
+			Protocol: "https",
+			Host:     "proxy.example.test",
+			Port:     443,
+			Username: "proxy-user",
+			Password: "cache-proxy-password",
+		},
+	}
+	full, meta, err := marshalSchedulerCacheAccountWithCipher(account, cipher)
+	require.NoError(t, err)
+	require.NotContains(t, string(full), "cache-access-secret")
+	require.NotContains(t, string(full), "cache-api-secret")
+	require.NotContains(t, string(full), "cache-proxy-password")
+	require.NotContains(t, string(meta), "cache-api-secret")
+
+	decoded, err := decodeCachedAccountWithCipher(full, cipher)
+	require.NoError(t, err)
+	require.Equal(t, account.Credentials, decoded.Credentials)
+	require.Equal(t, account.Proxy, decoded.Proxy)
+
+	var tampered map[string]any
+	require.NoError(t, json.Unmarshal(full, &tampered))
+	tampered["ID"] = float64(100)
+	tamperedJSON, err := json.Marshal(tampered)
+	require.NoError(t, err)
+	_, err = decodeCachedAccountWithCipher(tamperedJSON, cipher)
+	require.Error(t, err)
+
+	var proxyTampered map[string]any
+	require.NoError(t, json.Unmarshal(full, &proxyTampered))
+	proxyPayload := proxyTampered["Proxy"].(map[string]any)
+	proxyPayload["Password"] = proxyPayload["Password"].(string) + "A"
+	proxyTamperedJSON, err := json.Marshal(proxyTampered)
+	require.NoError(t, err)
+	_, err = decodeCachedAccountWithCipher(proxyTamperedJSON, cipher)
+	require.Error(t, err)
+
+	legacyPayload, err := json.Marshal(account)
+	require.NoError(t, err)
+	_, err = decodeCachedAccountWithCipher(legacyPayload, cipher)
+	require.ErrorIs(t, err, errLegacySchedulerCredentialCache)
+}
+
+func TestCredentialCipherRejectsTamperWrongKeyAndWrongAAD(t *testing.T) {
+	cipher := testCredentialCipher(t, "a", "primary")
+	storage, err := cipher.Encrypt(7, "grok", map[string]any{"refresh_token": "secret"})
+	require.NoError(t, err)
+
+	tampered := make(map[string]any, len(storage))
+	for key, value := range storage {
+		tampered[key] = value
+	}
+	envelopeJSON, err := json.Marshal(tampered[credentialEnvelopeKey])
+	require.NoError(t, err)
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(envelopeJSON, &envelope))
+	envelope["ciphertext"] = envelope["ciphertext"].(string) + "A"
+	tampered[credentialEnvelopeKey] = envelope
+	_, _, err = cipher.Decrypt(7, "grok", tampered)
+	require.Error(t, err)
+
+	wrongKey := testCredentialCipher(t, "b", "primary")
+	_, _, err = wrongKey.Decrypt(7, "grok", storage)
+	require.Error(t, err)
+	_, _, err = cipher.Decrypt(8, "grok", storage)
+	require.Error(t, err)
+	_, _, err = cipher.Decrypt(7, "openai", storage)
+	require.Error(t, err)
+}
+
+func TestCredentialCipherLegacyDualReadAndPartialEnvelopeFailClosed(t *testing.T) {
+	cipher := testCredentialCipher(t, "c", "primary")
+	legacy := map[string]any{"api_key": "legacy-secret", "base_url": "https://example.test"}
+	decoded, isLegacy, err := cipher.Decrypt(9, "openai", legacy)
+	require.NoError(t, err)
+	require.True(t, isLegacy)
+	require.Equal(t, legacy, decoded)
+
+	_, _, err = cipher.Decrypt(9, "openai", map[string]any{credentialFingerprintKey: "forged"})
+	require.Error(t, err)
+}
+
+func TestCredentialCipherRejectsPlaintextSmuggledBesideEnvelope(t *testing.T) {
+	cipher := testCredentialCipher(t, "c", "primary")
+	storage, err := cipher.Encrypt(10, "openai", map[string]any{"access_token": "encrypted-secret"})
+	require.NoError(t, err)
+
+	storage["access_token"] = "plaintext-leak"
+	_, _, err = cipher.Decrypt(10, "openai", storage)
+	require.ErrorContains(t, err, "unexpected top-level field")
+
+	delete(storage, "access_token")
+	envelopeJSON, err := json.Marshal(storage[credentialEnvelopeKey])
+	require.NoError(t, err)
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(envelopeJSON, &envelope))
+	envelope["plaintext_leak"] = "secret"
+	storage[credentialEnvelopeKey] = envelope
+	_, _, err = cipher.Decrypt(10, "openai", storage)
+	require.ErrorContains(t, err, "decode envelope")
+}
+
+func TestMigrateLegacyAccountCredentialsIsAtomicAndWritesOnlyEnvelope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	cipher := testCredentialCipher(t, "d", "primary")
+	legacy := `{"api_key":"legacy-secret","base_url":"https://api.example.test"}`
+	softDeletedLegacy := `{"refresh_token":"soft-deleted-secret"}`
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").WithArgs(credentialMigrationAdvisoryLockID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)SELECT\s+id,\s*platform,\s*credentials\s+FROM\s+accounts\s+ORDER\s+BY\s+id\s+FOR\s+UPDATE`).WillReturnRows(
+		sqlmock.NewRows([]string{"id", "platform", "credentials"}).
+			AddRow(int64(11), "openai", []byte(legacy)).
+			AddRow(int64(12), "grok", []byte(softDeletedLegacy)),
+	)
+	mock.ExpectExec("UPDATE accounts").
+		WithArgs(encryptedCredentialArgument{forbidden: "legacy-secret"}, int64(11), legacy).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE accounts").
+		WithArgs(encryptedCredentialArgument{forbidden: "soft-deleted-secret"}, int64(12), softDeletedLegacy).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, migrateLegacyAccountCredentials(context.Background(), db, cipher))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+type encryptedCredentialArgument struct {
+	forbidden string
+}
+
+func (a encryptedCredentialArgument) Match(value driver.Value) bool {
+	var encoded string
+	switch typed := value.(type) {
+	case string:
+		encoded = typed
+	case []byte:
+		encoded = string(typed)
+	default:
+		return false
+	}
+	return strings.Contains(encoded, credentialEnvelopeKey) && !strings.Contains(encoded, a.forbidden)
+}
+
+func TestMigrateLegacyAccountCredentialsRollsBackWholeBatchOnInvalidRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	cipher := testCredentialCipher(t, "e", "primary")
+	legacy := `{"api_key":"legacy-secret"}`
+	invalid := `{"` + credentialFingerprintKey + `":"forged"}`
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").WithArgs(credentialMigrationAdvisoryLockID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)SELECT\s+id,\s*platform,\s*credentials\s+FROM\s+accounts\s+ORDER\s+BY\s+id\s+FOR\s+UPDATE`).WillReturnRows(
+		sqlmock.NewRows([]string{"id", "platform", "credentials"}).
+			AddRow(int64(11), "openai", []byte(legacy)).
+			AddRow(int64(12), "grok", []byte(invalid)),
+	)
+	mock.ExpectRollback()
+
+	err = migrateLegacyAccountCredentials(context.Background(), db, cipher)
+	require.ErrorContains(t, err, "account 12")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -42,8 +43,9 @@ import (
 //   - sql: 原生 SQL 执行器，用于复杂查询和批量操作
 //   - schedulerCache: 调度器缓存，用于在账号状态变更时同步快照
 type accountRepository struct {
-	client *dbent.Client // Ent ORM 客户端
-	sql    sqlExecutor   // 原生 SQL 执行接口
+	client           *dbent.Client // Ent ORM 客户端
+	sql              sqlExecutor   // 原生 SQL 执行接口
+	credentialCipher *CredentialCipher
 	// schedulerCache 用于在账号状态变更时主动同步快照到缓存，
 	// 确保粘性会话能及时感知账号不可用状态。
 	// Used to proactively sync account snapshot to cache when status changes,
@@ -73,43 +75,75 @@ const postgresParameterBatchSize = 50000
 
 // NewAccountRepository 创建账户仓储实例。
 // 这是对外暴露的构造函数，返回接口类型以便于依赖注入。
-func NewAccountRepository(client *dbent.Client, sqlDB *sql.DB, schedulerCache service.SchedulerCache) service.AccountRepository {
-	return newAccountRepositoryWithSQL(client, sqlDB, schedulerCache)
+func NewAccountRepository(client *dbent.Client, sqlDB *sql.DB, schedulerCache service.SchedulerCache, credentialCipher *CredentialCipher) service.AccountRepository {
+	return newAccountRepositoryWithCipher(client, sqlDB, schedulerCache, credentialCipher)
 }
 
 // NewAdminAccountRepository exposes the account repository's atomic duplication capability
 // as an explicit dependency of the admin service.
-func NewAdminAccountRepository(client *dbent.Client, sqlDB *sql.DB, schedulerCache service.SchedulerCache) service.AdminAccountRepository {
-	return newAccountRepositoryWithSQL(client, sqlDB, schedulerCache)
+func NewAdminAccountRepository(client *dbent.Client, sqlDB *sql.DB, schedulerCache service.SchedulerCache, credentialCipher *CredentialCipher) service.AdminAccountRepository {
+	return newAccountRepositoryWithCipher(client, sqlDB, schedulerCache, credentialCipher)
 }
 
 // newAccountRepositoryWithSQL 是内部构造函数，支持依赖注入 SQL 执行器。
 // 这种设计便于单元测试时注入 mock 对象。
 func newAccountRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor, schedulerCache service.SchedulerCache) *accountRepository {
-	return &accountRepository{client: client, sql: sqlq, schedulerCache: schedulerCache}
+	return newAccountRepositoryWithCipher(client, sqlq, schedulerCache, nil)
+}
+
+func newAccountRepositoryWithCipher(client *dbent.Client, sqlq sqlExecutor, schedulerCache service.SchedulerCache, credentialCipher *CredentialCipher) *accountRepository {
+	return &accountRepository{client: client, sql: sqlq, schedulerCache: schedulerCache, credentialCipher: credentialCipher}
 }
 
 func (r *accountRepository) Create(ctx context.Context, account *service.Account) error {
-	if err := createAccountRecord(ctx, r.client, account); err != nil {
+	client := r.client
+	var tx *dbent.Tx
+	if contextTx := dbent.TxFromContext(ctx); contextTx != nil {
+		client = contextTx.Client()
+	} else {
+		var err error
+		tx, err = r.client.Tx(ctx)
+		if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
+			return err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+			ctx = dbent.NewTxContext(ctx, tx)
+			client = tx.Client()
+		}
+	}
+	if err := createAccountRecord(ctx, client, r.credentialCipher, account); err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
-		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue account create failed: account=%d err=%v", account.ID, err)
+	if err := enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
+		return err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func createAccountRecord(ctx context.Context, client *dbent.Client, account *service.Account) error {
+func createAccountRecord(ctx context.Context, client *dbent.Client, credentialCipher *CredentialCipher, account *service.Account) error {
 	if account == nil {
 		return service.ErrAccountNilInput
 	}
 
+	credentialStorage := normalizeJSONMap(account.Credentials)
+	if credentialCipher != nil {
+		// The database-generated ID is part of AEAD AAD. Insert only an empty
+		// placeholder, then replace it with ciphertext immediately; plaintext is
+		// never persisted even if the second write fails.
+		credentialStorage = map[string]any{}
+	}
 	builder := client.Account.Create().
 		SetName(account.Name).
 		SetNillableNotes(account.Notes).
 		SetPlatform(account.Platform).
 		SetType(account.Type).
-		SetCredentials(normalizeJSONMap(account.Credentials)).
+		SetCredentials(credentialStorage).
 		SetExtra(normalizeJSONMap(account.Extra)).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
@@ -163,9 +197,20 @@ func createAccountRecord(ctx context.Context, client *dbent.Client, account *ser
 		return translatePersistenceError(err, service.ErrAccountNotFound, nil)
 	}
 
+	if credentialCipher != nil {
+		credentialStorage, err = credentialCipher.Encrypt(created.ID, created.Platform, account.Credentials)
+		if err != nil {
+			return err
+		}
+		created, err = client.Account.UpdateOneID(created.ID).SetCredentials(credentialStorage).Save(ctx)
+		if err != nil {
+			return translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		}
+	}
 	account.ID = created.ID
 	account.CreatedAt = created.CreatedAt
 	account.UpdatedAt = created.UpdatedAt
+	account.CredentialStorage = copyJSONMap(credentialStorage)
 	return nil
 }
 
@@ -189,7 +234,7 @@ func (r *accountRepository) CreateWithAccountGroups(ctx context.Context, account
 		txClient = r.client
 	}
 
-	if err := createAccountRecord(ctx, txClient, account); err != nil {
+	if err := createAccountRecord(ctx, txClient, r.credentialCipher, account); err != nil {
 		return err
 	}
 	groupIDs := make([]int64, 0, len(groups))
@@ -286,7 +331,10 @@ func (r *accountRepository) GetByIDs(ctx context.Context, ids []int64) ([]*servi
 
 	outByID := make(map[int64]*service.Account, len(entAccounts))
 	for _, entAcc := range entAccounts {
-		out := accountEntityToService(entAcc)
+		out, err := r.accountEntityToServiceDecrypted(entAcc)
+		if err != nil {
+			return nil, err
+		}
 		if out == nil {
 			continue
 		}
@@ -482,7 +530,7 @@ func (r *accountRepository) updateLockedAccount(
 	explicitRateSyncEnabled *bool,
 	explicitRateMultiplier *float64,
 ) (*dbent.Account, error) {
-	extra, err := lockAndMergeAccountProbeExtra(ctx, client, account, explicitProbeEnabled, explicitRateSyncEnabled)
+	extra, err := r.lockAndMergeAccountProbeExtra(ctx, client, account, explicitProbeEnabled, explicitRateSyncEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -492,13 +540,20 @@ func (r *accountRepository) updateLockedAccount(
 	if account.Status == service.StatusError {
 		schedulable = false
 	}
+	credentialStorage := normalizeJSONMap(account.Credentials)
+	if r.credentialCipher != nil {
+		credentialStorage, err = r.credentialCipher.Encrypt(account.ID, account.Platform, account.Credentials)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	builder := client.Account.UpdateOneID(account.ID).
 		SetName(account.Name).
 		SetNillableNotes(account.Notes).
 		SetPlatform(account.Platform).
 		SetType(account.Type).
-		SetCredentials(normalizeJSONMap(account.Credentials)).
+		SetCredentials(credentialStorage).
 		SetExtra(extra).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
@@ -568,9 +623,15 @@ func (r *accountRepository) updateLockedAccount(
 	builder.SetQuotaDimension(dbaccount.QuotaDimension(account.QuotaDimensionOrDefault()))
 	builder.SetNillableParentAccountID(account.ParentAccountID)
 
-	return builder.Save(ctx)
+	updated, err := builder.Save(ctx)
+	if err == nil {
+		account.CredentialStorage = copyJSONMap(credentialStorage)
+	}
+	return updated, err
 }
 
+// lockAndMergeAccountProbeExtra preserves the legacy test seam. Production
+// repositories call the cipher-aware method below.
 func lockAndMergeAccountProbeExtra(
 	ctx context.Context,
 	client *dbent.Client,
@@ -578,7 +639,25 @@ func lockAndMergeAccountProbeExtra(
 	explicitProbeEnabled *bool,
 	explicitRateSyncEnabled *bool,
 ) (map[string]any, error) {
-	credentials, err := json.Marshal(normalizeJSONMap(account.Credentials))
+	return (&accountRepository{}).lockAndMergeAccountProbeExtra(ctx, client, account, explicitProbeEnabled, explicitRateSyncEnabled)
+}
+
+func (r *accountRepository) lockAndMergeAccountProbeExtra(
+	ctx context.Context,
+	client *dbent.Client,
+	account *service.Account,
+	explicitProbeEnabled *bool,
+	explicitRateSyncEnabled *bool,
+) (map[string]any, error) {
+	credentialComparison := normalizeJSONMap(account.Credentials)
+	var err error
+	if r.credentialCipher != nil {
+		credentialComparison, err = r.credentialCipher.Encrypt(account.ID, account.Platform, account.Credentials)
+		if err != nil {
+			return nil, err
+		}
+	}
+	credentials, err := json.Marshal(credentialComparison)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +665,7 @@ func lockAndMergeAccountProbeExtra(
 	if account.ProxyID != nil {
 		proxyID = *account.ProxyID
 	}
-	rows, err := client.QueryContext(ctx, `
+	identityQuery := `
 		SELECT
 			platform = $2
 			AND type = $3
@@ -598,8 +677,8 @@ func lockAndMergeAccountProbeExtra(
 				AND type = 'apikey'
 				AND $3 = 'apikey'
 				AND credentials -> 'api_key' IS NOT DISTINCT FROM $4::jsonb -> 'api_key'
-				AND `+ollamaCloudBaseURLMatchesSQL("credentials ->> 'base_url'")+`
-				AND `+ollamaCloudBaseURLMatchesSQL("$4::jsonb ->> 'base_url'")+`,
+				AND ` + ollamaCloudBaseURLMatchesSQL("credentials ->> 'base_url'") + `
+				AND ` + ollamaCloudBaseURLMatchesSQL("$4::jsonb ->> 'base_url'") + `,
 				false
 			),
 			proxy_id IS NOT DISTINCT FROM $5,
@@ -612,7 +691,36 @@ func lockAndMergeAccountProbeExtra(
 		FROM accounts
 		WHERE id = $1 AND deleted_at IS NULL
 		FOR NO KEY UPDATE
-	`, account.ID, account.Platform, account.Type, string(credentials), proxyID)
+	`
+	if r.credentialCipher != nil {
+		identityQuery = `
+		SELECT
+			platform = $2
+			AND type = $3
+			AND credentials ->> '` + credentialFingerprintKey + `' = $4::jsonb ->> '` + credentialFingerprintKey + `',
+			COALESCE(
+				platform IN ('openai', 'anthropic')
+				AND $2 IN ('openai', 'anthropic')
+				AND type = 'apikey'
+				AND $3 = 'apikey'
+				AND credentials ->> '` + credentialAPIKeyIndexKey + `' IS NOT DISTINCT FROM $4::jsonb ->> '` + credentialAPIKeyIndexKey + `'
+				AND credentials @> '{"` + credentialOllamaBaseURLKey + `":true}'::jsonb
+				AND $4::jsonb @> '{"` + credentialOllamaBaseURLKey + `":true}'::jsonb,
+				false
+			),
+			proxy_id IS NOT DISTINCT FROM $5,
+			extra -> 'upstream_billing_probe_enabled',
+			extra -> 'upstream_billing_rate_sync_enabled',
+			extra -> 'upstream_billing_probe',
+			extra -> 'ollama_cloud_usage_session',
+			extra -> 'ollama_cloud_usage_auto_refresh',
+			extra -> 'ollama_cloud_usage_snapshot'
+		FROM accounts
+		WHERE id = $1 AND deleted_at IS NULL
+		FOR NO KEY UPDATE
+	`
+	}
+	rows, err := client.QueryContext(ctx, identityQuery, account.ID, account.Platform, account.Type, string(credentials), proxyID)
 	if err != nil {
 		return nil, err
 	}
@@ -752,6 +860,9 @@ func decodeAccountExtraJSON(raw []byte) (any, bool, error) {
 }
 
 func (r *accountRepository) UpdateCredentials(ctx context.Context, id int64, credentials map[string]any) error {
+	if r.credentialCipher != nil {
+		return r.updateEncryptedCredentials(ctx, id, credentials)
+	}
 	payload, err := json.Marshal(normalizeJSONMap(credentials))
 	if err != nil {
 		return err
@@ -815,6 +926,105 @@ func (r *accountRepository) UpdateCredentials(ctx context.Context, id int64, cre
 	}
 	if affected == 0 {
 		return service.ErrAccountNotFound
+	}
+	if err := enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		return err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	if contextTx == nil {
+		r.syncSchedulerAccountSnapshot(baseCtx, id)
+	}
+	return nil
+}
+
+func (r *accountRepository) updateEncryptedCredentials(ctx context.Context, id int64, credentials map[string]any) error {
+	baseCtx := ctx
+	contextTx := dbent.TxFromContext(ctx)
+	client := r.client
+	var tx *dbent.Tx
+	if contextTx != nil {
+		client = contextTx.Client()
+	} else {
+		var err error
+		tx, err = r.client.Tx(ctx)
+		if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
+			return err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+			ctx = dbent.NewTxContext(ctx, tx)
+			client = tx.Client()
+		}
+	}
+	rows, err := client.QueryContext(ctx, `
+		SELECT platform, type, credentials, extra
+		FROM accounts
+		WHERE id = $1 AND deleted_at IS NULL
+		FOR NO KEY UPDATE
+	`, id)
+	if err != nil {
+		return err
+	}
+	var platform, accountType string
+	var storedJSON, extraJSON []byte
+	if !rows.Next() {
+		_ = rows.Close()
+		return service.ErrAccountNotFound
+	}
+	if err := rows.Scan(&platform, &accountType, &storedJSON, &extraJSON); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	var stored, extra map[string]any
+	if err := json.Unmarshal(storedJSON, &stored); err != nil {
+		return fmt.Errorf("decode stored credentials for account %d: %w", id, err)
+	}
+	if err := json.Unmarshal(extraJSON, &extra); err != nil {
+		return fmt.Errorf("decode account extra for account %d: %w", id, err)
+	}
+	previous, _, err := r.credentialCipher.Decrypt(id, platform, stored)
+	if err != nil {
+		return fmt.Errorf("decrypt credentials for account %d: %w", id, err)
+	}
+	previousFingerprint, err := r.credentialCipher.Fingerprint(previous)
+	if err != nil {
+		return err
+	}
+	nextFingerprint, err := r.credentialCipher.Fingerprint(credentials)
+	if err != nil {
+		return err
+	}
+	credentialsChanged := previousFingerprint != nextFingerprint
+	if credentialsChanged && accountType == service.AccountTypeAPIKey {
+		delete(extra, service.UpstreamBillingProbeExtraKey)
+	}
+	if credentialsChanged && (platform == service.PlatformOpenAI || platform == service.PlatformAnthropic) {
+		before := &service.Account{Platform: platform, Type: accountType, Credentials: previous}
+		after := &service.Account{Platform: platform, Type: accountType, Credentials: credentials}
+		beforeKey, _ := previous["api_key"].(string)
+		afterKey, _ := credentials["api_key"].(string)
+		if beforeKey != afterKey || !service.IsOllamaCloudUsageAccount(before) || !service.IsOllamaCloudUsageAccount(after) {
+			delete(extra, service.OllamaCloudUsageSessionExtraKey)
+			delete(extra, service.OllamaCloudUsageAutoRefreshExtraKey)
+			delete(extra, service.OllamaCloudUsageSnapshotExtraKey)
+		}
+	}
+	credentialStorage, err := r.credentialCipher.Encrypt(id, platform, credentials)
+	if err != nil {
+		return err
+	}
+	if _, err := client.Account.UpdateOneID(id).
+		SetCredentials(credentialStorage).
+		SetExtra(normalizeJSONMap(extra)).
+		Save(ctx); err != nil {
+		return translatePersistenceError(err, service.ErrAccountNotFound, nil)
 	}
 	if err := enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		return err
@@ -1192,9 +1402,14 @@ func (r *accountRepository) ListOAuthRefreshCandidatePage(ctx context.Context, o
 			AND type = 'oauth'`
 	}
 	if options.RequireRefreshToken {
-		query += `
+		if r.credentialCipher != nil {
+			query += `
+			AND credentials @> '{"` + credentialHasRefreshKey + `": true}'::jsonb`
+		} else {
+			query += `
 			AND credentials ? 'refresh_token'
 			AND btrim(credentials->>'refresh_token') <> ''`
+		}
 	}
 	if options.ExcludeRetryCooldown {
 		query += `
@@ -1346,6 +1561,10 @@ func (r *accountRepository) SetGrokCredentialErrorIfMatch(
 	snapshot service.GrokCredentialMutationSnapshot,
 	errorMsg string,
 ) (bool, error) {
+	credentialMatch, err := r.credentialMatchArgumentFromJSON(snapshot.CredentialsJSON)
+	if err != nil {
+		return false, err
+	}
 	result, err := r.sql.ExecContext(ctx, `
 		WITH updated AS (
 		UPDATE accounts AS a
@@ -1363,7 +1582,7 @@ func (r *accountRepository) SetGrokCredentialErrorIfMatch(
 			AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
 			AND (a.overload_until IS NULL OR a.overload_until <= NOW())
 			AND (a.auto_pause_on_expired IS NOT TRUE OR a.expires_at IS NULL OR a.expires_at > NOW())
-			AND a.credentials = $7::jsonb
+			AND `+r.credentialMatchClause("a.credentials", "$7")+`
 			AND a.proxy_id IS NOT DISTINCT FROM $8
 			AND ($2 <> $9 OR (
 				a.proxy_id IS NOT NULL AND NOT EXISTS (
@@ -1375,7 +1594,7 @@ func (r *accountRepository) SetGrokCredentialErrorIfMatch(
 		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
 		SELECT $10, updated.id, NULL, NULL FROM updated
 	`, service.StatusError, errorMsg, id, service.StatusActive, service.PlatformGrok, service.AccountTypeOAuth,
-		snapshot.CredentialsJSON, snapshot.ProxyID, string(service.GrokCredentialReasonProxyInvalid),
+		credentialMatch, snapshot.ProxyID, string(service.GrokCredentialReasonProxyInvalid),
 		service.SchedulerOutboxEventAccountChanged)
 	if err != nil {
 		return false, err
@@ -1402,9 +1621,18 @@ func (r *accountRepository) SetGrokOAuthErrorIfCredentialsUnchanged(
 	if r == nil || r.sql == nil {
 		return false, errors.New("account repository SQL executor is not configured")
 	}
-	expectedJSON, err := json.Marshal(normalizeJSONMap(expectedCredentials))
+	if r.credentialCipher != nil {
+		if refresh, ok := expectedCredentials["refresh_token"].(string); ok && strings.TrimSpace(refresh) != "" {
+			return false, nil
+		}
+	}
+	expectedJSON, err := r.credentialMatchArgument(expectedCredentials)
 	if err != nil {
 		return false, err
+	}
+	refreshAbsentClause := "AND NULLIF(BTRIM(a.credentials->>'refresh_token'), '') IS NULL"
+	if r.credentialCipher != nil {
+		refreshAbsentClause = ""
 	}
 	result, err := r.sql.ExecContext(ctx, `
 		WITH updated AS (
@@ -1418,8 +1646,8 @@ func (r *accountRepository) SetGrokOAuthErrorIfCredentialsUnchanged(
 			AND a.platform = $4
 			AND a.type = $5
 			AND a.status = $6
-			AND a.credentials = $7::jsonb
-			AND NULLIF(BTRIM(a.credentials->>'refresh_token'), '') IS NULL
+			AND `+r.credentialMatchClause("a.credentials", "$7")+`
+			`+refreshAbsentClause+`
 		RETURNING a.id
 		)
 		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
@@ -1431,7 +1659,7 @@ func (r *accountRepository) SetGrokOAuthErrorIfCredentialsUnchanged(
 		service.PlatformGrok,
 		service.AccountTypeOAuth,
 		service.StatusActive,
-		string(expectedJSON),
+		expectedJSON,
 		service.SchedulerOutboxEventAccountChanged,
 	)
 	if err != nil {
@@ -1463,11 +1691,11 @@ func (r *accountRepository) UpdateGrokOAuthCredentialsIfUnchanged(
 	if r == nil || r.sql == nil {
 		return false, errors.New("account repository SQL executor is not configured")
 	}
-	expectedJSON, err := json.Marshal(normalizeJSONMap(expectedCredentials))
+	expectedJSON, err := r.credentialMatchArgument(expectedCredentials)
 	if err != nil {
 		return false, err
 	}
-	credentialsJSON, err := json.Marshal(normalizeJSONMap(credentials))
+	credentialsJSON, err := r.credentialStorageJSON(id, service.PlatformGrok, credentials)
 	if err != nil {
 		return false, err
 	}
@@ -1480,18 +1708,18 @@ func (r *accountRepository) UpdateGrokOAuthCredentialsIfUnchanged(
 			AND a.deleted_at IS NULL
 			AND a.platform = $3
 			AND a.type = $4
-			AND a.credentials = $5::jsonb
+			AND `+r.credentialMatchClause("a.credentials", "$5")+`
 			AND a.proxy_id IS NOT DISTINCT FROM $6
 		RETURNING a.id
 		)
 		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
 		SELECT $7, updated.id, NULL, NULL FROM updated
 	`,
-		string(credentialsJSON),
+		credentialsJSON,
 		id,
 		service.PlatformGrok,
 		service.AccountTypeOAuth,
-		string(expectedJSON),
+		expectedJSON,
 		expectedProxyID,
 		service.SchedulerOutboxEventAccountChanged,
 	)
@@ -1523,7 +1751,7 @@ func (r *accountRepository) SetGrokOAuthRefreshErrorIfCredentialsUnchanged(
 	if r == nil || r.sql == nil {
 		return false, errors.New("account repository SQL executor is not configured")
 	}
-	expectedJSON, err := json.Marshal(normalizeJSONMap(expectedCredentials))
+	expectedJSON, err := r.credentialMatchArgument(expectedCredentials)
 	if err != nil {
 		return false, err
 	}
@@ -1539,7 +1767,7 @@ func (r *accountRepository) SetGrokOAuthRefreshErrorIfCredentialsUnchanged(
 			AND a.platform = $4
 			AND a.type = $5
 			AND a.status = $6
-			AND a.credentials = $7::jsonb
+			AND `+r.credentialMatchClause("a.credentials", "$7")+`
 			AND a.proxy_id IS NOT DISTINCT FROM $8
 		RETURNING a.id
 		)
@@ -1552,7 +1780,7 @@ func (r *accountRepository) SetGrokOAuthRefreshErrorIfCredentialsUnchanged(
 		service.PlatformGrok,
 		service.AccountTypeOAuth,
 		service.StatusActive,
-		string(expectedJSON),
+		expectedJSON,
 		expectedProxyID,
 		service.SchedulerOutboxEventAccountChanged,
 	)
@@ -1584,7 +1812,7 @@ func (r *accountRepository) SetGrokOAuthRefreshTempUnschedulableIfCredentialsUnc
 	if r == nil || r.sql == nil {
 		return false, errors.New("account repository SQL executor is not configured")
 	}
-	expectedJSON, err := json.Marshal(normalizeJSONMap(expectedCredentials))
+	expectedJSON, err := r.credentialMatchArgument(expectedCredentials)
 	if err != nil {
 		return false, err
 	}
@@ -1599,7 +1827,7 @@ func (r *accountRepository) SetGrokOAuthRefreshTempUnschedulableIfCredentialsUnc
 			AND a.platform = $4
 			AND a.type = $5
 			AND a.status = $6
-			AND a.credentials = $7::jsonb
+			AND `+r.credentialMatchClause("a.credentials", "$7")+`
 			AND a.proxy_id IS NOT DISTINCT FROM $8
 			AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until < $1)
 		RETURNING a.id
@@ -1613,7 +1841,7 @@ func (r *accountRepository) SetGrokOAuthRefreshTempUnschedulableIfCredentialsUnc
 		service.PlatformGrok,
 		service.AccountTypeOAuth,
 		service.StatusActive,
-		string(expectedJSON),
+		expectedJSON,
 		expectedProxyID,
 		service.SchedulerOutboxEventAccountChanged,
 	)
@@ -2301,6 +2529,10 @@ func (r *accountRepository) SetGrokCredentialTempUnschedulableIfMatch(
 	until time.Time,
 	reason string,
 ) (bool, error) {
+	credentialMatch, err := r.credentialMatchArgumentFromJSON(snapshot.CredentialsJSON)
+	if err != nil {
+		return false, err
+	}
 	result, err := r.sql.ExecContext(ctx, `
 		WITH updated AS (
 		UPDATE accounts AS a
@@ -2320,14 +2552,14 @@ func (r *accountRepository) SetGrokCredentialTempUnschedulableIfMatch(
 			AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
 			AND (a.overload_until IS NULL OR a.overload_until <= NOW())
 			AND (a.auto_pause_on_expired IS NOT TRUE OR a.expires_at IS NULL OR a.expires_at > NOW())
-			AND a.credentials = $7::jsonb
+			AND `+r.credentialMatchClause("a.credentials", "$7")+`
 			AND a.proxy_id IS NOT DISTINCT FROM $8
 		RETURNING a.id
 		)
 		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
 		SELECT $9, updated.id, NULL, NULL FROM updated
 	`, until, reason, id, service.StatusActive, service.PlatformGrok, service.AccountTypeOAuth,
-		snapshot.CredentialsJSON, snapshot.ProxyID, service.SchedulerOutboxEventAccountChanged)
+		credentialMatch, snapshot.ProxyID, service.SchedulerOutboxEventAccountChanged)
 	if err != nil {
 		return false, err
 	}
@@ -2640,7 +2872,7 @@ func (r *accountRepository) updateUpstreamBillingProbeSnapshotInTx(
 	if err != nil {
 		return err
 	}
-	credentials, err := json.Marshal(account.Credentials)
+	credentials, err := r.credentialMatchArgument(account.Credentials)
 	if err != nil {
 		return err
 	}
@@ -2695,13 +2927,13 @@ func (r *accountRepository) updateUpstreamBillingProbeSnapshotInTx(
 		WHERE id = $2
 			AND platform = $3
 			AND type = $4
-			AND credentials = $5::jsonb
+			AND `+r.credentialMatchClause("credentials", "$5")+`
 			AND proxy_id IS NOT DISTINCT FROM $6
 			AND COALESCE(extra -> 'upstream_billing_probe', 'null'::jsonb) = $7::jsonb
 			AND COALESCE(extra -> 'upstream_billing_probe_enabled', 'null'::jsonb) = $8::jsonb
 			AND COALESCE(extra -> 'upstream_billing_rate_sync_enabled', 'null'::jsonb) = $9::jsonb
 			AND deleted_at IS NULL
-	`, string(payload), account.ID, account.Platform, account.Type, string(credentials), proxyID, string(expectedSnapshotJSON), string(expectedEnabledJSON), string(expectedRateSyncEnabledJSON), rateMultiplier)
+	`, string(payload), account.ID, account.Platform, account.Type, credentials, proxyID, string(expectedSnapshotJSON), string(expectedEnabledJSON), string(expectedRateSyncEnabledJSON), rateMultiplier)
 	if err != nil {
 		return err
 	}
@@ -2792,6 +3024,9 @@ func ollamaCloudUsageSnapshotClearRequested(extra map[string]any) bool {
 func (r *accountRepository) BulkUpdate(ctx context.Context, ids []int64, updates service.AccountBulkUpdate) (int64, error) {
 	if len(ids) == 0 {
 		return 0, nil
+	}
+	if r.credentialCipher != nil && len(updates.Credentials) > 0 {
+		return r.bulkUpdateEncryptedCredentials(ctx, ids, updates)
 	}
 
 	setClauses := make([]string, 0, 8)
@@ -3004,6 +3239,79 @@ func (r *accountRepository) BulkUpdate(ctx context.Context, ids []int64, updates
 	return rows, nil
 }
 
+func (r *accountRepository) bulkUpdateEncryptedCredentials(ctx context.Context, ids []int64, updates service.AccountBulkUpdate) (int64, error) {
+	if r == nil || r.client == nil {
+		return 0, errors.New("account repository client is not configured")
+	}
+	if dbent.TxFromContext(ctx) != nil {
+		return r.bulkUpdateEncryptedCredentialsInTx(ctx, ids, updates)
+	}
+	tx, err := r.client.Tx(ctx)
+	if errors.Is(err, dbent.ErrTxStarted) {
+		return r.bulkUpdateEncryptedCredentialsInTx(ctx, ids, updates)
+	}
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	txCtx := dbent.NewTxContext(ctx, tx)
+	txRepo := newAccountRepositoryWithCipher(tx.Client(), tx.Client(), nil, r.credentialCipher)
+	rows, err := txRepo.bulkUpdateEncryptedCredentialsInTx(txCtx, ids, updates)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return rows, nil
+}
+
+func (r *accountRepository) bulkUpdateEncryptedCredentialsInTx(ctx context.Context, ids []int64, updates service.AccountBulkUpdate) (int64, error) {
+	credentialPatch := copyJSONMap(updates.Credentials)
+	updates.Credentials = nil
+	baseRows, err := r.BulkUpdate(ctx, ids, updates)
+	if err != nil {
+		return 0, err
+	}
+	seen := make(map[int64]struct{}, len(ids))
+	var credentialRows int64
+	client := clientFromContext(ctx, r.client)
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		entity, err := client.Account.Query().
+			Where(dbaccount.IDEQ(id), dbaccount.DeletedAtIsNil()).
+			Only(ctx)
+		if dbent.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		account, err := r.accountEntityToServiceDecrypted(entity)
+		if err != nil {
+			return 0, err
+		}
+		merged := copyJSONMap(normalizeJSONMap(account.Credentials))
+		for key, value := range credentialPatch {
+			merged[key] = value
+		}
+		if err := r.UpdateCredentials(ctx, id, merged); err != nil {
+			return 0, err
+		}
+		credentialRows++
+	}
+	if credentialRows > baseRows {
+		return credentialRows, nil
+	}
+	return baseRows, nil
+}
+
 type accountGroupQueryOptions struct {
 	status               string
 	schedulable          bool
@@ -3103,7 +3411,10 @@ func (r *accountRepository) accountsToService(ctx context.Context, accounts []*d
 
 	outAccounts := make([]service.Account, 0, len(accounts))
 	for _, acc := range accounts {
-		out := accountEntityToService(acc)
+		out, err := r.accountEntityToServiceDecrypted(acc)
+		if err != nil {
+			return nil, err
+		}
 		if out == nil {
 			continue
 		}
@@ -3326,6 +3637,12 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 	}
 
 	rateMultiplier := m.RateMultiplier
+	credentials := copyJSONMap(m.Credentials)
+	if hasCredentialEnvelope(credentials) {
+		// Callers without an injected credential cipher (for example usage-log
+		// label hydration) must never receive or serialize the envelope.
+		credentials = nil
+	}
 
 	return &service.Account{
 		ID:                      m.ID,
@@ -3333,7 +3650,8 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 		Notes:                   m.Notes,
 		Platform:                m.Platform,
 		Type:                    m.Type,
-		Credentials:             copyJSONMap(m.Credentials),
+		Credentials:             credentials,
+		CredentialStorage:       copyJSONMap(m.Credentials),
 		Extra:                   copyJSONMap(m.Extra),
 		ProxyID:                 m.ProxyID,
 		ProxyFallbackOriginID:   m.ProxyFallbackOriginID,
@@ -3362,11 +3680,63 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 	}
 }
 
+func (r *accountRepository) accountEntityToServiceDecrypted(m *dbent.Account) (*service.Account, error) {
+	out := accountEntityToService(m)
+	if out == nil || r == nil || r.credentialCipher == nil {
+		return out, nil
+	}
+	credentials, _, err := r.credentialCipher.Decrypt(m.ID, m.Platform, m.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt credentials for account %d: %w", m.ID, err)
+	}
+	out.Credentials = credentials
+	return out, nil
+}
+
 func normalizeJSONMap(in map[string]any) map[string]any {
 	if in == nil {
 		return map[string]any{}
 	}
 	return in
+}
+
+func (r *accountRepository) credentialMatchArgument(credentials map[string]any) (string, error) {
+	if r != nil && r.credentialCipher != nil {
+		return r.credentialCipher.Fingerprint(credentials)
+	}
+	encoded, err := json.Marshal(normalizeJSONMap(credentials))
+	return string(encoded), err
+}
+
+func (r *accountRepository) credentialMatchArgumentFromJSON(raw string) (string, error) {
+	if r == nil || r.credentialCipher == nil {
+		return raw, nil
+	}
+	var credentials map[string]any
+	if err := json.Unmarshal([]byte(raw), &credentials); err != nil || credentials == nil {
+		return "", errors.New("credential snapshot must be a JSON object")
+	}
+	return r.credentialCipher.Fingerprint(credentials)
+}
+
+func (r *accountRepository) credentialMatchClause(column, placeholder string) string {
+	if r != nil && r.credentialCipher != nil {
+		return column + " ->> '" + credentialFingerprintKey + "' = " + placeholder
+	}
+	return column + " = " + placeholder + "::jsonb"
+}
+
+func (r *accountRepository) credentialStorageJSON(accountID int64, platform string, credentials map[string]any) (string, error) {
+	storage := normalizeJSONMap(credentials)
+	var err error
+	if r != nil && r.credentialCipher != nil {
+		storage, err = r.credentialCipher.Encrypt(accountID, platform, credentials)
+		if err != nil {
+			return "", err
+		}
+	}
+	encoded, err := json.Marshal(storage)
+	return string(encoded), err
 }
 
 func copyJSONMap(in map[string]any) map[string]any {
@@ -3775,7 +4145,11 @@ func (r *accountRepository) ListShadowsByParent(ctx context.Context, parentID in
 	}
 	out := make([]*service.Account, 0, len(rows))
 	for _, m := range rows {
-		out = append(out, accountEntityToService(m))
+		account, err := r.accountEntityToServiceDecrypted(m)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, account)
 	}
 	return out, nil
 }

--- a/backend/internal/repository/account_repo_ollama_cloud_usage.go
+++ b/backend/internal/repository/account_repo_ollama_cloud_usage.go
@@ -27,9 +27,36 @@ func ollamaCloudBaseURLMatchesSQL(expression string) string {
 	return ollamaCloudBaseURLMatchSQLPrefix + expression + ollamaCloudBaseURLMatchSQLSuffix
 }
 
+func (r *accountRepository) credentialAPIKeySQL() string {
+	if r != nil && r.credentialCipher != nil {
+		return "credentials ->> '" + credentialAPIKeyIndexKey + "'"
+	}
+	return "credentials ->> 'api_key'"
+}
+
+func (r *accountRepository) credentialAPIKeyQueryValue(apiKey string) string {
+	if r != nil && r.credentialCipher != nil {
+		return r.credentialCipher.APIKeyIndex(apiKey)
+	}
+	return apiKey
+}
+
+func (r *accountRepository) ollamaCloudUsageEligibleSQL() string {
+	if r == nil || r.credentialCipher == nil {
+		return ollamaCloudUsageEligibleSQL
+	}
+	return `
+	platform IN ('openai', 'anthropic')
+	AND type = 'apikey'
+	AND credentials @> '{"` + credentialOllamaBaseURLKey + `":true}'::jsonb
+	AND jsonb_typeof(credentials -> '` + credentialAPIKeyIndexKey + `') = 'string'
+`
+}
+
 // ListOllamaCloudUsageGroupAccounts resolves every sibling for all supplied
-// identities with one ID query and one batch hydration. API keys are query
-// parameters only; no derived shared key is persisted.
+// identities with one ID query and one batch hydration. In encrypted mode the
+// persisted equality projection is a domain-separated keyed HMAC, never the
+// API key itself.
 func (r *accountRepository) ListOllamaCloudUsageGroupAccounts(ctx context.Context, accounts []*service.Account) ([]service.Account, error) {
 	if r == nil || r.sql == nil {
 		return nil, service.ErrOllamaCloudUsageUnavailable
@@ -44,11 +71,12 @@ func (r *accountRepository) ListOllamaCloudUsageGroupAccounts(ctx context.Contex
 		if !ok || apiKey == "" {
 			continue
 		}
-		if _, duplicate := seen[apiKey]; duplicate {
+		queryValue := r.credentialAPIKeyQueryValue(apiKey)
+		if _, duplicate := seen[queryValue]; duplicate {
 			continue
 		}
-		seen[apiKey] = struct{}{}
-		keys = append(keys, apiKey)
+		seen[queryValue] = struct{}{}
+		keys = append(keys, queryValue)
 	}
 	if len(keys) == 0 {
 		return []service.Account{}, nil
@@ -57,8 +85,8 @@ func (r *accountRepository) ListOllamaCloudUsageGroupAccounts(ctx context.Contex
 		SELECT id
 		FROM accounts
 		WHERE deleted_at IS NULL
-			AND `+ollamaCloudUsageEligibleSQL+`
-			AND credentials ->> 'api_key' = ANY($1)
+			AND `+r.ollamaCloudUsageEligibleSQL()+`
+			AND `+r.credentialAPIKeySQL()+` = ANY($1)
 		ORDER BY id
 	`, pq.Array(keys))
 	if err != nil {
@@ -190,7 +218,7 @@ func (r *accountRepository) updateOllamaCloudUsageGroup(
 		if !matchesProxy {
 			return service.ErrOllamaCloudUsageIdentityChanged
 		}
-		members, err := lockOllamaCloudUsageGroup(txCtx, client, account, apiKey)
+		members, err := r.lockOllamaCloudUsageGroup(txCtx, client, account, apiKey)
 		if err != nil {
 			return err
 		}
@@ -235,6 +263,7 @@ func (r *accountRepository) updateOllamaCloudUsageGroup(
 		for index := range members {
 			memberIDs[index] = members[index].id
 		}
+		apiKeyQueryValue := r.credentialAPIKeyQueryValue(apiKey)
 		result, err := client.ExecContext(txCtx, `
 			UPDATE accounts
 			SET extra = (COALESCE(extra, '{}'::jsonb)
@@ -243,10 +272,10 @@ func (r *accountRepository) updateOllamaCloudUsageGroup(
 					- 'ollama_cloud_usage_snapshot') || $1::jsonb,
 				updated_at = NOW()
 			WHERE deleted_at IS NULL
-				AND `+ollamaCloudUsageEligibleSQL+`
-				AND credentials ->> 'api_key' = $2
+				AND `+r.ollamaCloudUsageEligibleSQL()+`
+				AND `+r.credentialAPIKeySQL()+` = $2
 				AND id = ANY($3)
-		`, string(encoded), apiKey, pq.Array(memberIDs))
+		`, string(encoded), apiKeyQueryValue, pq.Array(memberIDs))
 		if err != nil {
 			return err
 		}
@@ -277,13 +306,13 @@ func (r *accountRepository) updateOllamaCloudUsageGroup(
 	return tx.Commit()
 }
 
-func lockOllamaCloudUsageGroup(
+func (r *accountRepository) lockOllamaCloudUsageGroup(
 	ctx context.Context,
 	client *dbent.Client,
 	account *service.Account,
 	apiKey string,
 ) ([]lockedOllamaCloudUsageMember, error) {
-	credentials, err := json.Marshal(normalizeJSONMap(account.Credentials))
+	credentialMatch, err := r.credentialMatchArgument(account.Credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -291,24 +320,25 @@ func lockOllamaCloudUsageGroup(
 	if account.ProxyID != nil {
 		proxyID = *account.ProxyID
 	}
+	apiKeyQueryValue := r.credentialAPIKeyQueryValue(apiKey)
 	rows, err := client.QueryContext(ctx, `
 		SELECT
 			id,
 			id = $2
 				AND platform = $3
 				AND type = $4
-				AND credentials = $5::jsonb
+				AND `+r.credentialMatchClause("credentials", "$5")+`
 				AND proxy_id IS NOT DISTINCT FROM $6,
 			COALESCE((extra -> 'ollama_cloud_usage_session')::text, 'null'),
 			COALESCE((extra -> 'ollama_cloud_usage_auto_refresh')::text, 'null'),
 			COALESCE((extra -> 'ollama_cloud_usage_snapshot')::text, 'null')
 		FROM accounts
 		WHERE deleted_at IS NULL
-			AND `+ollamaCloudUsageEligibleSQL+`
-			AND credentials ->> 'api_key' = $1
+			AND `+r.ollamaCloudUsageEligibleSQL()+`
+			AND `+r.credentialAPIKeySQL()+` = $1
 		ORDER BY id
 		FOR NO KEY UPDATE
-	`, apiKey, account.ID, account.Platform, account.Type, string(credentials), proxyID)
+	`, apiKeyQueryValue, account.ID, account.Platform, account.Type, credentialMatch, proxyID)
 	if err != nil {
 		return nil, err
 	}
@@ -425,23 +455,22 @@ func (r *accountRepository) ListDueOllamaCloudUsageAccounts(
 	rows, err := r.sql.QueryContext(ctx, `
 		WITH eligible AS (
 			SELECT id,
-				credentials ->> 'api_key' AS api_key,
+				`+r.credentialAPIKeySQL()+` AS api_key,
 				last_used_at,
 				extra -> 'ollama_cloud_usage_snapshot' AS snapshot
 			FROM accounts
 			WHERE deleted_at IS NULL
 				AND status = 'active'
-				AND `+ollamaCloudUsageEligibleSQL+`
+				AND `+r.ollamaCloudUsageEligibleSQL()+`
 				AND jsonb_typeof(extra -> 'ollama_cloud_usage_session') = 'string'
 				AND extra @> '{"ollama_cloud_usage_auto_refresh": true}'::jsonb
 		), group_activity AS (
-			SELECT credentials ->> 'api_key' AS api_key,
+			SELECT `+r.credentialAPIKeySQL()+` AS api_key,
 				MAX(last_used_at) AS group_last_used_at
 			FROM accounts
 			WHERE deleted_at IS NULL
-				AND `+ollamaCloudUsageEligibleSQL+`
-				AND jsonb_typeof(credentials -> 'api_key') = 'string'
-			GROUP BY credentials ->> 'api_key'
+				AND `+r.ollamaCloudUsageEligibleSQL()+`
+			GROUP BY `+r.credentialAPIKeySQL()+`
 		), joined AS (
 			SELECT e.id, e.api_key, e.snapshot, g.group_last_used_at,
 				e.snapshot #>> '{status}' AS status,

--- a/backend/internal/repository/ent.go
+++ b/backend/internal/repository/ent.go
@@ -88,6 +88,15 @@ func InitEnt(cfg *config.Config) (*ent.Client, *sql.DB, error) {
 		_ = client.Close()
 		return nil, nil, fmt.Errorf("validate config after secret bootstrap: %w", err)
 	}
+	credentialCipher, err := NewCredentialCipher(cfg)
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("initialize account credential encryption: %w", err)
+	}
+	if err := migrateLegacyAccountCredentials(migrationCtx, drv.DB(), credentialCipher); err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("migrate account credentials: %w", err)
+	}
 
 	// SIMPLE 模式：启动时补齐各平台默认分组。
 	// - anthropic/openai/gemini: 确保存在 <platform>-default

--- a/backend/internal/repository/gemini_token_cache.go
+++ b/backend/internal/repository/gemini_token_cache.go
@@ -2,7 +2,9 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -11,31 +13,82 @@ import (
 )
 
 const (
-	oauthTokenKeyPrefix       = "oauth:token:"
-	oauthRefreshLockKeyPrefix = "oauth:refresh_lock:"
+	legacyOAuthTokenKeyPrefix    = "oauth:token:"
+	encryptedOAuthTokenKeyPrefix = "oauth:token:v1:"
+	oauthRefreshLockKeyPrefix    = "oauth:refresh_lock:"
 )
 
 type geminiTokenCache struct {
-	rdb *redis.Client
+	rdb              *redis.Client
+	credentialCipher *CredentialCipher
 }
 
 func NewGeminiTokenCache(rdb *redis.Client) service.GeminiTokenCache {
-	return &geminiTokenCache{rdb: rdb}
+	return newGeminiTokenCache(rdb, nil)
+}
+
+func newGeminiTokenCache(rdb *redis.Client, credentialCipher *CredentialCipher) *geminiTokenCache {
+	return &geminiTokenCache{rdb: rdb, credentialCipher: credentialCipher}
+}
+
+// ProvideGeminiTokenCache constructs the shared provider access-token cache.
+// Release deployments use a versioned encrypted keyspace and purge only the
+// pre-encryption oauth:token:* keys; distributed refresh locks are preserved.
+func ProvideGeminiTokenCache(rdb *redis.Client, credentialCipher *CredentialCipher) (service.GeminiTokenCache, error) {
+	if credentialCipher != nil {
+		purgeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := purgeLegacyOAuthTokenCache(purgeCtx, rdb); err != nil {
+			return nil, err
+		}
+	}
+	return newGeminiTokenCache(rdb, credentialCipher), nil
 }
 
 func (c *geminiTokenCache) GetAccessToken(ctx context.Context, cacheKey string) (string, error) {
-	key := fmt.Sprintf("%s%s", oauthTokenKeyPrefix, cacheKey)
-	return c.rdb.Get(ctx, key).Result()
+	key := c.accessTokenKey(cacheKey)
+	storage, err := c.rdb.Get(ctx, key).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) && c.credentialCipher != nil {
+			// A rolling upgrade may leave the old plaintext key behind after the
+			// startup scan. Never read it; remove the exact legacy key and miss.
+			if deleteErr := c.rdb.Del(ctx, legacyOAuthTokenKeyPrefix+cacheKey).Err(); deleteErr != nil {
+				return "", deleteErr
+			}
+		}
+		return "", err
+	}
+	if c.credentialCipher == nil {
+		return storage, nil
+	}
+	token, legacy, err := c.credentialCipher.DecryptOAuthTokenCache(cacheKey, storage)
+	if err != nil {
+		return "", fmt.Errorf("decrypt OAuth access-token cache: %w", err)
+	}
+	if legacy {
+		if err := c.rdb.Del(ctx, key).Err(); err != nil {
+			return "", err
+		}
+		return "", redis.Nil
+	}
+	return token, nil
 }
 
 func (c *geminiTokenCache) SetAccessToken(ctx context.Context, cacheKey string, token string, ttl time.Duration) error {
-	key := fmt.Sprintf("%s%s", oauthTokenKeyPrefix, cacheKey)
-	return c.rdb.Set(ctx, key, token, ttl).Err()
+	key := c.accessTokenKey(cacheKey)
+	storage := token
+	if c.credentialCipher != nil {
+		var err error
+		storage, err = c.credentialCipher.EncryptOAuthTokenCache(cacheKey, token)
+		if err != nil {
+			return fmt.Errorf("encrypt OAuth access-token cache: %w", err)
+		}
+	}
+	return c.rdb.Set(ctx, key, storage, ttl).Err()
 }
 
 func (c *geminiTokenCache) DeleteAccessToken(ctx context.Context, cacheKey string) error {
-	key := fmt.Sprintf("%s%s", oauthTokenKeyPrefix, cacheKey)
-	return c.rdb.Del(ctx, key).Err()
+	return c.rdb.Del(ctx, encryptedOAuthTokenKeyPrefix+cacheKey, legacyOAuthTokenKeyPrefix+cacheKey).Err()
 }
 
 func (c *geminiTokenCache) AcquireRefreshLock(ctx context.Context, cacheKey string, ttl time.Duration) (bool, error) {
@@ -46,4 +99,39 @@ func (c *geminiTokenCache) AcquireRefreshLock(ctx context.Context, cacheKey stri
 func (c *geminiTokenCache) ReleaseRefreshLock(ctx context.Context, cacheKey string) error {
 	key := fmt.Sprintf("%s%s", oauthRefreshLockKeyPrefix, cacheKey)
 	return c.rdb.Del(ctx, key).Err()
+}
+
+func (c *geminiTokenCache) accessTokenKey(cacheKey string) string {
+	if c != nil && c.credentialCipher != nil {
+		return encryptedOAuthTokenKeyPrefix + cacheKey
+	}
+	return legacyOAuthTokenKeyPrefix + cacheKey
+}
+
+func purgeLegacyOAuthTokenCache(ctx context.Context, rdb *redis.Client) error {
+	if rdb == nil {
+		return errors.New("redis client is required to purge legacy OAuth token cache")
+	}
+	var cursor uint64
+	for {
+		keys, next, err := rdb.Scan(ctx, cursor, legacyOAuthTokenKeyPrefix+"*", 512).Result()
+		if err != nil {
+			return fmt.Errorf("scan legacy OAuth token cache: %w", err)
+		}
+		legacyKeys := make([]string, 0, len(keys))
+		for _, key := range keys {
+			if strings.HasPrefix(key, legacyOAuthTokenKeyPrefix) && !strings.HasPrefix(key, encryptedOAuthTokenKeyPrefix) {
+				legacyKeys = append(legacyKeys, key)
+			}
+		}
+		if len(legacyKeys) > 0 {
+			if err := rdb.Del(ctx, legacyKeys...).Err(); err != nil {
+				return fmt.Errorf("purge legacy OAuth token cache: %w", err)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return nil
+		}
+	}
 }

--- a/backend/internal/repository/gemini_token_cache_integration_test.go
+++ b/backend/internal/repository/gemini_token_cache_integration_test.go
@@ -20,13 +20,16 @@ type GeminiTokenCacheSuite struct {
 
 func (s *GeminiTokenCacheSuite) SetupTest() {
 	s.IntegrationRedisSuite.SetupTest()
-	s.cache = NewGeminiTokenCache(s.rdb)
+	s.cache = newGeminiTokenCache(s.rdb, testCredentialCipher(s.T(), "6", "primary"))
 }
 
 func (s *GeminiTokenCacheSuite) TestDeleteAccessToken() {
 	cacheKey := "project-123"
 	token := "token-value"
 	require.NoError(s.T(), s.cache.SetAccessToken(s.ctx, cacheKey, token, time.Minute))
+	raw, err := s.rdb.Get(s.ctx, encryptedOAuthTokenKeyPrefix+cacheKey).Result()
+	require.NoError(s.T(), err)
+	require.NotContains(s.T(), raw, token)
 
 	got, err := s.cache.GetAccessToken(s.ctx, cacheKey)
 	require.NoError(s.T(), err)

--- a/backend/internal/repository/gemini_token_cache_test.go
+++ b/backend/internal/repository/gemini_token_cache_test.go
@@ -4,12 +4,87 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGeminiTokenCacheEncryptsAccessTokensAndRejectsTamperAndWrongAAD(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	cipher := testCredentialCipher(t, "8", "primary")
+	cache := newGeminiTokenCache(rdb, cipher)
+	cacheKey := "openai:account:42"
+	token := "provider-access-token-secret"
+
+	require.NoError(t, cache.SetAccessToken(ctx, cacheKey, token, time.Hour))
+	redisKey := encryptedOAuthTokenKeyPrefix + cacheKey
+	firstStorage, err := mr.Get(redisKey)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(firstStorage, credentialCacheSecretPrefix))
+	require.NotContains(t, firstStorage, token)
+
+	got, err := cache.GetAccessToken(ctx, cacheKey)
+	require.NoError(t, err)
+	require.Equal(t, token, got)
+
+	require.NoError(t, cache.SetAccessToken(ctx, cacheKey, token, time.Hour))
+	secondStorage, err := mr.Get(redisKey)
+	require.NoError(t, err)
+	require.NotEqual(t, firstStorage, secondStorage, "each cache write must use a fresh nonce")
+	_, _, err = cipher.DecryptSchedulerProxyPassword(42, "openai", 9, secondStorage)
+	require.Error(t, err, "OAuth tokens and scheduler proxy passwords use domain-separated AEAD keys")
+
+	mr.Set(redisKey, secondStorage+"A")
+	_, err = cache.GetAccessToken(ctx, cacheKey)
+	require.Error(t, err)
+
+	mr.Set(encryptedOAuthTokenKeyPrefix+"openai:account:43", secondStorage)
+	_, err = cache.GetAccessToken(ctx, "openai:account:43")
+	require.Error(t, err, "cache key is authenticated as AEAD context")
+}
+
+func TestGeminiTokenCacheLegacyPlaintextIsDeletedAndTreatedAsMiss(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	cache := newGeminiTokenCache(rdb, testCredentialCipher(t, "9", "primary"))
+	cacheKey := "grok:account:77"
+
+	mr.Set(encryptedOAuthTokenKeyPrefix+cacheKey, "legacy-plaintext-token")
+	_, err := cache.GetAccessToken(ctx, cacheKey)
+	require.ErrorIs(t, err, redis.Nil)
+	require.False(t, mr.Exists(encryptedOAuthTokenKeyPrefix+cacheKey))
+
+	mr.Set(legacyOAuthTokenKeyPrefix+cacheKey, "rolling-upgrade-plaintext-token")
+	_, err = cache.GetAccessToken(ctx, cacheKey)
+	require.ErrorIs(t, err, redis.Nil)
+	require.False(t, mr.Exists(legacyOAuthTokenKeyPrefix+cacheKey))
+}
+
+func TestPurgeLegacyOAuthTokenCachePreservesEncryptedValuesAndRefreshLocks(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	cache := newGeminiTokenCache(rdb, testCredentialCipher(t, "7", "primary"))
+
+	require.NoError(t, cache.SetAccessToken(ctx, "openai:account:5", "encrypted-token", time.Hour))
+	mr.Set(legacyOAuthTokenKeyPrefix+"openai:account:6", "legacy-plaintext-token")
+	mr.Set(oauthRefreshLockKeyPrefix+"openai:account:6", "lock-owner")
+
+	require.NoError(t, purgeLegacyOAuthTokenCache(ctx, rdb))
+	require.True(t, mr.Exists(encryptedOAuthTokenKeyPrefix+"openai:account:5"))
+	require.False(t, mr.Exists(legacyOAuthTokenKeyPrefix+"openai:account:6"))
+	require.True(t, mr.Exists(oauthRefreshLockKeyPrefix+"openai:account:6"))
+}
 
 func TestGeminiTokenCache_DeleteAccessToken_RedisError(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{

--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -45,6 +45,7 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 	// users: columns required by repository queries
 	requireColumn(t, tx, "users", "username", "character varying", 100, false)
 	requireColumn(t, tx, "users", "notes", "text", 0, false)
+	requireColumn(t, tx, "users", "token_version", "bigint", 0, false)
 
 	// accounts: schedulable and rate-limit fields
 	requireColumn(t, tx, "accounts", "notes", "text", 0, true)

--- a/backend/internal/repository/refresh_token_cache.go
+++ b/backend/internal/repository/refresh_token_cache.go
@@ -11,10 +11,116 @@ import (
 )
 
 const (
-	refreshTokenKeyPrefix   = "refresh_token:"
-	userRefreshTokensPrefix = "user_refresh_tokens:"
-	tokenFamilyPrefix       = "token_family:"
+	refreshTokenKeyPrefix         = "refresh_token:"
+	userRefreshTokensPrefix       = "user_refresh_tokens:"
+	tokenFamilyPrefix             = "token_family:"
+	consumedRefreshTokenKeyPrefix = "consumed_refresh_token:"
+	revokedTokenFamilyKeyPrefix   = "revoked_token_family:"
+	refreshTombstoneFallbackTTL   = 5 * time.Minute
 )
+
+var storeRefreshTokenScript = redis.NewScript(`
+if redis.call("EXISTS", KEYS[4]) == 1 then
+  return 0
+end
+
+local ttl = tonumber(ARGV[2])
+if not ttl or ttl < 1 then
+  return redis.error_reply("invalid refresh token ttl")
+end
+
+redis.call("PSETEX", KEYS[1], ttl, ARGV[1])
+redis.call("SADD", KEYS[2], ARGV[3])
+redis.call("SADD", KEYS[3], ARGV[3])
+
+local user_ttl = redis.call("PTTL", KEYS[2])
+if user_ttl < ttl then
+  redis.call("PEXPIRE", KEYS[2], ttl)
+end
+local family_ttl = redis.call("PTTL", KEYS[3])
+if family_ttl < ttl then
+  redis.call("PEXPIRE", KEYS[3], ttl)
+end
+return 1
+`)
+
+var consumeRefreshTokenScript = redis.NewScript(`
+local raw = redis.call("GET", KEYS[1])
+if raw then
+  local ttl = redis.call("PTTL", KEYS[1])
+  local fallback_ttl = tonumber(ARGV[6])
+  if ttl < fallback_ttl then
+    ttl = fallback_ttl
+  end
+  redis.call("DEL", KEYS[1])
+  redis.call("PSETEX", KEYS[2], ttl, raw)
+
+  local ok, data = pcall(cjson.decode, raw)
+  if ok then
+    if data.user_id then
+      redis.call("SREM", ARGV[3] .. tostring(data.user_id), ARGV[1])
+    end
+    if data.family_id then
+      redis.call("SREM", ARGV[4] .. tostring(data.family_id), ARGV[1])
+    end
+  end
+  return {1, raw}
+end
+
+raw = redis.call("GET", KEYS[2])
+if not raw then
+  return {0}
+end
+
+local ttl = redis.call("PTTL", KEYS[2])
+local fallback_ttl = tonumber(ARGV[6])
+if ttl < fallback_ttl then
+  ttl = fallback_ttl
+end
+local ok, data = pcall(cjson.decode, raw)
+if not ok then
+  return {3, raw}
+end
+
+local family_id = data.family_id and tostring(data.family_id) or ""
+local user_id = data.user_id and tostring(data.user_id) or ""
+if family_id ~= "" then
+  local family_key = ARGV[4] .. family_id
+  redis.call("PSETEX", ARGV[5] .. family_id, ttl, "1")
+  local hashes = redis.call("SMEMBERS", family_key)
+  for _, hash in ipairs(hashes) do
+    redis.call("DEL", ARGV[2] .. hash)
+    if user_id ~= "" then
+      redis.call("SREM", ARGV[3] .. user_id, hash)
+    end
+  end
+  redis.call("DEL", family_key)
+end
+return {2, raw}
+`)
+
+var revokeTokenFamilyScript = redis.NewScript(`
+local hashes = redis.call("SMEMBERS", KEYS[1])
+local ttl = tonumber(ARGV[3])
+for _, hash in ipairs(hashes) do
+  local token_key = ARGV[1] .. hash
+  local token_ttl = redis.call("PTTL", token_key)
+  if token_ttl > ttl then
+    ttl = token_ttl
+  end
+  local raw = redis.call("GET", token_key)
+  if raw then
+    local ok, data = pcall(cjson.decode, raw)
+    if ok and data.user_id then
+      redis.call("SREM", ARGV[2] .. tostring(data.user_id), hash)
+    end
+  end
+  redis.call("DEL", token_key)
+end
+redis.call("DEL", KEYS[1])
+redis.call("PSETEX", KEYS[2], ttl, "1")
+return #hashes
+`)
 
 // refreshTokenKey generates the Redis key for a refresh token.
 func refreshTokenKey(tokenHash string) string {
@@ -31,9 +137,19 @@ func tokenFamilyKey(familyID string) string {
 	return tokenFamilyPrefix + familyID
 }
 
+func consumedRefreshTokenKey(tokenHash string) string {
+	return consumedRefreshTokenKeyPrefix + tokenHash
+}
+
+func revokedTokenFamilyKey(familyID string) string {
+	return revokedTokenFamilyKeyPrefix + familyID
+}
+
 type refreshTokenCache struct {
 	rdb *redis.Client
 }
+
+var _ service.RefreshTokenReplayAcknowledger = (*refreshTokenCache)(nil)
 
 // NewRefreshTokenCache creates a new RefreshTokenCache implementation.
 func NewRefreshTokenCache(rdb *redis.Client) service.RefreshTokenCache {
@@ -41,12 +157,27 @@ func NewRefreshTokenCache(rdb *redis.Client) service.RefreshTokenCache {
 }
 
 func (c *refreshTokenCache) StoreRefreshToken(ctx context.Context, tokenHash string, data *service.RefreshTokenData, ttl time.Duration) error {
+	if data == nil || data.UserID <= 0 || data.FamilyID == "" || ttl <= 0 {
+		return fmt.Errorf("invalid refresh token data")
+	}
 	key := refreshTokenKey(tokenHash)
 	val, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("marshal refresh token data: %w", err)
 	}
-	return c.rdb.Set(ctx, key, val, ttl).Err()
+	stored, err := storeRefreshTokenScript.Run(ctx, c.rdb, []string{
+		key,
+		userRefreshTokensKey(data.UserID),
+		tokenFamilyKey(data.FamilyID),
+		revokedTokenFamilyKey(data.FamilyID),
+	}, val, ttl.Milliseconds(), tokenHash).Int()
+	if err != nil {
+		return fmt.Errorf("store refresh token atomically: %w", err)
+	}
+	if stored != 1 {
+		return service.ErrRefreshTokenReused
+	}
+	return nil
 }
 
 func (c *refreshTokenCache) GetRefreshToken(ctx context.Context, tokenHash string) (*service.RefreshTokenData, error) {
@@ -63,6 +194,61 @@ func (c *refreshTokenCache) GetRefreshToken(ctx context.Context, tokenHash strin
 		return nil, fmt.Errorf("unmarshal refresh token data: %w", err)
 	}
 	return &data, nil
+}
+
+func (c *refreshTokenCache) ConsumeRefreshToken(ctx context.Context, tokenHash string) (*service.RefreshTokenData, error) {
+	result, err := consumeRefreshTokenScript.Run(ctx, c.rdb, []string{
+		refreshTokenKey(tokenHash),
+		consumedRefreshTokenKey(tokenHash),
+	},
+		tokenHash,
+		refreshTokenKeyPrefix,
+		userRefreshTokensPrefix,
+		tokenFamilyPrefix,
+		revokedTokenFamilyKeyPrefix,
+		refreshTombstoneFallbackTTL.Milliseconds(),
+	).Slice()
+	if err != nil {
+		return nil, fmt.Errorf("consume refresh token atomically: %w", err)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("consume refresh token returned no status")
+	}
+	status, ok := result[0].(int64)
+	if !ok {
+		return nil, fmt.Errorf("consume refresh token returned invalid status %T", result[0])
+	}
+	if status == 0 {
+		return nil, service.ErrRefreshTokenNotFound
+	}
+	if len(result) < 2 {
+		return nil, fmt.Errorf("consume refresh token returned no payload")
+	}
+	raw, ok := result[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("consume refresh token returned invalid payload %T", result[1])
+	}
+	var data service.RefreshTokenData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, fmt.Errorf("unmarshal consumed refresh token data: %w", err)
+	}
+	switch status {
+	case 1:
+		return &data, nil
+	case 2:
+		return &data, service.ErrRefreshTokenReused
+	case 3:
+		return nil, fmt.Errorf("consumed refresh token tombstone is malformed")
+	default:
+		return nil, fmt.Errorf("consume refresh token returned unknown status %d", status)
+	}
+}
+
+func (c *refreshTokenCache) AcknowledgeRefreshTokenReplay(ctx context.Context, tokenHash string) error {
+	if err := c.rdb.Del(ctx, consumedRefreshTokenKey(tokenHash)).Err(); err != nil {
+		return fmt.Errorf("acknowledge refresh token replay: %w", err)
+	}
+	return nil
 }
 
 func (c *refreshTokenCache) DeleteRefreshToken(ctx context.Context, tokenHash string) error {
@@ -98,30 +284,17 @@ func (c *refreshTokenCache) DeleteUserRefreshTokens(ctx context.Context, userID 
 }
 
 func (c *refreshTokenCache) DeleteTokenFamily(ctx context.Context, familyID string) error {
-	// Get all token hashes in this family
-	tokenHashes, err := c.GetFamilyTokenHashes(ctx, familyID)
-	if err != nil && err != redis.Nil {
-		return fmt.Errorf("get family token hashes: %w", err)
-	}
-
-	if len(tokenHashes) == 0 {
+	if familyID == "" {
 		return nil
 	}
-
-	// Build keys to delete
-	keys := make([]string, 0, len(tokenHashes)+1)
-	for _, hash := range tokenHashes {
-		keys = append(keys, refreshTokenKey(hash))
+	_, err := revokeTokenFamilyScript.Run(ctx, c.rdb, []string{
+		tokenFamilyKey(familyID),
+		revokedTokenFamilyKey(familyID),
+	}, refreshTokenKeyPrefix, userRefreshTokensPrefix, refreshTombstoneFallbackTTL.Milliseconds()).Result()
+	if err != nil {
+		return fmt.Errorf("revoke refresh token family atomically: %w", err)
 	}
-	keys = append(keys, tokenFamilyKey(familyID))
-
-	// Delete all keys in a pipeline
-	pipe := c.rdb.Pipeline()
-	for _, key := range keys {
-		pipe.Del(ctx, key)
-	}
-	_, err = pipe.Exec(ctx)
-	return err
+	return nil
 }
 
 func (c *refreshTokenCache) AddToUserTokenSet(ctx context.Context, userID int64, tokenHash string, ttl time.Duration) error {

--- a/backend/internal/repository/refresh_token_cache_test.go
+++ b/backend/internal/repository/refresh_token_cache_test.go
@@ -1,0 +1,137 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func newRefreshTokenCacheTest(t *testing.T) (*refreshTokenCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+	return &refreshTokenCache{rdb: rdb}, mr
+}
+
+func refreshTokenTestData(userID int64, familyID string) *service.RefreshTokenData {
+	now := time.Now().UTC()
+	return &service.RefreshTokenData{
+		UserID:            userID,
+		TokenVersion:      7,
+		TokenVersionEpoch: 1,
+		FamilyID:          familyID,
+		CreatedAt:         now,
+		ExpiresAt:         now.Add(time.Hour),
+	}
+}
+
+func TestRefreshTokenCacheConsumeAllowsExactlyOneOf32ConcurrentCallers(t *testing.T) {
+	cache, _ := newRefreshTokenCacheTest(t)
+	ctx := context.Background()
+	const (
+		callers   = 32
+		tokenHash = "concurrent-parent"
+	)
+	require.NoError(t, cache.StoreRefreshToken(ctx, tokenHash, refreshTokenTestData(42, "concurrent-family"), time.Hour))
+
+	start := make(chan struct{})
+	results := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-start
+			data, err := cache.ConsumeRefreshToken(ctx, tokenHash)
+			if data == nil || data.UserID != 42 || data.FamilyID != "concurrent-family" {
+				results <- errors.New("consume did not return the authenticated tombstone data")
+				return
+			}
+			results <- err
+		}()
+	}
+	close(start)
+
+	successes := 0
+	replays := 0
+	for i := 0; i < callers; i++ {
+		err := <-results
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, service.ErrRefreshTokenReused):
+			replays++
+		default:
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, 1, successes)
+	require.Equal(t, callers-1, replays)
+}
+
+func TestRefreshTokenCacheReplayRevokesWinnerChildAndBlocksFamily(t *testing.T) {
+	cache, mr := newRefreshTokenCacheTest(t)
+	ctx := context.Background()
+	const (
+		userID     = int64(43)
+		familyID   = "replayed-family"
+		parentHash = "replayed-parent"
+		childHash  = "winner-child"
+	)
+	data := refreshTokenTestData(userID, familyID)
+	require.NoError(t, cache.StoreRefreshToken(ctx, parentHash, data, time.Hour))
+
+	consumed, err := cache.ConsumeRefreshToken(ctx, parentHash)
+	require.NoError(t, err)
+	require.Equal(t, data.UserID, consumed.UserID)
+	require.True(t, mr.Exists(consumedRefreshTokenKey(parentHash)))
+	require.Greater(t, mr.TTL(consumedRefreshTokenKey(parentHash)), time.Duration(0))
+
+	child := *data
+	child.CreatedAt = time.Now().UTC()
+	child.ExpiresAt = child.CreatedAt.Add(time.Hour)
+	require.NoError(t, cache.StoreRefreshToken(ctx, childHash, &child, time.Hour))
+
+	replayed, err := cache.ConsumeRefreshToken(ctx, parentHash)
+	require.ErrorIs(t, err, service.ErrRefreshTokenReused)
+	require.Equal(t, data.UserID, replayed.UserID)
+	require.True(t, mr.Exists(revokedTokenFamilyKey(familyID)))
+	require.Greater(t, mr.TTL(revokedTokenFamilyKey(familyID)), time.Duration(0))
+
+	_, err = cache.GetRefreshToken(ctx, childHash)
+	require.ErrorIs(t, err, service.ErrRefreshTokenNotFound)
+	require.False(t, mr.Exists(userRefreshTokensKey(userID)))
+	require.False(t, mr.Exists(tokenFamilyKey(familyID)))
+	require.ErrorIs(t,
+		cache.StoreRefreshToken(ctx, "blocked-grandchild", &child, time.Hour),
+		service.ErrRefreshTokenReused,
+	)
+	require.NoError(t, cache.AcknowledgeRefreshTokenReplay(ctx, parentHash))
+	require.False(t, mr.Exists(consumedRefreshTokenKey(parentHash)))
+	require.True(t, mr.Exists(revokedTokenFamilyKey(familyID)), "acknowledging the old token must retain family revocation")
+	_, err = cache.ConsumeRefreshToken(ctx, parentHash)
+	require.ErrorIs(t, err, service.ErrRefreshTokenNotFound)
+}
+
+func TestRefreshTokenCacheReplayBeforeChildStoreBlocksWinner(t *testing.T) {
+	cache, mr := newRefreshTokenCacheTest(t)
+	ctx := context.Background()
+	data := refreshTokenTestData(44, "early-replay-family")
+	require.NoError(t, cache.StoreRefreshToken(ctx, "early-parent", data, time.Millisecond))
+	_, err := cache.ConsumeRefreshToken(ctx, "early-parent")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, mr.TTL(consumedRefreshTokenKey("early-parent")), refreshTombstoneFallbackTTL)
+	_, err = cache.ConsumeRefreshToken(ctx, "early-parent")
+	require.ErrorIs(t, err, service.ErrRefreshTokenReused)
+	require.GreaterOrEqual(t, mr.TTL(revokedTokenFamilyKey(data.FamilyID)), refreshTombstoneFallbackTTL)
+	require.ErrorIs(t,
+		cache.StoreRefreshToken(ctx, "late-child", data, time.Hour),
+		service.ErrRefreshTokenReused,
+	)
+}

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -60,6 +61,8 @@ for index = 1, #ARGV do
 end
 return updated
 `)
+
+var errLegacySchedulerCredentialCache = errors.New("legacy plaintext scheduler credential cache rejected")
 
 var (
 	// epoch 标识 bucket writer 的代际，retired key 是持久退休标记。
@@ -220,16 +223,17 @@ return 1
 )
 
 type schedulerCache struct {
-	rdb            *redis.Client
-	mgetChunkSize  int
-	writeChunkSize int
+	rdb              *redis.Client
+	mgetChunkSize    int
+	writeChunkSize   int
+	credentialCipher *CredentialCipher
 }
 
-func NewSchedulerCache(rdb *redis.Client) service.SchedulerCache {
-	return newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
+func NewSchedulerCache(rdb *redis.Client, credentialCipher *CredentialCipher) service.SchedulerCache {
+	return newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize, credentialCipher)
 }
 
-func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChunkSize int) service.SchedulerCache {
+func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChunkSize int, credentialCipher *CredentialCipher) service.SchedulerCache {
 	if mgetChunkSize <= 0 {
 		mgetChunkSize = defaultSchedulerSnapshotMGetChunkSize
 	}
@@ -237,10 +241,51 @@ func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChun
 		writeChunkSize = defaultSchedulerSnapshotWriteChunkSize
 	}
 	return &schedulerCache{
-		rdb:            rdb,
-		mgetChunkSize:  mgetChunkSize,
-		writeChunkSize: writeChunkSize,
+		rdb:              rdb,
+		mgetChunkSize:    mgetChunkSize,
+		writeChunkSize:   writeChunkSize,
+		credentialCipher: credentialCipher,
 	}
+}
+
+// purgeLegacySchedulerAccountPayloads removes only the full-account and
+// metadata payloads that may have been written before cache encryption. Bucket
+// epochs, retirement markers, lifecycle/refresh locks, active versions,
+// snapshots, last-used side keys, and the outbox watermark are persistent
+// fencing state and must survive a process restart.
+func purgeLegacySchedulerAccountPayloads(ctx context.Context, rdb *redis.Client) error {
+	if rdb == nil {
+		return errors.New("redis client is required to purge scheduler cache")
+	}
+	for _, prefix := range []string{schedulerAccountPrefix, schedulerAccountMetaPrefix} {
+		var cursor uint64
+		for {
+			keys, next, err := rdb.Scan(ctx, cursor, prefix+"*", 512).Result()
+			if err != nil {
+				return fmt.Errorf("scan scheduler account payloads for credential migration: %w", err)
+			}
+			payloadKeys := make([]string, 0, len(keys))
+			for _, key := range keys {
+				if len(key) <= len(prefix) || key[:len(prefix)] != prefix {
+					continue
+				}
+				accountID, parseErr := strconv.ParseInt(key[len(prefix):], 10, 64)
+				if parseErr == nil && accountID > 0 {
+					payloadKeys = append(payloadKeys, key)
+				}
+			}
+			if len(payloadKeys) > 0 {
+				if err := rdb.Del(ctx, payloadKeys...).Err(); err != nil {
+					return fmt.Errorf("purge scheduler account payloads for credential migration: %w", err)
+				}
+			}
+			cursor = next
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+	return nil
 }
 
 func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.SchedulerBucket) ([]*service.Account, bool, error) {
@@ -296,8 +341,18 @@ func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.Schedul
 		if val == nil {
 			return nil, false, nil
 		}
-		account, err := decodeCachedAccount(val)
+		account, err := c.decodeCachedAccount(val)
 		if err != nil {
+			if errors.Is(err, errLegacySchedulerCredentialCache) {
+				deleteKeys := make([]string, 0, len(ids)*2)
+				for _, id := range ids {
+					deleteKeys = append(deleteKeys, schedulerAccountKey(id), schedulerAccountMetaKey(id))
+				}
+				if deleteErr := c.rdb.Del(ctx, deleteKeys...).Err(); deleteErr != nil {
+					return nil, false, deleteErr
+				}
+				return nil, false, nil
+			}
 			return nil, false, err
 		}
 		if err := applySchedulerLastUsed(account, lastUsedValues[i]); err != nil {
@@ -575,8 +630,14 @@ func (c *schedulerCache) GetAccount(ctx context.Context, accountID int64) (*serv
 	if len(values) != 2 || values[0] == nil {
 		return nil, nil
 	}
-	account, err := decodeCachedAccount(values[0])
+	account, err := c.decodeCachedAccount(values[0])
 	if err != nil {
+		if errors.Is(err, errLegacySchedulerCredentialCache) {
+			if deleteErr := c.DeleteAccount(ctx, accountID); deleteErr != nil {
+				return nil, deleteErr
+			}
+			return nil, nil
+		}
 		return nil, err
 	}
 	if err := applySchedulerLastUsed(account, values[1]); err != nil {
@@ -760,6 +821,14 @@ func applySchedulerLastUsed(account *service.Account, value any) error {
 }
 
 func decodeCachedAccount(val any) (*service.Account, error) {
+	return decodeCachedAccountWithCipher(val, nil)
+}
+
+func (c *schedulerCache) decodeCachedAccount(val any) (*service.Account, error) {
+	return decodeCachedAccountWithCipher(val, c.credentialCipher)
+}
+
+func decodeCachedAccountWithCipher(val any, credentialCipher *CredentialCipher) (*service.Account, error) {
 	var payload []byte
 	switch raw := val.(type) {
 	case string:
@@ -772,6 +841,26 @@ func decodeCachedAccount(val any) (*service.Account, error) {
 	var account service.Account
 	if err := json.Unmarshal(payload, &account); err != nil {
 		return nil, err
+	}
+	if credentialCipher != nil {
+		credentials, legacy, err := credentialCipher.Decrypt(account.ID, account.Platform, account.Credentials)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt scheduler credentials for account %d: %w", account.ID, err)
+		}
+		if legacy {
+			return nil, errLegacySchedulerCredentialCache
+		}
+		account.Credentials = credentials
+		if account.Proxy != nil && account.Proxy.Password != "" {
+			password, proxyLegacy, err := credentialCipher.DecryptSchedulerProxyPassword(account.ID, account.Platform, account.Proxy.ID, account.Proxy.Password)
+			if err != nil {
+				return nil, fmt.Errorf("decrypt scheduler proxy password for account %d: %w", account.ID, err)
+			}
+			if proxyLegacy {
+				return nil, errLegacySchedulerCredentialCache
+			}
+			account.Proxy.Password = password
+		}
 	}
 	return &account, nil
 }
@@ -797,7 +886,7 @@ func (c *schedulerCache) writeAccountIDs(ctx context.Context, accounts []service
 	}
 
 	for _, account := range accounts {
-		fullPayload, metaPayload, err := marshalSchedulerCacheAccount(account)
+		fullPayload, metaPayload, err := c.marshalSchedulerCacheAccount(account)
 		if err != nil {
 			slog.Warn("scheduler cache skips account with unencodable payload",
 				"account_id", account.ID,
@@ -827,11 +916,44 @@ func (c *schedulerCache) writeAccountIDs(ctx context.Context, accounts []service
 }
 
 func marshalSchedulerCacheAccount(account service.Account) ([]byte, []byte, error) {
-	fullPayload, err := json.Marshal(account)
+	return marshalSchedulerCacheAccountWithCipher(account, nil)
+}
+
+func (c *schedulerCache) marshalSchedulerCacheAccount(account service.Account) ([]byte, []byte, error) {
+	return marshalSchedulerCacheAccountWithCipher(account, c.credentialCipher)
+}
+
+func marshalSchedulerCacheAccountWithCipher(account service.Account, credentialCipher *CredentialCipher) ([]byte, []byte, error) {
+	fullAccount := account
+	metadataAccount := buildSchedulerMetadataAccount(account)
+	if credentialCipher != nil {
+		storage, err := credentialCipher.Encrypt(account.ID, account.Platform, account.Credentials)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encrypt scheduler account credentials: %w", err)
+		}
+		fullAccount.Credentials = storage
+		metaStorage, err := credentialCipher.Encrypt(metadataAccount.ID, metadataAccount.Platform, metadataAccount.Credentials)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encrypt scheduler metadata credentials: %w", err)
+		}
+		metadataAccount.Credentials = metaStorage
+		if fullAccount.Proxy != nil {
+			proxyCopy := *fullAccount.Proxy
+			fullAccount.Proxy = &proxyCopy
+			if proxyCopy.Password != "" {
+				passwordStorage, err := credentialCipher.EncryptSchedulerProxyPassword(account.ID, account.Platform, proxyCopy.ID, proxyCopy.Password)
+				if err != nil {
+					return nil, nil, fmt.Errorf("encrypt scheduler proxy password: %w", err)
+				}
+				proxyCopy.Password = passwordStorage
+			}
+		}
+	}
+	fullPayload, err := json.Marshal(fullAccount)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal account: %w", err)
 	}
-	metaPayload, err := json.Marshal(buildSchedulerMetadataAccount(account))
+	metaPayload, err := json.Marshal(metadataAccount)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal account metadata: %w", err)
 	}

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -15,7 +15,7 @@ import (
 func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T) {
 	ctx := context.Background()
 	rdb := testRedis(t)
-	cache := NewSchedulerCache(rdb)
+	cache := NewSchedulerCache(rdb, nil)
 
 	bucket := service.SchedulerBucket{GroupID: 2, Platform: service.PlatformGemini, Mode: service.SchedulerModeSingle}
 	now := time.Now().UTC().Truncate(time.Second)
@@ -108,7 +108,7 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 func TestSchedulerCacheRetireAndReopenFencesOldEpochIntegration(t *testing.T) {
 	ctx := context.Background()
 	rdb := testRedis(t)
-	cache := NewSchedulerCache(rdb)
+	cache := NewSchedulerCache(rdb, nil)
 	bucket := service.SchedulerBucket{GroupID: 77, Platform: service.PlatformAntigravity, Mode: service.SchedulerModeForced}
 	account := service.Account{ID: 7701, Platform: service.PlatformAntigravity, Type: service.AccountTypeOAuth}
 
@@ -141,7 +141,7 @@ func TestSchedulerCacheRetireAndReopenFencesOldEpochIntegration(t *testing.T) {
 func TestSchedulerCacheGroupLifecycleLeaseOwnerAndTTLIntegration(t *testing.T) {
 	ctx := context.Background()
 	rdb := testRedis(t)
-	cache := NewSchedulerCache(rdb)
+	cache := NewSchedulerCache(rdb, nil)
 	const groupID int64 = 78
 	const ttl = 500 * time.Millisecond
 

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -28,9 +28,47 @@ func newSchedulerCacheUnitWithRedis(t *testing.T) (*schedulerCache, *miniredis.M
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
-	cache, ok := newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize).(*schedulerCache)
+	cache, ok := newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize, nil).(*schedulerCache)
 	require.True(t, ok)
 	return cache, mr
+}
+
+func TestPurgeLegacySchedulerAccountPayloadsPreservesPersistentFencingState(t *testing.T) {
+	ctx := context.Background()
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 91, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+
+	legacyAccountKey := schedulerAccountKey("42")
+	legacyMetaKey := schedulerAccountMetaKey("42")
+	mr.Set(legacyAccountKey, `{"Credentials":{"access_token":"legacy-secret"}}`)
+	mr.Set(legacyMetaKey, `{"Credentials":{"api_key":"legacy-secret"}}`)
+
+	preserved := map[string]string{
+		schedulerAccountLastUsedPrefix + "42":              "1700000000000",
+		schedulerBucketKey(schedulerEpochPrefix, bucket):   "7",
+		schedulerBucketKey(schedulerRetiredPrefix, bucket): "1",
+		schedulerBucketKey(schedulerLockPrefix, bucket):    "snapshot-owner",
+		schedulerGroupLifecycleLockKey(bucket.GroupID):     "lifecycle-owner",
+		schedulerOutboxWatermarkKey:                        "1234",
+		schedulerBucketSetKey:                              "persistent-bucket-set-sentinel",
+		schedulerBucketKey(schedulerActivePrefix, bucket):  "7",
+		schedulerBucketKey(schedulerReadyPrefix, bucket):   "1",
+		schedulerBucketKey(schedulerVersionPrefix, bucket): "7",
+		schedulerAccountPrefix + "not-an-account-id":       "unrelated",
+		schedulerAccountMetaPrefix + "not-an-account-id":   "unrelated-meta",
+	}
+	for key, value := range preserved {
+		mr.Set(key, value)
+	}
+
+	require.NoError(t, purgeLegacySchedulerAccountPayloads(ctx, cache.rdb))
+	require.False(t, mr.Exists(legacyAccountKey))
+	require.False(t, mr.Exists(legacyMetaKey))
+	for key, want := range preserved {
+		got, err := mr.Get(key)
+		require.NoError(t, err, key)
+		require.Equal(t, want, got, key)
+	}
 }
 
 func TestSchedulerCacheWriteAccountIDsSkipsUnencodableTimes(t *testing.T) {

--- a/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
+++ b/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
@@ -21,7 +21,7 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 
 	accountRepo := newAccountRepositoryWithSQL(client, integrationDB, nil)
 	outboxRepo := NewSchedulerOutboxRepository(integrationDB)
-	cache := NewSchedulerCache(rdb)
+	cache := NewSchedulerCache(rdb, nil)
 
 	cfg := &config.Config{
 		RunMode: config.RunModeStandard,

--- a/backend/internal/repository/totp_cache.go
+++ b/backend/internal/repository/totp_cache.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -10,6 +11,14 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
+
+var consumeTotpLoginSessionScript = redis.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if value then
+  redis.call("DEL", KEYS[1])
+end
+return value
+`)
 
 const (
 	totpSetupKeyPrefix    = "totp:setup:"
@@ -103,6 +112,30 @@ func (c *TotpCache) SetLoginSession(ctx context.Context, tempToken string, sessi
 	return nil
 }
 
+// ConsumeLoginSession atomically returns and deletes a TOTP login session.
+// A Lua GET+DEL is used instead of separate commands so concurrent valid-code
+// requests cannot all proceed to token issuance.
+func (c *TotpCache) ConsumeLoginSession(ctx context.Context, tempToken string) (*service.TotpLoginSession, error) {
+	key := totpLoginKeyPrefix + tempToken
+	result, err := consumeTotpLoginSessionScript.Run(ctx, c.rdb, []string{key}).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("consume login session: %w", err)
+	}
+	data, ok := result.(string)
+	if !ok {
+		return nil, fmt.Errorf("consume login session: unexpected redis result type %T", result)
+	}
+
+	var session service.TotpLoginSession
+	if err := json.Unmarshal([]byte(data), &session); err != nil {
+		return nil, fmt.Errorf("unmarshal consumed login session: %w", err)
+	}
+	return &session, nil
+}
+
 // DeleteLoginSession deletes a TOTP login session
 func (c *TotpCache) DeleteLoginSession(ctx context.Context, tempToken string) error {
 	key := totpLoginKeyPrefix + tempToken
@@ -154,18 +187,21 @@ func totpStepUpKey(userID int64, sessionKey string) string {
 }
 
 // SetStepUpGrant 记录一次 step-up 验证通过（sudo 窗口），绑定用户+会话。
-func (c *TotpCache) SetStepUpGrant(ctx context.Context, userID int64, sessionKey string, ttl time.Duration) error {
-	return c.rdb.Set(ctx, totpStepUpKey(userID, sessionKey), "1", ttl).Err()
+func (c *TotpCache) SetStepUpGrant(ctx context.Context, userID int64, sessionKey, credentialGeneration string, ttl time.Duration) error {
+	if credentialGeneration == "" {
+		return fmt.Errorf("set step-up grant: empty credential generation")
+	}
+	return c.rdb.Set(ctx, totpStepUpKey(userID, sessionKey), credentialGeneration, ttl).Err()
 }
 
 // HasStepUpGrant 检查 step-up 授权是否仍在有效期内。
-func (c *TotpCache) HasStepUpGrant(ctx context.Context, userID int64, sessionKey string) (bool, error) {
-	_, err := c.rdb.Get(ctx, totpStepUpKey(userID, sessionKey)).Result()
+func (c *TotpCache) HasStepUpGrant(ctx context.Context, userID int64, sessionKey, credentialGeneration string) (bool, error) {
+	storedGeneration, err := c.rdb.Get(ctx, totpStepUpKey(userID, sessionKey)).Result()
 	if err != nil {
 		if err == redis.Nil {
 			return false, nil
 		}
 		return false, fmt.Errorf("get step-up grant: %w", err)
 	}
-	return true, nil
+	return subtle.ConstantTimeCompare([]byte(storedGeneration), []byte(credentialGeneration)) == 1, nil
 }

--- a/backend/internal/repository/totp_cache_security_test.go
+++ b/backend/internal/repository/totp_cache_security_test.go
@@ -1,0 +1,101 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func newTotpSecurityCache(t *testing.T) (*TotpCache, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	cache, ok := NewTotpCache(client).(*TotpCache)
+	require.True(t, ok)
+	return cache, server
+}
+
+func TestTotpCacheConsumeLoginSessionExactlyOnceConcurrently(t *testing.T) {
+	cache, _ := newTotpSecurityCache(t)
+	ctx := context.Background()
+	const callers = 32
+	const token = "fake-local-temp-token"
+
+	require.NoError(t, cache.SetLoginSession(ctx, token, &service.TotpLoginSession{
+		UserID:      42,
+		Email:       "local@example.test",
+		TokenExpiry: time.Now().Add(time.Minute),
+	}, time.Minute))
+
+	start := make(chan struct{})
+	var winners atomic.Int32
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			session, err := cache.ConsumeLoginSession(ctx, token)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if session != nil {
+				if session.UserID != 42 {
+					errs <- fmt.Errorf("unexpected consumed user id: %d", session.UserID)
+					return
+				}
+				winners.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(1), winners.Load())
+	remaining, err := cache.GetLoginSession(ctx, token)
+	require.NoError(t, err)
+	require.Nil(t, remaining)
+}
+
+func TestTotpCacheConsumeLoginSessionRedisFailureFailsClosed(t *testing.T) {
+	cache, server := newTotpSecurityCache(t)
+	ctx := context.Background()
+	require.NoError(t, cache.SetLoginSession(ctx, "fake-local-temp-token", &service.TotpLoginSession{UserID: 7}, time.Minute))
+
+	server.Close()
+	session, err := cache.ConsumeLoginSession(ctx, "fake-local-temp-token")
+	require.Error(t, err)
+	require.Nil(t, session)
+}
+
+func TestTotpCacheStepUpGrantIsCredentialGenerationBound(t *testing.T) {
+	cache, _ := newTotpSecurityCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, cache.SetStepUpGrant(ctx, 11, "session-a", "generation-a", time.Minute))
+	granted, err := cache.HasStepUpGrant(ctx, 11, "session-a", "generation-a")
+	require.NoError(t, err)
+	require.True(t, granted)
+
+	granted, err = cache.HasStepUpGrant(ctx, 11, "session-a", "generation-b")
+	require.NoError(t, err)
+	require.False(t, granted)
+}

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -33,6 +33,7 @@ type userRepository struct {
 }
 
 var _ service.RedeemUserAdjustmentRepository = (*userRepository)(nil)
+var _ service.UserTokenVersionRepository = (*userRepository)(nil)
 
 func NewUserRepository(client *dbent.Client, sqlDB *sql.DB) service.UserRepository {
 	return newUserRepositoryWithSQL(client, sqlDB)
@@ -40,6 +41,91 @@ func NewUserRepository(client *dbent.Client, sqlDB *sql.DB) service.UserReposito
 
 func newUserRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor) *userRepository {
 	return &userRepository{client: client, sql: sqlq}
+}
+
+// GetTokenVersion returns the authoritative, persistent security stamp for an
+// active user. JWT middleware and token minting consume the value hydrated by
+// the repository instead of relying on mutable in-memory state.
+func (r *userRepository) GetTokenVersion(ctx context.Context, userID int64) (int64, error) {
+	return r.getTokenVersion(ctx, userID, false)
+}
+
+func (r *userRepository) getTokenVersion(ctx context.Context, userID int64, includeDeleted bool) (int64, error) {
+	if userID <= 0 {
+		return 0, service.ErrUserNotFound
+	}
+	exec := txAwareSQLExecutor(ctx, r.sql, r.client)
+	if exec == nil {
+		return 0, errors.New("token version SQL executor is not configured")
+	}
+
+	query := `SELECT token_version FROM users WHERE id = $1 AND deleted_at IS NULL`
+	if includeDeleted {
+		query = `SELECT token_version FROM users WHERE id = $1`
+	}
+	rows, err := exec.QueryContext(ctx, query, userID)
+	if err != nil {
+		return 0, fmt.Errorf("query user token version: %w", err)
+	}
+	return scanUserTokenVersion(rows)
+}
+
+// IncrementTokenVersion atomically advances the persistent security stamp.
+// There is deliberately no read-modify-write window: concurrent revoke-all
+// operations each produce a distinct version and none can be lost.
+func (r *userRepository) IncrementTokenVersion(ctx context.Context, userID int64) (int64, error) {
+	if userID <= 0 {
+		return 0, service.ErrUserNotFound
+	}
+	exec := txAwareSQLExecutor(ctx, r.sql, r.client)
+	if exec == nil {
+		return 0, errors.New("token version SQL executor is not configured")
+	}
+
+	rows, err := exec.QueryContext(ctx, `
+UPDATE users
+SET token_version = token_version + 1
+WHERE id = $1 AND deleted_at IS NULL
+RETURNING token_version
+`, userID)
+	if err != nil {
+		return 0, fmt.Errorf("increment user token version: %w", err)
+	}
+	return scanUserTokenVersion(rows)
+}
+
+func scanUserTokenVersion(rows *sql.Rows) (int64, error) {
+	if rows == nil {
+		return 0, errors.New("nil token version rows")
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return 0, err
+		}
+		return 0, service.ErrUserNotFound
+	}
+	var version int64
+	if err := rows.Scan(&version); err != nil {
+		return 0, fmt.Errorf("scan user token version: %w", err)
+	}
+	if version < 0 {
+		return 0, fmt.Errorf("invalid negative token version for user")
+	}
+	return version, nil
+}
+
+func (r *userRepository) hydrateUserTokenVersion(ctx context.Context, user *service.User, includeDeleted bool) error {
+	if user == nil {
+		return service.ErrUserNotFound
+	}
+	version, err := r.getTokenVersion(ctx, user.ID, includeDeleted)
+	if err != nil {
+		return err
+	}
+	user.TokenVersion = version
+	user.TokenVersionResolved = true
+	return nil
 }
 
 func (r *userRepository) Create(ctx context.Context, userIn *service.User) error {
@@ -165,6 +251,10 @@ func (r *userRepository) create(ctx context.Context, userIn *service.User, guard
 	}
 
 	applyUserEntityToService(userIn, created)
+	// token_version is database-defaulted for new users; make that durable value
+	// explicit so the first JWT is minted without the legacy fingerprint fallback.
+	userIn.TokenVersion = 0
+	userIn.TokenVersionResolved = true
 	return nil
 }
 
@@ -175,6 +265,9 @@ func (r *userRepository) GetByID(ctx context.Context, id int64) (*service.User, 
 	}
 
 	out := userEntityToService(m)
+	if err := r.hydrateUserTokenVersion(ctx, out, false); err != nil {
+		return nil, err
+	}
 	groups, err := r.loadAllowedGroups(ctx, []int64{id})
 	if err != nil {
 		return nil, err
@@ -192,6 +285,9 @@ func (r *userRepository) GetByIDIncludeDeleted(ctx context.Context, id int64) (*
 		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
 	}
 	out := userEntityToService(m)
+	if err := r.hydrateUserTokenVersion(ctx, out, true); err != nil {
+		return nil, err
+	}
 	groups, err := r.loadAllowedGroups(ctx, []int64{id})
 	if err != nil {
 		return nil, err
@@ -219,6 +315,9 @@ func (r *userRepository) GetByEmail(ctx context.Context, email string) (*service
 	m := matches[0]
 
 	out := userEntityToService(m)
+	if err := r.hydrateUserTokenVersion(ctx, out, false); err != nil {
+		return nil, err
+	}
 	groups, err := r.loadAllowedGroups(ctx, []int64{m.ID})
 	if err != nil {
 		return nil, err
@@ -283,6 +382,9 @@ func (r *userRepository) Update(ctx context.Context, userIn *service.User, field
 		return translatePersistenceError(err, service.ErrUserNotFound, nil)
 	}
 	oldEmail := existing.Email
+	securityBoundaryChanged := fields.PasswordHash ||
+		(fields.Role && existing.Role != userIn.Role) ||
+		(fields.Status && existing.Status != userIn.Status)
 
 	updateOp := txClient.User.UpdateOneID(userIn.ID)
 	if fields.Email {
@@ -333,6 +435,14 @@ func (r *userRepository) Update(ctx context.Context, userIn *service.User, field
 	updated, err := updateOp.Save(txCtx)
 	if err != nil {
 		return translatePersistenceError(err, service.ErrUserNotFound, service.ErrEmailExists)
+	}
+	if securityBoundaryChanged {
+		version, err := r.IncrementTokenVersion(txCtx, userIn.ID)
+		if err != nil {
+			return err
+		}
+		userIn.TokenVersion = version
+		userIn.TokenVersionResolved = true
 	}
 
 	if fields.AllowedGroups {
@@ -1355,6 +1465,9 @@ func (r *userRepository) GetFirstAdmin(ctx context.Context) (*service.User, erro
 	}
 
 	out := userEntityToService(m)
+	if err := r.hydrateUserTokenVersion(ctx, out, false); err != nil {
+		return nil, err
+	}
 	groups, err := r.loadAllowedGroups(ctx, []int64{m.ID})
 	if err != nil {
 		return nil, err

--- a/backend/internal/repository/user_repo_token_version_test.go
+++ b/backend/internal/repository/user_repo_token_version_test.go
@@ -1,0 +1,129 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserRepositoryGetTokenVersionReadsPersistentStamp(t *testing.T) {
+	repo, mock := newRedeemAdjustmentRepoMock(t)
+	mock.ExpectQuery(`SELECT token_version FROM users WHERE id = \$1 AND deleted_at IS NULL`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"token_version"}).AddRow(int64(9)))
+
+	version, err := repo.GetTokenVersion(context.Background(), 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(9), version)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserRepositoryIncrementTokenVersionIsSingleAtomicStatement(t *testing.T) {
+	repo, mock := newRedeemAdjustmentRepoMock(t)
+	mock.ExpectQuery(`(?s)UPDATE users\s+SET token_version = token_version \+ 1\s+WHERE id = \$1 AND deleted_at IS NULL\s+RETURNING token_version`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"token_version"}).AddRow(int64(10)))
+
+	version, err := repo.IncrementTokenVersion(context.Background(), 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), version)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserRepositoryIncrementTokenVersionRejectsMissingUser(t *testing.T) {
+	repo, mock := newRedeemAdjustmentRepoMock(t)
+	mock.ExpectQuery(`(?s)UPDATE users\s+SET token_version = token_version \+ 1\s+WHERE id = \$1 AND deleted_at IS NULL\s+RETURNING token_version`).
+		WithArgs(int64(404)).
+		WillReturnRows(sqlmock.NewRows([]string{"token_version"}))
+
+	_, err := repo.IncrementTokenVersion(context.Background(), 404)
+	require.ErrorIs(t, err, service.ErrUserNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserRepositoryGetByIDHydratesPersistentTokenVersion(t *testing.T) {
+	repo, _ := newUserEntRepo(t)
+	ctx := context.Background()
+	user := &service.User{
+		Email:        "persistent-stamp@example.com",
+		Username:     "persistent-stamp",
+		PasswordHash: "hash",
+		Role:         service.RoleUser,
+		Status:       service.StatusActive,
+	}
+	require.NoError(t, repo.Create(ctx, user))
+	_, err := repo.sql.ExecContext(ctx, `UPDATE users SET token_version = 12 WHERE id = $1`, user.ID)
+	require.NoError(t, err)
+
+	loaded, err := repo.GetByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.True(t, loaded.TokenVersionResolved)
+	require.Equal(t, int64(12), loaded.TokenVersion)
+}
+
+func TestUserRepositoryPasswordUpdateAdvancesTokenVersionInTransaction(t *testing.T) {
+	repo, _ := newUserEntRepo(t)
+	ctx := context.Background()
+	user := &service.User{
+		Email:        "password-stamp@example.com",
+		Username:     "password-stamp",
+		PasswordHash: "old-hash",
+		Role:         service.RoleUser,
+		Status:       service.StatusActive,
+	}
+	require.NoError(t, repo.Create(ctx, user))
+	user.PasswordHash = "new-hash"
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{PasswordHash: true}))
+	require.True(t, user.TokenVersionResolved)
+	require.Equal(t, int64(1), user.TokenVersion)
+
+	loaded, err := repo.GetByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, "new-hash", loaded.PasswordHash)
+	require.Equal(t, int64(1), loaded.TokenVersion)
+}
+
+func TestUserRepositoryRoleAndStatusTransitionsAdvanceTokenVersion(t *testing.T) {
+	repo, _ := newUserEntRepo(t)
+	ctx := context.Background()
+	user := &service.User{
+		Email:        "authorization-stamp@example.com",
+		Username:     "authorization-stamp",
+		PasswordHash: "hash",
+		Role:         service.RoleUser,
+		Status:       service.StatusActive,
+	}
+	require.NoError(t, repo.Create(ctx, user))
+
+	user.Role = service.RoleAdmin
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{Role: true}))
+	require.Equal(t, int64(1), user.TokenVersion)
+
+	user.Role = service.RoleUser
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{Role: true}))
+	require.Equal(t, int64(2), user.TokenVersion, "demotion and later restoration must not revive pre-demotion tokens")
+
+	user.Status = service.StatusDisabled
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{Status: true}))
+	require.Equal(t, int64(3), user.TokenVersion)
+
+	user.Status = service.StatusActive
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{Status: true}))
+	require.Equal(t, int64(4), user.TokenVersion, "disable and later re-enable must not revive pre-disable tokens")
+
+	loaded, err := repo.GetByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, service.RoleUser, loaded.Role)
+	require.Equal(t, service.StatusActive, loaded.Status)
+	require.Equal(t, int64(4), loaded.TokenVersion)
+
+	// Idempotent writes are not a security-boundary transition and should not
+	// churn every active session merely because a caller resubmits the same value.
+	require.NoError(t, repo.Update(ctx, user, service.UserUpdateFields{Role: true, Status: true}))
+	require.Equal(t, int64(4), user.TokenVersion)
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/Wei-Shaw/sub2api/ent"
@@ -49,7 +50,7 @@ func ProvideSessionLimitCache(rdb *redis.Client, cfg *config.Config) service.Ses
 }
 
 // ProvideSchedulerCache 创建调度快照缓存，并注入快照分块参数。
-func ProvideSchedulerCache(rdb *redis.Client, cfg *config.Config) service.SchedulerCache {
+func ProvideSchedulerCache(rdb *redis.Client, cfg *config.Config, credentialCipher *CredentialCipher) (service.SchedulerCache, error) {
 	mgetChunkSize := defaultSchedulerSnapshotMGetChunkSize
 	writeChunkSize := defaultSchedulerSnapshotWriteChunkSize
 	if cfg != nil {
@@ -60,11 +61,19 @@ func ProvideSchedulerCache(rdb *redis.Client, cfg *config.Config) service.Schedu
 			writeChunkSize = cfg.Gateway.Scheduling.SnapshotWriteChunkSize
 		}
 	}
-	return newSchedulerCacheWithChunkSizes(rdb, mgetChunkSize, writeChunkSize)
+	if credentialCipher != nil {
+		purgeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := purgeLegacySchedulerAccountPayloads(purgeCtx, rdb); err != nil {
+			return nil, err
+		}
+	}
+	return newSchedulerCacheWithChunkSizes(rdb, mgetChunkSize, writeChunkSize, credentialCipher), nil
 }
 
 // ProviderSet is the Wire provider set for all repositories
 var ProviderSet = wire.NewSet(
+	NewCredentialCipher,
 	NewUserRepository,
 	NewAPIKeyRepository,
 	NewGroupRepository,
@@ -123,7 +132,7 @@ var ProviderSet = wire.NewSet(
 	NewIdentityCache,
 	NewRedeemCache,
 	NewUpdateCache,
-	NewGeminiTokenCache,
+	ProvideGeminiTokenCache,
 	NewImageTaskStore,
 	NewBatchImageQueue,
 	NewBatchImageDownloadLimiter,

--- a/backend/internal/server/middleware/admin_auth.go
+++ b/backend/internal/server/middleware/admin_auth.go
@@ -169,6 +169,10 @@ func validateJWTForAdmin(
 			AbortWithError(c, 401, "TOKEN_EXPIRED", "Token has expired")
 			return false
 		}
+		if errors.Is(err, service.ErrTokenRevoked) {
+			AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked")
+			return false
+		}
 		AbortWithError(c, 401, "INVALID_TOKEN", "Invalid token")
 		return false
 	}
@@ -186,9 +190,9 @@ func validateJWTForAdmin(
 		return false
 	}
 
-	// 校验 TokenVersion，确保管理员改密后旧 token 失效
+	// 与仓储从数据库加载的持久化安全戳比较，覆盖改密和 revoke-all。
 	if claims.TokenVersion != user.TokenVersion {
-		AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked (password changed)")
+		AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked")
 		return false
 	}
 

--- a/backend/internal/server/middleware/jwt_auth.go
+++ b/backend/internal/server/middleware/jwt_auth.go
@@ -64,6 +64,10 @@ func jwtAuth(
 				AbortWithError(c, 401, "TOKEN_EXPIRED", "Token has expired")
 				return
 			}
+			if errors.Is(err, service.ErrTokenRevoked) {
+				AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked")
+				return
+			}
 			AbortWithError(c, 401, "INVALID_TOKEN", "Invalid token")
 			return
 		}
@@ -81,10 +85,10 @@ func jwtAuth(
 			return
 		}
 
-		// Security: Validate TokenVersion to ensure token hasn't been invalidated
-		// This check ensures tokens issued before a password change are rejected
+		// Compare the JWT stamp with the persistent value hydrated by userRepository.
+		// Revoke-all and password credential changes atomically advance that value.
 		if claims.TokenVersion != user.TokenVersion {
-			AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked (password changed)")
+			AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked")
 			return
 		}
 

--- a/backend/internal/server/middleware/security_headers.go
+++ b/backend/internal/server/middleware/security_headers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -92,6 +93,8 @@ func GenerateNonce() (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
+var generateCSPNonce = GenerateNonce
+
 // GetNonceFromContext retrieves the CSP nonce from gin context
 func GetNonceFromContext(c *gin.Context) string {
 	if nonce, exists := c.Get(CSPNonceKey); exists {
@@ -134,11 +137,12 @@ func SecurityHeaders(cfg config.CSPConfig, getFrameSrcOrigins func() []string) g
 
 		if cfg.Enabled {
 			// Generate nonce for this request
-			nonce, err := GenerateNonce()
+			nonce, err := generateCSPNonce()
 			if err != nil {
-				// crypto/rand 失败时降级为无 nonce 的 CSP 策略
-				log.Printf("[SecurityHeaders] %v — 降级为无 nonce 的 CSP", err)
-				c.Header("Content-Security-Policy", strings.ReplaceAll(finalPolicy, NonceTemplate, "'unsafe-inline'"))
+				// Never relax script-src when the nonce cannot be generated.
+				log.Printf("[SecurityHeaders] %v — rejecting response because CSP nonce generation failed", err)
+				c.AbortWithStatus(http.StatusInternalServerError)
+				return
 			} else {
 				c.Set(CSPNonceKey, nonce)
 				c.Header("Content-Security-Policy", strings.ReplaceAll(finalPolicy, NonceTemplate, "'nonce-"+nonce+"'"))
@@ -166,12 +170,6 @@ func enhanceCSPPolicy(policy string) string {
 	// Add nonce placeholder to script-src if not present
 	if !strings.Contains(policy, NonceTemplate) && !strings.Contains(policy, "'nonce-") {
 		policy = addToDirective(policy, "script-src", NonceTemplate)
-	}
-
-	for _, required := range requiredCSPDirectiveValues {
-		if !directiveHasValue(policy, required.directive, required.value) {
-			policy = addToDirective(policy, required.directive, required.value)
-		}
 	}
 
 	return policy

--- a/backend/internal/server/middleware/security_headers_test.go
+++ b/backend/internal/server/middleware/security_headers_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -125,11 +126,29 @@ func TestSecurityHeaders(t *testing.T) {
 
 		csp := w.Header().Get("Content-Security-Policy")
 		assert.NotEmpty(t, csp)
-		// Policy is auto-enhanced with nonce and Cloudflare Insights domain
+		// Policy is auto-enhanced only with a nonce; configured source lists are
+		// never widened with third-party domains.
 		assert.Contains(t, csp, "default-src 'self'")
 		assert.Contains(t, csp, "'nonce-")
-		assert.Contains(t, csp, CloudflareInsightsDomain)
-		assert.Equal(t, 1, countDirectiveValue(csp, "worker-src", TencentCaptchaWorkerSource))
+		assert.NotContains(t, csp, CloudflareInsightsDomain)
+		assert.Equal(t, 0, countDirectiveValue(csp, "worker-src", TencentCaptchaWorkerSource))
+	})
+
+	t.Run("csp_nonce_failure_fails_closed", func(t *testing.T) {
+		original := generateCSPNonce
+		generateCSPNonce = func() (string, error) { return "", errors.New("entropy unavailable") }
+		defer func() { generateCSPNonce = original }()
+
+		middleware := SecurityHeaders(config.CSPConfig{Enabled: true, Policy: "default-src 'self'"}, nil)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		middleware(c)
+
+		assert.True(t, c.IsAborted())
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.NotContains(t, w.Header().Get("Content-Security-Policy"), "'unsafe-inline'")
 	})
 
 	t.Run("api_route_skips_csp_nonce_generation", func(t *testing.T) {
@@ -295,7 +314,7 @@ func TestEnhanceCSPPolicy(t *testing.T) {
 		enhanced := enhanceCSPPolicy(policy)
 
 		assert.Contains(t, enhanced, NonceTemplate)
-		assert.Contains(t, enhanced, CloudflareInsightsDomain)
+		assert.NotContains(t, enhanced, CloudflareInsightsDomain)
 	})
 
 	t.Run("does_not_duplicate_nonce_placeholder", func(t *testing.T) {
@@ -307,7 +326,7 @@ func TestEnhanceCSPPolicy(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 
-	t.Run("does_not_duplicate_cloudflare_domain", func(t *testing.T) {
+	t.Run("preserves_explicit_cloudflare_domain", func(t *testing.T) {
 		policy := "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com"
 		enhanced := enhanceCSPPolicy(policy)
 
@@ -315,28 +334,29 @@ func TestEnhanceCSPPolicy(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 
-	t.Run("adds_tencent_captcha_domain_for_web_sdk", func(t *testing.T) {
+	t.Run("does_not_widen_policy_with_provider_domains", func(t *testing.T) {
 		policy := "default-src 'self'; script-src 'self' __CSP_NONCE__"
 		enhanced := enhanceCSPPolicy(policy)
 
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "frame-src", TencentCaptchaDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "style-src", TencentCaptchaStaticDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "frame-src", TencentCaptchaDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "style-src", TencentCaptchaStaticDomain))
 		assert.Contains(t, config.DefaultCSPPolicy, "style-src 'self' 'unsafe-inline' https://*.captcha.gtimg.com")
+		assert.Contains(t, config.DefaultCSPPolicy, "object-src 'none'")
 
 		// 入口脚本会再从 CDN 拉核心 JS，国际站还会换用 ca./global. 两个主机；
 		// 缺任意一个都会让天御 SDK 触发 script-src 拦截。
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaCDNDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaGlobalDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaGlobalCDNDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaPrehandleDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", TencentCaptchaJQueryDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "connect-src", TencentCaptchaDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "connect-src", TencentCaptchaPrehandleDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "connect-src", TencentCaptchaRceDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "frame-src", TencentCaptchaGlobalDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "frame-src", TencentCaptchaPrehandleDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "worker-src", TencentCaptchaWorkerSource))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaCDNDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaGlobalDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaGlobalCDNDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaPrehandleDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", TencentCaptchaJQueryDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "connect-src", TencentCaptchaDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "connect-src", TencentCaptchaPrehandleDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "connect-src", TencentCaptchaRceDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "frame-src", TencentCaptchaGlobalDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "frame-src", TencentCaptchaPrehandleDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "worker-src", TencentCaptchaWorkerSource))
 	})
 
 	t.Run("does_not_duplicate_tencent_captcha_worker_source", func(t *testing.T) {
@@ -360,7 +380,7 @@ func TestEnhanceCSPPolicy(t *testing.T) {
 
 		assert.Contains(t, enhanced, "script-src")
 		assert.Contains(t, enhanced, NonceTemplate)
-		assert.Contains(t, enhanced, CloudflareInsightsDomain)
+		assert.NotContains(t, enhanced, CloudflareInsightsDomain)
 	})
 
 	t.Run("preserves_existing_nonce", func(t *testing.T) {
@@ -372,32 +392,32 @@ func TestEnhanceCSPPolicy(t *testing.T) {
 		assert.Contains(t, enhanced, "'nonce-existing'")
 	})
 
-	t.Run("adds_airwallex_domains_for_payment_sdk", func(t *testing.T) {
+	t.Run("does_not_add_airwallex_domains", func(t *testing.T) {
 		policy := "default-src 'self'; script-src 'self' __CSP_NONCE__; style-src 'self'; frame-src 'self'"
 		enhanced := enhanceCSPPolicy(policy)
 
 		assert.Contains(t, enhanced, "script-src 'self' __CSP_NONCE__")
-		assert.Contains(t, enhanced, AirwallexStaticDomain)
-		assert.Contains(t, enhanced, AirwallexCheckoutDomain)
-		assert.Contains(t, enhanced, AirwallexDemoStaticDomain)
-		assert.Contains(t, enhanced, AirwallexDemoCheckoutDomain)
+		assert.NotContains(t, enhanced, AirwallexStaticDomain)
+		assert.NotContains(t, enhanced, AirwallexCheckoutDomain)
+		assert.NotContains(t, enhanced, AirwallexDemoStaticDomain)
+		assert.NotContains(t, enhanced, AirwallexDemoCheckoutDomain)
 		assert.Contains(t, enhanced, "style-src 'self'")
 		assert.Contains(t, enhanced, "frame-src 'self'")
 	})
 
-	t.Run("does_not_duplicate_airwallex_domains", func(t *testing.T) {
+	t.Run("preserves_only_explicit_airwallex_domains", func(t *testing.T) {
 		policy := "default-src 'self'; script-src 'self' https://static.airwallex.com https://static-demo.airwallex.com; frame-src https://checkout.airwallex.com https://checkout-demo.airwallex.com"
 		enhanced := enhanceCSPPolicy(policy)
 
 		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", AirwallexStaticDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", AirwallexCheckoutDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "style-src", AirwallexStaticDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "style-src", AirwallexCheckoutDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", AirwallexCheckoutDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "style-src", AirwallexStaticDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "style-src", AirwallexCheckoutDomain))
 		assert.Equal(t, 1, countDirectiveValue(enhanced, "frame-src", AirwallexCheckoutDomain))
 		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", AirwallexDemoStaticDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "script-src", AirwallexDemoCheckoutDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "style-src", AirwallexDemoStaticDomain))
-		assert.Equal(t, 1, countDirectiveValue(enhanced, "style-src", AirwallexDemoCheckoutDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "script-src", AirwallexDemoCheckoutDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "style-src", AirwallexDemoStaticDomain))
+		assert.Equal(t, 0, countDirectiveValue(enhanced, "style-src", AirwallexDemoCheckoutDomain))
 		assert.Equal(t, 1, countDirectiveValue(enhanced, "frame-src", AirwallexDemoCheckoutDomain))
 	})
 }

--- a/backend/internal/server/middleware/step_up.go
+++ b/backend/internal/server/middleware/step_up.go
@@ -12,6 +12,12 @@ import (
 // StepUpAuthMiddleware 敏感操作 step-up 2FA 门控中间件类型。
 type StepUpAuthMiddleware gin.HandlerFunc
 
+// RequiredStepUpAuthMiddleware 是不受 step_up_enabled 功能开关影响的强制门控。
+// 它用于上游凭证导入、OAuth token 交换等一旦被滥用便可持久化接管资源的操作。
+type RequiredStepUpAuthMiddleware gin.HandlerFunc
+
+const contextKeyRequiredStepUp = "sub2api.required_step_up"
+
 // stepUpGrantChecker 抽象 TOTP step-up 授权检查能力（由 TotpService 实现）。
 type stepUpGrantChecker interface {
 	HasStepUpGrant(ctx context.Context, userID int64, sessionKey string) (bool, error)
@@ -50,7 +56,37 @@ func NewStepUpAuthMiddleware(
 	userService *service.UserService,
 	settingService *service.SettingService,
 ) StepUpAuthMiddleware {
-	return StepUpAuthMiddleware(stepUpAuth(totpService, userService, stepUpSettingsOrNil(settingService)))
+	return StepUpAuthMiddleware(stepUpAuth(
+		stepUpGrantCheckerOrNil(totpService),
+		stepUpUserReaderOrNil(userService),
+		stepUpSettingsOrNil(settingService),
+	))
+}
+
+// NewRequiredStepUpAuthMiddleware 将既有 step-up 门控提升为强制门控。
+// 强制门控跳过功能开关读取，因此设置关闭或读取异常都不能放行敏感请求。
+func NewRequiredStepUpAuthMiddleware(stepUpAuth StepUpAuthMiddleware) RequiredStepUpAuthMiddleware {
+	return RequiredStepUpAuthMiddleware(func(c *gin.Context) {
+		if stepUpAuth == nil {
+			AbortWithError(c, 503, "STEP_UP_UNAVAILABLE", "Step-up verification service unavailable")
+			return
+		}
+		c.Set(contextKeyRequiredStepUp, true)
+		gin.HandlerFunc(stepUpAuth)(c)
+	})
+}
+
+// IsStepUpRequired reports whether the current route requires step-up regardless of the feature flag.
+func IsStepUpRequired(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	required, ok := c.Get(contextKeyRequiredStepUp)
+	if !ok {
+		return false
+	}
+	value, ok := required.(bool)
+	return ok && value
 }
 
 // stepUpSettingsOrNil 将可能为 nil 的具体指针归一化为接口，
@@ -60,6 +96,20 @@ func stepUpSettingsOrNil(settingService *service.SettingService) stepUpSettingRe
 		return nil
 	}
 	return settingService
+}
+
+func stepUpGrantCheckerOrNil(totpService *service.TotpService) stepUpGrantChecker {
+	if totpService == nil {
+		return nil
+	}
+	return totpService
+}
+
+func stepUpUserReaderOrNil(userService *service.UserService) stepUpUserReader {
+	if userService == nil {
+		return nil
+	}
+	return userService
 }
 
 func stepUpAuth(grantChecker stepUpGrantChecker, userReader stepUpUserReader, settings stepUpSettingReader) gin.HandlerFunc {
@@ -80,7 +130,12 @@ func EnforceStepUp(
 	userService *service.UserService,
 	settingService *service.SettingService,
 ) bool {
-	return enforceStepUp(c, totpService, userService, stepUpSettingsOrNil(settingService))
+	return enforceStepUp(
+		c,
+		stepUpGrantCheckerOrNil(totpService),
+		stepUpUserReaderOrNil(userService),
+		stepUpSettingsOrNil(settingService),
+	)
 }
 
 // EnforceStepUpAlways 与 EnforceStepUp 语义相同但不读取功能开关，无条件执行门控。
@@ -91,13 +146,13 @@ func EnforceStepUpAlways(
 	totpService *service.TotpService,
 	userService *service.UserService,
 ) bool {
-	return enforceStepUp(c, totpService, userService, nil)
+	return enforceStepUp(c, stepUpGrantCheckerOrNil(totpService), stepUpUserReaderOrNil(userService), nil)
 }
 
 func enforceStepUp(c *gin.Context, grantChecker stepUpGrantChecker, userReader stepUpUserReader, settings stepUpSettingReader) bool {
 	// 功能开关关闭时直接放行（含 admin API key），恢复门控引入前的行为。
-	// settings 为 nil 时保持门控（fail-closed）：正常装配不会出现 nil。
-	if settings != nil && !settings.IsStepUpEnabled(c.Request.Context()) {
+	// 强制门控路由不读取功能开关；settings 为 nil 时也保持门控（fail-closed）。
+	if !IsStepUpRequired(c) && settings != nil && !settings.IsStepUpEnabled(c.Request.Context()) {
 		return true
 	}
 
@@ -106,10 +161,13 @@ func enforceStepUp(c *gin.Context, grantChecker stepUpGrantChecker, userReader s
 			"Admin API key cannot access this endpoint; a two-factor verified admin session is required")
 		return false
 	}
-
 	subject, ok := GetAuthSubjectFromContext(c)
 	if !ok || subject.UserID <= 0 {
 		AbortWithError(c, 401, "UNAUTHORIZED", "Authorization required")
+		return false
+	}
+	if grantChecker == nil || userReader == nil {
+		AbortWithError(c, 503, "STEP_UP_UNAVAILABLE", "Step-up verification service unavailable")
 		return false
 	}
 

--- a/backend/internal/server/middleware/step_up_test.go
+++ b/backend/internal/server/middleware/step_up_test.go
@@ -164,3 +164,96 @@ func TestEnforceStepUpTypedNilSettingServiceFailsClosed(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
+
+func TestEnforceStepUpTypedNilDependenciesFailClosed(t *testing.T) {
+	require.Nil(t, stepUpGrantCheckerOrNil(nil))
+	require.Nil(t, stepUpUserReaderOrNil(nil))
+
+	c, rec := newStepUpTestContext(t)
+	c.Set(string(ContextKeyUser), AuthSubject{UserID: 1})
+
+	ok := EnforceStepUpAlways(c, nil, nil)
+
+	require.False(t, ok)
+	require.True(t, c.IsAborted())
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "STEP_UP_UNAVAILABLE")
+}
+
+func TestRequiredStepUpIgnoresDisabledSetting(t *testing.T) {
+	disabled := stubStepUpSettingReader{enabled: false}
+
+	t.Run("rejects admin api key", func(t *testing.T) {
+		c, rec := newStepUpTestContext(t)
+		c.Set("auth_method", service.AuditAuthMethodAdminAPIKey)
+		required := NewRequiredStepUpAuthMiddleware(StepUpAuthMiddleware(stepUpAuth(
+			stubStepUpGrantChecker{granted: true},
+			stubStepUpUserReader{user: &service.User{ID: 1, TotpEnabled: true}},
+			disabled,
+		)))
+
+		gin.HandlerFunc(required)(c)
+
+		require.True(t, IsStepUpRequired(c))
+		require.True(t, c.IsAborted())
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Contains(t, rec.Body.String(), "STEP_UP_ADMIN_API_KEY_FORBIDDEN")
+	})
+
+	t.Run("requires recent grant", func(t *testing.T) {
+		c, rec := newStepUpTestContext(t)
+		c.Set(string(ContextKeyUser), AuthSubject{UserID: 1})
+		required := NewRequiredStepUpAuthMiddleware(StepUpAuthMiddleware(stepUpAuth(
+			stubStepUpGrantChecker{granted: false},
+			stubStepUpUserReader{user: &service.User{ID: 1, TotpEnabled: true}},
+			disabled,
+		)))
+
+		gin.HandlerFunc(required)(c)
+
+		require.True(t, c.IsAborted())
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Contains(t, rec.Body.String(), "STEP_UP_REQUIRED")
+	})
+
+	t.Run("fails closed when grant store is unavailable", func(t *testing.T) {
+		c, rec := newStepUpTestContext(t)
+		c.Set(string(ContextKeyUser), AuthSubject{UserID: 1})
+		required := NewRequiredStepUpAuthMiddleware(StepUpAuthMiddleware(stepUpAuth(
+			stubStepUpGrantChecker{err: errors.New("redis down")},
+			stubStepUpUserReader{user: &service.User{ID: 1, TotpEnabled: true}},
+			disabled,
+		)))
+
+		gin.HandlerFunc(required)(c)
+
+		require.True(t, c.IsAborted())
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		require.Contains(t, rec.Body.String(), "STEP_UP_UNAVAILABLE")
+	})
+
+	t.Run("passes with recent grant", func(t *testing.T) {
+		c, _ := newStepUpTestContext(t)
+		c.Set(string(ContextKeyUser), AuthSubject{UserID: 1})
+		required := NewRequiredStepUpAuthMiddleware(StepUpAuthMiddleware(stepUpAuth(
+			stubStepUpGrantChecker{granted: true},
+			stubStepUpUserReader{user: &service.User{ID: 1, TotpEnabled: true}},
+			disabled,
+		)))
+
+		gin.HandlerFunc(required)(c)
+
+		require.False(t, c.IsAborted())
+	})
+}
+
+func TestRequiredStepUpNilDelegateFailsClosed(t *testing.T) {
+	c, rec := newStepUpTestContext(t)
+	required := NewRequiredStepUpAuthMiddleware(nil)
+
+	gin.HandlerFunc(required)(c)
+
+	require.True(t, c.IsAborted())
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "STEP_UP_UNAVAILABLE")
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -20,6 +20,7 @@ func RegisterAdminRoutes(
 	settingService *service.SettingService,
 	panelRateLimiter *middleware.PanelRateLimiter,
 ) {
+	requiredStepUpAuth := middleware.NewRequiredStepUpAuthMiddleware(stepUpAuth)
 	admin := v1.Group("/admin")
 	admin.Use(gin.HandlerFunc(adminAuth))
 	// 面板全局按用户限流（默认管理员豁免，可在系统设置中关闭豁免）
@@ -35,31 +36,31 @@ func RegisterAdminRoutes(
 		registerDashboardRoutes(admin, h)
 
 		// 用户管理
-		registerUserManagementRoutes(admin, h)
+		registerUserManagementRoutes(admin, h, requiredStepUpAuth)
 
 		// 分组管理
 		registerGroupRoutes(admin, h)
 
 		// 账号管理
-		registerAccountRoutes(admin, h, stepUpAuth)
+		registerAccountRoutes(admin, h, requiredStepUpAuth)
 
 		// 公告管理
 		registerAnnouncementRoutes(admin, h)
 
 		// OpenAI OAuth
-		registerOpenAIOAuthRoutes(admin, h)
+		registerOpenAIOAuthRoutes(admin, h, requiredStepUpAuth)
 
 		// Gemini OAuth
-		registerGeminiOAuthRoutes(admin, h)
+		registerGeminiOAuthRoutes(admin, h, requiredStepUpAuth)
 
 		// Antigravity OAuth
-		registerAntigravityOAuthRoutes(admin, h)
+		registerAntigravityOAuthRoutes(admin, h, requiredStepUpAuth)
 
 		// Grok OAuth
-		registerGrokOAuthRoutes(admin, h)
+		registerGrokOAuthRoutes(admin, h, requiredStepUpAuth)
 
 		// 代理管理
-		registerProxyRoutes(admin, h, stepUpAuth)
+		registerProxyRoutes(admin, h, requiredStepUpAuth)
 
 		// 卡密管理
 		registerRedeemCodeRoutes(admin, h)
@@ -68,19 +69,19 @@ func RegisterAdminRoutes(
 		registerPromoCodeRoutes(admin, h)
 
 		// 系统设置
-		registerSettingsRoutes(admin, h)
+		registerSettingsRoutes(admin, h, requiredStepUpAuth)
 
 		// 数据管理
-		registerDataManagementRoutes(admin, h, stepUpAuth)
+		registerDataManagementRoutes(admin, h, requiredStepUpAuth)
 
 		// 数据库备份恢复
-		registerBackupRoutes(admin, h, stepUpAuth)
+		registerBackupRoutes(admin, h, requiredStepUpAuth)
 
 		// 运维监控（Ops）
 		registerOpsRoutes(admin, h)
 
 		// 系统管理
-		registerSystemRoutes(admin, h)
+		registerSystemRoutes(admin, h, requiredStepUpAuth)
 
 		// 订阅管理
 		registerSubscriptionRoutes(admin, h)
@@ -288,8 +289,10 @@ func registerDashboardRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	}
 }
 
-func registerUserManagementRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
-	users := admin.Group("/users")
+func registerUserManagementRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
+	// User records contain authentication identities and can create or promote
+	// administrators. Require recent 2FA for the entire management surface.
+	users := admin.Group("/users", gin.HandlerFunc(requiredStepUpAuth))
 	{
 		users.GET("", h.Admin.User.List)
 		users.GET("/:id", h.Admin.User.GetByID)
@@ -345,8 +348,13 @@ func registerGroupRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	}
 }
 
-func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAuth middleware.StepUpAuthMiddleware) {
+func registerAccountRoutes(
+	admin *gin.RouterGroup,
+	h *handler.Handlers,
+	requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware,
+) {
 	accounts := admin.Group("/accounts")
+	requireStepUp := gin.HandlerFunc(requiredStepUpAuth)
 	{
 		accounts.GET("", h.Admin.Account.List)
 		accounts.GET("/upstream-billing-probe/settings", h.Admin.Account.GetUpstreamBillingProbeSettings)
@@ -355,25 +363,25 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.GET("/ollama-cloud-usage/settings", h.Admin.Account.GetOllamaCloudUsageSettings)
 		accounts.PUT("/ollama-cloud-usage/settings", h.Admin.Account.UpdateOllamaCloudUsageSettings)
 		accounts.GET("/:id", h.Admin.Account.GetByID)
-		accounts.POST("", h.Admin.Account.Create)
-		accounts.POST("/:id/duplicate", h.Admin.Account.Duplicate)
+		accounts.POST("", requireStepUp, h.Admin.Account.Create)
+		accounts.POST("/:id/duplicate", requireStepUp, h.Admin.Account.Duplicate)
 		accounts.POST("/check-mixed-channel", h.Admin.Account.CheckMixedChannel)
-		accounts.POST("/import/codex-session", h.Admin.Account.ImportCodexSession)
-		accounts.POST("/sync/crs", h.Admin.Account.SyncFromCRS)
+		accounts.POST("/import/codex-session", requireStepUp, h.Admin.Account.ImportCodexSession)
+		accounts.POST("/sync/crs", requireStepUp, h.Admin.Account.SyncFromCRS)
 		accounts.POST("/sync/crs/preview", h.Admin.Account.PreviewFromCRS)
-		accounts.PUT("/:id", h.Admin.Account.Update)
+		accounts.PUT("/:id", requireStepUp, h.Admin.Account.Update)
 		accounts.PUT("/:id/upstream-billing-probe", h.Admin.Account.SetUpstreamBillingProbeEnabled)
 		accounts.POST("/:id/upstream-billing-probe", h.Admin.Account.ProbeUpstreamBilling)
 		accounts.GET("/:id/ollama-cloud-usage", h.Admin.Account.GetOllamaCloudUsage)
-		accounts.PUT("/:id/ollama-cloud-usage/session", h.Admin.Account.SaveOllamaCloudUsageSession)
-		accounts.DELETE("/:id/ollama-cloud-usage/session", h.Admin.Account.DeleteOllamaCloudUsageSession)
+		accounts.PUT("/:id/ollama-cloud-usage/session", requireStepUp, h.Admin.Account.SaveOllamaCloudUsageSession)
+		accounts.DELETE("/:id/ollama-cloud-usage/session", requireStepUp, h.Admin.Account.DeleteOllamaCloudUsageSession)
 		accounts.PUT("/:id/ollama-cloud-usage/auto-refresh", h.Admin.Account.SetOllamaCloudUsageAutoRefresh)
 		accounts.POST("/:id/ollama-cloud-usage/refresh", h.Admin.Account.RefreshOllamaCloudUsage)
-		accounts.DELETE("/:id", h.Admin.Account.Delete)
+		accounts.DELETE("/:id", requireStepUp, h.Admin.Account.Delete)
 		accounts.POST("/:id/test", h.Admin.Account.Test)
 		accounts.POST("/:id/recover-state", h.Admin.Account.RecoverState)
 		accounts.POST("/:id/refresh", h.Admin.Account.Refresh)
-		accounts.POST("/:id/apply-oauth-credentials", h.Admin.Account.ApplyOAuthCredentials)
+		accounts.POST("/:id/apply-oauth-credentials", requireStepUp, h.Admin.Account.ApplyOAuthCredentials)
 		accounts.POST("/:id/set-privacy", h.Admin.Account.SetPrivacy)
 		accounts.POST("/:id/refresh-tier", h.Admin.Account.RefreshTier)
 		accounts.GET("/:id/stats", h.Admin.Account.GetStats)
@@ -391,14 +399,14 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.POST("/models/sync-upstream-preview", h.Admin.Account.SyncUpstreamModelsPreview)
 		accounts.GET("/:id/models", h.Admin.Account.GetAvailableModels)
 		accounts.POST("/:id/models/sync-upstream", h.Admin.Account.SyncUpstreamModels)
-		accounts.POST("/batch", h.Admin.Account.BatchCreate)
-		// 账号导出泄露上游凭证原文——要求 step-up 2FA
-		accounts.GET("/data", gin.HandlerFunc(stepUpAuth), h.Admin.Account.ExportData)
-		accounts.POST("/data", h.Admin.Account.ImportData)
-		accounts.POST("/batch-update-credentials", h.Admin.Account.BatchUpdateCredentials)
+		accounts.POST("/batch", requireStepUp, h.Admin.Account.BatchCreate)
+		// 账号导出泄露上游凭证原文——无论功能开关如何都强制 step-up 2FA。
+		accounts.GET("/data", requireStepUp, h.Admin.Account.ExportData)
+		accounts.POST("/data", requireStepUp, h.Admin.Account.ImportData)
+		accounts.POST("/batch-update-credentials", requireStepUp, h.Admin.Account.BatchUpdateCredentials)
 		accounts.POST("/batch-refresh-tier", h.Admin.Account.BatchRefreshTier)
-		accounts.POST("/bulk-update", h.Admin.Account.BulkUpdate)
-		accounts.POST("/batch-delete", h.Admin.Account.BatchDelete)
+		accounts.POST("/bulk-update", requireStepUp, h.Admin.Account.BulkUpdate)
+		accounts.POST("/batch-delete", requireStepUp, h.Admin.Account.BatchDelete)
 		accounts.POST("/batch-clear-error", h.Admin.Account.BatchClearError)
 		accounts.POST("/batch-refresh", h.Admin.Account.BatchRefresh)
 
@@ -406,15 +414,15 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.GET("/antigravity/default-model-mapping", h.Admin.Account.GetAntigravityDefaultModelMapping)
 
 		// Spark 影子账号
-		accounts.POST("/:id/shadow", h.Admin.OpenAIOAuth.CreateShadow)
+		accounts.POST("/:id/shadow", requireStepUp, h.Admin.OpenAIOAuth.CreateShadow)
 
 		// Claude OAuth routes
 		accounts.POST("/generate-auth-url", h.Admin.OAuth.GenerateAuthURL)
 		accounts.POST("/generate-setup-token-url", h.Admin.OAuth.GenerateSetupTokenURL)
-		accounts.POST("/exchange-code", h.Admin.OAuth.ExchangeCode)
-		accounts.POST("/exchange-setup-token-code", h.Admin.OAuth.ExchangeSetupTokenCode)
-		accounts.POST("/cookie-auth", h.Admin.OAuth.CookieAuth)
-		accounts.POST("/setup-token-cookie-auth", h.Admin.OAuth.SetupTokenCookieAuth)
+		accounts.POST("/exchange-code", requireStepUp, h.Admin.OAuth.ExchangeCode)
+		accounts.POST("/exchange-setup-token-code", requireStepUp, h.Admin.OAuth.ExchangeSetupTokenCode)
+		accounts.POST("/cookie-auth", requireStepUp, h.Admin.OAuth.CookieAuth)
+		accounts.POST("/setup-token-cookie-auth", requireStepUp, h.Admin.OAuth.SetupTokenCookieAuth)
 	}
 }
 
@@ -430,65 +438,70 @@ func registerAnnouncementRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	}
 }
 
-func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	openai := admin.Group("/openai")
+	requireStepUp := gin.HandlerFunc(requiredStepUpAuth)
 	{
 		openai.POST("/generate-auth-url", h.Admin.OpenAIOAuth.GenerateAuthURL)
-		openai.POST("/exchange-code", h.Admin.OpenAIOAuth.ExchangeCode)
-		openai.POST("/refresh-token", h.Admin.OpenAIOAuth.RefreshToken)
-		openai.POST("/accounts/:id/refresh", h.Admin.OpenAIOAuth.RefreshAccountToken)
-		openai.POST("/create-from-oauth", h.Admin.OpenAIOAuth.CreateAccountFromOAuth)
-		openai.POST("/create-from-codex-pat", h.Admin.OpenAIOAuth.CreateAccountFromCodexPAT)
+		openai.POST("/exchange-code", requireStepUp, h.Admin.OpenAIOAuth.ExchangeCode)
+		openai.POST("/refresh-token", requireStepUp, h.Admin.OpenAIOAuth.RefreshToken)
+		openai.POST("/accounts/:id/refresh", requireStepUp, h.Admin.OpenAIOAuth.RefreshAccountToken)
+		openai.POST("/create-from-oauth", requireStepUp, h.Admin.OpenAIOAuth.CreateAccountFromOAuth)
+		openai.POST("/create-from-codex-pat", requireStepUp, h.Admin.OpenAIOAuth.CreateAccountFromCodexPAT)
 		openai.GET("/accounts/:id/quota", h.Admin.OpenAIOAuth.QueryQuota)
 		openai.POST("/accounts/:id/quota/refresh", h.Admin.OpenAIOAuth.RefreshQuota)
 		openai.POST("/accounts/:id/reset-quota", h.Admin.OpenAIOAuth.ResetQuota)
 	}
 }
 
-func registerGeminiOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerGeminiOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	gemini := admin.Group("/gemini")
 	{
 		gemini.POST("/oauth/auth-url", h.Admin.GeminiOAuth.GenerateAuthURL)
-		gemini.POST("/oauth/exchange-code", h.Admin.GeminiOAuth.ExchangeCode)
+		gemini.POST("/oauth/exchange-code", gin.HandlerFunc(requiredStepUpAuth), h.Admin.GeminiOAuth.ExchangeCode)
 		gemini.GET("/oauth/capabilities", h.Admin.GeminiOAuth.GetCapabilities)
 	}
 }
 
-func registerAntigravityOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerAntigravityOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	antigravity := admin.Group("/antigravity")
+	requireStepUp := gin.HandlerFunc(requiredStepUpAuth)
 	{
 		antigravity.POST("/oauth/auth-url", h.Admin.AntigravityOAuth.GenerateAuthURL)
-		antigravity.POST("/oauth/exchange-code", h.Admin.AntigravityOAuth.ExchangeCode)
-		antigravity.POST("/oauth/refresh-token", h.Admin.AntigravityOAuth.RefreshToken)
+		antigravity.POST("/oauth/exchange-code", requireStepUp, h.Admin.AntigravityOAuth.ExchangeCode)
+		antigravity.POST("/oauth/refresh-token", requireStepUp, h.Admin.AntigravityOAuth.RefreshToken)
 	}
 }
 
-func registerGrokOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerGrokOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	grok := admin.Group("/grok")
+	requireStepUp := gin.HandlerFunc(requiredStepUpAuth)
 	{
 		grok.GET("/oauth/capabilities", h.Admin.GrokOAuth.GetCapabilities)
 		grok.POST("/oauth/auth-url", h.Admin.GrokOAuth.GenerateAuthURL)
-		grok.POST("/oauth/exchange-code", h.Admin.GrokOAuth.ExchangeCode)
-		grok.POST("/oauth/refresh-token", h.Admin.GrokOAuth.RefreshToken)
-		grok.POST("/oauth/sso-token", h.Admin.GrokOAuth.ValidateSSOToken)
-		grok.POST("/oauth/password", h.Admin.GrokOAuth.AuthorizePassword)
-		grok.POST("/oauth/create-from-oauth", h.Admin.GrokOAuth.CreateAccountFromOAuth)
-		grok.POST("/sso-to-oauth", h.Admin.GrokOAuth.CreateAccountsFromSSO)
-		grok.POST("/oauth/reconcile", h.Admin.GrokOAuth.ReconcileOAuthAccounts)
-		grok.POST("/accounts/:id/refresh", h.Admin.GrokOAuth.RefreshAccountToken)
+		grok.POST("/oauth/exchange-code", requireStepUp, h.Admin.GrokOAuth.ExchangeCode)
+		grok.POST("/oauth/refresh-token", requireStepUp, h.Admin.GrokOAuth.RefreshToken)
+		grok.POST("/oauth/sso-token", requireStepUp, h.Admin.GrokOAuth.ValidateSSOToken)
+		grok.POST("/oauth/password", requireStepUp, h.Admin.GrokOAuth.AuthorizePassword)
+		grok.POST("/oauth/create-from-oauth", requireStepUp, h.Admin.GrokOAuth.CreateAccountFromOAuth)
+		grok.POST("/sso-to-oauth", requireStepUp, h.Admin.GrokOAuth.CreateAccountsFromSSO)
+		grok.POST("/oauth/reconcile", requireStepUp, h.Admin.GrokOAuth.ReconcileOAuthAccounts)
+		grok.POST("/accounts/:id/refresh", requireStepUp, h.Admin.GrokOAuth.RefreshAccountToken)
 		grok.GET("/accounts/:id/quota", h.Admin.GrokOAuth.QueryQuota)
 		grok.POST("/accounts/:id/reset-quota", h.Admin.GrokOAuth.ResetQuota)
 		grok.GET("/runtime-sanity", h.Admin.GrokOAuth.RuntimeSanity)
 	}
 }
 
-func registerProxyRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAuth middleware.StepUpAuthMiddleware) {
-	proxies := admin.Group("/proxies")
+func registerProxyRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
+	// Proxy DTOs and exports include credentials, while mutations can redirect
+	// upstream traffic. Protect the whole surface independently of the optional
+	// global step-up feature flag.
+	proxies := admin.Group("/proxies", gin.HandlerFunc(requiredStepUpAuth))
 	{
 		proxies.GET("", h.Admin.Proxy.List)
 		proxies.GET("/all", h.Admin.Proxy.GetAll)
-		// 代理导出泄露账号密码原文——要求 step-up 2FA
-		proxies.GET("/data", gin.HandlerFunc(stepUpAuth), h.Admin.Proxy.ExportData)
+		proxies.GET("/data", h.Admin.Proxy.ExportData)
 		proxies.POST("/data", h.Admin.Proxy.ImportData)
 		proxies.GET("/:id", h.Admin.Proxy.GetByID)
 		proxies.POST("", h.Admin.Proxy.Create)
@@ -531,7 +544,7 @@ func registerPromoCodeRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	}
 }
 
-func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	adminSettings := admin.Group("/settings")
 	{
 		adminSettings.GET("", h.Admin.Setting.GetSettings)
@@ -545,8 +558,8 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		adminSettings.POST("/email-templates/:event/:locale/restore-official", h.Admin.Setting.RestoreOfficialEmailTemplate)
 		// Admin API Key 管理
 		adminSettings.GET("/admin-api-key", h.Admin.Setting.GetAdminAPIKey)
-		adminSettings.POST("/admin-api-key/regenerate", h.Admin.Setting.RegenerateAdminAPIKey)
-		adminSettings.DELETE("/admin-api-key", h.Admin.Setting.DeleteAdminAPIKey)
+		adminSettings.POST("/admin-api-key/regenerate", gin.HandlerFunc(requiredStepUpAuth), h.Admin.Setting.RegenerateAdminAPIKey)
+		adminSettings.DELETE("/admin-api-key", gin.HandlerFunc(requiredStepUpAuth), h.Admin.Setting.DeleteAdminAPIKey)
 		// 529过载冷却配置
 		adminSettings.GET("/overload-cooldown", h.Admin.Setting.GetOverloadCooldownSettings)
 		adminSettings.PUT("/overload-cooldown", h.Admin.Setting.UpdateOverloadCooldownSettings)
@@ -573,8 +586,9 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	}
 }
 
-func registerDataManagementRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAuth middleware.StepUpAuthMiddleware) {
-	dataManagement := admin.Group("/data-management")
+func registerDataManagementRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
+	// This surface manages external storage credentials and database exports.
+	dataManagement := admin.Group("/data-management", gin.HandlerFunc(requiredStepUpAuth))
 	{
 		dataManagement.GET("/agent/health", h.Admin.DataManagement.GetAgentHealth)
 		dataManagement.GET("/config", h.Admin.DataManagement.GetConfig)
@@ -586,30 +600,29 @@ func registerDataManagementRoutes(admin *gin.RouterGroup, h *handler.Handlers, s
 		dataManagement.POST("/sources/:source_type/profiles/:profile_id/activate", h.Admin.DataManagement.SetActiveSourceProfile)
 		dataManagement.POST("/s3/test", h.Admin.DataManagement.TestS3)
 		dataManagement.GET("/s3/profiles", h.Admin.DataManagement.ListS3Profiles)
-		// 修改 S3 目标可将数据备份外泄——要求 step-up 2FA
-		dataManagement.POST("/s3/profiles", gin.HandlerFunc(stepUpAuth), h.Admin.DataManagement.CreateS3Profile)
-		dataManagement.PUT("/s3/profiles/:profile_id", gin.HandlerFunc(stepUpAuth), h.Admin.DataManagement.UpdateS3Profile)
+		dataManagement.POST("/s3/profiles", h.Admin.DataManagement.CreateS3Profile)
+		dataManagement.PUT("/s3/profiles/:profile_id", h.Admin.DataManagement.UpdateS3Profile)
 		dataManagement.DELETE("/s3/profiles/:profile_id", h.Admin.DataManagement.DeleteS3Profile)
-		dataManagement.POST("/s3/profiles/:profile_id/activate", gin.HandlerFunc(stepUpAuth), h.Admin.DataManagement.SetActiveS3Profile)
-		dataManagement.POST("/backups", gin.HandlerFunc(stepUpAuth), h.Admin.DataManagement.CreateBackupJob)
+		dataManagement.POST("/s3/profiles/:profile_id/activate", h.Admin.DataManagement.SetActiveS3Profile)
+		dataManagement.POST("/backups", h.Admin.DataManagement.CreateBackupJob)
 		dataManagement.GET("/backups", h.Admin.DataManagement.ListBackupJobs)
 		dataManagement.GET("/backups/:job_id", h.Admin.DataManagement.GetBackupJob)
 	}
 }
 
-func registerBackupRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAuth middleware.StepUpAuthMiddleware) {
-	backup := admin.Group("/backups")
+func registerBackupRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
+	// Backup configuration, payloads and restore operations contain or control
+	// the entire database. Protect the whole surface unconditionally.
+	backup := admin.Group("/backups", gin.HandlerFunc(requiredStepUpAuth))
 	{
 		// S3 存储配置
 		backup.GET("/s3-config", h.Admin.Backup.GetS3Config)
-		// 修改 S3 目标可将数据库备份外泄——要求 step-up 2FA
-		backup.PUT("/s3-config", gin.HandlerFunc(stepUpAuth), h.Admin.Backup.UpdateS3Config)
+		backup.PUT("/s3-config", h.Admin.Backup.UpdateS3Config)
 		backup.POST("/s3-config/test", h.Admin.Backup.TestS3Connection)
 
 		// 异步生图对象存储配置（与备份共用 S3 客户端，可直接复用备份凭证）
 		backup.GET("/image-storage", h.Admin.Backup.GetImageStorageConfig)
-		// 同 S3 配置：改写对象存储目标可将生成内容导向外部账号——要求 step-up 2FA
-		backup.PUT("/image-storage", gin.HandlerFunc(stepUpAuth), h.Admin.Backup.UpdateImageStorageConfig)
+		backup.PUT("/image-storage", h.Admin.Backup.UpdateImageStorageConfig)
 		backup.POST("/image-storage/test", h.Admin.Backup.TestImageStorageConnection)
 
 		// 定时备份配置
@@ -617,27 +630,26 @@ func registerBackupRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAut
 		backup.PUT("/schedule", h.Admin.Backup.UpdateSchedule)
 
 		// 备份操作
-		backup.POST("", gin.HandlerFunc(stepUpAuth), h.Admin.Backup.CreateBackup)
+		backup.POST("", h.Admin.Backup.CreateBackup)
 		backup.GET("", h.Admin.Backup.ListBackups)
 		backup.GET("/:id", h.Admin.Backup.GetBackup)
 		backup.DELETE("/:id", h.Admin.Backup.DeleteBackup)
-		// 备份下载链接可直接取走整库数据——要求 step-up 2FA
-		backup.GET("/:id/download-url", gin.HandlerFunc(stepUpAuth), h.Admin.Backup.GetDownloadURL)
+		backup.GET("/:id/download-url", h.Admin.Backup.GetDownloadURL)
 
-		// 恢复操作：整库覆盖可回滚安全设置（含 step-up 开关本身）——要求 step-up 2FA
-		backup.POST("/:id/restore", gin.HandlerFunc(stepUpAuth), h.Admin.Backup.RestoreBackup)
+		backup.POST("/:id/restore", h.Admin.Backup.RestoreBackup)
 	}
 }
 
-func registerSystemRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
+func registerSystemRoutes(admin *gin.RouterGroup, h *handler.Handlers, requiredStepUpAuth middleware.RequiredStepUpAuthMiddleware) {
 	system := admin.Group("/system")
+	requireStepUp := gin.HandlerFunc(requiredStepUpAuth)
 	{
 		system.GET("/version", h.Admin.System.GetVersion)
 		system.GET("/check-updates", h.Admin.System.CheckUpdates)
 		system.GET("/rollback-versions", h.Admin.System.GetRollbackVersions)
-		system.POST("/update", h.Admin.System.PerformUpdate)
-		system.POST("/rollback", h.Admin.System.Rollback)
-		system.POST("/restart", h.Admin.System.RestartService)
+		system.POST("/update", requireStepUp, h.Admin.System.PerformUpdate)
+		system.POST("/rollback", requireStepUp, h.Admin.System.Rollback)
+		system.POST("/restart", requireStepUp, h.Admin.System.RestartService)
 	}
 }
 

--- a/backend/internal/server/routes/admin_credential_stepup_routes_test.go
+++ b/backend/internal/server/routes/admin_credential_stepup_routes_test.go
@@ -1,0 +1,152 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/handler"
+	servermiddleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newRequiredStepUpAdminRouteTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	handlers := &handler.Handlers{Admin: &handler.AdminHandlers{}}
+	adminAuth := servermiddleware.AdminAuthMiddleware(func(c *gin.Context) {
+		if c.GetHeader("X-Test-Admin-API-Key") == "1" {
+			c.Set("auth_method", service.AuditAuthMethodAdminAPIKey)
+		} else {
+			c.Set("auth_method", service.AuditAuthMethodJWT)
+		}
+		c.Next()
+	})
+	auditLog := servermiddleware.AuditLogMiddleware(func(c *gin.Context) { c.Next() })
+	stepUp := servermiddleware.StepUpAuthMiddleware(func(c *gin.Context) {
+		if !servermiddleware.IsStepUpRequired(c) {
+			servermiddleware.AbortWithError(c, http.StatusInternalServerError, "REQUIRED_STEP_UP_MARKER_MISSING", "required step-up marker missing")
+			return
+		}
+		if c.GetString("auth_method") == service.AuditAuthMethodAdminAPIKey {
+			servermiddleware.AbortWithError(c, http.StatusForbidden, "STEP_UP_ADMIN_API_KEY_FORBIDDEN", "admin API key forbidden")
+			return
+		}
+		servermiddleware.AbortWithError(c, http.StatusTeapot, "REQUIRED_STEP_UP_REACHED", "required step-up reached")
+	})
+
+	RegisterAdminRoutes(router.Group("/api/v1"), handlers, adminAuth, auditLog, stepUp, nil, nil)
+	return router
+}
+
+func TestAdminHighRiskRoutesRequireUnconditionalStepUp(t *testing.T) {
+	router := newRequiredStepUpAdminRouteTestRouter(t)
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/api/v1/admin/accounts"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/42/duplicate"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/import/codex-session"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/sync/crs"},
+		{method: http.MethodPut, path: "/api/v1/admin/accounts/42"},
+		{method: http.MethodPut, path: "/api/v1/admin/accounts/42/ollama-cloud-usage/session"},
+		{method: http.MethodDelete, path: "/api/v1/admin/accounts/42/ollama-cloud-usage/session"},
+		{method: http.MethodDelete, path: "/api/v1/admin/accounts/42"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/42/apply-oauth-credentials"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/batch"},
+		{method: http.MethodGet, path: "/api/v1/admin/accounts/data"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/data"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/batch-update-credentials"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/bulk-update"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/batch-delete"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/42/shadow"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/exchange-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/exchange-setup-token-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/cookie-auth"},
+		{method: http.MethodPost, path: "/api/v1/admin/accounts/setup-token-cookie-auth"},
+		{method: http.MethodPost, path: "/api/v1/admin/openai/exchange-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/openai/refresh-token"},
+		{method: http.MethodPost, path: "/api/v1/admin/openai/accounts/42/refresh"},
+		{method: http.MethodPost, path: "/api/v1/admin/openai/create-from-oauth"},
+		{method: http.MethodPost, path: "/api/v1/admin/openai/create-from-codex-pat"},
+		{method: http.MethodPost, path: "/api/v1/admin/gemini/oauth/exchange-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/antigravity/oauth/exchange-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/antigravity/oauth/refresh-token"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/exchange-code"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/refresh-token"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/sso-token"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/password"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/create-from-oauth"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/sso-to-oauth"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/oauth/reconcile"},
+		{method: http.MethodPost, path: "/api/v1/admin/grok/accounts/42/refresh"},
+		{method: http.MethodGet, path: "/api/v1/admin/users"},
+		{method: http.MethodGet, path: "/api/v1/admin/users/42"},
+		{method: http.MethodPost, path: "/api/v1/admin/users/42/auth-identities"},
+		{method: http.MethodPost, path: "/api/v1/admin/users"},
+		{method: http.MethodPut, path: "/api/v1/admin/users/42"},
+		{method: http.MethodDelete, path: "/api/v1/admin/users/42"},
+		{method: http.MethodGet, path: "/api/v1/admin/users/42/api-keys"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies/all"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies/data"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies/data"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies/42"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies"},
+		{method: http.MethodPut, path: "/api/v1/admin/proxies/42"},
+		{method: http.MethodDelete, path: "/api/v1/admin/proxies/42"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies/42/test"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies/42/quality-check"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies/42/stats"},
+		{method: http.MethodGet, path: "/api/v1/admin/proxies/42/accounts"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies/batch-delete"},
+		{method: http.MethodPost, path: "/api/v1/admin/proxies/batch"},
+		{method: http.MethodGet, path: "/api/v1/admin/data-management/agent/health"},
+		{method: http.MethodPut, path: "/api/v1/admin/data-management/config"},
+		{method: http.MethodPost, path: "/api/v1/admin/data-management/s3/profiles"},
+		{method: http.MethodPost, path: "/api/v1/admin/data-management/backups"},
+		{method: http.MethodGet, path: "/api/v1/admin/backups/s3-config"},
+		{method: http.MethodPut, path: "/api/v1/admin/backups/s3-config"},
+		{method: http.MethodGet, path: "/api/v1/admin/backups"},
+		{method: http.MethodPost, path: "/api/v1/admin/backups"},
+		{method: http.MethodGet, path: "/api/v1/admin/backups/42/download-url"},
+		{method: http.MethodPost, path: "/api/v1/admin/backups/42/restore"},
+		{method: http.MethodPost, path: "/api/v1/admin/system/update"},
+		{method: http.MethodPost, path: "/api/v1/admin/system/rollback"},
+		{method: http.MethodPost, path: "/api/v1/admin/system/restart"},
+		{method: http.MethodPost, path: "/api/v1/admin/settings/admin-api-key/regenerate"},
+		{method: http.MethodDelete, path: "/api/v1/admin/settings/admin-api-key"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path+" requires marker", func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tc.method, tc.path, strings.NewReader("{}"))
+			request.Header.Set("Content-Type", "application/json")
+
+			router.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusTeapot, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "REQUIRED_STEP_UP_REACHED")
+		})
+
+		t.Run(tc.method+" "+tc.path+" rejects admin api key", func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tc.method, tc.path, strings.NewReader("{}"))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("X-Test-Admin-API-Key", "1")
+
+			router.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusForbidden, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "STEP_UP_ADMIN_API_KEY_FORBIDDEN")
+		})
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -20,12 +20,16 @@ import (
 )
 
 type Account struct {
-	ID                      int64
-	Name                    string
-	Notes                   *string
-	Platform                string
-	Type                    string
-	Credentials             map[string]any
+	ID          int64
+	Name        string
+	Notes       *string
+	Platform    string
+	Type        string
+	Credentials map[string]any
+	// CredentialStorage is the authenticated database representation observed
+	// when this account was loaded. It is never serialized or exposed and is
+	// used only for storage-boundary CAS diagnostics/migrations.
+	CredentialStorage       map[string]any `json:"-"`
 	Extra                   map[string]any
 	ProxyID                 *int64
 	ProxyFallbackOriginID   *int64

--- a/backend/internal/service/auth_email_binding.go
+++ b/backend/internal/service/auth_email_binding.go
@@ -202,6 +202,16 @@ func (s *AuthService) updateBoundEmailIdentityWithClient(
 		}
 		return ErrServiceUnavailable
 	}
+	versionRepo, ok := s.userRepo.(UserTokenVersionRepository)
+	if !ok {
+		return ErrServiceUnavailable
+	}
+	tokenVersion, err := versionRepo.IncrementTokenVersion(ctx, currentUser.ID)
+	if err != nil {
+		return ErrServiceUnavailable
+	}
+	currentUser.TokenVersion = tokenVersion
+	currentUser.TokenVersionResolved = true
 
 	if err := replaceBoundEmailAuthIdentityWithClient(ctx, client, currentUser.ID, oldEmail, email, "auth_service_email_bind"); err != nil {
 		if errors.Is(err, ErrEmailExists) {

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -53,15 +53,21 @@ var (
 // maxTokenLength 限制 token 大小，避免超长 header 触发解析时的异常内存分配。
 const maxTokenLength = 8192
 
+// currentTokenVersionEpoch distinguishes durable token_version claims from the
+// pre-migration fingerprint scheme. Legacy tokens omit the field (zero) and
+// are deterministically rejected after migration 221.
+const currentTokenVersionEpoch = 1
+
 // refreshTokenPrefix is the prefix for refresh tokens to distinguish them from access tokens.
 const refreshTokenPrefix = "rt_"
 
 // JWTClaims JWT载荷数据
 type JWTClaims struct {
-	UserID       int64  `json:"user_id"`
-	Email        string `json:"email"`
-	Role         string `json:"role"`
-	TokenVersion int64  `json:"token_version"` // Used to invalidate tokens on password change
+	UserID            int64  `json:"user_id"`
+	Email             string `json:"email"`
+	Role              string `json:"role"`
+	TokenVersion      int64  `json:"token_version"`
+	TokenVersionEpoch int    `json:"token_version_epoch"`
 	// SessionID 会话 ID（与 refresh token family 对应），用于单会话撤销与 step-up 授权绑定。
 	SessionID string `json:"sid,omitempty"`
 	// BindingHash 会话指纹哈希（IP+UA），会话绑定开启时校验；空值表示旧 token（平滑升级）。
@@ -1296,39 +1302,40 @@ func (s *AuthService) ValidateToken(tokenString string) (*JWTClaims, error) {
 		return nil, ErrTokenTooLarge
 	}
 
-	// 使用解析器并限制可接受的签名算法，防止算法混淆。
-	parser := jwt.NewParser(jwt.WithValidMethods([]string{
-		jwt.SigningMethodHS256.Name,
-		jwt.SigningMethodHS384.Name,
-		jwt.SigningMethodHS512.Name,
-	}))
-
-	// 保留默认 claims 校验（exp/nbf），避免放行过期或未生效的 token。
+	// Verify structure, the one algorithm we mint, and the signature before
+	// considering expiration. Separating these stages prevents a combined
+	// "bad signature + expired" parser error from being treated as a refreshable
+	// expired token.
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}),
+		jwt.WithoutClaimsValidation(),
+	)
 	token, err := parser.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (any, error) {
-		// 验证签名方法
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		if token.Method != jwt.SigningMethodHS256 {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(s.cfg.JWT.Secret), nil
 	})
-
-	if err != nil {
-		if errors.Is(err, jwt.ErrTokenExpired) {
-			// token 过期但仍返回 claims（用于 RefreshToken 等场景）
-			// jwt-go 在解析时即使遇到过期错误，token.Claims 仍会被填充
-			if claims, ok := token.Claims.(*JWTClaims); ok {
-				return claims, ErrTokenExpired
-			}
-			return nil, ErrTokenExpired
-		}
+	if err != nil || token == nil || !token.Valid {
 		return nil, ErrInvalidToken
 	}
 
-	if claims, ok := token.Claims.(*JWTClaims); ok && token.Valid {
-		return claims, nil
+	claims, ok := token.Claims.(*JWTClaims)
+	if !ok || claims.ExpiresAt == nil || claims.IssuedAt == nil || claims.NotBefore == nil {
+		return nil, ErrInvalidToken
+	}
+	if claims.TokenVersionEpoch != currentTokenVersionEpoch {
+		return claims, ErrTokenRevoked
 	}
 
-	return nil, ErrInvalidToken
+	now := time.Now()
+	if claims.IssuedAt.Time.After(now) || claims.NotBefore.Time.After(now) {
+		return nil, ErrInvalidToken
+	}
+	if !now.Before(claims.ExpiresAt.Time) {
+		return claims, ErrTokenExpired
+	}
+	return claims, nil
 }
 
 func randomHexString(byteLength int) (string, error) {
@@ -1358,11 +1365,13 @@ func (s *AuthService) GenerateToken(ctx context.Context, user *User) (string, er
 	if err != nil {
 		return "", fmt.Errorf("generate session id: %w", err)
 	}
-	return s.generateAccessToken(user, sessionID, sessionBindingHashFromContext(ctx))
+	return s.generateAccessToken(user, sessionID, sessionBindingHashFromContext(ctx), resolvedTokenVersion(user))
 }
 
 // generateAccessToken 生成带会话 ID 与绑定指纹的 access token。
-func (s *AuthService) generateAccessToken(user *User, sessionID, bindingHash string) (string, error) {
+// tokenVersion is explicit so a refresh already in flight cannot cross a
+// concurrent revoke-all boundary and mint a token at the newly advanced stamp.
+func (s *AuthService) generateAccessToken(user *User, sessionID, bindingHash string, tokenVersion int64) (string, error) {
 	now := time.Now()
 	var expiresAt time.Time
 	if s.cfg.JWT.AccessTokenExpireMinutes > 0 {
@@ -1373,12 +1382,13 @@ func (s *AuthService) generateAccessToken(user *User, sessionID, bindingHash str
 	}
 
 	claims := &JWTClaims{
-		UserID:       user.ID,
-		Email:        user.Email,
-		Role:         user.Role,
-		TokenVersion: resolvedTokenVersion(user),
-		SessionID:    sessionID,
-		BindingHash:  bindingHash,
+		UserID:            user.ID,
+		Email:             user.Email,
+		Role:              user.Role,
+		TokenVersion:      tokenVersion,
+		TokenVersionEpoch: currentTokenVersionEpoch,
+		SessionID:         sessionID,
+		BindingHash:       bindingHash,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -1456,8 +1466,13 @@ func (s *AuthService) RefreshToken(ctx context.Context, oldTokenString string) (
 		}
 	}
 
-	// 生成新token
-	return s.GenerateToken(ctx, user)
+	// Generate at the version authenticated above. If revoke-all advances the
+	// database stamp concurrently, this token remains stale and is rejected.
+	sessionID, err := randomHexString(8)
+	if err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
+	return s.generateAccessToken(user, sessionID, sessionBindingHashFromContext(ctx), claims.TokenVersion)
 }
 
 // IsPasswordResetEnabled 检查是否启用密码重置功能
@@ -1597,8 +1612,8 @@ func (s *AuthService) ResetPassword(ctx context.Context, email, token, newPasswo
 	user.PasswordHash = hashedPassword
 	user.TokenVersion++ // Invalidate all existing tokens
 
-	// TokenVersion 无对应数据库列（见 resolvedTokenVersion：由 email+password_hash 指纹推导），
-	// 写回 password_hash 本身即可让旧 token 失效。
+	// Production repositories persist the password change and atomically advance
+	// token_version in the same transaction.
 	if err := s.userRepo.Update(ctx, user, UserUpdateFields{PasswordHash: true}); err != nil {
 		logger.LegacyPrintf("service.auth", "[Auth] Database error updating password for user %d: %v", user.ID, err)
 		return ErrServiceUnavailable
@@ -1632,6 +1647,13 @@ type TokenPairWithUser struct {
 // GenerateTokenPair 生成Access Token和Refresh Token对
 // familyID: 可选的Token家族ID，用于Token轮转时保持家族关系
 func (s *AuthService) GenerateTokenPair(ctx context.Context, user *User, familyID string) (*TokenPair, error) {
+	return s.generateTokenPairAtVersion(ctx, user, familyID, resolvedTokenVersion(user))
+}
+
+// generateTokenPairAtVersion mints both halves of a session at one already
+// authenticated security stamp. Keeping it explicit closes the race where a
+// stale refresh observes a post-revocation user row and resurrects a session.
+func (s *AuthService) generateTokenPairAtVersion(ctx context.Context, user *User, familyID string, tokenVersion int64) (*TokenPair, error) {
 	// 检查 refreshTokenCache 是否可用
 	if s.refreshTokenCache == nil {
 		return nil, errors.New("refresh token cache not configured")
@@ -1648,13 +1670,13 @@ func (s *AuthService) GenerateTokenPair(ctx context.Context, user *User, familyI
 	}
 
 	// 生成Access Token（携带会话ID与绑定指纹）
-	accessToken, err := s.generateAccessToken(user, familyID, sessionBindingHashFromContext(ctx))
+	accessToken, err := s.generateAccessToken(user, familyID, sessionBindingHashFromContext(ctx), tokenVersion)
 	if err != nil {
 		return nil, fmt.Errorf("generate access token: %w", err)
 	}
 
 	// 生成Refresh Token
-	refreshToken, err := s.generateRefreshToken(ctx, user, familyID)
+	refreshToken, err := s.generateRefreshToken(ctx, user, familyID, tokenVersion)
 	if err != nil {
 		return nil, fmt.Errorf("generate refresh token: %w", err)
 	}
@@ -1667,7 +1689,7 @@ func (s *AuthService) GenerateTokenPair(ctx context.Context, user *User, familyI
 }
 
 // generateRefreshToken 生成并存储Refresh Token
-func (s *AuthService) generateRefreshToken(ctx context.Context, user *User, familyID string) (string, error) {
+func (s *AuthService) generateRefreshToken(ctx context.Context, user *User, familyID string, tokenVersion int64) (string, error) {
 	// 生成随机Token
 	tokenBytes := make([]byte, 32)
 	if _, err := rand.Read(tokenBytes); err != nil {
@@ -1691,29 +1713,18 @@ func (s *AuthService) generateRefreshToken(ctx context.Context, user *User, fami
 	ttl := time.Duration(s.cfg.JWT.RefreshTokenExpireDays) * 24 * time.Hour
 
 	data := &RefreshTokenData{
-		UserID:       user.ID,
-		TokenVersion: resolvedTokenVersion(user),
-		FamilyID:     familyID,
-		BindingHash:  sessionBindingHashFromContext(ctx),
-		CreatedAt:    now,
-		ExpiresAt:    now.Add(ttl),
+		UserID:            user.ID,
+		TokenVersion:      tokenVersion,
+		TokenVersionEpoch: currentTokenVersionEpoch,
+		FamilyID:          familyID,
+		BindingHash:       sessionBindingHashFromContext(ctx),
+		CreatedAt:         now,
+		ExpiresAt:         now.Add(ttl),
 	}
 
 	// 存储Token数据
 	if err := s.refreshTokenCache.StoreRefreshToken(ctx, tokenHash, data, ttl); err != nil {
 		return "", fmt.Errorf("store refresh token: %w", err)
-	}
-
-	// 添加到用户Token集合
-	if err := s.refreshTokenCache.AddToUserTokenSet(ctx, user.ID, tokenHash, ttl); err != nil {
-		logger.LegacyPrintf("service.auth", "[Auth] Failed to add token to user set: %v", err)
-		// 不影响主流程
-	}
-
-	// 添加到家族Token集合
-	if err := s.refreshTokenCache.AddToFamilyTokenSet(ctx, familyID, tokenHash, ttl); err != nil {
-		logger.LegacyPrintf("service.auth", "[Auth] Failed to add token to family set: %v", err)
-		// 不影响主流程
 	}
 
 	return rawToken, nil
@@ -1734,22 +1745,44 @@ func (s *AuthService) RefreshTokenPair(ctx context.Context, refreshToken string)
 
 	tokenHash := hashToken(refreshToken)
 
-	// 获取Token数据
-	data, err := s.refreshTokenCache.GetRefreshToken(ctx, tokenHash)
+	// Atomically consume the token. Exactly one concurrent request can proceed;
+	// a replay returns the consumed tombstone so its user can be invalidated.
+	data, err := s.refreshTokenCache.ConsumeRefreshToken(ctx, tokenHash)
 	if err != nil {
+		if errors.Is(err, ErrRefreshTokenReused) {
+			if data == nil || data.UserID <= 0 {
+				return nil, ErrRefreshTokenReused
+			}
+			// A family marker blocks the winner's child refresh state. Advancing the
+			// persistent user stamp also invalidates any stateless child access token
+			// that raced ahead of replay detection.
+			if revokeErr := s.RevokeAllUserTokens(ctx, data.UserID); revokeErr != nil {
+				logger.LegacyPrintf("service.auth", "[Auth] Failed to invalidate user after refresh token replay: user=%d err=%v", data.UserID, revokeErr)
+				return nil, ErrServiceUnavailable
+			}
+			if acknowledger, ok := s.refreshTokenCache.(RefreshTokenReplayAcknowledger); ok {
+				if acknowledgeErr := acknowledger.AcknowledgeRefreshTokenReplay(ctx, tokenHash); acknowledgeErr != nil {
+					// The persistent stamp has already advanced, so the winner is
+					// invalid even if tombstone cleanup needs a later retry.
+					logger.LegacyPrintf("service.auth", "[Auth] Failed to acknowledge refresh token replay: user=%d err=%v", data.UserID, acknowledgeErr)
+				}
+			}
+			return nil, ErrRefreshTokenReused
+		}
 		if errors.Is(err, ErrRefreshTokenNotFound) {
-			// Token不存在，可能是已被使用（Token轮转）或已过期
-			logger.LegacyPrintf("service.auth", "[Auth] Refresh token not found, possible reuse attack")
+			logger.LegacyPrintf("service.auth", "[Auth] Refresh token not found")
 			return nil, ErrRefreshTokenInvalid
 		}
 		logger.LegacyPrintf("service.auth", "[Auth] Error getting refresh token: %v", err)
 		return nil, ErrServiceUnavailable
 	}
+	if data.TokenVersionEpoch != currentTokenVersionEpoch {
+		_ = s.refreshTokenCache.DeleteTokenFamily(ctx, data.FamilyID)
+		return nil, ErrTokenRevoked
+	}
 
 	// 检查Token是否过期
 	if time.Now().After(data.ExpiresAt) {
-		// 删除过期Token
-		_ = s.refreshTokenCache.DeleteRefreshToken(ctx, tokenHash)
 		return nil, ErrRefreshTokenExpired
 	}
 
@@ -1789,15 +1822,12 @@ func (s *AuthService) RefreshTokenPair(ctx context.Context, refreshToken string)
 		}
 	}
 
-	// Token轮转：立即使旧Token失效
-	if err := s.refreshTokenCache.DeleteRefreshToken(ctx, tokenHash); err != nil {
-		logger.LegacyPrintf("service.auth", "[Auth] Failed to delete old refresh token: %v", err)
-		// 继续处理，不影响主流程
-	}
-
 	// 生成新的Token对，保持同一个家族ID
-	pair, err := s.GenerateTokenPair(ctx, user, data.FamilyID)
+	pair, err := s.generateTokenPairAtVersion(ctx, user, data.FamilyID, data.TokenVersion)
 	if err != nil {
+		if errors.Is(err, ErrRefreshTokenReused) {
+			return nil, ErrRefreshTokenReused
+		}
 		return nil, err
 	}
 	return &TokenPairWithUser{
@@ -1838,15 +1868,14 @@ func (s *AuthService) RevokeAllUserSessions(ctx context.Context, userID int64) e
 }
 
 // RevokeAllUserTokens invalidates both stateless access tokens and refresh sessions.
-//
-// 注意：users 表没有 token_version 列（resolvedTokenVersion 由 email+password_hash
-// 指纹推导），因此对 user.TokenVersion 自增只影响内存副本。之前紧跟其后的整行
-// Update 不写任何有效数据，却会用旧快照覆盖并发写入的列，故已移除。
-// 会话撤销由下面的 refresh session 清理承担；改密路径通过 password_hash 变化
-// 改变指纹，从而使旧 token 失效。
+// The database increment is authoritative; Redis cleanup is defense in depth.
 func (s *AuthService) RevokeAllUserTokens(ctx context.Context, userID int64) error {
-	if _, err := s.userRepo.GetByID(ctx, userID); err != nil {
-		return fmt.Errorf("get user: %w", err)
+	versionRepo, ok := s.userRepo.(UserTokenVersionRepository)
+	if !ok {
+		return fmt.Errorf("persistent token version repository unavailable: %w", ErrServiceUnavailable)
+	}
+	if _, err := versionRepo.IncrementTokenVersion(ctx, userID); err != nil {
+		return fmt.Errorf("increment token version: %w", err)
 	}
 
 	if err := s.RevokeAllUserSessions(ctx, userID); err != nil {
@@ -1869,6 +1898,9 @@ func resolvedTokenVersion(user *User) int64 {
 		return user.TokenVersion
 	}
 
+	// Compatibility fallback for in-memory repositories and older unit-test
+	// fixtures. Production userRepository instances always hydrate the durable
+	// token_version column and set TokenVersionResolved.
 	material := strings.ToLower(strings.TrimSpace(user.Email)) + "\n" + user.PasswordHash
 	sum := sha256.Sum256([]byte(material))
 	fingerprint := int64(binary.BigEndian.Uint64(sum[:8]) & 0x7fffffffffffffff)

--- a/backend/internal/service/auth_service_email_bind_test.go
+++ b/backend/internal/service/auth_service_email_bind_test.go
@@ -733,25 +733,40 @@ func (s *emailBindCacheStub) IncrNotifyCodeUserRate(context.Context, int64, time
 }
 
 type emailBindRefreshTokenCacheStub struct {
-	mu       sync.Mutex
-	tokens   map[string]*service.RefreshTokenData
-	userSets map[int64]map[string]struct{}
-	families map[string]map[string]struct{}
+	mu              sync.Mutex
+	tokens          map[string]*service.RefreshTokenData
+	consumed        map[string]*service.RefreshTokenData
+	userSets        map[int64]map[string]struct{}
+	families        map[string]map[string]struct{}
+	revokedFamilies map[string]struct{}
 }
 
 func newEmailBindRefreshTokenCacheStub() *emailBindRefreshTokenCacheStub {
 	return &emailBindRefreshTokenCacheStub{
-		tokens:   make(map[string]*service.RefreshTokenData),
-		userSets: make(map[int64]map[string]struct{}),
-		families: make(map[string]map[string]struct{}),
+		tokens:          make(map[string]*service.RefreshTokenData),
+		consumed:        make(map[string]*service.RefreshTokenData),
+		userSets:        make(map[int64]map[string]struct{}),
+		families:        make(map[string]map[string]struct{}),
+		revokedFamilies: make(map[string]struct{}),
 	}
 }
 
 func (s *emailBindRefreshTokenCacheStub) StoreRefreshToken(_ context.Context, tokenHash string, data *service.RefreshTokenData, _ time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, revoked := s.revokedFamilies[data.FamilyID]; revoked {
+		return service.ErrRefreshTokenReused
+	}
 	cloned := *data
 	s.tokens[tokenHash] = &cloned
+	if s.userSets[data.UserID] == nil {
+		s.userSets[data.UserID] = make(map[string]struct{})
+	}
+	s.userSets[data.UserID][tokenHash] = struct{}{}
+	if s.families[data.FamilyID] == nil {
+		s.families[data.FamilyID] = make(map[string]struct{})
+	}
+	s.families[data.FamilyID][tokenHash] = struct{}{}
 	return nil
 }
 
@@ -764,6 +779,30 @@ func (s *emailBindRefreshTokenCacheStub) GetRefreshToken(_ context.Context, toke
 	}
 	cloned := *data
 	return &cloned, nil
+}
+
+func (s *emailBindRefreshTokenCacheStub) ConsumeRefreshToken(_ context.Context, tokenHash string) (*service.RefreshTokenData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if data, ok := s.tokens[tokenHash]; ok {
+		cloned := *data
+		delete(s.tokens, tokenHash)
+		delete(s.userSets[data.UserID], tokenHash)
+		delete(s.families[data.FamilyID], tokenHash)
+		s.consumed[tokenHash] = &cloned
+		return &cloned, nil
+	}
+	if data, ok := s.consumed[tokenHash]; ok {
+		cloned := *data
+		s.revokedFamilies[data.FamilyID] = struct{}{}
+		for childHash := range s.families[data.FamilyID] {
+			delete(s.tokens, childHash)
+			delete(s.userSets[data.UserID], childHash)
+		}
+		delete(s.families, data.FamilyID)
+		return &cloned, service.ErrRefreshTokenReused
+	}
+	return nil, service.ErrRefreshTokenNotFound
 }
 
 func (s *emailBindRefreshTokenCacheStub) DeleteRefreshToken(_ context.Context, tokenHash string) error {
@@ -795,6 +834,7 @@ func (s *emailBindRefreshTokenCacheStub) DeleteUserRefreshTokens(_ context.Conte
 func (s *emailBindRefreshTokenCacheStub) DeleteTokenFamily(_ context.Context, familyID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.revokedFamilies[familyID] = struct{}{}
 	for tokenHash := range s.families[familyID] {
 		delete(s.tokens, tokenHash)
 		for _, tokenSet := range s.userSets {

--- a/backend/internal/service/auth_service_register_test.go
+++ b/backend/internal/service/auth_service_register_test.go
@@ -131,6 +131,10 @@ func (s *refreshTokenCacheStub) GetRefreshToken(context.Context, string) (*Refre
 	return nil, ErrRefreshTokenNotFound
 }
 
+func (s *refreshTokenCacheStub) ConsumeRefreshToken(context.Context, string) (*RefreshTokenData, error) {
+	return nil, ErrRefreshTokenNotFound
+}
+
 func (s *refreshTokenCacheStub) DeleteRefreshToken(context.Context, string) error {
 	return nil
 }

--- a/backend/internal/service/auth_service_token_version_test.go
+++ b/backend/internal/service/auth_service_token_version_test.go
@@ -1,0 +1,469 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type tokenVersionUserRepoStub struct {
+	*userRepoStub
+}
+
+func (s *tokenVersionUserRepoStub) GetTokenVersion(_ context.Context, userID int64) (int64, error) {
+	user, err := s.GetByID(context.Background(), userID)
+	if err != nil {
+		return 0, err
+	}
+	return user.TokenVersion, nil
+}
+
+func (s *tokenVersionUserRepoStub) IncrementTokenVersion(_ context.Context, userID int64) (int64, error) {
+	user, err := s.GetByID(context.Background(), userID)
+	if err != nil {
+		return 0, err
+	}
+	user.TokenVersion++
+	user.TokenVersionResolved = true
+	return user.TokenVersion, nil
+}
+
+type tokenVersionRaceCache struct {
+	mu              sync.Mutex
+	tokens          map[string]*RefreshTokenData
+	consumed        map[string]*RefreshTokenData
+	revokedFamilies map[string]struct{}
+	onStore         func()
+	storeErr        error
+	consumeErr      error
+	storeCalls      int
+	revokedUserIDs  []int64
+}
+
+func newTokenVersionRaceCache() *tokenVersionRaceCache {
+	return &tokenVersionRaceCache{
+		tokens:          make(map[string]*RefreshTokenData),
+		consumed:        make(map[string]*RefreshTokenData),
+		revokedFamilies: make(map[string]struct{}),
+	}
+}
+
+func (s *tokenVersionRaceCache) StoreRefreshToken(_ context.Context, tokenHash string, data *RefreshTokenData, _ time.Duration) error {
+	s.mu.Lock()
+	s.storeCalls++
+	if s.storeErr != nil {
+		err := s.storeErr
+		s.mu.Unlock()
+		return err
+	}
+	if _, revoked := s.revokedFamilies[data.FamilyID]; revoked {
+		s.mu.Unlock()
+		return ErrRefreshTokenReused
+	}
+	hook := s.onStore
+	s.onStore = nil
+	s.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, revoked := s.revokedFamilies[data.FamilyID]; revoked {
+		return ErrRefreshTokenReused
+	}
+	cloned := *data
+	s.tokens[tokenHash] = &cloned
+	return nil
+}
+
+func (s *tokenVersionRaceCache) GetRefreshToken(_ context.Context, tokenHash string) (*RefreshTokenData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.tokens[tokenHash]
+	if !ok {
+		return nil, ErrRefreshTokenNotFound
+	}
+	cloned := *data
+	return &cloned, nil
+}
+
+func (s *tokenVersionRaceCache) ConsumeRefreshToken(_ context.Context, tokenHash string) (*RefreshTokenData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.consumeErr != nil {
+		return nil, s.consumeErr
+	}
+	if data, ok := s.tokens[tokenHash]; ok {
+		cloned := *data
+		delete(s.tokens, tokenHash)
+		s.consumed[tokenHash] = &cloned
+		return &cloned, nil
+	}
+	if data, ok := s.consumed[tokenHash]; ok {
+		cloned := *data
+		s.revokedFamilies[data.FamilyID] = struct{}{}
+		for childHash, child := range s.tokens {
+			if child.FamilyID == data.FamilyID {
+				delete(s.tokens, childHash)
+			}
+		}
+		return &cloned, ErrRefreshTokenReused
+	}
+	return nil, ErrRefreshTokenNotFound
+}
+
+func (s *tokenVersionRaceCache) AcknowledgeRefreshTokenReplay(_ context.Context, tokenHash string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.consumed, tokenHash)
+	return nil
+}
+
+func (s *tokenVersionRaceCache) DeleteRefreshToken(_ context.Context, tokenHash string) error {
+	s.mu.Lock()
+	delete(s.tokens, tokenHash)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *tokenVersionRaceCache) DeleteUserRefreshTokens(_ context.Context, userID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens = make(map[string]*RefreshTokenData)
+	s.revokedUserIDs = append(s.revokedUserIDs, userID)
+	return nil
+}
+
+func (s *tokenVersionRaceCache) DeleteTokenFamily(_ context.Context, familyID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revokedFamilies[familyID] = struct{}{}
+	for tokenHash, data := range s.tokens {
+		if data.FamilyID == familyID {
+			delete(s.tokens, tokenHash)
+		}
+	}
+	return nil
+}
+func (s *tokenVersionRaceCache) AddToUserTokenSet(context.Context, int64, string, time.Duration) error {
+	return nil
+}
+func (s *tokenVersionRaceCache) AddToFamilyTokenSet(context.Context, string, string, time.Duration) error {
+	return nil
+}
+func (s *tokenVersionRaceCache) GetUserTokenHashes(context.Context, int64) ([]string, error) {
+	return nil, nil
+}
+func (s *tokenVersionRaceCache) GetFamilyTokenHashes(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (s *tokenVersionRaceCache) IsTokenInFamily(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
+func TestRefreshInFlightCannotCrossRevokeAllTokenVersionBoundary(t *testing.T) {
+	ctx := context.Background()
+	user := &User{
+		ID:                   42,
+		Email:                "race@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         4,
+		TokenVersionResolved: true,
+	}
+	repo := &tokenVersionUserRepoStub{userRepoStub: &userRepoStub{user: user}}
+	cache := newTokenVersionRaceCache()
+	svc := NewAuthService(nil, repo, nil, cache, &config.Config{JWT: config.JWTConfig{
+		Secret:                 "test-token-version-race-secret",
+		ExpireHour:             1,
+		RefreshTokenExpireDays: 7,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	original, err := svc.GenerateTokenPair(ctx, user, "")
+	require.NoError(t, err)
+
+	// Revoke precisely after the old refresh token passed its version check but
+	// while the replacement pair is being minted.
+	cache.onStore = func() {
+		require.NoError(t, svc.RevokeAllUserTokens(ctx, user.ID))
+	}
+	replacement, err := svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), user.TokenVersion)
+	require.Equal(t, []int64{42}, cache.revokedUserIDs)
+
+	accessClaims, err := svc.ValidateToken(replacement.AccessToken)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), accessClaims.TokenVersion, "in-flight refresh must retain its authenticated pre-revocation stamp")
+	require.NotEqual(t, user.TokenVersion, accessClaims.TokenVersion)
+
+	cache.mu.Lock()
+	storedReplacement := cache.tokens[hashToken(replacement.RefreshToken)]
+	cache.mu.Unlock()
+	require.NotNil(t, storedReplacement)
+	require.Equal(t, int64(4), storedReplacement.TokenVersion)
+
+	_, err = svc.RefreshTokenPair(ctx, replacement.RefreshToken)
+	require.ErrorIs(t, err, ErrTokenRevoked)
+}
+
+func TestRefreshTokenPairFailsClosedWhenReplacementStoreFails(t *testing.T) {
+	ctx := context.Background()
+	user := &User{
+		ID:                   81,
+		Email:                "store-failure@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         2,
+		TokenVersionResolved: true,
+	}
+	repo := &tokenVersionUserRepoStub{userRepoStub: &userRepoStub{user: user}}
+	cache := newTokenVersionRaceCache()
+	svc := NewAuthService(nil, repo, nil, cache, &config.Config{JWT: config.JWTConfig{
+		Secret:                 "test-refresh-store-failure-secret",
+		ExpireHour:             1,
+		RefreshTokenExpireDays: 7,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	original, err := svc.GenerateTokenPair(ctx, user, "")
+	require.NoError(t, err)
+	cache.mu.Lock()
+	cache.storeErr = errors.New("redis write failed")
+	storeCallsBefore := cache.storeCalls
+	cache.mu.Unlock()
+
+	replacement, err := svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.Error(t, err)
+	require.Nil(t, replacement, "a pair with unpersisted refresh state must never escape")
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	require.Equal(t, storeCallsBefore+1, cache.storeCalls)
+	require.Empty(t, cache.tokens)
+}
+
+func TestRefreshTokenPairFailsClosedWhenAtomicConsumeFails(t *testing.T) {
+	ctx := context.Background()
+	user := &User{
+		ID:                   82,
+		Email:                "consume-failure@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         3,
+		TokenVersionResolved: true,
+	}
+	repo := &tokenVersionUserRepoStub{userRepoStub: &userRepoStub{user: user}}
+	cache := newTokenVersionRaceCache()
+	svc := NewAuthService(nil, repo, nil, cache, &config.Config{JWT: config.JWTConfig{
+		Secret:                 "test-refresh-consume-failure-secret",
+		ExpireHour:             1,
+		RefreshTokenExpireDays: 7,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	original, err := svc.GenerateTokenPair(ctx, user, "")
+	require.NoError(t, err)
+	cache.mu.Lock()
+	cache.consumeErr = errors.New("redis unavailable")
+	storeCallsBefore := cache.storeCalls
+	cache.mu.Unlock()
+
+	replacement, err := svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.ErrorIs(t, err, ErrServiceUnavailable)
+	require.Nil(t, replacement)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	require.Equal(t, storeCallsBefore, cache.storeCalls, "consume errors must not mint/store a child")
+	require.Contains(t, cache.tokens, hashToken(original.RefreshToken), "failed consume must not delete the parent")
+}
+
+func TestRefreshTokenReplayAdvancesPersistentVersionAndInvalidatesWinner(t *testing.T) {
+	ctx := context.Background()
+	user := &User{
+		ID:                   83,
+		Email:                "refresh-replay@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         10,
+		TokenVersionResolved: true,
+	}
+	repo := &tokenVersionUserRepoStub{userRepoStub: &userRepoStub{user: user}}
+	cache := newTokenVersionRaceCache()
+	svc := NewAuthService(nil, repo, nil, cache, &config.Config{JWT: config.JWTConfig{
+		Secret:                 "test-refresh-replay-secret",
+		ExpireHour:             1,
+		RefreshTokenExpireDays: 7,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	original, err := svc.GenerateTokenPair(ctx, user, "")
+	require.NoError(t, err)
+	winner, err := svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.NoError(t, err)
+
+	replayed, err := svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.ErrorIs(t, err, ErrRefreshTokenReused)
+	require.Nil(t, replayed)
+	require.Equal(t, int64(11), user.TokenVersion)
+	require.Equal(t, []int64{user.ID}, cache.revokedUserIDs)
+
+	claims, err := svc.ValidateToken(winner.AccessToken)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), claims.TokenVersion)
+	require.NotEqual(t, user.TokenVersion, claims.TokenVersion)
+	_, err = svc.RefreshToken(ctx, winner.AccessToken)
+	require.ErrorIs(t, err, ErrTokenRevoked, "replay must invalidate the winner's stateless access token")
+
+	cache.mu.Lock()
+	require.Empty(t, cache.tokens, "replay must remove the winner's child refresh state")
+	_, familyRevoked := cache.revokedFamilies[claims.SessionID]
+	cache.mu.Unlock()
+	require.True(t, familyRevoked)
+
+	_, err = svc.RefreshTokenPair(ctx, original.RefreshToken)
+	require.ErrorIs(t, err, ErrRefreshTokenInvalid)
+	require.Equal(t, int64(11), user.TokenVersion, "an acknowledged replay must not repeatedly revoke later logins")
+}
+
+func TestPersistentTokenVersionMigrationRequiresOneFreshLogin(t *testing.T) {
+	svc := NewAuthService(nil, &userRepoStub{}, nil, nil, &config.Config{JWT: config.JWTConfig{
+		Secret:     "test-token-version-migration-secret",
+		ExpireHour: 1,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+	legacyUser := &User{
+		ID:           77,
+		Email:        "legacy-session@example.com",
+		PasswordHash: "legacy-password-hash",
+		Role:         RoleUser,
+		Status:       StatusActive,
+		TokenVersion: 0,
+	}
+	now := time.Now()
+	legacyUnsignedClaims := &JWTClaims{
+		UserID:       legacyUser.ID,
+		Email:        legacyUser.Email,
+		Role:         legacyUser.Role,
+		TokenVersion: resolvedTokenVersion(legacyUser),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+		},
+	}
+	legacyToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacyUnsignedClaims).
+		SignedString([]byte("test-token-version-migration-secret"))
+	require.NoError(t, err)
+	legacyClaims, err := svc.ValidateToken(legacyToken)
+	require.ErrorIs(t, err, ErrTokenRevoked)
+	require.NotNil(t, legacyClaims)
+	require.Equal(t, 0, legacyClaims.TokenVersionEpoch)
+
+	// Migration 221 initializes the durable stamp to zero. That intentionally
+	// rejects pre-migration fingerprint claims and forces one fresh login.
+	migratedUser := *legacyUser
+	migratedUser.TokenVersion = 0
+	migratedUser.TokenVersionResolved = true
+	require.NotEqual(t, currentTokenVersionEpoch, legacyClaims.TokenVersionEpoch)
+
+	freshToken, err := svc.GenerateToken(context.Background(), &migratedUser)
+	require.NoError(t, err)
+	freshClaims, err := svc.ValidateToken(freshToken)
+	require.NoError(t, err)
+	require.Equal(t, currentTokenVersionEpoch, freshClaims.TokenVersionEpoch)
+	require.Equal(t, migratedUser.TokenVersion, freshClaims.TokenVersion)
+}
+
+func TestRefreshTokenPairRejectsLegacyTokenVersionEpoch(t *testing.T) {
+	ctx := context.Background()
+	user := &User{
+		ID:                   78,
+		Email:                "legacy-refresh@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         0,
+		TokenVersionResolved: true,
+	}
+	repo := &tokenVersionUserRepoStub{userRepoStub: &userRepoStub{user: user}}
+	cache := newTokenVersionRaceCache()
+	legacyRefresh := "rt_legacy_refresh_token"
+	cache.tokens[hashToken(legacyRefresh)] = &RefreshTokenData{
+		UserID:       user.ID,
+		TokenVersion: user.TokenVersion,
+		FamilyID:     "legacy-family",
+		CreatedAt:    time.Now().Add(-time.Minute),
+		ExpiresAt:    time.Now().Add(time.Hour),
+		// TokenVersionEpoch intentionally omitted, as in pre-migration Redis data.
+	}
+	svc := NewAuthService(nil, repo, nil, cache, &config.Config{JWT: config.JWTConfig{
+		Secret:                 "test-legacy-refresh-epoch-secret",
+		ExpireHour:             1,
+		RefreshTokenExpireDays: 7,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	_, err := svc.RefreshTokenPair(ctx, legacyRefresh)
+	require.ErrorIs(t, err, ErrTokenRevoked)
+}
+
+func TestValidateTokenNeverTreatsInvalidSignatureAsRefreshableExpiry(t *testing.T) {
+	user := &User{
+		ID:                   79,
+		Email:                "signature-check@example.com",
+		Role:                 RoleUser,
+		Status:               StatusActive,
+		TokenVersion:         0,
+		TokenVersionResolved: true,
+	}
+	svc := NewAuthService(nil, &userRepoStub{user: user}, nil, nil, &config.Config{JWT: config.JWTConfig{
+		Secret:     "real-signing-secret",
+		ExpireHour: 1,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+	now := time.Now()
+	claims := &JWTClaims{
+		UserID:            user.ID,
+		Email:             user.Email,
+		Role:              user.Role,
+		TokenVersion:      user.TokenVersion,
+		TokenVersionEpoch: currentTokenVersionEpoch,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(-time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now.Add(-time.Hour)),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Hour)),
+		},
+	}
+	forged, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("attacker-secret"))
+	require.NoError(t, err)
+
+	parsed, err := svc.ValidateToken(forged)
+	require.ErrorIs(t, err, ErrInvalidToken)
+	require.Nil(t, parsed)
+	_, err = svc.RefreshToken(context.Background(), forged)
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestValidateTokenRejectsUnmintedHMACAlgorithms(t *testing.T) {
+	svc := NewAuthService(nil, &userRepoStub{}, nil, nil, &config.Config{JWT: config.JWTConfig{
+		Secret:     "single-algorithm-secret",
+		ExpireHour: 1,
+	}}, nil, nil, nil, nil, nil, nil, nil, nil)
+	now := time.Now()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &JWTClaims{
+		UserID:            80,
+		Email:             "algorithm@example.com",
+		Role:              RoleUser,
+		TokenVersionEpoch: currentTokenVersionEpoch,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+		},
+	}).SignedString([]byte("single-algorithm-secret"))
+	require.NoError(t, err)
+
+	_, err = svc.ValidateToken(token)
+	require.ErrorIs(t, err, ErrInvalidToken)
+}

--- a/backend/internal/service/refresh_token_cache.go
+++ b/backend/internal/service/refresh_token_cache.go
@@ -12,12 +12,13 @@ var ErrRefreshTokenNotFound = errors.New("refresh token not found")
 
 // RefreshTokenData 存储在Redis中的Refresh Token数据
 type RefreshTokenData struct {
-	UserID       int64     `json:"user_id"`
-	TokenVersion int64     `json:"token_version"`          // 用于检测密码更改后的Token失效
-	FamilyID     string    `json:"family_id"`              // Token家族ID，用于防重放攻击
-	BindingHash  string    `json:"binding_hash,omitempty"` // 会话指纹哈希（IP+UA），会话绑定开启时校验
-	CreatedAt    time.Time `json:"created_at"`
-	ExpiresAt    time.Time `json:"expires_at"`
+	UserID            int64     `json:"user_id"`
+	TokenVersion      int64     `json:"token_version"`       // 持久化会话撤销版本
+	TokenVersionEpoch int       `json:"token_version_epoch"` // 0 is legacy; only the current epoch is accepted
+	FamilyID          string    `json:"family_id"`           // Token家族ID，用于防重放攻击
+	BindingHash       string    `json:"binding_hash,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+	ExpiresAt         time.Time `json:"expires_at"`
 }
 
 // RefreshTokenCache 管理Refresh Token的Redis缓存
@@ -39,6 +40,12 @@ type RefreshTokenCache interface {
 	// 返回 (nil, ErrRefreshTokenNotFound) 如果Token不存在
 	// 返回 (nil, err) 如果发生其他错误
 	GetRefreshToken(ctx context.Context, tokenHash string) (*RefreshTokenData, error)
+
+	// ConsumeRefreshToken atomically removes and returns a refresh token.
+	// Exactly one concurrent caller may receive (data, nil). Replays return the
+	// original data together with ErrRefreshTokenReused so the caller can revoke
+	// its user/family; cache failures must return an error without minting.
+	ConsumeRefreshToken(ctx context.Context, tokenHash string) (*RefreshTokenData, error)
 
 	// DeleteRefreshToken 删除单个Refresh Token
 	// 用于Token轮转时使旧Token失效
@@ -71,4 +78,13 @@ type RefreshTokenCache interface {
 	// IsTokenInFamily 检查Token是否属于指定家族
 	// 用于验证Token家族关系
 	IsTokenInFamily(ctx context.Context, familyID string, tokenHash string) (bool, error)
+}
+
+// RefreshTokenReplayAcknowledger removes a consumed-token tombstone only after
+// its authoritative user/family revocation has succeeded. Keeping this
+// separate from ordinary token deletion prevents logout calls from suppressing
+// replay detection, while avoiding repeated replays becoming a persistent
+// account-wide token_version denial of service.
+type RefreshTokenReplayAcknowledger interface {
+	AcknowledgeRefreshTokenReplay(ctx context.Context, tokenHash string) error
 }

--- a/backend/internal/service/totp_service.go
+++ b/backend/internal/service/totp_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -15,14 +16,15 @@ import (
 )
 
 var (
-	ErrTotpNotEnabled      = infraerrors.BadRequest("TOTP_NOT_ENABLED", "totp feature is not enabled")
-	ErrTotpAlreadyEnabled  = infraerrors.BadRequest("TOTP_ALREADY_ENABLED", "totp is already enabled for this account")
-	ErrTotpNotSetup        = infraerrors.BadRequest("TOTP_NOT_SETUP", "totp is not set up for this account")
-	ErrTotpInvalidCode     = infraerrors.BadRequest("TOTP_INVALID_CODE", "invalid totp code")
-	ErrTotpSetupExpired    = infraerrors.BadRequest("TOTP_SETUP_EXPIRED", "totp setup session expired")
-	ErrTotpTooManyAttempts = infraerrors.TooManyRequests("TOTP_TOO_MANY_ATTEMPTS", "too many verification attempts, please try again later")
-	ErrVerifyCodeRequired  = infraerrors.BadRequest("VERIFY_CODE_REQUIRED", "email verification code is required")
-	ErrPasswordRequired    = infraerrors.BadRequest("PASSWORD_REQUIRED", "password is required")
+	ErrTotpNotEnabled        = infraerrors.BadRequest("TOTP_NOT_ENABLED", "totp feature is not enabled")
+	ErrTotpAlreadyEnabled    = infraerrors.BadRequest("TOTP_ALREADY_ENABLED", "totp is already enabled for this account")
+	ErrTotpNotSetup          = infraerrors.BadRequest("TOTP_NOT_SETUP", "totp is not set up for this account")
+	ErrTotpInvalidCode       = infraerrors.BadRequest("TOTP_INVALID_CODE", "invalid totp code")
+	ErrTotpSetupExpired      = infraerrors.BadRequest("TOTP_SETUP_EXPIRED", "totp setup session expired")
+	ErrTotpTooManyAttempts   = infraerrors.TooManyRequests("TOTP_TOO_MANY_ATTEMPTS", "too many verification attempts, please try again later")
+	ErrTotpCredentialChanged = infraerrors.BadRequest("TOTP_CREDENTIAL_CHANGED", "totp credential changed; verify again")
+	ErrVerifyCodeRequired    = infraerrors.BadRequest("VERIFY_CODE_REQUIRED", "email verification code is required")
+	ErrPasswordRequired      = infraerrors.BadRequest("PASSWORD_REQUIRED", "password is required")
 )
 
 // TotpCache defines cache operations for TOTP service
@@ -35,6 +37,7 @@ type TotpCache interface {
 	// Login session methods (for 2FA login flow)
 	GetLoginSession(ctx context.Context, tempToken string) (*TotpLoginSession, error)
 	SetLoginSession(ctx context.Context, tempToken string, session *TotpLoginSession, ttl time.Duration) error
+	ConsumeLoginSession(ctx context.Context, tempToken string) (*TotpLoginSession, error)
 	DeleteLoginSession(ctx context.Context, tempToken string) error
 
 	// Rate limiting
@@ -43,8 +46,8 @@ type TotpCache interface {
 	ClearVerifyAttempts(ctx context.Context, userID int64) error
 
 	// Step-up grant methods (敏感操作 sudo 窗口)
-	SetStepUpGrant(ctx context.Context, userID int64, sessionKey string, ttl time.Duration) error
-	HasStepUpGrant(ctx context.Context, userID int64, sessionKey string) (bool, error)
+	SetStepUpGrant(ctx context.Context, userID int64, sessionKey, credentialGeneration string, ttl time.Duration) error
+	HasStepUpGrant(ctx context.Context, userID int64, sessionKey, credentialGeneration string) (bool, error)
 }
 
 // SecretEncryptor defines encryption operations for TOTP secrets
@@ -249,14 +252,9 @@ func (s *TotpService) CompleteSetup(ctx context.Context, userID int64, totpCode,
 		return ErrTotpInvalidCode
 	}
 
-	setupSecretPrefix := "N/A"
-	if len(session.Secret) >= 4 {
-		setupSecretPrefix = session.Secret[:4]
-	}
 	slog.Debug("totp_complete_setup_before_encrypt",
 		"user_id", userID,
-		"secret_len", len(session.Secret),
-		"secret_prefix", setupSecretPrefix)
+		"secret_len", len(session.Secret))
 
 	// Encrypt the secret
 	encryptedSecret, err := s.encryptor.Encrypt(session.Secret)
@@ -268,24 +266,24 @@ func (s *TotpService) CompleteSetup(ctx context.Context, userID int64, totpCode,
 		"user_id", userID,
 		"encrypted_len", len(encryptedSecret))
 
-	// Verify encryption by decrypting
+	// Verify encryption before persisting it. A broken encryptor must fail closed.
 	decrypted, decErr := s.encryptor.Decrypt(encryptedSecret)
 	if decErr != nil {
 		slog.Debug("totp_complete_setup_verify_failed",
 			"user_id", userID,
 			"error", decErr)
-	} else {
-		decryptedPrefix := "N/A"
-		if len(decrypted) >= 4 {
-			decryptedPrefix = decrypted[:4]
-		}
-		slog.Debug("totp_complete_setup_verified",
-			"user_id", userID,
-			"original_len", len(session.Secret),
-			"decrypted_len", len(decrypted),
-			"match", session.Secret == decrypted,
-			"decrypted_prefix", decryptedPrefix)
+		return fmt.Errorf("verify encrypted totp secret: %w", decErr)
 	}
+	if subtle.ConstantTimeCompare([]byte(session.Secret), []byte(decrypted)) != 1 {
+		slog.Debug("totp_complete_setup_verify_failed",
+			"user_id", userID,
+			"error", "plaintext mismatch")
+		return fmt.Errorf("verify encrypted totp secret: plaintext mismatch")
+	}
+	slog.Debug("totp_complete_setup_verified",
+		"user_id", userID,
+		"original_len", len(session.Secret),
+		"decrypted_len", len(decrypted))
 
 	// Update user with encrypted TOTP secret
 	if err := s.userRepo.UpdateTotpSecret(ctx, userID, &encryptedSecret); err != nil {
@@ -336,7 +334,13 @@ func (s *TotpService) VerifyCode(ctx context.Context, userID int64, code string)
 
 	// Check rate limiting
 	attempts, err := s.cache.GetVerifyAttempts(ctx, userID)
-	if err == nil && attempts >= maxTotpAttempts {
+	if err != nil {
+		slog.Debug("totp_verify_attempts_read_failed",
+			"user_id", userID,
+			"error", err)
+		return infraerrors.InternalServer("TOTP_VERIFY_ERROR", "failed to verify totp code")
+	}
+	if attempts >= maxTotpAttempts {
 		return ErrTotpTooManyAttempts
 	}
 
@@ -370,14 +374,9 @@ func (s *TotpService) VerifyCode(ctx context.Context, userID int64, code string)
 		return infraerrors.InternalServer("TOTP_VERIFY_ERROR", "failed to verify totp code")
 	}
 
-	secretPrefix := "N/A"
-	if len(secret) >= 4 {
-		secretPrefix = secret[:4]
-	}
 	slog.Debug("totp_verify_decrypted",
 		"user_id", userID,
-		"secret_len", len(secret),
-		"secret_prefix", secretPrefix)
+		"secret_len", len(secret))
 
 	// Verify the code
 	valid := totp.Validate(code, secret)
@@ -385,17 +384,26 @@ func (s *TotpService) VerifyCode(ctx context.Context, userID int64, code string)
 		"user_id", userID,
 		"valid", valid,
 		"secret_len", len(secret),
-		"secret_prefix", secretPrefix,
 		"server_time", time.Now().UTC().Format(time.RFC3339))
 
 	if !valid {
 		// Increment failed attempts
-		_, _ = s.cache.IncrementVerifyAttempts(ctx, userID)
+		if _, err := s.cache.IncrementVerifyAttempts(ctx, userID); err != nil {
+			slog.Debug("totp_verify_attempts_increment_failed",
+				"user_id", userID,
+				"error", err)
+			return infraerrors.InternalServer("TOTP_VERIFY_ERROR", "failed to verify totp code")
+		}
 		return ErrTotpInvalidCode
 	}
 
 	// Clear attempt counter on success
-	_ = s.cache.ClearVerifyAttempts(ctx, userID)
+	if err := s.cache.ClearVerifyAttempts(ctx, userID); err != nil {
+		slog.Debug("totp_verify_attempts_clear_failed",
+			"user_id", userID,
+			"error", err)
+		return infraerrors.InternalServer("TOTP_VERIFY_ERROR", "failed to verify totp code")
+	}
 
 	return nil
 }
@@ -406,10 +414,21 @@ const StepUpGrantTTL = 15 * time.Minute
 // VerifyStepUp 校验 TOTP 码并授予当前会话一段时间的 step-up 权限。
 // 返回授权有效期，供前端展示/设置提醒。
 func (s *TotpService) VerifyStepUp(ctx context.Context, userID int64, sessionKey, code string) (time.Duration, error) {
+	credentialGeneration, err := s.currentTotpCredentialGeneration(ctx, userID)
+	if err != nil {
+		return 0, err
+	}
 	if err := s.VerifyCode(ctx, userID, code); err != nil {
 		return 0, err
 	}
-	if err := s.cache.SetStepUpGrant(ctx, userID, sessionKey, StepUpGrantTTL); err != nil {
+	currentGeneration, err := s.currentTotpCredentialGeneration(ctx, userID)
+	if err != nil {
+		return 0, err
+	}
+	if subtle.ConstantTimeCompare([]byte(credentialGeneration), []byte(currentGeneration)) != 1 {
+		return 0, ErrTotpCredentialChanged
+	}
+	if err := s.cache.SetStepUpGrant(ctx, userID, sessionKey, credentialGeneration, StepUpGrantTTL); err != nil {
 		return 0, fmt.Errorf("store step-up grant: %w", err)
 	}
 	return StepUpGrantTTL, nil
@@ -417,7 +436,29 @@ func (s *TotpService) VerifyStepUp(ctx context.Context, userID int64, sessionKey
 
 // HasStepUpGrant 检查当前会话是否在 step-up 有效期内。
 func (s *TotpService) HasStepUpGrant(ctx context.Context, userID int64, sessionKey string) (bool, error) {
-	return s.cache.HasStepUpGrant(ctx, userID, sessionKey)
+	credentialGeneration, err := s.currentTotpCredentialGeneration(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	return s.cache.HasStepUpGrant(ctx, userID, sessionKey, credentialGeneration)
+}
+
+// currentTotpCredentialGeneration binds step-up grants to the exact encrypted
+// credential currently stored for the user. Rotating or disabling TOTP changes
+// this generation, so an otherwise-live Redis grant cannot be replayed.
+func (s *TotpService) currentTotpCredentialGeneration(ctx context.Context, userID int64) (string, error) {
+	user, err := s.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("get user: %w", err)
+	}
+	if !user.TotpEnabled || user.TotpSecretEncrypted == nil || *user.TotpSecretEncrypted == "" {
+		return "", ErrTotpNotSetup
+	}
+
+	h := sha256.New()
+	_, _ = h.Write([]byte("sub2api/totp-step-up-generation/v1\x00"))
+	_, _ = h.Write([]byte(*user.TotpSecretEncrypted))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // CreateLoginSession creates a temporary login session for 2FA
@@ -469,6 +510,12 @@ func (s *TotpService) createLoginSession(
 // GetLoginSession retrieves a login session
 func (s *TotpService) GetLoginSession(ctx context.Context, tempToken string) (*TotpLoginSession, error) {
 	return s.cache.GetLoginSession(ctx, tempToken)
+}
+
+// ConsumeLoginSession atomically retrieves and deletes a pending 2FA login
+// session. Only the caller receiving a non-nil session may issue tokens.
+func (s *TotpService) ConsumeLoginSession(ctx context.Context, tempToken string) (*TotpLoginSession, error) {
+	return s.cache.ConsumeLoginSession(ctx, tempToken)
 }
 
 // DeleteLoginSession deletes a login session

--- a/backend/internal/service/totp_service_security_test.go
+++ b/backend/internal/service/totp_service_security_test.go
@@ -1,0 +1,271 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+)
+
+type totpSecurityUserRepo struct {
+	UserRepository
+	user *User
+}
+
+func (r *totpSecurityUserRepo) GetByID(context.Context, int64) (*User, error) {
+	if r.user == nil {
+		return nil, errors.New("fake user missing")
+	}
+	return r.user, nil
+}
+
+func (r *totpSecurityUserRepo) UpdateTotpSecret(_ context.Context, _ int64, encryptedSecret *string) error {
+	r.user.TotpSecretEncrypted = encryptedSecret
+	return nil
+}
+
+func (r *totpSecurityUserRepo) EnableTotp(context.Context, int64) error {
+	r.user.TotpEnabled = true
+	now := time.Now()
+	r.user.TotpEnabledAt = &now
+	return nil
+}
+
+func (r *totpSecurityUserRepo) DisableTotp(context.Context, int64) error {
+	r.user.TotpEnabled = false
+	r.user.TotpEnabledAt = nil
+	r.user.TotpSecretEncrypted = nil
+	return nil
+}
+
+type totpSecurityCache struct {
+	setupSession     *TotpSetupSession
+	loginSession     *TotpLoginSession
+	getAttemptsErr   error
+	incrementErr     error
+	clearAttemptsErr error
+	attempts         int
+	grantGeneration  string
+	grantSessionKey  string
+}
+
+func (c *totpSecurityCache) GetSetupSession(context.Context, int64) (*TotpSetupSession, error) {
+	return c.setupSession, nil
+}
+
+func (c *totpSecurityCache) SetSetupSession(_ context.Context, _ int64, session *TotpSetupSession, _ time.Duration) error {
+	c.setupSession = session
+	return nil
+}
+
+func (c *totpSecurityCache) DeleteSetupSession(context.Context, int64) error {
+	c.setupSession = nil
+	return nil
+}
+
+func (c *totpSecurityCache) GetLoginSession(context.Context, string) (*TotpLoginSession, error) {
+	return c.loginSession, nil
+}
+
+func (c *totpSecurityCache) SetLoginSession(_ context.Context, _ string, session *TotpLoginSession, _ time.Duration) error {
+	c.loginSession = session
+	return nil
+}
+
+func (c *totpSecurityCache) ConsumeLoginSession(context.Context, string) (*TotpLoginSession, error) {
+	session := c.loginSession
+	c.loginSession = nil
+	return session, nil
+}
+
+func (c *totpSecurityCache) DeleteLoginSession(context.Context, string) error {
+	c.loginSession = nil
+	return nil
+}
+
+func (c *totpSecurityCache) IncrementVerifyAttempts(context.Context, int64) (int, error) {
+	if c.incrementErr != nil {
+		return 0, c.incrementErr
+	}
+	c.attempts++
+	return c.attempts, nil
+}
+
+func (c *totpSecurityCache) GetVerifyAttempts(context.Context, int64) (int, error) {
+	if c.getAttemptsErr != nil {
+		return 0, c.getAttemptsErr
+	}
+	return c.attempts, nil
+}
+
+func (c *totpSecurityCache) ClearVerifyAttempts(context.Context, int64) error {
+	if c.clearAttemptsErr != nil {
+		return c.clearAttemptsErr
+	}
+	c.attempts = 0
+	return nil
+}
+
+func (c *totpSecurityCache) SetStepUpGrant(_ context.Context, _ int64, sessionKey, credentialGeneration string, _ time.Duration) error {
+	c.grantSessionKey = sessionKey
+	c.grantGeneration = credentialGeneration
+	return nil
+}
+
+func (c *totpSecurityCache) HasStepUpGrant(_ context.Context, _ int64, sessionKey, credentialGeneration string) (bool, error) {
+	return c.grantSessionKey == sessionKey && c.grantGeneration == credentialGeneration, nil
+}
+
+type totpSecurityEncryptor struct {
+	plainToCipher map[string]string
+	cipherToPlain map[string]string
+}
+
+func (e totpSecurityEncryptor) Encrypt(plaintext string) (string, error) {
+	if ciphertext, ok := e.plainToCipher[plaintext]; ok {
+		return ciphertext, nil
+	}
+	return "", errors.New("fake plaintext not configured")
+}
+
+func (e totpSecurityEncryptor) Decrypt(ciphertext string) (string, error) {
+	if plaintext, ok := e.cipherToPlain[ciphertext]; ok {
+		return plaintext, nil
+	}
+	return "", errors.New("fake ciphertext not configured")
+}
+
+type totpSecuritySettingRepo struct {
+	SettingRepository
+}
+
+func (totpSecuritySettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	if key == SettingKeyTotpEnabled {
+		return "true", nil
+	}
+	return "", errors.New("fake setting missing")
+}
+
+func newTotpSecurityService(user *User, cache *totpSecurityCache, encryptor SecretEncryptor) *TotpService {
+	return NewTotpService(
+		&totpSecurityUserRepo{user: user},
+		encryptor,
+		cache,
+		NewSettingService(totpSecuritySettingRepo{}, nil),
+		nil,
+		nil,
+	)
+}
+
+func differentTotpCode(valid string) string {
+	first := byte('0')
+	if valid[0] == '0' {
+		first = '1'
+	}
+	return string(first) + valid[1:]
+}
+
+func TestTotpSecretAndPrefixNeverAppearInDebugLogs(t *testing.T) {
+	const secret = "JBSWY3DPEHPK3PXP"
+	const ciphertext = "fake-encrypted-totp-secret"
+	cache := &totpSecurityCache{setupSession: &TotpSetupSession{
+		Secret:     secret,
+		SetupToken: "fake-setup-token",
+		CreatedAt:  time.Now(),
+	}}
+	user := &User{ID: 42, Email: "local@example.test", Role: RoleAdmin}
+	svc := newTotpSecurityService(user, cache, totpSecurityEncryptor{
+		plainToCipher: map[string]string{secret: ciphertext},
+		cipherToPlain: map[string]string{ciphertext: secret},
+	})
+
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, svc.CompleteSetup(context.Background(), user.ID, code, "fake-setup-token"))
+	require.NoError(t, svc.VerifyCode(context.Background(), user.ID, code))
+
+	output := logs.String()
+	require.Contains(t, output, "totp_complete_setup_before_encrypt")
+	require.Contains(t, output, "totp_verify_result")
+	require.NotContains(t, output, secret)
+	require.NotContains(t, output, secret[:4])
+	require.NotContains(t, output, "secret_prefix")
+	require.NotContains(t, output, "decrypted_prefix")
+}
+
+func TestTotpVerifyCodeRateLimitStorageErrorsFailClosed(t *testing.T) {
+	const secret = "JBSWY3DPEHPK3PXP"
+	const ciphertext = "fake-ciphertext"
+	validCode, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	user := &User{ID: 42, TotpEnabled: true, TotpSecretEncrypted: stringPointer(ciphertext)}
+	encryptor := totpSecurityEncryptor{cipherToPlain: map[string]string{ciphertext: secret}}
+
+	tests := []struct {
+		name  string
+		cache *totpSecurityCache
+		code  string
+	}{
+		{name: "attempt counter read", cache: &totpSecurityCache{getAttemptsErr: errors.New("fake redis read failure")}, code: validCode},
+		{name: "attempt counter increment", cache: &totpSecurityCache{incrementErr: errors.New("fake redis increment failure")}, code: differentTotpCode(validCode)},
+		{name: "attempt counter clear", cache: &totpSecurityCache{clearAttemptsErr: errors.New("fake redis clear failure")}, code: validCode},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := newTotpSecurityService(user, test.cache, encryptor)
+			err := svc.VerifyCode(context.Background(), user.ID, test.code)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrTotpInvalidCode)
+		})
+	}
+}
+
+func TestStepUpGrantCannotSurviveTotpRotationOrDisable(t *testing.T) {
+	const secretA = "JBSWY3DPEHPK3PXP"
+	const secretB = "KRSXG5DSNFXGOIDB"
+	const cipherA = "fake-ciphertext-a"
+	const cipherB = "fake-ciphertext-b"
+	user := &User{ID: 42, TotpEnabled: true, TotpSecretEncrypted: stringPointer(cipherA)}
+	cache := &totpSecurityCache{}
+	svc := newTotpSecurityService(user, cache, totpSecurityEncryptor{cipherToPlain: map[string]string{
+		cipherA: secretA,
+		cipherB: secretB,
+	}})
+
+	code, err := totp.GenerateCode(secretA, time.Now())
+	require.NoError(t, err)
+	_, err = svc.VerifyStepUp(context.Background(), user.ID, "session-a", code)
+	require.NoError(t, err)
+
+	granted, err := svc.HasStepUpGrant(context.Background(), user.ID, "session-a")
+	require.NoError(t, err)
+	require.True(t, granted)
+
+	user.TotpSecretEncrypted = stringPointer(cipherB)
+	granted, err = svc.HasStepUpGrant(context.Background(), user.ID, "session-a")
+	require.NoError(t, err)
+	require.False(t, granted)
+
+	user.TotpEnabled = false
+	user.TotpSecretEncrypted = nil
+	granted, err = svc.HasStepUpGrant(context.Background(), user.ID, "session-a")
+	require.ErrorIs(t, err, ErrTotpNotSetup)
+	require.False(t, granted)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -23,9 +23,10 @@ type User struct {
 	Concurrency    int
 	Status         string
 	AllowedGroups  []int64
-	TokenVersion   int64 // Incremented on password change to invalidate existing tokens
-	// TokenVersionResolved indicates TokenVersion already contains the fingerprint-derived
-	// value expected in JWT claims and refresh-token state.
+	TokenVersion   int64 // Persistent security stamp advanced to invalidate existing tokens.
+	// TokenVersionResolved indicates TokenVersion was loaded from durable storage.
+	// False is retained only for legacy in-memory callers and unit-test repositories,
+	// where resolvedTokenVersion derives the historical password fingerprint.
 	TokenVersionResolved bool
 	SignupSource         string
 	LastLoginAt          *time.Time

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -181,6 +181,14 @@ type UserRepository interface {
 	DisableTotp(ctx context.Context, userID int64) error
 }
 
+// UserTokenVersionRepository is the durable security-stamp capability required
+// by revoke-all flows. IncrementTokenVersion must be a single atomic database
+// operation so concurrent logins cannot lose a revocation event.
+type UserTokenVersionRepository interface {
+	GetTokenVersion(ctx context.Context, userID int64) (int64, error)
+	IncrementTokenVersion(ctx context.Context, userID int64) (int64, error)
+}
+
 // RegistrationEmailDomainRepository 是生产用户仓储为非白名单域名单账户兜底策略提供的可选能力。
 // 它独立于 UserRepository，避免无关测试桩和服务消费者实现注册专用方法。
 type RegistrationEmailDomainRepository interface {
@@ -1036,8 +1044,8 @@ func (s *UserService) ChangePassword(ctx context.Context, userID int64, req Chan
 	// This ensures that any tokens issued before the password change become invalid
 	user.TokenVersion++
 
-	// TokenVersion 没有对应的数据库列（见 resolvedTokenVersion：它由 email+password_hash
-	// 指纹推导），改密写回 password_hash 即可让旧 token 失效。
+	// Production repositories update password_hash and atomically advance the
+	// persistent token_version in the same transaction.
 	if err := s.userRepo.Update(ctx, user, UserUpdateFields{PasswordHash: true}); err != nil {
 		return fmt.Errorf("update user: %w", err)
 	}

--- a/backend/migrations/221_add_users_token_version.sql
+++ b/backend/migrations/221_add_users_token_version.sql
@@ -1,0 +1,32 @@
+-- Persist the per-user security stamp used by access and refresh tokens.
+--
+-- Existing deployments intentionally start at version 0. Tokens issued before
+-- this migration used an email/password fingerprint instead, so they no longer
+-- match and every existing session must authenticate once after the upgrade.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS token_version BIGINT NOT NULL DEFAULT 0;
+
+-- Repair a partially-created column as well as creating it from scratch.
+ALTER TABLE users
+    ALTER COLUMN token_version SET DEFAULT 0;
+UPDATE users SET token_version = 0 WHERE token_version IS NULL;
+ALTER TABLE users
+    ALTER COLUMN token_version SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'users_token_version_nonnegative'
+          AND conrelid = 'users'::regclass
+    ) THEN
+        ALTER TABLE users
+            ADD CONSTRAINT users_token_version_nonnegative
+            CHECK (token_version >= 0);
+    END IF;
+END
+$$;
+
+COMMENT ON COLUMN users.token_version IS
+    'Persistent JWT/refresh-token security stamp; atomically incremented to revoke all sessions.';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@vueuse/core": "^10.7.0",
     "axios": "^1.18.0",
     "chart.js": "^4.4.1",
-    "dompurify": "^3.3.1",
+    "dompurify": "3.4.13",
     "driver.js": "^1.4.0",
     "file-saver": "^2.0.5",
     "marked": "^17.0.1",
@@ -32,12 +32,10 @@
     "vue-chartjs": "^5.3.0",
     "vue-draggable-plus": "^0.6.1",
     "vue-i18n": "^9.14.5",
-    "vue-router": "^4.2.5",
-    "xlsx": "^0.18.5"
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@intlify/message-compiler": "9.14.5",
-    "@types/dompurify": "^3.0.5",
     "@types/file-saver": "^2.0.7",
     "@types/mdx": "^2.0.13",
     "@types/node": "^20.10.5",
@@ -63,7 +61,11 @@
     "overrides": {
       "js-cookie": "3.0.7",
       "form-data@<4.0.6": ">=4.0.6",
-      "postcss@<8.5.18": ">=8.5.18"
+      "postcss@<8.5.18": ">=8.5.18",
+      "yaml@>=1.0.0 <1.10.3": "1.10.3",
+      "uuid@<11.1.1": "11.1.1",
+      "uuid@>=13.0.0 <13.0.1": "13.0.1",
+      "mermaid@<11.16.1": "11.16.1"
     }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,10 @@ overrides:
   js-cookie: 3.0.7
   form-data@<4.0.6: '>=4.0.6'
   postcss@<8.5.18: '>=8.5.18'
+  yaml@>=1.0.0 <1.10.3: 1.10.3
+  uuid@<11.1.1: 11.1.1
+  uuid@>=13.0.0 <13.0.1: 13.0.1
+  mermaid@<11.16.1: 11.16.1
 
 importers:
 
@@ -35,8 +39,8 @@ importers:
         specifier: ^4.4.1
         version: 4.5.1
       dompurify:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: 3.4.13
+        version: 3.4.13
       driver.js:
         specifier: ^1.4.0
         version: 1.4.0
@@ -67,16 +71,10 @@ importers:
       vue-router:
         specifier: ^4.2.5
         version: 4.6.4(vue@3.5.26(typescript@5.6.3))
-      xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
     devDependencies:
       '@intlify/message-compiler':
         specifier: 9.14.5
         version: 9.14.5
-      '@types/dompurify':
-        specifier: ^3.0.5
-        version: 3.2.0
       '@types/file-saver':
         specifier: ^2.0.7
         version: 2.0.7
@@ -277,20 +275,8 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@chevrotain/cst-dts-gen@12.0.0':
-    resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
-
-  '@chevrotain/gast@12.0.0':
-    resolution: {integrity: sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==}
-
-  '@chevrotain/regexp-to-ast@12.0.0':
-    resolution: {integrity: sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==}
-
-  '@chevrotain/types@12.0.0':
-    resolution: {integrity: sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==}
-
-  '@chevrotain/utils@12.0.0':
-    resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -690,8 +676,8 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mermaid-js/parser@1.1.0':
-    resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1296,67 +1282,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1523,10 +1498,6 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
-  '@types/dompurify@3.2.0':
-    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
-    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1644,6 +1615,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -1783,10 +1755,6 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -1944,10 +1912,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
-
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -1976,15 +1940,6 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
-  chevrotain-allstar@0.4.1:
-    resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
-    peerDependencies:
-      chevrotain: ^12.0.0
-
-  chevrotain@12.0.0:
-    resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
-    engines: {node: '>=22.0.0'}
-
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -2008,10 +1963,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -2074,11 +2025,6 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
-  crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2105,8 +2051,8 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.33.2:
-    resolution: {integrity: sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==}
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
     engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
@@ -2322,11 +2268,8 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
-
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   driver.js@1.4.0:
     resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
@@ -2576,10 +2519,6 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
-
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -2641,11 +2580,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -2952,10 +2892,6 @@ packages:
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
-  langium@4.2.2:
-    resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
-
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
@@ -3129,8 +3065,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.14.0:
-    resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3974,10 +3910,6 @@ packages:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
 
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4225,12 +4157,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@13.0.1:
+    resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
     hasBin: true
 
   v8n@1.5.1:
@@ -4340,23 +4272,6 @@ packages:
       jsdom:
         optional: true
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -4398,6 +4313,7 @@ packages:
   vue-i18n@9.14.5:
     resolution: {integrity: sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==}
     engines: {node: '>= 16'}
+    deprecated: v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html
     peerDependencies:
       vue: ^3.0.0
 
@@ -4457,17 +4373,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -4496,11 +4404,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -4515,8 +4418,8 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yargs-parser@18.1.3:
@@ -4715,20 +4618,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@chevrotain/cst-dts-gen@12.0.0':
-    dependencies:
-      '@chevrotain/gast': 12.0.0
-      '@chevrotain/types': 12.0.0
-
-  '@chevrotain/gast@12.0.0':
-    dependencies:
-      '@chevrotain/types': 12.0.0
-
-  '@chevrotain/regexp-to-ast@12.0.0': {}
-
-  '@chevrotain/types@12.0.0': {}
-
-  '@chevrotain/utils@12.0.0': {}
+  '@chevrotain/types@11.1.2': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -5125,7 +5015,7 @@ snapshots:
       leva: 0.10.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react: 0.562.0(react@19.2.3)
       marked: 17.0.6
-      mermaid: 11.14.0
+      mermaid: 11.16.1
       motion: 12.23.26(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       numeral: 2.0.6
       polished: 4.3.1
@@ -5160,7 +5050,7 @@ snapshots:
       unified: 11.0.5
       url-join: 5.0.0
       use-merge-value: 1.2.0(react@19.2.3)
-      uuid: 13.0.0
+      uuid: 13.0.1
     transitivePeerDependencies:
       - '@types/mdast'
       - '@types/react'
@@ -5207,9 +5097,9 @@ snapshots:
       '@types/react': 19.2.7
       react: 19.2.3
 
-  '@mermaid-js/parser@1.1.0':
+  '@mermaid-js/parser@1.2.0':
     dependencies:
-      langium: 4.2.2
+      '@chevrotain/types': 11.1.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6039,10 +5929,6 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
-  '@types/dompurify@3.2.0':
-    dependencies:
-      dompurify: 3.3.1
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6375,8 +6261,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adler-32@1.3.1: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -6589,11 +6473,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  cfb@1.2.2:
-    dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
-
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -6620,19 +6499,6 @@ snapshots:
       '@kurkle/color': 0.3.4
 
   check-error@2.1.3: {}
-
-  chevrotain-allstar@0.4.1(chevrotain@12.0.0):
-    dependencies:
-      chevrotain: 12.0.0
-      lodash-es: 4.18.1
-
-  chevrotain@12.0.0:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 12.0.0
-      '@chevrotain/gast': 12.0.0
-      '@chevrotain/regexp-to-ast': 12.0.0
-      '@chevrotain/types': 12.0.0
-      '@chevrotain/utils': 12.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -6665,8 +6531,6 @@ snapshots:
       wrap-ansi: 6.2.0
 
   clsx@2.1.1: {}
-
-  codepage@1.15.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -6719,9 +6583,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
-
-  crc-32@1.2.2: {}
+      yaml: 1.10.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6738,17 +6600,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.2):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.33.2
+      cytoscape: 3.34.0
 
-  cytoscape-fcose@2.2.0(cytoscape@3.33.2):
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.33.2
+      cytoscape: 3.34.0
 
-  cytoscape@3.33.2: {}
+  cytoscape@3.34.0: {}
 
   d3-array@2.12.1:
     dependencies:
@@ -6975,11 +6837,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.3.1:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.3.3:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7287,8 +7145,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
-
-  frac@1.1.2: {}
 
   fraction.js@5.3.4: {}
 
@@ -7758,15 +7614,6 @@ snapshots:
 
   khroma@2.1.0: {}
 
-  langium@4.2.2:
-    dependencies:
-      '@chevrotain/regexp-to-ast': 12.0.0
-      chevrotain: 12.0.0
-      chevrotain-allstar: 0.4.1(chevrotain@12.0.0)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
@@ -8064,29 +7911,29 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.14.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.1.0
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
-      cytoscape: 3.33.2
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.2)
-      cytoscape-fcose: 2.2.0(cytoscape@3.33.2)
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.4.13
+      es-toolkit: 1.45.1
       katex: 0.16.45
       khroma: 2.1.0
-      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -9163,10 +9010,6 @@ snapshots:
     dependencies:
       extend-shallow: 3.0.2
 
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
-
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
@@ -9430,9 +9273,9 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
-  uuid@13.0.0: {}
+  uuid@13.0.1: {}
 
   v8n@1.5.1: {}
 
@@ -9532,21 +9375,6 @@ snapshots:
       - supports-color
       - terser
 
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
   vscode-uri@3.1.0: {}
 
   vue-chartjs@5.3.3(chart.js@4.5.1)(vue@3.5.26(typescript@5.6.3)):
@@ -9635,11 +9463,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wmf@1.0.2: {}
-
   word-wrap@1.2.5: {}
-
-  word@0.3.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -9663,16 +9487,6 @@ snapshots:
 
   ws@8.19.0: {}
 
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
-
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -9681,7 +9495,7 @@ snapshots:
 
   y18n@4.0.3: {}
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/frontend/src/utils/__tests__/embedded-url.spec.ts
+++ b/frontend/src/utils/__tests__/embedded-url.spec.ts
@@ -28,25 +28,23 @@ describe('embedded-url', () => {
   it('adds embedded query parameters including locale and source context', () => {
     const result = buildEmbeddedUrl(
       'https://pay.example.com/checkout?plan=pro',
-      42,
-      'token-123',
       'dark',
       'zh-CN',
     )
 
     const url = new URL(result)
     expect(url.searchParams.get('plan')).toBe('pro')
-    expect(url.searchParams.get('user_id')).toBe('42')
-    expect(url.searchParams.get('token')).toBe('token-123')
+    expect(url.searchParams.has('user_id')).toBe(false)
+    expect(url.searchParams.has('token')).toBe(false)
     expect(url.searchParams.get('theme')).toBe('dark')
     expect(url.searchParams.get('lang')).toBe('zh-CN')
     expect(url.searchParams.get('ui_mode')).toBe('embedded')
-    expect(url.searchParams.get('src_host')).toBe('https://app.example.com')
-    expect(url.searchParams.get('src_url')).toBe('https://app.example.com/user/purchase')
+    expect(url.searchParams.has('src_host')).toBe(false)
+    expect(url.searchParams.has('src_url')).toBe(false)
   })
 
   it('omits optional params when they are empty', () => {
-    const result = buildEmbeddedUrl('https://pay.example.com/checkout', undefined, '', 'light')
+    const result = buildEmbeddedUrl('https://pay.example.com/checkout', 'light')
 
     const url = new URL(result)
     expect(url.searchParams.get('theme')).toBe('light')
@@ -57,7 +55,7 @@ describe('embedded-url', () => {
   })
 
   it('returns original string for invalid url input', () => {
-    expect(buildEmbeddedUrl('not a url', 1, 'token')).toBe('not a url')
+    expect(buildEmbeddedUrl('not a url')).toBe('not a url')
   })
 
   it('detects dark mode from document root class', () => {

--- a/frontend/src/utils/embedded-url.ts
+++ b/frontend/src/utils/embedded-url.ts
@@ -1,44 +1,29 @@
 /**
  * Shared URL builder for iframe-embedded pages.
  * Used by PurchaseSubscriptionView and CustomPageView to build consistent URLs
- * with user_id, token, theme, lang, ui_mode, src_host, and src parameters.
+ * with non-secret presentation context only. Authentication credentials must
+ * never be placed in iframe URLs because URLs leak through history, logs, and
+ * the embedded origin itself.
  */
 
-const EMBEDDED_USER_ID_QUERY_KEY = 'user_id'
-const EMBEDDED_AUTH_TOKEN_QUERY_KEY = 'token'
 const EMBEDDED_THEME_QUERY_KEY = 'theme'
 const EMBEDDED_LANG_QUERY_KEY = 'lang'
 const EMBEDDED_UI_MODE_QUERY_KEY = 'ui_mode'
 const EMBEDDED_UI_MODE_VALUE = 'embedded'
-const EMBEDDED_SRC_HOST_QUERY_KEY = 'src_host'
-const EMBEDDED_SRC_QUERY_KEY = 'src_url'
 
 export function buildEmbeddedUrl(
   baseUrl: string,
-  userId?: number,
-  authToken?: string | null,
   theme: 'light' | 'dark' = 'light',
   lang?: string,
 ): string {
   if (!baseUrl) return baseUrl
   try {
     const url = new URL(baseUrl)
-    if (userId) {
-      url.searchParams.set(EMBEDDED_USER_ID_QUERY_KEY, String(userId))
-    }
-    if (authToken) {
-      url.searchParams.set(EMBEDDED_AUTH_TOKEN_QUERY_KEY, authToken)
-    }
     url.searchParams.set(EMBEDDED_THEME_QUERY_KEY, theme)
     if (lang) {
       url.searchParams.set(EMBEDDED_LANG_QUERY_KEY, lang)
     }
     url.searchParams.set(EMBEDDED_UI_MODE_QUERY_KEY, EMBEDDED_UI_MODE_VALUE)
-    // Source tracking: let the embedded page know where it's being loaded from
-    if (typeof window !== 'undefined') {
-      url.searchParams.set(EMBEDDED_SRC_HOST_QUERY_KEY, window.location.origin)
-      url.searchParams.set(EMBEDDED_SRC_QUERY_KEY, window.location.href)
-    }
     return url.toString()
   } catch {
     return baseUrl

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -4,12 +4,13 @@
     <!-- iframe mode -->
     <iframe
       v-if="isHomeContentUrl"
-      :src="homeContent.trim()"
+      :src="sanitizedHomeUrl"
       class="h-screen w-full border-0"
+      sandbox=""
+      referrerpolicy="no-referrer"
       allowfullscreen
     ></iframe>
-    <!-- HTML mode - SECURITY: homeContent is admin-only setting, XSS risk is acceptable -->
-    <div v-else v-html="homeContent"></div>
+    <div v-else v-html="sanitizedHomeHtml"></div>
   </div>
 
   <!-- Compact Home Page -->
@@ -480,6 +481,7 @@ import { useAuthStore, useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { sanitizeUrl } from '@/utils/url'
+import DOMPurify from 'dompurify'
 
 const { t } = useI18n()
 
@@ -495,11 +497,20 @@ const homeContent = computed(() => appStore.cachedPublicSettings?.home_content |
 const hasHomeContent = computed(() => homeContent.value.trim().length > 0)
 const compactHomeEnabled = computed(() => appStore.cachedPublicSettings?.compact_home_enabled === true)
 
-// Check if homeContent is a URL (for iframe display)
-const isHomeContentUrl = computed(() => {
+const sanitizedHomeHtml = computed(() => DOMPurify.sanitize(homeContent.value, {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: ['iframe', 'object', 'embed', 'form', 'style'],
+  FORBID_ATTR: ['style'],
+}))
+
+const sanitizedHomeUrl = computed(() => {
   const content = homeContent.value.trim()
-  return content.startsWith('http://') || content.startsWith('https://')
+  if (!content.startsWith('http://') && !content.startsWith('https://')) return ''
+  return sanitizeUrl(content)
 })
+
+// Check if homeContent is a URL (for iframe display)
+const isHomeContentUrl = computed(() => sanitizedHomeUrl.value !== '')
 
 // Theme
 const isDark = ref(document.documentElement.classList.contains('dark'))

--- a/frontend/src/views/__tests__/HomeView.compact.spec.ts
+++ b/frontend/src/views/__tests__/HomeView.compact.spec.ts
@@ -76,13 +76,25 @@ describe('HomeView compact mode', () => {
     expect(wrapper.find('[data-testid="compact-home"]').exists()).toBe(false)
   })
 
+  it('sanitizes active content from custom HTML', () => {
+    const wrapper = mountHome({
+      home_content: '<img id="probe" src="x" onerror="window.pwned=true"><script>window.pwned=true</script>',
+    })
+
+    expect(wrapper.find('script').exists()).toBe(false)
+    expect(wrapper.get('#probe').attributes('onerror')).toBeUndefined()
+  })
+
   it('renders custom URL content ahead of compact mode', () => {
     const wrapper = mountHome({
       compact_home_enabled: true,
       home_content: ' https://example.com/home ',
     })
 
-    expect(wrapper.get('iframe').attributes('src')).toBe('https://example.com/home')
+    const frame = wrapper.get('iframe')
+    expect(frame.attributes('src')).toBe('https://example.com/home')
+    expect(frame.attributes('sandbox')).toBe('')
+    expect(frame.attributes('referrerpolicy')).toBe('no-referrer')
     expect(wrapper.find('[data-testid="compact-home"]').exists()).toBe(false)
   })
 

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -567,12 +567,18 @@ const getRequestTypeLabel = (log: AdminUsageLog): string => {
   return t('usage.unknown')
 }
 
+const serializeCsvCell = (value: unknown): string => {
+  const raw = String(value ?? '')
+  // Prevent spreadsheet formula injection when the CSV is opened in Excel.
+  const safe = /^[=+\-@\t\r]/.test(raw) ? `'${raw}` : raw
+  return `"${safe.replace(/"/g, '""')}"`
+}
+
 const exportToExcel = async () => {
   if (exporting.value) return; exporting.value = true; exportProgress.show = true
   const c = new AbortController(); exportAbortController = c
   try {
     let p = 1; let total = pagination.total; let exportedCount = 0
-    const XLSX = await import('xlsx')
     const headers = [
       t('usage.time'), t('admin.usage.user'), t('usage.apiKeyFilter'),
       t('admin.usage.account'), t('usage.requestedModel'), t('usage.sentUpstreamModel'), t('usage.upstreamResponseModel'), t('usage.upstreamModelMismatch'), t('usage.reasoningEffort'), t('admin.usage.group'),
@@ -586,7 +592,7 @@ const exportToExcel = async () => {
       t('usage.firstToken'), t('usage.duration'),
       t('admin.usage.requestId'), t('usage.userAgent'), t('admin.usage.ipAddress')
     ]
-    const ws = XLSX.utils.aoa_to_sheet([headers])
+    const csvRows: unknown[][] = [headers]
     while (true) {
       const res = await adminUsageAPI.list(
         buildUsageListParams(p, 100, true),
@@ -606,7 +612,7 @@ const exportToExcel = async () => {
         log.request_id || '', log.user_agent || '', log.ip_address || ''
       ])
       if (rows.length) {
-        XLSX.utils.sheet_add_aoa(ws, rows, { origin: -1 })
+        csvRows.push(...rows)
       }
       exportedCount += rows.length
       exportProgress.current = exportedCount
@@ -614,9 +620,11 @@ const exportToExcel = async () => {
       if (exportedCount >= total || res.items.length < 100) break; p++
     }
     if(!c.signal.aborted) {
-      const wb = XLSX.utils.book_new()
-      XLSX.utils.book_append_sheet(wb, ws, 'Usage')
-      saveAs(new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), `usage_${filters.value.start_date}_to_${filters.value.end_date}.xlsx`)
+      const csv = csvRows.map((row) => row.map(serializeCsvCell).join(',')).join('\r\n')
+      saveAs(
+        new Blob(['\uFEFF', csv], { type: 'text/csv;charset=utf-8' }),
+        `usage_${filters.value.start_date}_to_${filters.value.end_date}.csv`,
+      )
       appStore.showSuccess(t('usage.exportSuccess'))
     }
   } catch (error) { console.error('Failed to export:', error); appStore.showError('Export Failed') }

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -4,7 +4,7 @@ import { defineComponent, ref } from 'vue'
 
 import UsageView from '../UsageView.vue'
 
-const { list, exportList, getStats, getSnapshotV2, getById, getModelStats, listErrorLogs, routeQuery, aoaToSheet, sheetAddAoa, saveAs, xlsxWrite } = vi.hoisted(() => {
+const { list, exportList, getStats, getSnapshotV2, getById, getModelStats, listErrorLogs, routeQuery, saveAs } = vi.hoisted(() => {
   vi.stubGlobal('localStorage', {
     getItem: vi.fn(() => null),
     setItem: vi.fn(),
@@ -20,10 +20,7 @@ const { list, exportList, getStats, getSnapshotV2, getById, getModelStats, listE
     getModelStats: vi.fn(),
     listErrorLogs: vi.fn(),
     routeQuery: {} as Record<string, string>,
-		aoaToSheet: vi.fn(() => ({})),
-		sheetAddAoa: vi.fn(),
 		saveAs: vi.fn(),
-		xlsxWrite: vi.fn(() => new Uint8Array([1, 2, 3])),
   }
 })
 
@@ -46,6 +43,13 @@ const formatLocalDate = (date: Date): string => {
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
 }
+
+const readBlobAsText = (blob: Blob): Promise<string> => new Promise((resolve, reject) => {
+	const reader = new FileReader()
+	reader.onload = () => resolve(String(reader.result ?? ''))
+	reader.onerror = () => reject(reader.error)
+	reader.readAsText(blob)
+})
 
 vi.mock('@/api/admin', () => ({
   adminAPI: {
@@ -70,16 +74,6 @@ vi.mock('@/api/admin/usage', () => ({
 }))
 
 vi.mock('file-saver', () => ({ saveAs }))
-
-vi.mock('xlsx', () => ({
-	utils: {
-		aoa_to_sheet: aoaToSheet,
-		sheet_add_aoa: sheetAddAoa,
-		book_new: vi.fn(() => ({})),
-		book_append_sheet: vi.fn(),
-	},
-	write: xlsxWrite,
-}))
 
 vi.mock('@/api/admin/ops', () => ({
   listErrorLogs,
@@ -591,10 +585,7 @@ describe('admin UsageView model audit export', () => {
 		})
 		getSnapshotV2.mockReset().mockResolvedValue({ trend: [], models: [], groups: [] })
 		getModelStats.mockReset().mockResolvedValue({ models: [] })
-		aoaToSheet.mockClear()
-		sheetAddAoa.mockClear()
 		saveAs.mockClear()
-		xlsxWrite.mockClear()
 	})
 
 	afterEach(() => {
@@ -609,15 +600,46 @@ describe('admin UsageView model audit export', () => {
 		await (wrapper.vm as any).exportToExcel()
 		await flushPromises()
 
-		const headers = aoaToSheet.mock.calls[0][0][0]
-		expect(headers.slice(4, 8)).toEqual([
-			'Requested model',
-			'Sent upstream model',
-			'Upstream response model',
-			'Upstream model mismatch',
-		])
-		const row = sheetAddAoa.mock.calls[0][1][0]
-		expect(row.slice(4, 8)).toEqual(['gpt-5.6-sol', 'gpt-5.5', 'gpt-5.4', 'Yes'])
 		expect(saveAs).toHaveBeenCalledTimes(1)
+		const [blob, filename] = saveAs.mock.calls[0]
+		vi.useRealTimers()
+		const csv = await readBlobAsText(blob)
+		expect(csv).toContain('"Requested model","Sent upstream model","Upstream response model","Upstream model mismatch"')
+		expect(csv).toContain('"gpt-5.6-sol","gpt-5.5","gpt-5.4","Yes"')
+		expect(filename).toMatch(/\.csv$/)
+	})
+
+	it('neutralizes spreadsheet formulas in exported CSV cells', async () => {
+		exportList.mockResolvedValueOnce({
+			items: [{
+				id: 2,
+				created_at: '2026-08-04T00:00:00Z',
+				model: '=2+2',
+				upstream_model: '+SUM(1,1)',
+				upstream_response_model: '@cmd',
+				request_type: 'sync',
+				input_tokens: 1,
+				output_tokens: 1,
+				cache_read_tokens: 0,
+				cache_creation_tokens: 0,
+				duration_ms: 10,
+			}],
+			total: 1,
+			pages: 1,
+		})
+
+		const wrapper = mountRouteFilteredUsageView()
+		vi.advanceTimersByTime(120)
+		await flushPromises()
+
+		await (wrapper.vm as any).exportToExcel()
+		await flushPromises()
+
+		const [blob] = saveAs.mock.calls[0]
+		vi.useRealTimers()
+		const csv = await readBlobAsText(blob)
+		expect(csv).toContain('"\'=2+2"')
+		expect(csv).toContain('"\'+SUM(1,1)"')
+		expect(csv).toContain('"\'@cmd"')
 	})
 })

--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -107,6 +107,8 @@
           <iframe
             :src="embeddedUrl"
             class="custom-embed-frame"
+            sandbox="allow-scripts allow-forms allow-popups"
+            referrerpolicy="no-referrer"
             allowfullscreen
           ></iframe>
         </div>
@@ -177,8 +179,6 @@ const embeddedUrl = computed(() => {
   if (!menuItem.value || isMarkdownMode.value) return ''
   return buildEmbeddedUrl(
     menuItem.value.url,
-    authStore.user?.id,
-    authStore.token,
     pageTheme.value,
     locale.value,
   )
@@ -187,7 +187,7 @@ const embeddedUrl = computed(() => {
 const isValidUrl = computed(() => {
   if (isMarkdownMode.value) return false
   const url = embeddedUrl.value
-  return url.startsWith('http://') || url.startsWith('https://')
+  return url.startsWith('https://')
 })
 
 function generateHeadingId(text: string, index: number): string {


### PR DESCRIPTION
## Summary

This draft proposes a defense-in-depth hardening pass across authentication, session revocation, provider credential storage, administrative step-up checks, and browser-facing token/XSS boundaries.

- encrypt provider credentials at rest in PostgreSQL and derived Redis caches with AES-256-GCM
- add durable token-version based session revocation and atomic refresh-token rotation/replay handling
- make TOTP login-session consumption atomic and bind step-up grants to the current TOTP credential generation
- require TOTP step-up for high-impact account, credential, proxy, backup, user-management, and update operations
- remove embedded-page access-token propagation, sanitize configurable home HTML, and make CSP nonce failures fail closed
- update the vulnerable image-processing dependency and remove the unnecessary spreadsheet dependency

## Why

Several security boundaries relied on plaintext secret persistence, non-atomic read/delete sequences, refresh-token-only revocation, or feature-gated step-up checks. Under concurrent requests or a stolen administrative/user session, these behaviors could leave credentials or replacement sessions usable longer than intended.

The changes move those checks to shared fail-closed decision points and add regression coverage for concurrency and replay behavior. This is intentionally opened as a draft because the patch spans multiple security boundaries; I am happy to split it into smaller maintainer-preferred PRs.

## Operational impact

- release mode now requires `CREDENTIAL_ENCRYPTION_KEY` containing exactly 32 bytes encoded as 64 hexadecimal characters
- `CREDENTIAL_ENCRYPTION_KEY_ID` is optional and identifies the active key; this patch does not yet implement a multi-key rotation keyring
- legacy plaintext account credentials are migrated transactionally at startup; malformed ciphertext or a wrong key fails startup instead of silently discarding credentials
- existing access/refresh sessions are intentionally invalidated once by the new token-version epoch and users must sign in again
- high-risk administrative operations require a recent TOTP step-up grant
- the `xlsx` frontend dependency is removed; CSV export remains available with spreadsheet-formula escaping

## Validation

- `go test -mod=readonly -tags=unit ./... -count=1 -timeout=15m` — pass
- 32 concurrent uses of one refresh token — exactly one succeeds
- 32 concurrent uses of one TOTP login session — exactly one succeeds
- repository, service, handler, and middleware security regression suites — pass
- production frontend build — pass
- Trivy HIGH/CRITICAL vulnerability and secret scan of the built image — zero findings
- local ZAP baseline — 59 pass, 0 fail, 2 informational/warning results
- `git diff --check` — pass

All attack reproductions and concurrency tests used local fake data, in-memory/test databases, or network-disabled containers. No external OAuth provider, real subscription account, or third-party host was attacked.

## Security handling

The repository currently has no `SECURITY.md` and GitHub private vulnerability reporting is disabled. This public draft intentionally omits step-by-step exploit instructions. Maintainers can advise a preferred private channel for detailed reproductions and whether the changes should be split before review.
