### PR TITLE
fix(claude): stop Claude OAuth tokens from silently never refreshing

### DIFF
--- a/backend/internal/pkg/oauth/oauth.go
+++ b/backend/internal/pkg/oauth/oauth.go
@@ -184,13 +184,17 @@ func BuildAuthorizationURL(state, codeChallenge, scope string) string {
 
 // TokenResponse represents the token response from OAuth provider
 type TokenResponse struct {
-	AccessToken  string       `json:"access_token"`
-	TokenType    string       `json:"token_type"`
-	ExpiresIn    int64        `json:"expires_in"`
-	RefreshToken string       `json:"refresh_token,omitempty"`
-	Scope        string       `json:"scope,omitempty"`
-	Organization *OrgInfo     `json:"organization,omitempty"`
-	Account      *AccountInfo `json:"account,omitempty"`
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// RefreshTokenExpiresIn 是 refresh_token 的剩余有效期（秒）。
+	// Anthropic 的 token 端点会返回该字段，官方 Claude Code 据此记录
+	// refreshTokenExpiresAt 并在临近到期时提示重新授权。
+	RefreshTokenExpiresIn int64        `json:"refresh_token_expires_in,omitempty"`
+	Scope                 string       `json:"scope,omitempty"`
+	Organization          *OrgInfo     `json:"organization,omitempty"`
+	Account               *AccountInfo `json:"account,omitempty"`
 }
 
 // OrgInfo represents organization info from OAuth response

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -334,11 +334,18 @@ func (a *Account) GetCredential(key string) string {
 	}
 }
 
+// maxPlausibleUnixSeconds 用于区分秒级与毫秒级 Unix 时间戳。
+// 1e11 秒 ≈ 公元 5138 年，任何真实的秒级时间戳都远小于它；
+// 而当前的毫秒级时间戳约为 1.7e12，必然大于它。
+const maxPlausibleUnixSeconds = int64(1e11)
+
 // GetCredentialAsTime 解析凭证中的时间戳字段，支持多种格式
 // 兼容以下格式：
 //   - RFC3339 字符串: "2025-01-01T00:00:00Z"
 //   - Unix 时间戳字符串: "1735689600"
 //   - Unix 时间戳数字: 1735689600 (float64/int64/json.Number)
+//   - Unix 毫秒时间戳: 1735689600000（如 Claude Code 的 ~/.claude/.credentials.json
+//     里的 expiresAt，导入凭据时可能被原样写入）
 func (a *Account) GetCredentialAsTime(key string) *time.Time {
 	s := a.GetCredential(key)
 	if s == "" {
@@ -350,6 +357,12 @@ func (a *Account) GetCredentialAsTime(key string) *time.Time {
 	}
 	// 尝试 Unix 时间戳（纯数字字符串）
 	if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
+		// 毫秒级时间戳按秒解析会得到公元 5000 年之后的时间，导致
+		// time.Until() 永远大于刷新窗口，token 因此永不刷新。
+		if ts > maxPlausibleUnixSeconds {
+			t := time.UnixMilli(ts)
+			return &t
+		}
 		t := time.Unix(ts, 0)
 		return &t
 	}

--- a/backend/internal/service/account_credential_expires_at_test.go
+++ b/backend/internal/service/account_credential_expires_at_test.go
@@ -1,0 +1,100 @@
+//go:build unit
+
+package service
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GetCredentialAsTime 必须同时兼容秒级与毫秒级 Unix 时间戳。
+// Claude Code 的 ~/.claude/.credentials.json 用毫秒记录 expiresAt，
+// 导入凭据时可能被原样写入 credentials；若按秒解析会落到公元 5000 年之后，
+// 使 time.Until() 永远大于刷新窗口，token 因此永不刷新，
+// 直到 access_token 到期后请求只能拿到上游 401。
+func TestGetCredentialAsTime_UnitDetection(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  time.Time
+	}{
+		{
+			name:  "unix seconds string",
+			value: "1700000000",
+			want:  time.Unix(1700000000, 0),
+		},
+		{
+			name:  "unix seconds number",
+			value: float64(1700000000),
+			want:  time.Unix(1700000000, 0),
+		},
+		{
+			name:  "unix milliseconds string",
+			value: "1700000000000",
+			want:  time.UnixMilli(1700000000000),
+		},
+		{
+			name:  "unix milliseconds number",
+			value: float64(1700000000000),
+			want:  time.UnixMilli(1700000000000),
+		},
+		{
+			name:  "rfc3339 string",
+			value: "2023-11-14T22:13:20Z",
+			want:  time.Unix(1700000000, 0),
+		},
+		{
+			// 边界：秒级时间戳的合理上限之内仍按秒解析
+			name:  "large but plausible unix seconds",
+			value: "9999999999",
+			want:  time.Unix(9999999999, 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := &Account{Credentials: map[string]any{"expires_at": tt.value}}
+
+			got := account.GetCredentialAsTime("expires_at")
+
+			require.NotNil(t, got)
+			require.True(t, tt.want.Equal(*got), "want %s, got %s", tt.want.UTC(), got.UTC())
+		})
+	}
+}
+
+func TestGetCredentialAsTime_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials map[string]any
+	}{
+		{name: "missing", credentials: map[string]any{}},
+		{name: "nil value", credentials: map[string]any{"expires_at": nil}},
+		{name: "invalid string", credentials: map[string]any{"expires_at": "invalid"}},
+		{name: "nil credentials", credentials: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := &Account{Credentials: tt.credentials}
+
+			require.Nil(t, account.GetCredentialAsTime("expires_at"))
+		})
+	}
+}
+
+// 毫秒时间戳被按秒解析时的具体后果：一个早已过期的 token 看起来还有数万年寿命。
+func TestGetCredentialAsTime_MillisecondsDoNotLandInTheFarFuture(t *testing.T) {
+	expiredMillis := strconv.FormatInt(time.Now().Add(-1*time.Hour).UnixMilli(), 10)
+
+	account := &Account{Credentials: map[string]any{"expires_at": expiredMillis}}
+
+	got := account.GetCredentialAsTime("expires_at")
+
+	require.NotNil(t, got)
+	require.True(t, got.Before(time.Now()), "an expired millisecond timestamp must parse as expired, got %s", got.UTC())
+	require.Negative(t, time.Until(*got))
+}

--- a/backend/internal/service/oauth_refresh_api.go
+++ b/backend/internal/service/oauth_refresh_api.go
@@ -460,6 +460,11 @@ func BuildClaudeAccountCredentials(tokenInfo *TokenInfo) map[string]any {
 	if tokenInfo.RefreshToken != "" {
 		creds["refresh_token"] = tokenInfo.RefreshToken
 	}
+	// 上游未返回 refresh_token_expires_in 时保持字段缺省，
+	// 由 MergeCredentials 保留此前记录的值，避免把已知信息覆盖成空。
+	if tokenInfo.RefreshTokenExpiresAt > 0 {
+		creds["refresh_token_expires_at"] = strconv.FormatInt(tokenInfo.RefreshTokenExpiresAt, 10)
+	}
 	if tokenInfo.Scope != "" {
 		creds["scope"] = tokenInfo.Scope
 	}

--- a/backend/internal/service/oauth_refresh_api_test.go
+++ b/backend/internal/service/oauth_refresh_api_test.go
@@ -759,6 +759,41 @@ func TestBuildClaudeAccountCredentials_Minimal(t *testing.T) {
 	require.False(t, hasScope, "scope should not be set when empty")
 }
 
+func TestBuildClaudeAccountCredentials_RefreshTokenExpiresAt(t *testing.T) {
+	tokenInfo := &TokenInfo{
+		AccessToken:           "at-123",
+		TokenType:             "Bearer",
+		ExpiresIn:             3600,
+		ExpiresAt:             1700000000,
+		RefreshToken:          "rt-456",
+		RefreshTokenExpiresAt: 1702592000,
+	}
+
+	creds := BuildClaudeAccountCredentials(tokenInfo)
+
+	require.Equal(t, "1702592000", creds["refresh_token_expires_at"])
+}
+
+func TestBuildClaudeAccountCredentials_RefreshTokenExpiresAtOmittedWhenUnknown(t *testing.T) {
+	// 上游未返回 refresh_token_expires_in 时不写该字段，
+	// 交给 MergeCredentials 保留此前记录的值。
+	tokenInfo := &TokenInfo{
+		AccessToken:  "at-123",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		ExpiresAt:    1700000000,
+		RefreshToken: "rt-456",
+	}
+
+	creds := BuildClaudeAccountCredentials(tokenInfo)
+
+	_, has := creds["refresh_token_expires_at"]
+	require.False(t, has, "refresh_token_expires_at should be omitted when upstream did not return it")
+
+	merged := MergeCredentials(map[string]any{"refresh_token_expires_at": "1702592000"}, creds)
+	require.Equal(t, "1702592000", merged["refresh_token_expires_at"], "previously known value must survive")
+}
+
 // refreshAPIAccountRepoWithRace supports returning a different account on subsequent GetByID calls
 // to simulate race conditions where another worker has refreshed the token.
 type refreshAPIAccountRepoWithRace struct {

--- a/backend/internal/service/oauth_service.go
+++ b/backend/internal/service/oauth_service.go
@@ -137,10 +137,22 @@ type TokenInfo struct {
 	ExpiresIn    int64  `json:"expires_in"`
 	ExpiresAt    int64  `json:"expires_at"`
 	RefreshToken string `json:"refresh_token,omitempty"`
-	Scope        string `json:"scope,omitempty"`
-	OrgUUID      string `json:"org_uuid,omitempty"`
-	AccountUUID  string `json:"account_uuid,omitempty"`
-	EmailAddress string `json:"email_address,omitempty"`
+	// RefreshTokenExpiresAt 是 refresh_token 的到期时间（Unix 秒）。
+	// 为 0 表示上游未返回 refresh_token_expires_in。
+	RefreshTokenExpiresAt int64  `json:"refresh_token_expires_at,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
+	OrgUUID               string `json:"org_uuid,omitempty"`
+	AccountUUID           string `json:"account_uuid,omitempty"`
+	EmailAddress          string `json:"email_address,omitempty"`
+}
+
+// refreshTokenExpiresAtFromResponse 把上游返回的 refresh_token_expires_in（秒）
+// 换算成绝对到期时间；上游未返回时返回 0。
+func refreshTokenExpiresAtFromResponse(refreshTokenExpiresIn int64) int64 {
+	if refreshTokenExpiresIn <= 0 {
+		return 0
+	}
+	return time.Now().Unix() + refreshTokenExpiresIn
 }
 
 // ExchangeCode exchanges authorization code for tokens
@@ -259,12 +271,13 @@ func (s *OAuthService) exchangeCodeForToken(ctx context.Context, code, codeVerif
 	}
 
 	tokenInfo := &TokenInfo{
-		AccessToken:  tokenResp.AccessToken,
-		TokenType:    tokenResp.TokenType,
-		ExpiresIn:    tokenResp.ExpiresIn,
-		ExpiresAt:    time.Now().Unix() + tokenResp.ExpiresIn,
-		RefreshToken: tokenResp.RefreshToken,
-		Scope:        tokenResp.Scope,
+		AccessToken:           tokenResp.AccessToken,
+		TokenType:             tokenResp.TokenType,
+		ExpiresIn:             tokenResp.ExpiresIn,
+		ExpiresAt:             time.Now().Unix() + tokenResp.ExpiresIn,
+		RefreshToken:          tokenResp.RefreshToken,
+		RefreshTokenExpiresAt: refreshTokenExpiresAtFromResponse(tokenResp.RefreshTokenExpiresIn),
+		Scope:                 tokenResp.Scope,
 	}
 
 	if tokenResp.Organization != nil && tokenResp.Organization.UUID != "" {
@@ -293,12 +306,13 @@ func (s *OAuthService) RefreshToken(ctx context.Context, refreshToken string, pr
 	}
 
 	return &TokenInfo{
-		AccessToken:  tokenResp.AccessToken,
-		TokenType:    tokenResp.TokenType,
-		ExpiresIn:    tokenResp.ExpiresIn,
-		ExpiresAt:    time.Now().Unix() + tokenResp.ExpiresIn,
-		RefreshToken: tokenResp.RefreshToken,
-		Scope:        tokenResp.Scope,
+		AccessToken:           tokenResp.AccessToken,
+		TokenType:             tokenResp.TokenType,
+		ExpiresIn:             tokenResp.ExpiresIn,
+		ExpiresAt:             time.Now().Unix() + tokenResp.ExpiresIn,
+		RefreshToken:          tokenResp.RefreshToken,
+		RefreshTokenExpiresAt: refreshTokenExpiresAtFromResponse(tokenResp.RefreshTokenExpiresIn),
+		Scope:                 tokenResp.Scope,
 	}, nil
 }
 

--- a/backend/internal/service/token_refresher.go
+++ b/backend/internal/service/token_refresher.go
@@ -48,11 +48,18 @@ func (r *ClaudeTokenRefresher) CanRefresh(account *Account) bool {
 }
 
 // NeedsRefresh 检查token是否需要刷新
-// 基于 expires_at 字段判断是否在刷新窗口内
+// 基于 expires_at 字段判断是否在刷新窗口内。
+// expires_at 缺失或无法解析时，说明过期时间未知，此时应当刷新一次以建立已知状态：
+// 若继续沿用旧 access_token，它会在到期后静默失效，请求只能拿到上游 401。
+// 与 GrokTokenRefresher / OpenAITokenRefresher 的处理保持一致：
+// 没有 refresh_token 就无从刷新，直接跳过。
 func (r *ClaudeTokenRefresher) NeedsRefresh(account *Account, refreshWindow time.Duration) bool {
+	if account == nil || strings.TrimSpace(account.GetCredential("refresh_token")) == "" {
+		return false
+	}
 	expiresAt := account.GetCredentialAsTime("expires_at")
 	if expiresAt == nil {
-		return false
+		return true
 	}
 	return time.Until(*expiresAt) < refreshWindow
 }

--- a/backend/internal/service/token_refresher_test.go
+++ b/backend/internal/service/token_refresher_test.go
@@ -14,6 +14,11 @@ func TestClaudeTokenRefresher_NeedsRefresh(t *testing.T) {
 	refresher := &ClaudeTokenRefresher{}
 	refreshWindow := 30 * time.Minute
 
+	// 毫秒级时间戳：Claude Code 的 ~/.claude/.credentials.json 用毫秒记录 expiresAt，
+	// 导入凭据时可能被原样写入 credentials。
+	expiredMillis := strconv.FormatInt(time.Now().Add(-1*time.Hour).UnixMilli(), 10)
+	futureMillis := strconv.FormatInt(time.Now().Add(12*time.Hour).UnixMilli(), 10)
+
 	tests := []struct {
 		name        string
 		credentials map[string]any
@@ -22,61 +27,97 @@ func TestClaudeTokenRefresher_NeedsRefresh(t *testing.T) {
 		{
 			name: "expires_at as string - expired",
 			credentials: map[string]any{
-				"expires_at": "1000", // 1970-01-01 00:16:40 UTC, 已过期
+				"refresh_token": "rt-test",
+				"expires_at":    "1000", // 1970-01-01 00:16:40 UTC, 已过期
 			},
 			wantRefresh: true,
 		},
 		{
 			name: "expires_at as float64 - expired",
 			credentials: map[string]any{
-				"expires_at": float64(1000), // 数字类型，已过期
+				"refresh_token": "rt-test",
+				"expires_at":    float64(1000), // 数字类型，已过期
 			},
 			wantRefresh: true,
 		},
 		{
 			name: "expires_at as RFC3339 - expired",
 			credentials: map[string]any{
-				"expires_at": "1970-01-01T00:00:00Z", // RFC3339 格式，已过期
+				"refresh_token": "rt-test",
+				"expires_at":    "1970-01-01T00:00:00Z", // RFC3339 格式，已过期
 			},
 			wantRefresh: true,
 		},
 		{
 			name: "expires_at as string - far future",
 			credentials: map[string]any{
-				"expires_at": "9999999999", // 远未来
+				"refresh_token": "rt-test",
+				"expires_at":    "9999999999", // 远未来
 			},
 			wantRefresh: false,
 		},
 		{
 			name: "expires_at as float64 - far future",
 			credentials: map[string]any{
-				"expires_at": float64(9999999999), // 远未来，数字类型
+				"refresh_token": "rt-test",
+				"expires_at":    float64(9999999999), // 远未来，数字类型
 			},
 			wantRefresh: false,
 		},
 		{
 			name: "expires_at as RFC3339 - far future",
 			credentials: map[string]any{
-				"expires_at": "2099-12-31T23:59:59Z", // RFC3339 格式，远未来
+				"refresh_token": "rt-test",
+				"expires_at":    "2099-12-31T23:59:59Z", // RFC3339 格式，远未来
 			},
 			wantRefresh: false,
 		},
 		{
-			name:        "expires_at missing",
-			credentials: map[string]any{},
-			wantRefresh: false,
+			// 过期时间未知时刷新一次，避免旧 access_token 静默失效后只能拿到上游 401
+			name: "expires_at missing - refresh to establish known state",
+			credentials: map[string]any{
+				"refresh_token": "rt-test",
+			},
+			wantRefresh: true,
 		},
 		{
-			name: "expires_at is nil",
+			name: "expires_at is nil - refresh to establish known state",
 			credentials: map[string]any{
-				"expires_at": nil,
+				"refresh_token": "rt-test",
+				"expires_at":    nil,
+			},
+			wantRefresh: true,
+		},
+		{
+			name: "expires_at is invalid string - refresh to establish known state",
+			credentials: map[string]any{
+				"refresh_token": "rt-test",
+				"expires_at":    "invalid",
+			},
+			wantRefresh: true,
+		},
+		{
+			// 毫秒时间戳按秒解析会落到公元 5000 年之后，导致 token 永不刷新
+			name: "expires_at as unix millis - expired",
+			credentials: map[string]any{
+				"refresh_token": "rt-test",
+				"expires_at":    expiredMillis,
+			},
+			wantRefresh: true,
+		},
+		{
+			name: "expires_at as unix millis - outside window",
+			credentials: map[string]any{
+				"refresh_token": "rt-test",
+				"expires_at":    futureMillis,
 			},
 			wantRefresh: false,
 		},
 		{
-			name: "expires_at is invalid string",
+			// 没有 refresh_token 就无从刷新，与 Grok/OpenAI 刷新器保持一致
+			name: "no refresh_token - skipped even when expired",
 			credentials: map[string]any{
-				"expires_at": "invalid",
+				"expires_at": "1000",
 			},
 			wantRefresh: false,
 		},
@@ -115,13 +156,15 @@ func TestClaudeTokenRefresher_NeedsRefresh_WithinWindow(t *testing.T) {
 		{
 			name: "string type - within refresh window",
 			credentials: map[string]any{
-				"expires_at": strconv.FormatInt(expiresAt, 10),
+				"refresh_token": "rt-test",
+				"expires_at":    strconv.FormatInt(expiresAt, 10),
 			},
 		},
 		{
 			name: "float64 type - within refresh window",
 			credentials: map[string]any{
-				"expires_at": float64(expiresAt),
+				"refresh_token": "rt-test",
+				"expires_at":    float64(expiresAt),
 			},
 		},
 	}
@@ -154,13 +197,15 @@ func TestClaudeTokenRefresher_NeedsRefresh_OutsideWindow(t *testing.T) {
 		{
 			name: "string type - outside refresh window",
 			credentials: map[string]any{
-				"expires_at": strconv.FormatInt(expiresAt, 10),
+				"refresh_token": "rt-test",
+				"expires_at":    strconv.FormatInt(expiresAt, 10),
 			},
 		},
 		{
 			name: "float64 type - outside refresh window",
 			credentials: map[string]any{
-				"expires_at": float64(expiresAt),
+				"refresh_token": "rt-test",
+				"expires_at":    float64(expiresAt),
 			},
 		},
 	}


### PR DESCRIPTION
## Problem

Claude OAuth accounts can stop refreshing entirely. The stored `access_token` is then served past its expiry until the upstream rejects it:

```
401 {"type":"error","error":{"type":"authentication_error",
     "message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}
```

The failure is silent: `ClaudeTokenProvider.GetAccessToken` logs `claude_token_refresh_failed` at Warn and then returns the stale token anyway (`claude_token_provider.go:121`), so the only visible symptom is an upstream 401 that looks like a credential problem rather than a refresh problem.

## Root cause

`ClaudeTokenRefresher.NeedsRefresh` (`token_refresher.go:52`) is the single gate used by **both** refresh paths:

- the background `TokenRefreshService` — `token_refresh_service.go:619`
- the on-demand second check inside `OAuthRefreshAPI.RefreshIfNeeded` — `oauth_refresh_api.go:250`

If it returns `false`, nothing refreshes, ever. Two ways that happens:

**1. `expires_at` recorded in Unix milliseconds.**

`GetCredentialAsTime` (`account.go:342`) parsed every numeric timestamp as seconds:

```go
if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
    t := time.Unix(ts, 0)
    return &t
}
```

A millisecond value therefore lands far in the future and `time.Until()` saturates:

```
expires_at=1786102299052 -> time.Unix() = 58569-04-30 | time.Until = 2562047h47m | NeedsRefresh(3min) = false
```

This is reachable in normal use: Claude Code stores `expiresAt` in **milliseconds** in `~/.claude/.credentials.json`, and account credentials are persisted as supplied — `CreateAccountRequest.Credentials` is a raw `map[string]any` and only `NormalizeHeaderOverrideCredentials` runs over it (`admin_account.go:312`), so an imported credential document carries the millisecond value straight into the DB.

**2. `expires_at` missing or unparseable returned `false`, meaning "never refresh".**

This also contradicts the provider, which treats a nil expiry as *needing* a refresh:

```go
// claude_token_provider.go:82
needsRefresh := expiresAt == nil || time.Until(*expiresAt) <= claudeTokenRefreshSkew
```

So the provider requests a refresh, `RefreshIfNeeded` silently declines it at step 3, and the stale token is served and cached anyway.

`GrokTokenRefresher` (`grok_token_refresher.go:49`) and `OpenAITokenRefresher` (`token_refresher.go:103`) already treat an unknown expiry as "refresh" and skip accounts with no refresh token. Claude was the odd one out.

## Changes

- **`GetCredentialAsTime` detects millisecond timestamps.** Values above `1e11` (which as seconds would be year 5138) are parsed with `time.UnixMilli`. Shared by every platform's expiry handling, so Gemini/OpenAI/Grok/Antigravity benefit from the same normalization.
- **`ClaudeTokenRefresher.NeedsRefresh` treats an unknown expiry as "refresh now"** and skips accounts without a `refresh_token`, matching the existing Grok/OpenAI refreshers.
- **Parse `refresh_token_expires_in` and persist it as `refresh_token_expires_at`.** The Anthropic token endpoint returns this field; sub2api discarded it, so a refresh token that expires in ~28 days fails with no warning and no way to surface the deadline in the UI. It is omitted when upstream does not return it, so `MergeCredentials` preserves any previously known value.

## Ground truth used

Refresh behaviour was cross-checked against the official Claude Code client (v2.1.222). Its own OAuth refresh records:

```js
expiresAt: Date.now() + e.expires_in * 1000,           // milliseconds
refreshTokenExpiresAt: vFo(e.refresh_token_expires_in, true),
```

and refreshes when `Date.now() + 300000 >= expiresAt` (a 5-minute window). It warns the user once `refreshTokenExpiresAt` is within 3 days. That confirms both that `refresh_token_expires_in` is a real response field and that the millisecond `expiresAt` in `.credentials.json` is what users are copying in.

## Testing

```
go build ./...                 # OK
go test -tags=unit ./...       # OK
```

Two failures are **pre-existing** and unrelated — verified to reproduce identically on a clean checkout of `main` (`git stash` + rerun):

- `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` (`internal/service`)
- `TestAliyunCaptchaVerifier_TransportError` (`internal/repository`)

New/updated coverage:

- `TestGetCredentialAsTime_UnitDetection` — seconds vs milliseconds vs RFC3339, including the `9999999999` boundary that must stay seconds.
- `TestGetCredentialAsTime_MillisecondsDoNotLandInTheFarFuture` — regression test for the exact defect.
- `TestClaudeTokenRefresher_NeedsRefresh` — extended with millisecond cases, unknown-expiry cases, and a no-`refresh_token` case. Existing cases were given a `refresh_token` so they exercise the window logic rather than the new guard.
- `TestBuildClaudeAccountCredentials_RefreshTokenExpiresAt{,OmittedWhenUnknown}` — including that a previously known value survives `MergeCredentials`.

## Deliberately not included

Two further differences from the official client were found but left out, because they change the outbound request to Anthropic and I could not verify them against a live token endpoint without risking a regression for setups that work today:

1. Claude Code sends `scope` on refresh (the value matches this repo's `oauth.ScopeAPI` exactly); `claude_oauth_service.go:236` omits it. Note the Anthropic SDK's own `userOAuthProvider` also omits it, so this is likely tolerated.
2. Claude Code sends `anthropic-beta: oauth-2025-04-20` on `/v1/oauth/token`; `claude_oauth_service.go:246` does not.

Happy to add either if you would like them in scope.

---

<details>
<summary>中文摘要</summary>

Claude OAuth 账号可能完全停止刷新，过期的 `access_token` 会被继续发往上游，直到返回 401。

`ClaudeTokenRefresher.NeedsRefresh` 是后台定时刷新和请求路径二次确认**共用的唯一闸门**，两种情况下它会永远返回 `false`：

1. `expires_at` 存成了毫秒。`GetCredentialAsTime` 一律按秒解析，`1786102299052` 会变成公元 58569 年，`time.Until()` 饱和到最大值。Claude Code 的 `~/.claude/.credentials.json` 正是用毫秒记录 `expiresAt`，而账号凭据是原样入库的。
2. `expires_at` 缺失或无法解析时返回 `false`（永不刷新），这与 `ClaudeTokenProvider` 第 82 行的判断相互矛盾 —— provider 认为该刷新，`RefreshIfNeeded` 却静默否决。

修复：`GetCredentialAsTime` 自动识别毫秒时间戳；`NeedsRefresh` 在过期时间未知时刷新一次，并对齐 Grok/OpenAI 的 `refresh_token` 守卫；解析并保存 `refresh_token_expires_in`，以便在 refresh token（约 28 天）到期前有迹可循。

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
