### PR TITLE
fix(openai): preserve Codex usage percentages for scheduling thresholds

### DIFF
--- a/backend/internal/service/account_scheduling_threshold_eval.go
+++ b/backend/internal/service/account_scheduling_threshold_eval.go
@@ -245,7 +245,7 @@ func openAIThresholdCandidate(extra map[string]any, window string) *accountSched
 	}
 	return &accountSchedulingThresholdCandidate{
 		window:      window,
-		usedPercent: utilizationAsPercent(usedPercent),
+		usedPercent: schedulingPercentValue(usedPercent),
 		until:       parseSchedulingResetAt(extra[resetAtKey]),
 	}
 }

--- a/backend/internal/service/account_scheduling_threshold_eval_test.go
+++ b/backend/internal/service/account_scheduling_threshold_eval_test.go
@@ -96,7 +96,7 @@ func TestEvaluateAccountSchedulingThreshold_AnthropicIgnoresExpiredFiveHourWindo
 	require.True(t, wantUntil.Equal(*decision.Until))
 }
 
-func TestEvaluateAccountSchedulingThreshold_FractionalPlatformsKeepFractionSemantics(t *testing.T) {
+func TestEvaluateAccountSchedulingThreshold_OpenAIPreservesPercentageSemantics(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
@@ -104,17 +104,32 @@ func TestEvaluateAccountSchedulingThreshold_FractionalPlatformsKeepFractionSeman
 	openAIAccount := &Account{
 		Platform: PlatformOpenAI,
 		Extra: map[string]any{
-			"codex_5h_used_percent": 0.91,
+			"codex_5h_used_percent": 1.0,
 			"codex_5h_reset_at":     openAIUntil.Format(time.RFC3339),
 		},
 	}
 
+	candidate := openAIThresholdCandidate(openAIAccount.Extra, "5h")
+	require.NotNil(t, candidate)
+	require.Equal(t, 1.0, candidate.usedPercent)
+
 	openAIDecision := EvaluateAccountSchedulingThreshold(openAIAccount, map[string]int{
 		PlatformOpenAI: 90,
 	}, now)
+	require.False(t, openAIDecision.ShouldPause)
 
+	openAIAccount.Extra["codex_5h_used_percent"] = 91.0
+	openAIDecision = EvaluateAccountSchedulingThreshold(openAIAccount, map[string]int{
+		PlatformOpenAI: 90,
+	}, now)
 	require.True(t, openAIDecision.ShouldPause)
 	require.Equal(t, 91.0, openAIDecision.UsedPercent)
+}
+
+func TestEvaluateAccountSchedulingThreshold_AnthropicPreservesFractionalUtilizationSemantics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 
 	anthropicUntil := now.Add(5 * time.Hour)
 	anthropicAccount := &Account{


### PR DESCRIPTION
## 问题
OpenAI Codex 的用量快照本身已经是百分比，但调度阈值判断会将 `[0,1]` 范围内的值按小数比例再次转换，导致 1% 被错误识别为 100%。

## 根因
OpenAI 用量快照复用了面向小数比例利用率的转换逻辑。

## 改动
- 将 Codex 的 5 小时和 7 天用量快照直接按百分比读取。
- 保留 Anthropic 利用率原有的小数比例转换逻辑。
- 补充针对 1% 和触发调度阈值的百分比值的回归测试。

## 测试
以下检查均已通过：

- `cd backend && go test -tags=unit ./internal/service -run TestEvaluateAccountSchedulingThreshold_ -count=1`
- `cd backend && go test -tags=unit ./internal/service -count=1`
- `cd backend && go vet -tags=unit ./internal/service`
- `git diff --check`

Fixes #5468.
