### PR TITLE
fix(openai): sync OAuth account models from Codex manifest

### DIFF
--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -65,6 +65,7 @@ func setupSyncUpstreamModelsRouter(adminSvc service.AdminService, upstream servi
 		upstream,
 		&config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
 		nil,
+		nil,
 	)
 	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, nil, accountTestSvc, nil, nil, nil, nil, nil)
 	router.POST("/api/v1/admin/accounts/:id/models/sync-upstream", handler.SyncUpstreamModels)

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -146,6 +146,7 @@ type AccountTestService struct {
 	cfg                       *config.Config
 	settingService            *SettingService
 	tlsFPProfileService       *TLSFingerprintProfileService
+	openAIModelsManifest      openAIModelsManifestFetcher
 	agentIdentityTaskMu       sync.Mutex
 	agentIdentityWS           agentIdentityWSConnectionInvalidator
 	// grokWSDialer is optional; realtime account tests use the default OpenAI-style
@@ -169,6 +170,7 @@ func NewAccountTestService(
 	httpUpstream HTTPUpstream,
 	cfg *config.Config,
 	tlsFPProfileService *TLSFingerprintProfileService,
+	openAIModelsManifest openAIModelsManifestFetcher,
 ) *AccountTestService {
 	return &AccountTestService{
 		accountRepo:               accountRepo,
@@ -179,6 +181,7 @@ func NewAccountTestService(
 		httpUpstream:              httpUpstream,
 		cfg:                       cfg,
 		tlsFPProfileService:       tlsFPProfileService,
+		openAIModelsManifest:      openAIModelsManifest,
 	}
 }
 

--- a/backend/internal/service/upstream_models.go
+++ b/backend/internal/service/upstream_models.go
@@ -16,6 +16,10 @@ import (
 
 const upstreamModelsBodyLimit int64 = 8 << 20
 
+type openAIModelsManifestFetcher interface {
+	FetchCodexModelsManifest(context.Context, *Account, string, string) (*CodexModelsManifest, error)
+}
+
 // UpstreamModelSyncErrorKind classifies model sync failures for safe HTTP mapping.
 type UpstreamModelSyncErrorKind string
 
@@ -84,6 +88,9 @@ func (s *AccountTestService) FetchUpstreamSupportedModels(ctx context.Context, a
 	if account.Platform == PlatformAntigravity && account.Type != AccountTypeAPIKey {
 		return s.fetchAntigravityOAuthUpstreamModels(ctx, account)
 	}
+	if account.IsOpenAIOAuth() {
+		return s.fetchOpenAIOAuthUpstreamModels(ctx, account)
+	}
 
 	if s.httpUpstream == nil {
 		return nil, newUpstreamModelSyncConfigError("Upstream HTTP client is not configured", nil)
@@ -128,6 +135,48 @@ func (s *AccountTestService) FetchUpstreamSupportedModels(ctx context.Context, a
 		return nil, newUpstreamModelSyncUpstreamError("Upstream returned no supported models", nil)
 	}
 
+	return models, nil
+}
+
+func (s *AccountTestService) fetchOpenAIOAuthUpstreamModels(ctx context.Context, account *Account) ([]string, error) {
+	if s.openAIModelsManifest == nil {
+		return nil, newUpstreamModelSyncConfigError("OpenAI models manifest service is not configured", nil)
+	}
+
+	manifest, err := s.openAIModelsManifest.FetchCodexModelsManifest(ctx, account, "", "")
+	if err != nil {
+		return nil, newUpstreamModelSyncUpstreamError("Failed to request OpenAI models manifest", err)
+	}
+	if manifest == nil || manifest.NotModified {
+		return nil, newUpstreamModelSyncUpstreamError("OpenAI models manifest response was unusable", nil)
+	}
+
+	var envelope struct {
+		Models []struct {
+			Slug string `json:"slug"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(manifest.Body, &envelope); err != nil {
+		return nil, newUpstreamModelSyncUpstreamError("OpenAI models manifest response was not valid JSON", err)
+	}
+
+	seen := make(map[string]struct{}, len(envelope.Models))
+	models := make([]string, 0, len(envelope.Models))
+	for _, model := range envelope.Models {
+		slug := strings.TrimSpace(model.Slug)
+		if slug == "" {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		models = append(models, slug)
+	}
+	if len(models) == 0 {
+		return nil, newUpstreamModelSyncUpstreamError("OpenAI models manifest returned no supported models", nil)
+	}
+	sort.Strings(models)
 	return models, nil
 }
 

--- a/backend/internal/service/upstream_models_test.go
+++ b/backend/internal/service/upstream_models_test.go
@@ -40,6 +40,17 @@ func grokOAuthModelSyncTestAccount(baseURL string) *Account {
 	}
 }
 
+type openAIModelsManifestFetcherStub struct {
+	manifest *CodexModelsManifest
+	err      error
+	calls    int
+}
+
+func (s *openAIModelsManifestFetcherStub) FetchCodexModelsManifest(context.Context, *Account, string, string) (*CodexModelsManifest, error) {
+	s.calls++
+	return s.manifest, s.err
+}
+
 func TestBuildV1ModelsURL(t *testing.T) {
 	t.Parallel()
 
@@ -322,9 +333,11 @@ func TestFetchUpstreamSupportedModelsParsesOpenAIResponse(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"data":[{"id":"gpt-5"},{"id":"gpt-5"},{"name":"o3"}]}`)),
 	}}
+	manifestFetcher := &openAIModelsManifestFetcherStub{}
 	svc := &AccountTestService{
-		httpUpstream: upstream,
-		cfg:          upstreamModelSyncTestConfig(),
+		httpUpstream:         upstream,
+		cfg:                  upstreamModelSyncTestConfig(),
+		openAIModelsManifest: manifestFetcher,
 	}
 
 	models, err := svc.FetchUpstreamSupportedModels(context.Background(), &Account{
@@ -340,6 +353,61 @@ func TestFetchUpstreamSupportedModelsParsesOpenAIResponse(t *testing.T) {
 	require.Equal(t, []string{"gpt-5", "o3"}, models)
 	require.Equal(t, "https://openai.example.com/v1/models", upstream.lastReq.URL.String())
 	require.Equal(t, "Bearer openai-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Zero(t, manifestFetcher.calls)
+}
+
+func TestFetchUpstreamSupportedModelsOpenAIOAuthUsesCodexManifest(t *testing.T) {
+	t.Parallel()
+
+	manifestFetcher := &openAIModelsManifestFetcherStub{manifest: &CodexModelsManifest{
+		Body: []byte(`{"models":[{"slug":" z-model "},{"slug":""},{"slug":"a-model"},{"slug":"z-model"},{"slug":"   "}]}`),
+	}}
+	svc := &AccountTestService{openAIModelsManifest: manifestFetcher}
+
+	models, err := svc.FetchUpstreamSupportedModels(context.Background(), &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "oauth-access-token",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a-model", "z-model"}, models)
+	require.Equal(t, 1, manifestFetcher.calls)
+}
+
+func TestFetchUpstreamSupportedModelsOpenAIOAuthSanitizesManifestFailure(t *testing.T) {
+	t.Parallel()
+
+	manifestFetcher := &openAIModelsManifestFetcherStub{err: errors.New("upstream leaked SECRET_TOKEN")}
+	svc := &AccountTestService{openAIModelsManifest: manifestFetcher}
+
+	_, err := svc.FetchUpstreamSupportedModels(context.Background(), &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	})
+	require.Error(t, err)
+
+	var syncErr *UpstreamModelSyncError
+	require.True(t, errors.As(err, &syncErr))
+	require.Equal(t, UpstreamModelSyncErrorUpstream, syncErr.Kind)
+	require.Equal(t, "Failed to request OpenAI models manifest", syncErr.SafeMessage())
+	require.NotContains(t, syncErr.SafeMessage(), "SECRET_TOKEN")
+}
+
+func TestFetchUpstreamSupportedModelsOpenAIOAuthRequiresManifestService(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&AccountTestService{}).FetchUpstreamSupportedModels(context.Background(), &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	})
+	require.Error(t, err)
+
+	var syncErr *UpstreamModelSyncError
+	require.True(t, errors.As(err, &syncErr))
+	require.Equal(t, UpstreamModelSyncErrorConfiguration, syncErr.Kind)
+	require.Equal(t, "OpenAI models manifest service is not configured", syncErr.SafeMessage())
 }
 
 func TestFetchUpstreamSupportedModelsParsesGrokAPIKeyResponse(t *testing.T) {

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -241,6 +241,7 @@ func ProvideAccountTestService(
 		httpUpstream,
 		cfg,
 		tlsFPProfileService,
+		openAIGatewayService,
 	)
 	service.agentIdentityWS = openAIGatewayService
 	service.SetSettingService(settingService)


### PR DESCRIPTION
## 问题

OpenAI OAuth 账户同步上游模型时沿用 `/v1/models` 请求，无法获得 Codex 客户端实际使用的模型清单。

## 根因

账户模型同步流程未区分 OpenAI OAuth 与 API-key 账户，也未复用 Codex 模型 manifest 服务。重复/重叠预检查未发现等效的活跃实现。

## 改动

OpenAI OAuth 账户改为从 Codex manifest 获取模型 slug，并对结果去空、去重和排序；manifest 请求失败、无效或未配置时返回经过清理的同步错误。API-key `/v1/models` 行为保持不变，并补充服务注入与覆盖测试。

## 测试

- `cd backend && go test ./internal/service -run 'TestFetchUpstreamSupportedModels(OpenAIOAuth|ParsesOpenAIResponse)|TestBuildUpstreamModelsRequestsForAPIKeyAccounts' -count=1`
- `cd backend && go test ./internal/handler/admin -run TestAccountHandlerSyncUpstreamModels -count=1`
- `cd backend && go test ./internal/service -count=1`
- `cd backend && go test ./internal/handler/admin -count=1`
- `cd backend && go vet ./internal/service ./internal/handler/admin`
- 对五个已批准的 Go 文件执行 `gofmt` 检查
- `git diff --check`
- 新增行静态安全扫描，无发现

Fixes #5473
