### PR TITLE
fix(openai-oauth): 个人订阅到期时间不再被 POID workspace 的 entitlement 覆盖

### DIFF
--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -269,22 +269,35 @@ func (s *OpenAIOAuthService) enrichTokenInfo(ctx context.Context, tokenInfo *Ope
 			orgID = atClaims.OpenAIAuth.POID
 		}
 	}
+	// accounts/check 命中的记录不属于个人账号时，必须改用个人订阅端点拿到期时间，
+	// 否则会把 workspace 权益的 expires_at 当成个人订阅到期日展示。
+	forcePersonalSubscriptionLookup := false
 	if info := fetchChatGPTAccountInfo(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, orgID); info != nil {
 		// chatgpt_plan_type from the ID token is the canonical personal-plan value.
 		// accounts/check is a multi-account/workspace endpoint; inactive team or
 		// business workspaces can otherwise overwrite Pro/Free with internal
 		// workspace billing plan names such as self_serve_business_usage_based.
-		if shouldApplyChatGPTAccountInfoPlanType(tokenInfo.PlanType, info.PlanType) {
+		appliedAccountInfoPlanType := shouldApplyChatGPTAccountInfoPlanType(tokenInfo.PlanType, info.PlanType)
+		if appliedAccountInfoPlanType {
 			tokenInfo.PlanType = info.PlanType
 		}
+		// plan_type 与 subscription_expires_at 必须描述同一份订阅。套餐取自
+		// accounts/check 时，到期时间跟着取同一条记录；套餐保留了 JWT 里的个人值时，
+		// 只有该记录确实就是个人账号才能用它的 entitlement.expires_at——poid 指向的
+		// 默认 Personal workspace 与 chatgpt_account_id 可以是两个不同的标识，
+		// 混用会显示成「个人 Pro + workspace 到期时间」。
 		if info.SubscriptionExpiresAt != "" {
-			tokenInfo.SubscriptionExpiresAt = info.SubscriptionExpiresAt
+			if appliedAccountInfoPlanType || chatGPTAccountInfoBelongsToTokenAccount(tokenInfo, info) {
+				tokenInfo.SubscriptionExpiresAt = info.SubscriptionExpiresAt
+			} else {
+				forcePersonalSubscriptionLookup = true
+			}
 		}
 		if tokenInfo.Email == "" && info.Email != "" {
 			tokenInfo.Email = info.Email
 		}
 	}
-	if strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
+	if forcePersonalSubscriptionLookup || strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
 		if expiresAt := fetchChatGPTSubscriptionExpiresAt(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, resolveChatGPTSubscriptionAccountID(tokenInfo, orgID)); expiresAt != "" {
 			tokenInfo.SubscriptionExpiresAt = expiresAt
 		}
@@ -296,6 +309,17 @@ func (s *OpenAIOAuthService) enrichTokenInfo(ctx context.Context, tokenInfo *Ope
 
 func shouldApplyChatGPTAccountInfoPlanType(current, candidate string) bool {
 	return strings.TrimSpace(candidate) != "" && strings.TrimSpace(current) == ""
+}
+
+// chatGPTAccountInfoBelongsToTokenAccount 判断 accounts/check 命中的那条记录是不是
+// token 自己的个人 ChatGPT 账号。两侧任一缺 ID 时无法区分，返回 true 保持既有行为。
+func chatGPTAccountInfoBelongsToTokenAccount(tokenInfo *OpenAITokenInfo, info *ChatGPTAccountInfo) bool {
+	personalID := strings.TrimSpace(tokenInfo.ChatGPTAccountID)
+	sourceID := strings.TrimSpace(info.AccountID)
+	if personalID == "" || sourceID == "" {
+		return true
+	}
+	return strings.EqualFold(personalID, sourceID)
 }
 
 func resolveChatGPTSubscriptionAccountID(tokenInfo *OpenAITokenInfo, orgID string) string {

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -88,8 +88,12 @@ func disableOpenAITraining(ctx context.Context, clientFactory PrivacyClientFacto
 
 // ChatGPTAccountInfo 从 chatgpt.com/backend-api/accounts/check 获取的账号信息
 type ChatGPTAccountInfo struct {
-	PlanType              string
-	Email                 string
+	PlanType string
+	Email    string
+	// AccountID 是本条信息所属账号的标识（优先取 account.account_id，否则取 accounts
+	// 的 map key）。accounts/check 是多账号/工作区端点，调用方需要据此判断拿到的
+	// plan_type / expires_at 到底属于个人账号还是某个 workspace。
+	AccountID             string
 	SubscriptionExpiresAt string // entitlement.expires_at (RFC3339)
 }
 
@@ -149,7 +153,7 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 		if acctRaw, ok := accounts[orgID]; ok {
 			if acct, ok := acctRaw.(map[string]any); ok {
 				if isUsableChatGPTAccountCandidate(acct, time.Now()) {
-					fillAccountInfo(info, acct)
+					fillAccountInfo(info, acct, orgID)
 				}
 			}
 		}
@@ -160,9 +164,10 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 		type candidate struct {
 			planType  string
 			expiresAt string
+			accountID string
 		}
 		var defaultC, paidC, anyC candidate
-		for _, acctRaw := range accounts {
+		for key, acctRaw := range accounts {
 			acct, ok := acctRaw.(map[string]any)
 			if !ok {
 				continue
@@ -175,26 +180,27 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 				continue
 			}
 			ea := extractEntitlementExpiresAt(acct)
+			id := chatGPTAccountObjectID(acct, key)
 			if anyC.planType == "" {
-				anyC = candidate{planType, ea}
+				anyC = candidate{planType, ea, id}
 			}
 			if account, ok := acct["account"].(map[string]any); ok {
 				if isDefault, _ := account["is_default"].(bool); isDefault {
-					defaultC = candidate{planType, ea}
+					defaultC = candidate{planType, ea, id}
 				}
 			}
 			if !strings.EqualFold(planType, "free") && paidC.planType == "" {
-				paidC = candidate{planType, ea}
+				paidC = candidate{planType, ea, id}
 			}
 		}
 		// 优先级：default > 非 free > 任意
 		switch {
 		case defaultC.planType != "":
-			info.PlanType, info.SubscriptionExpiresAt = defaultC.planType, defaultC.expiresAt
+			info.PlanType, info.SubscriptionExpiresAt, info.AccountID = defaultC.planType, defaultC.expiresAt, defaultC.accountID
 		case paidC.planType != "":
-			info.PlanType, info.SubscriptionExpiresAt = paidC.planType, paidC.expiresAt
+			info.PlanType, info.SubscriptionExpiresAt, info.AccountID = paidC.planType, paidC.expiresAt, paidC.accountID
 		default:
-			info.PlanType, info.SubscriptionExpiresAt = anyC.planType, anyC.expiresAt
+			info.PlanType, info.SubscriptionExpiresAt, info.AccountID = anyC.planType, anyC.expiresAt, anyC.accountID
 		}
 	}
 
@@ -263,10 +269,23 @@ func fetchChatGPTSubscriptionExpiresAt(ctx context.Context, clientFactory Privac
 	return activeUntil
 }
 
-// fillAccountInfo 从单个 account 对象中提取 plan_type 和 subscription_expires_at
-func fillAccountInfo(info *ChatGPTAccountInfo, acct map[string]any) {
+// fillAccountInfo 从单个 account 对象中提取 plan_type 和 subscription_expires_at。
+// fallbackID 是该对象在 accounts 里的 map key，用于 account.account_id 缺失时兜底。
+func fillAccountInfo(info *ChatGPTAccountInfo, acct map[string]any, fallbackID string) {
 	info.PlanType = extractPlanType(acct)
 	info.SubscriptionExpiresAt = extractEntitlementExpiresAt(acct)
+	info.AccountID = chatGPTAccountObjectID(acct, fallbackID)
+}
+
+// chatGPTAccountObjectID 取单个 account 对象的账号标识。
+// accounts 的 map key 有时是 "default" 这类别名，所以优先读 account.account_id。
+func chatGPTAccountObjectID(acct map[string]any, fallbackID string) string {
+	if account, ok := acct["account"].(map[string]any); ok {
+		if id, ok := account["account_id"].(string); ok && strings.TrimSpace(id) != "" {
+			return strings.TrimSpace(id)
+		}
+	}
+	return strings.TrimSpace(fallbackID)
 }
 
 // extractPlanType 从单个 account 对象中提取 plan_type

--- a/backend/internal/service/openai_subscription_test.go
+++ b/backend/internal/service/openai_subscription_test.go
@@ -125,3 +125,222 @@ func TestShouldApplyChatGPTAccountInfoPlanType(t *testing.T) {
 	require.False(t, shouldApplyChatGPTAccountInfoPlanType("", ""))
 	require.True(t, shouldApplyChatGPTAccountInfoPlanType("", "pro"))
 }
+
+func TestChatGPTAccountInfoBelongsToTokenAccount(t *testing.T) {
+	require.False(t, chatGPTAccountInfoBelongsToTokenAccount(
+		&OpenAITokenInfo{ChatGPTAccountID: "personal-a"}, &ChatGPTAccountInfo{AccountID: "workspace-b"}))
+	require.True(t, chatGPTAccountInfoBelongsToTokenAccount(
+		&OpenAITokenInfo{ChatGPTAccountID: "personal-a"}, &ChatGPTAccountInfo{AccountID: "PERSONAL-A"}))
+	// 任一侧缺 ID 时无法区分，保持既有行为（采用 accounts/check 的值）。
+	require.True(t, chatGPTAccountInfoBelongsToTokenAccount(
+		&OpenAITokenInfo{}, &ChatGPTAccountInfo{AccountID: "workspace-b"}))
+	require.True(t, chatGPTAccountInfoBelongsToTokenAccount(
+		&OpenAITokenInfo{ChatGPTAccountID: "personal-a"}, &ChatGPTAccountInfo{}))
+}
+
+// accounts 的 map key 可能是 "default" 这类别名，account.account_id 才是账号标识。
+func TestFetchChatGPTAccountInfo_ReportsAccountID(t *testing.T) {
+	futureAt := time.Now().Add(720 * time.Hour).UTC().Format(time.RFC3339)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accounts": map[string]any{
+				"default": map[string]any{
+					"account": map[string]any{
+						"account_id": "personal-account-a",
+						"plan_type":  "plus",
+						"is_default": true,
+					},
+					"entitlement": map[string]any{"expires_at": futureAt},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	oldURL := chatGPTAccountsCheckURL
+	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
+	t.Cleanup(func() { chatGPTAccountsCheckURL = oldURL })
+
+	got := fetchChatGPTAccountInfo(context.Background(), newTestPrivacyClientFactory(), "access-token", "", "")
+	require.NotNil(t, got)
+	require.Equal(t, "plus", got.PlanType)
+	require.Equal(t, "personal-account-a", got.AccountID, "应优先取 account.account_id 而不是 map key")
+}
+
+// issue #5459：poid 指向的默认 Personal workspace 与 chatgpt_account_id 是两个不同的
+// 标识时，accounts/check 返回的是 workspace 的 entitlement.expires_at。plan_type 那侧
+// 已被 shouldApplyChatGPTAccountInfoPlanType 挡住（保留 JWT 里的个人套餐），到期时间
+// 这侧原先无条件覆盖，于是显示成「个人 Pro + workspace 到期时间」。
+func TestEnrichTokenInfo_WorkspaceEntitlementDoesNotOverridePersonalSubscription(t *testing.T) {
+	const (
+		personalAccountID   = "personal-account-a"
+		workspaceAccountID  = "personal-workspace-b"
+		personalActiveUntil = "2027-03-01T00:00:00Z"
+	)
+	workspaceExpiresAt := time.Now().Add(720 * time.Hour).UTC().Format(time.RFC3339)
+
+	subscriptionCalls := 0
+	server := newChatGPTBackendTestServer(t, chatGPTBackendTestServerConfig{
+		accountsCheck: map[string]any{
+			"accounts": map[string]any{
+				workspaceAccountID: map[string]any{
+					"account": map[string]any{
+						"account_id": workspaceAccountID,
+						"plan_type":  "pro",
+						"is_default": true,
+					},
+					"entitlement": map[string]any{"expires_at": workspaceExpiresAt},
+				},
+			},
+		},
+		onSubscription: func(accountID string) map[string]any {
+			subscriptionCalls++
+			require.Equal(t, personalAccountID, accountID,
+				"必须用个人 chatgpt_account_id 查订阅，而不是 poid workspace")
+			return map[string]any{"plan_type": "pro", "active_until": personalActiveUntil, "will_renew": true}
+		},
+	})
+	defer server.Close()
+
+	tokenInfo := &OpenAITokenInfo{
+		AccessToken:      "access-token",
+		ChatGPTAccountID: personalAccountID,
+		OrganizationID:   workspaceAccountID,
+		PlanType:         "pro", // 来自 id_token 的个人套餐
+	}
+	svc := &OpenAIOAuthService{privacyClientFactory: newTestPrivacyClientFactory()}
+	svc.enrichTokenInfo(context.Background(), tokenInfo, "")
+
+	require.Equal(t, "pro", tokenInfo.PlanType)
+	require.Equal(t, personalActiveUntil, tokenInfo.SubscriptionExpiresAt,
+		"到期时间必须来自个人订阅 active_until，不能是 workspace 的 entitlement.expires_at")
+	require.NotEqual(t, workspaceExpiresAt, tokenInfo.SubscriptionExpiresAt)
+	require.Equal(t, 1, subscriptionCalls)
+}
+
+// 单个人账号（poid == chatgpt_account_id）是绝大多数情况，行为必须保持不变：
+// 直接用 accounts/check 的 entitlement，不额外打订阅端点。
+func TestEnrichTokenInfo_KeepsEntitlementWhenAccountMatches(t *testing.T) {
+	const personalAccountID = "personal-account-a"
+	entitlementExpiresAt := time.Now().Add(720 * time.Hour).UTC().Format(time.RFC3339)
+
+	subscriptionCalls := 0
+	server := newChatGPTBackendTestServer(t, chatGPTBackendTestServerConfig{
+		accountsCheck: map[string]any{
+			"accounts": map[string]any{
+				personalAccountID: map[string]any{
+					"account": map[string]any{
+						"account_id": personalAccountID,
+						"plan_type":  "plus",
+						"is_default": true,
+					},
+					"entitlement": map[string]any{"expires_at": entitlementExpiresAt},
+				},
+			},
+		},
+		onSubscription: func(string) map[string]any {
+			subscriptionCalls++
+			return map[string]any{}
+		},
+	})
+	defer server.Close()
+
+	tokenInfo := &OpenAITokenInfo{
+		AccessToken:      "access-token",
+		ChatGPTAccountID: personalAccountID,
+		OrganizationID:   personalAccountID,
+		PlanType:         "plus",
+	}
+	svc := &OpenAIOAuthService{privacyClientFactory: newTestPrivacyClientFactory()}
+	svc.enrichTokenInfo(context.Background(), tokenInfo, "")
+
+	require.Equal(t, entitlementExpiresAt, tokenInfo.SubscriptionExpiresAt)
+	require.Zero(t, subscriptionCalls, "账号一致时不应额外请求订阅端点")
+}
+
+// 反向不变式：套餐本身就取自 accounts/check（JWT 没有 plan_type）时，到期时间必须
+// 跟着取同一条记录，否则会变成「workspace 套餐 + 个人到期时间」的另一种错配。
+func TestEnrichTokenInfo_WorkspacePlanTypeKeepsItsOwnExpiry(t *testing.T) {
+	const workspaceAccountID = "workspace-b"
+	workspaceExpiresAt := time.Now().Add(720 * time.Hour).UTC().Format(time.RFC3339)
+
+	subscriptionCalls := 0
+	server := newChatGPTBackendTestServer(t, chatGPTBackendTestServerConfig{
+		accountsCheck: map[string]any{
+			"accounts": map[string]any{
+				workspaceAccountID: map[string]any{
+					"account": map[string]any{
+						"account_id": workspaceAccountID,
+						"plan_type":  "self_serve_business_usage_based",
+						"is_default": true,
+					},
+					"entitlement": map[string]any{"expires_at": workspaceExpiresAt},
+				},
+			},
+		},
+		onSubscription: func(string) map[string]any {
+			subscriptionCalls++
+			return map[string]any{}
+		},
+	})
+	defer server.Close()
+
+	tokenInfo := &OpenAITokenInfo{
+		AccessToken:      "access-token",
+		ChatGPTAccountID: "personal-account-a",
+		OrganizationID:   workspaceAccountID,
+		// id_token 没带 chatgpt_plan_type
+	}
+	svc := &OpenAIOAuthService{privacyClientFactory: newTestPrivacyClientFactory()}
+	svc.enrichTokenInfo(context.Background(), tokenInfo, "")
+
+	require.Equal(t, "self_serve_business_usage_based", tokenInfo.PlanType)
+	require.Equal(t, workspaceExpiresAt, tokenInfo.SubscriptionExpiresAt,
+		"套餐与到期时间必须来自同一条记录")
+	require.Zero(t, subscriptionCalls)
+}
+
+type chatGPTBackendTestServerConfig struct {
+	accountsCheck  map[string]any
+	onSubscription func(accountID string) map[string]any
+}
+
+// newChatGPTBackendTestServer 同时接管 accounts/check 与 subscriptions 两个端点，
+// 并在 t.Cleanup 里还原包级 URL 变量。
+func newChatGPTBackendTestServer(t *testing.T, cfg chatGPTBackendTestServerConfig) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			_ = json.NewEncoder(w).Encode(cfg.accountsCheck)
+		case "/backend-api/subscriptions":
+			body := map[string]any{}
+			if cfg.onSubscription != nil {
+				body = cfg.onSubscription(r.URL.Query().Get("account_id"))
+			}
+			_ = json.NewEncoder(w).Encode(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	oldAccounts, oldSubscriptions := chatGPTAccountsCheckURL, chatGPTSubscriptionsURL
+	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
+	chatGPTSubscriptionsURL = server.URL + "/backend-api/subscriptions"
+	t.Cleanup(func() {
+		chatGPTAccountsCheckURL, chatGPTSubscriptionsURL = oldAccounts, oldSubscriptions
+	})
+	return server
+}
+
+// enrichTokenInfo 收尾还会调用 disableOpenAITraining，它的 URL 是常量、指向真实
+// chatgpt.com，测试无法接管。给客户端一个短超时让它快速失败——该调用只写
+// PrivacyMode，不影响本组用例的断言。
+func newTestPrivacyClientFactory() PrivacyClientFactory {
+	return func(string) (*req.Client, error) {
+		return req.C().SetTimeout(time.Second), nil
+	}
+}


### PR DESCRIPTION
Fixes #5459

## 问题

OpenAI OAuth 账号页显示「个人 Pro + 一个对不上的到期时间」。报告者给的脱敏数据里：

```text
chatgpt_account_id = <个人账号-A>
poid               = <Personal-workspace-B>     # A != B
accounts/check → accounts["<Personal-workspace-B>"].entitlement.expires_at = <workspace-时间-X>
GET /backend-api/subscriptions?account_id=<个人账号-A> → active_until = <个人订阅时间-Y>
```

`X != Y`，页面显示的是 `Pro + X`。

## 根因：同一函数里两个相邻字段的取值口径不一致

`enrichTokenInfo`（`openai_oauth_service.go:272-291`）：

```go
if info := fetchChatGPTAccountInfo(...); info != nil {
    // plan_type：有护栏（#3641 加的）
    if shouldApplyChatGPTAccountInfoPlanType(tokenInfo.PlanType, info.PlanType) {
        tokenInfo.PlanType = info.PlanType
    }
    // subscription_expires_at：无条件覆盖  ← 缺同样的护栏
    if info.SubscriptionExpiresAt != "" {
        tokenInfo.SubscriptionExpiresAt = info.SubscriptionExpiresAt
    }
}
```

`shouldApplyChatGPTAccountInfoPlanType` 只在个人值为空时才让 accounts/check 补位，所以 `plan_type` 保住了 id_token 里的 `pro`；`subscription_expires_at` 没有这层保护，被 workspace 的 `entitlement.expires_at` 盖掉。两个字段于是描述了两份不同的订阅。

`fetchChatGPTAccountInfo` 命中哪条记录由 access_token JWT 的 `poid` 决定（`openai_privacy_service.go:148-156`），poid 指向 Personal workspace 时拿到的就是 workspace 权益。

**正确的来源代码里本来就有**——用个人 `chatgpt_account_id` 查 `/backend-api/subscriptions` 的 `active_until`（`resolveChatGPTSubscriptionAccountID` 第一顺位就是 `ChatGPTAccountID`）。但它被守卫挡着：

```go
if strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {   // workspace 值一写进去就永远为 false
    ... fetchChatGPTSubscriptionExpiresAt(...)
}
```

## 改动

把不变式写死成「**plan_type 与 subscription_expires_at 必须描述同一份订阅**」：

| 情形 | plan_type 来源 | 到期时间取法 | 相对旧行为 |
|---|---|---|---|
| id_token 没带 `chatgpt_plan_type` | accounts/check | 跟着取同一条记录 | 不变 |
| id_token 带个人套餐，且命中记录就是个人账号（`poid == chatgpt_account_id`，绝大多数情况） | id_token | accounts/check 的 entitlement | 不变 |
| id_token 带个人套餐，但命中记录是别的账号（本 issue） | id_token | **强制回落个人订阅端点 `active_until`** | 修复点 |
| 任一侧缺 ID，无法区分归属 | — | 沿用 accounts/check | 不变 |

为此给 `ChatGPTAccountInfo` 补了 `AccountID`：优先读 `account.account_id`，缺失时退回 `accounts` 的 map key——key 有可能是 `"default"` 这类别名，直接拿 key 比对会把本来正确的个人记录误判成"别的账号"。

第三行的实现是把 `forcePersonalSubscriptionLookup` 加进已有的兜底条件，而不是新写一条请求链路：

```go
if forcePersonalSubscriptionLookup || strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
    if expiresAt := fetchChatGPTSubscriptionExpiresAt(..., resolveChatGPTSubscriptionAccountID(tokenInfo, orgID)); expiresAt != "" {
        tokenInfo.SubscriptionExpiresAt = expiresAt
    }
}
```

这样也顺带修掉存量：`RefreshAccountToken` 的无 refresh_token 分支（`openai_oauth_service.go:342-353`）会用 `account.GetCredential("subscription_expires_at")` 预填 tokenInfo，旧逻辑下已经被污染的 workspace 时间会因为"非空"而永远不再刷新；现在只要检出归属不符就会重新拉个人 `active_until` 覆盖掉。

**未包含（有意为之）**：
- 不改 `shouldApplyChatGPTAccountInfoPlanType` 的语义，#3641 的护栏原样保留。
- 归属不符且个人订阅端点也没返回 `active_until` 时，到期时间留空而不是退回 workspace 值——展示一个属于别人的日期比不展示更有害，这也是 issue 的诉求。
- 不新增账号级配置开关；判定完全靠上游返回的标识，无需站长干预。

## 验证

```
go build ./...                                                 OK
go vet -tags unit ./internal/service/                          OK
gofmt -l （本 PR 三个文件）                                     干净
go test -tags unit ./internal/service/                         ok  147.6s
go test -tags unit ./internal/handler/... ./internal/pkg/...   全部 ok
```

新增 6 个用例（追加在既有的 `openai_subscription_test.go`，沿用该文件的 httptest 模式）：

- `TestEnrichTokenInfo_WorkspaceEntitlementDoesNotOverridePersonalSubscription` —— 复刻 issue 场景，并断言订阅端点**收到的是个人 `chatgpt_account_id`**、只被调用一次；
- `TestEnrichTokenInfo_KeepsEntitlementWhenAccountMatches` —— 单人账号行为不变，且**不额外打订阅端点**（防止我这版引入多余请求）；
- `TestEnrichTokenInfo_WorkspacePlanTypeKeepsItsOwnExpiry` —— 反向不变式：套餐取自 accounts/check 时到期时间必须跟着走，不能变成「workspace 套餐 + 个人到期时间」的另一种错配；
- `TestFetchChatGPTAccountInfo_ReportsAccountID` —— map key 为 `"default"` 时须取 `account.account_id`；
- `TestChatGPTAccountInfoBelongsToTokenAccount` —— 大小写不敏感、缺 ID 时保守返回 true。

**回滚验证**：把 `subscription_expires_at` 改回无条件覆盖后，`TestEnrichTokenInfo_WorkspaceEntitlementDoesNotOverridePersonalSubscription` FAIL —— `expected: "2027-03-01T00:00:00Z"（个人 active_until）, actual: "2026-09-09T01:25:08Z"（workspace entitlement）`，正是 issue 描述的症状。

一处测试实现说明：`enrichTokenInfo` 收尾会调 `disableOpenAITraining`，它的 URL 是常量、指向真实 chatgpt.com，测试接管不了；给测试用 `req.Client` 设了 1 秒超时让它快速失败（该调用只写 `PrivacyMode`，与本组断言无关），这也是三个 enrich 用例各耗时约 0.7 秒的原因。

golangci-lint v2.9 无法在本地运行（其 go.mod 锁 toolchain go1.25，低于本仓库的 go 1.26.5，加载配置即报错），这一项留给 CI。
