### PR TITLE
fix(openai): retry rejected reasoning content

### DIFF
--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -15,8 +15,9 @@ import (
 const maxOpenAIResponsesRejectedFieldRetries = 6
 
 var (
-	openAIResponsesRejectedNamespaceParamPattern = regexp.MustCompile(`(?i)^input\[(\d+)\]\.namespace$`)
-	openAIResponsesRejectedMessageParamPattern   = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|input\[\d+\]\.namespace)(?:["']|\b)`)
+	openAIResponsesRejectedNamespaceParamPattern        = regexp.MustCompile(`(?i)^input\[(\d+)\]\.namespace$`)
+	openAIResponsesRejectedReasoningContentParamPattern = regexp.MustCompile(`(?i)^input\[(\d+)\]\.content$`)
+	openAIResponsesRejectedMessageParamPattern          = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|input\[\d+\]\.namespace)(?:["']|\b)`)
 )
 
 type openAIResponsesRejectedFieldRetryState struct {
@@ -61,12 +62,18 @@ func normalizeOpenAIResponsesRejectedFieldRetryBody(statusCode int, body, respon
 	}
 
 	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(responseBody)))
+	param := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.param").String()))
+	if code == "array_above_max_length" {
+		if index, ok := openAIResponsesRejectedReasoningContentIndex(param); ok {
+			return removeOpenAIResponsesRejectedReasoningContentAtIndex(body, index)
+		}
+		return nil, "", false, nil
+	}
+
 	message := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(responseBody)))
 	if !isExplicitOpenAIResponsesFieldRejection(code, message) {
 		return nil, "", false, nil
 	}
-
-	param := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.param").String()))
 	if param == "" {
 		param = openAIResponsesRejectedParamFromMessage(message)
 	}
@@ -110,6 +117,37 @@ func openAIResponsesRejectedNamespaceIndex(param string) (int, bool) {
 		return index, true
 	}
 	return 0, false
+}
+
+func openAIResponsesRejectedReasoningContentIndex(param string) (int, bool) {
+	match := openAIResponsesRejectedReasoningContentParamPattern.FindStringSubmatch(strings.TrimSpace(param))
+	if len(match) != 2 {
+		return 0, false
+	}
+	index, err := strconv.Atoi(match[1])
+	if err == nil && index >= 0 {
+		return index, true
+	}
+	return 0, false
+}
+
+func removeOpenAIResponsesRejectedReasoningContentAtIndex(body []byte, index int) ([]byte, string, bool, error) {
+	itemPath := fmt.Sprintf("input.%d", index)
+	itemType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, itemPath+".type").String()))
+	if itemType != "reasoning" {
+		return nil, "", false, nil
+	}
+
+	contentPath := itemPath + ".content"
+	content := gjson.GetBytes(body, contentPath)
+	if !content.Exists() || !content.IsArray() || len(content.Array()) == 0 {
+		return nil, "", false, nil
+	}
+	retryBody, err := sjson.DeleteBytes(body, contentPath)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("delete rejected reasoning content at input[%d]: %w", index, err)
+	}
+	return retryBody, "indexed reasoning content array rejection", true, nil
 }
 
 func removeOpenAIResponsesRejectedNamespaceAtIndex(body []byte, index int) ([]byte, string, bool, error) {

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -30,6 +30,107 @@ func TestOpenAIResponsesRejectedFieldRetryStateRejectsDuplicateBodyAndCap(t *tes
 	require.False(t, state.Allow([]byte(`{"model":"gpt-5.5","variant":"overflow"}`)))
 }
 
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRemovesRejectedReasoningContent(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"keep user"}]},{"type":"reasoning","id":"rs_keep","summary":[{"type":"summary_text","text":"keep summary"}],"encrypted_content":"keep encrypted","content":[{"type":"reasoning_text","text":"remove content"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"keep assistant"}]}]}`)
+	responseBody := []byte(`{"error":{"code":"array_above_max_length","message":"Invalid 'input[1].content': array too long. Expected an array with maximum length 0, but got an array with length 1 instead.","param":"input[1].content","type":"invalid_request_error"}}`)
+
+	retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "indexed reasoning content array rejection", reason)
+	require.False(t, gjson.GetBytes(retryBody, "input.1.content").Exists())
+	require.Equal(t, "rs_keep", gjson.GetBytes(retryBody, "input.1.id").String())
+	require.Equal(t, "keep summary", gjson.GetBytes(retryBody, "input.1.summary.0.text").String())
+	require.Equal(t, "keep encrypted", gjson.GetBytes(retryBody, "input.1.encrypted_content").String())
+	require.Equal(t, "keep user", gjson.GetBytes(retryBody, "input.0.content.0.text").String())
+	require.Equal(t, "keep assistant", gjson.GetBytes(retryBody, "input.2.content.0.text").String())
+}
+
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRejectsUnsafeReasoningContentRetries(t *testing.T) {
+	validError := `{"error":{"code":"array_above_max_length","message":"Invalid input content","param":"input[0].content","type":"invalid_request_error"}}`
+	tests := []struct {
+		name         string
+		statusCode   int
+		body         string
+		responseBody string
+	}{
+		{
+			name:         "non bad request status",
+			statusCode:   http.StatusUnprocessableEntity,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: validError,
+		},
+		{
+			name:         "wrong error code",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: `{"error":{"code":"invalid_request_error","message":"Invalid input content","param":"input[0].content","type":"invalid_request_error"}}`,
+		},
+		{
+			name:         "message-only parameter is not trusted",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: `{"error":{"code":"array_above_max_length","message":"Invalid 'input[0].content'","type":"invalid_request_error"}}`,
+		},
+		{
+			name:         "message item",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"message","content":[{"type":"input_text","text":"keep"}]}]}`,
+			responseBody: validError,
+		},
+		{
+			name:         "function call item",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"function_call","content":[{"type":"input_text","text":"keep"}],"arguments":"{}"}]}`,
+			responseBody: validError,
+		},
+		{
+			name:         "missing content",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","summary":[]}]}`,
+			responseBody: validError,
+		},
+		{
+			name:         "empty content array",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[]}]}`,
+			responseBody: validError,
+		},
+		{
+			name:         "negative index",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: `{"error":{"code":"array_above_max_length","message":"Invalid input content","param":"input[-1].content","type":"invalid_request_error"}}`,
+		},
+		{
+			name:         "out of range index",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: `{"error":{"code":"array_above_max_length","message":"Invalid input content","param":"input[9].content","type":"invalid_request_error"}}`,
+		},
+		{
+			name:         "different structured parameter",
+			statusCode:   http.StatusBadRequest,
+			body:         `{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`,
+			responseBody: `{"error":{"code":"array_above_max_length","message":"Invalid input content","param":"input[0].summary","type":"invalid_request_error"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(
+				tt.statusCode,
+				[]byte(tt.body),
+				[]byte(tt.responseBody),
+			)
+			require.NoError(t, err)
+			require.False(t, changed)
+			require.Nil(t, retryBody)
+		})
+	}
+}
+
 func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRejectsAmbiguousErrors(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -189,6 +290,28 @@ func TestOpenAIGatewayService_RetriesExplicitMaxOutputTokensRejection(t *testing
 	require.Equal(t, int64(4096), gjson.GetBytes(upstream.bodies[0], "max_output_tokens").Int())
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "max_output_tokens").Exists())
 	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.content.max_output_tokens").String())
+}
+
+func TestOpenAIGatewayService_RetriesRejectedReasoningContent(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]},{"type":"reasoning","summary":[{"type":"summary_text","text":"keep"}],"content":[{"type":"reasoning_text","text":"remove"}]}]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"array_above_max_length","message":"Invalid 'input[1].content': array too long. Expected an array with maximum length 0, but got an array with length 1 instead.","param":"input[1].content","type":"invalid_request_error"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		newOpenAIRejectedFieldTestContext(body),
+		newOpenAIOAuthNamespaceTestAccount(),
+		body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.True(t, gjson.GetBytes(upstream.bodies[0], "input.1.content").Exists())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.1.content").Exists())
+	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.1.summary.0.text").String())
 }
 
 func TestOpenAIGatewayService_ComposesProactiveNamespaceStripWithRejectedFieldRetry(t *testing.T) {


### PR DESCRIPTION
## Summary

- retry an OpenAI Responses request when the upstream explicitly rejects a non-empty `reasoning.content` array
- trust only `array_above_max_length` with structured `input[N].content`
- preserve all non-reasoning items and reuse the existing retry-loop guards

## Production symptom

OpenAI returned HTTP 400 for an indexed reasoning content array; sub2api surfaced the failure as a generic 502. The same request shape failed across multiple models while unrelated Responses requests remained healthy.

## Tests

- `go test ./internal/service -run ReasoningContent -count=1`
- `go test ./internal/service -count=1`