### PR TITLE
fix(composite): support opt-in Messages dispatch

### DIFF
--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -142,7 +142,7 @@ type CreateGroupRequest struct {
 	MCPXMLInject        *bool              `json:"mcp_xml_inject"`
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes []string `json:"supported_model_scopes"`
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       bool                                      `json:"allow_messages_dispatch"`
 	AllowLive                   bool                                      `json:"allow_live"`
 	RequireOAuthOnly            bool                                      `json:"require_oauth_only"`
@@ -209,7 +209,7 @@ type UpdateGroupRequest struct {
 	MCPXMLInject        *bool              `json:"mcp_xml_inject"`
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes *[]string `json:"supported_model_scopes"`
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       *bool                                      `json:"allow_messages_dispatch"`
 	AllowLive                   *bool                                      `json:"allow_live"`
 	RequireOAuthOnly            *bool                                      `json:"require_oauth_only"`

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -175,7 +175,7 @@ type AdminGroup struct {
 	// MCP XML 协议注入（仅 antigravity 平台使用）
 	MCPXMLInject bool `json:"mcp_xml_inject"`
 
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// OpenAI Messages 调度配置（openai 和 composite 平台使用）
 	DefaultMappedModel          string                                   `json:"default_mapped_model"`
 	MessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
 	ModelsListConfig            domain.GroupModelsListConfig             `json:"models_list_config"`

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -55,7 +55,8 @@ func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"input_tokens": estimated})
 }
 
-// CountTokens handles Anthropic-compatible POST /v1/messages/count_tokens for OpenAI groups.
+// CountTokens handles Anthropic-compatible POST /v1/messages/count_tokens for OpenAI groups
+// and Composite groups whose resolved target is OpenAI.
 // It validates billing and routes to an OpenAI token-count bridge without taking concurrency slots
 // or recording usage.
 func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -687,7 +687,7 @@ func TestResolveOpenAIMessagesDispatchMappedModel(t *testing.T) {
 	})
 }
 
-func TestOpenAIGatewayMessagesDispatchGateAllowsGrokGroups(t *testing.T) {
+func TestOpenAIGatewayMessagesDispatchGate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("openai_group_without_dispatch_flag_is_rejected", func(t *testing.T) {
@@ -715,10 +715,10 @@ func TestOpenAIGatewayMessagesDispatchGateAllowsGrokGroups(t *testing.T) {
 		require.Contains(t, rec.Body.String(), "This group does not allow /v1/messages dispatch")
 	})
 
-	t.Run("grok_group_without_dispatch_flag_reaches_gateway_dependencies", func(t *testing.T) {
+	t.Run("composite_group_without_dispatch_flag_is_rejected", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)
-		c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"grok-4.3","messages":[{"role":"user","content":"hi"}]}`))
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`))
 		groupID := int64(4102)
 		c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
 			ID:      5102,
@@ -726,7 +726,7 @@ func TestOpenAIGatewayMessagesDispatchGateAllowsGrokGroups(t *testing.T) {
 			User:    &service.User{ID: 6102},
 			Group: &service.Group{
 				ID:                    groupID,
-				Platform:              service.PlatformGrok,
+				Platform:              service.PlatformComposite,
 				AllowMessagesDispatch: false,
 			},
 		})
@@ -735,10 +735,108 @@ func TestOpenAIGatewayMessagesDispatchGateAllowsGrokGroups(t *testing.T) {
 		h := &OpenAIGatewayHandler{}
 		h.Messages(c)
 
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Equal(t, "permission_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+		require.Contains(t, rec.Body.String(), "This group does not allow /v1/messages dispatch")
+	})
+
+	t.Run("composite_group_with_dispatch_flag_reaches_gateway_dependencies", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`))
+		groupID := int64(4103)
+		c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+			ID:      5103,
+			GroupID: &groupID,
+			User:    &service.User{ID: 6103},
+			Group: &service.Group{
+				ID:                    groupID,
+				Platform:              service.PlatformComposite,
+				AllowMessagesDispatch: true,
+			},
+		})
+		c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 6103, Concurrency: 1})
+
+		h := &OpenAIGatewayHandler{}
+		h.Messages(c)
+
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 		require.Equal(t, "api_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
 		require.NotContains(t, rec.Body.String(), "This group does not allow /v1/messages dispatch")
 	})
+
+	t.Run("grok_group_without_dispatch_flag_reaches_gateway_dependencies", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"grok-4.3","messages":[{"role":"user","content":"hi"}]}`))
+		groupID := int64(4104)
+		c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+			ID:      5104,
+			GroupID: &groupID,
+			User:    &service.User{ID: 6104},
+			Group: &service.Group{
+				ID:                    groupID,
+				Platform:              service.PlatformGrok,
+				AllowMessagesDispatch: false,
+			},
+		})
+		c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 6104, Concurrency: 1})
+
+		h := &OpenAIGatewayHandler{}
+		h.Messages(c)
+
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		require.Equal(t, "api_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+		require.NotContains(t, rec.Body.String(), "This group does not allow /v1/messages dispatch")
+	})
+}
+
+func TestOpenAIGatewayCountTokensDispatchGateForCompositeGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, tc := range []struct {
+		name          string
+		allowDispatch bool
+		wantStatus    int
+		wantGateError bool
+	}{
+		{
+			name:          "disabled_is_rejected",
+			allowDispatch: false,
+			wantStatus:    http.StatusForbidden,
+			wantGateError: true,
+		},
+		{
+			name:          "enabled_reaches_gateway_dependencies",
+			allowDispatch: true,
+			wantStatus:    http.StatusServiceUnavailable,
+			wantGateError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`))
+			groupID := int64(4201)
+			c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+				ID:      5201,
+				GroupID: &groupID,
+				User:    &service.User{ID: 6201},
+				Group: &service.Group{
+					ID:                    groupID,
+					Platform:              service.PlatformComposite,
+					AllowMessagesDispatch: tc.allowDispatch,
+				},
+			})
+			c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 6201, Concurrency: 1})
+
+			h := &OpenAIGatewayHandler{}
+			h.CountTokens(c)
+
+			require.Equal(t, tc.wantStatus, rec.Code)
+			require.Equal(t, tc.wantGateError, strings.Contains(rec.Body.String(), "This group does not allow /v1/messages dispatch"))
+		})
+	}
 }
 
 func TestOpenAIModelMappedBody(t *testing.T) {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -258,7 +258,7 @@ type CreateGroupInput struct {
 	MCPXMLInject        *bool
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes []string
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       bool
 	AllowLive                   bool
 	DefaultMappedModel          string
@@ -331,7 +331,7 @@ type UpdateGroupInput struct {
 	MCPXMLInject        *bool
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes *[]string
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       *bool
 	AllowLive                   *bool
 	DefaultMappedModel          *string

--- a/backend/internal/service/admin_service_group_test.go
+++ b/backend/internal/service/admin_service_group_test.go
@@ -947,6 +947,61 @@ func TestAdminService_UpdateGroup_NormalizesMessagesDispatchModelConfig(t *testi
 	}, repo.updated.MessagesDispatchModelConfig)
 }
 
+func TestAdminService_CreateGroup_PreservesMessagesDispatchFieldsForCompositePlatform(t *testing.T) {
+	repo := &groupRepoStubForAdmin{}
+	svc := &adminServiceImpl{groupRepo: repo}
+
+	group, err := svc.CreateGroup(context.Background(), &CreateGroupInput{
+		Name:                  "composite-group",
+		Description:           "multi-provider messages dispatch",
+		Platform:              PlatformComposite,
+		RateMultiplier:        1.0,
+		AllowMessagesDispatch: true,
+		DefaultMappedModel:    "gpt-5.6-sol",
+		MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+			SonnetMappedModel: " gpt-5.3-codex-high ",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.NotNil(t, repo.created)
+	require.True(t, repo.created.AllowMessagesDispatch)
+	require.Equal(t, "gpt-5.6-sol", repo.created.DefaultMappedModel)
+	require.Equal(t, OpenAIMessagesDispatchModelConfig{
+		SonnetMappedModel: "gpt-5.3-codex",
+	}, repo.created.MessagesDispatchModelConfig)
+}
+
+func TestAdminService_UpdateGroup_PreservesMessagesDispatchFieldsForCompositePlatform(t *testing.T) {
+	existingGroup := &Group{
+		ID:                    1,
+		Name:                  "existing-composite-group",
+		Platform:              PlatformComposite,
+		Status:                StatusActive,
+		AllowMessagesDispatch: true,
+		DefaultMappedModel:    "gpt-5.6-sol",
+		MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+			SonnetMappedModel: "gpt-5.3-codex",
+		},
+	}
+	repo := &groupRepoStubForAdmin{getByID: existingGroup}
+	svc := &adminServiceImpl{groupRepo: repo}
+
+	group, err := svc.UpdateGroup(context.Background(), 1, &UpdateGroupInput{
+		Description: ptrString("updated description"),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.NotNil(t, repo.updated)
+	require.True(t, repo.updated.AllowMessagesDispatch)
+	require.Equal(t, "gpt-5.6-sol", repo.updated.DefaultMappedModel)
+	require.Equal(t, OpenAIMessagesDispatchModelConfig{
+		SonnetMappedModel: "gpt-5.3-codex",
+	}, repo.updated.MessagesDispatchModelConfig)
+}
+
 func TestAdminService_CreateGroup_ClearsMessagesDispatchFieldsForNonOpenAIPlatform(t *testing.T) {
 	repo := &groupRepoStubForAdmin{}
 	svc := &adminServiceImpl{groupRepo: repo}

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -97,7 +97,7 @@ type APIKeyAuthGroupSnapshot struct {
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes []string `json:"supported_model_scopes,omitempty"`
 
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       bool                              `json:"allow_messages_dispatch"`
 	AllowLive                   bool                              `json:"allow_live"`
 	DefaultMappedModel          string                            `json:"default_mapped_model,omitempty"`

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -92,7 +92,7 @@ type Group struct {
 	// 分组排序
 	SortOrder int
 
-	// OpenAI Messages 调度配置（仅 openai 平台使用）
+	// Messages 调度字段支持 openai/composite；AllowLive 仍仅限 openai。
 	AllowMessagesDispatch       bool
 	AllowLive                   bool
 	RequireOAuthOnly            bool // 仅允许非 apikey 类型账号关联（OpenAI/Antigravity/Anthropic/Gemini）

--- a/backend/internal/service/openai_messages_dispatch.go
+++ b/backend/internal/service/openai_messages_dispatch.go
@@ -106,7 +106,7 @@ func (g *Group) ResolveMessagesDispatchModel(requestedModel string) string {
 }
 
 func sanitizeGroupMessagesDispatchFields(g *Group) {
-	if g == nil || g.Platform == PlatformOpenAI {
+	if g == nil || g.Platform == PlatformOpenAI || g.Platform == PlatformComposite {
 		return
 	}
 	g.AllowMessagesDispatch = false

--- a/backend/internal/service/openai_messages_dispatch_test.go
+++ b/backend/internal/service/openai_messages_dispatch_test.go
@@ -48,7 +48,7 @@ func TestGroupResolveMessagesDispatchModel_GrokRequiresCrossClientMapping(t *tes
 	require.Empty(t, group.ResolveMessagesDispatchModel("gpt-5.3-codex"))
 }
 
-func TestSanitizeGroupMessagesDispatchFields_ClearsNonOpenAIPlatform(t *testing.T) {
+func TestSanitizeGroupMessagesDispatchFields_ClearsAnthropicPlatform(t *testing.T) {
 	t.Parallel()
 
 	group := &Group{
@@ -68,4 +68,34 @@ func TestSanitizeGroupMessagesDispatchFields_ClearsNonOpenAIPlatform(t *testing.
 	require.False(t, group.AllowMessagesDispatch)
 	require.Empty(t, group.DefaultMappedModel)
 	require.Equal(t, OpenAIMessagesDispatchModelConfig{}, group.MessagesDispatchModelConfig)
+}
+
+func TestSanitizeGroupMessagesDispatchFields_PreservesSupportedPlatforms(t *testing.T) {
+	t.Parallel()
+
+	for _, platform := range []string{PlatformOpenAI, PlatformComposite} {
+		platform := platform
+		t.Run(platform, func(t *testing.T) {
+			t.Parallel()
+
+			config := OpenAIMessagesDispatchModelConfig{
+				SonnetMappedModel: "gpt-5.3-codex",
+				ExactModelMappings: map[string]string{
+					"claude-fable-5": "gpt-5.6-sol",
+				},
+			}
+			group := &Group{
+				Platform:                    platform,
+				AllowMessagesDispatch:       true,
+				DefaultMappedModel:          "gpt-5.6-sol",
+				MessagesDispatchModelConfig: config,
+			}
+
+			sanitizeGroupMessagesDispatchFields(group)
+
+			require.True(t, group.AllowMessagesDispatch)
+			require.Equal(t, "gpt-5.6-sol", group.DefaultMappedModel)
+			require.Equal(t, config, group.MessagesDispatchModelConfig)
+		})
+	}
 }

--- a/frontend/src/i18n/locales/en/admin/overview.ts
+++ b/frontend/src/i18n/locales/en/admin/overview.ts
@@ -1110,7 +1110,7 @@ export default {
       openaiMessages: {
         title: 'OpenAI Messages Dispatch',
         allowDispatch: 'Allow /v1/messages dispatch',
-        allowDispatchHint: 'When enabled, API keys in this OpenAI group can dispatch requests through /v1/messages endpoint',
+        allowDispatchHint: 'When enabled, this OpenAI group, or Composite requests resolved to OpenAI, can use the /v1/messages compatibility bridge',
         familyMappingTitle: 'Family Default Mapping',
         familyMappingHint: 'Requests that match the Opus, Sonnet, or Haiku families will prefer the target model configured here.',
         opusModel: 'Opus Target Model',

--- a/frontend/src/i18n/locales/zh/admin/overview.ts
+++ b/frontend/src/i18n/locales/zh/admin/overview.ts
@@ -1108,7 +1108,7 @@ export default {
       openaiMessages: {
         title: 'OpenAI Messages 调度配置',
         allowDispatch: '允许 /v1/messages 调度',
-        allowDispatchHint: '启用后，此 OpenAI 分组的 API Key 可以通过 /v1/messages 端点调度请求',
+        allowDispatchHint: '启用后，此 OpenAI 分组，或 Composite 分组中解析到 OpenAI 目标的请求，可以使用 /v1/messages 兼容转发',
         familyMappingTitle: '系列默认映射',
         familyMappingHint: '当请求命中 Opus、Sonnet、Haiku 系列时，会优先使用这里配置的目标模型。',
         opusModel: 'Opus 映射模型',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -625,7 +625,7 @@ export interface AdminGroup extends Group {
   active_account_count?: number
   rate_limited_account_count?: number
 
-  // OpenAI Messages 调度配置（仅 openai 平台使用）
+  // OpenAI Messages 调度配置（OpenAI/Composite 平台使用）
   default_mapped_model?: string
   messages_dispatch_model_config?: OpenAIMessagesDispatchModelConfig
   models_list_config?: ModelsListConfig

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1579,9 +1579,9 @@
           </p>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- OpenAI Messages 调度配置（OpenAI/Composite 平台） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="supportsMessagesDispatchPlatform(createForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -3282,9 +3282,9 @@
           </p>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- OpenAI Messages 调度配置（OpenAI/Composite 平台） -->
         <div
-          v-if="editForm.platform === 'openai'"
+          v-if="supportsMessagesDispatchPlatform(editForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -4387,6 +4387,7 @@ import {
   messagesDispatchConfigToFormState,
   messagesDispatchFormStateToConfig,
   resetMessagesDispatchFormState,
+  supportsMessagesDispatchPlatform,
   type MessagesDispatchMappingRow,
 } from "./groupsMessagesDispatch";
 import {
@@ -4949,7 +4950,7 @@ const createForm = reactive({
   claude_code_only: false,
   fallback_group_id: null as number | null,
   fallback_group_id_on_invalid_request: null as number | null,
-  // OpenAI Messages 调度配置（仅 openai 平台使用）
+  // Messages 调度支持 OpenAI/Composite；Live 仍仅限 OpenAI。
   allow_messages_dispatch: false,
   allow_live: false,
   opus_mapped_model: createMessagesDispatchDefaults.opus_mapped_model,
@@ -5308,7 +5309,7 @@ const editForm = reactive({
   claude_code_only: false,
   fallback_group_id: null as number | null,
   fallback_group_id_on_invalid_request: null as number | null,
-  // OpenAI Messages 调度配置（仅 openai 平台使用）
+  // Messages 调度支持 OpenAI/Composite；Live 仍仅限 OpenAI。
   allow_messages_dispatch: false,
   allow_live: false,
   default_mapped_model: '',
@@ -5864,7 +5865,7 @@ const handleCreateGroup = async () => {
         createForm.supported_model_scopes,
       ),
       messages_dispatch_model_config:
-        createForm.platform === "openai"
+        supportsMessagesDispatchPlatform(createForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: createForm.allow_messages_dispatch,
               opus_mapped_model: createForm.opus_mapped_model,
@@ -6128,7 +6129,7 @@ const handleUpdateGroup = async () => {
         editForm.supported_model_scopes,
       ),
       messages_dispatch_model_config:
-        editForm.platform === "openai"
+        supportsMessagesDispatchPlatform(editForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: editForm.allow_messages_dispatch,
               opus_mapped_model: editForm.opus_mapped_model,
@@ -6506,8 +6507,10 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       createForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!supportsMessagesDispatchPlatform(newVal)) {
       resetMessagesDispatchFormState(createForm);
+    }
+    if (newVal !== "openai") {
       createForm.allow_live = false;
     }
     if (!isProfitControlPlatform(newVal)) {
@@ -6554,8 +6557,10 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!supportsMessagesDispatchPlatform(newVal)) {
       resetMessagesDispatchFormState(editForm);
+    }
+    if (newVal !== "openai") {
       editForm.allow_live = false;
     }
     if (!isProfitControlPlatform(newVal)) {
@@ -6597,20 +6602,6 @@ watch(
     resetDisabledBatchImagePricing(editForm);
   },
 );
-
-watch(
-  () => editForm.platform,
-  (newVal) => {
-    if (!['anthropic', 'antigravity'].includes(newVal)) {
-      editForm.fallback_group_id_on_invalid_request = null
-    }
-    if (newVal !== 'openai') {
-      editForm.allow_messages_dispatch = false
-      editForm.allow_live = false
-      editForm.default_mapped_model = ''
-    }
-  }
-)
 
 // 点击外部关闭账号搜索下拉框
 const handleClickOutside = (event: MouseEvent) => {

--- a/frontend/src/views/admin/__tests__/groupsMessagesDispatch.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsMessagesDispatch.spec.ts
@@ -5,9 +5,19 @@ import {
   messagesDispatchConfigToFormState,
   messagesDispatchFormStateToConfig,
   resetMessagesDispatchFormState,
+  supportsMessagesDispatchPlatform,
 } from "../groupsMessagesDispatch";
 
 describe("groupsMessagesDispatch", () => {
+  it("supports messages dispatch for openai and composite groups", () => {
+    expect(supportsMessagesDispatchPlatform("openai")).toBe(true);
+    expect(supportsMessagesDispatchPlatform("composite")).toBe(true);
+    expect(supportsMessagesDispatchPlatform("anthropic")).toBe(false);
+    expect(supportsMessagesDispatchPlatform("gemini")).toBe(false);
+    expect(supportsMessagesDispatchPlatform("antigravity")).toBe(false);
+    expect(supportsMessagesDispatchPlatform("grok")).toBe(false);
+  });
+
   it("returns the expected default form state", () => {
     expect(createDefaultMessagesDispatchFormState()).toEqual({
       allow_messages_dispatch: false,

--- a/frontend/src/views/admin/groupsMessagesDispatch.ts
+++ b/frontend/src/views/admin/groupsMessagesDispatch.ts
@@ -1,4 +1,7 @@
-import type { OpenAIMessagesDispatchModelConfig } from "@/types";
+import type {
+  GroupPlatform,
+  OpenAIMessagesDispatchModelConfig,
+} from "@/types";
 
 export interface MessagesDispatchMappingRow {
   claude_model: string;
@@ -11,6 +14,12 @@ export interface MessagesDispatchFormState {
   sonnet_mapped_model: string;
   haiku_mapped_model: string;
   exact_model_mappings: MessagesDispatchMappingRow[];
+}
+
+export function supportsMessagesDispatchPlatform(
+  platform: GroupPlatform,
+): boolean {
+  return platform === "openai" || platform === "composite";
 }
 
 export function createDefaultMessagesDispatchFormState(): MessagesDispatchFormState {


### PR DESCRIPTION
## Summary

- preserve `allow_messages_dispatch` and its model mappings for Composite groups
- expose the existing Messages dispatch controls when creating or editing a Composite group
- cover persistence and the `/v1/messages` plus `/v1/messages/count_tokens` dispatch gates

## Behavior

This is an explicit opt-in. Existing Composite groups remain unchanged and dispatch stays disabled until an administrator enables it. Only requests resolved to an OpenAI-compatible target enter the Messages-to-Responses bridge; Composite requests resolved to Anthropic keep the native Anthropic path.

The change reuses existing database columns and auth-cache invalidation, so it requires no schema migration or cache-version bump. OpenAI Live remains limited to OpenAI groups.

## Difference from #5013

This is a narrow fix for the existing group-level switch. It does not add endpoint-aware default routing and does not automatically authorize detector- or route-resolved Composite requests while the switch is off. That keeps the broader routing behavior opt-in and avoids coupling this fix to the larger endpoint-default-routing change in #5013.

`/v1/messages/count_tokens` intentionally continues to use the existing OpenAI bridge semantics; this PR does not expand into the separate accounting concern tracked in #5456.

## Tests

- `go test -tags=unit ./...`
- `go vet ./...`
- `go test ./internal/service ./internal/handler ./internal/server/routes -count=1`
- `go test -tags=integration ./internal/middleware ./internal/server/routes`
- full frontend Vitest suite: 221 files / 1532 tests
- frontend ESLint and `vue-tsc --noEmit`
- production frontend build
- deployed a v0.1.173 backport canary and verified Composite `/v1/messages`, `/v1/messages/count_tokens`, OpenAI account selection, model rewrite, and Responses upstream routing

Fixes #4813
Refs #4799, #4422, #1942, #5013, #5456
