### PR TITLE
fix(settings): cache unset scheduling thresholds

### DIFF
--- a/backend/internal/service/backup_service_test.go
+++ b/backend/internal/service/backup_service_test.go
@@ -24,8 +24,10 @@ import (
 // ─── Mocks ───
 
 type mockSettingRepo struct {
-	mu   sync.Mutex
-	data map[string]string
+	mu            sync.Mutex
+	data          map[string]string
+	getValueErr   error
+	getValueCalls int
 }
 
 func newMockSettingRepo() *mockSettingRepo {
@@ -45,6 +47,10 @@ func (m *mockSettingRepo) Get(_ context.Context, key string) (*Setting, error) {
 func (m *mockSettingRepo) GetValue(_ context.Context, key string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.getValueCalls++
+	if m.getValueErr != nil {
+		return "", m.getValueErr
+	}
 	v, ok := m.data[key]
 	if !ok {
 		return "", nil

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -1114,6 +1114,13 @@ func (s *SettingService) GetAccountSchedulingThresholds(ctx context.Context) map
 
 		raw, err := s.settingRepo.GetValue(dbCtx, SettingKeyAccountSchedulingThresholds)
 		if err != nil {
+			if errors.Is(err, ErrSettingNotFound) {
+				accountSchedulingThresholdsCache.Store(&cachedAccountSchedulingThresholds{
+					thresholds: cloneAccountSchedulingThresholds(thresholds),
+					expiresAt:  time.Now().Add(accountSchedulingThresholdsCacheTTL).UnixNano(),
+				})
+				return cloneAccountSchedulingThresholds(thresholds), nil
+			}
 			slog.Warn("failed to get account scheduling thresholds, falling back to defaults", "error", err)
 			accountSchedulingThresholdsCache.Store(&cachedAccountSchedulingThresholds{
 				thresholds: cloneAccountSchedulingThresholds(thresholds),

--- a/backend/internal/service/setting_service_platform_threshold_test.go
+++ b/backend/internal/service/setting_service_platform_threshold_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,25 @@ func TestGetAccountSchedulingThresholds_ReadsStoredValue(t *testing.T) {
 	require.Equal(t, 100, got[PlatformAnthropic])
 	require.Equal(t, 88, got[PlatformGrok])
 	require.NotContains(t, got, "kiro")
+}
+
+func TestGetAccountSchedulingThresholds_MissingSettingUsesDefaultsAndNormalCacheTTL(t *testing.T) {
+	svc := newSettingServiceForPlatformThresholdTest(nil)
+	repo := svc.settingRepo.(*mockSettingRepo)
+	repo.getValueErr = ErrSettingNotFound
+
+	got := svc.GetAccountSchedulingThresholds(context.Background())
+	require.Equal(t, defaultAccountSchedulingThresholds(), got)
+	require.Equal(t, 1, repo.getValueCalls)
+
+	repo.data[SettingKeyAccountSchedulingThresholds] = `{"openai":91}`
+	got = svc.GetAccountSchedulingThresholds(context.Background())
+	require.Equal(t, 100, got[PlatformOpenAI], "missing-setting defaults should remain cached for the normal TTL")
+	require.Equal(t, 1, repo.getValueCalls)
+
+	cached, ok := accountSchedulingThresholdsCache.Load().(*cachedAccountSchedulingThresholds)
+	require.True(t, ok)
+	require.Greater(t, cached.expiresAt, time.Now().Add(accountSchedulingThresholdsCacheTTL-time.Second).UnixNano())
 }
 
 func TestUpdateSettings_OmittedAccountSchedulingThresholdsDoesNotCacheDefaults(t *testing.T) {


### PR DESCRIPTION
## 问题
未设置调度阈值时，默认值未按正常缓存策略保存。

## 根因
ErrSettingNotFound 与真正的读取错误使用了相同的告警和短 TTL 路径。

## 改动
ErrSettingNotFound 现在使用默认值并采用正常缓存 TTL，且不记录 warning；真正的错误仍保留 warning 和短 TTL。

## 测试
`go test -tags=unit ./internal/service -run 'Test(AccountSchedulingThresholds|GetAccountSchedulingThresholds|PlatformSchedulingThresholds)' -count=1`
`go test -tags=unit ./internal/service -count=1`
`go vet ./internal/service`
`git diff --check`

Fixes #5500
