### PR TITLE
fix(openai): 上游 HTML 403 不再被当成账号级错误处罚账号

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -914,6 +914,28 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 }
 
 func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	// 上游代理 / CDN 在请求到达 OpenAI API 之前就拦下时，回的是 HTML 403 页面而不是
+	// {"error":{...}} 结构化错误。这类响应描述的是「这条链路 / 这个端点被挡了」，
+	// 不构成账号凭据或权限失效的证据——例如无效的 /v1/responses 子路径（#5334）。
+	//
+	// 据此写账号状态会把请求级错误放大成账号级处罚：首次即 temp-unschedulable，
+	// 连续 openAI403DisableThreshold 次直接永久禁用；而 403 又在 failover 状态集里，
+	// 同一个坏请求会被逐个账号重放，足以把整组账号打下线。
+	//
+	// 与既有口径一致：count_tokens 路径的 isOpenAIOAuthInputTokensUnsupported 已把
+	// 「HTML 403 page without a structured error」按端点级响应处理；
+	// shouldApplyOpenAIAlphaSearchAccountErrorSideEffects 的不变式也是端点级错误
+	// 只换号、不写账号错误状态。这里只跳过账号处罚，不改变 failover 行为——
+	// 换个走不同代理的账号仍有可能成功。
+	if isHTMLResponse(responseBody) {
+		slog.Warn(
+			"openai_403_html_body_skips_account_penalty",
+			"account_id", account.ID,
+			"upstream_message", upstreamMsg,
+		)
+		return false
+	}
+
 	msg := buildForbiddenErrorMessage(
 		"Access forbidden (403):",
 		upstreamMsg,

--- a/backend/internal/service/ratelimit_service_403_html_test.go
+++ b/backend/internal/service/ratelimit_service_403_html_test.go
@@ -1,0 +1,176 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// countingOpenAI403CounterCache 在既有桩的基础上记录递增次数。
+// HTML 403 不仅不能处罚账号，连计数都不能加——否则后续真实的账号级 403
+// 会踩着这些"白涨"的计数提前触发永久禁用。
+type countingOpenAI403CounterCache struct {
+	openAI403CounterCacheStub
+	increments int
+}
+
+func (s *countingOpenAI403CounterCache) IncrementOpenAI403Count(ctx context.Context, accountID int64, window int) (int64, error) {
+	s.increments++
+	return s.openAI403CounterCacheStub.IncrementOpenAI403Count(ctx, accountID, window)
+}
+
+type openAI403TestHarness struct {
+	svc     *RateLimitService
+	repo    *rateLimitAccountRepoStub
+	counter *countingOpenAI403CounterCache
+	blocker *runtimeBlockRecorder
+	account *Account
+}
+
+func newOpenAI403TestHarness(t *testing.T, accountID int64, counts ...int64) *openAI403TestHarness {
+	t.Helper()
+	repo := &rateLimitAccountRepoStub{}
+	counter := &countingOpenAI403CounterCache{openAI403CounterCacheStub: openAI403CounterCacheStub{counts: counts}}
+	blocker := &runtimeBlockRecorder{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetOpenAI403CounterCache(counter)
+	svc.SetAccountRuntimeBlocker(blocker)
+	return &openAI403TestHarness{
+		svc:     svc,
+		repo:    repo,
+		counter: counter,
+		blocker: blocker,
+		account: &Account{ID: accountID, Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+	}
+}
+
+func (h *openAI403TestHarness) handle(body string) bool {
+	return h.svc.HandleUpstreamError(
+		context.Background(), h.account, http.StatusForbidden, http.Header{}, []byte(body),
+	)
+}
+
+func (h *openAI403TestHarness) requireNoAccountPenalty(t *testing.T) {
+	t.Helper()
+	require.Equal(t, 0, h.repo.setErrorCalls, "端点级 403 不得永久禁用账号")
+	require.Equal(t, 0, h.repo.tempCalls, "端点级 403 不得把账号设为临时不可调度")
+	require.Empty(t, h.blocker.accounts, "端点级 403 不得触发调度阻断通知")
+	require.Equal(t, 0, h.counter.increments, "端点级 403 不得递增连续 403 计数")
+}
+
+// issue #5334：无效的 /v1/responses 子路径被转发后，上游代理在到达 OpenAI API
+// 之前回 HTML 403 页面。这是链路/端点级响应，不是账号凭据失效的证据。
+const openAI403HTMLBody = "<!DOCTYPE html>\n<html><head><title>403 Forbidden</title></head>" +
+	"<body><h1>403 Forbidden</h1></body></html>"
+
+func TestHandleUpstreamError_OpenAIHTML403DoesNotPenalizeAccount(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"doctype_prefixed", openAI403HTMLBody},
+		{"bare_html_tag", "<html><body>403 Forbidden</body></html>"},
+		{"leading_whitespace_and_uppercase", "\n\t  <!DOCTYPE HTML><html><body>Forbidden</body></html>"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newOpenAI403TestHarness(t, 501, 1)
+
+			shouldDisable := h.handle(tc.body)
+
+			require.False(t, shouldDisable, "HTML 403 不得判定账号应下线")
+			h.requireNoAccountPenalty(t)
+		})
+	}
+}
+
+// 一个持有 API Key 的调用方反复打无效子路径时，既有实现会在第
+// openAI403DisableThreshold 次把账号永久禁用。修复后连续多少次都不该升级。
+func TestHandleUpstreamError_OpenAIHTML403RepeatedNeverEscalates(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 502, 1, 2, 3, 4, 5)
+
+	for i := 0; i < openAI403DisableThreshold+2; i++ {
+		require.False(t, h.handle(openAI403HTMLBody), "第 %d 次 HTML 403 仍不得判定账号应下线", i+1)
+	}
+
+	h.requireNoAccountPenalty(t)
+}
+
+// 对照不变式：真正的结构化 JSON 403 是账号级证据，处罚链路必须原样保留。
+// 缺了这组断言，上面的跳过逻辑一旦写宽就会把真实的封号 403 也放过去。
+func TestHandleUpstreamError_OpenAIStructured403StillPenalizes(t *testing.T) {
+	t.Run("first_hit_temp_unschedulable", func(t *testing.T) {
+		h := newOpenAI403TestHarness(t, 503, 1)
+
+		require.True(t, h.handle(`{"error":{"message":"Your account is not authorized"}}`))
+		require.Equal(t, 1, h.counter.increments)
+		require.Equal(t, 1, h.repo.tempCalls)
+		require.Equal(t, 0, h.repo.setErrorCalls)
+		require.Contains(t, h.repo.lastTempReason, "Your account is not authorized")
+		require.Len(t, h.blocker.accounts, 1)
+	})
+
+	t.Run("threshold_disables", func(t *testing.T) {
+		h := newOpenAI403TestHarness(t, 504, int64(openAI403DisableThreshold))
+
+		require.True(t, h.handle(`{"error":{"message":"workspace forbidden by policy"}}`))
+		require.Equal(t, 1, h.repo.setErrorCalls)
+		require.Contains(t, h.repo.lastErrorMsg, "workspace forbidden by policy")
+	})
+
+	// 非 HTML 的非结构化响应（纯文本网关错误）不在本次放行范围内，维持原有处罚。
+	t.Run("plain_text_body_unchanged", func(t *testing.T) {
+		h := newOpenAI403TestHarness(t, 505, 1)
+
+		require.True(t, h.handle("Forbidden"))
+		require.Equal(t, 1, h.repo.tempCalls)
+	})
+}
+
+// 作用域守卫：放行只针对 OpenAI 平台。其他平台的 403 处理不受影响。
+func TestHandleUpstreamError_HTML403OnOtherPlatformsUnchanged(t *testing.T) {
+	for _, platform := range []string{PlatformAnthropic, PlatformGemini} {
+		t.Run(platform, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			account := &Account{ID: 506, Platform: platform, Type: AccountTypeAPIKey}
+
+			shouldDisable := svc.HandleUpstreamError(
+				context.Background(), account, http.StatusForbidden, http.Header{}, []byte(openAI403HTMLBody),
+			)
+
+			require.True(t, shouldDisable)
+			require.Equal(t, 1, repo.setErrorCalls, "其他平台保持原有 SetError 行为")
+		})
+	}
+}
+
+func TestIsHTMLResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"doctype_lower", "<!doctype html><html></html>", true},
+		{"doctype_upper", "<!DOCTYPE HTML>", true},
+		{"bare_html", "<html lang=\"en\">", true},
+		{"leading_whitespace", "\n\n   <html>", true},
+		{"json_error", `{"error":{"message":"forbidden"}}`, false},
+		{"plain_text", "Forbidden", false},
+		{"empty", "", false},
+		// XML/SVG 之类不是 HTML，不在放行范围内。
+		{"xml_declaration", `<?xml version="1.0"?><error/>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isHTMLResponse([]byte(tc.body)))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5334

## 问题

上游代理 / CDN 在请求到达 OpenAI API 之前拦下时，回的是 HTML 403 页面而不是 `{"error":{...}}` 结构化错误。`handleOpenAI403` 不区分响应形态，把它当成账号级 403 处理。

实测（`HandleUpstreamError(403, "<!DOCTYPE html>…")`，OAuth 账号）：

```
修改前  第 1 次  shouldDisable=true  tempUnschedulable=1  调度阻断通知=1
                 reason="OpenAI 403 temporary cooldown (1/3): Access forbidden (403): <!DOCTYPE html>\n<html>…"
        第 3 次  shouldDisable=true  setError=1   ← 账号被永久禁用
        对照 JSON 403             tempUnschedulable=1（正确，账号级证据）

修改后  HTML 403 任意次数         shouldDisable=false  setError=0  tempUnschedulable=0  计数递增=0
        对照 JSON 403             完全不变
```

403 同时在 failover 状态集里（`shouldFailoverUpstreamError` 含 403），所以同一个坏请求会被逐个账号重放，每个账号各挨一次处罚。#5334 给出的触发方式是 `POST /v1/responses/not-exist`：该路径能通过 `guardResponsesSubpath`（`sanitizedUpstreamPathSuffix` 只校验字符集与层深，不校验端点是否受支持），转发后拿回 HTML 403。**任何持有 API Key 的调用方重复几次就能把一个分组的账号逐个打成永久禁用。**

附带问题：整张 HTML 页面会被 `buildForbiddenErrorMessage` 拼进账号错误信息写库，并显示在管理端。

## 仓库对这类响应早有口径，只是漏了这条路径

- `openai_gateway_count_tokens.go` 的 `isOpenAIOAuthInputTokensUnsupported`：

  ```go
  // OAuth's platform endpoint can be blocked by an upstream proxy before it
  // reaches the API and return an HTML 403 page without a structured error.
  // Treat that endpoint-level response like the other unsupported cases so
  // count_tokens remains a local, non-health-affecting convenience request.
  if statusCode == http.StatusForbidden && isHTMLResponse(body) {
  ```

- `shouldApplyOpenAIAlphaSearchAccountErrorSideEffects` 的既定不变式：端点级错误「只换号，不写账号错误状态」。

两处都已经把「端点级响应 ≠ 账号不健康」写成了明确政策。本 PR 是把它应用到主转发路径，不是提出新政策。

## 改动

`handleOpenAI403` 入口复用现成的 `isHTMLResponse`，命中即跳过账号处罚：不递增连续 403 计数、不设临时不可调度、不永久禁用，并打一条 warn 日志便于排查。

**不递增计数**是关键的一点：只跳过处罚而仍然计数的话，这些"白涨"的次数会让之后一次真实的账号级 403 提前踩到永久禁用阈值。测试对此有独立断言。

**failover 行为不变**（`shouldFailoverUpstreamError(403)` 未动）：HTML 403 常来自边缘节点对某条出口链路的拦截，换一个走不同代理的账号仍有可能成功，继续换号是有价值的；本 PR 只否定"据此给账号记账"。

## 明确不在本次范围

- **入口语义校验**（#5334 建议方案 1，对不支持的子路径直接返回 404）：现有 `sanitizedUpstreamPathSuffix` 是**结构**守卫，看注释是有意做成前向兼容的（上游新增子路径无需改网关）。改成端点白名单会牺牲这一点，且需要单独确认 POST 侧的合法子路径全集，属独立决策。本 PR 落地后，即便这类请求继续被转发，也不再有账号被处罚。
- **非 OpenAI 平台**：Antigravity / Anthropic / Gemini 的 403 处理未动，有专门的作用域守卫测试锁定。
- **纯文本非结构化 403**（如 `Forbidden`）：不在放行范围。HTML 有明确的「这是一张给浏览器看的错误页」语义，裸文本没有，放宽会误伤真实的账号级错误。有测试锁定其维持原处罚。
- **401 的同类问题**：`handleAuthError` 路径未做同样区分。401 的账号级含义比 403 强得多（凭据失效基本就是账号问题），需要单独论证，不夹带。

## 测试

新增 `ratelimit_service_403_html_test.go`（5 组 / 17 个子用例，`//go:build unit`）：

- **主复现**：三种 HTML 形态（`<!DOCTYPE html>` 前缀、裸 `<html>`、前导空白 + 大写 DOCTYPE）均不处罚账号，四项断言逐个覆盖 setError / tempUnschedulable / 调度阻断通知 / **计数递增**。
- **不升级**：连续 `openAI403DisableThreshold + 2` 次 HTML 403，仍不得永久禁用 —— 直接对着既有实现会挂掉的那个点。
- **对照不变式**：结构化 JSON 403 的处罚链一字不动（首次 temp-unschedulable、达阈值 setError），缺这组断言的话跳过逻辑一旦写宽就会放过真实封号。纯文本 403 一并锁定维持原状。
- **作用域守卫**：Anthropic / Gemini 收到同样的 HTML 403 仍走原有 `SetError`。
- `isHTMLResponse` 8 个边界：大小写、前导空白、JSON、纯文本、空 body、XML 声明（不算 HTML）。

为统计递增次数新增了 `countingOpenAI403CounterCache`（内嵌既有的 `openAI403CounterCacheStub`），未修改任何既有桩或既有测试。`TestRateLimitService_HandleUpstreamError_OpenAI403FirstHitTempUnschedulable` 与 `..._OpenAI403ThresholdDisables` 原样通过。

**回滚验证**：撤掉 `handleOpenAI403` 的守卫，4 条用例立即失败（`Should be false — HTML 403 不得判定账号应下线`），恢复后转绿。

**本地验证**：`go build ./...` 通过；`gofmt -l` 两个文件均干净；`go vet -tags unit ./internal/service/` 通过；`go test -tags unit ./internal/service/` ok 147.916s；`./internal/handler/... ./internal/pkg/... ./internal/repository/...` 全部通过。
