### PR TITLE
fix(openai): 探测响应未跑完时不再落标为「上游不支持 Responses」

### DIFF
--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -23,6 +24,11 @@ const openaiResponsesProbeTimeout = 15 * time.Second
 
 // responsesProbeMaxBodyBytes 限制读取探测响应体的字节数,够判定 output 项类型即可。
 const responsesProbeMaxBodyBytes = 256 * 1024
+
+// openaiResponsesProbeMaxOutputTokens 是探测请求的输出预算。
+// 推理型模型可能把预算全烧在 reasoning 上,还没轮到 function_call 就被截断——
+// 那种响应不能用来判定工具能力,见 responsesProbeVerdictIsConclusive。
+const openaiResponsesProbeMaxOutputTokens = 512
 
 // openaiResponsesProbePayload 构造探测用的 Responses 请求体。
 //
@@ -61,7 +67,7 @@ func openaiResponsesProbePayload(modelID string) []byte {
 			},
 		},
 		"tool_choice":       "required",
-		"max_output_tokens": 512,
+		"max_output_tokens": openaiResponsesProbeMaxOutputTokens,
 		"stream":            false,
 	})
 	return body
@@ -175,6 +181,20 @@ func (s *AccountTestService) ProbeOpenAIAPIKeyResponsesSupport(ctx context.Conte
 		return
 	}
 
+	// 本次响应不足以下结论时保持 unknown，与网络层失败、响应体读取失败一致：
+	// 标记一旦写成 false 就会一直粘住（只有下次账号创建/更新才重探），网关会静默
+	// 改走 /v1/chat/completions —— 对 Codex 客户端意味着 prompt 缓存前缀被打散。
+	// 宁可不写，让请求继续走既有的 Responses 路径。
+	if !responsesProbeVerdictIsConclusive(resp.StatusCode, bodyBytes) {
+		logger.LegacyPrintf("service.openai_probe",
+			"probe_inconclusive_keep_unknown: account_id=%d base_url=%s probe_model=%s status=%d response_status=%s reason=%s",
+			accountID, normalizedBaseURL, probeModel, resp.StatusCode,
+			gjson.GetBytes(bodyBytes, "status").String(),
+			gjson.GetBytes(bodyBytes, "incomplete_details.reason").String(),
+		)
+		return
+	}
+
 	supported := decideResponsesProbeSupport(resp.StatusCode, bodyBytes)
 
 	if err := s.accountRepo.UpdateExtra(ctx, accountID, map[string]any{
@@ -184,10 +204,53 @@ func (s *AccountTestService) ProbeOpenAIAPIKeyResponsesSupport(ctx context.Conte
 		return
 	}
 
+	if !supported {
+		// 落标为不支持等于把该账号长期钉在 /v1/chat/completions 上，成本与缓存命中率
+		// 都会变化，且不会自动恢复。这条必须能被运维看到（#5371）。
+		slog.Warn(
+			"openai_responses_probe_marked_unsupported",
+			"account_id", accountID,
+			"account_name", account.Name,
+			"base_url", normalizedBaseURL,
+			"probe_model", probeModel,
+			"upstream_status", resp.StatusCode,
+		)
+	}
+
 	logger.LegacyPrintf("service.openai_probe",
 		"probe_done: account_id=%d base_url=%s probe_model=%s status=%d supported=%v",
 		accountID, normalizedBaseURL, probeModel, resp.StatusCode, supported,
 	)
+}
+
+// responsesProbeVerdictIsConclusive 判断本次探测响应是否足以对「上游是否支持带工具的
+// Responses 调用」下结论。
+//
+// 2xx 分支靠「output 里有没有 function_call」下结论，但这只在响应真的跑完时成立：
+//
+//   - status=incomplete 且 incomplete_details.reason=max_output_tokens：探测请求自己
+//     只给了 openaiResponsesProbeMaxOutputTokens 的预算，推理型模型可能把预算全烧在
+//     reasoning 上，还没轮到 function_call 就被截断。此时「没有 function_call」是探测
+//     预算不足造成的，不是上游能力缺失。
+//   - status=failed：HTTP 200 携带的失败响应（上游瞬时故障）同样不构成能力证据。
+//
+// 其余 2xx 一律可下结论——尤其 status=completed 却只回 reasoning 的上游（火山方舟
+// coding/v3 × kimi-k2.6），仍按原逻辑判为不支持。
+//
+// 非 2xx 的结论只看状态码、不依赖响应内容，恒可下结论。
+// 缺少 status 字段的响应体（含非 JSON）也按可下结论处理，保持既有行为。
+func responsesProbeVerdictIsConclusive(status int, body []byte) bool {
+	if status < 200 || status >= 300 {
+		return true
+	}
+	switch strings.TrimSpace(gjson.GetBytes(body, "status").String()) {
+	case "failed":
+		return false
+	case "incomplete":
+		return strings.TrimSpace(gjson.GetBytes(body, "incomplete_details.reason").String()) != "max_output_tokens"
+	default:
+		return true
+	}
 }
 
 // isResponsesEndpointSupportedByStatus 根据探测响应的 HTTP 状态码判定上游

--- a/backend/internal/service/openai_apikey_responses_probe_verdict_test.go
+++ b/backend/internal/service/openai_apikey_responses_probe_verdict_test.go
@@ -1,0 +1,176 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/stretchr/testify/require"
+)
+
+func newResponsesProbeAccount(id int64) Account {
+	return Account{
+		ID:          id,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Name:        "compat-upstream",
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://compat-upstream.example/v1",
+		},
+	}
+}
+
+// runResponsesProbe 跑一次探测，返回落库的 extra 更新；未落库时返回 nil。
+func runResponsesProbe(t *testing.T, status int, body string) map[string]any {
+	t.Helper()
+	account := newResponsesProbeAccount(4200)
+	// 带缓冲且不阻塞：探测决定不落标时通道应保持为空。
+	updateCalls := make(chan map[string]any, 1)
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}},
+		updateExtraCalls:      updateCalls,
+	}
+	svc := &AccountTestService{
+		accountRepo: repo,
+		httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}},
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+
+	svc.ProbeOpenAIAPIKeyResponsesSupport(context.Background(), account.ID)
+
+	select {
+	case updates := <-updateCalls:
+		return updates
+	default:
+		return nil
+	}
+}
+
+// issue #5371：账号一旦被落标为「不支持 Responses」，网关就长期改走
+// /v1/chat/completions，Codex 的 prompt 缓存前缀被打散；而探测只在账号创建/更新时
+// 跑一次，标记不会自动恢复。因此判据不成立的响应绝不能落标。
+func TestProbeOpenAIAPIKeyResponsesSupport_InconclusiveResponseKeepsUnknown(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			// 探测请求自带 openaiResponsesProbeMaxOutputTokens 预算，推理型模型可能
+			// 把预算烧在 reasoning 上就被截断——没有 function_call 是预算不足所致。
+			name: "incomplete_max_output_tokens",
+			body: `{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},` +
+				`"output":[{"type":"reasoning","summary":[]}]}`,
+		},
+		{
+			// HTTP 200 携带的失败响应是上游瞬时故障，不构成工具能力证据。
+			name: "failed_status_on_http_200",
+			body: `{"status":"failed","error":{"code":"server_error","message":"upstream hiccup"},"output":[]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Nil(t, runResponsesProbe(t, http.StatusOK, tc.body),
+				"判据不成立时必须保持 unknown，不得落标")
+		})
+	}
+}
+
+// 对照不变式：能下结论的响应仍要落标，否则「不落标」写宽了就等于把整个探测废掉。
+func TestProbeOpenAIAPIKeyResponsesSupport_ConclusiveResponsesStillPersist(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "completed_with_function_call",
+			status: http.StatusOK,
+			body:   `{"status":"completed","output":[{"type":"function_call","name":"probe_ping"}]}`,
+			want:   true,
+		},
+		{
+			// 火山方舟 coding/v3 × kimi-k2.6：端点在、跑完了、就是不产出 function_call。
+			// 这正是探测要抓的目标，必须继续落标为不支持。
+			name:   "completed_reasoning_only",
+			status: http.StatusOK,
+			body:   `{"status":"completed","output":[{"type":"reasoning"}]}`,
+			want:   false,
+		},
+		{
+			// 非 max_output_tokens 的截断（如内容过滤）不在放行范围内，维持原判定。
+			name:   "incomplete_other_reason",
+			status: http.StatusOK,
+			body:   `{"status":"incomplete","incomplete_details":{"reason":"content_filter"},"output":[]}`,
+			want:   false,
+		},
+		{
+			// 响应体没有 status 字段（第三方兼容上游常见）时维持既有行为。
+			name:   "no_status_field",
+			status: http.StatusOK,
+			body:   `{"output":[{"type":"function_call","name":"probe_ping"}]}`,
+			want:   true,
+		},
+		{
+			name:   "endpoint_absent_404",
+			status: http.StatusNotFound,
+			body:   `{"error":{"message":"Not Found"}}`,
+			want:   false,
+		},
+		{
+			// 非 2xx 的结论只看状态码：body 里的 status=failed 不该让它变成"不下结论"。
+			name:   "server_error_stays_conservative_true",
+			status: http.StatusInternalServerError,
+			body:   `{"status":"failed"}`,
+			want:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			updates := runResponsesProbe(t, tc.status, tc.body)
+			require.NotNil(t, updates, "能下结论的响应必须落标")
+			require.Equal(t, tc.want, updates[openai_compat.ExtraKeyResponsesSupported])
+		})
+	}
+}
+
+func TestResponsesProbeVerdictIsConclusive(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"200_completed", 200, `{"status":"completed","output":[]}`, true},
+		{"200_incomplete_max_output_tokens", 200,
+			`{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}`, false},
+		{"200_incomplete_content_filter", 200,
+			`{"status":"incomplete","incomplete_details":{"reason":"content_filter"}}`, true},
+		{"200_incomplete_without_reason", 200, `{"status":"incomplete"}`, true},
+		{"200_failed", 200, `{"status":"failed"}`, false},
+		{"200_no_status_field", 200, `{"output":[]}`, true},
+		{"200_non_json", 200, `not-json`, true},
+		{"200_empty_body", 200, ``, true},
+		// 非 2xx 只看状态码，不读 body。
+		{"404_ignores_body_status", 404, `{"status":"failed"}`, true},
+		{"500_ignores_body_status", 500, `{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, responsesProbeVerdictIsConclusive(tc.status, []byte(tc.body)))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5371

## 先更正 issue 的机制描述

#5371 认为「上游 /v1/responses 开始报错时，网关会自动降级到 /v1/chat/completions」。核对代码后这个机制不存在：`openai_gateway_forward.go:111` 的分流只读 `accounts.extra.openai_responses_supported`，运行时错误不会写这个标记。全仓唯一的写入点是 `ProbeOpenAIAPIKeyResponsesSupport`，而它**只在管理端创建/更新账号时触发一次**（`admin/account_handler.go:1041`）。

这反而解释了报告里最反常的两点：**为什么一粘就是 32 小时不恢复**（没有任何重探时机），**为什么最后是账号余额耗尽被停调度才自己弹回去**（换了别的账号）。真正的成因是那一次探测下了错误的永久结论。

## 问题

`decideResponsesProbeSupport` 的 2xx 分支靠「output 里有没有 `function_call`」判定工具能力，但这只在响应真的跑完时成立。实测（`decideResponsesProbeSupport(200, body)`）：

```
incomplete + reason=max_output_tokens   -> 写入 supported=false   ← 误判
failed（HTTP 200 携带失败）              -> 写入 supported=false   ← 误判
completed + 仅 reasoning                 -> 写入 supported=false   ← 正确，这是探测本来要抓的
completed + function_call                -> 写入 supported=true    ← 正确
```

前两种的成因：

- **`incomplete` / `max_output_tokens`**：探测请求自己只给了 `max_output_tokens: 512`。推理型模型可能把预算全烧在 reasoning 上，还没轮到 `function_call` 就被截断。「没有 function_call」是探测预算不足造成的，与上游能力无关。
- **`failed`**：HTTP 200 携带的失败响应是上游瞬时故障，同样不构成能力证据。

代价不对称得厉害：判错一次 = 该账号被长期钉在 `/v1/chat/completions` 上，Codex 的 prompt 缓存前缀在协议转换中被打散，#5371 实测命中率 ~85% → ~17%、成本涨 3.5 倍，且不会自动恢复。

## 同一个函数里已经写明了正确的口径，2xx 分支漏了

`decideResponsesProbeSupport` 对非 2xx 的注释原文：

```go
//   - 其他非 2xx（401/403/422/5xx 等）：端点存在,但本次无法判定工具能力
//     （鉴权/校验/瞬时故障）→ 保守按 true,保持既有"端点存在即支持"行为
```

`isResponsesEndpointSupportedByStatus` 也写着「5xx 也视为"端点存在"——上游偶发故障不应误判为不支持」，`openaiResponsesProbeTimeout` 的注释是「超时则保持 unknown，不下结论」。

**「瞬时故障不下结论」已经是这个文件的既定原则，只是 2xx 分支没有执行它。**

## 改动

新增 `responsesProbeVerdictIsConclusive(status, body)`，在落标前拦一道；判据不成立时保持 unknown 直接返回，与既有的网络层失败、响应体读取失败两处早返回完全一致（网关随后按「现状即证据」继续走 Responses）。

`decideResponsesProbeSupport` 本体与它的 9 个既有用例**一行未改**。

判据不成立的条件刻意收窄：

| 响应 | 结论 |
|---|---|
| `status=failed` | 不下结论 |
| `status=incomplete` 且 `incomplete_details.reason=max_output_tokens` | 不下结论 |
| `status=incomplete` 其他 reason（如 `content_filter`） | 照旧判定 |
| `status=completed` | 照旧判定（含火山方舟那种只回 reasoning 的，仍落标 false） |
| 无 `status` 字段 / 非 JSON | 照旧判定（第三方兼容上游常见，保持既有行为） |
| 非 2xx | 恒可下结论，只看状态码不读 body |

顺带把硬编码的 `512` 提成 `openaiResponsesProbeMaxOutputTokens`，让注释能指向它——预算是本次误判的直接来源，写死在字面量里不利于日后调整。

另加一条 `slog.Warn("openai_responses_probe_marked_unsupported", ...)`：落标为不支持会长期改变该账号的成本结构且不自动恢复，这是 #5371 诉求 1「降级要可见」在**决策发生的那个点**的落法，比在每个请求上打日志要合适。

## 明确不在本次范围

- **定期回探 / 自动恢复**（#5371 诉求 2）：需要新的后台任务与重探节流策略，是独立的功能设计。本 PR 先堵住「一次误判永久生效」这个入口——不再有账号因为瞬时故障被错误钉住。
- **「Responses 不可用时直接标记账号不可调度」开关**（诉求 3）：产品决策，且已有 `openai_responses_mode = force_responses` 可让管理员手动强制。
- **降级请求数 / 缓存命中率面板指标**（诉求 4）：监控体系改动。
- **调大探测预算**：把 512 提高能降低截断概率，但治标——预算再大也存在被烧完的模型。而且改大会同时抬高每次账号编辑的探测成本与延迟。修复后这类响应保持 unknown、继续走 Responses，等价于探测前的行为，安全。
- **账号详情页标注当前实际使用的端点**（诉求 1 的前端部分）：前端改动，且 `openai_responses_supported` 已在 extra 里，可另开 PR。

## 测试

新增 `openai_apikey_responses_probe_verdict_test.go`（3 组 / 18 个子用例）：

- **主复现**（端到端走 `ProbeOpenAIAPIKeyResponsesSupport`，断言 `UpdateExtra` **根本没被调用**）：`incomplete/max_output_tokens` 与 `failed` 两种响应必须保持 unknown。
- **对照不变式**（同样端到端，断言确实落标且值正确）：`completed+function_call`→true、`completed` 仅 reasoning→false（火山方舟场景，探测的原始目标）、`incomplete/content_filter`→false、无 status 字段→true、404→false、500+body 里带 `status:failed`→true（证明非 2xx 不读 body）。缺这组断言的话，「不下结论」一旦写宽就等于把整个探测废掉。
- `responsesProbeVerdictIsConclusive` 10 个边界：含非 JSON、空 body、`incomplete` 无 reason、非 2xx 忽略 body status。

**回滚验证**：把 `ProbeOpenAIAPIKeyResponsesSupport` 里的守卫短路掉，两条主复现用例立即失败（`Expected nil, but got: map[...]{"openai_responses_supported":false}`），恢复后转绿。

**本地验证**：`go build ./...` 通过；`gofmt -l` 两个文件均干净；`go vet -tags unit ./internal/service/` 通过；`go test -tags unit ./internal/service/` ok 147.093s（含既有的 `TestDecideResponsesProbeSupport` 9 个用例、`TestProbeOpenAIAPIKeyResponsesSupportUsesCodexProbeHeaders` 原样通过）；`./internal/handler/... ./internal/pkg/...` 全部通过。
