### PR TITLE
fix(frontend): show security audit menu in simple mode

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -775,7 +775,6 @@ const adminNavItems = computed((): NavItem[] => {
       path: '/admin/security-audit',
       label: t('nav.securityAudit'),
       icon: ShieldIcon,
-      hideInSimpleMode: true,
       expandOnly: true,
       featureFlag: flagRiskControl,
       children: [


### PR DESCRIPTION
Closes #5509

## Problem

In simple mode (`RUN_MODE=simple`) the **Security Audit** sidebar group — which contains **Risk Control** (`/admin/risk-control`) and **Prompt Audit** (`/admin/prompt-audit`) — is hidden via `hideInSimpleMode: true`, even though nothing else in the stack restricts these pages:

- **Router guard doesn't block them.** The simple-mode `restrictedPaths` list in `frontend/src/router/index.ts` only covers `/admin/groups`, `/admin/subscriptions`, `/admin/redeem`, `/subscriptions` and `/redeem`. Neither risk-control path is listed, so navigation succeeds.
- **Backend doesn't block them.** The `/risk-control` route group (`internal/server/routes/admin.go`) and the `/prompt-audit` route group have no `RunMode` gate, and there is no `RunMode` check anywhere in `internal/securityaudit/`, `internal/service/content_moderation.go`, or `internal/handler/admin/content_moderation_handler.go`. Moderation still runs on the request path through `handler/content_moderation_helper.go` and `handler/security_audit_helper.go`.
- **The settings page already links there.** `/admin/settings` stays visible in simple mode (`AppSidebar.vue` explicitly pushes it back in), and the risk control card in `SettingsView.vue` renders both the `risk_control_enabled` toggle and a `<router-link to="/admin/risk-control">` shortcut, unconditionally.

So the feature is fully functional in simple mode and already reachable through a normal, product-provided path — the missing sidebar entry is the only inconsistency.

## Change

Drop `hideInSimpleMode: true` from the security audit group so the menu matches the behaviour the rest of the stack already implements.

Simple mode targets individual developers and internal teams, but those deployments may well want content moderation too. Whether to run it is already decided by the `risk_control_enabled` setting (opt-in, defaults to `false`): operators who want it turn it on in settings, operators who don't never see the menu. `hideInSimpleMode` stacks a second layer of hiding on top of that switch — a layer that is backed by no route or backend restriction, and that hides the menu precisely from simple-mode operators who have deliberately enabled risk control.

The group remains gated by `featureFlag: flagRiskControl`, so nothing new appears for anyone who hasn't enabled risk control.

## Testing

```
npx vitest run src/components/layout          # 17 passed (incl. AppSidebar.spec.ts)
npx vitest run src/router                     # 46 passed
npx vitest run src/features/prompt-audit/__tests__/integrationSurface.spec.ts   # 3 passed
```