### PR TITLE
feat(scheduling): 允许 OpenAI 账号通过混合调度加入 Anthropic/Gemini 分组

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -844,6 +844,19 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 			// 转发请求 - 根据账号平台分流
 			c.Set("parsed_request", attemptParsedReq)
+
+			// 跨平台协议转换：anthropic/gemini 分组选中了启用混合调度的 openai 账号。
+			// ForwardAsAnthropic 内部完成 Anthropic Messages ↔ OpenAI（Responses 或
+			// ChatCompletions 回退）的双向转换并写入 HTTP 响应，与 anthropic 透传路径
+			// 完全分离，因此走独立的 usage/failover 短路，不复用下面的 ForwardResult 逻辑。
+			if account.Platform == service.PlatformOpenAI && account.IsMixedSchedulingEnabled() {
+				if h.forwardAsOpenAICompatInAnthropicGroup(c, reqLog, account, currentAPIKey, currentSubscription, attemptBody, reqModel, fs, sessionKey, sessionBoundAccountID, pricingAt, streamStarted) {
+					return
+				}
+				// 转换失败但允许 failover（未写入字节）：继续外层循环尝试下一个账号
+				continue
+			}
+
 			var result *service.ForwardResult
 			requestCtx := c.Request.Context()
 			if fs.SwitchCount > 0 {
@@ -2441,6 +2454,167 @@ func (h *GatewayHandler) submitMandatoryUsageRecordTask(parent context.Context, 
 		}
 	}()
 	task(ctx)
+}
+
+// forwardAsOpenAICompatInAnthropicGroup 在 anthropic/gemini 分组中选中了启用混合调度的
+// openai 账号时，走 OpenAI 兼容协议转换路径（ForwardAsAnthropic）转发请求。
+//
+// 返回 true 表示请求已终结（响应已写入或错误已回传），调用方应 return；
+// 返回 false 表示该账号失败且尚未向客户端写入内容，调用方可 failover 到下一个账号。
+//
+// 与 anthropic 透传路径完全分离：ForwardAsAnthropic 自行写入 HTTP 响应并产出
+// *OpenAIForwardResult，因此计费走 OpenAI usage 管道，不参与 anthropic 的 ForwardResult 逻辑。
+func (h *GatewayHandler) forwardAsOpenAICompatInAnthropicGroup(
+	c *gin.Context,
+	reqLog *zap.Logger,
+	account *service.Account,
+	currentAPIKey *service.APIKey,
+	subscription *service.UserSubscription,
+	body []byte,
+	reqModel string,
+	fs *FailoverState,
+	sessionKey string,
+	sessionBoundAccountID int64,
+	pricingAt time.Time,
+	streamStarted bool,
+) bool {
+	// 计费/配额按实际服务账号的平台（openai）归属，覆盖分组平台。
+	// QuotaPlatform 优先读 ResolvedTargetPlatform，注入后计费自动落到 openai 桶。
+	ctx := service.WithResolvedTargetPlatform(c.Request.Context(), service.PlatformOpenAI)
+	c.Request = c.Request.WithContext(ctx)
+
+	forwardStart := time.Now()
+	writerSizeBeforeForward := c.Writer.Size()
+
+	defaultMappedModel := ""
+	if currentAPIKey.Group != nil {
+		defaultMappedModel = currentAPIKey.Group.ResolveMessagesDispatchModel(reqModel)
+	}
+
+	// OpenAI 缓存键从 anthropic metadata 会话派生，与 OpenAI 分组的 /v1/messages 入口保持一致。
+	promptCacheKey := service.ExtractClientSessionID(c)
+
+	result, err := func() (*service.OpenAIForwardResult, error) {
+		return h.openAIGatewayService.ForwardAsAnthropic(c.Request.Context(), c, account, body, promptCacheKey, defaultMappedModel)
+	}()
+
+	forwardDurationMs := time.Since(forwardStart).Milliseconds()
+	upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
+	responseLatencyMs := forwardDurationMs
+	if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
+		responseLatencyMs = forwardDurationMs - upstreamLatencyMs
+	}
+	service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+	if err == nil && result != nil && result.FirstTokenMs != nil {
+		service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
+	}
+
+	if err != nil {
+		var failoverErr *service.UpstreamFailoverError
+		if errors.As(err, &failoverErr) {
+			// 流式内容已写入客户端，无法撤销，禁止 failover 以防止流拼接腐化
+			if c.Writer.Size() != writerSizeBeforeForward {
+				h.handleFailoverExhausted(c, failoverErr, account.Platform, true)
+				return true
+			}
+			if failoverErr.ShouldReportAccountScheduleFailure() {
+				h.openAIGatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), false, nil)
+			}
+			if !failoverErr.ShouldRetryNextAccount() {
+				h.handleFailoverExhausted(c, failoverErr, account.Platform, streamStarted)
+				return true
+			}
+			action := fs.HandleFailoverError(c.Request.Context(), h.gatewayService, account.ID, account.Platform, account.GetPoolModeRetryCount(), failoverErr)
+			switch action {
+			case FailoverContinue:
+				// 允许外层循环 failover 到下一个账号
+				return false
+			case FailoverExhausted:
+				h.handleFailoverExhausted(c, fs.LastFailoverErr, account.Platform, streamStarted)
+				return true
+			case FailoverCanceled:
+				failoverClientGone(c)
+				return true
+			}
+		}
+		// 非可重试错误：提交部分 usage（若上游已计量），写错误响应，终结请求
+		upstreamErrorAlreadyCommunicated := gatewayForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
+		if !upstreamErrorAlreadyCommunicated {
+			h.ensureForwardErrorResponse(c, streamStarted)
+		}
+		reqLog.Error("gateway.openai_compat_forward_failed",
+			zap.Int64("account_id", account.ID),
+			zap.String("account_platform", account.Platform),
+			zap.Bool("upstream_error_response_already_written", upstreamErrorAlreadyCommunicated),
+			zap.Error(err),
+		)
+		h.submitOpenAICompatUsage(c, result, currentAPIKey, account, subscription, reqModel, pricingAt, body)
+		return true
+	}
+
+	if result != nil {
+		h.openAIGatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), true, result.FirstTokenMs)
+	} else {
+		h.openAIGatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), true, nil)
+	}
+
+	// 绑定粘性会话（与 anthropic 透传成功路径一致）
+	if sessionKey != "" && (sessionBoundAccountID == 0 || sessionBoundAccountID == account.ID) {
+		if err := h.gatewayService.BindStickySession(c.Request.Context(), currentAPIKey.GroupID, sessionKey, account.ID); err != nil {
+			reqLog.Warn("gateway.bind_sticky_session_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+		}
+	}
+
+	h.submitOpenAICompatUsage(c, result, currentAPIKey, account, subscription, reqModel, pricingAt, body)
+	return true
+}
+
+// submitOpenAICompatUsage 通过 OpenAI usage 管道提交协议转换路径的用量记录。
+func (h *GatewayHandler) submitOpenAICompatUsage(
+	c *gin.Context,
+	result *service.OpenAIForwardResult,
+	apiKey *service.APIKey,
+	account *service.Account,
+	subscription *service.UserSubscription,
+	reqModel string,
+	pricingAt time.Time,
+	body []byte,
+) {
+	if result == nil {
+		return
+	}
+	userAgent := c.GetHeader("User-Agent")
+	clientIP := ip.GetClientIP(c)
+	requestPayloadHash := service.HashUsageRequestPayload(body)
+	inboundEndpoint := GetInboundEndpoint(c)
+	upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account, result)
+	quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+	sessionID := service.ExtractClientSessionID(c)
+
+	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
+		if err := h.openAIGatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
+			Result:             result,
+			APIKey:             apiKey,
+			User:               apiKey.User,
+			Account:            account,
+			Subscription:       subscription,
+			InboundEndpoint:    inboundEndpoint,
+			UpstreamEndpoint:   upstreamEndpoint,
+			UserAgent:          userAgent,
+			IPAddress:          clientIP,
+			RequestPayloadHash: requestPayloadHash,
+			APIKeyService:      h.apiKeyService,
+			QuotaPlatform:      quotaPlatform,
+			SessionID:          sessionID,
+			PricingAt:          pricingAt,
+		}); err != nil {
+			logger.L().With(
+				zap.String("component", "handler.gateway.openai_compat"),
+				zap.String("model", reqModel),
+				zap.Int64("account_id", account.ID),
+			).Error("gateway.openai_compat_record_usage_failed", zap.Error(err))
+		}
+	})
 }
 
 // getUserMsgQueueMode 获取当前请求的 UMQ 模式

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1666,10 +1666,13 @@ func (a *Account) IsOpenAITokenExpired() bool {
 	return time.Now().Add(60 * time.Second).After(*expiresAt)
 }
 
-// IsMixedSchedulingEnabled 检查 antigravity 账户是否启用混合调度
-// 启用后可参与 anthropic/gemini 分组的账户调度
+// IsMixedSchedulingEnabled 检查账户是否启用混合调度。
+// 原先只对 antigravity 账号生效（参与 anthropic/gemini 分组的调度池）；
+// 现已泛化：任意平台账号设置了 extra.mixed_scheduling=true 即视为启用，
+// 使 openai 账号也能参与 anthropic/gemini 分组的调度池（跨平台协议转换）。
+// antigravity 账号的行为保持不变。
 func (a *Account) IsMixedSchedulingEnabled() bool {
-	if a.Platform != PlatformAntigravity {
+	if a.Platform != PlatformAntigravity && a.Platform != PlatformOpenAI {
 		return false
 	}
 	if a.Extra == nil {

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -957,6 +957,29 @@ func (s *GatewayService) resolvePlatform(ctx context.Context, groupID *int64, gr
 	return PlatformAnthropic, false, nil
 }
 
+// mixedSchedulingEligiblePlatforms 返回在混合调度模式下应查询的平台列表。
+// anthropic/gemini 请求会同时查询 antigravity 和 openai 账号池——后者通过
+// extra.mixed_scheduling 开启跨平台协议转换（详见 IsMixedSchedulingEnabled）。
+// 返回值始终包含请求平台本身。
+func mixedSchedulingEligiblePlatforms(platform string) []string {
+	if platform == PlatformAnthropic || platform == PlatformGemini {
+		return []string{platform, PlatformAntigravity, PlatformOpenAI}
+	}
+	return []string{platform}
+}
+
+// isMixedSchedulingCandidate 判断异平台账号是否满足混合调度参与条件。
+// 同平台账号始终参与；antigravity/openai 账号需显式启用 mixed_scheduling。
+func isMixedSchedulingCandidate(account *Account, platform string) bool {
+	if account == nil {
+		return false
+	}
+	if account.Platform == platform {
+		return true
+	}
+	return account.IsMixedSchedulingEnabled()
+}
+
 func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *int64, platform string, hasForcePlatform bool) ([]Account, bool, error) {
 	if s.schedulerSnapshot != nil {
 		accounts, useMixed, err := s.schedulerSnapshot.ListSchedulableAccounts(ctx, groupID, platform, hasForcePlatform)
@@ -986,7 +1009,7 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 	}
 	useMixed := (platform == PlatformAnthropic || platform == PlatformGemini) && !hasForcePlatform
 	if useMixed {
-		platforms := []string{platform, PlatformAntigravity}
+		platforms := mixedSchedulingEligiblePlatforms(platform)
 		var accounts []Account
 		var err error
 		if groupID != nil {
@@ -1005,7 +1028,7 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 		}
 		filtered := make([]Account, 0, len(accounts))
 		for _, acc := range accounts {
-			if acc.Platform == PlatformAntigravity && !acc.IsMixedSchedulingEnabled() {
+			if !isMixedSchedulingCandidate(&acc, platform) {
 				continue
 			}
 			filtered = append(filtered, acc)
@@ -1084,10 +1107,7 @@ func (s *GatewayService) isAccountAllowedForPlatform(account *Account, platform 
 		return false
 	}
 	if useMixed {
-		if account.Platform == platform {
-			return true
-		}
-		return account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled()
+		return isMixedSchedulingCandidate(account, platform)
 	}
 	return account.Platform == platform
 }

--- a/backend/internal/service/scheduler_snapshot_bulk_event_test.go
+++ b/backend/internal/service/scheduler_snapshot_bulk_event_test.go
@@ -108,7 +108,12 @@ func TestSchedulerBulkAccountEventScopesOpenAIRebuildToFreshPlatform(t *testing.
 	err := svc.handleBulkAccountEvent(context.Background(), bulkEventPayload([]int64{1}, []int64{11}), make(map[batchSeenKey]struct{}))
 
 	require.NoError(t, err)
-	require.ElementsMatch(t, schedulerBucketsForTest([]int64{11, 12}, PlatformOpenAI), cache.capturedBuckets())
+	// OpenAI 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+	// 批量事件需保守刷新兼容平台快照（与 antigravity 对称）。
+	require.ElementsMatch(t,
+		schedulerBucketsForTest([]int64{11, 12}, PlatformAnthropic, PlatformGemini, PlatformOpenAI),
+		cache.capturedBuckets(),
+	)
 	set, deleted := cache.accountWrites()
 	require.Equal(t, []int64{1}, set)
 	require.Empty(t, deleted)
@@ -122,7 +127,12 @@ func TestSchedulerBulkAccountEventRebuildsOpenAIUngroupedBucket(t *testing.T) {
 	err := svc.handleBulkAccountEvent(context.Background(), bulkEventPayload([]int64{6}, nil), make(map[batchSeenKey]struct{}))
 
 	require.NoError(t, err)
-	require.ElementsMatch(t, schedulerBucketsForTest([]int64{0}, PlatformOpenAI), cache.capturedBuckets())
+	// OpenAI 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+	// ungrouped 快照（group 0）也需保守刷新兼容平台（与 antigravity 对称）。
+	require.ElementsMatch(t,
+		schedulerBucketsForTest([]int64{0}, PlatformAnthropic, PlatformGemini, PlatformOpenAI),
+		cache.capturedBuckets(),
+	)
 }
 
 func TestSchedulerBulkAccountEventKeepsGroupedAndUngroupedBuckets(t *testing.T) {
@@ -136,7 +146,12 @@ func TestSchedulerBulkAccountEventKeepsGroupedAndUngroupedBuckets(t *testing.T) 
 	err := svc.handleBulkAccountEvent(context.Background(), bulkEventPayload([]int64{7, 8}, nil), make(map[batchSeenKey]struct{}))
 
 	require.NoError(t, err)
-	require.ElementsMatch(t, schedulerBucketsForTest([]int64{0, 51}, PlatformOpenAI), cache.capturedBuckets())
+	// OpenAI 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+	// 批量事件需保守刷新兼容平台快照（与 antigravity 对称）。
+	require.ElementsMatch(t,
+		schedulerBucketsForTest([]int64{0, 51}, PlatformAnthropic, PlatformGemini, PlatformOpenAI),
+		cache.capturedBuckets(),
+	)
 }
 
 func TestSchedulerBulkAccountEventDoesNotCrossCurrentGroupsBetweenPlatforms(t *testing.T) {
@@ -150,8 +165,10 @@ func TestSchedulerBulkAccountEventDoesNotCrossCurrentGroupsBetweenPlatforms(t *t
 	err := svc.handleBulkAccountEvent(context.Background(), bulkEventPayload([]int64{9, 10}, []int64{63}), make(map[batchSeenKey]struct{}))
 
 	require.NoError(t, err)
+	// OpenAI 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+	// 需保守刷新这两个兼容平台的快照；Grok 不参与混合调度，仅刷自身平台。
 	want := append(
-		schedulerBucketsForTest([]int64{61, 63}, PlatformOpenAI),
+		schedulerBucketsForTest([]int64{61, 63}, PlatformAnthropic, PlatformGemini, PlatformOpenAI),
 		schedulerBucketsForTest([]int64{62, 63}, PlatformGrok)...,
 	)
 	require.ElementsMatch(t, want, cache.capturedBuckets())
@@ -165,7 +182,12 @@ func TestSchedulerBulkAccountEventUsesGroupZeroInSimpleMode(t *testing.T) {
 	err := svc.handleBulkAccountEvent(context.Background(), bulkEventPayload([]int64{11}, []int64{72}), make(map[batchSeenKey]struct{}))
 
 	require.NoError(t, err)
-	require.ElementsMatch(t, schedulerBucketsForTest([]int64{0}, PlatformOpenAI), cache.capturedBuckets())
+	// OpenAI 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+	// 批量事件需保守刷新兼容平台快照以清理关闭 mixed_scheduling 后的旧数据（与 antigravity 对称）。
+	require.ElementsMatch(t,
+		schedulerBucketsForTest([]int64{0}, PlatformAnthropic, PlatformGemini, PlatformOpenAI),
+		cache.capturedBuckets(),
+	)
 }
 
 func TestSchedulerBulkAccountEventConservativelyExpandsAntigravityPlatforms(t *testing.T) {

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -609,11 +609,12 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 		}
 		accountGroupIDs := s.normalizeGroupIDs(account.GroupIDs)
 		switch account.Platform {
-		case PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformGrok:
+		case PlatformAnthropic, PlatformGemini, PlatformGrok:
 			addPlatformGroups(account.Platform, accountGroupIDs)
-		case PlatformAntigravity:
-			// 批量更新可能刚关闭 mixed_scheduling，仍需清理两个兼容平台的旧快照。
-			addPlatformGroups(PlatformAntigravity, accountGroupIDs)
+		case PlatformAntigravity, PlatformOpenAI:
+			// antigravity/openai 账号可能通过 mixed_scheduling 参与 anthropic/gemini 调度池，
+			// 批量更新可能刚切换该开关，仍需清理两个兼容平台的旧快照。
+			addPlatformGroups(account.Platform, accountGroupIDs)
 			addPlatformGroups(PlatformAnthropic, accountGroupIDs)
 			addPlatformGroups(PlatformGemini, accountGroupIDs)
 		default:
@@ -817,7 +818,9 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 	}
 
 	buckets := s.bucketsForPlatform(account.Platform, groupIDs, seen)
-	if account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled() {
+	if account.IsMixedSchedulingEnabled() {
+		// 启用混合调度的 antigravity/openai 账号参与 anthropic/gemini 调度池，
+		// 账号变更时必须同步刷新这两个兼容平台的快照，避免池内容过期。
 		buckets = append(buckets, s.bucketsForPlatform(PlatformAnthropic, groupIDs, seen)...)
 		buckets = append(buckets, s.bucketsForPlatform(PlatformGemini, groupIDs, seen)...)
 	}
@@ -1464,7 +1467,7 @@ func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucke
 	}
 
 	if useMixed {
-		platforms := []string{bucket.Platform, PlatformAntigravity}
+		platforms := mixedSchedulingEligiblePlatforms(bucket.Platform)
 		var accounts []Account
 		var err error
 		if groupID > 0 {
@@ -1479,7 +1482,7 @@ func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucke
 		}
 		filtered := make([]Account, 0, len(accounts))
 		for _, acc := range accounts {
-			if acc.Platform == PlatformAntigravity && !acc.IsMixedSchedulingEnabled() {
+			if !isMixedSchedulingCandidate(&acc, bucket.Platform) {
 				continue
 			}
 			filtered = append(filtered, acc)

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3121,8 +3121,8 @@
       </div>
 
       <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
-        <!-- Mixed Scheduling (only for antigravity accounts) -->
-        <div v-if="form.platform === 'antigravity'" class="flex items-center gap-2">
+        <!-- Mixed Scheduling (antigravity/openai accounts: enable cross-platform protocol conversion) -->
+        <div v-if="form.platform === 'antigravity' || form.platform === 'openai'" class="flex items-center gap-2">
           <label class="flex cursor-pointer items-center gap-2">
             <input
               type="checkbox"
@@ -4827,6 +4827,13 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_responses_mode = openAIResponsesMode.value
   } else {
     delete extra.openai_responses_mode
+  }
+
+  // 混合调度：openai 账号启用后可参与 anthropic/gemini 分组调度（协议转换）
+  if (mixedScheduling.value) {
+    extra.mixed_scheduling = true
+  } else {
+    delete extra.mixed_scheduling
   }
 
   return Object.keys(extra).length > 0 ? extra : undefined

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2599,6 +2599,35 @@
             </div>
           </div>
         </div>
+        <!-- Mixed Scheduling (openai accounts: editable, enables cross-platform protocol conversion into anthropic/gemini groups) -->
+        <div v-if="account?.platform === 'openai'" class="flex items-center gap-2">
+          <label class="flex cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              v-model="mixedScheduling"
+              class="h-4 w-4 cursor-pointer rounded border-gray-300 text-primary-500 focus:ring-primary-500 dark:border-dark-500"
+            />
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+              {{ t('admin.accounts.mixedScheduling') }}
+            </span>
+          </label>
+          <div class="group relative">
+            <span
+              class="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-gray-200 text-xs text-gray-500 hover:bg-gray-300 dark:bg-dark-600 dark:text-gray-400 dark:hover:bg-dark-500"
+            >
+              ?
+            </span>
+            <!-- Tooltip（向下显示避免被弹窗裁剪） -->
+            <div
+              class="pointer-events-none absolute left-0 top-full z-[100] mt-1.5 w-72 rounded bg-gray-900 px-3 py-2 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 dark:bg-gray-700"
+            >
+              {{ t('admin.accounts.mixedSchedulingTooltip') }}
+              <div
+                class="absolute bottom-full left-3 border-4 border-transparent border-b-gray-900 dark:border-b-gray-700"
+              ></div>
+            </div>
+          </div>
+        </div>
         <div v-if="account?.platform === 'antigravity'" class="mt-3 flex items-center gap-2">
           <label class="flex cursor-pointer items-center gap-2">
             <input
@@ -4595,6 +4624,18 @@ const handleSubmit = async () => {
         newExtra.allow_overages = true
       } else {
         delete newExtra.allow_overages
+      }
+      updatePayload.extra = newExtra
+    }
+
+    // For openai accounts, handle mixed_scheduling in extra (cross-platform protocol conversion)
+    if (props.account.platform === 'openai') {
+      const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
+      const newExtra: Record<string, unknown> = { ...currentExtra }
+      if (mixedScheduling.value) {
+        newExtra.mixed_scheduling = true
+      } else {
+        delete newExtra.mixed_scheduling
       }
       updatePayload.extra = newExtra
     }

--- a/frontend/src/components/common/GroupSelector.vue
+++ b/frontend/src/components/common/GroupSelector.vue
@@ -69,7 +69,7 @@ interface Props {
   modelValue: number[]
   groups: AdminGroup[]
   platform?: GroupPlatform // Optional platform filter
-  mixedScheduling?: boolean // For antigravity accounts: allow anthropic/gemini groups
+  mixedScheduling?: boolean // For antigravity/openai accounts: allow anthropic/gemini groups via cross-platform protocol conversion
   searchable?: boolean | 'auto'
 }
 
@@ -91,10 +91,11 @@ const isSearchable = computed(() => {
 const filteredGroups = computed(() => {
   let result: AdminGroup[] = props.groups
   if (props.platform) {
-    // antigravity 账户启用混合调度后，可选择 anthropic/gemini 分组
-    if (props.platform === 'antigravity' && props.mixedScheduling) {
+    // antigravity/openai 账户启用混合调度后，可选择 anthropic/gemini 分组
+    // （openai 账号经协议转换服务 anthropic/gemini 协议请求）
+    if ((props.platform === 'antigravity' || props.platform === 'openai') && props.mixedScheduling) {
       result = result.filter(
-        (g) => g.platform === 'antigravity' || g.platform === 'anthropic' || g.platform === 'gemini' || g.platform === 'composite'
+        (g) => g.platform === props.platform || g.platform === 'anthropic' || g.platform === 'gemini' || g.platform === 'composite'
       )
     } else {
       // 默认：只能选择同 platform 的分组；composite 分组可接收任意具体平台账号


### PR DESCRIPTION
很多用户（比如cc用户）希望直接用 OpenAI 账号（GPT）来服务 Anthropic 协议请求，目前 混合调度仅对 antigravity 账号生效，如果强行将 OpenAI 账号加入 Anthropic 分组，请求会失败。

此PR把混合调度机制扩展到OpenAI账号：
允许OpenAI 账号设置“在 /v1/messages 中使用”参与 anthropic调度池，此时anthropic请求的混合调度查询现在会同时查询 anthropic, antigravity, openai三个平台。
当 anthropic/gemini 分组选中 OpenAI 账号时，内部自动完成 Anthropic Messages到OpenAI Responses/ChatCompletions 双向转换，且走独立的 OpenAI usage 管道，支持 failover 到下一个账号。
计费配额按实际服务账号的平台扣减，

现有 OpenAI 账号默认不参与混合调度，需手动开启。

## 测试

- [x] `go build ` 通过
- [x] `go vet` 通过
- [x] 调度相关单元测试通过
- [x] handler 全部单元测试通过
- [x] 前端 `vue-tsc` 类型检查通过
- [x] VM 环境实际部署验证：OpenAI 账号开关、分组选择器、协议转换链路