### PR TITLE
fix: retry Codex capacity errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,10 @@ If you disable URL validation or response header filtering, harden your network 
 - Enforce TLS-only outbound traffic
 - Strip sensitive upstream response headers at the proxy
 
+#### OpenAI Responses SSE lifecycle buffering
+
+`gateway.openai_responses_first_event_timeout_seconds` controls how long lifecycle SSE events are held before the first semantic payload or retryable upstream error. The default is `2` seconds. When Codex reports `Selected model is at capacity. Please try a different model.`, configure `40-60` seconds, with `60` seconds as the recommended starting point, so the capacity error can trigger automatic failover before the response is committed. A channel can override the global value through `features_config.responses_first_event_timeout`.
+
 #### OpenAI Responses WebSocket ingress limits
 
 `gateway.openai_ws` bounds the lifetime and aggregate count of client-facing

--- a/README_CN.md
+++ b/README_CN.md
@@ -617,6 +617,7 @@ SECURITY_FORWARDED_CLIENT_IP_HEADERS=True-Client-IP,X-CDN-Client-IP
 - `gateway.upstream_response_read_max_bytes`：限制非流式上游响应读取大小（默认 `8MB`），用于防止异常响应导致内存放大。
 - `gateway.proxy_probe_response_read_max_bytes`：限制代理探测响应读取大小（默认 `1MB`）。
 - `gateway.gemini_debug_response_headers`：默认 `false`，仅在排障时短时开启，避免高频请求日志开销。
+- `gateway.openai_responses_first_event_timeout_seconds`：Responses SSE 首个生命周期事件缓存窗口，单位为秒，默认 `2`。Codex 出现 `Selected model is at capacity. Please try a different model.` 时建议配置为 `40-60`，推荐先使用 `60`，让容量错误事件在首个正常 payload 到达前触发自动故障转移。单个通道可在 `features_config.responses_first_event_timeout` 中覆盖全局值。
 - `/auth/register`、`/auth/login`、`/auth/login/2fa`、`/auth/send-verify-code` 已提供服务端兜底限流（Redis 故障时 fail-close）。
 - 推荐将 WAF/CDN 作为第一层防护，服务端限流与响应读取上限作为第二层兜底；两层同时保留，避免旁路流量与误配置风险。
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -61,6 +61,15 @@ const (
 // 可通过 gateway.upstream_response_read_max_bytes 配置项覆盖。
 const DefaultUpstreamResponseReadMaxBytes int64 = 128 * 1024 * 1024
 
+const (
+	// DefaultOpenAIResponsesFirstEventTimeoutSeconds is the default lifecycle
+	// event buffering window for OpenAI Responses SSE streams.
+	DefaultOpenAIResponsesFirstEventTimeoutSeconds = 2
+	// MaxOpenAIResponsesFirstEventTimeoutSeconds bounds the configured buffering
+	// window so a lifecycle-only stream cannot hold a response indefinitely.
+	MaxOpenAIResponsesFirstEventTimeoutSeconds = 600
+)
+
 type Config struct {
 	Server                  ServerConfig                  `mapstructure:"server"`
 	Log                     LogConfig                     `mapstructure:"log"`
@@ -892,6 +901,10 @@ type GatewayConfig struct {
 	// OpenAIHighEffortFirstOutputTimeoutSeconds: high/xhigh/max 推理的首个语义输出超时（秒）。
 	// 0 表示回退到 OpenAIFirstOutputTimeoutSeconds。
 	OpenAIHighEffortFirstOutputTimeoutSeconds int `mapstructure:"openai_high_effort_first_output_timeout_seconds"`
+	// OpenAIResponsesFirstEventTimeoutSeconds: Responses SSE 首个事件缓存时长（秒）。
+	// 生命周期事件会在该时长内等待首个语义输出或可重试错误，以支持流中途容量错误触发故障转移。
+	// 0 表示立即释放生命周期事件，默认 2 秒。
+	OpenAIResponsesFirstEventTimeoutSeconds int `mapstructure:"openai_responses_first_event_timeout_seconds"`
 	// 请求体最大字节数，用于网关请求体大小限制
 	MaxBodySize int64 `mapstructure:"max_body_size"`
 	// TextMaxBodySize limits endpoints that cannot carry inline image/video payloads.
@@ -2262,6 +2275,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_response_header_timeout", 0)
 	viper.SetDefault("gateway.openai_first_output_timeout_seconds", 0)
 	viper.SetDefault("gateway.openai_high_effort_first_output_timeout_seconds", 0)
+	viper.SetDefault("gateway.openai_responses_first_event_timeout_seconds", DefaultOpenAIResponsesFirstEventTimeoutSeconds)
 	viper.SetDefault("gateway.log_upstream_error_body", true)
 	viper.SetDefault("gateway.log_upstream_error_body_max_bytes", 2048)
 	viper.SetDefault("gateway.inject_beta_for_apikey", false)
@@ -3172,6 +3186,9 @@ func (c *Config) Validate() error {
 	if c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds < 0 || c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds > 1800 ||
 		(c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds > 0 && c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds < 30) {
 		return fmt.Errorf("gateway.openai_high_effort_first_output_timeout_seconds must be 0 or between 30-1800 seconds")
+	}
+	if c.Gateway.OpenAIResponsesFirstEventTimeoutSeconds < 0 || c.Gateway.OpenAIResponsesFirstEventTimeoutSeconds > MaxOpenAIResponsesFirstEventTimeoutSeconds {
+		return fmt.Errorf("gateway.openai_responses_first_event_timeout_seconds must be between 0-%d seconds", MaxOpenAIResponsesFirstEventTimeoutSeconds)
 	}
 	if c.Gateway.Live.MaxSessionDurationSeconds <= 0 {
 		c.Gateway.Live.MaxSessionDurationSeconds = 3600

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -374,6 +374,38 @@ func TestLoadDefaultOpenAIFirstOutputTimeoutsDisabled(t *testing.T) {
 	require.Zero(t, cfg.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds)
 }
 
+func TestLoadDefaultOpenAIResponsesFirstEventTimeout(t *testing.T) {
+	resetViperWithJWTSecret(t)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 2, cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds)
+}
+
+func TestLoadOpenAIResponsesFirstEventTimeoutFromEnv(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_SECONDS", "0")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Zero(t, cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds)
+}
+
+func TestValidateOpenAIResponsesFirstEventTimeout(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	for _, seconds := range []int{0, 1, 2, 600} {
+		cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds = seconds
+		require.NoError(t, cfg.Validate(), "seconds=%d", seconds)
+	}
+	for _, seconds := range []int{-1, 601} {
+		cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds = seconds
+		require.ErrorContains(t, cfg.Validate(), "gateway.openai_responses_first_event_timeout_seconds", "seconds=%d", seconds)
+	}
+}
+
 func TestLoadOpenAIFirstOutputTimeoutsFromEnv(t *testing.T) {
 	resetViperWithJWTSecret(t)
 	t.Setenv("GATEWAY_OPENAI_FIRST_OUTPUT_TIMEOUT_SECONDS", "90")

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -2224,6 +2224,7 @@ func TestOpenAIResponses_APIKeyPassthroughSSERateLimitUsesConfiguredPoolRetry(t 
 	cfg.Default.RateMultiplier = 1
 	cfg.Security.URLAllowlist.Enabled = false
 	cfg.Gateway.MaxAccountSwitches = 1
+	cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds = 2
 
 	accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: accounts}
 	upstream := &openAIHTTPPassthroughSSERateLimitUpstream{}

--- a/backend/internal/service/openai_capacity_shed_test.go
+++ b/backend/internal/service/openai_capacity_shed_test.go
@@ -94,6 +94,8 @@ func TestOpenAIStreamErrorFrameDoesNotStartClientOutput(t *testing.T) {
 		{`{"type":"response.failed","response":{"error":{"code":"server_is_overloaded"}}}`, "response.failed", false},
 		{`{"type":"response.created","response":{"id":"resp_1"}}`, "response.created", false},
 		{`{"type":"response.in_progress","response":{"id":"resp_1"}}`, "response.in_progress", false},
+		{`{"type":"response.queued","response":{"id":"resp_1"}}`, "response.queued", false},
+		{`{"type":"keepalive","sequence_number":3}`, "keepalive", false},
 		{`{"type":"response.output_text.delta","delta":"hi"}`, "response.output_text.delta", true},
 		{`[DONE]`, "", true},
 	}
@@ -107,7 +109,10 @@ func TestOpenAIStreamErrorFrameDoesNotStartClientOutput(t *testing.T) {
 func TestOpenAIStreamCapacityShedErrorFramePrecedingFailedStillFailsOver(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
-		Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+		Gateway: config.GatewayConfig{
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
+		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
 
@@ -124,11 +129,17 @@ func TestOpenAIStreamCapacityShedErrorFramePrecedingFailedStillFailsOver(t *test
 			"event: response.in_progress",
 			`data: {"type":"response.in_progress","response":{"id":"resp_1"},"sequence_number":1}`,
 			"",
+			"event: response.queued",
+			`data: {"response":{"id":"resp_1"},"sequence_number":2}`,
+			"",
+			"event: keepalive",
+			`data: {"sequence_number":3}`,
+			"",
 			"event: error",
-			`data: {"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."},"sequence_number":2}`,
+			`data: {"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."},"sequence_number":4}`,
 			"",
 			"event: response.failed",
-			`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}},"sequence_number":3}`,
+			`data: {"response":{"id":"resp_1","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}},"sequence_number":5}`,
 			"",
 		}, "\n"))),
 		Header: http.Header{"X-Request-Id": []string{"rid-shed-error-then-failed"}},
@@ -140,6 +151,43 @@ func TestOpenAIStreamCapacityShedErrorFramePrecedingFailedStillFailsOver(t *test
 	require.ErrorAs(t, err, &failoverErr)
 	require.True(t, failoverErr.RetryableOnSameAccount)
 	require.True(t, failoverErr.RequestScopedTransient)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, rec.Body.String())
+}
+
+func TestOpenAIStreamCapacityErrorEventImmediatelyFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{
+		Gateway: config.GatewayConfig{
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
+		},
+	}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.queued",
+			`data: {"response":{"id":"resp_capacity"}}`,
+			"",
+			"event: error",
+			`data: {"error":{"code":"server_is_overloaded","message":"model capacity exhausted"}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-capacity-error"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{
+		ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Name: "acc",
+	}, time.Now(), "model", "model")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.True(t, failoverErr.RequestScopedTransient)
+	require.Contains(t, string(failoverErr.ResponseBody), "model capacity exhausted")
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
 }

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -784,7 +784,7 @@ func openAIStreamClientOutputStarted(c *gin.Context, localStarted bool) bool {
 
 func openAIStreamEventIsPreamble(eventType string) bool {
 	switch strings.TrimSpace(eventType) {
-	case "response.created", "response.in_progress":
+	case "response.created", "response.in_progress", "response.queued", "keepalive":
 		return true
 	default:
 		return false
@@ -1255,10 +1255,60 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	}
 	scanBuf := getSSEScannerBuf64K()
 	scanner.Buffer(scanBuf[:0], maxLineSize)
-	defer putSSEScannerBuf64K(scanBuf)
 	documentScanner := newOpenAISSEJSONDocumentScanner(scanner)
+	initialEventTimeout := s.openAIResponsesInitialEventTimeout(ctx, c)
+	initialEventDelayEnabled := initialEventTimeout > 0
+	var initialEventTimer *time.Timer
+	var initialEventCh <-chan time.Time
+	startInitialEventTimer := func() {
+		if !initialEventDelayEnabled || initialEventTimer != nil {
+			return
+		}
+		initialEventTimer = time.NewTimer(initialEventTimeout)
+		initialEventCh = initialEventTimer.C
+	}
+	stopInitialEventTimer := func() {
+		if initialEventTimer == nil {
+			return
+		}
+		if !initialEventTimer.Stop() {
+			select {
+			case <-initialEventTimer.C:
+			default:
+			}
+		}
+		initialEventTimer = nil
+		initialEventCh = nil
+	}
+	defer stopInitialEventTimer()
+
+	type passthroughScanEvent struct {
+		line string
+		err  error
+	}
+	events := make(chan passthroughScanEvent, openAIDefaultStreamQueueSize)
+	done := make(chan struct{})
+	go func() {
+		defer close(events)
+		defer putSSEScannerBuf64K(scanBuf)
+		for documentScanner.Scan() {
+			select {
+			case events <- passthroughScanEvent{line: documentScanner.Text()}:
+			case <-done:
+				return
+			}
+		}
+		if err := documentScanner.Err(); err != nil {
+			select {
+			case events <- passthroughScanEvent{err: err}:
+			case <-done:
+			}
+		}
+	}()
+	defer close(done)
 
 	needModelReplace := strings.TrimSpace(originalModel) != "" && strings.TrimSpace(mappedModel) != "" && strings.TrimSpace(originalModel) != strings.TrimSpace(mappedModel)
+	currentSSEEventType := ""
 	resultWithUsage := func() *openaiStreamingResultPassthrough {
 		return &openaiStreamingResultPassthrough{
 			usage:            usage,
@@ -1269,145 +1319,185 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 	}
 
-	for documentScanner.Scan() {
-		line := documentScanner.Text()
-		lineStartsClientOutput := false
-		forceFlushFailedEvent := false
-		if data, ok := extractOpenAISSEDataLine(line); ok {
-			dataBytes := []byte(data)
-			trimmedData := strings.TrimSpace(data)
-			rawEventType := strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
-			observer.ObserveOpenAI(dataBytes, rawEventType)
-			if needModelReplace && strings.Contains(data, mappedModel) {
-				line = s.replaceModelInSSELine(line, mappedModel, originalModel)
-				if replacedData, replaced := extractOpenAISSEDataLine(line); replaced {
-					dataBytes = []byte(replacedData)
-					trimmedData = strings.TrimSpace(replacedData)
-				}
+	var scanErr error
+scanLoop:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				break scanLoop
 			}
-			if normalizedData, normalized := normalizeOpenAIResponsesFunctionCallArguments(dataBytes); normalized {
-				dataBytes = normalizedData
-				trimmedData = strings.TrimSpace(string(normalizedData))
-				line = "data: " + string(normalizedData)
+			if event.err != nil {
+				scanErr = event.err
+				break scanLoop
 			}
-			if normalizedData, normalized := normalizeCompletedImageGenerationStatus(dataBytes); normalized {
-				dataBytes = normalizedData
-				trimmedData = strings.TrimSpace(string(normalizedData))
-				line = "data: " + string(normalizedData)
+			line := event.line
+			if eventType, ok := extractOpenAISSEEventLine(line); ok {
+				currentSSEEventType = eventType
 			}
-			if trimmedData != "[DONE]" {
-				restoredData, restoreErr := restoreOpenAIResponsesNamespacePayload(c, dataBytes)
-				if restoreErr != nil {
-					return resultWithUsage(), fmt.Errorf("restore OpenAI passthrough namespace response: %w", restoreErr)
+			lineStartsClientOutput := false
+			forceFlushFailedEvent := false
+			if data, ok := extractOpenAISSEDataLine(line); ok {
+				dataBytes := []byte(data)
+				trimmedData := strings.TrimSpace(data)
+				rawEventType := openAISSEEventType(dataBytes, currentSSEEventType)
+				observer.ObserveOpenAI(dataBytes, rawEventType)
+				if needModelReplace && strings.Contains(data, mappedModel) {
+					line = s.replaceModelInSSELine(line, mappedModel, originalModel)
+					if replacedData, replaced := extractOpenAISSEDataLine(line); replaced {
+						dataBytes = []byte(replacedData)
+						trimmedData = strings.TrimSpace(replacedData)
+					}
 				}
-				if !bytes.Equal(restoredData, dataBytes) {
-					dataBytes = restoredData
-					trimmedData = strings.TrimSpace(string(restoredData))
-					line = "data: " + string(restoredData)
+				if normalizedData, normalized := normalizeOpenAIResponsesFunctionCallArguments(dataBytes); normalized {
+					dataBytes = normalizedData
+					trimmedData = strings.TrimSpace(string(normalizedData))
+					line = "data: " + string(normalizedData)
 				}
-			}
-			eventType := strings.TrimSpace(gjson.Get(trimmedData, "type").String())
-			if eventType == "response.failed" {
-				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
-				// response.failed 自带上游已消耗的 usage（input token 通常已扣）；必须先解析
-				// 再打 cyber 标记，否则 mark 记到的是解析前的 0，导致流式 cyber 按 0 token 计费
-				// 而漏记真实用量。对齐 WS V2 / Chat 流式路径（均先解析 usage 再 Mark）。
-				s.parseSSEUsageBytes(dataBytes, usage)
-				if hit, code, msg := detectOpenAICyberPolicy(dataBytes); hit {
-					MarkOpsCyberPolicy(c, CyberPolicyMark{
-						Code:           code,
-						Message:        msg,
-						Body:           truncateString(string(dataBytes), 4096),
-						UpstreamStatus: http.StatusOK,
-						UpstreamInTok:  usage.InputTokens,
-						UpstreamOutTok: usage.OutputTokens,
-					})
+				if normalizedData, normalized := normalizeCompletedImageGenerationStatus(dataBytes); normalized {
+					dataBytes = normalizedData
+					trimmedData = strings.TrimSpace(string(normalizedData))
+					line = "data: " + string(normalizedData)
 				}
-				if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
-					if status, errType, errMsg, matched := applyOpenAIStreamFailedErrorPassthroughRule(c, account.Platform, dataBytes, failedMessage); matched {
-						// 命中透传规则也要记录 ops 上游错误事件（对齐 CC/Messages 与
-						// antigravity 先例），否则透传命中的 failed 在监控中不可见。
-						s.recordOpenAIStreamUpstreamError(c, account, true, upstreamRequestID, "http_error", dataBytes, failedMessage)
-						MarkResponseCommitted(c)
-						c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
-						c.JSON(status, gin.H{
-							"error": gin.H{
-								"type":    errType,
-								"message": errMsg,
-							},
+				if trimmedData != "[DONE]" {
+					restoredData, restoreErr := restoreOpenAIResponsesNamespacePayload(c, dataBytes)
+					if restoreErr != nil {
+						return resultWithUsage(), fmt.Errorf("restore OpenAI passthrough namespace response: %w", restoreErr)
+					}
+					if !bytes.Equal(restoredData, dataBytes) {
+						dataBytes = restoredData
+						trimmedData = strings.TrimSpace(string(restoredData))
+						line = "data: " + string(restoredData)
+					}
+				}
+				eventType := openAISSEEventType([]byte(trimmedData), currentSSEEventType)
+				if eventType == "error" && !openAIStreamClientOutputStarted(c, clientOutputStarted) && isOpenAIUpstreamCapacityShedEvent(dataBytes) {
+					failedMessage = extractOpenAISSEErrorMessage(dataBytes)
+					s.parseSSEUsageBytes(dataBytes, usage)
+					return resultWithUsage(),
+						s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage, resp.Header)
+				}
+				if eventType == "response.failed" {
+					failedMessage = extractOpenAISSEErrorMessage(dataBytes)
+					// response.failed 自带上游已消耗的 usage（input token 通常已扣）；必须先解析
+					// 再打 cyber 标记，否则 mark 记到的是解析前的 0，导致流式 cyber 按 0 token 计费
+					// 而漏记真实用量。对齐 WS V2 / Chat 流式路径（均先解析 usage 再 Mark）。
+					s.parseSSEUsageBytes(dataBytes, usage)
+					if hit, code, msg := detectOpenAICyberPolicy(dataBytes); hit {
+						MarkOpsCyberPolicy(c, CyberPolicyMark{
+							Code:           code,
+							Message:        msg,
+							Body:           truncateString(string(dataBytes), 4096),
+							UpstreamStatus: http.StatusOK,
+							UpstreamInTok:  usage.InputTokens,
+							UpstreamOutTok: usage.OutputTokens,
 						})
-						return resultWithUsage(), fmt.Errorf("upstream response failed: passthrough rule matched message=%s", errMsg)
 					}
-					if openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
-						return resultWithUsage(),
-							s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage, resp.Header)
+					if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+						if status, errType, errMsg, matched := applyOpenAIStreamFailedErrorPassthroughRule(c, account.Platform, dataBytes, failedMessage); matched {
+							// 命中透传规则也要记录 ops 上游错误事件（对齐 CC/Messages 与
+							// antigravity 先例），否则透传命中的 failed 在监控中不可见。
+							s.recordOpenAIStreamUpstreamError(c, account, true, upstreamRequestID, "http_error", dataBytes, failedMessage)
+							MarkResponseCommitted(c)
+							c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+							c.JSON(status, gin.H{
+								"error": gin.H{
+									"type":    errType,
+									"message": errMsg,
+								},
+							})
+							return resultWithUsage(), fmt.Errorf("upstream response failed: passthrough rule matched message=%s", errMsg)
+						}
+						if openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
+							return resultWithUsage(),
+								s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage, resp.Header)
+						}
 					}
+					forceFlushFailedEvent = true
+					sawFailedEvent = true
 				}
-				forceFlushFailedEvent = true
-				sawFailedEvent = true
+				if trimmedData == "[DONE]" {
+					sawDone = true
+				}
+				if openAIStreamEventIsTerminalWithType(trimmedData, eventType) {
+					sawTerminalEvent = true
+				}
+				if responseID == "" {
+					responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
+				}
+				imageCounter.AddSSEData(dataBytes)
+				if sanitizedData, sanitized := sanitizeOpenAIResponseFailedEventForClient(
+					dataBytes,
+					eventType,
+					openAIStreamClientOutputStarted(c, clientOutputStarted),
+				); sanitized {
+					dataBytes = sanitizedData
+					trimmedData = strings.TrimSpace(string(sanitizedData))
+					line = "data: " + string(sanitizedData)
+				}
+				lineStartsClientOutput = forceFlushFailedEvent || openAIStreamDataStartsClientOutput(trimmedData, eventType)
+				if lineStartsClientOutput && trimmedData != "[DONE]" && !openAIStreamEventTypeIsTerminal(eventType) {
+					semanticOutputSeen = true
+				}
+				// OpenAI Responses streams that terminate with an empty
+				// response.completed (no output, no usage, no error, nothing sent
+				// to the client) are silent upstream refusals: fail over instead of
+				// recording a successful 0/0 usage turn (issue #5009).
+				if (eventType == "response.completed" || eventType == "response.done") &&
+					!sawFailedEvent && !semanticOutputSeen && !clientOutputStarted &&
+					openAIResponsesCompletedEventIsEmpty(dataBytes, usage) {
+					return resultWithUsage(), newOpenAIResponsesEmptyCompletedFailoverError(c, account, upstreamRequestID)
+				}
+				if firstTokenMs == nil && openAIStreamDataStartsVisibleOutput(trimmedData, eventType) {
+					ms := int(time.Since(startTime).Milliseconds())
+					firstTokenMs = &ms
+				}
+				s.parseSSEUsageBytes(dataBytes, usage)
 			}
-			if trimmedData == "[DONE]" {
-				sawDone = true
-			}
-			if openAIStreamEventIsTerminal(trimmedData) {
-				sawTerminalEvent = true
-			}
-			if responseID == "" {
-				responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
-			}
-			imageCounter.AddSSEData(dataBytes)
-			if sanitizedData, sanitized := sanitizeOpenAIResponseFailedEventForClient(
-				dataBytes,
-				eventType,
-				openAIStreamClientOutputStarted(c, clientOutputStarted),
-			); sanitized {
-				dataBytes = sanitizedData
-				trimmedData = strings.TrimSpace(string(sanitizedData))
-				line = "data: " + string(sanitizedData)
-			}
-			lineStartsClientOutput = forceFlushFailedEvent || openAIStreamDataStartsClientOutput(trimmedData, eventType)
-			if lineStartsClientOutput && trimmedData != "[DONE]" && !openAIStreamEventTypeIsTerminal(eventType) {
-				semanticOutputSeen = true
-			}
-			// OpenAI Responses streams that terminate with an empty
-			// response.completed (no output, no usage, no error, nothing sent
-			// to the client) are silent upstream refusals: fail over instead of
-			// recording a successful 0/0 usage turn (issue #5009).
-			if (eventType == "response.completed" || eventType == "response.done") &&
-				!sawFailedEvent && !semanticOutputSeen && !clientOutputStarted &&
-				openAIResponsesCompletedEventIsEmpty(dataBytes, usage) {
-				return resultWithUsage(), newOpenAIResponsesEmptyCompletedFailoverError(c, account, upstreamRequestID)
-			}
-			if firstTokenMs == nil && openAIStreamDataStartsVisibleOutput(trimmedData, eventType) {
-				ms := int(time.Since(startTime).Milliseconds())
-				firstTokenMs = &ms
-			}
-			s.parseSSEUsageBytes(dataBytes, usage)
-		}
 
-		if !clientDisconnected {
-			if !clientOutputStarted && !lineStartsClientOutput {
-				pendingLines = append(pendingLines, line)
-				continue
-			}
-			if !clientOutputStarted && len(pendingLines) > 0 {
-				if !writePendingLines() {
+			if !clientDisconnected {
+				if !clientOutputStarted && !lineStartsClientOutput && initialEventDelayEnabled {
+					pendingLines = append(pendingLines, line)
+					if line != "" {
+						startInitialEventTimer()
+					}
+					if line == "" {
+						currentSSEEventType = ""
+					}
 					continue
 				}
+				if !clientOutputStarted && len(pendingLines) > 0 {
+					if !writePendingLines() {
+						continue
+					}
+				}
+				if _, err := fmt.Fprintln(w, line); err != nil {
+					clientDisconnected = true
+					logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				} else {
+					clientOutputStarted = true
+					flushPending = true
+					if line == "" {
+						flushPendingOutput()
+					}
+				}
 			}
-			if _, err := fmt.Fprintln(w, line); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
-			} else {
+			if line == "" {
+				currentSSEEventType = ""
+			}
+		case <-initialEventCh:
+			stopInitialEventTimer()
+			if clientDisconnected || clientOutputStarted || len(pendingLines) == 0 {
+				continue
+			}
+			if writePendingLines() {
 				clientOutputStarted = true
 				flushPending = true
-				if line == "" {
-					flushPendingOutput()
-				}
+				flushPendingOutput()
 			}
 		}
 	}
-	if err := documentScanner.Err(); err != nil {
+	if err := scanErr; err != nil {
 		if (sawDone || sawTerminalEvent) && !sawFailedEvent {
 			s.clearOpenAIProxyStreamDisconnect(account)
 			return resultWithUsage(), nil

--- a/backend/internal/service/openai_gateway_passthrough_flush_test.go
+++ b/backend/internal/service/openai_gateway_passthrough_flush_test.go
@@ -23,6 +23,7 @@ type passthroughFlushTestWriter struct {
 	successfulWrites int
 	failedWrites     int
 	flushBodyLengths []int
+	flushEvents      chan struct{}
 }
 
 func (w *passthroughFlushTestWriter) Write(data []byte) (int, error) {
@@ -44,6 +45,9 @@ func (w *passthroughFlushTestWriter) WriteString(data string) (int, error) {
 func (w *passthroughFlushTestWriter) Flush() {
 	w.ResponseWriter.Flush()
 	w.flushBodyLengths = append(w.flushBodyLengths, w.recorder.Body.Len())
+	if w.flushEvents != nil {
+		w.flushEvents <- struct{}{}
+	}
 }
 
 type passthroughFlushTestErrorBody struct {
@@ -68,6 +72,16 @@ func runPassthroughFlushTest(
 	failAfterWrites int,
 	setups ...func(*gin.Context),
 ) (*openaiStreamingResultPassthrough, *httptest.ResponseRecorder, *passthroughFlushTestWriter, error) {
+	return runPassthroughFlushTestWithTimeout(t, body, failAfterWrites, 2, setups...)
+}
+
+func runPassthroughFlushTestWithTimeout(
+	t *testing.T,
+	body io.ReadCloser,
+	failAfterWrites int,
+	firstEventTimeoutSeconds int,
+	setups ...func(*gin.Context),
+) (*openaiStreamingResultPassthrough, *httptest.ResponseRecorder, *passthroughFlushTestWriter, error) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -78,6 +92,7 @@ func runPassthroughFlushTest(
 		ResponseWriter:  c.Writer,
 		recorder:        recorder,
 		failAfterWrites: failAfterWrites,
+		flushEvents:     make(chan struct{}, 16),
 	}
 	c.Writer = writer
 	for _, setup := range setups {
@@ -85,7 +100,10 @@ func runPassthroughFlushTest(
 	}
 
 	svc := &OpenAIGatewayService{cfg: &config.Config{
-		Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+		Gateway: config.GatewayConfig{
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: firstEventTimeoutSeconds,
+		},
 	}}
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -145,6 +163,102 @@ func TestOpenAIStreamingPassthroughKeepsPreamblePendingUntilFirstOutputBoundary(
 	}, writer.flushBodyLengths)
 }
 
+func TestOpenAIStreamingPassthroughZeroTimeoutReleasesLifecycleImmediately(t *testing.T) {
+	preamble := "event: response.queued\n" +
+		`data: {"response":{"id":"resp_zero"}}` + "\n\n"
+	terminal := `data: {"type":"response.completed","response":{"id":"resp_zero","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"
+	allowTerminal := make(chan struct{})
+	terminalWaiting := make(chan struct{})
+	reader := &stagedOpenAISSEReadCloser{
+		segments: [][]byte{[]byte(preamble), []byte(terminal)},
+		gates:    []<-chan struct{}{nil, allowTerminal},
+		waiting:  []chan struct{}{nil, terminalWaiting},
+	}
+
+	type runResult struct {
+		result   *openaiStreamingResultPassthrough
+		recorder *httptest.ResponseRecorder
+		writer   *passthroughFlushTestWriter
+		err      error
+	}
+	resultCh := make(chan runResult, 1)
+	writerCh := make(chan *passthroughFlushTestWriter, 1)
+	go func() {
+		result, recorder, writer, err := runPassthroughFlushTestWithTimeout(t, reader, -1, 0, func(c *gin.Context) {
+			writerCh <- c.Writer.(*passthroughFlushTestWriter)
+		})
+		resultCh <- runResult{result: result, recorder: recorder, writer: writer, err: err}
+	}()
+	writer := <-writerCh
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-terminalWaiting:
+	case <-timer.C:
+		t.Fatal("timed out waiting for terminal event read")
+	}
+	// The zero-second channel override must make the queued lifecycle event visible
+	// while the upstream reader is still blocked before the terminal event.
+	select {
+	case <-writer.flushEvents:
+	case <-timer.C:
+		t.Fatal("timed out waiting for lifecycle flush")
+	}
+	close(allowTerminal)
+	run := <-resultCh
+	require.NoError(t, run.err)
+	require.NotNil(t, run.result)
+	require.Equal(t, preamble+terminal, run.recorder.Body.String())
+	require.Equal(t, []int{len(preamble), len(preamble) + len(terminal)}, run.writer.flushBodyLengths)
+}
+
+func TestOpenAIStreamingPassthroughConfiguredTimeoutFlushesLifecycle(t *testing.T) {
+	preamble := "event: response.queued\n" +
+		`data: {"response":{"id":"resp_timer"}}` + "\n\n"
+	terminal := `data: {"type":"response.completed","response":{"id":"resp_timer","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"
+	allowTerminal := make(chan struct{})
+	terminalWaiting := make(chan struct{})
+	reader := &stagedOpenAISSEReadCloser{
+		segments: [][]byte{[]byte(preamble), []byte(terminal)},
+		gates:    []<-chan struct{}{nil, allowTerminal},
+		waiting:  []chan struct{}{nil, terminalWaiting},
+	}
+	type runResult struct {
+		result   *openaiStreamingResultPassthrough
+		recorder *httptest.ResponseRecorder
+		writer   *passthroughFlushTestWriter
+		err      error
+	}
+	resultCh := make(chan runResult, 1)
+	writerCh := make(chan *passthroughFlushTestWriter, 1)
+	go func() {
+		result, recorder, writer, err := runPassthroughFlushTestWithTimeout(t, reader, -1, 1, func(c *gin.Context) {
+			writerCh <- c.Writer.(*passthroughFlushTestWriter)
+		})
+		resultCh <- runResult{result: result, recorder: recorder, writer: writer, err: err}
+	}()
+	writer := <-writerCh
+
+	select {
+	case <-terminalWaiting:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for terminal event read")
+	}
+	select {
+	case <-writer.flushEvents:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for configured lifecycle flush")
+	}
+	require.Equal(t, preamble, writer.recorder.Body.String(), "configured timer should flush the lifecycle event before terminal release")
+	close(allowTerminal)
+	run := <-resultCh
+	require.NoError(t, run.err)
+	require.NotNil(t, run.result)
+	require.Equal(t, preamble+terminal, run.recorder.Body.String())
+	require.Equal(t, []int{len(preamble), len(preamble) + len(terminal)}, run.writer.flushBodyLengths)
+}
+
 func TestOpenAIStreamingPassthroughFlushesTerminalEventAtEOFWithoutBlankLine(t *testing.T) {
 	upstream := "event: response.completed\n" +
 		`data: {"type":"response.completed","response":{"id":"resp_eof","usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`
@@ -171,6 +285,26 @@ func TestOpenAIStreamingPassthroughFailedBeforeOutputCanStillFailOverWithoutFlus
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
+	require.Empty(t, recorder.Body.String())
+	require.Empty(t, writer.flushBodyLengths)
+}
+
+func TestOpenAIStreamingPassthroughQueuedMetadataBeforeCapacityErrorStillFailsOver(t *testing.T) {
+	upstream := "event: response.created\n" +
+		`data: {"type":"response.created","response":{"id":"resp_capacity"}}` + "\n\n" +
+		"event: response.queued\n" +
+		`data: {"response":{"id":"resp_capacity"}}` + "\n\n" +
+		"event: keepalive\n" +
+		`data: {"sequence_number":2}` + "\n\n" +
+		"event: error\n" +
+		`data: {"error":{"code":"server_is_overloaded","message":"model capacity exhausted"}}` + "\n\n"
+
+	_, recorder, writer, err := runPassthroughFlushTest(t, io.NopCloser(strings.NewReader(upstream)), -1)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.True(t, failoverErr.RequestScopedTransient)
 	require.Empty(t, recorder.Body.String())
 	require.Empty(t, writer.flushBodyLengths)
 }

--- a/backend/internal/service/openai_gateway_response_flush_test.go
+++ b/backend/internal/service/openai_gateway_response_flush_test.go
@@ -288,6 +288,87 @@ func TestOpenAIResponseFlush_PreambleWithoutTerminalRemainsBufferedForFailover(t
 	require.Empty(t, flushes)
 }
 
+func TestOpenAIResponseFlush_ReleasesLifecycleOnSemanticOutput(t *testing.T) {
+	preamble := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_output\"}}\n\n"
+	output := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ready\"}\n\n"
+	terminal := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_output\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ready\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+	allowOutput := make(chan struct{})
+	allowTerminal := make(chan struct{})
+	outputWaiting := make(chan struct{})
+	terminalWaiting := make(chan struct{})
+	reader := &stagedOpenAISSEReadCloser{
+		segments: [][]byte{[]byte(preamble), []byte(output), []byte(terminal)},
+		gates:    []<-chan struct{}{nil, allowOutput, allowTerminal},
+		waiting:  []chan struct{}{nil, outputWaiting, terminalWaiting},
+	}
+	recorder := newOpenAIResponseFlushRecorder()
+	resultCh, errCh := runOpenAIResponseFlushTestAsync(recorder, reader, config.GatewayConfig{})
+
+	waitOpenAIResponseFlushSignal(t, outputWaiting)
+	close(allowOutput)
+	waitOpenAIResponseFlushCount(t, recorder, 1)
+	gotBody, flushes := recorder.snapshot()
+	require.Equal(t, preamble+output, gotBody)
+	require.Equal(t, []string{preamble + output}, flushes)
+
+	close(allowTerminal)
+	require.NoError(t, <-errCh)
+	require.NotNil(t, <-resultCh)
+	gotBody, flushes = recorder.snapshot()
+	require.Equal(t, preamble+output+terminal, gotBody)
+	require.Len(t, flushes, 2)
+}
+
+func TestOpenAIResponseFlush_ReleasesLifecycleEventsAfterInitialWait(t *testing.T) {
+	preamble := "data: {\"type\":\"response.queued\",\"response\":{\"id\":\"resp_wait\"}}\n\n"
+	terminal := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_wait\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+	allowTerminal := make(chan struct{})
+	terminalWaiting := make(chan struct{})
+	reader := &stagedOpenAISSEReadCloser{
+		segments: [][]byte{[]byte(preamble), []byte(terminal)},
+		gates:    []<-chan struct{}{nil, allowTerminal},
+		waiting:  []chan struct{}{nil, terminalWaiting},
+	}
+	recorder := newOpenAIResponseFlushRecorder()
+	resultCh, errCh := runOpenAIResponseFlushTestAsync(recorder, reader, config.GatewayConfig{})
+
+	waitOpenAIResponseFlushSignal(t, terminalWaiting)
+	waitOpenAIResponseFlushCount(t, recorder, 1)
+	gotBody, flushes := recorder.snapshot()
+	require.Equal(t, preamble, gotBody)
+	require.Equal(t, []string{preamble}, flushes)
+
+	close(allowTerminal)
+	require.NoError(t, <-errCh)
+	require.NotNil(t, <-resultCh)
+	gotBody, flushes = recorder.snapshot()
+	require.Equal(t, preamble+terminal, gotBody)
+	require.Len(t, flushes, 2)
+}
+
+func TestOpenAIResponseFlush_ZeroTimeoutReleasesLifecycleImmediately(t *testing.T) {
+	preamble := "data: {\"type\":\"response.queued\",\"response\":{\"id\":\"resp_zero\"}}\n\n"
+	terminal := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_zero\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+	allowTerminal := make(chan struct{})
+	terminalWaiting := make(chan struct{})
+	reader := &stagedOpenAISSEReadCloser{
+		segments: [][]byte{[]byte(preamble), []byte(terminal)},
+		gates:    []<-chan struct{}{nil, allowTerminal},
+		waiting:  []chan struct{}{nil, terminalWaiting},
+	}
+	recorder := newOpenAIResponseFlushRecorder()
+	resultCh, errCh := runOpenAIResponseFlushTestAsyncWithConfig(recorder, reader, config.GatewayConfig{OpenAIResponsesFirstEventTimeoutSeconds: 0})
+
+	waitOpenAIResponseFlushCount(t, recorder, 1)
+	gotBody, flushes := recorder.snapshot()
+	require.Equal(t, preamble, gotBody)
+	require.Equal(t, []string{preamble}, flushes)
+
+	close(allowTerminal)
+	require.NoError(t, <-errCh)
+	require.NotNil(t, <-resultCh)
+}
+
 func TestOpenAIResponseFlush_CanceledAfterOutputFlushesResidualWithoutErrorEvent(t *testing.T) {
 	body := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n"
 	recorder := newOpenAIResponseFlushRecorder()
@@ -471,6 +552,13 @@ func TestOpenAIResponseFlush_ClientDisconnectStillDrainsUsage(t *testing.T) {
 }
 
 func runOpenAIResponseFlushTest(recorder *openAIResponseFlushRecorder, body io.ReadCloser, gatewayCfg config.GatewayConfig) (*openaiStreamingResult, error) {
+	if gatewayCfg.OpenAIResponsesFirstEventTimeoutSeconds == 0 {
+		gatewayCfg.OpenAIResponsesFirstEventTimeoutSeconds = 2
+	}
+	return runOpenAIResponseFlushTestWithConfig(recorder, body, gatewayCfg)
+}
+
+func runOpenAIResponseFlushTestWithConfig(recorder *openAIResponseFlushRecorder, body io.ReadCloser, gatewayCfg config.GatewayConfig) (*openaiStreamingResult, error) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
@@ -487,14 +575,25 @@ func runOpenAIResponseFlushTest(recorder *openAIResponseFlushRecorder, body io.R
 }
 
 func runOpenAIResponseFlushTestAsync(recorder *openAIResponseFlushRecorder, body io.ReadCloser, gatewayCfg config.GatewayConfig) (<-chan *openaiStreamingResult, <-chan error) {
+	return runOpenAIResponseFlushTestAsyncWithConfig(recorder, body, normalizedOpenAIResponseFlushGatewayConfig(gatewayCfg))
+}
+
+func runOpenAIResponseFlushTestAsyncWithConfig(recorder *openAIResponseFlushRecorder, body io.ReadCloser, gatewayCfg config.GatewayConfig) (<-chan *openaiStreamingResult, <-chan error) {
 	resultCh := make(chan *openaiStreamingResult, 1)
 	errCh := make(chan error, 1)
 	go func() {
-		result, err := runOpenAIResponseFlushTest(recorder, body, gatewayCfg)
+		result, err := runOpenAIResponseFlushTestWithConfig(recorder, body, gatewayCfg)
 		resultCh <- result
 		errCh <- err
 	}()
 	return resultCh, errCh
+}
+
+func normalizedOpenAIResponseFlushGatewayConfig(gatewayCfg config.GatewayConfig) config.GatewayConfig {
+	if gatewayCfg.OpenAIResponsesFirstEventTimeoutSeconds == 0 {
+		gatewayCfg.OpenAIResponsesFirstEventTimeoutSeconds = 2
+	}
+	return gatewayCfg
 }
 
 func waitOpenAIResponseFlushCount(t *testing.T, recorder *openAIResponseFlushRecorder, want int) {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -217,6 +217,36 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		firstOutputTimer = nil
 		firstOutputCh = nil
 	}
+	initialEventTimeout := s.openAIResponsesInitialEventTimeout(ctx, c)
+	// Keep Responses lifecycle events private for a short window so an upstream
+	// capacity error can arrive before the downstream response is committed.
+	// A normal output event releases the buffer immediately; the timer only
+	// prevents a lifecycle-only stream from waiting indefinitely.
+	initialEventDelayEnabled := !guardFirstOutput && initialEventTimeout > 0
+	var initialEventTimer *time.Timer
+	var initialEventCh <-chan time.Time
+	initialEventWaitExpired := false
+	startInitialEventTimer := func() {
+		if !initialEventDelayEnabled || initialEventTimer != nil {
+			return
+		}
+		initialEventTimer = time.NewTimer(initialEventTimeout)
+		initialEventCh = initialEventTimer.C
+	}
+	stopInitialEventTimer := func() {
+		if initialEventTimer == nil {
+			return
+		}
+		if !initialEventTimer.Stop() {
+			select {
+			case <-initialEventTimer.C:
+			default:
+			}
+		}
+		initialEventTimer = nil
+		initialEventCh = nil
+	}
+	defer stopInitialEventTimer()
 	// Track downstream writes separately from upstream reads: pre-output failover
 	// can buffer response.created / response.in_progress, so keepalive must be
 	// based on downstream idle time.
@@ -313,6 +343,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 	streamImageOutputs := make([]json.RawMessage, 0, 1)
 	streamSeenImages := make(map[string]struct{})
 	searchCounter := 0
+	currentSSEEventType := ""
 	// Dedup search tool calls across SSE events (item.done + response.completed
 	// both list the same call_id — counting both would ~2× the surcharge).
 	streamSearchSeen := make(map[string]struct{})
@@ -346,7 +377,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		if sawTerminalEvent && !sawFailedEvent {
 			s.clearOpenAIProxyStreamDisconnect(account)
 		}
-		if !sawTerminalEvent && !openAIStreamClientOutputStarted(c, clientOutputStarted) && !eventShouldFlush {
+		if !sawTerminalEvent && !clientOutputStarted && !eventShouldFlush {
 			return resultWithUsage(), s.newOpenAIStreamFailoverError(
 				c,
 				account,
@@ -358,7 +389,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		}
 		flushPending("Client disconnected during final flush, returning collected usage")
 		if !sawTerminalEvent {
-			if openAIStreamClientOutputStarted(c, clientOutputStarted) && !clientDisconnected {
+			if clientOutputStarted && !clientDisconnected {
 				s.recordOpenAIProxyStreamDisconnect(account, errors.New("stream ended before terminal event"), upstreamRequestID)
 			}
 			return resultWithUsage(), fmt.Errorf("stream usage incomplete: missing terminal event")
@@ -411,7 +442,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			sendErrorEvent("response_too_large")
 			return resultWithUsage(), scanErr, true
 		}
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) && !eventShouldFlush {
+		if !clientOutputStarted && !eventShouldFlush {
 			msg := "OpenAI stream disconnected before completion"
 			if errText := strings.TrimSpace(scanErr.Error()); errText != "" {
 				msg += ": " + errText
@@ -430,11 +461,14 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		if streamEarlyErr != nil {
 			return
 		}
+		if eventType, ok := extractOpenAISSEEventLine(line); ok {
+			currentSSEEventType = eventType
+		}
 		// Extract data from SSE line (supports both "data: " and "data:" formats)
 		if data, ok := extractOpenAISSEDataLine(line); ok {
 			dataBytes := []byte(data)
-			eventTypeRaw := gjson.GetBytes(dataBytes, "type").String()
-			eventType := strings.TrimSpace(eventTypeRaw)
+			eventTypeRaw := openAISSEEventType(dataBytes, currentSSEEventType)
+			eventType := eventTypeRaw
 			observer.ObserveOpenAI(dataBytes, eventTypeRaw)
 			// 初始上游 data 的 type 只解析一次：原始值保持终止事件的精确匹配，规范化值供后续分支复用。
 			if openAIStreamEventIsTerminalWithType(data, eventTypeRaw) {
@@ -442,6 +476,12 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			}
 			if responseID == "" {
 				responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
+			}
+			if eventType == "error" && !clientOutputStarted && !eventShouldFlush && isOpenAIUpstreamCapacityShedEvent(dataBytes) {
+				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
+				s.parseSSEUsageBytes(dataBytes, usage)
+				streamEarlyErr = s.newOpenAIStreamFailoverError(c, account, false, upstreamRequestID, dataBytes, failedMessage, resp.Header)
+				return
 			}
 			forceFlushFailedEvent := false
 			if eventType == "response.failed" {
@@ -460,7 +500,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 						UpstreamOutTok: usage.OutputTokens,
 					})
 				}
-				if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+				if !clientOutputStarted {
 					if status, errType, errMsg, matched := applyOpenAIStreamFailedErrorPassthroughRule(c, account.Platform, dataBytes, failedMessage); matched {
 						sawFailedEvent = true
 						// 命中透传规则也要记录 ops 上游错误事件（对齐 CC/Messages 与
@@ -499,7 +539,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				dataBytes = correctedData
 				data = string(correctedData)
 				line = "data: " + data
-				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+				eventType = openAISSEEventType(dataBytes, currentSSEEventType)
 			}
 			if imageOutput, ok := extractImageGenerationOutputFromSSEData(dataBytes, streamSeenImages); ok {
 				streamImageOutputs = append(streamImageOutputs, imageOutput)
@@ -514,7 +554,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				dataBytes = normalizedData
 				data = string(normalizedData)
 				line = "data: " + data
-				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+				eventType = openAISSEEventType(dataBytes, currentSSEEventType)
 			}
 			restoredData, restoreErr := restoreGrokResponsesClientToolPayload(c, dataBytes)
 			if restoreErr != nil {
@@ -530,12 +570,12 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				dataBytes = restoredData
 				data = string(restoredData)
 				line = "data: " + data
-				eventType = strings.TrimSpace(gjson.GetBytes(dataBytes, "type").String())
+				eventType = openAISSEEventType(dataBytes, currentSSEEventType)
 			}
 			if sanitizedData, sanitized := sanitizeOpenAIResponseFailedEventForClient(
 				dataBytes,
 				eventType,
-				openAIStreamClientOutputStarted(c, clientOutputStarted),
+				clientOutputStarted,
 			); sanitized {
 				dataBytes = sanitizedData
 				data = string(sanitizedData)
@@ -548,6 +588,12 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			}
 			startsClientOutput := forceFlushFailedEvent || openAIStreamDataStartsClientOutput(data, eventType)
 			startsVisibleOutput := openAIStreamDataStartsVisibleOutput(data, eventType)
+			if startsClientOutput {
+				initialEventWaitExpired = false
+				stopInitialEventTimer()
+			} else if !clientOutputStarted && openAIStreamEventIsPreamble(eventType) {
+				startInitialEventTimer()
+			}
 			if guardFirstOutput {
 				eventStartsClientOutput = eventStartsClientOutput || startsClientOutput
 				eventStartsVisibleOutput = eventStartsVisibleOutput || startsVisibleOutput
@@ -597,6 +643,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 
 		// A blank line dispatches a guarded event from the attempt-local stage.
 		if guardFirstOutput && line == "" {
+			currentSSEEventType = ""
 			if !clientDisconnected {
 				if _, err := writePendingString("\n"); err != nil {
 					handlePendingWriteError(err)
@@ -612,6 +659,9 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		shouldFlush := false
 		if line == "" {
 			shouldFlush = eventShouldFlush || (queueDrained && clientOutputStarted)
+			if !guardFirstOutput && !initialEventDelayEnabled && !clientOutputStarted && pendingBytes() > 0 {
+				shouldFlush = true
+			}
 			eventShouldFlush = false
 		}
 		if !clientDisconnected {
@@ -632,21 +682,15 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				}
 			}
 		}
-	}
-
-	// 无超时/无 keepalive 的常见路径走同步扫描，减少 goroutine 与 channel 开销。
-	if streamInterval <= 0 && keepaliveInterval <= 0 && firstOutputTimeout <= 0 {
-		defer putSSEScannerBuf64K(scanBuf)
-		for documentScanner.Scan() {
-			processSSELine(documentScanner.Text(), true)
-			if streamEarlyErr != nil {
-				return resultWithUsage(), streamEarlyErr
+		if line == "" && initialEventWaitExpired {
+			initialEventWaitExpired = false
+			if !guardFirstOutput && !clientDisconnected && !clientOutputStarted {
+				flushPending("OpenAI Responses initial event wait elapsed; flushing buffered lifecycle events")
 			}
 		}
-		if result, err, done := handleScanErr(documentScanner.Err()); done {
-			return result, err
+		if line == "" {
+			currentSSEEventType = ""
 		}
-		return finalizeStream()
 	}
 
 	type scanEvent struct {
@@ -716,7 +760,13 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				markEventProcessed(ev)
 				return result, err
 			}
-			processSSELine(ev.line, len(events) == 0)
+			queueDrained := len(events) == 0
+			if streamInterval <= 0 && keepaliveInterval <= 0 && firstOutputTimeout <= 0 {
+				// This path was synchronous before initial-event buffering was added;
+				// retain its one-flush-per-event wire behavior.
+				queueDrained = true
+			}
+			processSSELine(ev.line, queueDrained)
 			markEventProcessed(ev)
 			if streamEarlyErr != nil {
 				return resultWithUsage(), streamEarlyErr
@@ -740,7 +790,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			// legacy stream_timeout path so partial SSE is not dual-written.
 			if account != nil && account.Platform == PlatformGrok {
 				s.tempUnscheduleGrok(ctx, account, grokStreamIdleCooldown, "grok stream idle timeout")
-				if !openAIStreamClientOutputStarted(c, clientOutputStarted) && !eventShouldFlush {
+				if !clientOutputStarted && !eventShouldFlush {
 					_ = resp.Body.Close()
 					return resultWithUsage(), grokStreamIdleFailoverError(account, streamInterval)
 				}
@@ -761,6 +811,16 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				ctx, c, account, startTime, originalModel, reasoningEffort,
 				firstOutputTimeout, "semantic_output", resp.Header,
 			)
+
+		case <-initialEventCh:
+			stopInitialEventTimer()
+			if eventInProgress {
+				initialEventWaitExpired = true
+				continue
+			}
+			if !guardFirstOutput && !clientDisconnected && !clientOutputStarted {
+				flushPending("OpenAI Responses initial event wait elapsed; flushing buffered lifecycle events")
+			}
 
 		case <-keepaliveCh:
 			if clientDisconnected {
@@ -828,6 +888,14 @@ func extractOpenAISSEEventLine(line string) (string, bool) {
 		start++
 	}
 	return strings.TrimSpace(line[start:]), true
+}
+
+func openAISSEEventType(data []byte, fallback string) string {
+	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
+	if eventType != "" {
+		return eventType
+	}
+	return strings.TrimSpace(fallback)
 }
 
 type openAICompatSSEFrame struct {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1638,9 +1638,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputReturnsFailover(t *testing.T) 
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1680,9 +1681,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover(t
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1731,9 +1733,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputServerOverloadedCodeReturnsFai
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1773,9 +1776,10 @@ func TestOpenAIStreamingResponseFailedBeforeOutputRateLimitUsesPoolRetryPolicy(t
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1837,9 +1841,10 @@ func TestOpenAIStreamingResponseFailedRateLimitDoesNotBlockAccountScheduling(t *
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1934,9 +1939,10 @@ func TestOpenAIStreamingContextWindowResponseFailedBeforeOutputPassesThrough(t *
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -1972,9 +1978,10 @@ func TestOpenAIStreamingContextWindowResponseFailedBeforeOutputAppliesPassthroug
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2026,9 +2033,10 @@ func TestOpenAIStreamingPreambleOnlyMissingTerminalReturnsFailover(t *testing.T)
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 0,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			StreamDataIntervalTimeout:               0,
+			StreamKeepaliveInterval:                 0,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2065,8 +2073,9 @@ func TestOpenAIStreamingPreambleKeepaliveUsesDownstreamIdle(t *testing.T) {
 			StreamDataIntervalTimeout: 0,
 			// Keepalive is based on *downstream* idle time (last flush to client),
 			// not upstream event cadence. Interval is seconds (config unit).
-			StreamKeepaliveInterval: 1,
-			MaxLineSize:             defaultMaxLineSize,
+			StreamKeepaliveInterval:                 1,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2302,7 +2311,8 @@ func TestOpenAIStreamingPassthroughMissingTerminalEventReturnsIncompleteError(t 
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			MaxLineSize: defaultMaxLineSize,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2371,7 +2381,8 @@ func TestOpenAIStreamingPassthroughResponseFailedBeforeOutputReturnsFailover(t *
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			MaxLineSize: defaultMaxLineSize,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2407,7 +2418,8 @@ func TestOpenAIStreamingPassthroughContextWindowResponseFailedBeforeOutputApplie
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			MaxLineSize: defaultMaxLineSize,
+			MaxLineSize:                             defaultMaxLineSize,
+			OpenAIResponsesFirstEventTimeoutSeconds: 2,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}

--- a/backend/internal/service/openai_responses_first_event_timeout.go
+++ b/backend/internal/service/openai_responses_first_event_timeout.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	openAIResponsesFirstEventTimeoutFeatureKey = "responses_first_event_timeout"
+	defaultOpenAIResponsesFirstEventTimeout    = time.Duration(config.DefaultOpenAIResponsesFirstEventTimeoutSeconds) * time.Second
+)
+
+// openAIResponsesInitialEventTimeout resolves the process default and the
+// channel override used to hold Responses lifecycle SSE events before the
+// first semantic output or retryable upstream error.
+func (s *OpenAIGatewayService) openAIResponsesInitialEventTimeout(ctx context.Context, c *gin.Context) time.Duration {
+	timeout := defaultOpenAIResponsesFirstEventTimeout
+	if s != nil && s.cfg != nil {
+		seconds := s.cfg.Gateway.OpenAIResponsesFirstEventTimeoutSeconds
+		if seconds >= 0 && seconds <= config.MaxOpenAIResponsesFirstEventTimeoutSeconds {
+			timeout = time.Duration(seconds) * time.Second
+		}
+	}
+
+	if s == nil || s.channelService == nil {
+		return timeout
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	groupID := getOpenAIGroupIDFromContext(c)
+	if groupID <= 0 {
+		return timeout
+	}
+	channel, err := s.channelService.GetChannelForGroup(ctx, groupID)
+	if err != nil {
+		slog.Warn("failed to resolve OpenAI Responses first event timeout channel override", "group_id", groupID, "error", err)
+		return timeout
+	}
+	if channel == nil || channel.FeaturesConfig == nil {
+		return timeout
+	}
+	seconds, ok := parseOpenAIResponsesFirstEventTimeoutSeconds(channel.FeaturesConfig[openAIResponsesFirstEventTimeoutFeatureKey])
+	if !ok {
+		return timeout
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func parseOpenAIResponsesFirstEventTimeoutSeconds(value any) (int, bool) {
+	var seconds int64
+	switch value := value.(type) {
+	case int:
+		seconds = int64(value)
+	case int8:
+		seconds = int64(value)
+	case int16:
+		seconds = int64(value)
+	case int32:
+		seconds = int64(value)
+	case int64:
+		seconds = value
+	case uint:
+		if uint64(value) > math.MaxInt64 {
+			return 0, false
+		}
+		seconds = int64(value)
+	case uint8:
+		seconds = int64(value)
+	case uint16:
+		seconds = int64(value)
+	case uint32:
+		seconds = int64(value)
+	case uint64:
+		if value > math.MaxInt64 {
+			return 0, false
+		}
+		seconds = int64(value)
+	case float32:
+		if float64(value) != math.Trunc(float64(value)) || value < 0 || value > config.MaxOpenAIResponsesFirstEventTimeoutSeconds {
+			return 0, false
+		}
+		seconds = int64(value)
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) || value != math.Trunc(value) || value < 0 || value > config.MaxOpenAIResponsesFirstEventTimeoutSeconds {
+			return 0, false
+		}
+		seconds = int64(value)
+	case json.Number:
+		parsed, err := strconv.ParseInt(string(value), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		seconds = parsed
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		seconds = parsed
+	default:
+		return 0, false
+	}
+	if seconds < 0 || seconds > config.MaxOpenAIResponsesFirstEventTimeoutSeconds {
+		return 0, false
+	}
+	return int(seconds), true
+}

--- a/backend/internal/service/openai_responses_first_event_timeout_test.go
+++ b/backend/internal/service/openai_responses_first_event_timeout_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOpenAIResponsesFirstEventTimeoutSeconds(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  int
+		ok    bool
+	}{
+		{name: "json number", value: json.Number("3"), want: 3, ok: true},
+		{name: "float from json", value: float64(4), want: 4, ok: true},
+		{name: "integer", value: 5, want: 5, ok: true},
+		{name: "string", value: "6", want: 6, ok: true},
+		{name: "zero", value: 0, want: 0, ok: true},
+		{name: "fraction", value: 1.5, ok: false},
+		{name: "negative", value: -1, ok: false},
+		{name: "too large", value: 601, ok: false},
+		{name: "nan", value: math.NaN(), ok: false},
+		{name: "unsupported", value: true, ok: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseOpenAIResponsesFirstEventTimeoutSeconds(tc.value)
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponsesInitialEventTimeoutUsesGlobalAndChannelOverrides(t *testing.T) {
+	groupID := int64(42)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set("api_key", &APIKey{GroupID: &groupID})
+
+	channelService := NewChannelService(nil, nil, nil, nil)
+	channelService.cache.Store(populateChannelCache([]Channel{{
+		ID:             1,
+		Status:         StatusActive,
+		GroupIDs:       []int64{groupID},
+		FeaturesConfig: map[string]any{openAIResponsesFirstEventTimeoutFeatureKey: float64(4)},
+	}}, map[int64]string{groupID: PlatformOpenAI}))
+
+	svc := &OpenAIGatewayService{
+		cfg:            &config.Config{Gateway: config.GatewayConfig{OpenAIResponsesFirstEventTimeoutSeconds: 1}},
+		channelService: channelService,
+	}
+	require.Equal(t, 4*time.Second, svc.openAIResponsesInitialEventTimeout(context.Background(), c))
+
+	channelService.cache.Store(populateChannelCache([]Channel{{
+		ID:             1,
+		Status:         StatusActive,
+		GroupIDs:       []int64{groupID},
+		FeaturesConfig: map[string]any{openAIResponsesFirstEventTimeoutFeatureKey: "bad"},
+	}}, map[int64]string{groupID: PlatformOpenAI}))
+	require.Equal(t, time.Second, svc.openAIResponsesInitialEventTimeout(context.Background(), c))
+
+	channelService.cache.Store(populateChannelCache([]Channel{{
+		ID:             1,
+		Status:         StatusActive,
+		GroupIDs:       []int64{groupID},
+		FeaturesConfig: map[string]any{openAIResponsesFirstEventTimeoutFeatureKey: 0},
+	}}, map[int64]string{groupID: PlatformOpenAI}))
+	require.Zero(t, svc.openAIResponsesInitialEventTimeout(context.Background(), c))
+}
+
+func TestOpenAIResponsesInitialEventTimeoutFallsBackToDefault(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	require.Equal(t, defaultOpenAIResponsesFirstEventTimeout, svc.openAIResponsesInitialEventTimeout(context.Background(), nil))
+}

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -213,8 +213,11 @@ gateway:
   openai_first_output_timeout_seconds: 0
   # Optional high/xhigh/max override (seconds, 0=use the standard timeout)
   openai_high_effort_first_output_timeout_seconds: 0
-  # Responses SSE lifecycle event buffering (seconds, 0=flush immediately, default=2)
-  openai_responses_first_event_timeout_seconds: 2
+  # Responses SSE lifecycle event buffering (seconds, 0=flush immediately, runtime default=2)
+  # Codex 出现 "Selected model is at capacity. Please try a different model." 时建议配置 40-60 秒，推荐 60 秒。
+  # For "Selected model is at capacity" errors, use 40-60 seconds here; 60 seconds is a good starting point.
+  # Channel-level override: channel.features_config.responses_first_event_timeout
+  openai_responses_first_event_timeout_seconds: 60
   # Max request body size in bytes (default: 256MB)
   # 请求体最大字节数（默认 256MB）
   max_body_size: 268435456

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -213,6 +213,8 @@ gateway:
   openai_first_output_timeout_seconds: 0
   # Optional high/xhigh/max override (seconds, 0=use the standard timeout)
   openai_high_effort_first_output_timeout_seconds: 0
+  # Responses SSE lifecycle event buffering (seconds, 0=flush immediately, default=2)
+  openai_responses_first_event_timeout_seconds: 2
   # Max request body size in bytes (default: 256MB)
   # 请求体最大字节数（默认 256MB）
   max_body_size: 268435456


### PR DESCRIPTION
Fix Codex SSE requests that fail with:

`Selected model is at capacity. Please try a different model.`

Buffer initial lifecycle events so failover can run before the response is committed.