### PR TITLE
fix(openai-compat): parse usage from nested data envelopes

### DIFF
--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -981,15 +981,15 @@ func extractOpenAIUsageFromJSONBytes(body []byte) (OpenAIUsage, bool) {
 	}
 	// 部分 OpenAI 兼容上游（例如 Cline API）会将标准响应包在 data 字段中：
 	// {"data":{"choices": [...], "usage": {...}}, "success":true}。
-	// 按优先级尝试原生 OpenAI Responses、兼容层 data 包装和 Responses 包装，
+	// 按优先级先保留原有路径，再尝试兼容层 data 包装，
 	// 避免同步请求能正常返回但用量被静默记录为 0。
 	candidates := []struct {
 		usagePath      string
 		imageUsagePath string
 	}{
 		{usagePath: "usage", imageUsagePath: "tool_usage.image_gen"},
-		{usagePath: "data.usage", imageUsagePath: "data.tool_usage.image_gen"},
 		{usagePath: "response.usage", imageUsagePath: "response.tool_usage.image_gen"},
+		{usagePath: "data.usage", imageUsagePath: "data.tool_usage.image_gen"},
 		{usagePath: "data.response.usage", imageUsagePath: "data.response.tool_usage.image_gen"},
 	}
 	for _, candidate := range candidates {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -979,13 +979,24 @@ func extractOpenAIUsageFromJSONBytes(body []byte) (OpenAIUsage, bool) {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return OpenAIUsage{}, false
 	}
-	if usage, ok := openAIUsageFromGJSON(gjson.GetBytes(body, "usage")); ok {
-		mergeHostedImageGenToolUsage(gjson.GetBytes(body, "tool_usage.image_gen"), &usage)
-		return usage, true
+	// 部分 OpenAI 兼容上游（例如 Cline API）会将标准响应包在 data 字段中：
+	// {"data":{"choices": [...], "usage": {...}}, "success":true}。
+	// 按优先级尝试原生 OpenAI Responses、兼容层 data 包装和 Responses 包装，
+	// 避免同步请求能正常返回但用量被静默记录为 0。
+	candidates := []struct {
+		usagePath      string
+		imageUsagePath string
+	}{
+		{usagePath: "usage", imageUsagePath: "tool_usage.image_gen"},
+		{usagePath: "data.usage", imageUsagePath: "data.tool_usage.image_gen"},
+		{usagePath: "response.usage", imageUsagePath: "response.tool_usage.image_gen"},
+		{usagePath: "data.response.usage", imageUsagePath: "data.response.tool_usage.image_gen"},
 	}
-	if usage, ok := openAIUsageFromGJSON(gjson.GetBytes(body, "response.usage")); ok {
-		mergeHostedImageGenToolUsage(gjson.GetBytes(body, "response.tool_usage.image_gen"), &usage)
-		return usage, true
+	for _, candidate := range candidates {
+		if usage, ok := openAIUsageFromGJSON(gjson.GetBytes(body, candidate.usagePath)); ok {
+			mergeHostedImageGenToolUsage(gjson.GetBytes(body, candidate.imageUsagePath), &usage)
+			return usage, true
+		}
 	}
 	return OpenAIUsage{}, false
 }

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -483,6 +483,27 @@ func TestExtractOpenAIUsage_ReadsClineDataEnvelope(t *testing.T) {
 	require.Equal(t, 4, usage.CacheReadInputTokens)
 }
 
+func TestExtractOpenAIUsage_ReadsWrappedResponsesDataEnvelope(t *testing.T) {
+	body := []byte(`{"data":{"response":{"usage":{"input_tokens":11,"output_tokens":5,"total_tokens":16,"input_tokens_details":{"cached_tokens":2}}}}}`)
+
+	usage, ok := extractOpenAIUsageFromJSONBytes(body)
+
+	require.True(t, ok)
+	require.Equal(t, 11, usage.InputTokens)
+	require.Equal(t, 5, usage.OutputTokens)
+	require.Equal(t, 2, usage.CacheReadInputTokens)
+}
+
+func TestExtractOpenAIUsage_PreservesResponseUsagePriority(t *testing.T) {
+	body := []byte(`{"data":{"usage":{"prompt_tokens":100,"completion_tokens":50}},"response":{"usage":{"input_tokens":11,"output_tokens":5}}}`)
+
+	usage, ok := extractOpenAIUsageFromJSONBytes(body)
+
+	require.True(t, ok)
+	require.Equal(t, 11, usage.InputTokens)
+	require.Equal(t, 5, usage.OutputTokens)
+}
+
 func TestOpenAIGatewayService_BindHTTPResponseAccount(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -472,6 +472,17 @@ func TestExtractOpenAIUsage_CapturesImageInputTokens(t *testing.T) {
 	require.Zero(t, tu.ImageInputTokens)
 }
 
+func TestExtractOpenAIUsage_ReadsClineDataEnvelope(t *testing.T) {
+	body := []byte(`{"data":{"choices":[{"message":{"content":"OK"}}],"usage":{"prompt_tokens":8,"completion_tokens":27,"total_tokens":35,"prompt_tokens_details":{"cached_tokens":4}}},"success":true}`)
+
+	usage, ok := extractOpenAIUsageFromJSONBytes(body)
+
+	require.True(t, ok)
+	require.Equal(t, 8, usage.InputTokens)
+	require.Equal(t, 27, usage.OutputTokens)
+	require.Equal(t, 4, usage.CacheReadInputTokens)
+}
+
 func TestOpenAIGatewayService_BindHTTPResponseAccount(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Problem

Some OpenAI-compatible upstreams, including the Cline API, wrap Chat Completions responses in a top-level `data` field.

The request succeeds with HTTP 200 and contains valid token usage, but sub2api only checks `usage` and `response.usage`. As a result, usage is recorded as zero for non-streaming requests.

## Upstream reproduction

Endpoint:

```text
POST https://api.cline.bot/api/v1/chat/completions
```

Request headers:

```http
Authorization: Bearer $CLINE_API_KEY
x-client-type: cline-cli
Content-Type: application/json
```

Request body:

```json
{
  "model": "deepseek/deepseek-v4-flash",
  "messages": [
    {"role": "user", "content": "Reply with exactly OK"}
  ],
  "temperature": 0.7,
  "max_tokens": 32,
  "stream": false
}
```

Equivalent curl command:

```bash
curl -i 'https://api.cline.bot/api/v1/chat/completions' \\
  -H "Authorization: Bearer $CLINE_API_KEY" \\
  -H 'x-client-type: cline-cli' \\
  -H 'Content-Type: application/json' \\
  --data '{
    "model": "deepseek/deepseek-v4-flash",
    "messages": [
      {"role": "user", "content": "Reply with exactly OK"}
    ],
    "temperature": 0.7,
    "max_tokens": 32,
    "stream": false
  }'
```

Observed response:

```text
HTTP/1.1 200 OK
Content-Type: application/json
```

Relevant response shape:

```json
{
  "data": {
    "choices": [...],
    "usage": {
      "prompt_tokens": 8,
      "completion_tokens": 26,
      "total_tokens": 34
    }
  },
  "success": true
}
```

## Root cause

`extractOpenAIUsageFromJSONBytes` did not inspect `data.usage`. For the response above, both `usage` and `response.usage` are absent, so usage extraction fails even though the upstream response is valid.

## Changes

- Add support for `data.usage`.
- Add support for `data.response.usage` for the equivalent wrapped Responses shape.
- Preserve the existing lookup order for `usage` and `response.usage`.
- Reuse the existing field compatibility logic for `prompt_tokens` / `completion_tokens` and cached token details.
- Add regression tests for the Cline-style `data.usage` envelope, the wrapped Responses envelope, and the existing precedence rule.

## Scope

This change only affects internal usage extraction. The upstream response body is not modified.

Cline streaming responses currently expose usage at the top-level `usage` field in the final Chat Completions chunk and are unaffected by this change.

## Tests

- `git diff --check` passed.
- Focused unit tests passed:

  ```bash
  go test ./internal/service -run 'TestExtractOpenAIUsage_(ReadsClineDataEnvelope|ReadsWrappedResponsesDataEnvelope|PreservesResponseUsagePriority)$' -count=1
  ```

  Result: `ok github.com/Wei-Shaw/sub2api/internal/service 0.637s`

- The full Go test suite was not run because this PR is limited to the usage extraction path.
