### PR TITLE
Expose official pricing tiers and reference metadata in model plaza

### DIFF
--- a/backend/internal/handler/model_plaza_handler.go
+++ b/backend/internal/handler/model_plaza_handler.go
@@ -35,13 +35,24 @@ func NewModelPlazaHandler(
 	}
 }
 
+type modelPlazaOfficialPricingTier struct {
+	MinInputTokens  int      `json:"min_input_tokens"`
+	InputPrice      *float64 `json:"input_price"`
+	OutputPrice     *float64 `json:"output_price"`
+	CacheWritePrice *float64 `json:"cache_write_price"`
+	CacheReadPrice  *float64 `json:"cache_read_price"`
+}
+
 // modelPlazaOfficialPricing LiteLLM 官方参考价（USD per token）。
 type modelPlazaOfficialPricing struct {
-	InputPrice        *float64 `json:"input_price"`
-	OutputPrice       *float64 `json:"output_price"`
-	CacheWritePrice   *float64 `json:"cache_write_price"`
-	CacheWrite1hPrice *float64 `json:"cache_write_1h_price,omitempty"`
-	CacheReadPrice    *float64 `json:"cache_read_price"`
+	InputPrice        *float64                        `json:"input_price"`
+	OutputPrice       *float64                        `json:"output_price"`
+	CacheWritePrice   *float64                        `json:"cache_write_price"`
+	CacheWrite1hPrice *float64                        `json:"cache_write_1h_price,omitempty"`
+	CacheReadPrice    *float64                        `json:"cache_read_price"`
+	Tiers             []modelPlazaOfficialPricingTier `json:"tiers,omitempty"`
+	ReferenceModel    string                          `json:"reference_model,omitempty"`
+	ReferenceNote     string                          `json:"reference_note,omitempty"`
 }
 
 // modelPlazaModel 广场模型条目：渠道定价（白名单形态）+ 官方参考价。
@@ -194,11 +205,26 @@ func toModelPlazaOfficialPricing(p *service.PlazaOfficialPricing) *modelPlazaOff
 	if p == nil {
 		return nil
 	}
-	return &modelPlazaOfficialPricing{
+	dto := &modelPlazaOfficialPricing{
 		InputPrice:        p.InputPrice,
 		OutputPrice:       p.OutputPrice,
 		CacheWritePrice:   p.CacheWritePrice,
 		CacheWrite1hPrice: p.CacheWrite1hPrice,
 		CacheReadPrice:    p.CacheReadPrice,
+		ReferenceModel:    p.ReferenceModel,
+		ReferenceNote:     p.ReferenceNote,
 	}
+	if len(p.Tiers) > 0 {
+		dto.Tiers = make([]modelPlazaOfficialPricingTier, 0, len(p.Tiers))
+		for _, tier := range p.Tiers {
+			dto.Tiers = append(dto.Tiers, modelPlazaOfficialPricingTier{
+				MinInputTokens:  tier.MinInputTokens,
+				InputPrice:      tier.InputPrice,
+				OutputPrice:     tier.OutputPrice,
+				CacheWritePrice: tier.CacheWritePrice,
+				CacheReadPrice:  tier.CacheReadPrice,
+			})
+		}
+	}
+	return dto
 }

--- a/backend/internal/handler/model_plaza_handler_test.go
+++ b/backend/internal/handler/model_plaza_handler_test.go
@@ -125,3 +125,23 @@ func TestToModelPlazaOfficialPricing_NilPassthrough(t *testing.T) {
 }
 
 func testPtr(v float64) *float64 { return &v }
+func TestToModelPlazaOfficialPricing_IncludesTiersAndReferenceMetadata(t *testing.T) {
+	input := 2e-6
+	output := 6e-6
+	dto := toModelPlazaOfficialPricing(&service.PlazaOfficialPricing{
+		Tiers: []service.PlazaOfficialPricingTier{{
+			MinInputTokens: 256000,
+			InputPrice:     &input,
+			OutputPrice:    &output,
+		}},
+		ReferenceModel: "canonical-model",
+		ReferenceNote:  "Published reference price",
+	})
+
+	require.NotNil(t, dto)
+	require.Equal(t, "canonical-model", dto.ReferenceModel)
+	require.Equal(t, "Published reference price", dto.ReferenceNote)
+	require.Len(t, dto.Tiers, 1)
+	require.Equal(t, 256000, dto.Tiers[0].MinInputTokens)
+	require.Equal(t, &input, dto.Tiers[0].InputPrice)
+}

--- a/backend/internal/service/channel_plaza.go
+++ b/backend/internal/service/channel_plaza.go
@@ -9,12 +9,23 @@ import (
 
 // PlazaOfficialPricing 模型广场展示用的 LiteLLM 官方参考价（USD per token）。
 // 字段为 nil 表示官方数据中该项缺失（0 视为未配置）。
+type PlazaOfficialPricingTier struct {
+	MinInputTokens  int
+	InputPrice      *float64
+	OutputPrice     *float64
+	CacheWritePrice *float64
+	CacheReadPrice  *float64
+}
+
 type PlazaOfficialPricing struct {
 	InputPrice        *float64
 	OutputPrice       *float64
 	CacheWritePrice   *float64 // 5m 缓存写入（= LiteLLM cache_creation）
 	CacheWrite1hPrice *float64 // 1h 缓存写入（LiteLLM cache_creation_above_1hr）
 	CacheReadPrice    *float64
+	Tiers             []PlazaOfficialPricingTier
+	ReferenceModel    string
+	ReferenceNote     string
 }
 
 // PlazaModel 模型广场中单个模型条目：渠道定价 + 官方参考价。
@@ -245,9 +256,24 @@ func (s *ChannelService) lookupOfficialPricing(modelName string, memo map[string
 			CacheWritePrice:   nonZeroPtr(lp.CacheCreationInputTokenCost),
 			CacheWrite1hPrice: nonZeroPtr(lp.CacheCreationInputTokenCostAbove1hr),
 			CacheReadPrice:    nonZeroPtr(lp.CacheReadInputTokenCost),
+			ReferenceModel:    lp.PricingReferenceModel,
+			ReferenceNote:     lp.PricingReferenceNote,
+		}
+		if len(lp.OfficialPricingTiers) > 0 {
+			result.Tiers = make([]PlazaOfficialPricingTier, 0, len(lp.OfficialPricingTiers))
+			for _, tier := range lp.OfficialPricingTiers {
+				result.Tiers = append(result.Tiers, PlazaOfficialPricingTier{
+					MinInputTokens:  tier.MinInputTokens,
+					InputPrice:      nonZeroPtr(tier.InputCostPerToken),
+					OutputPrice:     nonZeroPtr(tier.OutputCostPerToken),
+					CacheWritePrice: nonZeroPtr(tier.CacheCreationInputTokenCost),
+					CacheReadPrice:  nonZeroPtr(tier.CacheReadInputTokenCost),
+				})
+			}
 		}
 		if result.InputPrice == nil && result.OutputPrice == nil &&
-			result.CacheWritePrice == nil && result.CacheWrite1hPrice == nil && result.CacheReadPrice == nil {
+			result.CacheWritePrice == nil && result.CacheWrite1hPrice == nil && result.CacheReadPrice == nil &&
+			len(result.Tiers) == 0 && result.ReferenceModel == "" && result.ReferenceNote == "" {
 			result = nil
 		}
 	}

--- a/backend/internal/service/channel_plaza_test.go
+++ b/backend/internal/service/channel_plaza_test.go
@@ -206,6 +206,13 @@ func TestListPlazaGroups_OfficialPricingFill(t *testing.T) {
 			CacheCreationInputTokenCost:         3.75e-6,
 			CacheCreationInputTokenCostAbove1hr: 6e-6,
 			CacheReadInputTokenCost:             3e-7,
+			OfficialPricingTiers: []LiteLLMOfficialPricingTier{{
+				MinInputTokens:     200000,
+				InputCostPerToken:  6e-6,
+				OutputCostPerToken: 22.5e-6,
+			}},
+			PricingReferenceModel: "claude-reference",
+			PricingReferenceNote:  "Published reference price",
 		},
 		"token-absent": {Mode: "image_generation", TokenPricingAbsent: true, OutputCostPerImage: 0.04},
 	})
@@ -229,6 +236,11 @@ func TestListPlazaGroups_OfficialPricingFill(t *testing.T) {
 	require.InDelta(t, 3e-6, *official.InputPrice, 1e-12)
 	require.InDelta(t, 6e-6, *official.CacheWrite1hPrice, 1e-12)
 	require.InDelta(t, 3e-7, *official.CacheReadPrice, 1e-12)
+	require.Equal(t, "claude-reference", official.ReferenceModel)
+	require.Equal(t, "Published reference price", official.ReferenceNote)
+	require.Len(t, official.Tiers, 1)
+	require.Equal(t, 200000, official.Tiers[0].MinInputTokens)
+	require.InDelta(t, 6e-6, *official.Tiers[0].InputPrice, 1e-12)
 	// 未命中:nil(GetModelPricing 的 claude 系列模糊匹配对非 claude 名不生效)
 	require.Nil(t, byName["unknown-model"].OfficialPricing)
 	// TokenPricingAbsent 条目不作为官方 token 价展示

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,7 @@ import (
 
 var (
 	openAIModelDatePattern     = regexp.MustCompile(`-\d{8}$`)
+	officialPricingTierPattern = regexp.MustCompile(`^(input_cost_per_token|output_cost_per_token|cache_read_input_token_cost|cache_creation_input_token_cost)_above_(\d+)k_tokens$`)
 	openAIModelBasePattern     = regexp.MustCompile(`^(gpt-\d+(?:\.\d+)?)(?:-|$)`)
 	openAIGPT54FallbackPricing = &LiteLLMModelPricing{
 		InputCostPerToken:               2.5e-06, // $2.5 per MTok
@@ -106,26 +108,37 @@ var (
 
 // LiteLLMModelPricing LiteLLM价格数据结构
 // 只保留我们需要的字段，使用指针来处理可能缺失的值
+type LiteLLMOfficialPricingTier struct {
+	MinInputTokens              int
+	InputCostPerToken           float64
+	OutputCostPerToken          float64
+	CacheReadInputTokenCost     float64
+	CacheCreationInputTokenCost float64
+}
+
 type LiteLLMModelPricing struct {
-	InputCostPerToken                   float64 `json:"input_cost_per_token"`
-	InputCostPerTokenPriority           float64 `json:"input_cost_per_token_priority"`
-	OutputCostPerToken                  float64 `json:"output_cost_per_token"`
-	OutputCostPerTokenPriority          float64 `json:"output_cost_per_token_priority"`
-	CacheCreationInputTokenCost         float64 `json:"cache_creation_input_token_cost"`
-	CacheCreationInputTokenCostPriority float64 `json:"cache_creation_input_token_cost_priority"`
-	CacheCreationInputTokenCostAbove1hr float64 `json:"cache_creation_input_token_cost_above_1hr"`
-	CacheReadInputTokenCost             float64 `json:"cache_read_input_token_cost"`
-	CacheReadInputTokenCostPriority     float64 `json:"cache_read_input_token_cost_priority"`
-	LongContextInputTokenThreshold      int     `json:"long_context_input_token_threshold,omitempty"`
-	LongContextInputCostMultiplier      float64 `json:"long_context_input_cost_multiplier,omitempty"`
-	LongContextOutputCostMultiplier     float64 `json:"long_context_output_cost_multiplier,omitempty"`
-	SupportsServiceTier                 bool    `json:"supports_service_tier"`
-	LiteLLMProvider                     string  `json:"litellm_provider"`
-	Mode                                string  `json:"mode"`
-	SupportsPromptCaching               bool    `json:"supports_prompt_caching"`
-	OutputCostPerImage                  float64 `json:"output_cost_per_image"`       // 图片生成模型每张图片价格
-	OutputCostPerImageToken             float64 `json:"output_cost_per_image_token"` // 图片输出 token 价格
-	InputCostPerImageToken              float64 `json:"input_cost_per_image_token"`  // 图片输入 token 价格（如 gpt-image-2 图片编辑）
+	InputCostPerToken                   float64                      `json:"input_cost_per_token"`
+	InputCostPerTokenPriority           float64                      `json:"input_cost_per_token_priority"`
+	OutputCostPerToken                  float64                      `json:"output_cost_per_token"`
+	OutputCostPerTokenPriority          float64                      `json:"output_cost_per_token_priority"`
+	CacheCreationInputTokenCost         float64                      `json:"cache_creation_input_token_cost"`
+	CacheCreationInputTokenCostPriority float64                      `json:"cache_creation_input_token_cost_priority"`
+	CacheCreationInputTokenCostAbove1hr float64                      `json:"cache_creation_input_token_cost_above_1hr"`
+	CacheReadInputTokenCost             float64                      `json:"cache_read_input_token_cost"`
+	CacheReadInputTokenCostPriority     float64                      `json:"cache_read_input_token_cost_priority"`
+	LongContextInputTokenThreshold      int                          `json:"long_context_input_token_threshold,omitempty"`
+	LongContextInputCostMultiplier      float64                      `json:"long_context_input_cost_multiplier,omitempty"`
+	LongContextOutputCostMultiplier     float64                      `json:"long_context_output_cost_multiplier,omitempty"`
+	SupportsServiceTier                 bool                         `json:"supports_service_tier"`
+	LiteLLMProvider                     string                       `json:"litellm_provider"`
+	Mode                                string                       `json:"mode"`
+	SupportsPromptCaching               bool                         `json:"supports_prompt_caching"`
+	OutputCostPerImage                  float64                      `json:"output_cost_per_image"`       // 图片生成模型每张图片价格
+	OutputCostPerImageToken             float64                      `json:"output_cost_per_image_token"` // 图片输出 token 价格
+	InputCostPerImageToken              float64                      `json:"input_cost_per_image_token"`  // 图片输入 token 价格（如 gpt-image-2 图片编辑）
+	OfficialPricingTiers                []LiteLLMOfficialPricingTier `json:"-"`
+	PricingReferenceModel               string                       `json:"pricing_reference_model"`
+	PricingReferenceNote                string                       `json:"pricing_reference_note"`
 
 	// TokenPricingAbsent 表示源数据中 input/output token 价格均缺失（仅有图片价）。
 	// 此类条目只可用于图片计费，token 计费必须回退到 fallback 或 fail-closed，
@@ -160,6 +173,8 @@ type LiteLLMRawEntry struct {
 	OutputCostPerImage                  *float64 `json:"output_cost_per_image"`
 	OutputCostPerImageToken             *float64 `json:"output_cost_per_image_token"`
 	InputCostPerImageToken              *float64 `json:"input_cost_per_image_token"`
+	PricingReferenceModel               string   `json:"pricing_reference_model"`
+	PricingReferenceNote                string   `json:"pricing_reference_note"`
 }
 
 // PricingService 动态价格服务
@@ -452,6 +467,9 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 			SupportsPromptCaching: entry.SupportsPromptCaching,
 			SupportsServiceTier:   entry.SupportsServiceTier,
 			TokenPricingAbsent:    entry.InputCostPerToken == nil && entry.OutputCostPerToken == nil,
+			PricingReferenceModel: strings.TrimSpace(entry.PricingReferenceModel),
+			PricingReferenceNote:  strings.TrimSpace(entry.PricingReferenceNote),
+			OfficialPricingTiers:  parseOfficialPricingTiers(rawEntry),
 		}
 
 		if entry.InputCostPerToken != nil {
@@ -512,6 +530,54 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 	}
 
 	return result, nil
+}
+
+func parseOfficialPricingTiers(rawEntry json.RawMessage) []LiteLLMOfficialPricingTier {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawEntry, &fields); err != nil {
+		return nil
+	}
+	tiers := make(map[int]*LiteLLMOfficialPricingTier)
+	for field, rawValue := range fields {
+		match := officialPricingTierPattern.FindStringSubmatch(field)
+		if match == nil {
+			continue
+		}
+		var value *float64
+		if err := json.Unmarshal(rawValue, &value); err != nil || value == nil || *value <= 0 {
+			continue
+		}
+		threshold, err := strconv.Atoi(match[2])
+		if err != nil || threshold <= 0 {
+			continue
+		}
+		minInputTokens := threshold * 1000
+		tier := tiers[minInputTokens]
+		if tier == nil {
+			tier = &LiteLLMOfficialPricingTier{MinInputTokens: minInputTokens}
+			tiers[minInputTokens] = tier
+		}
+		switch match[1] {
+		case "input_cost_per_token":
+			tier.InputCostPerToken = *value
+		case "output_cost_per_token":
+			tier.OutputCostPerToken = *value
+		case "cache_read_input_token_cost":
+			tier.CacheReadInputTokenCost = *value
+		case "cache_creation_input_token_cost":
+			tier.CacheCreationInputTokenCost = *value
+		}
+	}
+	thresholds := make([]int, 0, len(tiers))
+	for threshold := range tiers {
+		thresholds = append(thresholds, threshold)
+	}
+	sort.Ints(thresholds)
+	result := make([]LiteLLMOfficialPricingTier, 0, len(thresholds))
+	for _, threshold := range thresholds {
+		result = append(result, *tiers[threshold])
+	}
+	return result
 }
 
 // loadPricingData 从本地文件加载价格数据

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -719,3 +719,32 @@ func TestListModelNamesByProvider_EmptyCatalog(t *testing.T) {
 	require.NotNil(t, got)
 	require.Empty(t, got)
 }
+
+func TestPricingService_ParseOfficialDisplayMetadata(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"qwen3.7-plus": {
+			"input_cost_per_token": 0.0000004,
+			"output_cost_per_token": 0.0000016,
+			"input_cost_per_token_above_256k_tokens": 0.0000012,
+			"output_cost_per_token_above_256k_tokens": 0.0000048,
+			"cache_read_input_token_cost_above_256k_tokens": 0.00000012,
+			"cache_creation_input_token_cost_above_256k_tokens": 0.0000015,
+			"pricing_reference_model": "canonical-model",
+			"pricing_reference_note": "Published reference price"
+		}
+	}`))
+	require.NoError(t, err)
+
+	pricing := data["qwen3.7-plus"]
+	require.NotNil(t, pricing)
+	require.Equal(t, "canonical-model", pricing.PricingReferenceModel)
+	require.Equal(t, "Published reference price", pricing.PricingReferenceNote)
+	require.Equal(t, []LiteLLMOfficialPricingTier{{
+		MinInputTokens:              256000,
+		InputCostPerToken:           0.0000012,
+		OutputCostPerToken:          0.0000048,
+		CacheReadInputTokenCost:     0.00000012,
+		CacheCreationInputTokenCost: 0.0000015,
+	}}, pricing.OfficialPricingTiers)
+}

--- a/frontend/src/api/modelPlaza.ts
+++ b/frontend/src/api/modelPlaza.ts
@@ -7,6 +7,14 @@
 import { apiClient } from './client'
 import type { UserSupportedModelPricing } from './channels'
 
+export interface PlazaOfficialPricingTier {
+  min_input_tokens: number
+  input_price: number | null
+  output_price: number | null
+  cache_write_price: number | null
+  cache_read_price: number | null
+}
+
 /** LiteLLM 官方参考价（USD per token，字段缺失 = 官方数据未覆盖）。 */
 export interface PlazaOfficialPricing {
   input_price: number | null
@@ -16,6 +24,9 @@ export interface PlazaOfficialPricing {
   /** 1h 缓存写入（LiteLLM cache_creation_above_1hr），多数模型缺失。 */
   cache_write_1h_price?: number | null
   cache_read_price: number | null
+  tiers?: PlazaOfficialPricingTier[]
+  reference_model?: string
+  reference_note?: string
 }
 
 export interface PlazaModel {

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -82,6 +82,14 @@
                 {{ billingModeLabel(m) }}
               </span>
             </div>
+            <div
+              v-if="m.official_pricing?.reference_model"
+              class="mt-1 text-[11px] leading-4 text-gray-400 dark:text-dark-500"
+            >
+              {{ t('modelPlaza.table.referencePrice') }}:
+              <span class="font-mono">{{ m.official_pricing.reference_model }}</span>
+              <span v-if="m.official_pricing.reference_note" class="block">{{ m.official_pricing.reference_note }}</span>
+            </div>
           </td>
 
           <!-- token 计费:输入 / 输出(阶梯内联)/ 缓存(写/读) -->
@@ -161,10 +169,26 @@
           <td
             class="border-l border-gray-100 px-3 py-2.5 align-middle font-mono text-xs text-gray-500 dark:border-dark-700/60 dark:text-dark-400"
           >
-            {{ official(m.official_pricing?.input_price) }}
+            <div>{{ official(m.official_pricing?.input_price) }}</div>
+            <div
+              v-for="tier in officialPricingTiers(m)"
+              :key="`input-${tier.min_input_tokens}`"
+              class="mt-0.5 whitespace-nowrap"
+            >
+              <span class="mr-1 font-sans text-gray-400 dark:text-dark-500">{{ officialTierLabel(tier.min_input_tokens) }}</span>
+              {{ official(tier.input_price) }}
+            </div>
           </td>
           <td class="px-3 py-2.5 align-middle font-mono text-xs text-gray-500 dark:text-dark-400">
-            {{ official(m.official_pricing?.output_price) }}
+            <div>{{ official(m.official_pricing?.output_price) }}</div>
+            <div
+              v-for="tier in officialPricingTiers(m)"
+              :key="`output-${tier.min_input_tokens}`"
+              class="mt-0.5 whitespace-nowrap"
+            >
+              <span class="mr-1 font-sans text-gray-400 dark:text-dark-500">{{ officialTierLabel(tier.min_input_tokens) }}</span>
+              {{ official(tier.output_price) }}
+            </div>
           </td>
           <td class="px-3 py-2.5 align-middle">
             <div
@@ -182,6 +206,19 @@
               <div>
                 <span class="mr-1 font-sans font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheRead') }}</span>
                 {{ official(m.official_pricing.cache_read_price) }}
+              </div>
+              <div
+                v-for="tier in officialCacheTiers(m)"
+                :key="`cache-${tier.min_input_tokens}`"
+                class="pt-0.5"
+              >
+                <span class="mr-1 font-sans text-gray-400 dark:text-dark-500">{{ officialTierLabel(tier.min_input_tokens) }}</span>
+                <template v-if="tier.cache_write_price != null">
+                  <span class="font-sans">{{ t('modelPlaza.table.cacheWrite') }}</span> {{ official(tier.cache_write_price) }}
+                </template>
+                <template v-if="tier.cache_read_price != null">
+                  <span class="font-sans">{{ t('modelPlaza.table.cacheRead') }}</span> {{ official(tier.cache_read_price) }}
+                </template>
               </div>
             </div>
             <span v-else class="text-gray-400 dark:text-dark-500">-</span>
@@ -218,7 +255,7 @@ import {
   BILLING_MODE_IMAGE,
   type BillingMode
 } from '@/constants/channel'
-import type { PlazaModel } from '@/api/modelPlaza'
+import type { PlazaModel, PlazaOfficialPricingTier } from '@/api/modelPlaza'
 import type { UserPricingInterval } from '@/api/channels'
 
 const props = defineProps<{
@@ -314,12 +351,32 @@ function perUnitSuffix(m: PlazaModel): string {
     : t('modelPlaza.table.perUnitRequest')
 }
 
+
+function officialPricingTiers(m: PlazaModel): PlazaOfficialPricingTier[] {
+  return m.official_pricing?.tiers ?? []
+}
+
+function officialCacheTiers(m: PlazaModel): PlazaOfficialPricingTier[] {
+  return officialPricingTiers(m).filter(
+    (tier) => tier.cache_write_price != null || tier.cache_read_price != null
+  )
+}
+
+function officialTierLabel(minInputTokens: number): string {
+  return `>${formatTokenCount(minInputTokens)}`
+}
+
 function hasCachePricing(m: PlazaModel): boolean {
   return m.pricing?.cache_write_price != null || m.pricing?.cache_read_price != null
 }
 
 function hasOfficialCache(o: NonNullable<PlazaModel['official_pricing']>): boolean {
-  return o.cache_write_price != null || o.cache_read_price != null || o.cache_write_1h_price != null
+  return (
+    o.cache_write_price != null ||
+    o.cache_read_price != null ||
+    o.cache_write_1h_price != null ||
+    (o.tiers ?? []).some((tier) => tier.cache_write_price != null || tier.cache_read_price != null)
+  )
 }
 
 /** token 模式的阶梯定价(内联进输入/输出列)。 */

--- a/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
+++ b/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
@@ -405,3 +405,37 @@ describe('PlazaModelPricingTable', () => {
     expect(wrapper.text()).toContain('OpenAI')
   })
 })
+
+describe('official pricing metadata', () => {
+  it('renders long-context tiers and explicit reference metadata', () => {
+    const model = tokenModel({
+      name: 'kimi-for-coding-highspeed',
+      official_pricing: {
+        input_price: 0.95e-6,
+        output_price: 4e-6,
+        cache_write_price: null,
+        cache_read_price: 0.19e-6,
+        reference_model: 'kimi-k2.7-code',
+        reference_note: 'No separate public HighSpeed per-token price is published.',
+        tiers: [
+          {
+            min_input_tokens: 256000,
+            input_price: 2e-6,
+            output_price: 6e-6,
+            cache_write_price: 2.5e-6,
+            cache_read_price: 0.2e-6
+          }
+        ]
+      }
+    })
+
+    const text = mountTable([model], 1).text()
+    expect(text).toContain('kimi-k2.7-code')
+    expect(text).toContain('No separate public HighSpeed per-token price is published.')
+    expect(text).toContain('>256K')
+    expect(text).toContain('$2.00')
+    expect(text).toContain('$6.00')
+    expect(text).toContain('$2.50')
+    expect(text).toContain('$0.20')
+  })
+})

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -568,6 +568,7 @@ export default {
       cacheRead: 'Read',
       paidPrice: 'Your Price (Discounted)',
       officialPrice: 'Official Price',
+      referencePrice: 'Reference price',
       rate: 'Rate',
       unitPerMillion: '$ / 1M tokens',
       perUnitRequest: '/ request',

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -573,6 +573,7 @@ export default {
       cacheRead: '读取',
       paidPrice: '实付价格(折后)',
       officialPrice: '官方价格',
+      referencePrice: '参考价格',
       rate: '折扣倍率',
       unitPerMillion: '$ / 1M token',
       perUnitRequest: '/ 次',


### PR DESCRIPTION
## Summary

- parse explicit long-context price fields such as `*_above_256k_tokens` and `*_above_272k_tokens` into normalized pricing tiers
- carry catalog-provided `pricing_reference_model` and `pricing_reference_note` metadata through the pricing and model-plaza service layers
- expose optional `tiers`, `reference_model`, and `reference_note` fields in the public model-plaza response
- render long-context official prices and explicit reference-model notes in the model-plaza table
- add English and Chinese labels plus backend/frontend regression coverage

## Why

The model plaza currently exposes only one official price tier. The pricing catalog already contains higher long-context rates for models such as GPT and Qwen, but those fields are ignored. Some public aliases also use a canonical model as a price reference; without explicit metadata, the UI can only present that value as if it were an independent official price.

This change keeps the pricing catalog as the only source of public reference metadata. It does not infer or expose channel `model_mapping` values, and it does not change the billing path, channel pricing, or group multipliers.

## API compatibility

All new response fields are optional. Existing catalogs and clients continue to receive and render the current base official prices.

## Validation

- `go test -tags unit ./internal/service ./internal/handler`
- `vitest run src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts`
- `vue-tsc --noEmit`
- ESLint on the modified frontend files
