### PR TITLE
fix(i18n): move account scheduling threshold keys out of status block

### DIFF
--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -121,6 +121,12 @@ export default {
       antigravityProjectIdPlaceholder: 'your-gcp-project-id',
       antigravityProjectIdHint:
         'Antigravity standard-tier accounts that do not receive an automatic project_id need a user-owned GCP project.',
+      accountSchedulingThresholdOverride: 'Account Auto-Pause Threshold Override',
+      accountSchedulingThresholdOverrideHint:
+        'Override the platform auto-pause threshold for this account only. Disable to use platform settings.',
+      accountSchedulingThresholdOverrideValue: 'Account threshold percent',
+      accountSchedulingThresholdOverrideDisabledHint:
+        'Use 1-100. The account becomes temporarily unschedulable after reaching this usage percent; 100 disables it for this account.',
       status: {
         active: 'Active',
         inactive: 'Inactive',
@@ -131,10 +137,6 @@ export default {
         rateLimited: 'Rate Limited',
         overloaded: 'Overloaded',
         tempUnschedulable: 'Temp Unschedulable',
-      accountSchedulingThresholdOverride: 'Account Auto-Pause Threshold Override',
-      accountSchedulingThresholdOverrideHint: 'Override the platform auto-pause threshold for this account only. Disable to use platform settings.',
-      accountSchedulingThresholdOverrideValue: 'Account threshold percent',
-      accountSchedulingThresholdOverrideDisabledHint: 'Use 1-100. The account becomes temporarily unschedulable after reaching this usage percent; 100 disables it for this account.',
         quotaExceeded: 'Quota Exceeded',
         unschedulable: 'Unschedulable',
         rateLimitedUntil: 'Rate limited and removed from scheduling. Auto resumes at {time}',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -324,6 +324,12 @@ export default {
       antigravityProjectIdPlaceholder: 'your-gcp-project-id',
       antigravityProjectIdHint:
         'standard-tier 且未自动返回 project_id 的 Antigravity 账号需要填写用户自带 GCP project。',
+      accountSchedulingThresholdOverride: '账号自动停调阈值覆盖',
+      accountSchedulingThresholdOverrideHint:
+        '仅对当前账号覆盖平台级自动停调阈值；关闭后使用平台设置。',
+      accountSchedulingThresholdOverrideValue: '账号阈值百分比',
+      accountSchedulingThresholdOverrideDisabledHint:
+        '1-100，达到该用量百分比后临时不可调度；100 表示禁用当前账号自动停调。',
       status: {
         active: '正常',
         inactive: '停用',
@@ -334,10 +340,6 @@ export default {
         rateLimited: '限流中',
         overloaded: '过载中',
         tempUnschedulable: '临时不可调度',
-      accountSchedulingThresholdOverride: '账号自动停调阈值覆盖',
-      accountSchedulingThresholdOverrideHint: '仅对当前账号覆盖平台级自动停调阈值；关闭后使用平台设置。',
-      accountSchedulingThresholdOverrideValue: '账号阈值百分比',
-      accountSchedulingThresholdOverrideDisabledHint: '1-100，达到该用量百分比后临时不可调度；100 表示禁用当前账号自动停调。',
         quotaExceeded: '配额超限',
         unschedulable: '不可调度',
         rateLimitedUntil: '限流中，当前不参与调度，预计 {time} 自动恢复',


### PR DESCRIPTION
## 问题

`EditAccountModal.vue` 中「账号自动停调阈值覆盖」区块调用了 4 个 i18n 键:

```
admin.accounts.accountSchedulingThresholdOverride
admin.accounts.accountSchedulingThresholdOverrideHint
admin.accounts.accountSchedulingThresholdOverrideValue
admin.accounts.accountSchedulingThresholdOverrideDisabledHint
```

但这 4 行在 zh 和 en 两个语言包里都被写在了 `admin.accounts.status` 对象**内部**(缩进比同级 status 子键少 2 格,视觉上不易察觉),实际路径变成了 `admin.accounts.status.accountSchedulingThresholdOverride*`。

两种语言都错,`fallbackLocale: 'en'` 也兜不住 —— 打开任意账号的编辑弹窗、滚动到该区块,**标签、说明、输入框标签、hint 四行全部渲染裸 key**。

相关功能引入于 79df1647d(`feat(grok): 账单绝对金额、调度阈值 UI、搜索/Voice 计费与 /v1/web_search`)。

## 修改

把这 4 行从 `status: {}` 块移出、提到 `accounts` 层级(放在 `status` 之前),两条超长文案按文件既有风格折行。**文案一字未改,仅调整键的位置与缩进。**

## 验证

修复前:
<img width="1810" height="518" alt="image" src="https://github.com/user-attachments/assets/bf8ae25e-f81d-49be-bd76-fb39921e5eec" />

修复后:
<img width="1806" height="530" alt="image" src="https://github.com/user-attachments/assets/b6fd7bab-17f9-4f33-8d75-ec7a7b21baa2" />

