### PR TITLE
fix(channel): 定价冲突检测与定价缓存键的归一化对齐（#4754 修复残留）

### DIFF
--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -962,10 +962,26 @@ func conflictsBetween(a, b modelEntry) bool {
 	}
 }
 
-// toModelEntry 将模型名转换为 modelEntry
+// toModelEntry 将模型名转换为 modelEntry（用于模型映射的冲突检测）。
+// 归一化必须与 expandMappingToCache 写缓存键的方式一致：映射缓存只做 strings.ToLower。
 func toModelEntry(pattern string) modelEntry {
 	prefix, isWild := splitWildcardSuffix(strings.ToLower(pattern))
 	return modelEntry{pattern: pattern, prefix: prefix, wildcard: isWild}
+}
+
+// toPricingModelEntry 将模型名转换为 modelEntry（用于模型定价的冲突检测）。
+//
+// 与 toModelEntry 的区别：定价缓存的键走 normalizeChannelPricingModelName
+// （额外做 TrimSpace，并把 claude-* 的 "." 换成 "-"），冲突检测必须用同一套归一化，
+// 否则两个校验时看着不同、写进缓存后键相同的定价会互相静默覆盖。
+func toPricingModelEntry(pattern string) modelEntry {
+	// 先剥通配符再归一化，与 expandPricingToCache 的处理顺序保持一致
+	prefix, isWild := splitWildcardSuffix(pattern)
+	return modelEntry{
+		pattern:  pattern,
+		prefix:   normalizeChannelPricingModelName(prefix),
+		wildcard: isWild,
+	}
 }
 
 // validateNoConflictingModels 检查定价列表中是否有冲突模型模式（同一平台下）。
@@ -974,7 +990,7 @@ func validateNoConflictingModels(pricingList []ChannelModelPricing) error {
 	byPlatform := make(map[string][]modelEntry)
 	for _, p := range pricingList {
 		for _, model := range p.Models {
-			byPlatform[p.Platform] = append(byPlatform[p.Platform], toModelEntry(model))
+			byPlatform[p.Platform] = append(byPlatform[p.Platform], toPricingModelEntry(model))
 		}
 	}
 	for platform, entries := range byPlatform {

--- a/backend/internal/service/channel_service_test.go
+++ b/backend/internal/service/channel_service_test.go
@@ -414,6 +414,44 @@ func TestValidateNoConflictingModels(t *testing.T) {
 			wantErr:     true,
 			errContains: "conflict",
 		},
+		// 以下三例：冲突检测必须与 normalizeChannelPricingModelName 用同一套归一化，
+		// 否则校验放行、写进缓存后键相同，后写的定价会静默覆盖前一条。
+		{
+			name: "claude_dot_and_hyphen_spelling_conflict",
+			pricingList: []ChannelModelPricing{
+				{Platform: "anthropic", Models: []string{"claude-sonnet-4.5"}},
+				{Platform: "anthropic", Models: []string{"claude-sonnet-4-5"}},
+			},
+			wantErr:     true,
+			errContains: "conflict",
+		},
+		{
+			name: "claude_dot_and_hyphen_spelling_conflict_wildcard",
+			pricingList: []ChannelModelPricing{
+				{Platform: "anthropic", Models: []string{"claude-sonnet-4.5*"}},
+				{Platform: "anthropic", Models: []string{"claude-sonnet-4-5-x"}},
+			},
+			wantErr:     true,
+			errContains: "conflict",
+		},
+		{
+			name: "surrounding_whitespace_conflict",
+			pricingList: []ChannelModelPricing{
+				{Platform: "openai", Models: []string{"gpt-5.6"}},
+				{Platform: "openai", Models: []string{" gpt-5.6 "}},
+			},
+			wantErr:     true,
+			errContains: "conflict",
+		},
+		{
+			// 只有 claude-* 前缀才做 "." → "-"，别把其它平台也一起归一化了
+			name: "non_claude_dot_spelling_is_not_normalized",
+			pricingList: []ChannelModelPricing{
+				{Platform: "openai", Models: []string{"gpt-5.6"}},
+				{Platform: "openai", Models: []string{"gpt-5-6"}},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -468,6 +506,16 @@ func TestValidateNoConflictingMappings(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "conflict",
+		},
+		{
+			// 映射缓存（expandMappingToCache）只做 strings.ToLower，不做定价那套
+			// "." → "-"，所以这两个源模式在缓存里是两个不同的键、并不冲突。
+			// 这条用来卡住：定价侧的归一化修复不能顺手套到映射侧，否则会误报冲突。
+			name: "mapping keeps dot and hyphen spelling separate",
+			mapping: map[string]map[string]string{
+				"anthropic": {"claude-sonnet-4.5": "a", "claude-sonnet-4-5": "b"},
+			},
+			wantErr: false,
 		},
 		{
 			name: "wildcard vs exact conflict",


### PR DESCRIPTION
## 问题

渠道的模型定价里，两条**校验时看着不同、写进缓存后键相同**的定价可以同时保存成功，
进缓存后**后写的那条会静默覆盖前一条**——不报错、不告警，配置页上两条都还在，
但其中一条的价格永远不会生效。

这是 #4754 的修复残留。那个 issue 报的是 `claude-sonnet-4.5` / `claude-sonnet-4-5`
两种写法匹配不上导致 per_request 定价失效，修复给**查找侧**加了归一化，
**校验侧没动**，于是问题从「匹配不上」变成了「两条定价静默合并」。

## 复现步骤

给同一个渠道、同一个平台配置两条定价，模型名只差 `.` 和 `-` 的写法：

| 定价条目 | Platform | Models | input_price |
|---|---|---|---|
| A | `anthropic` | `claude-sonnet-4.5` | `0.000001` |
| B | `anthropic` | `claude-sonnet-4-5` | `0.000009` |

1. 保存渠道 —— **校验通过**，两条定价都存下来了
2. 等渠道缓存刷新（或重启服务）
3. 用 `claude-sonnet-4.5` 发一次请求，再用 `claude-sonnet-4-5` 发一次

**期望**：要么保存时就报冲突，要么两条各自生效
**实际**：两种写法算出来的价格**都是 `0.000009`**（取决于 map 写入顺序，A 被静默丢弃）

空白字符同理：`"gpt-5.6"` 和 `" gpt-5.6 "` 也能一起存进去，缓存里是同一个键。

## 原因

校验和缓存用了两套不同的归一化：

**校验侧** —— `validateNoConflictingModels` → `toModelEntry`（`channel_service.go`）：

```go
func toModelEntry(pattern string) modelEntry {
	prefix, isWild := splitWildcardSuffix(strings.ToLower(pattern))
	return modelEntry{pattern: pattern, prefix: prefix, wildcard: isWild}
}
```

只做 `strings.ToLower`。

**缓存侧** —— `expandPricingToCache` 写键时走 `normalizeChannelPricingModelName`：

```go
func normalizeChannelPricingModelName(model string) string {
	model = strings.ToLower(strings.TrimSpace(model))
	if strings.HasPrefix(model, "claude-") {
		model = strings.ReplaceAll(model, ".", "-")
	}
	return model
}
```

多做了 `TrimSpace`，以及对 `claude-*` 把 `.` 换成 `-`。

于是 `claude-sonnet-4.5` 与 `claude-sonnet-4-5`：

- 在校验眼里 prefix 分别是 `claude-sonnet-4.5` / `claude-sonnet-4-5` → 不冲突，放行
- 在缓存眼里 key 都是 `claude-sonnet-4-5` → 同一个 map 键，后写覆盖先写

```go
key := channelModelKey{groupID: gid, platform: pricingPlatform, model: normalizeChannelPricingModelName(model)}
cache.pricingByGroupModel[key] = pricing   // 同键直接覆盖，没有任何提示
```

## 修复

让定价的冲突检测用**和缓存键完全相同**的归一化。

新增 `toPricingModelEntry`，复用 `normalizeChannelPricingModelName`；
先剥通配符后缀再归一化，与 `expandPricingToCache` 的处理顺序保持一致：

```go
func toPricingModelEntry(pattern string) modelEntry {
	prefix, isWild := splitWildcardSuffix(pattern)
	return modelEntry{
		pattern:  pattern,
		prefix:   normalizeChannelPricingModelName(prefix),
		wildcard: isWild,
	}
}
```

`validateNoConflictingModels` 改用它。

### ⚠️ 为什么没有直接改 `toModelEntry`

因为它同时被**模型映射**的校验 `validateNoConflictingMappings` 使用，
而映射缓存 `expandMappingToCache` 写键时只做 `strings.ToLower`：

```go
key := channelModelKey{groupID: gid, platform: mappingPlatform, model: strings.ToLower(src)}
```

映射侧的 `claude-sonnet-4.5` 和 `claude-sonnet-4-5` 在缓存里本来就是两个不同的键、
并不冲突。如果把归一化一并套到映射校验上，就会把**本来合法**的映射配置误判成冲突。
所以这里分成两个函数：`toModelEntry` 保持原样给映射用，`toPricingModelEntry` 给定价用，
两边各自与自己的缓存键对齐。

## 测试

在 `channel_service_test.go` 已有的表驱动用例里补了 5 条：

**`TestValidateNoConflictingModels`**

| 用例 | 断言 |
|---|---|
| `claude_dot_and_hyphen_spelling_conflict` | `claude-sonnet-4.5` vs `claude-sonnet-4-5` → 报冲突 |
| `claude_dot_and_hyphen_spelling_conflict_wildcard` | `claude-sonnet-4.5*` vs `claude-sonnet-4-5-x` → 报冲突 |
| `surrounding_whitespace_conflict` | `gpt-5.6` vs `" gpt-5.6 "` → 报冲突 |
| `non_claude_dot_spelling_is_not_normalized` | `gpt-5.6` vs `gpt-5-6` → **不**报冲突（只有 `claude-` 前缀才换 `.`） |

**`TestValidateNoConflictingMappings`**

| 用例 | 断言 |
|---|---|
| `mapping keeps dot and hyphen spelling separate` | 映射里两种写法**不**冲突（卡住上面那条「别顺手套到映射侧」） |

验证：

```
# 打补丁前
$ go test -tags unit ./internal/service/ -run 'TestValidateNoConflicting'
--- FAIL: TestValidateNoConflictingModels/claude_dot_and_hyphen_spelling_conflict
--- FAIL: TestValidateNoConflictingModels/claude_dot_and_hyphen_spelling_conflict_wildcard
--- FAIL: TestValidateNoConflictingModels/surrounding_whitespace_conflict
exit 1

# 打补丁后
$ go test -tags unit ./internal/service/ -run 'TestValidateNoConflicting'
ok      github.com/Wei-Shaw/sub2api/internal/service    0.018s

# 整包回归
$ go test -tags unit ./internal/service/
ok      github.com/Wei-Shaw/sub2api/internal/service    149.477s
```

`go build ./...` 通过，`gofmt` 无改动。

## 影响面

只改了定价冲突检测这一处。行为变化是：**以前能存下去的一种错误配置，现在会在保存时报冲突**。
对已经存在这种配置的部署，下次编辑该渠道时会被拦下来并提示冲突——这正是应该发生的，
否则用户永远不知道自己有一条定价从来没生效过。

Ref #4754
