### PR TITLE
fix(group): 改分组 platform 后失效渠道缓存（否则最长 10 分钟按旧平台计价）

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -189,7 +189,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	adminAccountRepository := repository.NewAdminAccountRepository(client, db, schedulerCache)
 	proxyExitInfoProber := repository.NewProxyExitInfoProber(configConfig)
 	proxyLatencyCache := repository.NewProxyLatencyCache(redisClient)
-	adminService := service.NewAdminService(userRepository, adminGroupRepository, adminAccountRepository, proxyRepository, apiKeyRepository, redeemCodeRepository, userGroupRateRepository, userRPMCache, billingCacheService, proxyExitInfoProber, proxyLatencyCache, apiKeyAuthCacheInvalidator, client, settingService, subscriptionService, userSubscriptionRepository, privacyClientFactory, openAIGatewayService, affiliateService, compositeModelRouteRepository, compositeRouteResolver)
+	adminService := service.NewAdminService(userRepository, adminGroupRepository, adminAccountRepository, proxyRepository, apiKeyRepository, redeemCodeRepository, userGroupRateRepository, userRPMCache, billingCacheService, proxyExitInfoProber, proxyLatencyCache, apiKeyAuthCacheInvalidator, client, settingService, subscriptionService, userSubscriptionRepository, privacyClientFactory, openAIGatewayService, affiliateService, compositeModelRouteRepository, compositeRouteResolver, channelService)
 	adminUserHandler := admin.NewUserHandler(adminService, concurrencyService, serviceUserPlatformQuotaRepository, billingCache, totpService, userService, settingService)
 	groupCapacityService := service.NewGroupCapacityService(accountRepository, groupRepository, concurrencyService, sessionLimitCache, rpmCache)
 	groupHandler := admin.NewGroupHandler(adminService, dashboardService, groupCapacityService)

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1467,7 +1467,7 @@ func newContractDeps(t *testing.T) *contractDeps {
 	settingRepo := newStubSettingRepo()
 	settingService := service.NewSettingService(settingRepo, cfg)
 
-	adminService := service.NewAdminService(userRepo, groupRepo, &accountRepo, proxyRepo, apiKeyRepo, redeemRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	adminService := service.NewAdminService(userRepo, groupRepo, &accountRepo, proxyRepo, apiKeyRepo, redeemRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	authHandler := handler.NewAuthHandler(cfg, nil, userService, settingService, nil, redeemService, nil, nil)
 	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService)
 	usageHandler := handler.NewUsageHandler(usageService, apiKeyService, nil, nil)

--- a/backend/internal/service/admin_group.go
+++ b/backend/internal/service/admin_group.go
@@ -635,6 +635,9 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 		return nil, err
 	}
 
+	// 渠道缓存里存了 groupID → platform 的映射，改了平台要让它失效（见函数末尾）
+	previousPlatform := group.Platform
+
 	if input.Name != "" {
 		group.Name = input.Name
 	}
@@ -882,6 +885,13 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 
 	if s.authCacheInvalidator != nil {
 		s.authCacheInvalidator.InvalidateAuthCacheByGroupID(ctx, id)
+	}
+
+	// 平台变了就失效渠道缓存：该缓存持有 groupID → platform，而渠道定价 / 模型映射 /
+	// 模型白名单都按平台严格隔离。不失效的话，缓存最长 10 分钟仍按旧平台匹配，
+	// 期间定价查不到会静默回落到 LiteLLM 价格表、映射与白名单也不生效。
+	if group.Platform != previousPlatform && s.channelCacheInvalidator != nil {
+		s.channelCacheInvalidator.InvalidateCache()
 	}
 
 	// 如果指定了复制账号的源分组，同步绑定（替换当前分组的账号）

--- a/backend/internal/service/admin_group_platform_cache_test.go
+++ b/backend/internal/service/admin_group_platform_cache_test.go
@@ -1,0 +1,87 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// groupPlatformRepoStub 只实现 UpdateGroup 走到的两个方法，其余靠内嵌接口占位。
+type groupPlatformRepoStub struct {
+	GroupRepository
+	group   *Group
+	updated *Group
+}
+
+func (r *groupPlatformRepoStub) GetByID(_ context.Context, _ int64) (*Group, error) {
+	cloned := *r.group
+	return &cloned, nil
+}
+
+func (r *groupPlatformRepoStub) Update(_ context.Context, group *Group) error {
+	r.updated = group
+	return nil
+}
+
+type channelCacheInvalidatorSpy struct {
+	calls int
+}
+
+func (s *channelCacheInvalidatorSpy) InvalidateCache() { s.calls++ }
+
+// 渠道缓存持有 groupID → platform，而渠道定价/模型映射/模型白名单都按平台严格隔离。
+// 改了分组平台却不失效缓存，最长 10 分钟内这些查找仍按旧平台匹配（静默走错价）。
+func TestUpdateGroupInvalidatesChannelCacheOnPlatformChange(t *testing.T) {
+	tests := []struct {
+		name          string
+		fromPlatform  string
+		inputPlatform string
+		wantCalls     int
+	}{
+		{
+			name:          "platform changed invalidates",
+			fromPlatform:  PlatformAnthropic,
+			inputPlatform: PlatformOpenAI,
+			wantCalls:     1,
+		},
+		{
+			name:          "same platform does not invalidate",
+			fromPlatform:  PlatformAnthropic,
+			inputPlatform: PlatformAnthropic,
+			wantCalls:     0,
+		},
+		{
+			// 请求里不带 platform 字段时不应该动缓存
+			name:          "platform omitted does not invalidate",
+			fromPlatform:  PlatformAnthropic,
+			inputPlatform: "",
+			wantCalls:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &groupPlatformRepoStub{group: &Group{ID: 7, Name: "g", Platform: tt.fromPlatform}}
+			spy := &channelCacheInvalidatorSpy{}
+			svc := &adminServiceImpl{groupRepo: repo, channelCacheInvalidator: spy}
+
+			got, err := svc.UpdateGroup(context.Background(), 7, &UpdateGroupInput{Platform: tt.inputPlatform})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantCalls, spy.calls)
+		})
+	}
+}
+
+// 依赖可以不注入（例如测试或裁剪构建），此时不应 panic——缓存靠 TTL 自然重建。
+func TestUpdateGroupWithoutChannelCacheInvalidator(t *testing.T) {
+	repo := &groupPlatformRepoStub{group: &Group{ID: 7, Name: "g", Platform: PlatformAnthropic}}
+	svc := &adminServiceImpl{groupRepo: repo}
+
+	got, err := svc.UpdateGroup(context.Background(), 7, &UpdateGroupInput{Platform: PlatformOpenAI})
+	require.NoError(t, err)
+	require.Equal(t, PlatformOpenAI, got.Platform)
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -662,6 +662,14 @@ type adminServiceImpl struct {
 	affiliateService     adminRechargeAffiliateAccruer
 	compositeRouteRepo   CompositeModelRouteRepository
 	compositeResolver    *CompositeRouteResolver
+	// 分组平台变更后用来失效渠道缓存；可为 nil（缓存会在 TTL 到期后自然重建）
+	channelCacheInvalidator ChannelCacheInvalidator
+}
+
+// ChannelCacheInvalidator 失效渠道缓存。
+// 窄接口，避免 admin 服务依赖整个 ChannelService——与 APIKeyAuthCacheInvalidator 同一思路。
+type ChannelCacheInvalidator interface {
+	InvalidateCache()
 }
 
 type adminRechargeAffiliateAccruer interface {
@@ -695,6 +703,7 @@ func NewAdminService(
 	affiliateService *AffiliateService,
 	compositeRouteRepo CompositeModelRouteRepository,
 	compositeResolver *CompositeRouteResolver,
+	channelCacheInvalidator ChannelCacheInvalidator,
 ) AdminService {
 	return &adminServiceImpl{
 		userRepo:             userRepo,
@@ -721,5 +730,7 @@ func NewAdminService(
 		affiliateService:     affiliateService,
 		compositeRouteRepo:   compositeRouteRepo,
 		compositeResolver:    compositeResolver,
+
+		channelCacheInvalidator: channelCacheInvalidator,
 	}
 }

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -375,6 +375,13 @@ func channelLookupPlatform(ctx context.Context, groupPlatform string) string {
 	}
 	return groupPlatform
 }
+
+// InvalidateCache 失效并重建渠道缓存。
+// 供渠道以外、但会影响渠道缓存内容的变更调用（如分组平台变更）。
+func (s *ChannelService) InvalidateCache() {
+	s.invalidateCache()
+}
+
 func (s *ChannelService) invalidateCache() {
 	s.cache.Store((*channelCache)(nil))
 	s.cacheSF.Forget("channel_cache")

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -852,6 +852,7 @@ var ProviderSet = wire.NewSet(
 	ProvideScheduledTestRunnerService,
 	NewGroupCapacityService,
 	NewChannelService,
+	wire.Bind(new(ChannelCacheInvalidator), new(*ChannelService)),
 	NewModelPricingResolver,
 	NewContentModerationService,
 	NewAffiliateService,


### PR DESCRIPTION
## 问题

通过管理端修改**分组的 platform** 之后，渠道缓存最长 **10 分钟**仍然按**旧平台**匹配。
这段窗口里，渠道定价 / 模型映射 / 模型白名单**同时静默失效**——不报错、不告警。

对靠渠道定价结算的分组，直接的后果是**按另一套价格计费最长 10 分钟**。

## 复现步骤

前提：有一个渠道 C 绑定分组 G，并在 C 上为平台 `anthropic` 配了模型定价。

1. 正常发一次请求，确认走的是渠道 C 上配的价格（此时缓存已建立，`groupPlatform[G] = anthropic`）
2. 管理端把分组 G 的 platform 从 `anthropic` 改成 `openai`（不要碰任何渠道）
3. 立刻再发一次请求

**期望**：定价按新平台重新匹配，或者至少匹配不到时有迹可循
**实际**：接下来最长 10 分钟内

- 渠道定价查不到 → **静默回落到全局 LiteLLM 价格表**（另一套价格）
- 渠道的模型改名不生效
- 渠道的模型白名单不生效
- 日志里**没有任何东西**

10 分钟后缓存自然过期重建，一切又正常了——这也是它难被发现的原因。

**已知绕过办法**：改完分组平台后，随便打开一个渠道点一次保存（`ChannelService.Update` 会
立刻 `invalidateCache()`）。

## 原因

**证据 1 —— 缓存里确实存了分组平台，TTL 是 10 分钟**

`channel_service.go`：

```go
const (
	channelCacheTTL       = 10 * time.Minute
	channelErrorTTL       = 5 * time.Second
	channelCacheDBTimeout = 10 * time.Second
)

type channelCache struct {
	...
	groupPlatform map[int64]string // groupID → platform
	...
}
```

**证据 2 —— 定价/映射/白名单的查找都吃这个平台值**

```go
return &channelLookup{
	cache:    cache,
	channel:  ch,
	platform: channelLookupPlatform(ctx, cache.groupPlatform[groupID]),
}, nil
```

`channelLookup.platform` 之后被 `GetChannelModelPricing` / `ResolveChannelMapping` /
`IsModelRestricted` 共用，而这三者按平台严格隔离（代码注释原话：
「各平台严格独立：antigravity 分组只匹配 antigravity 定价」）。

**证据 3 —— 只有渠道自己的 CRUD 会失效缓存**

`invalidateCache()` 在 `channel_service.go` 里的全部调用点：

| 行 | 所在函数 |
|---|---|
| 761 | `(*ChannelService).Create` |
| 807 | `(*ChannelService).Update` |
| 925 | `(*ChannelService).Delete` |

**证据 4 —— 分组的 platform 是可改字段，且 UpdateGroup 完全没碰缓存**

`handler/admin/group_handler.go`：

```go
Platform string `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity grok composite"`
```

`service/admin_group.go` 的 `UpdateGroup` 里：

```go
if input.Platform != "" {
	group.Platform = input.Platform
}
```

整个 `UpdateGroup`（632~900 行）里 `invalidateCache` / `channelService` 的出现次数为 **0**。

## 修复

给 admin 服务注入一个**窄接口**，在 platform 真的发生变化时失效渠道缓存。

接口形状照抄仓库里已有的 `APIKeyAuthCacheInvalidator` 范式，避免 admin 服务依赖整个
`ChannelService`：

```go
// ChannelCacheInvalidator 失效渠道缓存。
type ChannelCacheInvalidator interface {
	InvalidateCache()
}
```

`ChannelService` 补一个导出方法转发到已有的私有实现：

```go
func (s *ChannelService) InvalidateCache() { s.invalidateCache() }
```

`UpdateGroup` 里，进入时记下原平台，落库成功后**只在平台确实变了**时失效
（紧挨着已有的 `authCacheInvalidator` 调用，位置与写法保持一致）：

```go
previousPlatform := group.Platform
...
if err := s.groupRepo.Update(ctx, group); err != nil {
	return nil, err
}

if s.authCacheInvalidator != nil {
	s.authCacheInvalidator.InvalidateAuthCacheByGroupID(ctx, id)
}

if group.Platform != previousPlatform && s.channelCacheInvalidator != nil {
	s.channelCacheInvalidator.InvalidateCache()
}
```

依赖是**可选的**：为 nil 时行为与现在完全一致（缓存靠 TTL 自然重建），
所以不会影响任何以裁剪方式构造 admin 服务的地方（例如已有的契约测试）。

接线：`wire.go` 加一条 `wire.Bind(new(ChannelCacheInvalidator), new(*ChannelService))`，
`wire_gen.go` 把已有的 `channelService` 传进 `NewAdminService`
（`channelService` 在 wire_gen 里第 140 行创建，`adminService` 在第 192 行，顺序上没有问题）。

### 为什么只在平台变化时失效，而不是每次改分组都失效

渠道缓存里与分组有关的只有 `groupPlatform` 这一项。改名、改倍率、改限额都不影响它，
每次都失效等于把整份渠道缓存无谓地重建一遍（`invalidateCache` 会同步重建）。

## 测试

新增 `admin_group_platform_cache_test.go`：

| 用例 | 断言 |
|---|---|
| `platform changed invalidates` | `anthropic` → `openai`，失效被调用 **1** 次 |
| `same platform does not invalidate` | 传入同一个平台，**0** 次 |
| `platform omitted does not invalidate` | 请求不带 platform 字段，**0** 次 |
| `TestUpdateGroupWithoutChannelCacheInvalidator` | 依赖为 nil 时不 panic，平台照常更新 |

验证：

```
# 把 UpdateGroup 里那段失效调用去掉后
$ go test -tags unit ./internal/service/ -run 'TestUpdateGroupInvalidatesChannelCache'
exit 1

# 加回来
$ go test -tags unit ./internal/service/ -run 'TestUpdateGroup'
ok      github.com/Wei-Shaw/sub2api/internal/service    0.014s

# 整包回归
$ go test -tags unit ./internal/service/ ./internal/server/
ok      github.com/Wei-Shaw/sub2api/internal/service    149.564s
ok      github.com/Wei-Shaw/sub2api/internal/server     1.771s
```

`go build ./...` 通过；`go vet -tags wireinject ./cmd/server/` 通过；改动到的文件 `gofmt` 无差异。

## 影响面

- 只在分组平台**确实改变**时多做一次缓存重建，其余路径行为不变
- 新依赖可为 nil，老的构造方式不受影响
- 没有改动任何计费/路由逻辑本身

## 相关

同一族的另一个问题（渠道缓存重建失败时会把缓存清空 5 秒，期间同样静默走错价）我另开一个 PR。
