### PR TITLE
fix: strip disabled truncation for OpenAI OAuth

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -194,6 +194,10 @@ func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuth
 			result.Modified = true
 		}
 	}
+	if truncation, ok := reqBody["truncation"].(string); ok && truncation == "disabled" {
+		delete(reqBody, "truncation")
+		result.Modified = true
+	}
 
 	// 请求带 reasoning 时补齐 include:["reasoning.encrypted_content"]，与真实 Codex 对齐
 	// （compact 端点形态不同，单独处理，此处跳过）。

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1669,6 +1669,24 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 	}
 }
 
+func TestApplyCodexOAuthTransform_StripsOnlyDisabledTruncation(t *testing.T) {
+	disabled := map[string]any{
+		"model":      "gpt-5.4",
+		"truncation": "disabled",
+		"input":      []any{map[string]any{"role": "user", "content": "hi"}},
+	}
+	applyCodexOAuthTransform(disabled, false, false)
+	require.NotContains(t, disabled, "truncation")
+
+	auto := map[string]any{
+		"model":      "gpt-5.4",
+		"truncation": "auto",
+		"input":      []any{map[string]any{"role": "user", "content": "hi"}},
+	}
+	applyCodexOAuthTransform(auto, false, false)
+	require.Equal(t, "auto", auto["truncation"])
+}
+
 func TestApplyCodexOAuthTransform_ExtractsSystemMessages(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.1",


### PR DESCRIPTION
## Summary

- remove `truncation: "disabled"` before forwarding Responses requests to the ChatGPT internal Codex endpoint through OpenAI OAuth accounts
- preserve `truncation: "auto"` so the gateway does not silently change non-default semantics
- add a focused regression test for both values

The public Responses API defaults to disabled truncation, so removing that explicit default preserves behavior while avoiding the internal endpoint's `Unsupported parameter: truncation` response.

Fixes #5547.

## Tests

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
