### PR TITLE
feat(grok): add grok-imagine-image-2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,8 @@ Sub2API supports both Grok subscription accounts through xAI OAuth and standard 
 - Codex CLI style Responses WebSocket ingress is accepted on the Responses targets and bridged to xAI HTTP/SSE Responses upstream
 - Text models: `grok-4.5`, `grok-4.3`, `grok-build-0.1`, `grok-composer-2.5-fast`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, and `grok-4.20-multi-agent-0309`
 - Media targets for Grok groups: `/v1/images/generations`, `/images/generations`, `/v1/images/edits`, `/images/edits`, `/v1/videos/generations`, `/videos/generations`, `/v1/videos/edits`, `/videos/edits`, `/v1/videos/extensions`, `/videos/extensions`, `/v1/videos/{request_id}`, and `/videos/{request_id}`. Generation, editing, and extension requests require the group image-generation permission.
-- Media models: `grok-imagine`, `grok-imagine-image-quality`, `grok-imagine-image`, `grok-imagine-edit`, `grok-imagine-video`, and `grok-imagine-video-1.5`
+- Media models: `grok-imagine`, `grok-imagine-image-2.0`, `grok-imagine-image-quality`, `grok-imagine-image`, `grok-imagine-edit`, `grok-imagine-video`, and `grok-imagine-video-1.5`
+- `grok-imagine-image-2.0` accepts `resolution` (`1k` or `2k`) and `quality` (`low` or `medium`, default `medium`). Built-in billing follows xAI's rate card: image inputs `$0.01/image`; outputs are `$0.04` (1K low), `$0.06` (2K low or 1K medium), and `$0.08` (2K medium). Channel image pricing can override output rates with tiers `1K-low`, `2K-low`, `1K-medium`, and `2K-medium`.
 - JSON image-edit and video-generation requests accept image references in `image`, `images`, `reference_images`, and `mask` objects. Use `url` for xAI-compatible payloads; the legacy `image_url` field remains accepted and is normalized to `url` before forwarding.
 - Out of scope for this provider: TTS, transcription, browser automation, cookies, and Grok web scraping
 

--- a/backend/internal/pkg/xai/models.go
+++ b/backend/internal/pkg/xai/models.go
@@ -55,6 +55,7 @@ const DefaultTextModel = "grok-4.5"
 
 // Official Imagine model IDs (https://docs.x.ai/docs/models).
 const (
+	DefaultImagineImage20Model       = "grok-imagine-image-2.0"
 	DefaultImagineImageQualityModel  = "grok-imagine-image-quality"
 	DefaultImagineImageFastModel     = "grok-imagine-image"
 	DefaultImagineVideoModel         = "grok-imagine-video"
@@ -94,6 +95,7 @@ var defaultModels = []Model{
 	{ID: "grok-4.20-0309-non-reasoning", Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok 4.20 Non Reasoning"},
 	{ID: "grok-4.20-multi-agent-0309", Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok 4.20 Multi Agent"},
 	// Imagine
+	{ID: DefaultImagineImage20Model, Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok Imagine Image 2.0"},
 	{ID: DefaultImagineImageQualityModel, Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok Imagine Image Quality"},
 	{ID: DefaultImagineImageFastModel, Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok Imagine Image"},
 	{ID: DefaultImagineVideoModel, Object: "model", Type: "model", OwnedBy: "xai", DisplayName: "Grok Imagine Video"},
@@ -174,6 +176,7 @@ func ModelMappingWithOptions(opts ModelMappingOptions) map[string]string {
 	// Backward-compatible client alias; xAI exposes image editing through the
 	// image-quality model rather than a separate grok-imagine-edit model.
 	mapping["grok-imagine-edit"] = DefaultImagineImageQualityModel
+	mapping["grok-imagine-image-2.0"] = DefaultImagineImage20Model
 	mapping["grok-imagine-image"] = DefaultImagineImageFastModel
 	mapping["grok-imagine-image-quality"] = DefaultImagineImageQualityModel
 	// Keep official IDs as identity so client-requested model strings are not

--- a/backend/internal/pkg/xai/models_test.go
+++ b/backend/internal/pkg/xai/models_test.go
@@ -17,6 +17,8 @@ func TestDefaultModelMappingExcludesCrossClientWildcards(t *testing.T) {
 	require.Equal(t, "grok-build-0.1", mapping["grok-build"])
 	require.Equal(t, DefaultTextModel, mapping["grok-build-latest"])
 	require.Equal(t, DefaultImagineImageQualityModel, mapping["grok-imagine-edit"])
+	require.Equal(t, DefaultImagineImage20Model, mapping["grok-imagine-image-2.0"])
+	require.Equal(t, DefaultImagineImage20Model, mapping["xai/grok-imagine-image-2.0"])
 	require.Equal(t, DefaultImagineVideo15LegacyModel, mapping["grok-imagine-video-1.5"])
 	require.Equal(t, DefaultImagineVideo15Model, mapping["grok-imagine-video-1.5-preview"])
 	require.Equal(t, "grok-4.5", mapping["xai/grok"])

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -366,6 +366,7 @@ func TestDefaultModelMappingIncludesGrokAliases(t *testing.T) {
 	require.Equal(t, DefaultImagineImageQualityModel, mapping["grok-imagine"])
 	require.Equal(t, DefaultImagineImageFastModel, mapping["grok-imagine-image"])
 	require.Equal(t, DefaultImagineImageQualityModel, mapping["grok-imagine-image-quality"])
+	require.Equal(t, DefaultImagineImage20Model, mapping["grok-imagine-image-2.0"])
 	require.Equal(t, DefaultImagineImageQualityModel, mapping["grok-imagine-edit"])
 	require.Equal(t, DefaultImagineVideoModel, mapping["grok-imagine-video"])
 	require.Equal(t, DefaultImagineVideo15LegacyModel, mapping["grok-imagine-video-1.5"])

--- a/backend/internal/service/account_grok_media_eligibility_test.go
+++ b/backend/internal/service/account_grok_media_eligibility_test.go
@@ -102,6 +102,23 @@ func TestGrokMediaCapabilityFiltersOnlyGeneration(t *testing.T) {
 	))
 }
 
+func TestGrokImagineImage20DefaultMappingIsSchedulable(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+	}
+
+	require.True(t, account.IsModelSupported(xai.DefaultImagineImage20Model))
+	require.Equal(t, xai.DefaultImagineImage20Model, account.GetMappedModel(xai.DefaultImagineImage20Model))
+	require.True(t, isOpenAICompatibleAccountEligibleForRequest(
+		context.Background(), account, PlatformGrok, xai.DefaultImagineImage20Model, false,
+		OpenAIEndpointCapabilityGrokMediaGeneration,
+	))
+}
+
 func TestNormalizeGrokMediaEligibilityExtra(t *testing.T) {
 	t.Run("boolean override is accepted", func(t *testing.T) {
 		extra, err := normalizeGrokMediaEligibilityExtra(PlatformGrok, map[string]any{GrokMediaEligibleExtraKey: false})

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1531,12 +1531,15 @@ type VideoPriceConfig struct {
 const (
 	defaultImageGenerationPrice = 0.134
 
-	defaultGrokImagineImagePrice1K        = 0.02
-	defaultGrokImagineImagePrice2K        = 0.02
-	defaultGrokImagineImageQualityPrice1K = 0.05
-	defaultGrokImagineImageQualityPrice2K = 0.07
-	defaultGrokImagineImage20Price1K      = 0.06 // default quality is Medium
-	defaultGrokImagineImage20Price2K      = 0.08
+	defaultGrokImagineImagePrice1K         = 0.02
+	defaultGrokImagineImagePrice2K         = 0.02
+	defaultGrokImagineImageQualityPrice1K  = 0.05
+	defaultGrokImagineImageQualityPrice2K  = 0.07
+	defaultGrokImagineImage20InputPrice    = 0.01
+	defaultGrokImagineImage20LowPrice1K    = 0.04
+	defaultGrokImagineImage20LowPrice2K    = 0.06
+	defaultGrokImagineImage20MediumPrice1K = 0.06
+	defaultGrokImagineImage20MediumPrice2K = 0.08
 
 	// 视频默认价为 xAI 官方**每秒**输出价格（USD/s），总价 = 每秒价 × 时长（秒）。
 	defaultGrokImagineVideoPrice480P    = 0.05
@@ -1664,16 +1667,36 @@ func (s *BillingService) CalculateAudioCost(mode string, durationOrUnits float64
 // groupConfig: 分组配置的价格（可能为 nil，表示使用默认值）
 // rateMultiplier: 费率倍数
 func (s *BillingService) CalculateImageCost(model string, imageSize string, imageCount int, groupConfig *ImagePriceConfig, rateMultiplier float64) *CostBreakdown {
+	return s.CalculateImageCostWithDetails(model, imageSize, "", imageCount, 0, groupConfig, rateMultiplier)
+}
+
+// CalculateImageCostWithDetails extends image billing with the quality and
+// input-image dimensions used by grok-imagine-image-2.0. Older image models
+// retain the legacy output-only behavior.
+func (s *BillingService) CalculateImageCostWithDetails(
+	model string,
+	imageSize string,
+	quality string,
+	imageCount int,
+	inputImageCount int,
+	groupConfig *ImagePriceConfig,
+	rateMultiplier float64,
+) *CostBreakdown {
 	if imageCount <= 0 {
 		return &CostBreakdown{}
 	}
 	imageSize = NormalizeImageBillingTierOrDefault(imageSize)
 
 	// 获取单价
-	unitPrice := s.getImageUnitPrice(model, imageSize, groupConfig)
+	unitPrice := s.getImageUnitPriceWithQuality(model, imageSize, quality, groupConfig)
 
 	// 计算总费用
-	totalCost := unitPrice * float64(imageCount)
+	imageOutputCost := unitPrice * float64(imageCount)
+	imageInputCost := 0.0
+	if isGrokImagineImage20Model(model) && inputImageCount > 0 {
+		imageInputCost = defaultGrokImagineImage20InputPrice * float64(inputImageCount)
+	}
+	totalCost := imageOutputCost + imageInputCost
 
 	// 应用倍率（保存时强制 > 0；负数按 0 处理避免按 1x 误扣）
 	if rateMultiplier < 0 {
@@ -1681,11 +1704,16 @@ func (s *BillingService) CalculateImageCost(model string, imageSize string, imag
 	}
 	actualCost := totalCost * rateMultiplier
 
-	return &CostBreakdown{
+	breakdown := &CostBreakdown{
 		TotalCost:   totalCost,
 		ActualCost:  actualCost,
 		BillingMode: string(BillingModeImage),
 	}
+	if isGrokImagineImage20Model(model) {
+		breakdown.ImageInputCost = imageInputCost
+		breakdown.ImageOutputCost = imageOutputCost
+	}
+	return breakdown
 }
 
 // CalculateVideoCost 计算视频生成费用（按秒计费，与 xAI 口径一致）。
@@ -1717,8 +1745,7 @@ func (s *BillingService) CalculateVideoCost(model string, resolution string, vid
 	}
 }
 
-// getImageUnitPrice 获取图片单价
-func (s *BillingService) getImageUnitPrice(model string, imageSize string, groupConfig *ImagePriceConfig) float64 {
+func (s *BillingService) getImageUnitPriceWithQuality(model string, imageSize string, quality string, groupConfig *ImagePriceConfig) float64 {
 	// 优先使用分组配置的价格
 	if groupConfig != nil {
 		switch imageSize {
@@ -1738,7 +1765,7 @@ func (s *BillingService) getImageUnitPrice(model string, imageSize string, group
 	}
 
 	// 回退到 LiteLLM 默认价格
-	return s.getDefaultImagePrice(model, imageSize)
+	return s.getDefaultImagePriceWithQuality(model, imageSize, quality)
 }
 
 func (s *BillingService) getVideoUnitPrice(model string, resolution string, groupConfig *VideoPriceConfig) float64 {
@@ -1768,7 +1795,11 @@ func (s *BillingService) getVideoUnitPrice(model string, resolution string, grou
 
 // getDefaultImagePrice 获取 LiteLLM 默认图片价格
 func (s *BillingService) getDefaultImagePrice(model string, imageSize string) float64 {
-	if price, ok := getDefaultGrokImagineImagePrice(model, imageSize); ok {
+	return s.getDefaultImagePriceWithQuality(model, imageSize, "")
+}
+
+func (s *BillingService) getDefaultImagePriceWithQuality(model string, imageSize string, quality string) float64 {
+	if price, ok := getDefaultGrokImagineImagePriceWithQuality(model, imageSize, quality); ok {
 		return price
 	}
 
@@ -1810,14 +1841,21 @@ func (s *BillingService) getDefaultVideoPrice(model string, resolution string) f
 	return s.getDefaultImagePrice(model, ImageBillingSize2K)
 }
 
-func getDefaultGrokImagineImagePrice(model string, imageSize string) (float64, bool) {
-	model = strings.ToLower(strings.TrimSpace(model))
+func getDefaultGrokImagineImagePriceWithQuality(model string, imageSize string, quality string) (float64, bool) {
+	model = normalizeGrokImagineBillingModel(model)
 	switch model {
 	case "grok-imagine-image-2.0":
+		if NormalizeGrokImagineImageQualityOrDefault(quality) == GrokImagineImageQualityLow {
+			return getGrokImagineImageTierPrice(
+				imageSize,
+				defaultGrokImagineImage20LowPrice1K,
+				defaultGrokImagineImage20LowPrice2K,
+			), true
+		}
 		return getGrokImagineImageTierPrice(
 			imageSize,
-			defaultGrokImagineImage20Price1K,
-			defaultGrokImagineImage20Price2K,
+			defaultGrokImagineImage20MediumPrice1K,
+			defaultGrokImagineImage20MediumPrice2K,
 		), true
 	case "grok-imagine-image-quality":
 		return getGrokImagineImageTierPrice(
@@ -1834,6 +1872,26 @@ func getDefaultGrokImagineImagePrice(model string, imageSize string) (float64, b
 	default:
 		return 0, false
 	}
+}
+
+func normalizeGrokImagineBillingModel(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	for _, prefix := range []string{"xai/", "x-ai/", "grok/"} {
+		model = strings.TrimPrefix(model, prefix)
+	}
+	return model
+}
+
+func isGrokImagineImage20Model(model string) bool {
+	return normalizeGrokImagineBillingModel(model) == "grok-imagine-image-2.0"
+}
+
+func grokImagineImagePricingTier(model string, imageSize string, quality string) string {
+	imageSize = NormalizeImageBillingTierOrDefault(imageSize)
+	if !isGrokImagineImage20Model(model) {
+		return imageSize
+	}
+	return imageSize + "-" + NormalizeGrokImagineImageQualityOrDefault(quality)
 }
 
 func getGrokImagineImageTierPrice(imageSize string, price1K float64, price2K float64) float64 {

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1042,6 +1042,31 @@ func TestCalculateGrokImagineImageCostUsesDefaultRateCard(t *testing.T) {
 	require.InDelta(t, 0.07, quality2K.TotalCost, 1e-10)
 }
 
+func TestCalculateGrokImagineImage20CostUsesResolutionQualityAndInputs(t *testing.T) {
+	svc := newTestBillingService()
+
+	tests := []struct {
+		name       string
+		size       string
+		quality    string
+		wantOutput float64
+	}{
+		{name: "1K low", size: "1K", quality: "low", wantOutput: 0.04},
+		{name: "2K low", size: "2K", quality: "low", wantOutput: 0.06},
+		{name: "1K medium", size: "1K", quality: "medium", wantOutput: 0.06},
+		{name: "2K default medium", size: "2K", quality: "", wantOutput: 0.08},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cost := svc.CalculateImageCostWithDetails("grok-imagine-image-2.0", tt.size, tt.quality, 1, 2, nil, 1.5)
+			require.InDelta(t, tt.wantOutput, cost.ImageOutputCost, 1e-10)
+			require.InDelta(t, 0.02, cost.ImageInputCost, 1e-10)
+			require.InDelta(t, tt.wantOutput+0.02, cost.TotalCost, 1e-10)
+			require.InDelta(t, (tt.wantOutput+0.02)*1.5, cost.ActualCost, 1e-10)
+		})
+	}
+}
+
 func TestCalculateGrokImagineVideoCostUsesDefaultRateCard(t *testing.T) {
 	svc := newTestBillingService()
 

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -59,6 +59,9 @@ type GrokMediaRequestInfo struct {
 	N               int
 	Size            string
 	SizeTier        string
+	ImageResolution string
+	ImageQuality    string
+	ImageQualitySet bool
 	Resolution      string
 	DurationSeconds int
 	InputImageURLs  []string
@@ -126,7 +129,14 @@ func ParseGrokMediaRequest(contentType string, body []byte) GrokMediaRequestInfo
 	info.Model = strings.TrimSpace(info.Model)
 	info.Prompt = strings.TrimSpace(info.Prompt)
 	info.Size = strings.TrimSpace(info.Size)
-	info.SizeTier = NormalizeImageBillingTierOrDefault(info.Size)
+	rawResolution := strings.TrimSpace(info.Resolution)
+	if _, ok := ClassifyImageBillingTier(rawResolution); ok {
+		info.ImageResolution = rawResolution
+		info.SizeTier = NormalizeImageBillingTierOrDefault(rawResolution)
+	} else {
+		info.SizeTier = NormalizeImageBillingTierOrDefault(info.Size)
+	}
+	info.ImageQuality = strings.TrimSpace(info.ImageQuality)
 	info.Resolution = NormalizeVideoBillingResolutionOrDefault(info.Resolution)
 	info.DurationSeconds = NormalizeVideoBillingDurationSecondsOrDefault(info.DurationSeconds)
 	if info.N <= 0 {
@@ -143,6 +153,10 @@ func parseGrokMediaJSONRequest(body []byte, info *GrokMediaRequestInfo) {
 	info.Prompt = strings.TrimSpace(gjson.GetBytes(body, "prompt").String())
 	info.Size = strings.TrimSpace(gjson.GetBytes(body, "size").String())
 	info.Resolution = strings.TrimSpace(gjson.GetBytes(body, "resolution").String())
+	if quality := gjson.GetBytes(body, "quality"); quality.Exists() {
+		info.ImageQuality = strings.TrimSpace(quality.String())
+		info.ImageQualitySet = true
+	}
 	if duration := gjson.GetBytes(body, "duration"); duration.Exists() && duration.Type == gjson.Number {
 		info.DurationSeconds = int(duration.Int())
 	}
@@ -257,6 +271,9 @@ func parseGrokMediaMultipartRequest(contentType string, body []byte, info *GrokM
 			info.Size = value
 		case "resolution":
 			info.Resolution = value
+		case "quality":
+			info.ImageQuality = value
+			info.ImageQualitySet = true
 		case "duration":
 			if duration, err := strconv.Atoi(value); err == nil {
 				info.DurationSeconds = duration
@@ -740,8 +757,10 @@ func (s *OpenAIGatewayService) ForwardGrokMedia(
 		ResponseHeaders:      resp.Header.Clone(),
 		Duration:             time.Since(startTime),
 		ImageCount:           usage.ImageCount,
+		ImageInputCount:      usage.ImageInputCount,
 		ImageSize:            usage.ImageSize,
 		ImageInputSize:       usage.ImageInputSize,
+		ImageQuality:         usage.ImageQuality,
 		ImageOutputSizes:     usage.ImageOutputSizes,
 		VideoCount:           usage.VideoCount,
 		VideoResolution:      usage.VideoResolution,
@@ -934,6 +953,12 @@ func prepareGrokMediaForwardBody(endpoint GrokMediaEndpoint, body []byte, conten
 	if info.Size != "" {
 		payload["size"] = info.Size
 	}
+	if info.ImageResolution != "" {
+		payload["resolution"] = info.ImageResolution
+	}
+	if info.ImageQualitySet {
+		payload["quality"] = info.ImageQuality
+	}
 
 	images := make([]map[string]string, 0, len(info.InputImageURLs)+len(info.Uploads))
 	for _, imageURL := range info.InputImageURLs {
@@ -1123,6 +1148,40 @@ func (r GrokMediaRequestInfo) HasInputImage() bool {
 	return len(r.InputImageURLs) > 0 || len(r.Uploads) > 0
 }
 
+const (
+	GrokImagineImageQualityLow    = "low"
+	GrokImagineImageQualityMedium = "medium"
+)
+
+func NormalizeGrokImagineImageQualityOrDefault(quality string) string {
+	switch strings.ToLower(strings.TrimSpace(quality)) {
+	case GrokImagineImageQualityLow:
+		return GrokImagineImageQualityLow
+	default:
+		return GrokImagineImageQualityMedium
+	}
+}
+
+// InputImageCount returns the number of distinct source and mask images sent
+// to Imagine. JSON edit normalization can mirror the first source in both
+// `image` and `images`, so URL references are de-duplicated for billing.
+func (r GrokMediaRequestInfo) InputImageCount() int {
+	seen := make(map[string]struct{}, len(r.InputImageURLs)+1)
+	for _, imageURL := range r.InputImageURLs {
+		if imageURL = strings.TrimSpace(imageURL); imageURL != "" {
+			seen[imageURL] = struct{}{}
+		}
+	}
+	if maskURL := strings.TrimSpace(r.MaskImageURL); maskURL != "" {
+		seen[maskURL] = struct{}{}
+	}
+	count := len(seen) + len(r.Uploads)
+	if r.MaskUpload != nil {
+		count++
+	}
+	return count
+}
+
 // NormalizeGrokMediaModelForEndpoint resolves the built-in upstream model alias
 // for a media endpoint before account-level model mapping and scheduling.
 func NormalizeGrokMediaModelForEndpoint(endpoint GrokMediaEndpoint, model string, hasInputImage bool) string {
@@ -1148,8 +1207,10 @@ type grokMediaUsageMetadata struct {
 	Model                string
 	BillingModel         string
 	ImageCount           int
+	ImageInputCount      int
 	ImageSize            string
 	ImageInputSize       string
+	ImageQuality         string
 	ImageOutputSizes     []string
 	VideoCount           int
 	VideoResolution      string
@@ -1162,8 +1223,13 @@ func grokMediaUsageFromResponse(endpoint GrokMediaEndpoint, requestInfo GrokMedi
 	switch endpoint {
 	case GrokMediaEndpointImagesGenerations, GrokMediaEndpointImagesEdits:
 		meta.ImageCount = countOpenAIResponseImageOutputsFromJSONBytes(responseBody)
+		meta.ImageInputCount = requestInfo.InputImageCount()
 		meta.ImageSize = requestInfo.SizeTier
-		meta.ImageInputSize = requestInfo.Size
+		meta.ImageInputSize = requestInfo.ImageResolution
+		if meta.ImageInputSize == "" {
+			meta.ImageInputSize = requestInfo.Size
+		}
+		meta.ImageQuality = NormalizeGrokImagineImageQualityOrDefault(requestInfo.ImageQuality)
 		meta.ImageOutputSizes = collectOpenAIResponseImageOutputSizesFromJSONBytes(responseBody)
 	case GrokMediaEndpointVideosGenerations, GrokMediaEndpointVideosEdits, GrokMediaEndpointVideosExtensions:
 		// Async video: capture request_id + create-time pricing params only.

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -372,7 +372,7 @@ func intervalToModelPricing(iv *PricingInterval, supportsCacheBreakdown bool, ch
 // GetRequestTierPrice 根据层级标签获取按次价格
 func (r *ModelPricingResolver) GetRequestTierPrice(resolved *ResolvedPricing, tierLabel string) float64 {
 	for _, tier := range resolved.RequestTiers {
-		if tier.TierLabel == tierLabel && tier.PerRequestPrice != nil {
+		if strings.EqualFold(strings.TrimSpace(tier.TierLabel), strings.TrimSpace(tierLabel)) && tier.PerRequestPrice != nil {
 			return *tier.PerRequestPrice
 		}
 	}

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -174,6 +174,7 @@ func TestGetRequestTierPrice(t *testing.T) {
 
 	require.InDelta(t, 0.04, r.GetRequestTierPrice(resolved, "1K"), 1e-12)
 	require.InDelta(t, 0.08, r.GetRequestTierPrice(resolved, "2K"), 1e-12)
+	require.InDelta(t, 0.08, r.GetRequestTierPrice(resolved, " 2k "), 1e-12)
 	require.InDelta(t, 0.0, r.GetRequestTierPrice(resolved, "4K"), 1e-12)
 }
 

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -848,6 +848,40 @@ func TestParseGrokMediaRequestAcceptsOfficialImageURLFields(t *testing.T) {
 	require.True(t, info.HasInputImage())
 }
 
+func TestParseGrokImagineImage20RequestUsesResolutionQualityAndDistinctInputs(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-imagine-image-2.0",
+		"resolution":"1k",
+		"quality":"low",
+		"image":{"url":"https://example.com/first.png"},
+		"images":[{"url":"https://example.com/first.png"},{"url":"https://example.com/second.png"}],
+		"mask":{"url":"https://example.com/mask.png"}
+	}`)
+
+	info := ParseGrokMediaRequest("application/json", body)
+	require.Equal(t, ImageBillingSize1K, info.SizeTier)
+	require.Equal(t, "1k", info.ImageResolution)
+	require.Equal(t, GrokImagineImageQualityLow, info.ImageQuality)
+	require.Equal(t, 3, info.InputImageCount())
+
+	meta := grokMediaUsageFromResponse(GrokMediaEndpointImagesEdits, info, []byte(`{"data":[{"url":"https://example.com/out.png"}]}`))
+	require.Equal(t, 1, meta.ImageCount)
+	require.Equal(t, 3, meta.ImageInputCount)
+	require.Equal(t, ImageBillingSize1K, meta.ImageSize)
+	require.Equal(t, GrokImagineImageQualityLow, meta.ImageQuality)
+}
+
+func TestParseGrokImagineImage20RequestDefaultsQualityWithoutInjectingIt(t *testing.T) {
+	body := []byte(`{"model":"grok-imagine-image-2.0","resolution":"2k"}`)
+
+	info := ParseGrokMediaRequest("application/json", body)
+	require.Empty(t, info.ImageQuality)
+	require.False(t, info.ImageQualitySet)
+
+	meta := grokMediaUsageFromResponse(GrokMediaEndpointImagesGenerations, info, []byte(`{"data":[{"url":"https://example.com/out.png"}]}`))
+	require.Equal(t, GrokImagineImageQualityMedium, meta.ImageQuality)
+}
+
 func TestNormalizeGrokMediaForwardBodyCanonicalizesImageURLAlias(t *testing.T) {
 	body := []byte(`{
 		"model":"grok-imagine-video-1.5",
@@ -916,7 +950,9 @@ func TestCanonicalizeGrokMediaImageURLFieldsReplacesEmptyOfficialURL(t *testing.
 
 func TestPrepareGrokImageEditNormalizesOfficialImageObjects(t *testing.T) {
 	body := []byte(`{
-		"model":"grok-imagine-image-quality",
+		"model":"grok-imagine-image-2.0",
+		"resolution":"2k",
+		"quality":"low",
 		"image":{"image_url":{"url":"https://example.com/first.png"}},
 		"images":["https://example.com/second.png"],
 		"mask":{"image_url":"https://example.com/mask.png"}
@@ -925,6 +961,8 @@ func TestPrepareGrokImageEditNormalizesOfficialImageObjects(t *testing.T) {
 	out, contentType, err := prepareGrokMediaForwardBody(GrokMediaEndpointImagesEdits, body, "application/json")
 	require.NoError(t, err)
 	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "2k", gjson.GetBytes(out, "resolution").String())
+	require.Equal(t, "low", gjson.GetBytes(out, "quality").String())
 	for _, path := range []string{"image", "images.0", "mask"} {
 		require.Equal(t, "image_url", gjson.GetBytes(out, path+".type").String())
 		require.NotEmpty(t, gjson.GetBytes(out, path+".url").String())

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -2293,6 +2293,48 @@ func TestOpenAIGatewayServiceRecordUsage_GroupImagePriceOverridesChannelImagePri
 	require.Equal(t, string(BillingModeImage), *usageRepo.lastLog.BillingMode)
 }
 
+func TestOpenAIGatewayServiceRecordUsage_GrokImagineImage20UsesQualityTierAndInputPrice(t *testing.T) {
+	groupID := int64(1271)
+	medium2KPrice := 0.18
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+	svc.resolver = newOpenAIImageChannelTierPricingResolverForTest(t, groupID, "grok-imagine-image-2.0", "2K-medium", medium2KPrice)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:       "resp_grok_image_20",
+			Model:           "grok-imagine-image-2.0",
+			BillingModel:    "grok-imagine-image-2.0",
+			ImageCount:      2,
+			ImageInputCount: 3,
+			ImageSize:       ImageBillingSize2K,
+			ImageInputSize:  "2k",
+			ImageQuality:    GrokImagineImageQualityMedium,
+			Duration:        time.Second,
+		},
+		APIKey: &APIKey{
+			ID:      101271,
+			GroupID: i64p(groupID),
+			Group: &Group{
+				ID:                   groupID,
+				Platform:             PlatformGrok,
+				RateMultiplier:       1,
+				ImageRateIndependent: true,
+				ImageRateMultiplier:  1,
+			},
+		},
+		User:    &User{ID: 201271},
+		Account: &Account{ID: 301271, Platform: PlatformGrok},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.InDelta(t, 0.36, usageRepo.lastLog.ImageOutputCost, 1e-12)
+	require.InDelta(t, 0.03, usageRepo.lastLog.ImageInputCost, 1e-12)
+	require.InDelta(t, 0.39, usageRepo.lastLog.TotalCost, 1e-12)
+	require.InDelta(t, 0.39, usageRepo.lastLog.ActualCost, 1e-12)
+}
+
 func TestOpenAIGatewayServiceRecordUsage_GroupVideoPriceOverridesChannelImagePrice(t *testing.T) {
 	groupID := int64(128)
 	channelPrice := 0.201
@@ -2611,6 +2653,24 @@ func newOpenAIImageChannelPricingResolverForTest(t *testing.T, groupID int64, mo
 	cache.pricingByGroupModel[channelModelKey{groupID: groupID, model: model}] = &ChannelModelPricing{
 		BillingMode:     BillingModeImage,
 		PerRequestPrice: &price,
+	}
+	cache.channelByGroupID[groupID] = &Channel{ID: groupID, Status: StatusActive}
+	cache.groupPlatform[groupID] = ""
+	cache.loadedAt = time.Now()
+	cs := &ChannelService{}
+	cs.cache.Store(cache)
+	return NewModelPricingResolver(cs, NewBillingService(&config.Config{}, nil))
+}
+
+func newOpenAIImageChannelTierPricingResolverForTest(t *testing.T, groupID int64, model string, tierLabel string, price float64) *ModelPricingResolver {
+	t.Helper()
+	cache := newEmptyChannelCache()
+	cache.pricingByGroupModel[channelModelKey{groupID: groupID, model: model}] = &ChannelModelPricing{
+		BillingMode: BillingModeImage,
+		Intervals: []PricingInterval{{
+			TierLabel:       tierLabel,
+			PerRequestPrice: &price,
+		}},
 	}
 	cache.channelByGroupID[groupID] = &Channel{ID: groupID, Status: StatusActive}
 	cache.groupPlatform[groupID] = ""

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -266,8 +266,10 @@ type OpenAIForwardResult struct {
 	FirstTokenMs          *int
 	ClientDisconnect      bool
 	ImageCount            int
+	ImageInputCount       int
 	ImageSize             string
 	ImageInputSize        string
+	ImageQuality          string
 	ImageOutputSize       string
 	ImageOutputSizes      []string
 	ImageSizeSource       string

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -688,13 +688,13 @@ func (s *OpenAIGatewayService) calculateOpenAIImageCost(
 	}
 	groupConfig := imagePriceConfigFromAPIKey(apiKey)
 	if apiKeyHasConfiguredImagePrice(apiKey, sizeTier) {
-		return s.billingService.CalculateImageCost(billingModel, sizeTier, result.ImageCount, groupConfig, multiplier)
+		return s.billingService.CalculateImageCostWithDetails(billingModel, sizeTier, result.ImageQuality, result.ImageCount, result.ImageInputCount, groupConfig, multiplier)
 	}
 	if refreshed := s.apiKeyWithFreshGroupMediaPricing(ctx, apiKey); refreshed != apiKey {
 		apiKey = refreshed
 		groupConfig = imagePriceConfigFromAPIKey(apiKey)
 		if apiKeyHasConfiguredImagePrice(apiKey, sizeTier) {
-			return s.billingService.CalculateImageCost(billingModel, sizeTier, result.ImageCount, groupConfig, multiplier)
+			return s.billingService.CalculateImageCostWithDetails(billingModel, sizeTier, result.ImageQuality, result.ImageCount, result.ImageInputCount, groupConfig, multiplier)
 		}
 	}
 	if resolved != nil && resolved.Source == PricingSourceChannel &&
@@ -706,18 +706,36 @@ func (s *OpenAIGatewayService) calculateOpenAIImageCost(
 			GroupID:        &gid,
 			Group:          apiKey.Group,
 			RequestCount:   result.ImageCount,
-			SizeTier:       sizeTier,
+			SizeTier:       grokImagineImagePricingTier(billingModel, sizeTier, result.ImageQuality),
 			RateMultiplier: multiplier,
 			Resolver:       s.resolver,
 			Resolved:       resolved,
 		})
 		if err == nil {
-			return cost
+			return addGrokImagineImage20InputCost(cost, billingModel, result.ImageInputCount, multiplier)
 		}
 		logger.LegacyPrintf("service.openai_gateway", "Calculate image channel cost failed: %v", err)
 	}
 
-	return s.billingService.CalculateImageCost(billingModel, sizeTier, result.ImageCount, groupConfig, multiplier)
+	return s.billingService.CalculateImageCostWithDetails(billingModel, sizeTier, result.ImageQuality, result.ImageCount, result.ImageInputCount, groupConfig, multiplier)
+}
+
+func addGrokImagineImage20InputCost(cost *CostBreakdown, model string, inputImageCount int, rateMultiplier float64) *CostBreakdown {
+	if cost == nil || !isGrokImagineImage20Model(model) {
+		return cost
+	}
+	if rateMultiplier < 0 {
+		rateMultiplier = 0
+	}
+	inputCost := 0.0
+	if inputImageCount > 0 {
+		inputCost = defaultGrokImagineImage20InputPrice * float64(inputImageCount)
+	}
+	cost.ImageOutputCost = cost.TotalCost
+	cost.ImageInputCost = inputCost
+	cost.TotalCost += inputCost
+	cost.ActualCost += inputCost * rateMultiplier
+	return cost
 }
 
 func (s *OpenAIGatewayService) calculateOpenAIVideoCost(

--- a/frontend/src/components/admin/channel/IntervalRow.vue
+++ b/frontend/src/components/admin/channel/IntervalRow.vue
@@ -42,7 +42,7 @@
           {{ mode === 'image' ? t('admin.channels.form.resolution') : t('admin.channels.form.tierLabel') }}
         </label>
         <input :value="interval.tier_label" @input="emitField('tier_label', ($event.target as HTMLInputElement).value)"
-          type="text" class="input mt-0.5 text-xs" :placeholder="mode === 'image' ? '1K / 2K / 4K' : ''" />
+          type="text" class="input mt-0.5 text-xs" :placeholder="mode === 'image' ? '1K / 2K / 1K-low / 2K-medium' : ''" />
       </div>
       <div class="w-20">
         <label class="text-xs text-gray-400">{{ t('admin.channels.form.minTokens') }}</label>

--- a/frontend/src/components/admin/channel/PricingEntryCard.vue
+++ b/frontend/src/components/admin/channel/PricingEntryCard.vue
@@ -292,7 +292,9 @@ function addMediaTier() {
   const intervals = [...(props.entry.intervals || [])]
   const labels = props.entry.billing_mode === 'video'
     ? ['480p', '720p', '1080p']
-    : ['1K', '2K', '4K', 'HD']
+    : props.entry.models.some(model => model.replace(/^(xai|x-ai|grok)\//, '') === 'grok-imagine-image-2.0')
+      ? ['1K-low', '2K-low', '1K-medium', '2K-medium']
+      : ['1K', '2K', '4K', 'HD']
   intervals.push({
     min_tokens: 0, max_tokens: null, tier_label: labels[intervals.length] || '',
     input_price: null, output_price: null, cache_write_price: null,

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -51,6 +51,7 @@ describe('useModelWhitelist', () => {
     expect(models).toContain('grok-4.5')
     expect(models).toContain('grok-4.5-latest')
     expect(models).toContain('grok-build-latest')
+    expect(models).toContain('grok-imagine-image-2.0')
     expect(models).toContain('grok-imagine-video-1.5-preview')
   })
 

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -155,6 +155,7 @@ const xaiModels = [
   'grok-4.20-reasoning',
   'grok-4.20-non-reasoning',
   'grok-imagine',
+  'grok-imagine-image-2.0',
   'grok-imagine-image-quality',
   'grok-imagine-image',
   'grok-imagine-video',
@@ -316,6 +317,7 @@ const grokPresetMappings = [
   { label: 'Composer legacy', from: 'composer-2.5', to: 'grok-composer-2.5-fast', color: 'bg-teal-100 text-teal-700 hover:bg-teal-200 dark:bg-teal-900/30 dark:text-teal-400' },
   { label: '4.20 Reasoning', from: 'grok-4.20-reasoning', to: 'grok-4.20-0309-reasoning', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: '4.20 Non Reasoning', from: 'grok-4.20-non-reasoning', to: 'grok-4.20-0309-non-reasoning', color: 'bg-violet-100 text-violet-700 hover:bg-violet-200 dark:bg-violet-900/30 dark:text-violet-400' },
+  { label: 'Imagine Image 2.0', from: 'grok-imagine-image-2.0', to: 'grok-imagine-image-2.0', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Imagine Image', from: 'grok-imagine', to: 'grok-imagine-image-quality', color: 'bg-sky-100 text-sky-700 hover:bg-sky-200 dark:bg-sky-900/30 dark:text-sky-400' },
   { label: 'Imagine Edit', from: 'grok-imagine-edit', to: 'grok-imagine-image-quality', color: 'bg-rose-100 text-rose-700 hover:bg-rose-200 dark:bg-rose-900/30 dark:text-rose-400' },
   { label: 'Imagine Video', from: 'grok-imagine-video-1.5', to: 'grok-imagine-video-1.5', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' }


### PR DESCRIPTION
本次改动 Summary：

- 新增 `grok-imagine-image-2.0` 模型注册。
  - 加入 Grok 默认模型列表。
  - 加入默认身份映射。
  - 支持 `xai/`、`x-ai/`、`grok/` 前缀。
  - 未配置自定义映射的 Grok 账号可直接参与调度，避免因模型不在映射中出现 `No eligible Grok media accounts`。

- 完善图片请求参数处理。
  - 支持 `resolution: 1k / 2k`。
  - 支持 `quality: low / medium`。
  - 未传 `quality` 时按官方默认 `medium` 计费。
  - JSON 和 multipart 图片编辑请求都能保留这些参数。
  - 修复图片 `resolution` 被当成视频分辨率处理的问题。

- 新增 2.0 默认计费规则。
  - 输入图片：`$0.01/张`。
  - 1K low：`$0.04/张`。
  - 2K low：`$0.06/张`。
  - 1K medium：`$0.06/张`。
  - 2K medium：`$0.08/张`。
  - 最终费用为：

```text
(输出单价 × 实际输出数 + $0.01 × 输入图数) × 图片费率倍率
```

- 新增图片编辑输入图统计。
  - 统计源图和 mask。
  - 对重复 URL 去重，防止 `image` 和 `images` 中同一图片重复收费。
  - 分开记录 `ImageInputCost` 和 `ImageOutputCost`。

- 完善尺寸判断。
  - 优先使用响应中的实际输出尺寸。
  - 其次使用请求的 `resolution`。
  - 再兼容旧的 `size`。
  - 无法判断时按 `2K`。

- 支持渠道精细定价。
  - 新增 `1K-low`、`2K-low`、`1K-medium`、`2K-medium` 四个渠道档位。
  - 档位标签匹配改为大小写不敏感。
  - 分组或渠道价格覆盖输出价格；输入图片仍按 `$0.01/张` 收取。

- 更新前端。
  - Grok 模型列表加入 `grok-imagine-image-2.0`。
  - 增加模型映射预设。
  - 渠道选择该模型时，自动提供四个质量定价档位。
  - 更新定价档位输入提示。

- 更新文档。
  - 补充支持模型。
  - 补充 `resolution`、`quality` 参数。
  - 补充默认价格和渠道档位说明。

- 增加测试覆盖。
  - 默认模型映射及调度资格。
  - 分辨率、质量参数解析和透传。
  - 四档默认输出价格。
  - 输入图片费用和去重。
  - 图片倍率计算。
  - 渠道质量档位定价。
  - 前端模型白名单。

验证结果：

- 后端完整 unit 测试通过。
- 前端模型白名单测试 `15/15` 通过。
- 历史图片、视频模型的映射和默认价格未修改。