### PR TITLE
fix(apicompat): normalize Chat function tool_choice for Responses

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -565,34 +565,51 @@ func TestChatCompletionsToResponses_NormalizesChatFunctionToolChoice(t *testing.
 	base := ChatCompletionsRequest{
 		Model:    "gpt-4o",
 		Messages: []ChatMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}},
+		Tools: []ChatTool{{
+			Type: "function",
+			Function: &ChatFunction{
+				Name:       "get_weather",
+				Parameters: json.RawMessage(`{"type":"object"}`),
+			},
+		}},
 	}
 
-	t.Run("Chat Completions function choice", func(t *testing.T) {
-		req := base
-		req.ToolChoice = json.RawMessage(`{"type":"function","function":{"name":"get_weather"}}`)
+	for _, tt := range []struct {
+		name       string
+		toolChoice string
+		want       string
+	}{
+		{
+			name:       "Chat Completions function choice",
+			toolChoice: `{"type":"function","function":{"name":"get_weather"}}`,
+			want:       `{"type":"function","name":"get_weather"}`,
+		},
+		{
+			name:       "Responses function choice",
+			toolChoice: `{"type":"function","name":"get_weather"}`,
+			want:       `{"type":"function","name":"get_weather"}`,
+		},
+		{
+			name:       "top-level name takes precedence",
+			toolChoice: `{"type":"function","name":"get_weather","function":{"name":"legacy_name"}}`,
+			want:       `{"type":"function","name":"get_weather"}`,
+		},
+		{
+			name:       "non-function choice",
+			toolChoice: `"required"`,
+			want:       `"required"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			req.ToolChoice = json.RawMessage(tt.toolChoice)
 
-		resp, err := ChatCompletionsToResponses(&req)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"type":"function","name":"get_weather"}`, string(resp.ToolChoice))
-	})
-
-	t.Run("Responses function choice", func(t *testing.T) {
-		req := base
-		req.ToolChoice = json.RawMessage(`{"type":"function","name":"get_weather"}`)
-
-		resp, err := ChatCompletionsToResponses(&req)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"type":"function","name":"get_weather"}`, string(resp.ToolChoice))
-	})
-
-	t.Run("non-function choice", func(t *testing.T) {
-		req := base
-		req.ToolChoice = json.RawMessage(`"required"`)
-
-		resp, err := ChatCompletionsToResponses(&req)
-		require.NoError(t, err)
-		assert.JSONEq(t, `"required"`, string(resp.ToolChoice))
-	})
+			resp, err := ChatCompletionsToResponses(&req)
+			require.NoError(t, err)
+			require.Len(t, resp.Tools, 1)
+			assert.JSONEq(t, tt.want, string(resp.ToolChoice))
+		})
+	}
 }
 
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -561,6 +561,40 @@ func TestChatCompletionsToResponses_LegacyFunctions(t *testing.T) {
 	assert.NotContains(t, tc, "function")
 }
 
+func TestChatCompletionsToResponses_NormalizesChatFunctionToolChoice(t *testing.T) {
+	base := ChatCompletionsRequest{
+		Model:    "gpt-4o",
+		Messages: []ChatMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}},
+	}
+
+	t.Run("Chat Completions function choice", func(t *testing.T) {
+		req := base
+		req.ToolChoice = json.RawMessage(`{"type":"function","function":{"name":"get_weather"}}`)
+
+		resp, err := ChatCompletionsToResponses(&req)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"type":"function","name":"get_weather"}`, string(resp.ToolChoice))
+	})
+
+	t.Run("Responses function choice", func(t *testing.T) {
+		req := base
+		req.ToolChoice = json.RawMessage(`{"type":"function","name":"get_weather"}`)
+
+		resp, err := ChatCompletionsToResponses(&req)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"type":"function","name":"get_weather"}`, string(resp.ToolChoice))
+	})
+
+	t.Run("non-function choice", func(t *testing.T) {
+		req := base
+		req.ToolChoice = json.RawMessage(`"required"`)
+
+		resp, err := ChatCompletionsToResponses(&req)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"required"`, string(resp.ToolChoice))
+	})
+}
+
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model:       "gpt-4o",

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -82,10 +82,11 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 		out.Tools = convertChatToolsToResponses(req.Tools, req.Functions)
 	}
 
-	// tool_choice: already compatible format — pass through directly.
-	// Legacy function_call needs mapping.
+	// tool_choice: Responses uses {"type":"function","name":"..."}, while
+	// Chat Completions uses {"type":"function","function":{"name":"..."}}.
+	// Normalize the latter before forwarding it to a Responses upstream.
 	if len(req.ToolChoice) > 0 {
-		out.ToolChoice = req.ToolChoice
+		out.ToolChoice = normalizeChatToolChoiceToResponses(req.ToolChoice)
 	} else if len(req.FunctionCall) > 0 {
 		tc, err := convertChatFunctionCallToToolChoice(req.FunctionCall)
 		if err != nil {
@@ -95,6 +96,28 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 	}
 
 	return out, nil
+}
+
+func normalizeChatToolChoiceToResponses(raw json.RawMessage) json.RawMessage {
+	var choice struct {
+		Type     string `json:"type"`
+		Name     string `json:"name"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &choice); err != nil || choice.Type != "function" || choice.Name != "" || choice.Function.Name == "" {
+		return raw
+	}
+
+	normalized, err := json.Marshal(map[string]string{
+		"type": "function",
+		"name": choice.Function.Name,
+	})
+	if err != nil {
+		return raw
+	}
+	return normalized
 }
 
 // convertChatMessagesToResponsesInput converts the Chat Completions messages

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -106,13 +106,20 @@ func normalizeChatToolChoiceToResponses(raw json.RawMessage) json.RawMessage {
 			Name string `json:"name"`
 		} `json:"function"`
 	}
-	if err := json.Unmarshal(raw, &choice); err != nil || choice.Type != "function" || choice.Name != "" || choice.Function.Name == "" {
+	if err := json.Unmarshal(raw, &choice); err != nil || choice.Type != "function" {
+		return raw
+	}
+	name := strings.TrimSpace(choice.Name)
+	if name == "" {
+		name = strings.TrimSpace(choice.Function.Name)
+	}
+	if name == "" {
 		return raw
 	}
 
 	normalized, err := json.Marshal(map[string]string{
 		"type": "function",
-		"name": choice.Function.Name,
+		"name": name,
 	})
 	if err != nil {
 		return raw


### PR DESCRIPTION
## Summary
- normalize the nested Chat Completions function `tool_choice` shape before forwarding it to a Responses upstream
- preserve an already Responses-native choice, prefer its top-level `name` when both forms are present, and leave non-function choices unchanged
- cover the conversion with a real Chat `tools` declaration

## Problem
Chat Completions represents a forced function choice as `{"type":"function","function":{"name":"..."}}`, while the Responses API requires the function name at the top level. Passing the Chat shape through causes Responses-compatible upstreams to reject the request because `tool_choice.name` is missing.

This only changes the Chat Completions-to-Responses conversion path. Native `/v1/responses` requests remain unchanged.

## Testing
- `go test ./internal/pkg/apicompat -run "^TestChatCompletionsToResponses" -count=1`
- `go test ./internal/pkg/apicompat -count=1`