### PR TITLE
fix(openai): bridge oversized passthrough websocket frames

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -92,6 +92,16 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
 				return fmt.Errorf("websocket ingress requires ws_v2 transport, got=%s", wsDecision.Transport)
 			}
+			// Keep passthrough as the fast path for ordinary frames, but do not
+			// let its early return bypass the oversized-frame HTTP bridge.
+			if s.shouldBridgeOpenAIWSHTTP(
+				account,
+				len(firstClientMessage),
+				gjson.GetBytes(firstClientMessage, "previous_response_id").String(),
+			) {
+				forceHTTPBridge = true
+				break
+			}
 			// 注意：透传 relay 只回调 hooks.AfterTurn，没有 turn 起始回调，
 			// 因此下面这条路径永远不会触发 hooks.BeforeTurn——分组利润控制的
 			// turn 级复核与 turn 级 pricingAt 冻结都不覆盖透传 ingress，

--- a/backend/internal/service/openai_ws_http_bridge_test.go
+++ b/backend/internal/service/openai_ws_http_bridge_test.go
@@ -41,7 +41,7 @@ func TestPrepareOpenAIWSHTTPBridgeBodyStripsWSFields(t *testing.T) {
 	require.Equal(t, "hi", gjson.GetBytes(body, "input").String())
 }
 
-func TestOpenAIWSHTTPBridgeDecisionKeepsSmallFramesOnWS(t *testing.T) {
+func TestOpenAIWSHTTPBridgeDecision(t *testing.T) {
 	svc := &OpenAIGatewayService{
 		cfg: &config.Config{
 			Gateway: config.GatewayConfig{
@@ -53,9 +53,15 @@ func TestOpenAIWSHTTPBridgeDecisionKeepsSmallFramesOnWS(t *testing.T) {
 		},
 	}
 
-	require.False(t, svc.shouldBridgeOpenAIWSHTTP(nil, 99, ""))
-	require.True(t, svc.shouldBridgeOpenAIWSHTTP(nil, 100, ""))
-	require.False(t, svc.shouldBridgeOpenAIWSHTTP(nil, 1000, "resp_existing"))
+	t.Run("small first frame stays on websocket", func(t *testing.T) {
+		require.False(t, svc.shouldBridgeOpenAIWSHTTP(nil, 99, ""))
+	})
+	t.Run("oversized first frame without previous response uses bridge", func(t *testing.T) {
+		require.True(t, svc.shouldBridgeOpenAIWSHTTP(nil, 100, ""))
+	})
+	t.Run("previous response keeps websocket continuation", func(t *testing.T) {
+		require.False(t, svc.shouldBridgeOpenAIWSHTTP(nil, 1000, "resp_existing"))
+	})
 
 	svc.cfg.Gateway.OpenAIWS.HTTPBridgeEnabled = false
 	require.False(t, svc.shouldBridgeOpenAIWSHTTP(nil, 1000, ""))
@@ -760,7 +766,7 @@ func TestProxyResponsesWebSocketFromClientForGrokUsesXAIHTTPBridgeAndPreservesMa
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_retention").Exists())
 }
 
-func TestOpenAIWSHTTPBridgeAcceptsFirstFrameAboveLegacy16MiB(t *testing.T) {
+func TestOpenAIWSHTTPBridgeAcceptsOversizedPassthroughFirstFrame(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	sseBody := strings.Join([]string{
@@ -784,16 +790,21 @@ func TestOpenAIWSHTTPBridgeAcceptsFirstFrameAboveLegacy16MiB(t *testing.T) {
 				Enabled:                  true,
 				APIKeyEnabled:            true,
 				ResponsesWebsocketsV2:    true,
+				ModeRouterV2Enabled:      true,
+				IngressModeDefault:       OpenAIWSIngressModeCtxPool,
 				ClientReadLimitBytes:     64 * 1024 * 1024,
 				HTTPBridgeEnabled:        true,
 				HTTPBridgeThresholdBytes: 15 * 1024 * 1024,
 			},
 		},
 	}
+	passthroughDialer := &openAIWSCaptureDialer{conn: &openAIWSCaptureConn{}}
 	svc := &OpenAIGatewayService{
-		cfg:           cfg,
-		httpUpstream:  upstream,
-		toolCorrector: NewCodexToolCorrector(),
+		cfg:                       cfg,
+		httpUpstream:              upstream,
+		toolCorrector:             NewCodexToolCorrector(),
+		openaiWSResolver:          NewOpenAIWSProtocolResolver(cfg),
+		openaiWSPassthroughDialer: passthroughDialer,
 	}
 	account := &Account{
 		ID:          9,
@@ -802,7 +813,7 @@ func TestOpenAIWSHTTPBridgeAcceptsFirstFrameAboveLegacy16MiB(t *testing.T) {
 		Type:        AccountTypeAPIKey,
 		Credentials: map[string]any{"api_key": "sk-upstream"},
 		Extra: map[string]any{
-			"openai_apikey_responses_websockets_v2_enabled": true,
+			"openai_apikey_responses_websockets_v2_mode": OpenAIWSIngressModePassthrough,
 		},
 		Concurrency: 1,
 		Status:      StatusActive,
@@ -890,6 +901,7 @@ func TestOpenAIWSHTTPBridgeAcceptsFirstFrameAboveLegacy16MiB(t *testing.T) {
 	require.False(t, gjson.GetBytes(upstream.lastBody, "generate").Exists())
 	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
 	require.Equal(t, "gpt-5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, 0, passthroughDialer.DialCount(), "oversized passthrough first frame must not open an upstream websocket")
 }
 
 func TestOpenAIWSHTTPBridgeKeepsContinuationFramesOnHTTPWithoutPreviousResponseID(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep account-level `passthrough` as the fast path for ordinary Responses WebSocket frames
- route oversized first frames without `previous_response_id` through the existing HTTP/SSE bridge before opening an upstream WebSocket
- preserve WebSocket continuation behavior for frames that carry `previous_response_id`
- extend regression coverage for small, oversized, and continuation-frame routing

## Root cause

With the WS v2 mode router enabled, the `passthrough` case returned before the shared oversized-frame bridge decision. A large first `response.create` was therefore forwarded as one upstream WebSocket message even when `http_bridge_enabled` was true and the payload exceeded `http_bridge_threshold_bytes`. Upstreams enforcing a per-message limit could close the connection with `1009 (Message Too Big)` before `response.completed`.

The fix evaluates the existing bridge predicate before the passthrough early return. No new threshold or transport policy is introduced.

Fixes #5467.

## Impact

- below-threshold passthrough frames continue to use upstream WebSocket transport
- frames with `previous_response_id` continue to use WebSocket continuation
- only oversized first frames without `previous_response_id` use the existing HTTP/SSE bridge; the downstream client still receives Responses events over its WebSocket connection

## Validation

- regression test failed on `upstream/main` by dialing passthrough for a 17 MiB first frame, then passed after the fix
- `go test ./internal/service -run 'TestOpenAIWSHTTPBridgeDecision|TestOpenAIWSHTTPBridgeAcceptsOversizedPassthroughFirstFrame|TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeRelaysByCaddyAdapter' -count=1`
- `make -C backend test-unit`
- `golangci-lint v2.9.0 run --timeout=30m ./...`
