### PR TITLE
fix(frontend): show persisted Grok subscription plans

### DIFF
--- a/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
+++ b/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildOpenAIUsageRefreshKey } from '../accountUsageRefresh'
+import { buildGrokUsageRefreshKey, buildOpenAIUsageRefreshKey } from '../accountUsageRefresh'
 
 describe('buildOpenAIUsageRefreshKey', () => {
   it('会在 codex 快照变化时生成不同 key', () => {
@@ -58,6 +58,104 @@ describe('buildOpenAIUsageRefreshKey', () => {
       updated_at: '2026-03-07T10:00:00Z',
       last_used_at: '2026-03-07T10:00:00Z',
       extra: {}
+    } as any)).toBe('')
+  })
+})
+
+describe('buildGrokUsageRefreshKey', () => {
+  it('changes when a canonical Grok billing or usage snapshot changes', () => {
+    const base = {
+      platform: 'grok',
+      extra: {
+        grok_billing_snapshot: { plan: 'Free', usage_percent: 0 },
+        grok_usage_snapshot: { subscription_tier: 'Free', status_code: 200 }
+      }
+    } as any
+
+    expect(buildGrokUsageRefreshKey(base)).not.toBe(buildGrokUsageRefreshKey({
+      ...base,
+      extra: {
+        ...base.extra,
+        grok_billing_snapshot: { plan: 'SuperGrok', usage_percent: 0 }
+      }
+    }))
+    expect(buildGrokUsageRefreshKey(base)).not.toBe(buildGrokUsageRefreshKey({
+      ...base,
+      extra: {
+        ...base.extra,
+        grok_usage_snapshot: { subscription_tier: 'SuperGrok', status_code: 200 }
+      }
+    }))
+  })
+
+  it('ignores object key order and a legacy alias shadowed by canonical usage', () => {
+    const first = {
+      platform: 'grok',
+      extra: {
+        grok_billing_snapshot: {
+          plan: 'SuperGrok',
+          limits: { monthly: 100, weekly: 25 }
+        },
+        grok_usage_snapshot: { status_code: 200, subscription_tier: 'SuperGrok' },
+        grok_quota_snapshot: { subscription_tier: 'Free' }
+      }
+    } as any
+    const reordered = {
+      platform: 'grok',
+      extra: {
+        grok_quota_snapshot: { subscription_tier: 'SuperGrok Heavy' },
+        grok_usage_snapshot: { subscription_tier: 'SuperGrok', status_code: 200 },
+        grok_billing_snapshot: {
+          limits: { weekly: 25, monthly: 100 },
+          plan: 'SuperGrok'
+        }
+      }
+    } as any
+
+    expect(buildGrokUsageRefreshKey(first)).toBe(buildGrokUsageRefreshKey(reordered))
+  })
+
+  it('uses the legacy quota alias only when the canonical snapshot is absent', () => {
+    const base = {
+      platform: 'grok',
+      extra: { grok_quota_snapshot: { subscription_tier: 'Free' } }
+    } as any
+    const next = {
+      platform: 'grok',
+      extra: { grok_quota_snapshot: { subscription_tier: 'SuperGrok' } }
+    } as any
+
+    expect(buildGrokUsageRefreshKey(base)).not.toBe(buildGrokUsageRefreshKey(next))
+  })
+
+  it('tracks the legacy tier when the canonical snapshot has no usable tier', () => {
+    for (const canonicalSnapshot of [
+      { status_code: 200 },
+      { status_code: 200, subscription_tier: '   ' },
+    ]) {
+      const base = {
+        platform: 'grok',
+        extra: {
+          grok_usage_snapshot: canonicalSnapshot,
+          grok_quota_snapshot: { subscription_tier: 'Free' },
+        },
+      } as any
+      const next = {
+        ...base,
+        extra: {
+          ...base.extra,
+          grok_quota_snapshot: { subscription_tier: 'SuperGrok' },
+        },
+      }
+
+      expect(buildGrokUsageRefreshKey(base)).not.toBe(buildGrokUsageRefreshKey(next))
+    }
+  })
+
+  it('returns an empty key for non-Grok accounts', () => {
+    expect(buildGrokUsageRefreshKey({
+      platform: 'openai',
+      extra: { grok_usage_snapshot: { subscription_tier: 'SuperGrok' } }
     } as any)).toBe('')
   })
 })

--- a/frontend/src/utils/accountUsageRefresh.ts
+++ b/frontend/src/utils/accountUsageRefresh.ts
@@ -5,6 +5,30 @@ const normalizeUsageRefreshValue = (value: unknown): string => {
   return String(value)
 }
 
+const normalizeSnapshotRefreshValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeSnapshotRefreshValue)
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeSnapshotRefreshValue(entry)])
+    )
+  }
+  return value
+}
+
+const serializeSnapshotRefreshValue = (value: unknown): string => {
+  if (value == null) return ''
+  return JSON.stringify(normalizeSnapshotRefreshValue(value)) ?? ''
+}
+
+const isNonBlankString = (value: unknown): value is string => (
+  typeof value === 'string' && value.trim().length > 0
+)
+
 export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platform' | 'type' | 'updated_at' | 'last_used_at' | 'rate_limit_reset_at' | 'extra'>): string => {
   if (account.platform !== 'openai' || account.type !== 'oauth') {
     return ''
@@ -26,4 +50,22 @@ export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platfo
     extra.codex_7d_reset_after_seconds,
     extra.codex_7d_window_minutes
   ].map(normalizeUsageRefreshValue).join('|')
+}
+
+export const buildGrokUsageRefreshKey = (account: Pick<Account, 'platform' | 'extra'>): string => {
+  if (account.platform !== 'grok') {
+    return ''
+  }
+
+  const extra = account.extra ?? {}
+  const usageSnapshot = extra.grok_usage_snapshot
+  const canonicalTier = (usageSnapshot as Record<string, unknown> | null | undefined)?.subscription_tier
+  const legacyQuotaFallback = isNonBlankString(canonicalTier)
+    ? undefined
+    : extra.grok_quota_snapshot
+  return [
+    serializeSnapshotRefreshValue(extra.grok_billing_snapshot),
+    serializeSnapshotRefreshValue(usageSnapshot),
+    serializeSnapshotRefreshValue(legacyQuotaFallback)
+  ].join('|')
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -525,7 +525,7 @@ import Icon from '@/components/icons/Icon.vue'
 import ErrorPassthroughRulesModal from '@/components/admin/ErrorPassthroughRulesModal.vue'
 import TLSFingerprintProfilesModal from '@/components/admin/TLSFingerprintProfilesModal.vue'
 import { fetchAllAccountIds } from '@/utils/accountSelection'
-import { buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
+import { buildGrokUsageRefreshKey, buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
 import { proxyExpiryBadgeClass, proxyExpiryLabelKey } from '@/utils/proxyExpiry'
 import { extractApiErrorMessage } from '@/utils/apiError'
@@ -1300,7 +1300,8 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
     current.rate_limit_reset_at !== next.rate_limit_reset_at ||
     current.overload_until !== next.overload_until ||
     current.temp_unschedulable_until !== next.temp_unschedulable_until ||
-    buildOpenAIUsageRefreshKey(current) !== buildOpenAIUsageRefreshKey(next)
+    buildOpenAIUsageRefreshKey(current) !== buildOpenAIUsageRefreshKey(next) ||
+    buildGrokUsageRefreshKey(current) !== buildGrokUsageRefreshKey(next)
   )
 }
 
@@ -1483,23 +1484,30 @@ const { pause: pauseAutoRefresh, resume: resumeAutoRefresh } = useIntervalFn(
 
 // Fresh billing/quota snapshots are authoritative. Imported credential tiers
 // can be stale, so they remain fallbacks together with legacy plan_type fields.
+function firstNonBlankString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => (
+    typeof value === 'string' && value.trim().length > 0
+  ))
+}
+
 function getAccountPlanType(row: any): string | undefined {
   if (!row) return undefined
   if (row.platform === 'grok') {
     const extra = (row.extra || {}) as Record<string, any>
     const billing = extra.grok_billing_snapshot as Record<string, any> | undefined
-    const quota = extra.grok_quota_snapshot as Record<string, any> | undefined
-    return (
-      billing?.plan ||
-      quota?.subscription_tier ||
-      row.credentials?.subscription_tier ||
-      extra.subscription_tier ||
-      row.credentials?.plan_type ||
-      row.parent_plan_type ||
-      undefined
+    const usage = extra.grok_usage_snapshot as Record<string, any> | undefined
+    const legacyQuota = extra.grok_quota_snapshot as Record<string, any> | undefined
+    return firstNonBlankString(
+      billing?.plan,
+      usage?.subscription_tier,
+      legacyQuota?.subscription_tier,
+      row.credentials?.subscription_tier,
+      extra.subscription_tier,
+      row.credentials?.plan_type,
+      row.parent_plan_type
     )
   }
-  return row.credentials?.plan_type || row.parent_plan_type || undefined
+  return firstNonBlankString(row.credentials?.plan_type, row.parent_plan_type)
 }
 
 function getOpenAIAuthMode(row: any): string | undefined {

--- a/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
@@ -270,6 +270,8 @@ describe('admin AccountsView — 账号行展示', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -356,6 +358,7 @@ describe('admin AccountsView — 账号行展示', () => {
         credentials: { subscription_tier: 'FREE', plan_type: 'legacy' },
         extra: {
           grok_billing_snapshot: { plan: 'SuperGrok' },
+          grok_usage_snapshot: { subscription_tier: 'SuperGrok Heavy' },
           subscription_tier: 'BASIC',
         },
       },
@@ -377,7 +380,8 @@ describe('admin AccountsView — 账号行展示', () => {
         type: 'oauth',
         credentials: { subscription_tier: 'FREE' },
         extra: {
-          grok_quota_snapshot: { subscription_tier: 'SuperGrok' },
+          grok_usage_snapshot: { subscription_tier: 'SuperGrok' },
+          grok_quota_snapshot: { subscription_tier: 'Free' },
           subscription_tier: 'BASIC',
         },
       },
@@ -395,6 +399,14 @@ describe('admin AccountsView — 账号行展示', () => {
         platform: 'grok',
         type: 'oauth',
         credentials: { plan_type: 'SuperGrok' },
+      },
+      {
+        id: 206,
+        name: 'legacy-quota-alias',
+        platform: 'grok',
+        type: 'oauth',
+        credentials: { subscription_tier: 'FREE' },
+        extra: { grok_quota_snapshot: { subscription_tier: 'SuperGrok' } },
       },
     ]
 
@@ -416,8 +428,105 @@ describe('admin AccountsView — 账号行展示', () => {
       'SuperGrok',
       'BASIC',
       'SuperGrok',
+      'SuperGrok',
     ])
 
+    wrapper.unmount()
+  })
+
+  it('skips malformed Grok plan fields and safely uses the next valid fallback', async () => {
+    const grokAccounts = [
+      {
+        id: 207,
+        name: 'legacy-fallback',
+        platform: 'grok',
+        type: 'oauth',
+        credentials: { subscription_tier: 'FREE' },
+        extra: {
+          grok_usage_snapshot: { subscription_tier: { name: 'SuperGrok Heavy' } },
+          grok_quota_snapshot: { subscription_tier: 'SuperGrok' },
+        },
+      },
+      {
+        id: 208,
+        name: 'credential-plan-fallback',
+        platform: 'grok',
+        type: 'oauth',
+        credentials: { subscription_tier: 0, plan_type: 'SuperGrok Heavy' },
+        extra: {
+          grok_billing_snapshot: { plan: {} },
+          grok_usage_snapshot: { subscription_tier: 1 },
+          grok_quota_snapshot: { subscription_tier: [] },
+          subscription_tier: '   ',
+        },
+      },
+      {
+        id: 209,
+        name: 'no-valid-plan',
+        platform: 'grok',
+        type: 'oauth',
+        credentials: { subscription_tier: {}, plan_type: 2 },
+        parent_plan_type: [],
+        extra: {
+          grok_billing_snapshot: { plan: [] },
+          grok_usage_snapshot: { subscription_tier: 1 },
+          grok_quota_snapshot: { subscription_tier: {} },
+          subscription_tier: null,
+        },
+      },
+    ]
+
+    listAccounts.mockResolvedValue({
+      items: grokAccounts,
+      total: grokAccounts.length,
+      page: 1,
+      page_size: 20,
+      pages: 1,
+    })
+
+    const wrapper = mountViewWithRow()
+    await flushPromises()
+
+    expect(wrapper.findAllComponents(PlatformTypeBadge).map((badge) => badge.props('planType'))).toEqual([
+      'SuperGrok',
+      'SuperGrok Heavy',
+      undefined,
+    ])
+    wrapper.unmount()
+  })
+
+  it('replaces a Grok row when auto refresh returns a changed canonical usage snapshot', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false)
+    localStorage.setItem('account-auto-refresh', JSON.stringify({ enabled: true, interval_seconds: 5 }))
+
+    const initialAccount = {
+      id: 207,
+      name: 'refresh-tier',
+      platform: 'grok',
+      type: 'oauth',
+      extra: { grok_usage_snapshot: { subscription_tier: 'Free', status_code: 200 } },
+    }
+    const refreshedAccount = {
+      ...initialAccount,
+      extra: { grok_usage_snapshot: { subscription_tier: 'SuperGrok', status_code: 200 } },
+    }
+    listAccounts.mockResolvedValue({ items: [initialAccount], total: 1, page: 1, page_size: 20, pages: 1 })
+    listWithEtag.mockResolvedValueOnce({
+      notModified: false,
+      etag: 'grok-snapshot-2',
+      data: { items: [refreshedAccount], total: 1, page: 1, page_size: 20, pages: 1 },
+    })
+
+    const wrapper = mountViewWithRow()
+    await flushPromises()
+    expect(wrapper.findComponent(PlatformTypeBadge).props('planType')).toBe('Free')
+
+    await vi.advanceTimersByTimeAsync(6000)
+    await flushPromises()
+
+    expect(listWithEtag).toHaveBeenCalledTimes(1)
+    expect(wrapper.findComponent(PlatformTypeBadge).props('planType')).toBe('SuperGrok')
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

- read Grok subscription tiers from the backend's canonical `grok_usage_snapshot`
- keep `grok_quota_snapshot` as a legacy fallback without allowing it to override canonical data
- include Grok billing and usage snapshots in incremental account-row refresh decisions
- reject blank or malformed plan values before they reach the badge component
- add regression coverage for canonical/legacy precedence, malformed data, and timer-driven refresh

## Root cause

The backend persists quota headers under `extra.grok_usage_snapshot`, while the account-list badge read `extra.grok_quota_snapshot`. The frontend fixture repeated the incorrect key, masking the mismatch. Incremental refresh also did not compare Grok snapshot state, so a Grok-only update could retain a stale row.

## Verification

- focused Vitest: 2 files, 18 tests passed
- frontend lint passed
- frontend typecheck passed
- CI-critical frontend suite: 13 files, 163 tests passed
- `git diff --check` passed
- frozen install completed with pnpm 9.15.4 and did not modify dependency manifests or the lockfile

The badge updates when the persisted account row is received on the next normal incremental/list refresh; this PR does not patch the probe response directly into account-row state.

Fixes #5569
