### PR TITLE
fix(openai): route native compaction to capable accounts

### DIFF
--- a/backend/internal/handler/openai_gateway_compact_body_signal_test.go
+++ b/backend/internal/handler/openai_gateway_compact_body_signal_test.go
@@ -77,6 +77,95 @@ func TestNormalizeOpenAIResponsesCompactRequest_RemoteV2PathAliasesStayOnRespons
 	}
 }
 
+func TestRequiresOpenAICompactAccount_RemoteV2UsesNativeRequestSignal(t *testing.T) {
+	h := &OpenAIGatewayHandler{}
+	tests := []struct {
+		name       string
+		body       []byte
+		betaHeader string
+		wantBefore bool
+		wantAfter  bool
+		path       string
+	}{
+		{
+			name:       "native_v2_with_trigger",
+			body:       []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			betaHeader: "remote_compaction_v2",
+			wantBefore: true,
+			wantAfter:  true,
+			path:       "/v1/responses",
+		},
+		{
+			name:       "native_v2_without_trigger",
+			body:       []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"message","role":"user","content":"hello"}]}`),
+			betaHeader: "remote_compaction_v2",
+			wantBefore: false,
+			wantAfter:  false,
+			path:       "/v1/responses",
+		},
+		{
+			name:       "ordinary_stream_with_trigger",
+			body:       []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			wantBefore: false,
+			wantAfter:  true,
+			path:       "/v1/responses",
+		},
+		{
+			name:       "responses_subpath_with_native_signal",
+			body:       []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			betaHeader: "remote_compaction_v2",
+			wantBefore: false,
+			wantAfter:  false,
+			path:       "/v1/responses/resp_123/cancel",
+		},
+		{
+			name:       "responses_suffix_collision",
+			body:       []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			betaHeader: "remote_compaction_v2",
+			wantBefore: false,
+			wantAfter:  false,
+			path:       "/v1/responses/resp_123/responses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newCompactBodySignalTestContext(t, tt.path, tt.body)
+			if tt.betaHeader != "" {
+				c.Request.Header.Set("x-codex-beta-features", tt.betaHeader)
+			}
+
+			require.Equal(t, tt.wantBefore, requiresOpenAICompactAccount(c, tt.body))
+			normalized, ok := h.normalizeOpenAIResponsesCompactRequest(c, zap.NewNop(), tt.body)
+			require.True(t, ok)
+			require.Equal(t, tt.wantAfter, requiresOpenAICompactAccount(c, normalized))
+		})
+	}
+}
+
+func TestRequiresOpenAICompactAccount_RemoteV2SupportsResponsesRootAliases(t *testing.T) {
+	h := &OpenAIGatewayHandler{}
+	body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`)
+
+	for _, path := range []string{
+		"/v1/responses",
+		"/v1/responses/",
+		"/openai/v1/responses",
+		"/responses",
+		"/backend-api/codex/responses",
+	} {
+		t.Run(path, func(t *testing.T) {
+			c := newCompactBodySignalTestContext(t, path, body)
+			c.Request.Header.Set("x-codex-beta-features", "remote_compaction_v2")
+
+			normalized, ok := h.normalizeOpenAIResponsesCompactRequest(c, zap.NewNop(), body)
+			require.True(t, ok)
+			require.Equal(t, path, c.Request.URL.Path)
+			require.True(t, requiresOpenAICompactAccount(c, normalized))
+		})
+	}
+}
+
 func TestNormalizeOpenAIResponsesCompactRequest_BodySignalTrailingSlashPromoted(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 	body := []byte(`{"model":"gpt-5.5","input":[{"type":"compaction_trigger"}]}`)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -182,6 +182,13 @@ func openAIResponsesRequiredCapability(imageIntent bool, platform string) servic
 	return service.OpenAIEndpointCapabilityChatCompletions
 }
 
+func openAIResponsesRequiredCapabilityForRequest(imageIntent bool, requireCompact bool, platform string) service.OpenAIEndpointCapability {
+	if requireCompact && platform == service.PlatformOpenAI {
+		return service.OpenAIEndpointCapabilityResponses
+	}
+	return openAIResponsesRequiredCapability(imageIntent, platform)
+}
+
 func allowOpenAICompatibleMessagesDispatch(apiKey *service.APIKey) bool {
 	if apiKey == nil || apiKey.Group == nil {
 		return true
@@ -377,6 +384,15 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 	forwardBody := openAIModelMappedBody(body, channelMapping.Mapped, channelMapping.MappedModel, h.gatewayService.ReplaceModelInBody)
 	seedOpenAIForwardImageIntentHint(c, channelMapping.Mapped, imageIntent)
+	forwardModel := reqModel
+	if channelMapping.Mapped {
+		forwardModel = channelMapping.MappedModel
+	}
+	c.Request = c.Request.WithContext(service.WithOpenAIForwardModel(
+		c.Request.Context(),
+		forwardModel,
+		isOpenAIRemoteCompactPath(c),
+	))
 
 	// 提前校验 function_call_output 是否具备可关联上下文，避免上游 400。
 	if !h.validateFunctionCallOutputRequest(c, body, reqLog) {
@@ -420,7 +436,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	if h.rejectIfCyberSessionBlocked(c, apiKey, sessionHashBody, reqModel, cyberBlockFormatResponses) {
 		return
 	}
-	requireCompact := isOpenAIRemoteCompactPath(c)
+	requireCompact := requiresOpenAICompactAccount(c, body)
 
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
@@ -437,7 +453,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 仅对 OpenAI 平台生效：Grok 生图走独立的 forwardGrokResponses 路径，不应被过滤。
 	// 复用前置权限与并发阶段在未修改 body 上确认的显式生图意图，避免大 tools 请求重复扫描。
 	// 该判断已排除 Codex 被动 image_gen namespace，避免 CC-only 账号被误过滤（#4476）。
-	requiredCapability := openAIResponsesRequiredCapability(imageIntent, requestPlatform)
+	requiredCapability := openAIResponsesRequiredCapabilityForRequest(imageIntent, requireCompact, requestPlatform)
 
 	// 分组利润控制：请求级装配定价上下文——pricingAt 固定本请求的
 	// D 与计费高峰因子，选号、槽位终检与全部 failover 重入共用同一门与阈值。
@@ -750,7 +766,12 @@ func isBareOpenAIResponsesPath(c *gin.Context) bool {
 		return false
 	}
 	normalizedPath := strings.TrimRight(strings.TrimSpace(c.Request.URL.Path), "/")
-	return strings.HasSuffix(normalizedPath, "/responses")
+	switch normalizedPath {
+	case EndpointResponses, "/openai/v1/responses", "/responses", "/backend-api/codex/responses":
+		return true
+	default:
+		return false
+	}
 }
 
 func isOpenAIRemoteCompactionV2Request(c *gin.Context, body []byte) bool {
@@ -766,6 +787,16 @@ func isOpenAIRemoteCompactionV2Request(c *gin.Context, body []byte) bool {
 		}
 	}
 	return false
+}
+
+func requiresOpenAICompactAccount(c *gin.Context, body []byte) bool {
+	if isOpenAIRemoteCompactPath(c) {
+		return true
+	}
+	if !isBareOpenAIResponsesPath(c) {
+		return false
+	}
+	return service.HasCompactionTriggerInInput(body) && isOpenAIRemoteCompactionV2Request(c, body)
 }
 
 // normalizeOpenAIResponsesCompactRequest keeps Codex remote compaction v2 on

--- a/backend/internal/handler/openai_profit_slot_recheck_test.go
+++ b/backend/internal/handler/openai_profit_slot_recheck_test.go
@@ -5,8 +5,7 @@ package handler
 // 槽位终检与生图跳门回归（handler 半程）：
 //   - 槽位获取成功后的利润终检：越线账号释放槽位并要求调用方排除重选，
 //     不写响应、不绑定粘连；
-//   - openAIResponsesRequiredCapability 的生图意图映射钉死（scheduler 的
-//     跳门条件依赖 CapabilityResponses ⇔ 显式生图意图这一耦合）。
+//   - openAIResponsesRequiredCapability 的请求能力映射覆盖生图与原生远程压缩。
 
 import (
 	"context"
@@ -141,10 +140,10 @@ func TestAcquireResponsesAccountSlotProfitRecheck(t *testing.T) {
 	})
 }
 
-// scheduler 跳门条件依赖"CapabilityResponses 仅在显式生图意图时被要求"这一
-// 映射；后续若扩展该 capability 的用途，本测试失败提示同步收窄跳门条件。
-func TestOpenAIResponsesRequiredCapabilityPinsImageIntentMapping(t *testing.T) {
+func TestOpenAIResponsesRequiredCapabilityForRequest(t *testing.T) {
 	require.Equal(t, service.OpenAIEndpointCapabilityResponses, openAIResponsesRequiredCapability(true, service.PlatformOpenAI))
 	require.Equal(t, service.OpenAIEndpointCapabilityChatCompletions, openAIResponsesRequiredCapability(false, service.PlatformOpenAI))
 	require.Equal(t, service.OpenAIEndpointCapabilityChatCompletions, openAIResponsesRequiredCapability(true, service.PlatformGrok))
+	require.Equal(t, service.OpenAIEndpointCapabilityResponses, openAIResponsesRequiredCapabilityForRequest(false, true, service.PlatformOpenAI))
+	require.Equal(t, service.OpenAIEndpointCapabilityChatCompletions, openAIResponsesRequiredCapabilityForRequest(false, true, service.PlatformGrok))
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -2154,11 +2154,9 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	// 入口已在请求开始经 WithOpenAIRequestPricingContext 装门并固定 pricingAt，
 	// 此处对同分组门直接复用（failover 重入阈值稳定），仅为不经 handler 装配的
 	// 内部调用兜底。图片/视频调度不在利润门范围：requiredImageCapability 非空的
-	// Images 调度不装门；requiredCapability == OpenAIEndpointCapabilityResponses
-	// 当前仅显式生图意图的 /v1/responses 设置（HTTP openAIResponsesRequiredCapability
-	// 与 WS 桥同款判定），同样不装门——若未来把该 capability 用于非生图流量，
-	// 需要同步收窄本条件（有测试钉死该映射）。
-	if requiredImageCapability == "" && requiredCapability != OpenAIEndpointCapabilityResponses {
+	// Images 调度不装门；其他使用 Responses 能力的文本请求（包括原生远程压缩）
+	// 仍须装门。其余媒体路径通过 WithOpenAIProfitControlSuppressed 显式跳过。
+	if requiredImageCapability == "" {
 		ctx = s.withOpenAIProfitControlGate(ctx, groupID)
 	}
 	platform = normalizeOpenAICompatiblePlatform(platform)

--- a/backend/internal/service/openai_account_scheduler_compact_test.go
+++ b/backend/internal/service/openai_account_scheduler_compact_test.go
@@ -116,6 +116,114 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactRejectsExplicitl
 	require.Nil(t, selection)
 }
 
+// TestOpenAIGatewayService_SelectAccountWithScheduler_CompactRequiresResponsesCapability
+// prevents a confirmed Chat Completions-only API key from silently dropping the
+// compaction trigger through the Responses-to-Chat fallback.
+func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactRequiresResponsesCapability(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(91005)
+	accounts := []Account{{
+		ID:          71050,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"openai_compact_supported":   true,
+			"openai_responses_supported": false,
+		},
+	}}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, _, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.4",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityResponses,
+		true,
+		false,
+		false,
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrNoAvailableAccounts))
+	require.Nil(t, selection)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactSkipsChatOnlyAccount(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(91006)
+	accounts := []Account{
+		{
+			ID:          71060,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    10,
+			Extra: map[string]any{
+				"openai_compact_supported":   true,
+				"openai_responses_supported": false,
+			},
+		},
+		{
+			ID:          71061,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    0,
+			Extra: map[string]any{
+				"openai_compact_supported":   true,
+				"openai_responses_supported": true,
+			},
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, _, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.6-sol",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityResponses,
+		true,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(71061), selection.Account.ID)
+}
+
 // TestOpenAIGatewayService_SelectAccountWithScheduler_CompactFallsBackToUnknown
 // 验证当没有"已知支持"账号时，compact 请求会回退到"未探测"账号。
 func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactFallsBackToUnknown(t *testing.T) {

--- a/backend/internal/service/openai_channel_restriction_test.go
+++ b/backend/internal/service/openai_channel_restriction_test.go
@@ -86,6 +86,226 @@ func TestOpenAISelectAccountForModelWithExclusions_UpstreamRestrictionSkipsDisal
 	require.Equal(t, int64(2), account.ID)
 }
 
+func TestIsUpstreamModelRestrictedByChannel_CompactMappingMatchesForwardPath(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Credentials: map[string]any{
+			"model_mapping":         map[string]any{"gpt-5.4-channel": "gpt-5.4-account"},
+			"compact_model_mapping": map[string]any{"gpt-5.4-account": "gpt-5.4-compact"},
+		},
+	}
+	tests := []struct {
+		name                   string
+		allowedUpstreamModel   string
+		useCompactModelMapping bool
+	}{
+		{
+			name:                   "legacy compact applies compact mapping after channel and account mapping",
+			allowedUpstreamModel:   "gpt-5.4-compact",
+			useCompactModelMapping: true,
+		},
+		{
+			name:                   "native v2 stops after channel and account mapping",
+			allowedUpstreamModel:   "gpt-5.4-account",
+			useCompactModelMapping: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			channelSvc := newTestChannelService(makeStandardRepo(Channel{
+				ID:                 1,
+				Status:             StatusActive,
+				GroupIDs:           []int64{10},
+				RestrictModels:     true,
+				BillingModelSource: BillingModelSourceUpstream,
+				ModelPricing: []ChannelModelPricing{
+					{Platform: PlatformOpenAI, Models: []string{tt.allowedUpstreamModel}},
+				},
+				ModelMapping: map[string]map[string]string{
+					PlatformOpenAI: {"gpt-5.4": "gpt-5.4-channel"},
+				},
+			}, map[int64]string{10: PlatformOpenAI}))
+			svc := &OpenAIGatewayService{channelService: channelSvc}
+			mapping := channelSvc.ResolveChannelMapping(context.Background(), 10, "gpt-5.4")
+			require.True(t, mapping.Mapped)
+			require.Equal(t, "gpt-5.4-channel", mapping.MappedModel)
+
+			ctx := WithOpenAIForwardModel(
+				context.Background(),
+				mapping.MappedModel,
+				tt.useCompactModelMapping,
+			)
+			require.False(t, svc.isUpstreamModelRestrictedByChannel(
+				ctx, 10, account, "gpt-5.4", true,
+			))
+			require.True(t, svc.isUpstreamModelRestrictedByChannel(
+				context.Background(), 10, account, "gpt-5.4", true,
+			), "without the forward-model context the restriction check follows a different chain")
+		})
+	}
+}
+
+func TestIsUpstreamModelRestrictedByChannel_PassthroughMatchesForwardPath(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.4-channel": "gpt-5.4-account"},
+			"compact_model_mapping": map[string]any{
+				"gpt-5.4-channel": "gpt-5.4-compact",
+			},
+		},
+		Extra: map[string]any{"openai_passthrough": true},
+	}
+	tests := []struct {
+		name                   string
+		allowedUpstreamModel   string
+		useCompactModelMapping bool
+	}{
+		{
+			name:                   "native v2 keeps channel-mapped model and ignores normal account mapping",
+			allowedUpstreamModel:   "gpt-5.4-channel",
+			useCompactModelMapping: false,
+		},
+		{
+			name:                   "legacy compact applies compact mapping to channel-mapped model",
+			allowedUpstreamModel:   "gpt-5.4-compact",
+			useCompactModelMapping: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			channelSvc := newTestChannelService(makeStandardRepo(Channel{
+				ID:                 1,
+				Status:             StatusActive,
+				GroupIDs:           []int64{10},
+				RestrictModels:     true,
+				BillingModelSource: BillingModelSourceUpstream,
+				ModelPricing: []ChannelModelPricing{
+					{Platform: PlatformOpenAI, Models: []string{tt.allowedUpstreamModel}},
+				},
+				ModelMapping: map[string]map[string]string{
+					PlatformOpenAI: {"gpt-5.4": "gpt-5.4-channel"},
+				},
+			}, map[int64]string{10: PlatformOpenAI}))
+			svc := &OpenAIGatewayService{channelService: channelSvc}
+			mapping := channelSvc.ResolveChannelMapping(context.Background(), 10, "gpt-5.4")
+			require.True(t, mapping.Mapped)
+			require.Equal(t, "gpt-5.4-channel", mapping.MappedModel)
+
+			ctx := WithOpenAIForwardModel(
+				context.Background(),
+				mapping.MappedModel,
+				tt.useCompactModelMapping,
+			)
+			require.False(t, svc.isUpstreamModelRestrictedByChannel(
+				ctx, 10, account, "gpt-5.4", true,
+			))
+		})
+	}
+}
+
+func TestIsUpstreamModelRestrictedByChannel_PassthroughFlagWithRawChatFallbackMatchesForwardPath(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.4-channel": "gpt-5.4-account"},
+			"compact_model_mapping": map[string]any{
+				"gpt-5.4-account": "gpt-5.4-compact",
+			},
+		},
+		Extra: map[string]any{
+			"openai_passthrough":         true,
+			"openai_responses_supported": false,
+		},
+	}
+
+	for _, useCompactModelMapping := range []bool{false, true} {
+		useCompactModelMapping := useCompactModelMapping
+		name := "native v2"
+		if useCompactModelMapping {
+			name = "legacy compact"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			channelSvc := newTestChannelService(makeStandardRepo(Channel{
+				ID:                 1,
+				Status:             StatusActive,
+				GroupIDs:           []int64{10},
+				RestrictModels:     true,
+				BillingModelSource: BillingModelSourceUpstream,
+				ModelPricing: []ChannelModelPricing{
+					{Platform: PlatformOpenAI, Models: []string{"gpt-5.4-account"}},
+				},
+				ModelMapping: map[string]map[string]string{
+					PlatformOpenAI: {"gpt-5.4": "gpt-5.4-channel"},
+				},
+			}, map[int64]string{10: PlatformOpenAI}))
+			svc := &OpenAIGatewayService{channelService: channelSvc}
+			ctx := WithOpenAIForwardModel(
+				context.Background(),
+				"gpt-5.4-channel",
+				useCompactModelMapping,
+			)
+
+			require.False(t, svc.isUpstreamModelRestrictedByChannel(
+				ctx, 10, account, "gpt-5.4", true,
+			))
+		})
+	}
+}
+
+func TestIsUpstreamModelRestrictedByChannel_ForwardModelContextMatchesNormalForwardPath(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.4-channel": "gpt-5.4-account"},
+		},
+		Extra: map[string]any{
+			"openai_passthrough":         true,
+			"openai_responses_supported": false,
+		},
+	}
+	channelSvc := newTestChannelService(makeStandardRepo(Channel{
+		ID:                 1,
+		Status:             StatusActive,
+		GroupIDs:           []int64{10},
+		RestrictModels:     true,
+		BillingModelSource: BillingModelSourceUpstream,
+		ModelPricing: []ChannelModelPricing{
+			{Platform: PlatformOpenAI, Models: []string{"gpt-5.4-account"}},
+		},
+		ModelMapping: map[string]map[string]string{
+			PlatformOpenAI: {"gpt-5.4": "gpt-5.4-channel"},
+		},
+	}, map[int64]string{10: PlatformOpenAI}))
+	svc := &OpenAIGatewayService{channelService: channelSvc}
+	ctx := WithOpenAIForwardModel(context.Background(), "gpt-5.4-channel", false)
+
+	require.False(t, svc.isUpstreamModelRestrictedByChannel(
+		ctx, 10, account, "gpt-5.4", false,
+	))
+}
+
 func TestOpenAISelectAccountForModelWithExclusions_StickyRestrictedUpstreamFallsBack(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_compaction_context.go
+++ b/backend/internal/service/openai_compaction_context.go
@@ -1,0 +1,32 @@
+package service
+
+import "context"
+
+type openAIForwardModelContextKey struct{}
+
+type openAIForwardModel struct {
+	model                  string
+	useCompactModelMapping bool
+}
+
+// WithOpenAIForwardModel records the model present in the forwarded request
+// body after channel mapping and whether the legacy compact-only model mapping
+// applies. Channel restriction checks then follow the same model chain used by
+// Forward.
+func WithOpenAIForwardModel(ctx context.Context, forwardModel string, useCompactModelMapping bool) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, openAIForwardModelContextKey{}, openAIForwardModel{
+		model:                  forwardModel,
+		useCompactModelMapping: useCompactModelMapping,
+	})
+}
+
+func openAIForwardModelFromContext(ctx context.Context) (openAIForwardModel, bool) {
+	if ctx == nil {
+		return openAIForwardModel{}, false
+	}
+	forwardModel, ok := ctx.Value(openAIForwardModelContextKey{}).(openAIForwardModel)
+	return forwardModel, ok
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -108,7 +108,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return s.forwardGrokResponses(ctx, c, account, body, originalModel, reqStream, startTime)
 	}
 
-	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		return s.forwardResponsesViaRawChatCompletions(ctx, c, account, body)
 	}
 	if account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey {
@@ -1026,6 +1026,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		return forwardResult, nil
 	}
+}
+
+func shouldForwardOpenAIResponsesViaRawChatCompletions(account *Account) bool {
+	return account != nil &&
+		account.Type == AccountTypeAPIKey &&
+		!openai_compat.ShouldUseResponsesAPI(account.Extra)
 }
 
 func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string, isStream bool, promptCacheKey string, isCodexCLI bool) (*http.Request, error) {

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -53,6 +53,50 @@ func TestForwardResponses_ForceChatCompletionsRoutesNonStreamingToChatCompletion
 	require.False(t, result.Stream)
 }
 
+func TestForwardResponses_PassthroughFlagWithUnsupportedResponsesUsesAccountMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, path := range []string{"/v1/responses", "/v1/responses/compact"} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.4-channel","input":"hello","stream":false}`)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"chatcmpl_mapping","object":"chat.completion","model":"gpt-5.4-account","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+				)),
+			}}
+			svc := &OpenAIGatewayService{
+				cfg:          rawChatCompletionsTestConfig(),
+				httpUpstream: upstream,
+			}
+			account := rawChatCompletionsTestAccount()
+			account.Credentials["model_mapping"] = map[string]any{
+				"gpt-5.4-channel": "gpt-5.4-account",
+			}
+			account.Credentials["compact_model_mapping"] = map[string]any{
+				"gpt-5.4-account": "gpt-5.4-compact",
+			}
+			account.Extra = map[string]any{
+				"openai_passthrough":                     true,
+				openai_compat.ExtraKeyResponsesSupported: false,
+			}
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, "http://upstream.example/v1/chat/completions", upstream.lastReq.URL.String())
+			require.Equal(t, "gpt-5.4-account", gjson.GetBytes(upstream.lastBody, "model").String())
+		})
+	}
+}
+
 func TestForwardResponses_ForceChatCompletionsRoutesStreamingToChatCompletions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -688,14 +688,41 @@ func prioritizeOpenAICompactAccounts(accounts []*Account) []*Account {
 // would be sent for a given request, honouring compact-only mappings when the
 // caller is on the /responses/compact path.
 func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedModel string, requireCompact bool) string {
+	// Forward checks the raw Chat Completions fallback before passthrough.
+	// These API-key accounts therefore apply normal account model_mapping and
+	// upstream normalization, but never compact_model_mapping.
+	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
+		upstreamModel := resolveOpenAIForwardModel(account, requestedModel, "")
+		return normalizeOpenAIModelForUpstream(account, upstreamModel)
+	}
+
+	// Passthrough accounts only replace authentication. Their Forward path
+	// keeps the channel-mapped model in the request body and does not apply the
+	// account's normal model_mapping. Legacy /responses/compact is the one
+	// exception: forwardOpenAIPassthrough applies compact_model_mapping
+	// directly to that channel-mapped model.
+	if account != nil && account.IsOpenAIPassthroughEnabled() {
+		upstreamModel := strings.TrimSpace(requestedModel)
+		if upstreamModel == "" {
+			return ""
+		}
+		if requireCompact {
+			return resolveOpenAICompactForwardModel(account, upstreamModel)
+		}
+		return upstreamModel
+	}
+
 	upstreamModel := resolveOpenAIForwardModel(account, requestedModel, "")
 	if upstreamModel == "" {
 		return ""
 	}
 	if requireCompact {
-		return resolveOpenAICompactForwardModel(account, upstreamModel)
+		compactModel := resolveOpenAICompactForwardModel(account, upstreamModel)
+		if compactModel != upstreamModel {
+			return compactModel
+		}
 	}
-	return upstreamModel
+	return normalizeOpenAIModelForUpstream(account, upstreamModel)
 }
 
 func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.Context, groupID *int64, platform string, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, stickyAccountID int64, requiredCapability OpenAIEndpointCapability, preferLowUpstreamRate bool) (*Account, error) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -598,6 +598,10 @@ func (s *OpenAIGatewayService) isUpstreamModelRestrictedByChannel(ctx context.Co
 	if s.channelService == nil {
 		return false
 	}
+	if compactForwardModel, ok := openAIForwardModelFromContext(ctx); ok {
+		requestedModel = compactForwardModel.model
+		requireCompact = compactForwardModel.useCompactModelMapping
+	}
 	upstreamModel := resolveOpenAIAccountUpstreamModelForRequest(account, requestedModel, requireCompact)
 	if upstreamModel == "" {
 		return false

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -735,12 +735,17 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 	}
 
 	account := &Account{
-		ID:             123,
-		Name:           "acc",
-		Platform:       PlatformOpenAI,
-		Type:           AccountTypeOAuth,
-		Concurrency:    1,
-		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		ID:          123,
+		Name:        "acc",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":          "oauth-token",
+			"chatgpt_account_id":    "chatgpt-acc",
+			"model_mapping":         map[string]any{"gpt-5.1-codex": "gpt-5.1-account"},
+			"compact_model_mapping": map[string]any{"gpt-5.1-codex": "gpt-5.1-compact"},
+		},
 		Extra:          map[string]any{"openai_passthrough": true},
 		Status:         StatusActive,
 		Schedulable:    true,
@@ -754,7 +759,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 
 	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "stream").Exists())
-	require.Equal(t, "gpt-5.1-codex", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "gpt-5.1-compact", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, "compact me", gjson.GetBytes(upstream.lastBody, "input.0.text").String())
 	require.Equal(t, "local-test-instructions", strings.TrimSpace(gjson.GetBytes(upstream.lastBody, "instructions").String()))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
@@ -2172,12 +2177,16 @@ func TestOpenAIGatewayService_APIKeyPassthrough_PreservesBodyAndUsesResponsesEnd
 	}
 
 	account := &Account{
-		ID:             456,
-		Name:           "apikey-acc",
-		Platform:       PlatformOpenAI,
-		Type:           AccountTypeAPIKey,
-		Concurrency:    1,
-		Credentials:    map[string]any{"api_key": "sk-api-key", "base_url": "https://api.openai.com"},
+		ID:          456,
+		Name:        "apikey-acc",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":       "sk-api-key",
+			"base_url":      "https://api.openai.com",
+			"model_mapping": map[string]any{"gpt-5.2": "gpt-5.2-account"},
+		},
 		Extra:          map[string]any{"openai_passthrough": true},
 		Status:         StatusActive,
 		Schedulable:    true,

--- a/backend/internal/service/openai_profit_control_pricing_test.go
+++ b/backend/internal/service/openai_profit_control_pricing_test.go
@@ -1,7 +1,7 @@
 package service
 
 // 请求级定价与利润门回归：请求级 pricingAt 定价上下文、门复用（failover 阈值稳定）、
-// 生图意图跳门、U 使用账号倍率且与探测新鲜度解耦、
+// Responses 文本能力利润门、U 使用账号倍率且与探测新鲜度解耦、
 // 用量记录定价时刻取值。
 
 import (
@@ -109,8 +109,9 @@ func TestProfitControl_UsesAccountRateInsteadOfProbeSnapshot(t *testing.T) {
 	require.Equal(t, openAIProfitFilterReasonThreshold, reason)
 }
 
-// 显式生图意图（requiredCapability=Responses）在唯一调度入口跳门（图片边界不装门）。
-func TestProfitControl_ResponsesImageIntentSkipsGateAtScheduler(t *testing.T) {
+// Responses 是端点能力，不代表媒体请求；原生远程压缩同样要求该能力，
+// 因此唯一文本调度入口必须照常安装利润门。
+func TestProfitControl_ResponsesCapabilityUsesTextGateAtScheduler(t *testing.T) {
 	now := time.Now()
 	expensive := upstreamCostTestAccount(51, UpstreamBillingProbeStatusOK, 0.8, now.Add(-time.Minute), 30*time.Minute)
 	expensive.Status = StatusActive
@@ -129,12 +130,8 @@ func TestProfitControl_ResponsesImageIntentSkipsGateAtScheduler(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoAvailableAccounts, "文本能力必须过利润门")
 
 	selection, _, err := svc.SelectAccountWithSchedulerForCapability(ctx, &groupID, "", "", "gpt-test", nil, OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityResponses, false, false, true)
-	require.NoError(t, err, "生图意图不装门，保持既有调度")
-	require.NotNil(t, selection)
-	require.Equal(t, expensive.ID, selection.Account.ID)
-	if selection.ReleaseFunc != nil {
-		selection.ReleaseFunc()
-	}
+	require.ErrorIs(t, err, ErrNoAvailableAccounts, "Responses 文本能力不得绕过利润门")
+	require.Nil(t, selection)
 }
 
 // 账号倍率缺失一律视为非法保守拒绝；手工或同步维护了倍率的任意账号类型都按


### PR DESCRIPTION
## Summary

- Detect native `remote_compaction_v2` requests from the exact Responses root, `stream: true`, beta feature header, and `compaction_trigger` input.
- Require both compact and Responses capabilities for OpenAI native compaction so Chat-Completions-only API-key accounts cannot silently discard the trigger.
- Preserve the native Responses wire and model while keeping legacy `/responses/compact` model mapping separate.
- Align channel restriction checks with the model that is actually forwarded.
- Keep Responses text traffic behind the defensive profit-control gate and cover mixed account pools.

## Root cause

Native compaction stays on `/v1/responses`, but account selection only derived `requireCompact` from the legacy `/responses/compact` path and otherwise requested Chat Completions capability. A Chat-only API-key account could therefore be selected, after which the Responses-to-Chat fallback dropped `compaction_trigger` and returned an ordinary successful response. Codex then saw zero `compaction` output items despite the backend recording HTTP 200.

Fixes #5478.

This is an updated current-main successor to #5492. The original author is retained as a commit co-author; this version also adds a mixed-pool routing regression and removes the Responses-capability/profit-gate coupling.

## Validation

- `go test ./internal/handler -count=1`
- `go test ./internal/service -count=1`
- `go test -tags=unit ./internal/handler -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `go test ./... -run "^$" -count=1`
- `git diff --cached --check`