### PR TITLE
[安全修复] 阻止篡改备份触发命令执行

### DIFF
--- a/backend/internal/service/backup_archive.go
+++ b/backend/internal/service/backup_archive.go
@@ -104,3 +104,17 @@ func cleanupBackupFiles(paths ...string) error {
 	}
 	return errors.Join(errs...)
 }
+
+// fileSHA256 计算文件 SHA256 十六进制摘要。
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/backend/internal/service/backup_service.go
+++ b/backend/internal/service/backup_service.go
@@ -125,6 +125,7 @@ type BackupRecord struct {
 	FileName      string       `json:"file_name"`
 	S3Key         string       `json:"s3_key"`
 	Parts         []BackupPart `json:"parts,omitempty"`
+	SHA256        string       `json:"sha256,omitempty"` // 单文件备份的完整性校验值；旧记录为空
 	SizeBytes     int64        `json:"size_bytes"`
 	TriggeredBy   string       `json:"triggered_by"` // manual, scheduled
 	ErrorMsg      string       `json:"error_message,omitempty"`
@@ -806,6 +807,10 @@ func (s *BackupService) uploadBackupArchive(ctx context.Context, record *BackupR
 		partSize = defaultBackupPartSizeBytes
 	}
 	if info.Size() <= partSize {
+		sum, err := fileSHA256(archivePath)
+		if err != nil {
+			return fmt.Errorf("hash backup archive: %w", err)
+		}
 		if _, err := objectStore.UploadFile(ctx, record.S3Key, archivePath, "application/gzip"); err != nil {
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), backupObjectCleanupTimeout)
 			cleanupErr := deleteBackupObjectKeys(cleanupCtx, objectStore, record)
@@ -813,6 +818,7 @@ func (s *BackupService) uploadBackupArchive(ctx context.Context, record *BackupR
 			return errors.Join(fmt.Errorf("backup upload: %w", err), cleanupErr)
 		}
 		record.Parts = nil
+		record.SHA256 = sum
 		return nil
 	}
 
@@ -903,26 +909,8 @@ func (s *BackupService) RestoreBackup(ctx context.Context, backupID string) erro
 		return s.restoreArchive(ctx, archivePath)
 	}
 
-	// 旧记录从 S3 流式下载
-	body, err := objectStore.Download(ctx, record.S3Key)
-	if err != nil {
-		return fmt.Errorf("S3 download failed: %w", err)
-	}
-	defer func() { _ = body.Close() }()
-
-	// 流式解压 gzip -> psql（不将全部数据加载到内存）
-	gzReader, err := gzip.NewReader(body)
-	if err != nil {
-		return fmt.Errorf("gzip reader: %w", err)
-	}
-	defer func() { _ = gzReader.Close() }()
-
-	// 流式恢复
-	if err := s.dumper.Restore(ctx, gzReader); err != nil {
-		return fmt.Errorf("pg restore: %w", err)
-	}
-
-	return nil
+	// 单文件记录：先校验完整性再恢复
+	return s.restoreSingleFileBackup(ctx, record, objectStore)
 }
 
 // StartRestore 异步恢复备份，立即返回
@@ -1022,25 +1010,7 @@ func (s *BackupService) executeRestore(record *BackupRecord, objectStore BackupO
 		return
 	}
 
-	body, err := objectStore.Download(ctx, record.S3Key)
-	if err != nil {
-		record.RestoreStatus = "failed"
-		record.RestoreError = fmt.Sprintf("S3 download failed: %v", err)
-		_ = s.saveRecord(context.Background(), record)
-		return
-	}
-	defer func() { _ = body.Close() }()
-
-	gzReader, err := gzip.NewReader(body)
-	if err != nil {
-		record.RestoreStatus = "failed"
-		record.RestoreError = fmt.Sprintf("gzip reader: %v", err)
-		_ = s.saveRecord(context.Background(), record)
-		return
-	}
-	defer func() { _ = gzReader.Close() }()
-
-	if err := s.dumper.Restore(ctx, gzReader); err != nil {
+	if err := s.restoreSingleFileBackup(ctx, record, objectStore); err != nil {
 		record.RestoreStatus = "failed"
 		record.RestoreError = fmt.Sprintf("pg restore: %v", err)
 		_ = s.saveRecord(context.Background(), record)
@@ -1061,7 +1031,7 @@ func (s *BackupService) downloadBackupParts(ctx context.Context, objectStore Bac
 	ordered := append([]BackupPart(nil), parts...)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Index < ordered[j].Index })
 	for i, part := range ordered {
-		if part.Index != i+1 || part.S3Key == "" || part.SizeBytes <= 0 {
+		if part.Index != i+1 || part.S3Key == "" || part.SizeBytes <= 0 || part.SHA256 == "" {
 			return "", fmt.Errorf("invalid backup part metadata at index %d", i+1)
 		}
 	}
@@ -1097,7 +1067,7 @@ func (s *BackupService) downloadBackupParts(ctx context.Context, objectStore Bac
 			cleanup()
 			return "", fmt.Errorf("backup part %d size mismatch: got %d, want %d", part.Index, written, part.SizeBytes)
 		}
-		if part.SHA256 != "" && !strings.EqualFold(part.SHA256, hex.EncodeToString(hash.Sum(nil))) {
+		if !strings.EqualFold(part.SHA256, hex.EncodeToString(hash.Sum(nil))) {
 			cleanup()
 			return "", fmt.Errorf("backup part %d checksum mismatch", part.Index)
 		}
@@ -1125,6 +1095,43 @@ func (s *BackupService) restoreArchive(ctx context.Context, archivePath string) 
 		return fmt.Errorf("pg restore: %w", err)
 	}
 	return nil
+}
+
+// restoreSingleFileBackup 下载单文件备份并恢复。
+// 仅恢复带 SHA256 校验值的新记录，避免对象存储内容被替换后直接执行。
+func (s *BackupService) restoreSingleFileBackup(ctx context.Context, record *BackupRecord, objectStore BackupObjectStore) error {
+	if record.SHA256 == "" {
+		return errors.New("backup integrity metadata is missing; legacy backup cannot be restored automatically")
+	}
+	body, err := objectStore.Download(ctx, record.S3Key)
+	if err != nil {
+		return fmt.Errorf("S3 download failed: %w", err)
+	}
+	defer func() { _ = body.Close() }()
+	return s.restoreSingleFileBody(ctx, record, body)
+}
+
+// restoreSingleFileBody 处理已下载的单文件备份流，校验通过后再恢复。
+func (s *BackupService) restoreSingleFileBody(ctx context.Context, record *BackupRecord, body io.Reader) error {
+	tmp, err := os.CreateTemp("", "sub2api-restore-*.sql.gz")
+	if err != nil {
+		return fmt.Errorf("create restore temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = cleanupBackupFiles(tmpPath) }()
+
+	hash := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hash), body); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("download backup: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close restore temp file: %w", err)
+	}
+	if !strings.EqualFold(record.SHA256, hex.EncodeToString(hash.Sum(nil))) {
+		return fmt.Errorf("backup checksum mismatch: stored SHA256 does not match downloaded object")
+	}
+	return s.restoreArchive(ctx, tmpPath)
 }
 
 // ─── 备份记录管理 ───

--- a/backend/internal/service/backup_service_test.go
+++ b/backend/internal/service/backup_service_test.go
@@ -700,6 +700,68 @@ func TestBackupService_RestoreBackup_Streaming(t *testing.T) {
 	require.Equal(t, dumpContent, string(dumper.restored))
 }
 
+func TestBackupService_SingleFileBackupRecordsSHA256(t *testing.T) {
+	repo := newMockSettingRepo()
+	seedS3Config(t, repo)
+
+	dumpContent := "-- dump\nCOPY t FROM stdin;\n1\n\\.\n"
+	dumper := &mockDumper{dumpData: []byte(dumpContent)}
+	store := newMockObjectStore()
+	svc := newTestBackupService(repo, dumper, store)
+
+	record, err := svc.CreateBackup(context.Background(), "manual", 14)
+	require.NoError(t, err)
+	require.Empty(t, record.Parts)
+	require.NotEmpty(t, record.SHA256)
+
+	want := fmt.Sprintf("%x", sha256.Sum256(store.objects[record.S3Key]))
+	require.Equal(t, want, record.SHA256)
+
+	// 落库记录同样携带校验值
+	stored, err := svc.GetBackupRecord(context.Background(), record.ID)
+	require.NoError(t, err)
+	require.Equal(t, want, stored.SHA256)
+}
+
+func TestBackupService_RestoreSingleFileSHA256MismatchFails(t *testing.T) {
+	repo := newMockSettingRepo()
+	seedS3Config(t, repo)
+
+	dumper := &mockDumper{dumpData: []byte("-- dump\nSELECT 1;\n")}
+	store := newMockObjectStore()
+	svc := newTestBackupService(repo, dumper, store)
+
+	record, err := svc.CreateBackup(context.Background(), "manual", 14)
+	require.NoError(t, err)
+
+	// 篡改对象存储内容（模拟 bucket 写权限攻击者）
+	store.mu.Lock()
+	store.objects[record.S3Key] = gzipBackupBytes(t, []byte("SELECT 1;\n\\! touch /tmp/pwned\n"))
+	store.mu.Unlock()
+
+	err = svc.RestoreBackup(context.Background(), record.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "checksum mismatch")
+	require.Empty(t, dumper.restored)
+}
+
+func TestBackupService_RestoreLegacyRecordWithoutSHA256Fails(t *testing.T) {
+	repo := newMockSettingRepo()
+	seedS3Config(t, repo)
+
+	dumper := &mockDumper{}
+	store := newMockObjectStore()
+	svc := newTestBackupService(repo, dumper, store)
+
+	record := &BackupRecord{ID: "legacy-1", Status: "completed", S3Key: "backups/legacy.sql.gz"}
+	require.NoError(t, svc.saveRecord(context.Background(), record))
+
+	err := svc.RestoreBackup(context.Background(), record.ID)
+	require.ErrorContains(t, err, "integrity metadata is missing")
+	require.Empty(t, dumper.restored)
+	require.Empty(t, store.objects)
+}
+
 func TestBackupService_RestoreBackup_SplitParts(t *testing.T) {
 	repo := newMockSettingRepo()
 	seedS3Config(t, repo)
@@ -770,8 +832,13 @@ func TestBackupService_DownloadBackupPartsRejectsMismatchedMetadata(t *testing.T
 	}{
 		{
 			name: "size",
-			part: BackupPart{Index: 1, S3Key: "backups/mismatch/size", SizeBytes: 4},
+			part: BackupPart{Index: 1, S3Key: "backups/mismatch/size", SizeBytes: 4, SHA256: fmt.Sprintf("%x", sha256.Sum256([]byte("abc")))},
 			want: "size mismatch",
+		},
+		{
+			name: "missing checksum",
+			part: BackupPart{Index: 1, S3Key: "backups/mismatch/missing", SizeBytes: 3},
+			want: "invalid backup part metadata",
 		},
 		{
 			name: "checksum",


### PR DESCRIPTION
## 安全修复（条件性 RCE）

备份对象此前在恢复前缺少完整性验证。具备对象存储写权限的攻击者可替换备份内容；当管理员随后执行恢复时，恶意 `psql` 元命令可能以应用进程权限执行主机命令。

攻击需要同时满足以下前提：攻击者能够修改对象存储中的备份，且管理员之后主动触发该备份的恢复。恢复入口本身仍要求管理员认证、step-up 2FA 和密码复验。

本 PR 在备份时记录 SHA256，并在启动 `psql` 前完成下载与校验，从对象完整性边界切断这条利用链。

## 变更说明

- 单文件备份上传前记录压缩归档的 SHA256
- 单文件恢复前先下载到临时文件并校验 SHA256，校验失败时不启动 `psql`
- 分卷恢复要求每个分卷都有 SHA256，并保持逐卷校验
- 移除复杂的 SQL/COPY 词法守卫，将修复范围收敛到对象完整性边界

## 兼容性注意事项（Breaking）

升级前已经生成、记录中没有 SHA256 的历史单文件备份，以及缺少分卷 SHA256 的历史分卷备份，将拒绝自动恢复。

升级前数据库中已有的业务数据不受影响：升级后仍可通过原有 `pg_dump` 流程生成带 SHA256 的新备份，并正常恢复。建议升级前保留旧版本恢复能力，或在升级后立即为当前数据库重新创建备份。

没有自动为历史对象回填 SHA256，因为升级后计算摘要只能证明当前对象内容，不能证明该对象此前未被篡改。

## 测试

- `go test -tags unit ./internal/service -run '^TestBackupService_' -count=1`
- 备份/恢复定向用例连续 10 次通过
- 定向 `-race` 测试通过
- `go vet -tags unit ./internal/service` 通过

完整 `internal/service` unit 回归仍有两个与本改动无关的既有失败：

- `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` 偶发超时
- `TestGrokQuotaServiceQueryQuotaFreeFallsBackToGrok45` 期望 3 项、实际 4 项
