### PR TITLE
fix(openai): preserve native compaction when desktop beta header is lost

### DIFF
--- a/backend/internal/handler/openai_gateway_compact_body_signal_test.go
+++ b/backend/internal/handler/openai_gateway_compact_body_signal_test.go
@@ -61,6 +61,19 @@ func TestNormalizeOpenAIResponsesCompactRequest_RemoteV2StaysOnResponses(t *test
 	require.False(t, streamMarkerExists)
 }
 
+func TestNormalizeOpenAIResponsesCompactRequest_HeaderlessDesktopV2StaysOnResponses(t *testing.T) {
+	h := &OpenAIGatewayHandler{}
+	body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`)
+	c := newCompactBodySignalTestContext(t, "/v1/responses", body)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/0.147.0-alpha.6.5 (Mac OS X 15.6; arm64)")
+
+	normalized, ok := h.normalizeOpenAIResponsesCompactRequest(c, zap.NewNop(), body)
+	require.True(t, ok)
+	require.Equal(t, "/v1/responses", c.Request.URL.Path)
+	require.Equal(t, body, normalized)
+	require.False(t, isOpenAIRemoteCompactPath(c))
+}
+
 func TestNormalizeOpenAIResponsesCompactRequest_RemoteV2PathAliasesStayOnResponses(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 	body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"compaction_trigger"}]}`)
@@ -103,6 +116,7 @@ func TestNormalizeOpenAIResponsesCompactRequest_NonRemoteV2BodySignalPromoted(t 
 		name       string
 		body       []byte
 		betaHeader string
+		userAgent  string
 		wantMarked bool
 	}{
 		{
@@ -114,12 +128,25 @@ func TestNormalizeOpenAIResponsesCompactRequest_NonRemoteV2BodySignalPromoted(t 
 			name:       "unrelated_header",
 			body:       []byte(`{"model":"gpt-5.5","stream":true,"input":[{"type":"compaction_trigger"}]}`),
 			betaHeader: "responses_websockets_v2",
+			userAgent:  "Codex Desktop/0.147.0-alpha.6.5",
 			wantMarked: true,
 		},
 		{
 			name:       "wrong_case_header",
 			body:       []byte(`{"model":"gpt-5.5","stream":true,"input":[{"type":"compaction_trigger"}]}`),
 			betaHeader: "REMOTE_COMPACTION_V2",
+			wantMarked: true,
+		},
+		{
+			name:       "desktop_before_remote_v2",
+			body:       []byte(`{"model":"gpt-5.5","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			userAgent:  "Codex Desktop/0.144.0",
+			wantMarked: true,
+		},
+		{
+			name:       "current_cli_without_header",
+			body:       []byte(`{"model":"gpt-5.5","stream":true,"input":[{"type":"compaction_trigger"}]}`),
+			userAgent:  "codex_cli_rs/0.147.0",
 			wantMarked: true,
 		},
 		{
@@ -139,6 +166,9 @@ func TestNormalizeOpenAIResponsesCompactRequest_NonRemoteV2BodySignalPromoted(t 
 			c := newCompactBodySignalTestContext(t, "/v1/responses", tt.body)
 			if tt.betaHeader != "" {
 				c.Request.Header.Set("x-codex-beta-features", tt.betaHeader)
+			}
+			if tt.userAgent != "" {
+				c.Request.Header.Set("User-Agent", tt.userAgent)
 			}
 
 			normalized, ok := h.normalizeOpenAIResponsesCompactRequest(c, zap.NewNop(), tt.body)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	openaiutil "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/securityaudit"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -753,19 +754,38 @@ func isBareOpenAIResponsesPath(c *gin.Context) bool {
 	return strings.HasSuffix(normalizedPath, "/responses")
 }
 
+// Codex 0.144.1 introduced the native remote_compaction_v2 Responses wire.
+const codexDesktopRemoteCompactionV2MinVersion = "0.144.1"
+
+func isCodexDesktopRemoteCompactionV2Request(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	userAgent := strings.TrimSpace(c.GetHeader("User-Agent"))
+	if !strings.HasPrefix(strings.ToLower(userAgent), "codex desktop/") {
+		return false
+	}
+	version, ok := openaiutil.ParseCodexEngineVersion(userAgent)
+	return ok && service.CompareVersions(version, codexDesktopRemoteCompactionV2MinVersion) >= 0
+}
+
 func isOpenAIRemoteCompactionV2Request(c *gin.Context, body []byte) bool {
 	stream, valid := parseOpenAICompatibleStream(body)
 	if !valid || !stream || c == nil || c.Request == nil {
 		return false
 	}
-	for _, header := range c.Request.Header.Values("x-codex-beta-features") {
+	betaHeaders := c.Request.Header.Values("x-codex-beta-features")
+	for _, header := range betaHeaders {
 		for _, feature := range strings.Split(header, ",") {
 			if strings.TrimSpace(feature) == "remote_compaction_v2" {
 				return true
 			}
 		}
 	}
-	return false
+	if len(betaHeaders) > 0 {
+		return false
+	}
+	return isCodexDesktopRemoteCompactionV2Request(c)
 }
 
 // normalizeOpenAIResponsesCompactRequest keeps Codex remote compaction v2 on


### PR DESCRIPTION
## 背景

多级 OpenAI 兼容网关中，前置旧版或定制网关可能丢失 `x-codex-beta-features`。下游 Sub2API 随后会把新版 Codex Desktop 发出的原生 remote compaction v2 请求误判为 legacy body-signal compact，并将：

```text
POST /v1/responses
```

改写为：

```text
POST /v1/responses/compact
```

OpenAI OAuth 上游不支持该旧式接口，最终表现为上游 404、网关 502。

Closes #5586

## 修改

- 保留现有 Beta Header 判定为最高优先级。
- 仅当 Beta Header 整体缺失时，允许 `Codex Desktop >= 0.144.1` 依据官方 UA 版本识别 native remote compaction v2。
- Header 存在但未声明 `remote_compaction_v2` 时不启用兜底。
- Codex CLI、旧版 Desktop、未知客户端继续走现有 `/responses/compact` 兼容链路。
- `stream:false`、缺少 `stream`、无 `compaction_trigger` 和非 Responses 根路径行为不变。

## 回归覆盖

- Header 明确声明的 native v2 保持原路径。
- Header 丢失的新版 Codex Desktop 保持 `/v1/responses` 和原始请求体。
- 无关 Beta Header 不被 Desktop UA 覆盖。
- 旧版 Desktop 和新版 CLI 的无 Header 请求仍提升为 `/responses/compact`。