### PR TITLE
fix(ops): 本地会话屏蔽请求仅落一条 error log，避免中间件双写

### DIFF
--- a/backend/internal/handler/openai_gateway_cyber_test.go
+++ b/backend/internal/handler/openai_gateway_cyber_test.go
@@ -1,9 +1,13 @@
 package handler
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -133,10 +137,107 @@ func TestRejectIfCyberSessionBlocked_FailOpen(t *testing.T) {
 
 	h := &OpenAIGatewayHandler{}
 	require.False(t, h.rejectIfCyberSessionBlocked(c, nil, []byte(`{}`), "gpt-5", cyberBlockFormatResponses), "nil apiKey → pass")
+	require.False(t, service.GetOpsSessionBlocked(c), "pass-through must not set session-block marker")
 
 	h2 := &OpenAIGatewayHandler{gatewayService: nil}
 	key := &service.APIKey{ID: 1}
 	require.False(t, h2.rejectIfCyberSessionBlocked(c, key, []byte(`{}`), "gpt-5", cyberBlockFormatResponses), "nil gateway service → pass")
+	require.False(t, service.GetOpsSessionBlocked(c), "nil gateway service pass-through must not set session-block marker")
+}
+
+// fakeSettingRepo is a minimal SettingRepository stub for the session-block test.
+// Only GetValue is exercised by GetCyberSessionBlockRuntime.
+type fakeSettingRepo struct {
+	vals map[string]string
+}
+
+var _ service.SettingRepository = (*fakeSettingRepo)(nil)
+
+func (r *fakeSettingRepo) Get(_ context.Context, _ string) (*service.Setting, error) {
+	return nil, errors.New("stub")
+}
+func (r *fakeSettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	v, ok := r.vals[key]
+	if !ok {
+		return "", service.ErrSettingNotFound
+	}
+	return v, nil
+}
+func (r *fakeSettingRepo) Set(_ context.Context, _, _ string) error { return nil }
+func (r *fakeSettingRepo) GetMultiple(_ context.Context, _ []string) (map[string]string, error) {
+	return r.vals, nil
+}
+func (r *fakeSettingRepo) SetMultiple(_ context.Context, _ map[string]string) error { return nil }
+func (r *fakeSettingRepo) GetAll(_ context.Context) (map[string]string, error)      { return r.vals, nil }
+func (r *fakeSettingRepo) Delete(_ context.Context, _ string) error                 { return nil }
+
+// fakeBlockCache implements both GatewayCache (no-op stubs) and
+// CyberSessionBlockStore so it can be injected as OpenAIGatewayService.cache.
+type fakeBlockCache struct {
+	blocked bool
+}
+
+var _ service.GatewayCache = (*fakeBlockCache)(nil)
+var _ service.CyberSessionBlockStore = (*fakeBlockCache)(nil)
+
+func (c *fakeBlockCache) GetSessionAccountID(_ context.Context, _ int64, _ string) (int64, error) {
+	return 0, service.ErrStickySessionNotFound
+}
+func (c *fakeBlockCache) SetSessionAccountID(_ context.Context, _ int64, _ string, _ int64, _ time.Duration) error {
+	return nil
+}
+func (c *fakeBlockCache) RefreshSessionTTL(_ context.Context, _ int64, _ string, _ time.Duration) error {
+	return nil
+}
+func (c *fakeBlockCache) DeleteSessionAccountID(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+func (c *fakeBlockCache) SetGrokVideoPendingBilling(_ context.Context, _ string, _ []byte, _ time.Duration) error {
+	return nil
+}
+func (c *fakeBlockCache) GetGrokVideoPendingBilling(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+func (c *fakeBlockCache) ClaimGrokVideoBilled(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}
+func (c *fakeBlockCache) ReleaseGrokVideoBilled(_ context.Context, _ string) error { return nil }
+func (c *fakeBlockCache) SetCyberSessionBlocked(_ context.Context, _ string, _ time.Duration) error {
+	return nil
+}
+func (c *fakeBlockCache) IsCyberSessionBlocked(_ context.Context, _ string) (bool, error) {
+	return c.blocked, nil
+}
+
+// TestRejectIfCyberSessionBlocked_SetsSessionBlockMarker verifies the blocked
+// path marks the gin context so OpsErrorLoggerMiddleware skips its own fallback
+// write (dedup with the explicit enqueueCyberSessionBlockedOpsEntry entry).
+func TestRejectIfCyberSessionBlocked_SetsSessionBlockMarker(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(`{}`))
+	c.Request.Header.Set("session_id", "sess-blocked")
+
+	settingSvc := service.NewSettingService(&fakeSettingRepo{vals: map[string]string{
+		service.SettingKeyCyberSessionBlockEnabled:    "true",
+		service.SettingKeyCyberSessionBlockTTLSeconds: "60",
+	}}, nil)
+
+	h := &OpenAIGatewayHandler{
+		gatewayService: service.NewOpenAIGatewayService(
+			nil, nil, nil, nil, nil, nil,
+			&fakeBlockCache{blocked: true},
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			settingSvc,
+			nil,
+		),
+	}
+	key := &service.APIKey{ID: 1}
+
+	require.False(t, service.GetOpsSessionBlocked(c), "前置：标记未设置")
+	require.True(t, h.rejectIfCyberSessionBlocked(c, key, []byte(`{}`), "gpt-5", cyberBlockFormatResponses), "blocked request must be rejected")
+	require.True(t, service.GetOpsSessionBlocked(c), "blocked request must set session-block marker")
+	require.Equal(t, http.StatusForbidden, c.Writer.Status(), "response must be 403")
 }
 
 // TestRecordCyberPolicyIfMarked_BlockKeyPlumbed verifies the 6th param is

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -3090,6 +3090,9 @@ func (h *OpenAIGatewayHandler) rejectIfCyberSessionBlocked(c *gin.Context, apiKe
 	if !h.gatewayService.IsCyberSessionBlocked(c.Request.Context(), key) {
 		return false
 	}
+	// 标记本地会话屏蔽：OpsErrorLoggerMiddleware 据此跳过自身兜底落库，
+	// 仅保留 enqueueCyberSessionBlockedOpsEntry 的显式条目，避免同 ID 双写。
+	service.MarkOpsSessionBlocked(c)
 	// body-signal compact 心跳可能已把响应头提交为 200（cyber 检查在用户槽位
 	// 长等待之后执行）：以 response.failed 终止事件回传；未提交时停拍后照常
 	// 写 JSON（#3887）。

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1811,8 +1811,10 @@ func shouldSkipOpsErrorLog(ctx context.Context, ops *service.OpsService, message
 	return false
 }
 
-// shouldSkipOpsErrorLogForCyber：cyber_policy 命中的请求由 recordCyberPolicyIfMarked
-// 统一落一条 status=403 的错误请求，故中间件跳过自身落库，避免双写。
+// shouldSkipOpsErrorLogForCyber：两类请求的 ops_error_logs 已由 handler 侧统一落库，
+// 中间件跳过自身兜底落库，避免双写：
+//   - 上游透传 cyber_policy：recordCyberPolicyIfMarked 统一落一条 status=403 的错误请求
+//   - 本地会话屏蔽：enqueueCyberSessionBlockedOpsEntry 显式落一条 cyber_policy_session_blocked
 func shouldSkipOpsErrorLogForCyber(c *gin.Context) bool {
-	return service.GetOpsCyberPolicy(c) != nil
+	return service.GetOpsCyberPolicy(c) != nil || service.GetOpsSessionBlocked(c)
 }

--- a/backend/internal/handler/ops_error_logger_cyber_test.go
+++ b/backend/internal/handler/ops_error_logger_cyber_test.go
@@ -20,3 +20,15 @@ func TestOpsErrorLoggerMiddlewareSkipsCyber(t *testing.T) {
 	require.NotNil(t, service.GetOpsCyberPolicy(c), "前置：mark 已设置")
 	require.True(t, shouldSkipOpsErrorLogForCyber(c), "cyber mark 命中应跳过中间件落库")
 }
+
+// 本地会话屏蔽标记存在时，中间件同样必须跳过自身落库（由
+// enqueueCyberSessionBlockedOpsEntry 显式落 cyber_policy_session_blocked）。
+func TestOpsErrorLoggerMiddlewareSkipsSessionBlock(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	service.MarkOpsSessionBlocked(c)
+
+	require.True(t, service.GetOpsSessionBlocked(c), "前置：session block 标记已设置")
+	require.True(t, shouldSkipOpsErrorLogForCyber(c), "session block 标记命中应跳过中间件落库")
+}

--- a/backend/internal/service/openai_cyber_session_block.go
+++ b/backend/internal/service/openai_cyber_session_block.go
@@ -10,6 +10,33 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// opsSessionBlockedKey 在 gin context 中携带「本地会话屏蔽命中」标记。
+// 由 handler 在 rejectIfCyberSessionBlocked 本地拦截时设置，
+// OpsErrorLoggerMiddleware 据此跳过自身兜底落库，避免与
+// enqueueCyberSessionBlockedOpsEntry 显式落库构成同 ID 双写。
+const opsSessionBlockedKey = "ops_session_blocked"
+
+// MarkOpsSessionBlocked 标记一次本地会话屏蔽（幂等，重复调用覆盖为 true）。
+func MarkOpsSessionBlocked(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(opsSessionBlockedKey, true)
+}
+
+// GetOpsSessionBlocked 返回本地会话屏蔽标记是否命中。
+func GetOpsSessionBlocked(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	if v, ok := c.Get(opsSessionBlockedKey); ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
 // CyberSessionBlockStore 是 cyber 会话屏蔽表的存取接口。
 // repository 层 gatewayCache 附带实现（类型断言探测接入，不改 GatewayCache
 // 共享接口）；测试 stub 不实现时屏蔽能力自动降级关闭。

--- a/backend/internal/service/openai_cyber_session_block_test.go
+++ b/backend/internal/service/openai_cyber_session_block_test.go
@@ -157,6 +157,20 @@ func (c *comboCacheAndStore) IsCyberSessionBlocked(ctx context.Context, key stri
 
 // --- tests ---
 
+// TestMarkGetOpsSessionBlocked verifies the gin-context session-block marker
+// helpers: absent → false, set → visible, nil context is safe.
+func TestMarkGetOpsSessionBlocked(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	require.False(t, GetOpsSessionBlocked(c), "no mark initially")
+
+	MarkOpsSessionBlocked(c)
+	require.True(t, GetOpsSessionBlocked(c), "mark must be visible after set")
+
+	require.False(t, GetOpsSessionBlocked(nil), "nil context → false")
+	require.NotPanics(t, func() { MarkOpsSessionBlocked(nil) }, "nil context mark must not panic")
+}
+
 // TestIsCyberSessionBlocked_EmptyKeyAndNilService covers the fail-open paths:
 // empty key, nil service, store missing → always false / no panic.
 func TestIsCyberSessionBlocked_EmptyKeyAndNilService(t *testing.T) {


### PR DESCRIPTION
## 问题

同一条请求 ID 会落两条 `ops_error_logs`。

- `rejectIfCyberSessionBlocked`（本地会话屏蔽拦截，`openai_gateway_handler.go`）在命中后由 `enqueueCyberSessionBlockedOpsEntry` 显式落一条 `cyber_policy_session_blocked`（`ErrorBody` 带 `session_block_key=...`）。
- 请求返回后 `OpsErrorLoggerMiddleware` 看到 status=403 进入兜底分支再写一条通用日志（不带 `session_block_key`）。
- 中间件防双写开关 `shouldSkipOpsErrorLogForCyber` 只检查 `GetOpsCyberPolicy(c) != nil`，而该标记仅在上游真正返回 `cyber_policy` 时设置；本地会话屏蔽路径从未到达上游，标记为 nil，跳过逻辑不生效 → 双写。
- 补充：compact-SSE 心跳已提交（wire=200）的路径同样双写——`MarkOpsStreamError` 会触发 `logOpsStreamError` 再补记一条。

## 修复

1. service 层新增 gin context 标记 `MarkOpsSessionBlocked` / `GetOpsSessionBlocked`（`openai_cyber_session_block.go`）。
2. `rejectIfCyberSessionBlocked` 在确认命中后、写任何响应前设置该标记（同时覆盖 compact-SSE 与标准路径）。
3. `shouldSkipOpsErrorLogForCyber` 扩展为同时检查会话屏蔽标记，中间件不再兜底落库。

修复后同一请求只保留语义专用条目（`cyber_policy_session_blocked` + `session_block_key`），不影响用户看到的响应。

## 测试

- `TestMarkGetOpsSessionBlocked`（service）
- `TestOpsErrorLoggerMiddlewareSkipsSessionBlock`（handler）
- `TestRejectIfCyberSessionBlocked_SetsSessionBlockMarker`（handler）
- 原有 fail-open 用例补充断言：放行时不设置标记
- `go build ./...`、`go vet`、`internal/handler` 与 `internal/service` 全量单测通过