### PR TITLE
fix(openai): normalize legacy Responses function tool choice

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -561,6 +561,26 @@ func TestChatCompletionsToResponses_LegacyFunctions(t *testing.T) {
 	assert.NotContains(t, tc, "function")
 }
 
+func TestChatCompletionsToResponses_NormalizesChatFunctionToolChoice(t *testing.T) {
+	req := &ChatCompletionsRequest{
+		Model:      "gpt-4o",
+		Messages:   []ChatMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}},
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":"get_weather"}}`),
+		Tools: []ChatTool{{
+			Type: "function",
+			Function: &ChatFunction{
+				Name:       "get_weather",
+				Parameters: json.RawMessage(`{"type":"object"}`),
+			},
+		}},
+	}
+
+	resp, err := ChatCompletionsToResponses(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Tools, 1)
+	assert.JSONEq(t, `{"type":"function","name":"get_weather"}`, string(resp.ToolChoice))
+}
+
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model:       "gpt-4o",

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -82,10 +82,11 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 		out.Tools = convertChatToolsToResponses(req.Tools, req.Functions)
 	}
 
-	// tool_choice: already compatible format — pass through directly.
-	// Legacy function_call needs mapping.
+	// Chat Completions nests a named function choice under "function", while
+	// Responses requires the name at the top level. Responses-native and string
+	// choices are left byte-for-byte unchanged by the normalizer.
 	if len(req.ToolChoice) > 0 {
-		out.ToolChoice = req.ToolChoice
+		out.ToolChoice, _ = NormalizeResponsesFunctionToolChoice(req.ToolChoice)
 	} else if len(req.FunctionCall) > 0 {
 		tc, err := convertChatFunctionCallToToolChoice(req.FunctionCall)
 		if err != nil {

--- a/backend/internal/pkg/apicompat/responses_tool_choice.go
+++ b/backend/internal/pkg/apicompat/responses_tool_choice.go
@@ -1,0 +1,70 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// NormalizeResponsesFunctionToolChoice converts the Chat Completions function
+// choice shape into the Responses API shape:
+//
+//	{"type":"function","function":{"name":"get_weather"}}
+//
+// becomes:
+//
+//	{"type":"function","name":"get_weather"}
+//
+// Responses-native choices and non-function choices are returned byte-for-byte
+// unchanged. Unknown top-level fields are preserved when a legacy choice is
+// normalized so provider-specific extensions are not discarded.
+func NormalizeResponsesFunctionToolChoice(raw json.RawMessage) (json.RawMessage, bool) {
+	var choice map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &choice); err != nil {
+		return raw, false
+	}
+
+	choiceType, ok := responsesToolChoiceString(choice["type"])
+	if !ok || choiceType != "function" {
+		return raw, false
+	}
+	legacyFunction, hasLegacyFunction := choice["function"]
+	if !hasLegacyFunction {
+		return raw, false
+	}
+
+	name, hasName := responsesToolChoiceString(choice["name"])
+	if !hasName || strings.TrimSpace(name) == "" {
+		var function map[string]json.RawMessage
+		if err := json.Unmarshal(legacyFunction, &function); err != nil {
+			return raw, false
+		}
+		name, hasName = responsesToolChoiceString(function["name"])
+		if !hasName || strings.TrimSpace(name) == "" {
+			return raw, false
+		}
+	}
+
+	encodedName, err := json.Marshal(name)
+	if err != nil {
+		return raw, false
+	}
+	choice["name"] = encodedName
+	delete(choice, "function")
+
+	normalized, err := json.Marshal(choice)
+	if err != nil {
+		return raw, false
+	}
+	return normalized, true
+}
+
+func responsesToolChoiceString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}

--- a/backend/internal/pkg/apicompat/responses_tool_choice_test.go
+++ b/backend/internal/pkg/apicompat/responses_tool_choice_test.go
@@ -1,0 +1,68 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeResponsesFunctionToolChoice(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "chat function choice",
+			input:       `{"type":"function","function":{"name":"get_weather"}}`,
+			want:        `{"type":"function","name":"get_weather"}`,
+			wantChanged: true,
+		},
+		{
+			name:        "top-level name wins and extensions survive",
+			input:       `{"type":"function","name":"get_weather","function":{"name":"legacy_name"},"provider_extension":{"enabled":true}}`,
+			want:        `{"type":"function","name":"get_weather","provider_extension":{"enabled":true}}`,
+			wantChanged: true,
+		},
+		{
+			name:  "responses function choice",
+			input: ` {"type":"function","name":"get_weather"} `,
+			want:  ` {"type":"function","name":"get_weather"} `,
+		},
+		{
+			name:  "string choice",
+			input: `"required"`,
+			want:  `"required"`,
+		},
+		{
+			name:  "non-function object choice",
+			input: `{"type":"web_search_preview"}`,
+			want:  `{"type":"web_search_preview"}`,
+		},
+		{
+			name:  "missing legacy name",
+			input: `{"type":"function","function":{}}`,
+			want:  `{"type":"function","function":{}}`,
+		},
+		{
+			name:  "malformed JSON",
+			input: `{"type":"function"`,
+			want:  `{"type":"function"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := json.RawMessage(tt.input)
+			got, changed := NormalizeResponsesFunctionToolChoice(input)
+			require.Equal(t, tt.wantChanged, changed)
+			if tt.wantChanged {
+				require.JSONEq(t, tt.want, string(got))
+				return
+			}
+			require.Equal(t, tt.want, string(got), "unchanged choices must retain their original bytes")
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -47,6 +47,16 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if normalized {
 		body = normalizedBody
 	}
+	// Responses requires a forced function name at the top level of tool_choice,
+	// but some Chat-compatible clients send it under function.name. Normalize at
+	// the common ingress before passthrough and account-specific transforms split.
+	normalizedBody, normalized, err = normalizeOpenAIResponsesFunctionToolChoiceBody(body)
+	if err != nil {
+		return nil, err
+	}
+	if normalized {
+		body = normalizedBody
+	}
 	// 在分流到 passthrough / Codex transform / 原生 ChatCompletions 之前统一修正
 	// 显式为 null 的工具 Schema type，否则 upstream 的 400 会被归一成可重试的 502，
 	// 同一份坏定义在账号池里反复重放。

--- a/backend/internal/service/openai_responses_tool_choice.go
+++ b/backend/internal/service/openai_responses_tool_choice.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// normalizeOpenAIResponsesFunctionToolChoiceBody accepts the Chat Completions
+// function-choice shape on the Responses ingress. The patch is deliberately
+// applied before account-specific routing so API-key, passthrough, OAuth, and
+// websocket Responses upstreams receive the same canonical shape.
+func normalizeOpenAIResponsesFunctionToolChoiceBody(body []byte) ([]byte, bool, error) {
+	if len(body) == 0 {
+		return body, false, nil
+	}
+
+	toolChoice := gjson.GetBytes(body, "tool_choice")
+	if !toolChoice.Exists() {
+		return body, false, nil
+	}
+	normalized, changed := apicompat.NormalizeResponsesFunctionToolChoice(json.RawMessage(toolChoice.Raw))
+	if !changed {
+		return body, false, nil
+	}
+
+	patched, err := sjson.SetRawBytes(body, "tool_choice", normalized)
+	if err != nil {
+		return body, false, fmt.Errorf("set normalized Responses tool_choice: %w", err)
+	}
+	return patched, true, nil
+}

--- a/backend/internal/service/openai_responses_tool_choice_test.go
+++ b/backend/internal/service/openai_responses_tool_choice_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIGatewayService_NormalizesResponsesFunctionToolChoiceForAPIKeyUpstreams(t *testing.T) {
+	tests := []struct {
+		name        string
+		passthrough bool
+	}{
+		{name: "standard forwarding"},
+		{name: "passthrough forwarding", passthrough: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"resp_tool_choice","model":"gpt-5.4","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`,
+				)),
+			}}
+			svc := newOpenAIImageGenerationControlTestService(upstream)
+			c, _ := newOpenAIImageGenerationControlTestContext(true, "compatibility-test/1.0")
+			account := newOpenAIImageGenerationControlTestAccount()
+			if tt.passthrough {
+				account.Extra = map[string]any{"openai_passthrough": true}
+			}
+
+			body := []byte(`{
+				"model":"gpt-5.4",
+				"instructions":"test function tool choice compatibility",
+				"input":"check the weather",
+				"stream":false,
+				"tools":[{"type":"function","name":"get_weather","description":"Get weather","parameters":{"type":"object"}}],
+				"tool_choice":{"type":"function","function":{"name":"get_weather"},"provider_extension":{"enabled":true}}
+			}`)
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.Equal(t, "function", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
+			require.Equal(t, "get_weather", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
+			require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice.function").Exists())
+			require.True(t, gjson.GetBytes(upstream.lastBody, "tool_choice.provider_extension.enabled").Bool())
+			require.Equal(t, "get_weather", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- normalize Chat Completions-style `tool_choice.function.name` at the common Responses ingress before API-key, passthrough, OAuth, and WebSocket routing
- reuse the same compatibility helper in the Chat Completions to Responses bridge
- preserve Responses-native choices byte-for-byte and retain unknown top-level provider extensions when normalization is required
- add regressions for the standard API-key path, API-key passthrough path, protocol bridge, malformed input, and non-function choices

## Why

The Responses API requires a forced function choice as `{"type":"function","name":"..."}`. Some Chat-compatible clients instead send `{"type":"function","function":{"name":"..."}}`. Strict Responses upstreams reject that nested shape, and the gateway can surface the rejection as a retryable upstream error.

This supersedes #5562. That version only changed the Chat-to-Responses bridge; this version is rebased on current `main` and also covers clients that call `/v1/responses` directly.

## Tests

- `go test -tags=unit ./internal/pkg/apicompat -run "TestNormalizeResponsesFunctionToolChoice|TestChatCompletionsToResponses_NormalizesChatFunctionToolChoice" -count=1`
- `go test -tags=unit ./internal/service -run "^TestOpenAIGatewayService_NormalizesResponsesFunctionToolChoiceForAPIKeyUpstreams$" -count=1 -timeout=3m`