### PR TITLE
fix(grok): preserve xhigh reasoning effort for Grok 4.6

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1232,11 +1232,7 @@ func writeGrokModelsList(c *gin.Context, modelIDs []string) {
 		if grokModelSupportsConfigurableReasoning(modelID) {
 			item.SupportsReasoningEffort = true
 			item.ReasoningEffort = "high"
-			item.ReasoningEfforts = []grokReasoningEffortOption{
-				{Value: "low", Label: "Low"},
-				{Value: "medium", Label: "Medium"},
-				{Value: "high", Label: "High", Default: true},
-			}
+			item.ReasoningEfforts = grokAdvertisedReasoningEfforts(modelID)
 		}
 		models = append(models, item)
 	}
@@ -1245,6 +1241,18 @@ func writeGrokModelsList(c *gin.Context, modelIDs []string) {
 		"object": "list",
 		"data":   models,
 	})
+}
+
+func grokAdvertisedReasoningEfforts(modelID string) []grokReasoningEffortOption {
+	opts := []grokReasoningEffortOption{
+		{Value: "low", Label: "Low"},
+		{Value: "medium", Label: "Medium"},
+		{Value: "high", Label: "High", Default: true},
+	}
+	if xai.IsGrok46Model(modelID) {
+		opts = append(opts, grokReasoningEffortOption{Value: "xhigh", Label: "Extra High"})
+	}
+	return opts
 }
 
 func grokModelSupportsConfigurableReasoning(modelID string) bool {

--- a/backend/internal/handler/gateway_models_test.go
+++ b/backend/internal/handler/gateway_models_test.go
@@ -145,6 +145,51 @@ func TestGatewayModels_Grok45AdvertisesReasoningEffortForGrokBuild(t *testing.T)
 	}, model.ReasoningEfforts)
 }
 
+func TestGatewayModels_Grok46AdvertisesXHighReasoningEffort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	groupID := int64(4410)
+	h := newGatewayModelsHandlerForTest(
+		&gatewayModelsAccountRepoStub{
+			byGroup: map[int64][]service.Account{
+				groupID: {
+					{
+						ID:       1,
+						Platform: service.PlatformGrok,
+						Credentials: map[string]any{
+							"model_mapping": map[string]any{"grok-4.6": "grok-4.6"},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		Group: &service.Group{ID: groupID, Platform: service.PlatformGrok},
+	})
+
+	h.Models(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got gatewayModelsResponseForTest
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Data, 1)
+	model := got.Data[0]
+	require.Equal(t, "grok-4.6", model.ID)
+	require.True(t, model.SupportsReasoningEffort)
+	require.Equal(t, "high", model.ReasoningEffort)
+	require.Equal(t, []gatewayReasoningEffortOptionForTest{
+		{Value: "low", Label: "Low"},
+		{Value: "medium", Label: "Medium"},
+		{Value: "high", Label: "High", Default: true},
+		{Value: "xhigh", Label: "Extra High"},
+	}, model.ReasoningEfforts)
+}
+
 func TestGatewayModels_GeminiGroupFiltersMappedModelsByPlatform(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/pkg/xai/models.go
+++ b/backend/internal/pkg/xai/models.go
@@ -223,6 +223,17 @@ func isGrokNativeOrAlias(model string) bool {
 		strings.HasPrefix(model, "composer")
 }
 
+// IsGrok46Model 判断是否 Grok 4.6 系列（含 -latest / 日期后缀 / 厂商前缀）。
+// 对齐 OpenAI 的 isOpenAIGPT56Model：按系列识别，不用主版本号比大小，
+// 避免把 grok-4.20 误判成「比 4.6 更新」。
+func IsGrok46Model(model string) bool {
+	normalized := strings.ToLower(StripGrokProviderPrefix(strings.TrimSpace(model)))
+	if normalized == "grok-4.6" {
+		return true
+	}
+	return strings.HasPrefix(normalized, "grok-4.6-")
+}
+
 // StripGrokProviderPrefix removes common provider prefixes accepted for
 // xAI/Grok models, returning the native model ID.
 func StripGrokProviderPrefix(model string) string {

--- a/backend/internal/pkg/xai/models_test.go
+++ b/backend/internal/pkg/xai/models_test.go
@@ -66,6 +66,23 @@ func TestDefaultModelsIncludesGrok46(t *testing.T) {
 	require.Equal(t, "grok-4.6", ResolveGrokTextResponsesModelID("grok-4.6-latest"))
 }
 
+func TestIsGrok46Model(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsGrok46Model("grok-4.6"))
+	require.True(t, IsGrok46Model("GROK-4.6"))
+	require.True(t, IsGrok46Model("grok-4.6-latest"))
+	require.True(t, IsGrok46Model("xai/grok-4.6"))
+	require.True(t, IsGrok46Model("x-ai/grok-4.6-0309"))
+	require.False(t, IsGrok46Model("grok-4.5"))
+	require.False(t, IsGrok46Model("grok-4.5-latest"))
+	require.False(t, IsGrok46Model("grok"))
+	require.False(t, IsGrok46Model("grok-4.3"))
+	require.False(t, IsGrok46Model("grok-4.60"))
+	require.False(t, IsGrok46Model("grok-4.20-0309-reasoning"))
+	require.False(t, IsGrok46Model("grok-4.20-multi-agent-0309"))
+	require.False(t, IsGrok46Model("grok-build-0.1"))
+}
+
 func TestResolveGrokTextResponsesModelID(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, "grok-4.5", ResolveGrokTextResponsesModelID(""))

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -558,7 +558,7 @@ func normalizeGrokResponsesReasoningEffort(body []byte, upstreamModel string) ([
 		if !value.Exists() {
 			continue
 		}
-		normalized, keep := normalizeGrokReasoningEffortValue(value.String())
+		normalized, keep := normalizeGrokReasoningEffortValue(value.String(), upstreamModel)
 		if !supportsEffort || !keep {
 			out, err = sjson.DeleteBytes(out, field)
 		} else {
@@ -569,7 +569,7 @@ func normalizeGrokResponsesReasoningEffort(body []byte, upstreamModel string) ([
 		}
 	}
 	if camel := gjson.GetBytes(out, "reasoningEffort"); camel.Exists() {
-		normalized, keep := normalizeGrokReasoningEffortValue(camel.String())
+		normalized, keep := normalizeGrokReasoningEffortValue(camel.String(), upstreamModel)
 		out, err = sjson.DeleteBytes(out, "reasoningEffort")
 		if err != nil {
 			return nil, fmt.Errorf("remove Grok reasoningEffort: %w", err)
@@ -595,7 +595,7 @@ func normalizeGrokChatReasoningEffort(body []byte, upstreamModel string) ([]byte
 	if raw == "" {
 		raw = strings.TrimSpace(gjson.GetBytes(body, "reasoningEffort").String())
 	}
-	normalized, keep := normalizeGrokReasoningEffortValue(raw)
+	normalized, keep := normalizeGrokReasoningEffortValue(raw, upstreamModel)
 	keep = keep && grokSupportsReasoningEffort(upstreamModel)
 	out := body
 	var err error
@@ -615,7 +615,7 @@ func normalizeGrokChatReasoningEffort(body []byte, upstreamModel string) ([]byte
 	return out, err
 }
 
-func normalizeGrokReasoningEffortValue(raw string) (string, bool) {
+func normalizeGrokReasoningEffortValue(raw, upstreamModel string) (string, bool) {
 	value := strings.NewReplacer("-", "", "_", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(raw)))
 	switch value {
 	case "none", "low", "medium", "high":
@@ -623,10 +623,19 @@ func normalizeGrokReasoningEffortValue(raw string) (string, bool) {
 	case "minimal":
 		return "low", true
 	case "xhigh", "extrahigh", "max", "ultra":
+		// 对齐 GPT-5.6 保留 max：只给当前支持该档位的系列原样/升到官方最高档。
+		// 目前仅 Grok 4.6；4.5 及更早由 xAI 把 xhigh 当成 high。
+		if grokSupportsXHighReasoningEffort(upstreamModel) {
+			return "xhigh", true
+		}
 		return "high", true
 	default:
 		return "", false
 	}
+}
+
+func grokSupportsXHighReasoningEffort(model string) bool {
+	return xai.IsGrok46Model(model)
 }
 
 func grokSupportsReasoningEffort(model string) bool {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -157,18 +157,25 @@ func TestPatchGrokResponsesBodyNormalizesReasoningEffortAliases(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		body string
-		path string
-		want string
+		name          string
+		upstreamModel string
+		body          string
+		path          string
+		want          string
 	}{
-		{name: "minimal nested", body: `{"input":"hi","reasoning":{"effort":"minimal"}}`, path: "reasoning.effort", want: "low"},
-		{name: "xhigh snake", body: `{"input":"hi","reasoning_effort":"xhigh"}`, path: "reasoning_effort", want: "high"},
-		{name: "max camel", body: `{"input":"hi","reasoningEffort":"max"}`, path: "reasoning_effort", want: "high"},
+		{name: "minimal nested", upstreamModel: "grok-4.5", body: `{"input":"hi","reasoning":{"effort":"minimal"}}`, path: "reasoning.effort", want: "low"},
+		{name: "4.5 xhigh snake", upstreamModel: "grok-4.5", body: `{"input":"hi","reasoning_effort":"xhigh"}`, path: "reasoning_effort", want: "high"},
+		{name: "4.5 max camel", upstreamModel: "grok-4.5", body: `{"input":"hi","reasoningEffort":"max"}`, path: "reasoning_effort", want: "high"},
+		{name: "4.3 ultra", upstreamModel: "grok-4.3", body: `{"input":"hi","reasoning_effort":"ultra"}`, path: "reasoning_effort", want: "high"},
+		{name: "4.6 keeps xhigh", upstreamModel: "grok-4.6", body: `{"input":"hi","reasoning_effort":"xhigh"}`, path: "reasoning_effort", want: "xhigh"},
+		{name: "4.6 nested xhigh", upstreamModel: "grok-4.6", body: `{"input":"hi","reasoning":{"effort":"xhigh"}}`, path: "reasoning.effort", want: "xhigh"},
+		{name: "4.6 max becomes xhigh", upstreamModel: "grok-4.6", body: `{"input":"hi","reasoningEffort":"max"}`, path: "reasoning_effort", want: "xhigh"},
+		{name: "4.6-latest keeps xhigh", upstreamModel: "grok-4.6-latest", body: `{"input":"hi","reasoning_effort":"xhigh"}`, path: "reasoning_effort", want: "xhigh"},
+		{name: "prefixed 4.6 keeps xhigh", upstreamModel: "xai/grok-4.6", body: `{"input":"hi","reasoning_effort":"xhigh"}`, path: "reasoning_effort", want: "xhigh"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			patched, err := patchGrokResponsesBody([]byte(tt.body), "grok-4.5")
+			patched, err := patchGrokResponsesBody([]byte(tt.body), tt.upstreamModel)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, gjson.GetBytes(patched, tt.path).String(), string(patched))
 			require.False(t, gjson.GetBytes(patched, "reasoningEffort").Exists())
@@ -193,6 +200,10 @@ func TestNormalizeGrokChatReasoningEffort(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "high", gjson.GetBytes(patched, "reasoning_effort").String())
 	require.False(t, gjson.GetBytes(patched, "reasoningEffort").Exists())
+
+	patched, err = normalizeGrokChatReasoningEffort([]byte(`{"reasoning_effort":"xhigh"}`), "grok-4.6")
+	require.NoError(t, err)
+	require.Equal(t, "xhigh", gjson.GetBytes(patched, "reasoning_effort").String())
 
 	patched, err = normalizeGrokChatReasoningEffort([]byte(`{"reasoning_effort":"high"}`), "grok-composer-2.5-fast")
 	require.NoError(t, err)


### PR DESCRIPTION
## 背景

xAI 文档写明 grok-4.6 起支持 `reasoning_effort=xhigh`；grok-4.5 及更早把 xhigh 当成 high。
Grok Build / 兼容客户端会发 xhigh，但网关出站前一律收到 high。

## 问题

`normalizeGrokReasoningEffortValue` 不看模型，把 xhigh/max/ultra 全部变成 high。
grok-4.6 的 xhigh 到不了上游。usage_logs 记的也是改写后的 high。

## 修复

- 增加 `xai.IsGrok46Model`，按系列识别（`grok-4.6` / `grok-4.6-*` / 厂商前缀），对齐 `isOpenAIGPT56Model`
- 不用版本号 >= 4.6，避免 grok-4.20 被误判
- 仅 4.6 系列：xhigh/max/ultra → 出站 xhigh
- 4.5 / 4.3 等：仍收到 high
- `/v1/models` 仅给 4.6 系列多列出 xhigh，默认仍是 high

## 范围

本 PR 只改 Grok 出站 effort 归一和 models 列表广告。

本 PR 不改变：

- OpenAI / Claude / GPT-5.6 max 路径
- Composer / grok-build-0.1 删除 effort 的行为
- 分组 `max_reasoning_effort` 封顶策略

## 测试

新增/扩展：

- `IsGrok46Model` 正反例（含 4.20、4.60、前缀）
- 4.5 xhigh→high；4.6 保留 xhigh；4.6 max→xhigh
- Chat Completions 路径同样
- `/v1/models` 4.6 列出 xhigh，4.5 不列出

验证：

```
cd backend
go test -tags=unit ./internal/pkg/xai ./internal/service ./internal/handler -count=1
```

本机无 Go 1.26.5，单测交 CI。