### PR TITLE
fix(antigravity): use official daily endpoint

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -54,7 +54,7 @@ const (
 
 	// Antigravity API 端点
 	antigravityProdBaseURL  = "https://cloudcode-pa.googleapis.com"
-	antigravityDailyBaseURL = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravityDailyBaseURL = "https://daily-cloudcode-pa.googleapis.com"
 )
 
 var userAgentVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -94,6 +94,9 @@ func TestForwardBaseURLs_Daily优先(t *testing.T) {
 	if len(urls) == 0 {
 		t.Fatal("ForwardBaseURLs 返回空列表")
 	}
+	if antigravityDailyBaseURL != "https://daily-cloudcode-pa.googleapis.com" {
+		t.Fatalf("daily URL 未与官方客户端对齐: got %s", antigravityDailyBaseURL)
+	}
 
 	// daily URL 应排在第一位
 	if urls[0] != antigravityDailyBaseURL {


### PR DESCRIPTION
## Summary

- replace the legacy `daily-cloudcode-pa.sandbox.googleapis.com` host with the current official Antigravity daily endpoint
- add regression coverage so the daily endpoint cannot silently drift back to the sandbox hostname
- keep endpoint-selection behavior unchanged; explicit `GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily` continues to select `BaseURLs[1]`

## Context

The current Antigravity desktop client sends model and quota requests to `daily-cloudcode-pa.googleapis.com`. With a Google AI Pro (`g1-pro-tier`) OAuth account that still had available quota, requests routed to the prod endpoint returned `429 RESOURCE_EXHAUSTED`, while the official daily endpoint returned successful inference.

This is the narrow hostname-alignment part of #5611 and complements #5612, which changes endpoint selection for paid accounts. It overlaps the one-line fix in #2300 but also adds a regression assertion and validation against current v0.1.176 behavior.

## Test plan

- [x] `go test ./internal/pkg/antigravity`
- [x] build a Linux/ARM64 v0.1.176 server with this patch
- [x] deploy with `GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily` and Antigravity UA 2.1.4
- [x] verify `gemini-2.5-flash` through the public gateway returns HTTP 200 instead of 429

Related to #5611, #5537, #2300, and #5612.