### PR TITLE
fix(apicompat): omit empty tool name on streamed arguments deltas

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions_tool_name_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions_tool_name_test.go
@@ -1,0 +1,44 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponsesEventToChatChunks_ArgumentsDeltaOmitsEmptyName pins that
+// streamed arguments-only deltas never re-emit the tool name as an empty
+// string. OpenAI-compatible clients accumulate the name from the first
+// tool-call delta; a trailing "name":"" would overwrite the accumulated name
+// and break tool dispatch ("unknown tool").
+func TestResponsesEventToChatChunks_ArgumentsDeltaOmitsEmptyName(t *testing.T) {
+	state := NewResponsesEventToChatState()
+
+	added := ResponsesEventToChatChunks(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_a",
+			Name:   "exec",
+		},
+	}, state)
+	require.Len(t, added, 1)
+	first, err := json.Marshal(added[0])
+	require.NoError(t, err)
+	require.Contains(t, string(first), `"name":"exec"`)
+
+	for _, fragment := range []string{`{"cmd":"ls"}`, `{"cmd":"ls","flags":"-la"}`} {
+		deltas := ResponsesEventToChatChunks(&ResponsesStreamEvent{
+			Type:        "response.function_call_arguments.delta",
+			OutputIndex: 0,
+			Delta:       fragment,
+		}, state)
+		require.Len(t, deltas, 1)
+		raw, err := json.Marshal(deltas[0])
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), `"name"`, "arguments delta must not carry a name field")
+		require.Contains(t, string(raw), `"arguments"`)
+	}
+}

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -714,7 +714,9 @@ type ChatToolCall struct {
 
 // ChatFunctionCall contains the function name and arguments.
 type ChatFunctionCall struct {
-	Name      string `json:"name"`
+	// Empty name is omitted so streamed arguments-only deltas never overwrite
+	// the tool name a client accumulated from the first delta.
+	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments"`
 }
 


### PR DESCRIPTION
Closes #5631

## 问题

`/v1/chat/completions` 流式响应中，`responses → chat` 转换器在每个 `function_call_arguments.delta` 里重复输出 `"name":""`（`ChatFunctionCall.Name` 缺少 `omitempty`）。OpenAI 兼容客户端从首个 delta 累积工具名，空串把名字覆盖，导致工具调用失败（`Error: unknown tool ""`）；空名历史还会让下一轮被上游拒绝（`missing field 'name'`）。

## 改动

`backend/internal/pkg/apicompat/types.go`：`ChatFunctionCall.Name` 改为 `json:"name,omitempty"` —— 只有空名被省略，正常名字照常输出；参数增量不再携带 name 字段，与 OpenAI/上游原生流式行为一致。

新增回归测试 `responses_to_chatcompletions_tool_name_test.go`：
- 首个 `output_item.added` delta 保留 `"name":"exec"`；
- 后续 `function_call_arguments.delta` 的 JSON **不包含** `"name"` 字段。

## 验证

- 修复前新测试失败（`"name":""` 出现在参数增量中），修复后通过。
- `go test ./internal/pkg/apicompat/...` ✅
- `go test ./internal/handler/ -run 'Chat|Responses|Stream'` ✅
- 线上复现消除：流式 31 个 delta 仅首个带 `name`；`/v1/responses` 客户端（Codex）路径不受影响（未触碰账户路由）。

## 影响面

仅影响流式 responses→chat 回程中"名字为空"的序列化；所有构造点中名字非空的场景输出逐字节不变。
