### PR TITLE
feat: persist used proxy_id on usage_logs

### DIFF
--- a/backend/internal/repository/usage_log_proxy_id_unit_test.go
+++ b/backend/internal/repository/usage_log_proxy_id_unit_test.go
@@ -1,0 +1,73 @@
+//go:build unit
+
+package repository
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func newProxyIDUsageLog(proxyID *int64) *service.UsageLog {
+	return &service.UsageLog{
+		UserID:       1,
+		APIKeyID:     2,
+		AccountID:    3,
+		RequestID:    "req-proxy-id",
+		Model:        "claude-3",
+		InputTokens:  10,
+		OutputTokens: 5,
+		TotalCost:    1.0,
+		ActualCost:   1.0,
+		ProxyID:      proxyID,
+		CreatedAt:    time.Now().UTC(),
+	}
+}
+
+func TestPrepareUsageLogInsert_ProxyIDArgWiring(t *testing.T) {
+	require.Len(t, usageLogInsertArgTypes, 60, "arg-type table must include proxy_id")
+	require.Equal(t, "bigint", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-2],
+		"proxy_id arg type must be bigint")
+
+	proxyID := int64(42)
+	prepared := prepareUsageLogInsert(newProxyIDUsageLog(&proxyID))
+	require.Len(t, prepared.args, len(usageLogInsertArgTypes))
+
+	proxyArg := prepared.args[len(prepared.args)-2]
+	ni, ok := proxyArg.(sql.NullInt64)
+	require.True(t, ok, "proxy_id arg should be a sql.NullInt64, got %T", proxyArg)
+	require.True(t, ni.Valid)
+	require.Equal(t, proxyID, ni.Int64)
+}
+
+func TestPrepareUsageLogInsert_ProxyIDNullWhenAbsent(t *testing.T) {
+	prepared := prepareUsageLogInsert(newProxyIDUsageLog(nil))
+	proxyArg := prepared.args[len(prepared.args)-2]
+	ni, ok := proxyArg.(sql.NullInt64)
+	require.True(t, ok, "proxy_id arg should be a sql.NullInt64, got %T", proxyArg)
+	require.False(t, ni.Valid, "absent proxy id must be NULL")
+}
+
+func TestUsageLogInsertQueries_IncludeProxyID(t *testing.T) {
+	require.Contains(t, usageLogSelectColumns, "proxy_id",
+		"SELECT column list must include proxy_id")
+
+	proxyID := int64(7)
+	log := newProxyIDUsageLog(&proxyID)
+	prepared := prepareUsageLogInsert(log)
+	key := usageLogBatchKey(log.RequestID, log.APIKeyID)
+
+	batchQuery, batchArgs := buildUsageLogBatchInsertQuery([]string{key},
+		map[string]usageLogInsertPrepared{key: prepared})
+	require.Contains(t, batchQuery, "proxy_id")
+	require.GreaterOrEqual(t, strings.Count(batchQuery, "proxy_id"), 3)
+	require.Len(t, batchArgs, len(prepared.args)+1)
+
+	bestEffortQuery, bestEffortArgs := buildUsageLogBestEffortInsertQuery([]usageLogInsertPrepared{prepared})
+	require.Contains(t, bestEffortQuery, "proxy_id")
+	require.Len(t, bestEffortArgs, len(prepared.args))
+}

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -82,6 +82,7 @@ var usageLogInsertArgTypes = [...]string{
 	"text",        // billing_mode
 	"numeric",     // account_stats_cost
 	"text",        // session_id
+	"bigint",      // proxy_id
 	"timestamptz", // created_at
 }
 
@@ -280,6 +281,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9,
@@ -287,7 +289,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -737,12 +739,12 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		) AS (VALUES `)
 
-	// Each batch row prepends the synthetic input_index before the 59
-	// usage-log column values.
-	args := make([]any, 0, len(keys)*60)
+	// Each batch row prepends the synthetic input_index before the usage-log column values.
+	args := make([]any, 0, len(keys)*(len(usageLogInsertArgTypes)+1))
 	argPos := 1
 	for idx, key := range keys {
 		if idx > 0 {
@@ -829,6 +831,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				billing_mode,
 				account_stats_cost,
 				session_id,
+				proxy_id,
 				created_at
 			)
 			SELECT
@@ -890,6 +893,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				billing_mode,
 				account_stats_cost,
 				session_id,
+				proxy_id,
 				created_at
 			FROM input
 			ON CONFLICT (request_id, api_key_id) DO NOTHING
@@ -991,10 +995,11 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		) AS (VALUES `)
 
-	args := make([]any, 0, len(preparedList)*59)
+	args := make([]any, 0, len(preparedList)*len(usageLogInsertArgTypes))
 	argPos := 1
 	for idx, prepared := range preparedList {
 		if idx > 0 {
@@ -1078,6 +1083,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		)
 		SELECT
@@ -1139,6 +1145,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		FROM input
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
@@ -1208,6 +1215,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			proxy_id,
 			created_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9,
@@ -1215,7 +1223,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 	`, prepared.args...)
@@ -1257,6 +1265,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 	billingTier := nullString(log.BillingTier)
 	billingMode := nullString(log.BillingMode)
 	sessionID := nullString(log.SessionID)
+	proxyID := nullInt64(log.ProxyID)
 	requestedModel := strings.TrimSpace(log.RequestedModel)
 	if requestedModel == "" {
 		requestedModel = strings.TrimSpace(log.Model)
@@ -1334,6 +1343,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			billingMode,
 			log.AccountStatsCost, // account_stats_cost
 			sessionID,            // session_id
+			proxyID,              // proxy_id
 			createdAt,
 		},
 	}

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, proxy_id, created_at"
 
 func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *service.UsageLog, err error) {
 	query := "SELECT " + usageLogSelectColumns + " FROM usage_logs WHERE id = $1"
@@ -498,6 +498,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		billingMode               sql.NullString
 		accountStatsCost          sql.NullFloat64
 		sessionID                 sql.NullString
+		proxyID                   sql.NullInt64
 		createdAt                 time.Time
 	)
 
@@ -561,6 +562,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&billingMode,
 		&accountStatsCost,
 		&sessionID,
+		&proxyID,
 		&createdAt,
 	); err != nil {
 		return nil, err
@@ -690,6 +692,10 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	}
 	if sessionID.Valid {
 		log.SessionID = &sessionID.String
+	}
+	if proxyID.Valid {
+		value := proxyID.Int64
+		log.ProxyID = &value
 	}
 
 	return log, nil

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -99,6 +99,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			sqlmock.AnyArg(), // billing_mode
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // session_id
+			sqlmock.AnyArg(), // proxy_id
 			createdAt,
 		).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(99), createdAt))
@@ -191,6 +192,7 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			sqlmock.AnyArg(), // billing_mode
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // session_id
+			sqlmock.AnyArg(), // proxy_id
 			createdAt,
 		).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(100), createdAt))
@@ -852,6 +854,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullFloat64{},
 			sql.NullString{},
+			sql.NullInt64{}, // proxy_id
 			now,
 		}})
 		require.NoError(t, err)
@@ -929,6 +932,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullInt64{},   // proxy_id
 			now,
 		}})
 		require.NoError(t, err)
@@ -989,6 +993,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullInt64{},   // proxy_id
 			now,
 		}})
 		require.NoError(t, err)
@@ -1049,6 +1054,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullInt64{},   // proxy_id
 			now,
 		}})
 		require.NoError(t, err)

--- a/backend/internal/repository/usage_log_session_id_unit_test.go
+++ b/backend/internal/repository/usage_log_session_id_unit_test.go
@@ -30,9 +30,9 @@ func newSessionIDUsageLog(sessionID *string) *service.UsageLog {
 
 // TestPrepareUsageLogInsert_SessionIDArgWiring pins the session_id column to the
 // arg slice / arg-type table so the five INSERT column lists stay in sync. session_id
-// is the penultimate arg (created_at is always last).
+// is the third-to-last arg (proxy_id then created_at follow it).
 func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
-	require.Len(t, usageLogInsertArgTypes, 59, "arg-type table must include session_id")
+	require.Len(t, usageLogInsertArgTypes, 60, "arg-type table must include session_id and proxy_id")
 
 	sessionID := "sess-persisted-123"
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(&sessionID))
@@ -40,14 +40,14 @@ func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
 	require.Len(t, prepared.args, len(usageLogInsertArgTypes),
 		"prepared args must match the arg-type table length")
 
-	// created_at is last; session_id is the arg immediately before it.
-	sessionArg := prepared.args[len(prepared.args)-2]
+	// created_at is last; proxy_id is second-to-last; session_id is third-to-last.
+	sessionArg := prepared.args[len(prepared.args)-3]
 	ns, ok := sessionArg.(sql.NullString)
 	require.True(t, ok, "session_id arg should be a sql.NullString, got %T", sessionArg)
 	require.True(t, ns.Valid)
 	require.Equal(t, sessionID, ns.String)
 
-	require.Equal(t, "text", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-2],
+	require.Equal(t, "text", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-3],
 		"session_id arg type must be text")
 }
 
@@ -55,14 +55,14 @@ func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
 // persisted as SQL NULL rather than an empty string.
 func TestPrepareUsageLogInsert_SessionIDNullWhenAbsent(t *testing.T) {
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(nil))
-	sessionArg := prepared.args[len(prepared.args)-2]
+	sessionArg := prepared.args[len(prepared.args)-3]
 	ns, ok := sessionArg.(sql.NullString)
 	require.True(t, ok, "session_id arg should be a sql.NullString, got %T", sessionArg)
 	require.False(t, ns.Valid, "absent session id must be NULL, not empty string")
 
 	empty := ""
 	preparedEmpty := prepareUsageLogInsert(newSessionIDUsageLog(&empty))
-	nsEmpty := preparedEmpty.args[len(preparedEmpty.args)-2].(sql.NullString)
+	nsEmpty := preparedEmpty.args[len(preparedEmpty.args)-3].(sql.NullString)
 	require.False(t, nsEmpty.Valid, "empty session id must also be NULL")
 }
 

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -1241,6 +1241,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		ImageSizeBreakdown:    result.ImageSizeBreakdown,
 		CacheTTLOverridden:    cacheTTLOverridden,
 		ChannelID:             optionalInt64Ptr(input.ChannelID),
+		ProxyID:               usedProxyID(account),
 		ModelMappingChain:     optionalTrimmedStringPtr(input.ModelMappingChain),
 		UserAgent:             optionalTrimmedStringPtr(input.UserAgent),
 		IPAddress:             optionalTrimmedStringPtr(input.IPAddress),

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -380,6 +380,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	usageLog.CreatedAt = time.Now()
 	// 设置渠道信息
 	usageLog.ChannelID = optionalInt64Ptr(input.ChannelID)
+	usageLog.ProxyID = usedProxyID(account)
 	usageLog.ModelMappingChain = optionalTrimmedStringPtr(input.ModelMappingChain)
 	// 设置计费模式
 	if cost != nil && cost.BillingMode != "" {

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -122,6 +122,10 @@ type UsageLog struct {
 	UpstreamModelMismatch *bool
 	// ChannelID 渠道 ID
 	ChannelID *int64
+	// ProxyID is the proxy actually used for the upstream request.
+	// Nil when the request did not go through a proxy (no proxy bound,
+	// proxy object missing, or custom BaseURL skipped the proxy).
+	ProxyID *int64
 	// ModelMappingChain 模型映射链，如 "a→b→c"
 	ModelMappingChain *string
 	// BillingTier 计费层级标签（per_request/image 模式）

--- a/backend/internal/service/usage_log_helpers.go
+++ b/backend/internal/service/usage_log_helpers.go
@@ -23,3 +23,15 @@ func optionalInt64Ptr(v int64) *int64 {
 	}
 	return &v
 }
+
+// usedProxyID returns the proxy actually used for the upstream request.
+// Matches gateway_forward: skip when custom BaseURL is enabled.
+func usedProxyID(account *Account) *int64 {
+	if account == nil || account.ProxyID == nil || *account.ProxyID == 0 || account.Proxy == nil {
+		return nil
+	}
+	if account.IsCustomBaseURLEnabled() && account.GetCustomBaseURL() != "" {
+		return nil
+	}
+	return account.ProxyID
+}

--- a/backend/internal/service/usage_log_helpers_test.go
+++ b/backend/internal/service/usage_log_helpers_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsedProxyID(t *testing.T) {
+	t.Parallel()
+
+	proxyID := int64(42)
+	zeroID := int64(0)
+	proxy := &Proxy{ID: proxyID, Name: "p"}
+
+	t.Run("nil_account", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, usedProxyID(nil))
+	})
+
+	t.Run("no_proxy", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, usedProxyID(&Account{}))
+	})
+
+	t.Run("proxy_id_without_object", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, usedProxyID(&Account{ProxyID: &proxyID}))
+	})
+
+	t.Run("zero_proxy_id", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, usedProxyID(&Account{ProxyID: &zeroID, Proxy: proxy}))
+	})
+
+	t.Run("uses_bound_proxy", func(t *testing.T) {
+		t.Parallel()
+		got := usedProxyID(&Account{ProxyID: &proxyID, Proxy: proxy})
+		require.NotNil(t, got)
+		require.Equal(t, proxyID, *got)
+	})
+
+	t.Run("skips_custom_base_url", func(t *testing.T) {
+		t.Parallel()
+		got := usedProxyID(&Account{
+			Platform: PlatformAnthropic,
+			Type:     AccountTypeOAuth,
+			ProxyID:  &proxyID,
+			Proxy:    proxy,
+			Extra: map[string]any{
+				"custom_base_url_enabled": true,
+				"custom_base_url":         "https://relay.example",
+			},
+		})
+		require.Nil(t, got)
+	})
+
+	t.Run("keeps_proxy_when_custom_base_url_empty", func(t *testing.T) {
+		t.Parallel()
+		got := usedProxyID(&Account{
+			Platform: PlatformAnthropic,
+			Type:     AccountTypeOAuth,
+			ProxyID:  &proxyID,
+			Proxy:    proxy,
+			Extra: map[string]any{
+				"custom_base_url_enabled": true,
+			},
+		})
+		require.NotNil(t, got)
+		require.Equal(t, proxyID, *got)
+	})
+}

--- a/backend/migrations/222_add_usage_log_proxy_id.sql
+++ b/backend/migrations/222_add_usage_log_proxy_id.sql
@@ -1,0 +1,9 @@
+-- Persist the proxy actually used for the upstream request so usage rows
+-- can be correlated by proxy without joining accounts (whose proxy_id may
+-- have changed since the request).
+--
+-- Nullable with no default: on PostgreSQL 11+ this is a metadata-only change,
+-- so it does NOT rewrite the (potentially large) usage_logs table. Historical
+-- rows and requests that did not go through a proxy stay NULL. No FK: matches
+-- channel_id (proxy may be deleted later; the snapshot id is still useful).
+ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS proxy_id BIGINT;


### PR DESCRIPTION
## 变更概述
usage_logs 落库时记录本次实际上游请求使用的代理 ID，避免事后只能从可能已变更的 `accounts.proxy_id` 反查。

## 行为
- 有代理对象且实际走了代理：写入 `proxy_id`
- 未绑定代理、代理对象缺失、Anthropic 自定义 BaseURL 跳过代理：写 `NULL`
- Live / 批量图结算路径当时拿不到 Account，保持 `NULL`
- 只落库，不改 Admin API / 前端

## 实现
- 迁移 `222_add_usage_log_proxy_id.sql`：可空 `BIGINT`，无 FK / 无索引 / 无历史回填
- `usedProxyID` 对齐 `gateway_forward` 选代理逻辑
- INSERT / SELECT / scan 列序同步为 60 列

## 测试
- `usedProxyID`：有代理、无代理、自定义 BaseURL 跳过
- `prepareUsageLogInsert` / INSERT 查询接线单测