### PR TITLE
fix(apicompat): keep Anthropic web_search from becoming a function_call

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1840,3 +1840,125 @@ func TestMessageStartSSE_StopReasonIsJSONNull(t *testing.T) {
 	require.Contains(t, sse, `"stop_reason":null`)
 	require.NotContains(t, sse, `"stop_reason":""`)
 }
+
+func TestAnthropicToResponses_WebSearchServerToolNoFunctionCall(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"Search the latest Go release"`)},
+			{Role: "assistant", Content: json.RawMessage(`[{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{"query":"Go 1.25 release"}}]`)},
+			{Role: "user", Content: json.RawMessage(`[{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[]}]`)},
+		},
+		Tools: []AnthropicTool{
+			{Type: "web_search_20250305", Name: "web_search"},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.Tools)
+	hosted := 0
+	for _, tool := range resp.Tools {
+		if tool.Type == "function" && tool.Name == "web_search" {
+			t.Fatalf("tools must not declare a function named web_search: %+v", tool)
+		}
+		if tool.Type == "web_search" {
+			hosted++
+		}
+	}
+	require.Equal(t, 1, hosted)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	var calls []ResponsesInputItem
+	for _, item := range items {
+		if item.Type == "function_call" && item.Name == "web_search" {
+			t.Fatalf("history must not replay web_search as function_call: %+v", item)
+		}
+		if item.Type == "function_call_output" && item.CallID == "srvtoolu_1" {
+			t.Fatalf("hosted web_search must not emit function_call_output: %+v", item)
+		}
+		if item.Type == "web_search_call" {
+			calls = append(calls, item)
+		}
+	}
+	require.Len(t, calls, 1)
+	assert.Equal(t, "srvtoolu_1", calls[0].ID)
+}
+
+func TestAnthropicToResponses_WebSearchToolUseHistoryIssue5533(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"what is the weather in tokyo"`)},
+			{Role: "assistant", Content: json.RawMessage(`[{"type":"tool_use","id":"toolu_ws","name":"web_search","input":{"query":"tokyo weather"}}]`)},
+			{Role: "user", Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"toolu_ws","content":"sunny"}]`)},
+		},
+		Tools: []AnthropicTool{
+			{Type: "web_search_20250305", Name: "web_search"},
+			{Name: "get_weather", Description: "Get weather", InputSchema: json.RawMessage(`{"type":"object","properties":{}}`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	for _, tool := range resp.Tools {
+		if tool.Type == "function" && tool.Name == "web_search" {
+			t.Fatalf("must not add function web_search: %+v", tool)
+		}
+	}
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	foundHosted := false
+	for _, item := range items {
+		if item.Type == "function_call" && item.Name == "web_search" {
+			t.Fatalf("issue 5533 regression: function_call named web_search: %+v", item)
+		}
+		if item.Type == "function_call_output" && item.CallID == "toolu_ws" {
+			t.Fatalf("hosted web_search result replayed as function_call_output: %+v", item)
+		}
+		if item.Type == "web_search_call" {
+			foundHosted = true
+			assert.Equal(t, "toolu_ws", item.ID)
+		}
+	}
+	require.True(t, foundHosted)
+}
+
+func TestAnthropicToResponses_CustomWebSearchFunctionPreserved(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 128,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"search docs"`)},
+			{Role: "assistant", Content: json.RawMessage(`[{"type":"tool_use","id":"call_1","name":"web_search","input":{"q":"docs"}}]`)},
+		},
+		Tools: []AnthropicTool{
+			{Name: "web_search", Description: "Search our docs", InputSchema: json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Tools, 1)
+	assert.Equal(t, "function", resp.Tools[0].Type)
+	assert.Equal(t, "web_search", resp.Tools[0].Name)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	foundFn := false
+	for _, item := range items {
+		if item.Type == "function_call" && item.Name == "web_search" {
+			foundFn = true
+		}
+		if item.Type == "web_search_call" {
+			t.Fatalf("custom function named web_search must stay a function_call: %+v", item)
+		}
+	}
+	require.True(t, foundFn)
+}

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -16,14 +16,8 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 		return nil, err
 	}
 
-	inputJSON, err := json.Marshal(input)
-	if err != nil {
-		return nil, err
-	}
-
 	out := &ResponsesRequest{
 		Model:   req.Model,
-		Input:   inputJSON,
 		Stream:  req.Stream,
 		Include: []string{"reasoning.encrypted_content"},
 	}
@@ -54,6 +48,13 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 	if len(req.Tools) > 0 {
 		out.Tools = convertAnthropicToolsToResponses(req.Tools)
 	}
+
+	input = reconcileResponsesWebSearch(out, input)
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	out.Input = inputJSON
 
 	// Determine reasoning effort: only output_config.effort controls the
 	// level; thinking.type is ignored. Default follows Codex CLI / airgate's
@@ -310,8 +311,10 @@ func anthropicAssistantToResponses(raw json.RawMessage) ([]ResponsesInputItem, e
 	}
 
 	// tool_use → function_call items.
+	// server_tool_use / hosted web_search → web_search_call so Codex does not
+	// see a function_call named web_search without a matching function tool.
 	for _, b := range blocks {
-		if b.Type != "tool_use" {
+		if b.Type != "tool_use" && b.Type != "server_tool_use" {
 			continue
 		}
 		args := "{}"
@@ -319,6 +322,16 @@ func anthropicAssistantToResponses(raw json.RawMessage) ([]ResponsesInputItem, e
 			args = string(b.Input)
 		}
 		fcID := toResponsesCallID(b.ID)
+		if b.Type == "server_tool_use" && isAnthropicHostedWebSearchName(b.Name) {
+			items = append(items, ResponsesInputItem{
+				Type:      "web_search_call",
+				ID:        fcID,
+				CallID:    fcID,
+				Name:      b.Name,
+				Arguments: args,
+			})
+			continue
+		}
 		items = append(items, ResponsesInputItem{
 			Type:      "function_call",
 			CallID:    fcID,
@@ -439,6 +452,77 @@ func mapAnthropicEffortToResponses(effort string) string {
 	return effort // low→low, medium→medium, high→high, unknown→passthrough
 }
 
+func isAnthropicHostedWebSearchName(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	return n == "web_search" || strings.HasPrefix(n, "web_search_")
+}
+
+func isAnthropicHostedWebSearchTool(t AnthropicTool) bool {
+	return strings.HasPrefix(t.Type, "web_search")
+}
+
+// reconcileResponsesWebSearch keeps hosted web_search tool calls consistent
+// with the tools list. OpenAI Responses returns 400 if input contains a
+// function_call named web_search but tools has no function with that name
+// (issue #5533: Anthropic server web_search was replayed as a function_call).
+func reconcileResponsesWebSearch(out *ResponsesRequest, input []ResponsesInputItem) []ResponsesInputItem {
+	functionNames := make(map[string]bool)
+	hasHostedWebSearch := false
+	for _, t := range out.Tools {
+		if t.Type == "function" && t.Name != "" {
+			functionNames[t.Name] = true
+		}
+		if t.Type == "web_search" || strings.HasPrefix(t.Type, "web_search") {
+			hasHostedWebSearch = true
+		}
+	}
+
+	hostedCallIDs := make(map[string]bool)
+	next := make([]ResponsesInputItem, 0, len(input))
+	for _, item := range input {
+		if item.Type == "function_call" && isAnthropicHostedWebSearchName(item.Name) && !functionNames[item.Name] {
+			item.Type = "web_search_call"
+			if item.ID == "" {
+				item.ID = item.CallID
+			}
+			hostedCallIDs[item.CallID] = true
+			if item.ID != "" {
+				hostedCallIDs[item.ID] = true
+			}
+			hasHostedWebSearch = true
+			next = append(next, item)
+			continue
+		}
+		if item.Type == "web_search_call" {
+			if item.CallID != "" {
+				hostedCallIDs[item.CallID] = true
+			}
+			if item.ID != "" {
+				hostedCallIDs[item.ID] = true
+			}
+			hasHostedWebSearch = true
+		}
+		if item.Type == "function_call_output" && hostedCallIDs[item.CallID] {
+			continue
+		}
+		next = append(next, item)
+	}
+
+	if hasHostedWebSearch {
+		found := false
+		for _, t := range out.Tools {
+			if t.Type == "web_search" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out.Tools = append(out.Tools, ResponsesTool{Type: "web_search"})
+		}
+	}
+	return next
+}
+
 // convertAnthropicToolsToResponses maps Anthropic tool definitions to
 // Responses API tools. Server-side tools like web_search are mapped to their
 // OpenAI equivalents; regular tools become function tools.
@@ -446,7 +530,7 @@ func convertAnthropicToolsToResponses(tools []AnthropicTool) []ResponsesTool {
 	var out []ResponsesTool
 	for _, t := range tools {
 		// Anthropic server tools like "web_search_20250305" → OpenAI {"type":"web_search"}
-		if strings.HasPrefix(t.Type, "web_search") {
+		if isAnthropicHostedWebSearchTool(t) {
 			out = append(out, ResponsesTool{Type: "web_search"})
 			continue
 		}


### PR DESCRIPTION
## Summary

Fixes the Anthropic `/v1/messages` → OpenAI Codex `/v1/responses` conversion so built-in `web_search` is not replayed as a `function_call` named `web_search`.

That mismatch makes upstream Responses return:

```
Invalid value for 'tool_call': no function named 'web_search' was specified in the 'tools' parameter.
```

## What changed

- Anthropic server tools (`web_search_20250305`, `server_tool_use`) stay hosted `{ "type": "web_search" }` / `web_search_call`.
- If history still has a `function_call` named `web_search` and `tools` has no matching function, rewrite it to `web_search_call` and ensure `tools` includes the hosted web_search tool.
- Drop the matching `function_call_output` (hosted search results are consumed server-side).
- A real client function that is actually named `web_search` is left alone.

This is not the same as #5160 (the opt-in `/v1/alpha/search` bridge).

## Test plan

- [x] Unit tests for server_tool_use, issue #5533 history replay, and a custom function named `web_search`
- [ ] `go test ./backend/internal/pkg/apicompat/ -count=1`

Fixes #5533