### PR TITLE
fix(i18n): add missing expired key to account status block used by proxy list

### DIFF
--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -130,6 +130,7 @@ export default {
       status: {
         active: 'Active',
         inactive: 'Inactive',
+        expired: 'Expired',
         error: 'Error',
         cooldown: 'Cooldown',
         paused: 'Paused',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -333,6 +333,7 @@ export default {
       status: {
         active: '正常',
         inactive: '停用',
+        expired: '已过期',
         error: '错误',
         cooldown: '冷却中',
         paused: '暂停',


### PR DESCRIPTION
## 问题

IP 管理列表代理到期i18n未设置
代理一旦到期,状态列直接渲染裸 key `admin.accounts.status.expired`。

## 修改

增加i18n配置

## 验证
修复前:
<img width="556" height="332" alt="image" src="https://github.com/user-attachments/assets/cb9e0242-7028-4665-b5f6-4d04f8b721b0" />

修复后:
<img width="414" height="330" alt="image" src="https://github.com/user-attachments/assets/f6896b4d-32be-401d-9921-c8e5feb5a265" />
