### PR TITLE
fix(deps): bump nanoid to 3.3.18 to resolve GHSA-2v37-7h3g-55p8

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -3322,8 +3322,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8443,7 +8443,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -8641,7 +8641,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## 问题

CI 的 Security Scan(frontend-security)目前在所有 PR 上失败:`pnpm audit --prod` 报出 nanoid 的 high 级通告 [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)(custom generators can loop indefinitely when size is zero),且该通告不在 `.github/audit-exceptions.yml` 白名单中,`check_pnpm_audit_exceptions.py` 退出 1。

命中的是 postcss 的传递依赖 `nanoid@3.3.17`(< 3.3.18 受影响,3.3.18 已修复)。

## 修改

仅更新 `frontend/pnpm-lock.yaml`:nanoid 3.3.17 → 3.3.18(postcss 的版本范围 `^3.3.16` 允许,无需改 package.json,也无需加审计白名单)。

## 验证

- `pnpm@9 install --frozen-lockfile` 全新安装通过(与 CI 相同的 pnpm 大版本)。
- 本地按 CI 同款命令复跑 `pnpm audit --prod --audit-level=high --json` + `check_pnpm_audit_exceptions.py`,输出 `Audit exceptions validated.`,nanoid 不再出现在审计结果中。
- 前端 vitest i18n 套件冒烟通过。


> 注:本 PR 只修 frontend-security;backend-security 的失败(go1.26.5 标准库漏洞)由 #5639 修复,两个合并后 Security Scan 才会整体转绿。
