### PR TITLE
chore(deps): bump Go to 1.26.6 to fix govulncheck stdlib findings

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.5'
+          go version | grep -q 'go1.26.6'
       - name: Unit tests
         working-directory: backend
         run: make test-unit
@@ -72,7 +72,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.5'
+          go version | grep -q 'go1.26.6'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.5'
+          go version | grep -q 'go1.26.6'
 
       # Docker setup for GoReleaser
       - name: Set up QEMU

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.5'
+          go version | grep -q 'go1.26.6'
       - name: Run govulncheck
         working-directory: backend
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.5-alpine
+ARG GOLANG_IMAGE=golang:1.26.6-alpine
 ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine
+FROM golang:1.26.6-alpine
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.5
+go 1.26.6
 
 require (
 	entgo.io/ent v0.14.5

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.5-alpine
+ARG GOLANG_IMAGE=golang:1.26.6-alpine
 ARG ALPINE_IMAGE=alpine:3.20
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn


### PR DESCRIPTION
## 问题

CI 的 Security Scan(backend-security)目前在所有 PR 上失败:govulncheck 在 go1.26.5 标准库上报出 6 个漏洞,全部标注 `Fixed in: …@go1.26.6`:

| 编号 | 包 |
|---|---|
| GO-2026-6218 | net/url |
| GO-2026-6090 | crypto/tls |
| GO-2026-6089 | net/http |
| GO-2026-6088 | encoding/xml |
| GO-2026-5972 | encoding/asn1 |
| GO-2026-5026 | net/http |

## 修改

Go 1.26.5 → 1.26.6,同步更新仓库内全部 8 处版本 pin:

- `backend/go.mod` 的 `go` 指令
- `Dockerfile` / `deploy/Dockerfile` 的 `GOLANG_IMAGE` ARG、`backend/Dockerfile` 的基础镜像(`golang:1.26.6-alpine` 已在 Docker Hub 发布,已确认)
- `backend-ci.yml`(2 处)、`security-scan.yml`、`release.yml` 的「Verify Go version」grep

## 验证

- `govulncheck ./...`(CI 同款命令)在 1.26.6 下输出 `No vulnerabilities found`,退出码 0。
- `go test -tags=unit ./...` 全部通过。

> 注:本 PR 只修 backend-security;frontend-security 的失败(nanoid 审计通告)由 #5638 修复,两个合并后 Security Scan 才会整体转绿。
