### PR TITLE
feat(antigravity): add Gemini 3.7 Flash model support

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -117,6 +117,12 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"gemini-3.1-flash-image": "gemini-3.1-flash-image",
 	// Gemini 3.1 image preview 映射
 	"gemini-3.1-flash-image-preview": "gemini-3.1-flash-image",
+	// Gemini 3.7 Flash
+	"gemini-3.7-flash": "gemini-3.7-flash",
+	"gemini-3.7-flash-high": "gemini-3.7-flash-high",
+	"gemini-3.7-flash-low": "gemini-3.7-flash-low",
+	"gemini-3.7-flash-medium": "gemini-3.7-flash-medium",
+	"gemini-3.7-flash-tiered": "gemini-3.7-flash-tiered",
 	// Gemini 3.6 Flash tiered models
 	"gemini-3.6-flash":        "gemini-3.6-flash",
 	"gemini-3.6-flash-high":   "gemini-3.6-flash-high",
@@ -160,3 +166,5 @@ var DefaultBedrockModelMapping = map[string]string{
 	"claude-haiku-4-5":          "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 	"claude-haiku-4-5-20251001": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 }
+
+

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -118,9 +118,9 @@ var DefaultAntigravityModelMapping = map[string]string{
 	// Gemini 3.1 image preview 映射
 	"gemini-3.1-flash-image-preview": "gemini-3.1-flash-image",
 	// Gemini 3.7 Flash
-	"gemini-3.7-flash": "gemini-3.7-flash",
-	"gemini-3.7-flash-high": "gemini-3.7-flash-high",
-	"gemini-3.7-flash-low": "gemini-3.7-flash-low",
+	"gemini-3.7-flash":        "gemini-3.7-flash",
+	"gemini-3.7-flash-high":   "gemini-3.7-flash-high",
+	"gemini-3.7-flash-low":    "gemini-3.7-flash-low",
 	"gemini-3.7-flash-medium": "gemini-3.7-flash-medium",
 	"gemini-3.7-flash-tiered": "gemini-3.7-flash-tiered",
 	// Gemini 3.6 Flash tiered models
@@ -166,5 +166,3 @@ var DefaultBedrockModelMapping = map[string]string{
 	"claude-haiku-4-5":          "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 	"claude-haiku-4-5-20251001": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 }
-
-

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -179,6 +179,11 @@ var geminiModels = []modelDef{
 	{ID: "gemini-3.1-flash-image", DisplayName: "Gemini 3.1 Flash Image", CreatedAt: "2026-02-19T00:00:00Z"},
 	{ID: "gemini-3.1-flash-image-preview", DisplayName: "Gemini 3.1 Flash Image Preview", CreatedAt: "2026-02-19T00:00:00Z"},
 	{ID: "gemini-3.6-flash", DisplayName: "Gemini 3.6 Flash", CreatedAt: "2026-07-21T00:00:00Z"},
+	{ID: "gemini-3.7-flash", DisplayName: "Gemini 3.7 Flash", CreatedAt: "2026-08-14T00:00:00Z"},
+	{ID: "gemini-3.7-flash-high", DisplayName: "Gemini 3.7 Flash High", CreatedAt: "2026-08-14T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.7-flash-low", DisplayName: "Gemini 3.7 Flash Low", CreatedAt: "2026-08-14T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.7-flash-medium", DisplayName: "Gemini 3.7 Flash Medium", CreatedAt: "2026-08-14T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.7-flash-tiered", DisplayName: "Gemini 3.7 Flash", CreatedAt: "2026-08-14T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.6-flash-high", DisplayName: "Gemini 3.6 Flash High", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.6-flash-low", DisplayName: "Gemini 3.6 Flash Low", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.6-flash-medium", DisplayName: "Gemini 3.6 Flash Medium", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
@@ -259,3 +264,5 @@ func IsGeminiReasoningModel(modelID string) bool {
 	}
 	return false
 }
+
+

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -264,5 +264,3 @@ func IsGeminiReasoningModel(modelID string) bool {
 	}
 	return false
 }
-
-

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -626,6 +626,11 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 				"gemini-3.1-pro-high",
 				"gemini-3.1-pro-low",
 				"gemini-3.6-flash",
+				"gemini-3.7-flash",
+				"gemini-3.7-flash-high",
+				"gemini-3.7-flash-low",
+				"gemini-3.7-flash-medium",
+				"gemini-3.7-flash-tiered",
 				"gemini-3.6-flash-high",
 				"gemini-3.6-flash-low",
 				"gemini-3.6-flash-medium",
@@ -2888,3 +2893,5 @@ func (a *Account) QuotaDimensionOrDefault() string {
 	}
 	return a.QuotaDimension
 }
+
+

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -2893,5 +2893,3 @@ func (a *Account) QuotaDimensionOrDefault() string {
 	}
 	return a.QuotaDimension
 }
-
-


### PR DESCRIPTION
## 背景

Gemini 3.7 Flash 已于 2026-08-13 发布，官方宣布支持 Antigravity（Google 反重力）。当前 Sub2API 的 Antigravity 模型目录和映射中没有 3.7，请求返回 503 / 404。

## 改动

1. **constants.go**：DefaultAntigravityModelMapping 增加 \gemini-3.7-flash\ 及思考档变体（high/low/medium/tiered）
2. **claude_types.go**：Antigravity geminiModels 列表增加 3.7 Flash 家族（变体标记 IsReasoning）
3. **account.go**：ensureAntigravityDefaultPassthroughs 默认直通列表增加 3.7 系列

## 验证（上游实测）

- g1-pro-tier（Google AI Pro）账号，daily 端点（GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily）下：
  - \gemini-3.7-flash-high\ / \-medium\ / \-low\ / \-tiered\ → **均返回 200**
  - \gemini-3.7-flash\（基础名）→ 404（与 3.6 相同的变体命名体系，基础名不存在）
- 本地测试：\internal/domain\、\internal/pkg/antigravity\、\internal/service\ 全部通过

## 备注

- 3.7 定价已在 model_pricing.json（上游价格仓库）中存在，无需额外处理
- 变体定价复用基础名（与 3.6 的 normalizeGeminiThinkingTierAlias 行为一致）