### PR TITLE
fix(openai): persist model circuit after consecutive failures

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -23,14 +23,14 @@
 - ownership: backend paths declared by the approved Spec
 - worktree/branch: `/Users/admin/code/opensource/sub2api/.worktrees/openai-fallback-only-sticky-backend` / `codex/openai-fallback-only-sticky-backend`
 - worker: `backend_worker`
-- reviewer: `/root/frontend_review`
+- reviewer: `/root/backend_review`
 - started_at: `2026-08-08T10:45:00Z`
-- finished_at: pending
-- verification: pending RED/GREEN and focused tests
-- commit: pending
-- review_findings: pending
-- verdict: pending
-- integration_ancestor: no
+- finished_at: `2026-08-08T15:06:00Z`
+- verification: initial enum compile RED; scheduler behavior GREEN; later race RED proved legacy order `[91002,91001]` instead of `[91002,91003,91001]` and advanced duplicated candidates; final RED proved image-incompatible primary was selected and a primary acquire error terminated selection. Final GREEN=`FallbackOnlySticky|PreviousResponse` 100 tests, focused service/repository/admin handler 8286 tests, broad backend 8539 tests across 105 packages, `git diff --check` exit 0.
+- commit: `d825d366b feat(admin): 支持账号级 OpenAI session sticky fallback 策略`
+- review_findings: reviewer successively blocked non-atomic probe/acquire, weighted sticky bypass, incomplete multi-primary retry, missing image capability filtering, and early return on primary acquire error. Each finding received a failing regression test before the implementation was corrected; `previous_response_id` ordering remained unchanged.
+- verdict: implementation verification `PASS`; independent immutable-tip re-review remains Task 3.
+- integration_ancestor: yes
 
 ## Task 2
 
@@ -48,6 +48,18 @@
 - verdict: `PASS`
 - integration_ancestor: no
 
-## Tasks 3-5
+## Task 3
 
-- status: pending tasks 1 and 2
+- task_id: `3`
+- dependencies: tasks 1 and 2
+- ownership: integration, review, history convergence and local merge Gate
+- worktree/branch: `/Users/admin/code/opensource/sub2api/.worktrees/openai-fallback-only-sticky` / `codex/openai-fallback-only-sticky`
+- started_at: `2026-08-08T14:00:00Z`
+- finished_at: pending local `merge-main`
+- verification: rewritten feature tip=`5d7f211e4`; backend focused 8286 tests PASS; backend broad 8539 tests / 105 packages PASS; frontend typecheck PASS; EditAccountModal focused 54/54 PASS. Full frontend remains base-equivalent at 1436/1438 with only `admin.system.rollback.spec.ts` 2 failures and 10 `GroupsView` unhandled mock errors.
+- commits: `d825d366b feat(admin): 支持账号级 OpenAI session sticky fallback 策略`; `5d7f211e4 feat(admin): add per-account OpenAI session sticky fallback mode（账号级）`
+- verdict: pending final immutable-tip review and `merge-main`
+
+## Tasks 4-5
+
+- status: pending Task 3

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,53 @@
+# OpenAI fallback-only sticky execution progress
+
+## Task 0
+
+- task_id: `0`
+- dependencies: none
+- ownership: read-only baseline verification
+- worktree/branch: `/Users/admin/code/opensource/sub2api/.worktrees/openai-fallback-only-sticky` / `codex/openai-fallback-only-sticky`
+- worker: root control plane
+- reviewer: approved Spec reviewer `spec_review` (`PASS`)
+- started_at: `2026-08-08T10:42:00Z`
+- finished_at: `2026-08-08T10:44:04Z`
+- verification: local `main=27725215bda20de6d43f23517aa222057061f9da`; `origin/main=cc67b1aca1d3b590609abef2fcd3a6ca31c5c651`; `origin/main...main=88 2`; integration tip after Spec bootstrap=`2c5805cb4ccd3d6c8be6b0e9d4fba011741fa9ad`; local patches=`620de2067f0e7727f52a61b046ae7b9983693054`, `27725215bda20de6d43f23517aa222057061f9da`; migrations end at coexisting `193_*`; `go test -tags=unit ./internal/service ./internal/handler/admin` exited 0; root `.gitignore` diff SHA-256=`d9ec86c57aa2f46049e247526d60aadb53c30c0d4887849f8455d806f70b3d65`
+- commit: Spec bootstrap `2c5805cb4ccd3d6c8be6b0e9d4fba011741fa9ad`
+- review_findings: none
+- verdict: `PASS`
+- integration_ancestor: yes
+
+## Task 1
+
+- task_id: `1`
+- dependencies: task 0
+- ownership: backend paths declared by the approved Spec
+- worktree/branch: `/Users/admin/code/opensource/sub2api/.worktrees/openai-fallback-only-sticky-backend` / `codex/openai-fallback-only-sticky-backend`
+- worker: `backend_worker`
+- reviewer: `/root/frontend_review`
+- started_at: `2026-08-08T10:45:00Z`
+- finished_at: pending
+- verification: pending RED/GREEN and focused tests
+- commit: pending
+- review_findings: pending
+- verdict: pending
+- integration_ancestor: no
+
+## Task 2
+
+- task_id: `2`
+- dependencies: task 0
+- ownership: frontend paths declared by the approved Spec
+- worktree/branch: `/Users/admin/code/opensource/sub2api/.worktrees/openai-fallback-only-sticky-frontend` / `codex/openai-fallback-only-sticky-frontend`
+- worker: `frontend_worker`
+- reviewer: pending
+- started_at: `2026-08-08T10:45:00Z`
+- finished_at: `2026-08-08T11:02:00Z`
+- verification: RED=`EditAccountModal.spec.ts` missing selector/round-trip behavior and `EditAccountModal.grokUpstream.spec.ts` missing helper export; GREEN=`EditAccountModal.spec.ts + EditAccountModal.grokUpstream.spec.ts` 54/54, `pnpm typecheck` exit 0, focused ESLint exit 0, `git diff --check` exit 0. Full `pnpm test:run` retains base-tip-equivalent failures: `admin.system.rollback.spec.ts` 2 failures and 10 `GroupsView` unhandled mock errors.
+- commit: `fa6289932070723eea4b0aa71dd8e84b09766a49 feat(admin): add per-account OpenAI session sticky fallback mode（账号级）`
+- review_findings: initial BLOCK for a full module mock missing `isOpenAISessionStickyMode`; fixed with a partial mock and history-rewritten into the feature commit; re-review found no blocking findings
+- verdict: `PASS`
+- integration_ancestor: no
+
+## Tasks 3-5
+
+- status: pending tasks 1 and 2

--- a/backend/ent/account.go
+++ b/backend/ent/account.go
@@ -81,6 +81,8 @@ type Account struct {
 	ParentAccountID *int64 `json:"parent_account_id,omitempty"`
 	// 'global' (default) or 'spark' (shadow reads codex_bengalfox).
 	QuotaDimension account.QuotaDimension `json:"quota_dimension,omitempty"`
+	// OpenaiSessionStickyMode holds the value of the "openai_session_sticky_mode" field.
+	OpenaiSessionStickyMode account.OpenaiSessionStickyMode `json:"openai_session_sticky_mode,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AccountQuery when eager-loading is set.
 	Edges        AccountEdges `json:"edges"`
@@ -177,7 +179,7 @@ func (*Account) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case account.FieldID, account.FieldProxyID, account.FieldProxyFallbackOriginID, account.FieldConcurrency, account.FieldLoadFactor, account.FieldPriority, account.FieldParentAccountID:
 			values[i] = new(sql.NullInt64)
-		case account.FieldName, account.FieldNotes, account.FieldPlatform, account.FieldType, account.FieldStatus, account.FieldErrorMessage, account.FieldTempUnschedulableReason, account.FieldSessionWindowStatus, account.FieldQuotaDimension:
+		case account.FieldName, account.FieldNotes, account.FieldPlatform, account.FieldType, account.FieldStatus, account.FieldErrorMessage, account.FieldTempUnschedulableReason, account.FieldSessionWindowStatus, account.FieldQuotaDimension, account.FieldOpenaiSessionStickyMode:
 			values[i] = new(sql.NullString)
 		case account.FieldCreatedAt, account.FieldUpdatedAt, account.FieldDeletedAt, account.FieldLastUsedAt, account.FieldExpiresAt, account.FieldRateLimitedAt, account.FieldRateLimitResetAt, account.FieldOverloadUntil, account.FieldTempUnschedulableUntil, account.FieldSessionWindowStart, account.FieldSessionWindowEnd:
 			values[i] = new(sql.NullTime)
@@ -409,6 +411,12 @@ func (_m *Account) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.QuotaDimension = account.QuotaDimension(value.String)
 			}
+		case account.FieldOpenaiSessionStickyMode:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field openai_session_sticky_mode", values[i])
+			} else if value.Valid {
+				_m.OpenaiSessionStickyMode = account.OpenaiSessionStickyMode(value.String)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -601,6 +609,9 @@ func (_m *Account) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("quota_dimension=")
 	builder.WriteString(fmt.Sprintf("%v", _m.QuotaDimension))
+	builder.WriteString(", ")
+	builder.WriteString("openai_session_sticky_mode=")
+	builder.WriteString(fmt.Sprintf("%v", _m.OpenaiSessionStickyMode))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/account/account.go
+++ b/backend/ent/account/account.go
@@ -78,6 +78,8 @@ const (
 	FieldParentAccountID = "parent_account_id"
 	// FieldQuotaDimension holds the string denoting the quota_dimension field in the database.
 	FieldQuotaDimension = "quota_dimension"
+	// FieldOpenaiSessionStickyMode holds the string denoting the openai_session_sticky_mode field in the database.
+	FieldOpenaiSessionStickyMode = "openai_session_sticky_mode"
 	// EdgeGroups holds the string denoting the groups edge name in mutations.
 	EdgeGroups = "groups"
 	// EdgeProxy holds the string denoting the proxy edge name in mutations.
@@ -162,6 +164,7 @@ var Columns = []string{
 	FieldSessionWindowStatus,
 	FieldParentAccountID,
 	FieldQuotaDimension,
+	FieldOpenaiSessionStickyMode,
 }
 
 var (
@@ -208,6 +211,8 @@ var (
 	DefaultConcurrency int
 	// DefaultPriority holds the default value on creation for the "priority" field.
 	DefaultPriority int
+	// DefaultOpenaiSessionStickyMode holds the default value on creation for the "openai_session_sticky_mode" field.
+	DefaultOpenaiSessionStickyMode OpenaiSessionStickyMode
 	// DefaultRateMultiplier holds the default value on creation for the "rate_multiplier" field.
 	DefaultRateMultiplier float64
 	// DefaultStatus holds the default value on creation for the "status" field.
@@ -236,6 +241,27 @@ const (
 
 func (qd QuotaDimension) String() string {
 	return string(qd)
+}
+
+// OpenaiSessionStickyMode defines the type for the "openai_session_sticky_mode" enum field.
+type OpenaiSessionStickyMode string
+
+const (
+	OpenaiSessionStickyModeNormal       OpenaiSessionStickyMode = "normal"
+	OpenaiSessionStickyModeFallbackOnly OpenaiSessionStickyMode = "fallback_only"
+)
+
+func (m OpenaiSessionStickyMode) String() string {
+	return string(m)
+}
+
+func OpenaiSessionStickyModeValidator(m OpenaiSessionStickyMode) error {
+	switch m {
+	case OpenaiSessionStickyModeNormal, OpenaiSessionStickyModeFallbackOnly:
+		return nil
+	default:
+		return fmt.Errorf("account: invalid enum value for openai_session_sticky_mode field: %q", m)
+	}
 }
 
 // QuotaDimensionValidator is a validator for the "quota_dimension" field enum values. It is called by the builders before save.

--- a/backend/ent/account_create.go
+++ b/backend/ent/account_create.go
@@ -419,6 +419,20 @@ func (_c *AccountCreate) SetNillableQuotaDimension(v *account.QuotaDimension) *A
 	return _c
 }
 
+// SetOpenaiSessionStickyMode sets the "openai_session_sticky_mode" field.
+func (_c *AccountCreate) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountCreate {
+	_c.mutation.SetOpenaiSessionStickyMode(v)
+	return _c
+}
+
+// SetNillableOpenaiSessionStickyMode sets the field if the given value is not nil.
+func (_c *AccountCreate) SetNillableOpenaiSessionStickyMode(v *account.OpenaiSessionStickyMode) *AccountCreate {
+	if v != nil {
+		_c.SetOpenaiSessionStickyMode(*v)
+	}
+	return _c
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (_c *AccountCreate) AddGroupIDs(ids ...int64) *AccountCreate {
 	_c.mutation.AddGroupIDs(ids...)
@@ -581,6 +595,10 @@ func (_c *AccountCreate) defaults() error {
 		v := account.DefaultQuotaDimension
 		_c.mutation.SetQuotaDimension(v)
 	}
+	if _, ok := _c.mutation.OpenaiSessionStickyMode(); !ok {
+		v := account.DefaultOpenaiSessionStickyMode
+		_c.mutation.SetOpenaiSessionStickyMode(v)
+	}
 	return nil
 }
 
@@ -656,6 +674,11 @@ func (_c *AccountCreate) check() error {
 	if v, ok := _c.mutation.QuotaDimension(); ok {
 		if err := account.QuotaDimensionValidator(v); err != nil {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
 		}
 	}
 	return nil
@@ -800,6 +823,10 @@ func (_c *AccountCreate) createSpec() (*Account, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
 		_node.QuotaDimension = value
+	}
+	if value, ok := _c.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
+		_node.OpenaiSessionStickyMode = value
 	}
 	if nodes := _c.mutation.GroupsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1425,6 +1452,16 @@ func (u *AccountUpsert) SetQuotaDimension(v account.QuotaDimension) *AccountUpse
 	return u
 }
 
+func (u *AccountUpsert) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsert {
+	u.Set(account.FieldOpenaiSessionStickyMode, v)
+	return u
+}
+
+func (u *AccountUpsert) UpdateOpenaiSessionStickyMode() *AccountUpsert {
+	u.SetExcluded(account.FieldOpenaiSessionStickyMode)
+	return u
+}
+
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.
 func (u *AccountUpsert) UpdateQuotaDimension() *AccountUpsert {
 	u.SetExcluded(account.FieldQuotaDimension)
@@ -2041,6 +2078,14 @@ func (u *AccountUpsertOne) SetQuotaDimension(v account.QuotaDimension) *AccountU
 	return u.Update(func(s *AccountUpsert) {
 		s.SetQuotaDimension(v)
 	})
+}
+
+func (u *AccountUpsertOne) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) { s.SetOpenaiSessionStickyMode(v) })
+}
+
+func (u *AccountUpsertOne) UpdateOpenaiSessionStickyMode() *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) { s.UpdateOpenaiSessionStickyMode() })
 }
 
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.
@@ -2826,6 +2871,14 @@ func (u *AccountUpsertBulk) SetQuotaDimension(v account.QuotaDimension) *Account
 	return u.Update(func(s *AccountUpsert) {
 		s.SetQuotaDimension(v)
 	})
+}
+
+func (u *AccountUpsertBulk) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) { s.SetOpenaiSessionStickyMode(v) })
+}
+
+func (u *AccountUpsertBulk) UpdateOpenaiSessionStickyMode() *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) { s.UpdateOpenaiSessionStickyMode() })
 }
 
 // UpdateQuotaDimension sets the "quota_dimension" field to the value that was provided on create.

--- a/backend/ent/account_update.go
+++ b/backend/ent/account_update.go
@@ -556,6 +556,11 @@ func (_u *AccountUpdate) SetQuotaDimension(v account.QuotaDimension) *AccountUpd
 	return _u
 }
 
+func (_u *AccountUpdate) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpdate {
+	_u.mutation.SetOpenaiSessionStickyMode(v)
+	return _u
+}
+
 // SetNillableQuotaDimension sets the "quota_dimension" field if the given value is not nil.
 func (_u *AccountUpdate) SetNillableQuotaDimension(v *account.QuotaDimension) *AccountUpdate {
 	if v != nil {
@@ -787,6 +792,11 @@ func (_u *AccountUpdate) check() error {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -945,6 +955,9 @@ func (_u *AccountUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1696,6 +1709,11 @@ func (_u *AccountUpdateOne) SetQuotaDimension(v account.QuotaDimension) *Account
 	return _u
 }
 
+func (_u *AccountUpdateOne) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) *AccountUpdateOne {
+	_u.mutation.SetOpenaiSessionStickyMode(v)
+	return _u
+}
+
 // SetNillableQuotaDimension sets the "quota_dimension" field if the given value is not nil.
 func (_u *AccountUpdateOne) SetNillableQuotaDimension(v *account.QuotaDimension) *AccountUpdateOne {
 	if v != nil {
@@ -1940,6 +1958,11 @@ func (_u *AccountUpdateOne) check() error {
 			return &ValidationError{Name: "quota_dimension", err: fmt.Errorf(`ent: validator failed for field "Account.quota_dimension": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		if err := account.OpenaiSessionStickyModeValidator(v); err != nil {
+			return &ValidationError{Name: "openai_session_sticky_mode", err: fmt.Errorf(`ent: validator failed for field "Account.openai_session_sticky_mode": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -2115,6 +2138,9 @@ func (_u *AccountUpdateOne) sqlSave(ctx context.Context) (_node *Account, err er
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenaiSessionStickyMode(); ok {
+		_spec.SetField(account.FieldOpenaiSessionStickyMode, field.TypeEnum, value)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -127,6 +127,7 @@ var (
 		{Name: "quota_dimension", Type: field.TypeEnum, Enums: []string{"global", "spark"}, Default: "global"},
 		{Name: "proxy_id", Type: field.TypeInt64, Nullable: true},
 		{Name: "parent_account_id", Type: field.TypeInt64, Nullable: true},
+		{Name: "openai_session_sticky_mode", Type: field.TypeEnum, Enums: []string{"normal", "fallback_only"}, Default: "normal"},
 	}
 	// AccountsTable holds the schema information for the "accounts" table.
 	AccountsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -2319,6 +2319,7 @@ type AccountMutation struct {
 	session_window_end          *time.Time
 	session_window_status       *string
 	quota_dimension             *account.QuotaDimension
+	openai_session_sticky_mode  *account.OpenaiSessionStickyMode
 	clearedFields               map[string]struct{}
 	groups                      map[int64]struct{}
 	removedgroups               map[int64]struct{}
@@ -3085,6 +3086,39 @@ func (m *AccountMutation) AddedPriority() (r int, exists bool) {
 func (m *AccountMutation) ResetPriority() {
 	m.priority = nil
 	m.addpriority = nil
+}
+
+// SetOpenaiSessionStickyMode sets the "openai_session_sticky_mode" field.
+func (m *AccountMutation) SetOpenaiSessionStickyMode(v account.OpenaiSessionStickyMode) {
+	m.openai_session_sticky_mode = &v
+}
+
+// OpenaiSessionStickyMode returns the value of the field in the mutation.
+func (m *AccountMutation) OpenaiSessionStickyMode() (r account.OpenaiSessionStickyMode, exists bool) {
+	if m.openai_session_sticky_mode == nil {
+		return r, false
+	}
+	return *m.openai_session_sticky_mode, true
+}
+
+// OldOpenaiSessionStickyMode returns the old field value.
+func (m *AccountMutation) OldOpenaiSessionStickyMode(ctx context.Context) (account.OpenaiSessionStickyMode, error) {
+	if !m.op.Is(OpUpdateOne) {
+		return "", errors.New("OldOpenaiSessionStickyMode is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return "", errors.New("OldOpenaiSessionStickyMode requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return "", fmt.Errorf("querying old value for OldOpenaiSessionStickyMode: %w", err)
+	}
+	return oldValue.OpenaiSessionStickyMode, nil
+}
+
+// ResetOpenaiSessionStickyMode resets changes to the field.
+func (m *AccountMutation) ResetOpenaiSessionStickyMode() {
+	m.openai_session_sticky_mode = nil
 }
 
 // SetRateMultiplier sets the "rate_multiplier" field.
@@ -4232,6 +4266,9 @@ func (m *AccountMutation) Fields() []string {
 	if m.quota_dimension != nil {
 		fields = append(fields, account.FieldQuotaDimension)
 	}
+	if m.openai_session_sticky_mode != nil {
+		fields = append(fields, account.FieldOpenaiSessionStickyMode)
+	}
 	return fields
 }
 
@@ -4302,6 +4339,8 @@ func (m *AccountMutation) Field(name string) (ent.Value, bool) {
 		return m.ParentAccountID()
 	case account.FieldQuotaDimension:
 		return m.QuotaDimension()
+	case account.FieldOpenaiSessionStickyMode:
+		return m.OpenaiSessionStickyMode()
 	}
 	return nil, false
 }
@@ -4373,6 +4412,8 @@ func (m *AccountMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldParentAccountID(ctx)
 	case account.FieldQuotaDimension:
 		return m.OldQuotaDimension(ctx)
+	case account.FieldOpenaiSessionStickyMode:
+		return m.OldOpenaiSessionStickyMode(ctx)
 	}
 	return nil, fmt.Errorf("unknown Account field %s", name)
 }
@@ -4598,6 +4639,13 @@ func (m *AccountMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetQuotaDimension(v)
+		return nil
+	case account.FieldOpenaiSessionStickyMode:
+		v, ok := value.(account.OpenaiSessionStickyMode)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOpenaiSessionStickyMode(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)
@@ -4908,6 +4956,9 @@ func (m *AccountMutation) ResetField(name string) error {
 		return nil
 	case account.FieldQuotaDimension:
 		m.ResetQuotaDimension()
+		return nil
+	case account.FieldOpenaiSessionStickyMode:
+		m.ResetOpenaiSessionStickyMode()
 		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -256,6 +256,9 @@ func init() {
 	accountDescSessionWindowStatus := accountFields[25].Descriptor()
 	// account.SessionWindowStatusValidator is a validator for the "session_window_status" field. It is called by the builders before save.
 	account.SessionWindowStatusValidator = accountDescSessionWindowStatus.Validators[0].(func(string) error)
+	// accountDescOpenaiSessionStickyMode is the enum sticky policy field.
+	accountDescOpenaiSessionStickyMode := accountFields[28].Descriptor()
+	account.DefaultOpenaiSessionStickyMode = account.OpenaiSessionStickyMode(accountDescOpenaiSessionStickyMode.Default.(string))
 	accountgroupFields := schema.AccountGroup{}.Fields()
 	_ = accountgroupFields
 	// accountgroupDescPriority is the schema descriptor for priority field.

--- a/backend/ent/schema/account.go
+++ b/backend/ent/schema/account.go
@@ -201,6 +201,10 @@ func (Account) Fields() []ent.Field {
 			Comment("Parent account id for a linked spark shadow (NULL = normal)."),
 		field.Enum("quota_dimension").Values("global", "spark").Default("global").
 			Comment("'global' (default) or 'spark' (shadow reads codex_bengalfox)."),
+		field.Enum("openai_session_sticky_mode").
+			Values("normal", "fallback_only").
+			Default("normal").
+			Comment("OpenAI session_hash sticky policy; fallback_only yields to ready higher-priority accounts."),
 	}
 }
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -1101,7 +1101,7 @@ func (h *AccountHandler) Test(c *gin.Context) {
 	}
 
 	if h.rateLimitService != nil {
-		if _, err := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), accountID); err != nil {
+		if _, err := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), accountID, req.ModelID); err != nil {
 			_ = c.Error(err)
 		}
 	}

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -141,6 +141,7 @@ type UpdateAccountRequest struct {
 	ProxyID                 *int64         `json:"proxy_id"`
 	Concurrency             *int           `json:"concurrency"`
 	Priority                *int           `json:"priority"`
+	OpenAISessionStickyMode *string        `json:"openai_session_sticky_mode"`
 	RateMultiplier          *float64       `json:"rate_multiplier"`
 	LoadFactor              *int           `json:"load_factor"`
 	Status                  string         `json:"status" binding:"omitempty,oneof=active inactive error"`
@@ -975,23 +976,24 @@ func (h *AccountHandler) Update(c *gin.Context) {
 	skipCheck := req.ConfirmMixedChannelRisk != nil && *req.ConfirmMixedChannelRisk
 
 	account, err := h.adminService.UpdateAccount(c.Request.Context(), accountID, &service.UpdateAccountInput{
-		Name:                  req.Name,
-		Notes:                 req.Notes,
-		Type:                  req.Type,
-		Credentials:           req.Credentials,
-		Extra:                 req.Extra,
-		ProxyID:               req.ProxyID,
-		Concurrency:           req.Concurrency, // 指针类型，nil 表示未提供
-		Priority:              req.Priority,    // 指针类型，nil 表示未提供
-		RateMultiplier:        req.RateMultiplier,
-		LoadFactor:            req.LoadFactor,
-		Status:                req.Status,
-		GroupIDs:              req.GroupIDs,
-		ExpiresAt:             req.ExpiresAt,
-		AutoPauseOnExpired:    req.AutoPauseOnExpired,
-		ProbeEnabled:          req.ProbeEnabled,
-		RateSyncEnabled:       req.RateSyncEnabled,
-		SkipMixedChannelCheck: skipCheck,
+		Name:                    req.Name,
+		Notes:                   req.Notes,
+		Type:                    req.Type,
+		Credentials:             req.Credentials,
+		Extra:                   req.Extra,
+		ProxyID:                 req.ProxyID,
+		Concurrency:             req.Concurrency, // 指针类型，nil 表示未提供
+		Priority:                req.Priority,    // 指针类型，nil 表示未提供
+		OpenAISessionStickyMode: req.OpenAISessionStickyMode,
+		RateMultiplier:          req.RateMultiplier,
+		LoadFactor:              req.LoadFactor,
+		Status:                  req.Status,
+		GroupIDs:                req.GroupIDs,
+		ExpiresAt:               req.ExpiresAt,
+		AutoPauseOnExpired:      req.AutoPauseOnExpired,
+		ProbeEnabled:            req.ProbeEnabled,
+		RateSyncEnabled:         req.RateSyncEnabled,
+		SkipMixedChannelCheck:   skipCheck,
 	})
 	if err != nil {
 		// 检查是否为混合渠道错误

--- a/backend/internal/handler/admin/scheduled_test_handler.go
+++ b/backend/internal/handler/admin/scheduled_test_handler.go
@@ -20,20 +20,28 @@ func NewScheduledTestHandler(scheduledTestSvc *service.ScheduledTestService) *Sc
 }
 
 type createScheduledTestPlanRequest struct {
-	AccountID      int64  `json:"account_id" binding:"required"`
-	ModelID        string `json:"model_id"`
-	CronExpression string `json:"cron_expression" binding:"required"`
-	Enabled        *bool  `json:"enabled"`
-	MaxResults     int    `json:"max_results"`
-	AutoRecover    *bool  `json:"auto_recover"`
+	AccountID            int64    `json:"account_id" binding:"required"`
+	ModelID              string   `json:"model_id"`
+	ModelIDs             []string `json:"model_ids"`
+	CronExpression       string   `json:"cron_expression"`
+	TriggerMode          string   `json:"trigger_mode"`
+	RetryIntervalMinutes *int     `json:"retry_interval_minutes"`
+	RetryCronExpression  *string  `json:"retry_cron_expression"`
+	Enabled              *bool    `json:"enabled"`
+	MaxResults           int      `json:"max_results"`
+	AutoRecover          *bool    `json:"auto_recover"`
 }
 
 type updateScheduledTestPlanRequest struct {
-	ModelID        string `json:"model_id"`
-	CronExpression string `json:"cron_expression"`
-	Enabled        *bool  `json:"enabled"`
-	MaxResults     int    `json:"max_results"`
-	AutoRecover    *bool  `json:"auto_recover"`
+	ModelID              string    `json:"model_id"`
+	ModelIDs             *[]string `json:"model_ids"`
+	CronExpression       string    `json:"cron_expression"`
+	TriggerMode          string    `json:"trigger_mode"`
+	RetryIntervalMinutes *int      `json:"retry_interval_minutes"`
+	RetryCronExpression  *string   `json:"retry_cron_expression"`
+	Enabled              *bool     `json:"enabled"`
+	MaxResults           int       `json:"max_results"`
+	AutoRecover          *bool     `json:"auto_recover"`
 }
 
 // ListByAccount GET /admin/accounts/:id/scheduled-test-plans
@@ -61,11 +69,15 @@ func (h *ScheduledTestHandler) Create(c *gin.Context) {
 	}
 
 	plan := &service.ScheduledTestPlan{
-		AccountID:      req.AccountID,
-		ModelID:        req.ModelID,
-		CronExpression: req.CronExpression,
-		Enabled:        true,
-		MaxResults:     req.MaxResults,
+		AccountID:            req.AccountID,
+		ModelID:              req.ModelID,
+		ModelIDs:             req.ModelIDs,
+		CronExpression:       req.CronExpression,
+		TriggerMode:          req.TriggerMode,
+		RetryIntervalMinutes: req.RetryIntervalMinutes,
+		RetryCronExpression:  req.RetryCronExpression,
+		Enabled:              true,
+		MaxResults:           req.MaxResults,
 	}
 	if req.Enabled != nil {
 		plan.Enabled = *req.Enabled
@@ -105,8 +117,22 @@ func (h *ScheduledTestHandler) Update(c *gin.Context) {
 	if req.ModelID != "" {
 		existing.ModelID = req.ModelID
 	}
+	if req.ModelIDs != nil {
+		existing.ModelIDs = *req.ModelIDs
+	}
 	if req.CronExpression != "" {
 		existing.CronExpression = req.CronExpression
+	}
+	if req.TriggerMode != "" {
+		existing.TriggerMode = req.TriggerMode
+	}
+	if req.RetryIntervalMinutes != nil {
+		existing.RetryIntervalMinutes = req.RetryIntervalMinutes
+		existing.RetryCronExpression = nil
+	}
+	if req.RetryCronExpression != nil {
+		existing.RetryCronExpression = req.RetryCronExpression
+		existing.RetryIntervalMinutes = nil
 	}
 	if req.Enabled != nil {
 		existing.Enabled = *req.Enabled

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -244,6 +244,7 @@ func AccountFromServiceShallow(a *service.Account) *Account {
 		Concurrency:             a.Concurrency,
 		LoadFactor:              a.LoadFactor,
 		Priority:                a.Priority,
+		OpenAISessionStickyMode: a.OpenAISessionStickyModeOrDefault(),
 		RateMultiplier:          a.BillingRateMultiplier(),
 		Status:                  a.Status,
 		ErrorMessage:            a.ErrorMessage,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -203,6 +203,7 @@ type Account struct {
 	Concurrency             int                            `json:"concurrency"`
 	LoadFactor              *int                           `json:"load_factor,omitempty"`
 	Priority                int                            `json:"priority"`
+	OpenAISessionStickyMode string                         `json:"openai_session_sticky_mode"`
 	RateMultiplier          float64                        `json:"rate_multiplier"`
 	Status                  string                         `json:"status"`
 	ErrorMessage            string                         `json:"error_message"`

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -113,6 +113,7 @@ func createAccountRecord(ctx context.Context, client *dbent.Client, account *ser
 		SetExtra(normalizeJSONMap(account.Extra)).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
+		SetOpenaiSessionStickyMode(dbaccount.OpenaiSessionStickyMode(account.OpenAISessionStickyModeOrDefault())).
 		SetStatus(account.Status).
 		SetErrorMessage(account.ErrorMessage).
 		SetSchedulable(account.Schedulable).
@@ -502,6 +503,7 @@ func (r *accountRepository) updateLockedAccount(
 		SetExtra(extra).
 		SetConcurrency(account.Concurrency).
 		SetPriority(account.Priority).
+		SetOpenaiSessionStickyMode(dbaccount.OpenaiSessionStickyMode(account.OpenAISessionStickyModeOrDefault())).
 		SetStatus(account.Status).
 		SetErrorMessage(account.ErrorMessage).
 		SetSchedulable(schedulable).
@@ -3426,6 +3428,7 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 		ProxyFallbackOriginID:   m.ProxyFallbackOriginID,
 		Concurrency:             m.Concurrency,
 		Priority:                m.Priority,
+		OpenAISessionStickyMode: string(m.OpenaiSessionStickyMode),
 		RateMultiplier:          &rateMultiplier,
 		LoadFactor:              m.LoadFactor,
 		Status:                  m.Status,

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2207,6 +2207,7 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 	payload := map[string]string{
 		"rate_limited_at":     now.Format(time.RFC3339),
 		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+		"updated_at":          now.Format(time.RFC3339Nano),
 	}
 	if len(reason) > 0 {
 		if value := strings.TrimSpace(reason[0]); value != "" {
@@ -2422,6 +2423,92 @@ func (r *accountRepository) ClearModelRateLimits(ctx context.Context, id int64) 
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
 	return nil
+}
+
+func (r *accountRepository) ClearModelRateLimit(ctx context.Context, id int64, modelID string) error {
+	if modelID == "" {
+		return nil
+	}
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(
+		ctx,
+		`UPDATE accounts
+		 SET extra = COALESCE(extra, '{}'::jsonb) #- ARRAY['model_rate_limits', $1]::text[], updated_at = NOW()
+		 WHERE id = $2 AND deleted_at IS NULL`,
+		modelID,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return service.ErrAccountNotFound
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear model rate limit failed: account=%d model=%s err=%v", id, modelID, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return nil
+}
+
+func (r *accountRepository) ClearModelRateLimitIfMatch(ctx context.Context, id int64, modelID string, observed json.RawMessage) (bool, error) {
+	if modelID == "" || len(observed) == 0 {
+		return false, nil
+	}
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(ctx, `
+		UPDATE accounts
+		SET extra = COALESCE(extra, '{}'::jsonb) #- ARRAY['model_rate_limits', $1]::text[], updated_at = NOW()
+		WHERE id = $2
+			AND deleted_at IS NULL
+			AND extra #> ARRAY['model_rate_limits', $1]::text[] = $3::jsonb
+	`, modelID, id, string(observed))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional model recovery failed: account=%d model=%s err=%v", id, modelID, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
+}
+
+func (r *accountRepository) RecoverAccountRuntimeStateIfUnchanged(ctx context.Context, id int64, observedUpdatedAt time.Time) (bool, error) {
+	result, err := r.sql.ExecContext(ctx, `
+		UPDATE accounts
+		SET status = CASE WHEN status = $3 THEN $4 ELSE status END,
+			error_message = CASE WHEN status = $3 THEN '' ELSE error_message END,
+			schedulable = CASE WHEN status = $3 THEN TRUE ELSE schedulable END,
+			rate_limited_at = NULL,
+			rate_limit_reset_at = NULL,
+			overload_until = NULL,
+			temp_unschedulable_until = NULL,
+			temp_unschedulable_reason = NULL,
+			extra = COALESCE(extra, '{}'::jsonb) - 'antigravity_quota_scopes',
+			updated_at = NOW()
+		WHERE id = $1 AND deleted_at IS NULL AND updated_at = $2
+	`, id, observedUpdatedAt, service.StatusError, service.StatusActive)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional account recovery failed: account=%d err=%v", id, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
 }
 
 func (r *accountRepository) UpdateSessionWindow(ctx context.Context, id int64, start, end *time.Time, status string) error {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -954,6 +955,101 @@ func (s *AccountRepoSuite) TestClearRateLimit() {
 	s.Require().Nil(got.RateLimitedAt)
 	s.Require().Nil(got.RateLimitResetAt)
 	s.Require().Nil(got.OverloadUntil)
+}
+
+func (s *AccountRepoSuite) TestClearModelRateLimitPreservesSiblingModels() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-model-clear"})
+	resetAt := time.Now().Add(time.Hour)
+	for _, modelID := range []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "AICredits"} {
+		s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, modelID, resetAt))
+	}
+
+	before, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	observed, err := json.Marshal(before.Extra["model_rate_limits"].(map[string]any)["gpt-5.6-sol"])
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-sol", resetAt))
+	cleared, err := s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, "gpt-5.6-sol", observed)
+	s.Require().NoError(err)
+	s.Require().False(cleared)
+
+	current, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	observed, err = json.Marshal(current.Extra["model_rate_limits"].(map[string]any)["gpt-5.6-sol"])
+	s.Require().NoError(err)
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+	cleared, err = s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, "gpt-5.6-sol", observed)
+	s.Require().NoError(err)
+	s.Require().True(cleared)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	limits, ok := got.Extra["model_rate_limits"].(map[string]any)
+	s.Require().True(ok)
+	s.Require().NotContains(limits, "gpt-5.6-sol")
+	s.Require().Contains(limits, "gpt-5.6-luna")
+	s.Require().Contains(limits, "gpt-5.6-terra")
+	s.Require().Contains(limits, "AICredits")
+}
+
+func (s *AccountRepoSuite) TestRecoverAccountRuntimeStateOnlyIfUnchanged() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name: "acc-conditional-recovery", Status: service.StatusActive, Schedulable: true,
+	})
+	until := time.Now().Add(time.Hour)
+	s.Require().NoError(s.repo.SetError(s.ctx, account.ID, "automatic upstream error"))
+	s.Require().NoError(s.repo.SetTempUnschedulable(s.ctx, account.ID, until, "automatic cooldown"))
+
+	observed, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	_, err = s.repo.sql.ExecContext(s.ctx, "UPDATE accounts SET updated_at = $2 WHERE id = $1", account.ID, observed.UpdatedAt.Add(time.Second))
+	s.Require().NoError(err)
+	recovered, err := s.repo.RecoverAccountRuntimeStateIfUnchanged(s.ctx, account.ID, observed.UpdatedAt)
+	s.Require().NoError(err)
+	s.Require().False(recovered)
+
+	current, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+	recovered, err = s.repo.RecoverAccountRuntimeStateIfUnchanged(s.ctx, account.ID, current.UpdatedAt)
+	s.Require().NoError(err)
+	s.Require().True(recovered)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Equal(service.StatusActive, got.Status)
+	s.Require().True(got.Schedulable)
+	s.Require().Nil(got.TempUnschedulableUntil)
+	s.Require().Nil(got.RateLimitResetAt)
+}
+
+func (s *AccountRepoSuite) TestConditionalModelRecoveryClearsTwoSiblingModels() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-two-model-recovery"})
+	resetAt := time.Now().Add(time.Hour)
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-luna", resetAt))
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.6-sol", resetAt))
+
+	observed, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	limits := observed.Extra["model_rate_limits"].(map[string]any)
+	for _, modelID := range []string{"gpt-5.6-luna", "gpt-5.6-sol"} {
+		raw, marshalErr := json.Marshal(limits[modelID])
+		s.Require().NoError(marshalErr)
+		cleared, clearErr := s.repo.ClearModelRateLimitIfMatch(s.ctx, account.ID, modelID, raw)
+		s.Require().NoError(clearErr)
+		s.Require().True(cleared)
+	}
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	remaining := got.Extra["model_rate_limits"].(map[string]any)
+	s.Require().NotContains(remaining, "gpt-5.6-luna")
+	s.Require().NotContains(remaining, "gpt-5.6-sol")
 }
 
 func (s *AccountRepoSuite) TestTempUnschedulableFieldsLoadedByGetByIDAndGetByIDs() {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -6,17 +6,46 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/accountgroup"
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+type canonicalRecoveryProbeUpstream struct {
+	model string
+}
+
+func (u *canonicalRecoveryProbeUpstream) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	return u.DoWithTLS(req, proxyURL, accountID, accountConcurrency, nil)
+}
+
+func (u *canonicalRecoveryProbeUpstream) DoWithTLS(req *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	u.model, _ = payload["model"].(string)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("data: {\"type\":\"response.completed\"}\n\n")),
+	}, nil
+}
 
 type AccountRepoSuite struct {
 	suite.Suite
@@ -993,6 +1022,43 @@ func (s *AccountRepoSuite) TestClearModelRateLimitPreservesSiblingModels() {
 	s.Require().Contains(limits, "gpt-5.6-luna")
 	s.Require().Contains(limits, "gpt-5.6-terra")
 	s.Require().Contains(limits, "AICredits")
+}
+
+func (s *AccountRepoSuite) TestModelRateLimitWriterFeedsConditionalRecoveryReader() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name: "transient-circuit-recovery", Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey,
+		Status: service.StatusActive, Schedulable: true, Credentials: map[string]any{
+			"api_key": "test-key",
+			"model_mapping": map[string]any{
+				"public-alias": "upstream-a",
+				"upstream-a":   "upstream-b",
+			},
+		}, Extra: map[string]any{}, Concurrency: 1,
+	})
+
+	err := s.repo.SetModelRateLimit(s.ctx, account.ID, "upstream-a", time.Now().Add(10*time.Minute), "openai_transient_failure_circuit")
+	s.Require().NoError(err)
+
+	rateLimits := service.NewRateLimitService(s.repo, nil, nil, nil, nil)
+	targets, err := rateLimits.ErrorRecoveryTargets(s.ctx, account.ID, "")
+	s.Require().NoError(err)
+	s.Require().Len(targets, 1)
+	s.Equal("upstream-a", targets[0].ModelID)
+	s.NotEmpty(targets[0].ObservedModelRateLimit)
+	upstream := &canonicalRecoveryProbeUpstream{}
+	tester := service.NewAccountTestService(s.repo, nil, nil, nil, nil, upstream, &config.Config{}, nil)
+	probe, err := tester.RunCanonicalTestBackground(s.ctx, account.ID, targets[0].ModelID)
+	s.Require().NoError(err)
+	s.Equal("success", probe.Status)
+	s.Equal("upstream-a", upstream.model)
+
+	recovered, err := rateLimits.RecoverErrorTargetAfterSuccessfulTest(s.ctx, account.ID, targets[0])
+	s.Require().NoError(err)
+	s.True(recovered.ClearedModelRateLimit)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.True(got.IsSchedulableForModelWithContext(s.ctx, "upstream-a"))
 }
 
 func (s *AccountRepoSuite) TestRecoverAccountRuntimeStateOnlyIfUnchanged() {

--- a/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
+++ b/backend/internal/repository/account_repo_upstream_billing_probe_update_test.go
@@ -478,6 +478,6 @@ func updatedAccountRows(id int64, extra string) *sqlmock.Rows {
 		id, now, now, nil, "test", nil, service.PlatformOpenAI, service.AccountTypeAPIKey,
 		[]byte(`{"api_key":"sk-test"}`), []byte(extra), nil, nil, 1, nil, 1, 1.0,
 		service.StatusActive, nil, nil, nil, false, true, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, service.QuotaDimensionGlobal,
+		nil, nil, nil, service.QuotaDimensionGlobal, "normal",
 	)
 }

--- a/backend/internal/repository/scheduled_test_repo.go
+++ b/backend/internal/repository/scheduled_test_repo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/lib/pq"
 )
 
 // --- Plan Repository ---
@@ -20,16 +21,16 @@ func NewScheduledTestPlanRepository(db *sql.DB) service.ScheduledTestPlanReposit
 
 func (r *scheduledTestPlanRepository) Create(ctx context.Context, plan *service.ScheduledTestPlan) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO scheduled_test_plans (account_id, model_id, cron_expression, enabled, max_results, auto_recover, next_run_at, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
-		RETURNING id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
-	`, plan.AccountID, plan.ModelID, plan.CronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
+		INSERT INTO scheduled_test_plans (account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, next_run_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
+		RETURNING id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+	`, plan.AccountID, plan.ModelID, pq.Array(nonNilModelIDs(plan.ModelIDs)), plan.CronExpression, plan.TriggerMode, plan.RetryIntervalMinutes, plan.RetryCronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
 	return scanPlan(row)
 }
 
 func (r *scheduledTestPlanRepository) GetByID(ctx context.Context, id int64) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+		SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans WHERE id = $1
 	`, id)
 	return scanPlan(row)
@@ -37,7 +38,7 @@ func (r *scheduledTestPlanRepository) GetByID(ctx context.Context, id int64) (*s
 
 func (r *scheduledTestPlanRepository) ListByAccountID(ctx context.Context, accountID int64) ([]*service.ScheduledTestPlan, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+		SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans WHERE account_id = $1
 		ORDER BY created_at DESC
 	`, accountID)
@@ -50,7 +51,7 @@ func (r *scheduledTestPlanRepository) ListByAccountID(ctx context.Context, accou
 
 func (r *scheduledTestPlanRepository) ListDue(ctx context.Context, now time.Time) ([]*service.ScheduledTestPlan, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+			SELECT id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_test_plans
 		WHERE enabled = true AND next_run_at <= $1
 		ORDER BY next_run_at ASC
@@ -65,11 +66,18 @@ func (r *scheduledTestPlanRepository) ListDue(ctx context.Context, now time.Time
 func (r *scheduledTestPlanRepository) Update(ctx context.Context, plan *service.ScheduledTestPlan) (*service.ScheduledTestPlan, error) {
 	row := r.db.QueryRowContext(ctx, `
 		UPDATE scheduled_test_plans
-		SET model_id = $2, cron_expression = $3, enabled = $4, max_results = $5, auto_recover = $6, next_run_at = $7, updated_at = NOW()
+		SET model_id = $2, model_ids = $3, cron_expression = $4, trigger_mode = $5, retry_interval_minutes = $6, retry_cron_expression = $7, enabled = $8, max_results = $9, auto_recover = $10, next_run_at = $11, updated_at = NOW()
 		WHERE id = $1
-		RETURNING id, account_id, model_id, cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
-	`, plan.ID, plan.ModelID, plan.CronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
+		RETURNING id, account_id, model_id, model_ids, cron_expression, trigger_mode, retry_interval_minutes, retry_cron_expression, enabled, max_results, auto_recover, last_run_at, next_run_at, created_at, updated_at
+	`, plan.ID, plan.ModelID, pq.Array(nonNilModelIDs(plan.ModelIDs)), plan.CronExpression, plan.TriggerMode, plan.RetryIntervalMinutes, plan.RetryCronExpression, plan.Enabled, plan.MaxResults, plan.AutoRecover, plan.NextRunAt)
 	return scanPlan(row)
+}
+
+func nonNilModelIDs(modelIDs []string) []string {
+	if modelIDs == nil {
+		return []string{}
+	}
+	return modelIDs
 }
 
 func (r *scheduledTestPlanRepository) Delete(ctx context.Context, id int64) error {
@@ -81,6 +89,13 @@ func (r *scheduledTestPlanRepository) UpdateAfterRun(ctx context.Context, id int
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE scheduled_test_plans SET last_run_at = $2, next_run_at = $3, updated_at = NOW() WHERE id = $1
 	`, id, lastRunAt, nextRunAt)
+	return err
+}
+
+func (r *scheduledTestPlanRepository) UpdateNextRun(ctx context.Context, id int64, nextRunAt time.Time) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduled_test_plans SET next_run_at = $2, updated_at = NOW() WHERE id = $1
+	`, id, nextRunAt)
 	return err
 }
 
@@ -96,14 +111,14 @@ func NewScheduledTestResultRepository(db *sql.DB) service.ScheduledTestResultRep
 
 func (r *scheduledTestResultRepository) Create(ctx context.Context, result *service.ScheduledTestResult) (*service.ScheduledTestResult, error) {
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO scheduled_test_results (plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-		RETURNING id, plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
-	`, result.PlanID, result.Status, result.ResponseText, result.ErrorMessage, result.LatencyMs, result.StartedAt, result.FinishedAt)
+		INSERT INTO scheduled_test_results (plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+		RETURNING id, plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
+	`, result.PlanID, result.ModelID, result.Status, result.ResponseText, result.ErrorMessage, result.LatencyMs, result.StartedAt, result.FinishedAt)
 
 	out := &service.ScheduledTestResult{}
 	if err := row.Scan(
-		&out.ID, &out.PlanID, &out.Status, &out.ResponseText, &out.ErrorMessage,
+		&out.ID, &out.PlanID, &out.ModelID, &out.Status, &out.ResponseText, &out.ErrorMessage,
 		&out.LatencyMs, &out.StartedAt, &out.FinishedAt, &out.CreatedAt,
 	); err != nil {
 		return nil, err
@@ -111,9 +126,20 @@ func (r *scheduledTestResultRepository) Create(ctx context.Context, result *serv
 	return out, nil
 }
 
+func (r *scheduledTestResultRepository) Update(ctx context.Context, result *service.ScheduledTestResult) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduled_test_results
+		SET model_id = $2, status = $3, response_text = $4, error_message = $5,
+		    latency_ms = $6, started_at = $7, finished_at = $8
+		WHERE id = $1
+	`, result.ID, result.ModelID, result.Status, result.ResponseText, result.ErrorMessage,
+		result.LatencyMs, result.StartedAt, result.FinishedAt)
+	return err
+}
+
 func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID int64, limit int) ([]*service.ScheduledTestResult, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, plan_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
+		SELECT id, plan_id, model_id, status, response_text, error_message, latency_ms, started_at, finished_at, created_at
 		FROM scheduled_test_results
 		WHERE plan_id = $1
 		ORDER BY created_at DESC
@@ -128,7 +154,7 @@ func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID
 	for rows.Next() {
 		r := &service.ScheduledTestResult{}
 		if err := rows.Scan(
-			&r.ID, &r.PlanID, &r.Status, &r.ResponseText, &r.ErrorMessage,
+			&r.ID, &r.PlanID, &r.ModelID, &r.Status, &r.ResponseText, &r.ErrorMessage,
 			&r.LatencyMs, &r.StartedAt, &r.FinishedAt, &r.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -138,18 +164,18 @@ func (r *scheduledTestResultRepository) ListByPlanID(ctx context.Context, planID
 	return results, rows.Err()
 }
 
-func (r *scheduledTestResultRepository) PruneOldResults(ctx context.Context, planID int64, keepCount int) error {
+func (r *scheduledTestResultRepository) PruneOldResults(ctx context.Context, planID int64, modelID string, keepCount int) error {
 	_, err := r.db.ExecContext(ctx, `
 		DELETE FROM scheduled_test_results
 		WHERE id IN (
 			SELECT id FROM (
-				SELECT id, ROW_NUMBER() OVER (PARTITION BY plan_id ORDER BY created_at DESC) AS rn
+				SELECT id, ROW_NUMBER() OVER (PARTITION BY plan_id, model_id ORDER BY created_at DESC) AS rn
 				FROM scheduled_test_results
-				WHERE plan_id = $1
+				WHERE plan_id = $1 AND model_id = $2
 			) ranked
-			WHERE rn > $2
+			WHERE rn > $3
 		)
-	`, planID, keepCount)
+	`, planID, modelID, keepCount)
 	return err
 }
 
@@ -162,7 +188,7 @@ type scannable interface {
 func scanPlan(row scannable) (*service.ScheduledTestPlan, error) {
 	p := &service.ScheduledTestPlan{}
 	if err := row.Scan(
-		&p.ID, &p.AccountID, &p.ModelID, &p.CronExpression, &p.Enabled, &p.MaxResults, &p.AutoRecover,
+		&p.ID, &p.AccountID, &p.ModelID, pq.Array(&p.ModelIDs), &p.CronExpression, &p.TriggerMode, &p.RetryIntervalMinutes, &p.RetryCronExpression, &p.Enabled, &p.MaxResults, &p.AutoRecover,
 		&p.LastRunAt, &p.NextRunAt, &p.CreatedAt, &p.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/backend/internal/repository/scheduled_test_repo_integration_test.go
+++ b/backend/internal/repository/scheduled_test_repo_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduledTestRepositoriesErrorRecoveryRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	account := mustCreateAccount(t, integrationEntClient, &service.Account{Name: "scheduled-recovery-roundtrip"})
+	t.Cleanup(func() { _ = integrationEntClient.Account.DeleteOneID(account.ID).Exec(ctx) })
+
+	planRepo := NewScheduledTestPlanRepository(integrationDB)
+	resultRepo := NewScheduledTestResultRepository(integrationDB)
+	interval := 5
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	plan, err := planRepo.Create(ctx, &service.ScheduledTestPlan{
+		AccountID: account.ID, ModelID: "gpt-5.6-luna", CronExpression: "*/30 * * * *",
+		ModelIDs: []string{"gpt-5.6-luna", "gpt-5.6-sol"},
+		TriggerMode: service.ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval,
+		Enabled: true, MaxResults: 100, AutoRecover: true, NextRunAt: &now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, service.ScheduledTestTriggerErrorRecovery, plan.TriggerMode)
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, plan.ModelIDs)
+	require.Equal(t, 5, *plan.RetryIntervalMinutes)
+	require.Nil(t, plan.RetryCronExpression)
+
+	result, err := resultRepo.Create(ctx, &service.ScheduledTestResult{
+		PlanID: plan.ID, ModelID: "gpt-5.6-sol", Status: "running",
+		StartedAt: now, FinishedAt: now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "gpt-5.6-sol", result.ModelID)
+	result.Status = "success"
+	result.ResponseText = "ok"
+	result.FinishedAt = now.Add(time.Second)
+	result.LatencyMs = 1000
+	require.NoError(t, resultRepo.Update(ctx, result))
+
+	results, err := resultRepo.ListByPlanID(ctx, plan.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "gpt-5.6-sol", results[0].ModelID)
+	require.Equal(t, "success", results[0].Status)
+	require.Equal(t, "ok", results[0].ResponseText)
+
+	nextRun := now.Add(time.Minute)
+	require.NoError(t, planRepo.UpdateNextRun(ctx, plan.ID, nextRun))
+	updated, err := planRepo.GetByID(ctx, plan.ID)
+	require.NoError(t, err)
+	require.WithinDuration(t, nextRun, *updated.NextRunAt, time.Millisecond)
+}
+
+func TestScheduledTestRepositoriesEmptyModelIDsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	account := mustCreateAccount(t, integrationEntClient, &service.Account{Name: "scheduled-recovery-all-models"})
+	t.Cleanup(func() { _ = integrationEntClient.Account.DeleteOneID(account.ID).Exec(ctx) })
+
+	interval := 5
+	plan, err := NewScheduledTestPlanRepository(integrationDB).Create(ctx, &service.ScheduledTestPlan{
+		AccountID: account.ID, ModelID: "gpt-5.6-luna", CronExpression: "*/30 * * * *",
+		TriggerMode: service.ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval,
+		Enabled: true, MaxResults: 100, AutoRecover: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, plan.ModelIDs)
+
+	plan.ModelIDs = nil
+	updated, err := NewScheduledTestPlanRepository(integrationDB).Update(ctx, plan)
+	require.NoError(t, err)
+	require.Empty(t, updated.ModelIDs)
+}

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -871,6 +871,7 @@ func buildSchedulerMetadataAccount(account service.Account) service.Account {
 		Concurrency:             account.Concurrency,
 		LoadFactor:              account.LoadFactor,
 		Priority:                account.Priority,
+		OpenAISessionStickyMode: account.OpenAISessionStickyModeOrDefault(),
 		RateMultiplier:          account.RateMultiplier,
 		Status:                  account.Status,
 		LastUsedAt:              account.LastUsedAt,

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -325,6 +325,18 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestBuildSchedulerMetadataAccount_PreservesOpenAISessionStickyMode(t *testing.T) {
+	account := service.Account{
+		ID:                      45,
+		Platform:                service.PlatformOpenAI,
+		OpenAISessionStickyMode: service.OpenAISessionStickyModeFallbackOnly,
+	}
+
+	got := buildSchedulerMetadataAccount(account)
+
+	require.Equal(t, service.OpenAISessionStickyModeFallbackOnly, got.OpenAISessionStickyMode)
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsGrokMediaEligibility(t *testing.T) {
 	t.Run("explicit override", func(t *testing.T) {
 		account := service.Account{

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -31,6 +31,10 @@ type Account struct {
 	ProxyFallbackOriginName *string // 仅展示用
 	Concurrency             int
 	Priority                int
+	// OpenAISessionStickyMode controls whether an OpenAI account can retain a
+	// session_hash binding while a strictly higher-priority account is ready.
+	// Empty values are treated as normal for legacy in-memory/cache records.
+	OpenAISessionStickyMode string
 	// RateMultiplier 账号计费倍率（>=0，允许 0 表示该账号计费为 0）。
 	// 使用指针用于兼容旧版本调度缓存（Redis）中缺字段的情况：nil 表示按 1.0 处理。
 	RateMultiplier     *float64
@@ -79,6 +83,33 @@ type Account struct {
 	headerOverrideCacheRawPtr         uintptr
 	headerOverrideCacheRawLen         int
 	headerOverrideCacheRawSig         uint64
+}
+
+const (
+	OpenAISessionStickyModeNormal       = "normal"
+	OpenAISessionStickyModeFallbackOnly = "fallback_only"
+)
+
+func normalizeOpenAISessionStickyMode(mode string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", OpenAISessionStickyModeNormal:
+		return OpenAISessionStickyModeNormal, true
+	case OpenAISessionStickyModeFallbackOnly:
+		return OpenAISessionStickyModeFallbackOnly, true
+	default:
+		return "", false
+	}
+}
+
+func (a *Account) OpenAISessionStickyModeOrDefault() string {
+	if a == nil {
+		return OpenAISessionStickyModeNormal
+	}
+	mode, ok := normalizeOpenAISessionStickyMode(a.OpenAISessionStickyMode)
+	if !ok {
+		return OpenAISessionStickyModeNormal
+	}
+	return mode
 }
 
 type OpenAIEndpointCapability string

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -525,9 +525,11 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		testModelID = openai.DefaultTestModel
 	}
 
-	// Align test routing with gateway behavior: OpenAI accounts apply normal
-	// account model mapping, and compact mode applies compact-only mapping on top.
-	testModelID = account.GetMappedModel(testModelID)
+	// Recovery targets already contain the canonical upstream model and must not
+	// pass through account mapping a second time.
+	if canonical, _ := ctx.Value(accountTestCanonicalModelContextKey{}).(bool); !canonical {
+		testModelID = account.GetMappedModel(testModelID)
+	}
 	if mode == AccountTestModeCompact {
 		testModelID = resolveOpenAICompactForwardModel(account, testModelID)
 		return s.testOpenAICompactConnection(c, account, testModelID)
@@ -1938,9 +1940,19 @@ func (s *AccountTestService) sendErrorAndEnd(c *gin.Context, errorMsg string) er
 	return fmt.Errorf("%s", errorMsg)
 }
 
+type accountTestCanonicalModelContextKey struct{}
+
 // RunTestBackground executes an account test in-memory (no real HTTP client),
 // capturing SSE output via httptest.NewRecorder, then parses the result.
 func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error) {
+	return s.runTestBackground(ctx, accountID, modelID)
+}
+
+func (s *AccountTestService) RunCanonicalTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error) {
+	return s.runTestBackground(context.WithValue(ctx, accountTestCanonicalModelContextKey{}, true), accountID, modelID)
+}
+
+func (s *AccountTestService) runTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error) {
 	startedAt := time.Now()
 
 	w := httptest.NewRecorder()

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -1963,6 +1963,7 @@ func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID in
 
 	return &ScheduledTestResult{
 		Status:       status,
+		ModelID:      modelID,
 		ResponseText: responseText,
 		ErrorMessage: errMsg,
 		LatencyMs:    finishedAt.Sub(startedAt).Milliseconds(),

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -223,6 +223,40 @@ func TestAccountTestService_OpenAIShadowUsesParentCredentialsAndShadowModel(t *t
 	require.Contains(t, recorder.Body.String(), `"success":true`)
 }
 
+func TestAccountTestService_RunCanonicalTestBackgroundDoesNotMapModelTwice(t *testing.T) {
+	resp := newJSONResponse(http.StatusOK, "")
+	resp.Body = io.NopCloser(strings.NewReader(`data: {"type":"response.completed"}
+
+`))
+	account := &Account{
+		ID:          201,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "test-token",
+			"model_mapping": map[string]any{
+				"public-alias": "upstream-a",
+				"upstream-a":   "upstream-b",
+			},
+		},
+	}
+	repo := &openAIAccountTestRepo{mockAccountRepoForGemini: mockAccountRepoForGemini{
+		accountsByID: map[int64]*Account{account.ID: account},
+	}}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+
+	result, err := svc.RunCanonicalTestBackground(context.Background(), account.ID, "upstream-a")
+
+	require.NoError(t, err)
+	require.Equal(t, "success", result.Status)
+	require.Len(t, upstream.requests, 1)
+	body, err := io.ReadAll(upstream.requests[0].Body)
+	require.NoError(t, err)
+	require.Equal(t, "upstream-a", gjson.GetBytes(body, "model").String())
+}
+
 func TestAccountTestService_OpenAIStreamEOFBeforeCompletedFails(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, recorder := newTestContext()

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -461,17 +461,18 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 	delete(accountExtra, OllamaCloudUsageAutoRefreshExtraKey)
 	delete(accountExtra, OllamaCloudUsageSnapshotExtraKey)
 	account := &Account{
-		Name:        input.Name,
-		Notes:       normalizeAccountNotes(input.Notes),
-		Platform:    input.Platform,
-		Type:        input.Type,
-		Credentials: input.Credentials,
-		Extra:       accountExtra,
-		ProxyID:     input.ProxyID,
-		Concurrency: normalizeAccountConcurrency(input.Platform, input.Type, input.Concurrency),
-		Priority:    input.Priority,
-		Status:      StatusActive,
-		Schedulable: true,
+		Name:                    input.Name,
+		Notes:                   normalizeAccountNotes(input.Notes),
+		Platform:                input.Platform,
+		Type:                    input.Type,
+		Credentials:             input.Credentials,
+		Extra:                   accountExtra,
+		ProxyID:                 input.ProxyID,
+		Concurrency:             normalizeAccountConcurrency(input.Platform, input.Type, input.Concurrency),
+		Priority:                input.Priority,
+		OpenAISessionStickyMode: OpenAISessionStickyModeNormal,
+		Status:                  StatusActive,
+		Schedulable:             true,
 	}
 	if input.ProbeEnabled != nil && *input.ProbeEnabled {
 		if !isUpstreamBillingProbeAccount(account) {
@@ -599,6 +600,13 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	account, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+	if input.OpenAISessionStickyMode != nil {
+		mode, ok := normalizeOpenAISessionStickyMode(*input.OpenAISessionStickyMode)
+		if !ok {
+			return nil, infraerrors.BadRequest("INVALID_OPENAI_SESSION_STICKY_MODE", "openai_session_sticky_mode must be normal or fallback_only")
+		}
+		account.OpenAISessionStickyMode = mode
 	}
 	var normalizedExtra map[string]any
 	if input.Extra != nil {

--- a/backend/internal/service/admin_account_sticky_mode_test.go
+++ b/backend/internal/service/admin_account_sticky_mode_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAccountStickyModeOmittedPreservesExistingValue(t *testing.T) {
+	accountID := int64(93001)
+	mode := OpenAISessionStickyModeFallbackOnly
+	repo := &updateAccountCredsRepoStub{account: &Account{
+		ID:                      accountID,
+		Name:                    "fallback",
+		Platform:                PlatformOpenAI,
+		Type:                    AccountTypeOAuth,
+		Status:                  StatusActive,
+		OpenAISessionStickyMode: mode,
+	}}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(context.Background(), accountID, &UpdateAccountInput{Name: "renamed"})
+
+	require.NoError(t, err)
+	require.Equal(t, "renamed", updated.Name)
+	require.Equal(t, mode, repo.account.OpenAISessionStickyMode)
+}
+
+func TestUpdateAccountStickyModeRejectsUnknownValue(t *testing.T) {
+	accountID := int64(93002)
+	repo := &updateAccountCredsRepoStub{account: &Account{
+		ID:       accountID,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+	}}
+	unknown := "sometimes"
+
+	_, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(context.Background(), accountID, &UpdateAccountInput{OpenAISessionStickyMode: &unknown})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "openai_session_sticky_mode")
+	require.Zero(t, repo.updateCalls)
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -370,23 +370,24 @@ type ShadowOptions struct {
 }
 
 type UpdateAccountInput struct {
-	Name                  string
-	Notes                 *string
-	Type                  string // Account type: oauth, setup-token, apikey
-	Credentials           map[string]any
-	Extra                 map[string]any
-	ProxyID               *int64
-	Concurrency           *int     // 使用指针区分"未提供"和"设置为0"
-	Priority              *int     // 使用指针区分"未提供"和"设置为0"
-	RateMultiplier        *float64 // 账号计费倍率（>=0，允许 0）
-	LoadFactor            *int
-	Status                string
-	GroupIDs              *[]int64
-	ExpiresAt             *int64
-	AutoPauseOnExpired    *bool
-	ProbeEnabled          *bool
-	RateSyncEnabled       *bool
-	SkipMixedChannelCheck bool // 跳过混合渠道检查（用户已确认风险）
+	Name                    string
+	Notes                   *string
+	Type                    string // Account type: oauth, setup-token, apikey
+	Credentials             map[string]any
+	Extra                   map[string]any
+	ProxyID                 *int64
+	Concurrency             *int     // 使用指针区分"未提供"和"设置为0"
+	Priority                *int     // 使用指针区分"未提供"和"设置为0"
+	OpenAISessionStickyMode *string  // nil 表示不修改；仅影响 OpenAI session_hash sticky
+	RateMultiplier          *float64 // 账号计费倍率（>=0，允许 0）
+	LoadFactor              *int
+	Status                  string
+	GroupIDs                *[]int64
+	ExpiresAt               *int64
+	AutoPauseOnExpired      *bool
+	ProbeEnabled            *bool
+	RateSyncEnabled         *bool
+	SkipMixedChannelCheck   bool // 跳过混合渠道检查（用户已确认风险）
 }
 
 // BulkUpdateAccountsInput describes the payload for bulk updating accounts.

--- a/backend/internal/service/concurrency_service.go
+++ b/backend/internal/service/concurrency_service.go
@@ -769,3 +769,12 @@ func (s *ConcurrencyService) GetAccountConcurrencyBatch(ctx context.Context, acc
 
 	return s.cache.GetAccountConcurrencyBatch(redisCtx, accountIDs)
 }
+
+// GetAccountConcurrency returns the current active slot count for one account.
+func (s *ConcurrencyService) GetAccountConcurrency(ctx context.Context, accountID int64) (int, error) {
+	counts, err := s.GetAccountConcurrencyBatch(ctx, []int64{accountID})
+	if err != nil {
+		return 0, err
+	}
+	return counts[accountID], nil
+}

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -17,6 +17,15 @@ const (
 	anthropicFableRateLimitKey = "claude-fable-5"
 )
 
+func isInternalModelRateLimitScope(modelID string) bool {
+	switch strings.TrimSpace(modelID) {
+	case antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey:
+		return true
+	default:
+		return false
+	}
+}
+
 // isRateLimitActiveForKey 检查指定 key 的限流是否生效
 func (a *Account) isRateLimitActiveForKey(key string) bool {
 	resetAt := a.modelRateLimitResetAt(key)
@@ -45,6 +54,17 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 	return false
 }
 
+func (a *Account) modelRateLimitKeyWithContext(ctx context.Context, requestedModel string) string {
+	if a == nil {
+		return ""
+	}
+	modelKey := a.GetMappedModel(requestedModel)
+	if a.Platform == PlatformAntigravity {
+		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
+	}
+	return strings.TrimSpace(modelKey)
+}
+
 // GetModelRateLimitRemainingTime 获取模型限流剩余时间
 // 返回 0 表示未限流或已过期
 func (a *Account) GetModelRateLimitRemainingTime(requestedModel string) time.Duration {
@@ -66,11 +86,7 @@ func (a *Account) modelRateLimitKeysForRequest(ctx context.Context, requestedMod
 		return nil
 	}
 
-	modelKey := a.GetMappedModel(requestedModel)
-	if a.Platform == PlatformAntigravity {
-		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
-	}
-	modelKey = strings.TrimSpace(modelKey)
+	modelKey := a.modelRateLimitKeyWithContext(ctx, requestedModel)
 	if modelKey == "" {
 		return nil
 	}

--- a/backend/internal/service/openai_account_model_transient.go
+++ b/backend/internal/service/openai_account_model_transient.go
@@ -10,8 +10,10 @@ const (
 	openAIModelTransientFailureWindow = time.Minute
 	openAIModelTransientShortCooldown = 10 * time.Second
 	openAIModelTransientLongCooldown  = 45 * time.Second
+	openAIModelTransientCircuitTTL    = 10 * time.Minute
 	openAIModelTransientDefaultMax    = 4096
 	openAIModelTransientMaxModelBytes = 512
+	openAIModelTransientMaxRequestIDs = 64
 )
 
 type openAIAccountModelKey struct {
@@ -20,22 +22,39 @@ type openAIAccountModelKey struct {
 }
 
 type openAIAccountModelTransientEntry struct {
-	failureStreak int
-	lastFailure   time.Time
-	blockUntil    time.Time
-	lastTouched   time.Time
+	failureStreak         int
+	lastFailure           time.Time
+	blockUntil            time.Time
+	lastTouched           time.Time
+	requestIDs            map[string]struct{}
+	durableStreak         int
+	persisting            bool
+	persisted             bool
+	persistenceGeneration uint64
+	mutationGeneration    uint64
 }
 
 type openAIAccountModelTransientDecision struct {
-	FailureStreak int
-	Cooldown      time.Duration
-	BlockUntil    time.Time
+	FailureStreak         int
+	Cooldown              time.Duration
+	BlockUntil            time.Time
+	Counted               bool
+	OpenCircuit           bool
+	PersistenceGeneration uint64
+}
+
+type openAIAccountModelTransientKeyLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 type openAIAccountModelTransientState struct {
-	mu         sync.Mutex
-	entries    map[openAIAccountModelKey]openAIAccountModelTransientEntry
-	maxEntries int
+	mu                        sync.Mutex
+	entries                   map[openAIAccountModelKey]openAIAccountModelTransientEntry
+	keyLocks                  map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock
+	maxEntries                int
+	nextPersistenceGeneration uint64
+	nextMutationGeneration    uint64
 }
 
 func newOpenAIAccountModelTransientState(maxEntries int) *openAIAccountModelTransientState {
@@ -44,7 +63,36 @@ func newOpenAIAccountModelTransientState(maxEntries int) *openAIAccountModelTran
 	}
 	return &openAIAccountModelTransientState{
 		entries:    make(map[openAIAccountModelKey]openAIAccountModelTransientEntry),
+		keyLocks:   make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock),
 		maxEntries: maxEntries,
+	}
+}
+
+func (s *openAIAccountModelTransientState) lockKey(key openAIAccountModelKey) func() {
+	s.mu.Lock()
+	if s.keyLocks == nil {
+		s.keyLocks = make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock)
+	}
+	keyLock := s.keyLocks[key]
+	if keyLock == nil {
+		keyLock = &openAIAccountModelTransientKeyLock{}
+		s.keyLocks[key] = keyLock
+	}
+	keyLock.refs++
+	s.mu.Unlock()
+
+	keyLock.mu.Lock()
+	return func() {
+		keyLock.mu.Unlock()
+		s.mu.Lock()
+		keyLock.refs--
+		if keyLock.refs == 0 {
+			delete(s.keyLocks, key)
+		}
+		if s.maxEntries > 0 && len(s.entries) > s.maxEntries {
+			s.evictOldestLocked()
+		}
+		s.mu.Unlock()
 	}
 }
 
@@ -64,7 +112,7 @@ func openAIAccountModelTransientKey(accountID int64, model string) (openAIAccoun
 	return openAIAccountModelKey{AccountID: accountID, Model: model}, true
 }
 
-func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model string, now time.Time) openAIAccountModelTransientDecision {
+func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model string, now time.Time, requestID ...string) openAIAccountModelTransientDecision {
 	key, ok := openAIAccountModelTransientKey(accountID, model)
 	if s == nil || !ok {
 		return openAIAccountModelTransientDecision{}
@@ -73,6 +121,8 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 		now = time.Now()
 	}
 
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.entries == nil {
@@ -89,8 +139,47 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 	if !exists || entry.lastFailure.IsZero() || now.Sub(entry.lastFailure) > openAIModelTransientFailureWindow || now.Before(entry.lastFailure) {
 		entry.failureStreak = 0
 		entry.blockUntil = time.Time{}
+		entry.requestIDs = nil
+		entry.durableStreak = 0
+		entry.persisting = false
+		entry.persisted = false
+		entry.persistenceGeneration = 0
+	}
+	currentRequestID := ""
+	openCircuit := false
+	if len(requestID) > 0 {
+		currentRequestID = strings.TrimSpace(requestID[0])
+	}
+	if currentRequestID != "" {
+		if _, duplicate := entry.requestIDs[currentRequestID]; duplicate {
+			return openAIAccountModelTransientDecision{
+				FailureStreak: entry.failureStreak,
+				BlockUntil:    entry.blockUntil,
+			}
+		}
+		if entry.requestIDs == nil {
+			entry.requestIDs = make(map[string]struct{})
+		}
+		if len(entry.requestIDs) >= openAIModelTransientMaxRequestIDs {
+			for oldestID := range entry.requestIDs {
+				delete(entry.requestIDs, oldestID)
+				break
+			}
+		}
+		entry.requestIDs[currentRequestID] = struct{}{}
+		if !entry.persisted && !entry.persisting {
+			entry.durableStreak++
+			if entry.durableStreak >= 3 {
+				s.nextPersistenceGeneration++
+				entry.persisting = true
+				entry.persistenceGeneration = s.nextPersistenceGeneration
+				openCircuit = true
+			}
+		}
 	}
 	entry.failureStreak++
+	s.nextMutationGeneration++
+	entry.mutationGeneration = s.nextMutationGeneration
 	entry.lastFailure = now
 	entry.lastTouched = now
 
@@ -108,10 +197,85 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 	}
 	s.entries[key] = entry
 	return openAIAccountModelTransientDecision{
-		FailureStreak: entry.failureStreak,
-		Cooldown:      cooldown,
-		BlockUntil:    entry.blockUntil,
+		FailureStreak:         entry.failureStreak,
+		Cooldown:              cooldown,
+		BlockUntil:            entry.blockUntil,
+		Counted:               true,
+		OpenCircuit:           openCircuit,
+		PersistenceGeneration: entry.persistenceGeneration,
 	}
+}
+
+func (s *openAIAccountModelTransientState) mutationGeneration(accountID int64, model string) uint64 {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return 0
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.entries[key].mutationGeneration
+}
+
+func (s *openAIAccountModelTransientState) mutationGenerations(accountID int64) map[string]uint64 {
+	if s == nil || accountID <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[string]uint64)
+	for key, entry := range s.entries {
+		if key.AccountID == accountID {
+			result[key.Model] = entry.mutationGeneration
+		}
+	}
+	return result
+}
+
+func (s *openAIAccountModelTransientState) clearCircuitIfGeneration(
+	accountID int64,
+	model string,
+	observedGeneration uint64,
+	clear func() (bool, error),
+) (bool, error) {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return clear()
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	if entry, exists := s.entries[key]; exists && entry.mutationGeneration != observedGeneration {
+		s.mu.Unlock()
+		return false, nil
+	}
+	s.mu.Unlock()
+	cleared, err := clear()
+	if err == nil && cleared {
+		s.mu.Lock()
+		delete(s.entries, key)
+		s.mu.Unlock()
+	}
+	return cleared, err
+}
+
+func (s *openAIAccountModelTransientState) finishCircuitPersistence(accountID int64, model string, generation uint64, persisted bool) {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, exists := s.entries[key]
+	if !exists || !entry.persisting || entry.persistenceGeneration != generation {
+		return
+	}
+	entry.persisting = false
+	entry.persisted = persisted
+	s.entries[key] = entry
 }
 
 func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model string) {
@@ -119,6 +283,8 @@ func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model 
 	if s == nil || !ok {
 		return
 	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
 	s.mu.Lock()
 	delete(s.entries, key)
 	s.mu.Unlock()
@@ -133,6 +299,8 @@ func (s *openAIAccountModelTransientState) isBlocked(accountID int64, model stri
 		now = time.Now()
 	}
 
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	entry, exists := s.entries[key]
@@ -165,6 +333,9 @@ func (s *openAIAccountModelTransientState) evictOldestLocked() {
 	var oldestTime time.Time
 	found := false
 	for key, entry := range s.entries {
+		if keyLock := s.keyLocks[key]; keyLock != nil && keyLock.refs > 0 {
+			continue
+		}
 		if !found || entry.lastTouched.Before(oldestTime) {
 			oldestKey = key
 			oldestTime = entry.lastTouched

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 )
 
 const (
@@ -105,8 +107,13 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		if len(canonicalModel) > 0 {
 			model = canonicalModel[0]
 		}
-		decision := s.recordOpenAIAccountModelTransientFailure(account, model, time.Now())
-		if decision.FailureStreak > 0 {
+		now := time.Now()
+		requestID := ""
+		if shouldPersistOpenAITransientCircuit(statusCode) {
+			requestID = openAITransientRequestID(ctx)
+		}
+		decision := s.recordOpenAIAccountModelTransientFailure(account, model, now, requestID)
+		if decision.Counted {
 			slog.Warn("openai_model_transient_state",
 				"account_id", account.ID,
 				"model", openAIAccountModelTransientModel(model),
@@ -115,8 +122,29 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 				"block_scope", "account_model",
 			)
 		}
+		if decision.OpenCircuit && strings.TrimSpace(model) != "" {
+			persisted := false
+			if s.rateLimitService.accountRepo != nil {
+				resetAt := now.Add(openAIModelTransientCircuitTTL)
+				if err := s.rateLimitService.accountRepo.SetModelRateLimit(stateCtx, account.ID, model, resetAt, "openai_transient_failure_circuit"); err != nil {
+					slog.Warn("openai_model_transient_circuit_persist_failed", "account_id", account.ID, "model", model, "error", err)
+				} else {
+					persisted = true
+					slog.Warn("openai_model_transient_circuit_opened", "account_id", account.ID, "model", model, "failure_streak", decision.FailureStreak, "reset_at", resetAt)
+				}
+			}
+			s.finishOpenAIAccountModelTransientPersistence(account.ID, model, decision.PersistenceGeneration, persisted)
+		}
 	}
 	return shouldDisable
+}
+
+func openAITransientRequestID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	requestID, _ := ctx.Value(ctxkey.RequestID).(string)
+	return strings.TrimSpace(requestID)
 }
 
 func shouldCooldownOpenAITransientUpstreamError(statusCode int, responseBody []byte) bool {
@@ -125,6 +153,15 @@ func shouldCooldownOpenAITransientUpstreamError(statusCode int, responseBody []b
 		return true
 	case http.StatusBadRequest:
 		return isOpenAITransientProcessingError(statusCode, "", responseBody)
+	default:
+		return false
+	}
+}
+
+func shouldPersistOpenAITransientCircuit(statusCode int) bool {
+	switch statusCode {
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, 520, 521, 522, 523, 524:
+		return true
 	default:
 		return false
 	}
@@ -274,7 +311,7 @@ func openAIAccountModelTransientModel(canonicalModel string) string {
 	return normalizeOpenAIAccountModelTransientModel(canonicalModel)
 }
 
-func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time) openAIAccountModelTransientDecision {
+func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time, requestID ...string) openAIAccountModelTransientDecision {
 	if s == nil || account == nil {
 		return openAIAccountModelTransientDecision{}
 	}
@@ -282,7 +319,7 @@ func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account 
 	if state == nil {
 		return openAIAccountModelTransientDecision{}
 	}
-	return state.recordFailure(account.ID, openAIAccountModelTransientModel(canonicalModel), now)
+	return state.recordFailure(account.ID, openAIAccountModelTransientModel(canonicalModel), now, requestID...)
 }
 
 func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID int64, model string) {
@@ -291,6 +328,35 @@ func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID i
 		return
 	}
 	state.recordSuccess(accountID, model)
+}
+
+func (s *OpenAIGatewayService) openAIAccountModelTransientGenerations(accountID int64) map[string]uint64 {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return nil
+	}
+	return state.mutationGenerations(accountID)
+}
+
+func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientStateIfGeneration(
+	accountID int64,
+	model string,
+	observedGeneration uint64,
+	clear func() (bool, error),
+) (bool, error) {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return clear()
+	}
+	return state.clearCircuitIfGeneration(accountID, model, observedGeneration, clear)
+}
+
+func (s *OpenAIGatewayService) finishOpenAIAccountModelTransientPersistence(accountID int64, model string, generation uint64, persisted bool) {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return
+	}
+	state.finishCircuitPersistence(accountID, model, generation, persisted)
 }
 
 func (s *OpenAIGatewayService) isOpenAIAccountModelRuntimeBlocked(account *Account, requestedModel string) bool {

--- a/backend/internal/service/openai_account_runtime_transient_test.go
+++ b/backend/internal/service/openai_account_runtime_transient_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,6 +17,165 @@ type transientCooldownAccountRepo struct {
 
 func (transientCooldownAccountRepo) SetOverloaded(context.Context, int64, time.Time) error {
 	return nil
+}
+
+type transientCircuitRateLimitCall struct {
+	accountID int64
+	model     string
+	resetAt   time.Time
+}
+
+type transientCircuitAccountRepo struct {
+	AccountRepository
+	calls []transientCircuitRateLimitCall
+}
+
+func (r *transientCircuitAccountRepo) SetOverloaded(context.Context, int64, time.Time) error {
+	return nil
+}
+
+func (r *transientCircuitAccountRepo) SetModelRateLimit(_ context.Context, accountID int64, model string, resetAt time.Time, _ ...string) error {
+	r.calls = append(r.calls, transientCircuitRateLimitCall{accountID: accountID, model: model, resetAt: resetAt})
+	return nil
+}
+
+func TestHandleOpenAITransientError_ThreeDistinctRequestsPersistModelCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5110, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	startedAt := time.Now()
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Len(t, repo.calls, 1)
+	require.Equal(t, account.ID, repo.calls[0].accountID)
+	require.Equal(t, "gpt-5.6-sol", repo.calls[0].model)
+	require.WithinDuration(t, startedAt.Add(10*time.Minute), repo.calls[0].resetAt, 2*time.Second)
+}
+
+func TestHandleOpenAITransientError_RetriesWithinOneRequestCountOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5111, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "same-request")
+
+	for range 3 {
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Empty(t, repo.calls)
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "gpt-5.6-sol"))
+}
+
+func TestHandleOpenAITransientError_MissingRequestIDDoesNotAdvanceDurableCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5112, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for range 2 {
+		svc.handleOpenAIAccountUpstreamError(context.Background(), account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "first-proven-request")
+	svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+
+	require.Empty(t, repo.calls)
+}
+
+func TestHandleOpenAITransientError_OpenCircuitPersistsOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5113, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3", "request-4", "request-5"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Len(t, repo.calls, 1)
+}
+
+func TestHandleOpenAITransientError_RetriesAfterCircuitThresholdCountOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5114, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3", "request-4", "request-4"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	state := svc.getOpenAIAccountModelTransientState()
+	key, ok := openAIAccountModelTransientKey(account.ID, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	entry := state.entries[key]
+	state.mu.Unlock()
+	require.Equal(t, 4, entry.failureStreak)
+}
+
+func TestOpenAIModelTransientState_StalePersistenceCompletionDoesNotMutateNewClaim(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var oldClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"old-1", "old-2", "old-3"} {
+		oldClaim = state.recordFailure(5115, "gpt-5.6-sol", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.recordSuccess(5115, "gpt-5.6-sol")
+
+	var newClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"new-1", "new-2", "new-3"} {
+		newClaim = state.recordFailure(5115, "gpt-5.6-sol", now.Add(time.Duration(i+3)*time.Millisecond), requestID)
+	}
+	require.NotEqual(t, oldClaim.PersistenceGeneration, newClaim.PersistenceGeneration)
+
+	state.finishCircuitPersistence(5115, "gpt-5.6-sol", oldClaim.PersistenceGeneration, true)
+	key, ok := openAIAccountModelTransientKey(5115, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	entry := state.entries[key]
+	state.mu.Unlock()
+	require.True(t, entry.persisting)
+	require.False(t, entry.persisted)
+	require.Equal(t, newClaim.PersistenceGeneration, entry.persistenceGeneration)
+}
+
+func TestOpenAIModelTransientState_RecoveryClearDoesNotBlockOtherAccount(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(2)
+	now := time.Now()
+	state.recordFailure(5201, "gpt-5.6-sol", now, "request-a")
+	observed := state.mutationGeneration(5201, "gpt-5.6-sol")
+	clearStarted := make(chan struct{})
+	releaseClear := make(chan struct{})
+	clearDone := make(chan struct{})
+	go func() {
+		defer close(clearDone)
+		_, _ = state.clearCircuitIfGeneration(5201, "gpt-5.6-sol", observed, func() (bool, error) {
+			close(clearStarted)
+			<-releaseClear
+			return true, nil
+		})
+	}()
+	<-clearStarted
+
+	otherDone := make(chan struct{})
+	go func() {
+		state.recordFailure(5202, "gpt-5.6-sol", now, "request-b")
+		close(otherDone)
+	}()
+	otherCompleted := false
+	select {
+	case <-otherDone:
+		otherCompleted = true
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(releaseClear)
+	<-clearDone
+
+	require.True(t, otherCompleted)
+	require.Equal(t, 1, state.size())
 }
 
 func TestHandleOpenAITransientError_BlocksOnlyRequestedModel(t *testing.T) {
@@ -61,6 +221,20 @@ func TestHandleOpenAITransientError_TransientStatusesUseModelScope(t *testing.T)
 
 func TestHandleOpenAITransientError_529RemainsOverloadOnly(t *testing.T) {
 	require.False(t, shouldCooldownOpenAITransientUpstreamError(529, []byte(`{"error":{"message":"overloaded"}}`)))
+}
+
+func TestHandleOpenAITransientError_Transient400DoesNotPersistDurableCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5116, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusBadRequest, http.Header{}, []byte(`{"error":{"message":"An error occurred while processing your request"}}`), "gpt-5.6-sol")
+	}
+
+	require.Empty(t, repo.calls)
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "gpt-5.6-sol"))
 }
 
 func TestHandleOpenAITransientError_CanonicalModelIsNotMappedTwice(t *testing.T) {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -412,6 +412,34 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 
+	if req.StickyAccountID > 0 && strings.TrimSpace(req.SessionHash) != "" && s.service != nil {
+		sticky, stickyErr := s.service.getSchedulableAccount(ctx, req.StickyAccountID)
+		if stickyErr == nil && sticky != nil && sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly {
+			selection, acquireErr := s.service.selectFallbackOnlyWithHigherPriorityAcquisition(
+				ctx,
+				req.GroupID,
+				req.Platform,
+				req.SessionHash,
+				req.StickyAccountID,
+				req.RequestedModel,
+				req.ExcludedIDs,
+				req.RequireCompact,
+				req.RequiredCapability,
+				req.RequiredImageCapability,
+				req.RequiredTransport,
+			)
+			if acquireErr != nil {
+				return nil, decision, acquireErr
+			}
+			if selection != nil {
+				decision.Layer = openAIAccountScheduleLayerLoadBalance
+				decision.SelectedAccountID = selection.Account.ID
+				decision.SelectedAccountType = selection.Account.Type
+				return selection, decision, nil
+			}
+		}
+	}
+
 	if !req.StickyWeighted {
 		selection, escapedSticky, err := s.selectBySessionHash(ctx, req)
 		if err != nil {
@@ -426,6 +454,16 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 		if escapedSticky {
 			req.PreserveStickyBinding = true
+			stickyAccountID := req.StickyAccountID
+			if stickyAccountID <= 0 {
+				stickyAccountID, _ = s.service.getStickySessionAccountID(ctx, req.GroupID, strings.TrimSpace(req.SessionHash))
+			}
+			if stickyAccountID > 0 {
+				sticky, stickyErr := s.service.getSchedulableAccount(ctx, stickyAccountID)
+				if stickyErr == nil && sticky != nil && sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly {
+					req.PreserveStickyBinding = false
+				}
+			}
 		}
 	}
 
@@ -498,6 +536,10 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 	if account == nil || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
+	}
+	if s.service.shouldEscapeFallbackOnlySticky(ctx, req.GroupID, req.Platform, sessionHash, account, req.RequestedModel, req.ExcludedIDs, req.RequireCompact, req.RequiredCapability, req.RequiredTransport) {
+		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
+		return nil, true, nil
 	}
 	escapeCfg := s.service.openAIStickyEscapeConfig()
 	if reason, errorRate, ttft, shouldEscape := s.shouldEscapeStickyAccount(accountID, escapeCfg); shouldEscape {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -87,6 +87,7 @@ type schedulerTestConcurrencyCache struct {
 	loadBatchErr    error
 	loadMap         map[int64]*AccountLoadInfo
 	acquireResults  map[int64]bool
+	acquireErrors   map[int64]error
 	waitCounts      map[int64]int
 	skipDefaultLoad bool
 	acquiredIDs     *[]int64
@@ -96,6 +97,11 @@ type schedulerTestConcurrencyCache struct {
 func (c schedulerTestConcurrencyCache) AcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
 	if c.acquiredIDs != nil {
 		*c.acquiredIDs = append(*c.acquiredIDs, accountID)
+	}
+	if c.acquireErrors != nil {
+		if err, ok := c.acquireErrors[accountID]; ok {
+			return false, err
+		}
 	}
 	if c.acquireResults != nil {
 		if result, ok := c.acquireResults[accountID]; ok {
@@ -144,6 +150,27 @@ func (c schedulerTestConcurrencyCache) GetAccountWaitingCount(ctx context.Contex
 		}
 	}
 	return 0, nil
+}
+
+func (c schedulerTestConcurrencyCache) GetAccountConcurrency(ctx context.Context, accountID int64) (int, error) {
+	if c.loadMap != nil {
+		if load, ok := c.loadMap[accountID]; ok && load != nil {
+			return load.CurrentConcurrency, nil
+		}
+	}
+	return 0, nil
+}
+
+func (c schedulerTestConcurrencyCache) GetAccountConcurrencyBatch(ctx context.Context, accountIDs []int64) (map[int64]int, error) {
+	result := make(map[int64]int, len(accountIDs))
+	for _, accountID := range accountIDs {
+		current, err := c.GetAccountConcurrency(ctx, accountID)
+		if err != nil {
+			return nil, err
+		}
+		result[accountID] = current
+	}
+	return result, nil
 }
 
 type schedulerTestGatewayCache struct {

--- a/backend/internal/service/openai_fallback_sticky_test.go
+++ b/backend/internal/service/openai_fallback_sticky_test.go
@@ -1,0 +1,388 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func fallbackStickyTestAccounts(groupID int64) []Account {
+	return []Account{
+		{
+			ID:                      91001,
+			Platform:                PlatformOpenAI,
+			Type:                    AccountTypeOAuth,
+			Status:                  StatusActive,
+			Schedulable:             true,
+			Concurrency:             1,
+			Priority:                200,
+			GroupIDs:                []int64{groupID},
+			Credentials:             map[string]any{"model_mapping": map[string]any{"gpt-ready": "gpt-ready"}},
+			Extra:                   map[string]any{"openai_oauth_responses_websockets_v2_enabled": true},
+			OpenAISessionStickyMode: OpenAISessionStickyModeFallbackOnly,
+		},
+		{
+			ID:                      91002,
+			Platform:                PlatformOpenAI,
+			Type:                    AccountTypeOAuth,
+			Status:                  StatusActive,
+			Schedulable:             true,
+			Concurrency:             1,
+			Priority:                1,
+			GroupIDs:                []int64{groupID},
+			Credentials:             map[string]any{"model_mapping": map[string]any{"gpt-ready": "gpt-ready"}},
+			OpenAISessionStickyMode: OpenAISessionStickyModeNormal,
+		},
+	}
+}
+
+func fallbackStickyTestAccountsWithTwoPrimaries(groupID int64) []Account {
+	accounts := fallbackStickyTestAccounts(groupID)
+	secondPrimary := accounts[1]
+	secondPrimary.ID = 91003
+	secondPrimary.Priority = 2
+	return append(accounts, secondPrimary)
+}
+
+func TestFallbackOnlyStickyEscapesToImmediatelyAvailableHigherPriorityAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9101)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:fallback-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "fallback-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[1].ID, selected.ID)
+	require.Equal(t, accounts[1].ID, cache.sessionBindings["openai:fallback-session"])
+}
+
+func TestNormalStickyKeepsExistingAccountEvenWhenHigherPriorityAccountIsAvailable(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9102)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[0].OpenAISessionStickyMode = OpenAISessionStickyModeNormal
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:normal-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "normal-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyKeepsAccountWhenHigherPriorityCandidateCannotServeRequest(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9103)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[1].Credentials = map[string]any{"model_mapping": map[string]any{"other-model": "other-model"}}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:unsupported-session": accounts[0].ID}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:       cache,
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "unsupported-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyKeepsAccountWhenHigherPrioritySlotIsFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9104)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:full-session": accounts[0].ID}}
+	concurrency := schedulerTestConcurrencyCache{loadMap: map[int64]*AccountLoadInfo{
+		accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: accounts[1].Concurrency, LoadRate: 100},
+	}}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selected, err := svc.SelectAccountForModel(ctx, &groupID, "full-session", "gpt-ready")
+
+	require.NoError(t, err)
+	require.Equal(t, accounts[0].ID, selected.ID)
+}
+
+func TestFallbackOnlyStickyRecoversWhenHigherPrioritySlotIsTakenAfterProbe(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9105)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "racy-session", "gpt-ready", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyRecoversAfterAllHigherPrioritySlotsRaceFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9109)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:multi-racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+			accounts[2].ID: {AccountID: accounts[2].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "multi-racy-session", "gpt-ready", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:multi-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyEscapesInAdvancedScheduler(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9106)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-session": accounts[0].ID}}
+	cfg := &config.Config{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[1].ID, selection.Account.ID)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerRecoversWhenHigherPrioritySlotIsTakenAfterProbe(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9107)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-racy-session": accounts[0].ID}}
+	concurrency := schedulerTestConcurrencyCache{
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-racy-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:advanced-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerRecoversAfterAllHigherPrioritySlotsRaceFull(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9110)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:advanced-multi-racy-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		loadMap: map[int64]*AccountLoadInfo{
+			accounts[1].ID: {AccountID: accounts[1].ID, CurrentConcurrency: 0},
+			accounts[2].ID: {AccountID: accounts[2].ID, CurrentConcurrency: 0},
+		},
+		acquireResults: map[int64]bool{
+			accounts[1].ID: false,
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 2
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-multi-racy-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	require.Equal(t, accounts[0].ID, cache.sessionBindings["openai:advanced-multi-racy-session"])
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerSkipsImageIncompatibleHigherPriorityAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9111)
+	accounts := fallbackStickyTestAccounts(groupID)
+	accounts[1].Type = AccountTypeSetupToken
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:image-capability-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	svc := &OpenAIGatewayService{
+		accountRepo:      schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:            cache,
+		cfg:              &config.Config{},
+		rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{
+			acquiredIDs: &acquiredIDs,
+		}),
+	}
+
+	selection, _, err := svc.SelectAccountWithSchedulerForImages(ctx, &groupID, "image-capability-session", "gpt-ready", nil, OpenAIImagesCapabilityBasic)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.Equal(t, []int64{accounts[0].ID}, acquiredIDs)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyAdvancedSchedulerContinuesAfterHigherPriorityAcquireError(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9112)
+	accounts := fallbackStickyTestAccountsWithTwoPrimaries(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:acquire-error-session": accounts[0].ID}}
+	var acquiredIDs []int64
+	concurrency := schedulerTestConcurrencyCache{
+		acquiredIDs: &acquiredIDs,
+		acquireErrors: map[int64]error{
+			accounts[1].ID: errors.New("temporary acquire failure"),
+		},
+		acquireResults: map[int64]bool{
+			accounts[2].ID: false,
+			accounts[0].ID: true,
+		},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(concurrency),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "acquire-error-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Equal(t, []int64{accounts[1].ID, accounts[2].ID, accounts[0].ID}, acquiredIDs)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestFallbackOnlyStickyEscapesWeightedAdvancedScheduler(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(9108)
+	accounts := fallbackStickyTestAccounts(groupID)
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:weighted-session": accounts[0].ID}}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 2
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 1
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true", "true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "weighted-session", "gpt-ready", nil, OpenAIUpstreamTransportAny, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, accounts[1].ID, selection.Account.ID)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -739,11 +739,170 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
+	if s.shouldEscapeFallbackOnlySticky(ctx, groupID, platform, sessionHash, account, requestedModel, excludedIDs, requireCompact, requiredCapability, OpenAIUpstreamTransportAny) {
+		return nil
+	}
 
 	// 刷新会话 TTL 并返回账号
 	// Refresh session TTL and return account
 	_ = s.refreshStickySessionTTL(ctx, groupID, sessionHash, openaiStickySessionTTL)
 	return account
+}
+
+// shouldEscapeFallbackOnlySticky reports whether a fallback-only sticky account
+// should yield to a strictly higher-priority account that can serve this request
+// immediately. The check is deliberately read-only: the eventual selection path
+// owns slot acquisition and sticky rebinding.
+func (s *OpenAIGatewayService) shouldEscapeFallbackOnlySticky(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	sessionHash string,
+	sticky *Account,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	requiredTransport OpenAIUpstreamTransport,
+) bool {
+	if sticky == nil || sticky.OpenAISessionStickyModeOrDefault() != OpenAISessionStickyModeFallbackOnly {
+		return false
+	}
+	if strings.TrimSpace(sessionHash) == "" {
+		return false
+	}
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	if err != nil {
+		return false
+	}
+	for i := range accounts {
+		candidate := &accounts[i]
+		if candidate.ID == sticky.ID || candidate.Priority >= sticky.Priority {
+			continue
+		}
+		if excludedIDs != nil {
+			if _, excluded := excludedIDs[candidate.ID]; excluded {
+				continue
+			}
+		}
+		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, candidate, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) {
+			continue
+		}
+		if groupID != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID) &&
+			s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+			continue
+		}
+		if !s.hasImmediatelyAvailableAccountSlot(ctx, fresh) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// selectFallbackOnlyWithHigherPriorityAcquisition atomically walks every
+// eligible higher-priority account before returning to the sticky fallback.
+// This closes the gap between a read-only capacity probe and slot acquisition.
+func (s *OpenAIGatewayService) selectFallbackOnlyWithHigherPriorityAcquisition(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	sessionHash string,
+	stickyAccountID int64,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	requiredImageCapability OpenAIImagesCapability,
+	requiredTransport OpenAIUpstreamTransport,
+) (*AccountSelectionResult, error) {
+	if stickyAccountID <= 0 {
+		return nil, nil
+	}
+	if _, excluded := excludedIDs[stickyAccountID]; excluded {
+		return nil, nil
+	}
+	sticky, err := s.getSchedulableAccount(ctx, stickyAccountID)
+	if err != nil || sticky == nil || sticky.OpenAISessionStickyModeOrDefault() != OpenAISessionStickyModeFallbackOnly {
+		return nil, err
+	}
+	sticky = s.recheckSelectedOpenAIAccountFromDB(ctx, sticky, groupID, platform, requestedModel, requireCompact, requiredCapability)
+	if sticky == nil || !s.openAIAccountMatchesSchedulingGroup(sticky, groupID) ||
+		!s.isOpenAIAccountTransportCompatible(sticky, requiredTransport) ||
+		!accountSupportsOpenAICapabilities(sticky, requiredCapability, requiredImageCapability) {
+		return nil, nil
+	}
+
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]*Account, 0, len(accounts)+1)
+	for i := range accounts {
+		candidate := &accounts[i]
+		if candidate.ID == sticky.ID || candidate.Priority >= sticky.Priority {
+			continue
+		}
+		if _, excluded := excludedIDs[candidate.ID]; excluded {
+			continue
+		}
+		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, candidate, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) ||
+			!accountSupportsOpenAICapabilities(fresh, requiredCapability, requiredImageCapability) {
+			continue
+		}
+		if groupID != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID) &&
+			s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+			continue
+		}
+		candidates = append(candidates, fresh)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return s.isBetterAccount(candidates[i], candidates[j])
+	})
+	candidates = append(candidates, sticky)
+
+	for _, candidate := range candidates {
+		fresh := s.recheckSelectedOpenAIAccountFromDB(ctx, candidate, groupID, platform, requestedModel, requireCompact, requiredCapability)
+		if fresh == nil || !s.openAIAccountMatchesSchedulingGroup(fresh, groupID) ||
+			!s.isOpenAIAccountTransportCompatible(fresh, requiredTransport) ||
+			!accountSupportsOpenAICapabilities(fresh, requiredCapability, requiredImageCapability) {
+			continue
+		}
+		result, acquireErr := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
+		if acquireErr != nil {
+			if fresh.ID != sticky.ID {
+				continue
+			}
+			_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, sticky.ID, openaiStickySessionTTL)
+			return nil, acquireErr
+		}
+		if result == nil || !result.Acquired {
+			continue
+		}
+		if sessionHash != "" && !gatewayProfitControlGateActive(ctx) {
+			_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
+		}
+		return s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
+	}
+
+	_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, sticky.ID, openaiStickySessionTTL)
+	cfg := s.schedulingConfig()
+	return s.newSelectionResult(ctx, sticky, false, nil, &AccountWaitPlan{
+		AccountID:      sticky.ID,
+		MaxConcurrency: sticky.Concurrency,
+		Timeout:        cfg.StickySessionWaitTimeout,
+		MaxWaiting:     cfg.StickySessionMaxWaiting,
+	})
+}
+
+func (s *OpenAIGatewayService) hasImmediatelyAvailableAccountSlot(ctx context.Context, account *Account) bool {
+	if account == nil || s.concurrencyService == nil || account.Concurrency <= 0 {
+		return true
+	}
+	current, err := s.concurrencyService.GetAccountConcurrency(ctx, account.ID)
+	return err == nil && current < account.Concurrency
 }
 
 // selectBestAccount 从候选账号中选择最佳账号（优先级 + LRU）。
@@ -873,6 +1032,30 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			stickyAccountID = accountID
 		}
 	}
+	stickyFallbackOnly := false
+	if stickyAccountID > 0 {
+		if sticky, stickyErr := s.getSchedulableAccount(ctx, stickyAccountID); stickyErr == nil && sticky != nil {
+			stickyFallbackOnly = sticky.OpenAISessionStickyModeOrDefault() == OpenAISessionStickyModeFallbackOnly
+		}
+	}
+	if stickyFallbackOnly && stickyAccountID > 0 && strings.TrimSpace(sessionHash) != "" {
+		selection, acquireErr := s.selectFallbackOnlyWithHigherPriorityAcquisition(
+			ctx,
+			groupID,
+			platform,
+			sessionHash,
+			stickyAccountID,
+			requestedModel,
+			excludedIDs,
+			requireCompact,
+			requiredCapability,
+			"",
+			OpenAIUpstreamTransportAny,
+		)
+		if acquireErr != nil || selection != nil {
+			return selection, acquireErr
+		}
+	}
 	if s.concurrencyService == nil || !cfg.LoadBatchEnabled {
 		account, err := s.selectAccountForModelWithExclusions(ctx, groupID, platform, sessionHash, requestedModel, excludedIDs, requireCompact, stickyAccountID, requiredCapability, preferLowUpstreamRate)
 		if err != nil {
@@ -939,6 +1122,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
+					} else if s.shouldEscapeFallbackOnlySticky(ctx, groupID, platform, sessionHash, account, requestedModel, excludedIDs, requireCompact, requiredCapability, OpenAIUpstreamTransportAny) {
 					} else {
 						result, err := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 						if err == nil && result != nil && result.Acquired {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -47,10 +47,11 @@ type modelRateLimitRecoveryRepository interface {
 }
 
 type ErrorRecoveryTarget struct {
-	ModelID                  string
-	ObservedModelRateLimit   json.RawMessage
-	ObservedAccountUpdatedAt time.Time
-	RecoverAccountState      bool
+	ModelID                     string
+	ObservedModelRateLimit      json.RawMessage
+	ObservedAccountUpdatedAt    time.Time
+	ObservedTransientGeneration uint64
+	RecoverAccountState         bool
 }
 
 // SuccessfulTestRecoveryResult 表示测试成功后恢复了哪些运行时状态。
@@ -1881,7 +1882,18 @@ func (s *RateLimitService) RecoverErrorTargetAfterSuccessfulTest(ctx context.Con
 		result.ClearedRateLimit = recovered
 	}
 	if len(target.ObservedModelRateLimit) > 0 {
-		cleared, err := repo.ClearModelRateLimitIfMatch(ctx, accountID, target.ModelID, target.ObservedModelRateLimit)
+		clear := func() (bool, error) {
+			return repo.ClearModelRateLimitIfMatch(ctx, accountID, target.ModelID, target.ObservedModelRateLimit)
+		}
+		cleared := false
+		var err error
+		if guard, ok := s.runtimeBlocker.(interface {
+			clearOpenAIAccountModelTransientStateIfGeneration(int64, string, uint64, func() (bool, error)) (bool, error)
+		}); ok {
+			cleared, err = guard.clearOpenAIAccountModelTransientStateIfGeneration(accountID, target.ModelID, target.ObservedTransientGeneration, clear)
+		} else {
+			cleared, err = clear()
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1939,6 +1951,12 @@ func hasAccountRecoverableRuntimeState(account *Account) bool {
 }
 
 func (s *RateLimitService) ErrorRecoveryTargets(ctx context.Context, accountID int64, accountProbeModel string) ([]ErrorRecoveryTarget, error) {
+	var observedTransientGenerations map[string]uint64
+	if observer, ok := s.runtimeBlocker.(interface {
+		openAIAccountModelTransientGenerations(int64) map[string]uint64
+	}); ok {
+		observedTransientGenerations = observer.openAIAccountModelTransientGenerations(accountID)
+	}
 	account, err := s.accountRepo.GetByID(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -1970,6 +1988,9 @@ func (s *RateLimitService) ErrorRecoveryTargets(ctx context.Context, accountID i
 				targets[modelID] = ErrorRecoveryTarget{
 					ModelID: modelID, ObservedModelRateLimit: observed, ObservedAccountUpdatedAt: account.UpdatedAt,
 				}
+				target := targets[modelID]
+				target.ObservedTransientGeneration = observedTransientGenerations[normalizeOpenAIAccountModelTransientModel(modelID)]
+				targets[modelID] = target
 			}
 		}
 	}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,10 +40,24 @@ type AccountRuntimeBlocker interface {
 	ClearAccountSchedulingBlock(accountID int64)
 }
 
+type modelRateLimitRecoveryRepository interface {
+	ClearModelRateLimit(ctx context.Context, id int64, modelID string) error
+	ClearModelRateLimitIfMatch(ctx context.Context, id int64, modelID string, observed json.RawMessage) (bool, error)
+	RecoverAccountRuntimeStateIfUnchanged(ctx context.Context, id int64, observedUpdatedAt time.Time) (bool, error)
+}
+
+type ErrorRecoveryTarget struct {
+	ModelID                  string
+	ObservedModelRateLimit   json.RawMessage
+	ObservedAccountUpdatedAt time.Time
+	RecoverAccountState      bool
+}
+
 // SuccessfulTestRecoveryResult 表示测试成功后恢复了哪些运行时状态。
 type SuccessfulTestRecoveryResult struct {
-	ClearedError     bool
-	ClearedRateLimit bool
+	ClearedError          bool
+	ClearedRateLimit      bool
+	ClearedModelRateLimit bool
 }
 
 // AccountRecoveryOptions 控制账号恢复时的附加行为。
@@ -1732,14 +1747,20 @@ func (s *RateLimitService) samplePassiveUsageFromHeaders(ctx context.Context, ac
 
 // ClearRateLimit 清除账号的限流状态
 func (s *RateLimitService) ClearRateLimit(ctx context.Context, accountID int64) error {
+	return s.clearRateLimit(ctx, accountID, true)
+}
+
+func (s *RateLimitService) clearRateLimit(ctx context.Context, accountID int64, clearAllModels bool) error {
 	if err := s.accountRepo.ClearRateLimit(ctx, accountID); err != nil {
 		return err
 	}
 	if err := s.accountRepo.ClearAntigravityQuotaScopes(ctx, accountID); err != nil {
 		return err
 	}
-	if err := s.accountRepo.ClearModelRateLimits(ctx, accountID); err != nil {
-		return err
+	if clearAllModels {
+		if err := s.accountRepo.ClearModelRateLimits(ctx, accountID); err != nil {
+			return err
+		}
 	}
 	// 清除限流时一并清理临时不可调度状态，避免周限/窗口重置后仍被本地临时状态阻断。
 	if err := s.accountRepo.ClearTempUnschedulable(ctx, accountID); err != nil {
@@ -1800,10 +1821,77 @@ func (s *RateLimitService) RecoverAccountState(ctx context.Context, accountID in
 	return result, nil
 }
 
-// RecoverAccountAfterSuccessfulTest 将一次成功测试视为正常请求，
-// 按需恢复 error / rate-limit / overload / temp-unsched / model-rate-limit 等运行时状态。
-func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64) (*SuccessfulTestRecoveryResult, error) {
-	return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+// RecoverAccountAfterSuccessfulTest 将成功测试视为目标模型已恢复，账号级自动状态也可一并恢复。
+func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64, modelID string) (*SuccessfulTestRecoveryResult, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SuccessfulTestRecoveryResult{}
+	if account.Status == StatusError {
+		if err := s.accountRepo.ClearError(ctx, accountID); err != nil {
+			return nil, err
+		}
+		result.ClearedError = true
+	}
+	if hasAccountRecoverableRuntimeState(account) {
+		if err := s.clearRateLimit(ctx, accountID, false); err != nil {
+			return nil, err
+		}
+		result.ClearedRateLimit = true
+	}
+
+	modelKey := strings.TrimSpace(modelID)
+	if !account.isRateLimitActiveForKey(modelKey) {
+		modelKey = account.modelRateLimitKeyWithContext(ctx, modelID)
+	}
+	if modelKey != "" && modelKey != creditsExhaustedKey && account.isRateLimitActiveForKey(modelKey) {
+		repo, ok := s.accountRepo.(modelRateLimitRecoveryRepository)
+		if !ok {
+			return nil, fmt.Errorf("account repository does not support targeted model recovery")
+		}
+		if err := repo.ClearModelRateLimit(ctx, accountID, modelKey); err != nil {
+			return nil, err
+		}
+		result.ClearedModelRateLimit = true
+	}
+	if result.ClearedError || result.ClearedRateLimit || result.ClearedModelRateLimit {
+		s.ResetOpenAI403Counter(ctx, accountID)
+		if result.ClearedError && !result.ClearedRateLimit {
+			s.notifyAccountSchedulingBlockCleared(accountID)
+		}
+	}
+	return result, nil
+}
+
+func (s *RateLimitService) RecoverErrorTargetAfterSuccessfulTest(ctx context.Context, accountID int64, target ErrorRecoveryTarget) (*SuccessfulTestRecoveryResult, error) {
+	repo, ok := s.accountRepo.(modelRateLimitRecoveryRepository)
+	if !ok {
+		return nil, fmt.Errorf("account repository does not support conditional error recovery")
+	}
+
+	result := &SuccessfulTestRecoveryResult{}
+	if target.RecoverAccountState {
+		recovered, err := repo.RecoverAccountRuntimeStateIfUnchanged(ctx, accountID, target.ObservedAccountUpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		result.ClearedError = recovered
+		result.ClearedRateLimit = recovered
+	}
+	if len(target.ObservedModelRateLimit) > 0 {
+		cleared, err := repo.ClearModelRateLimitIfMatch(ctx, accountID, target.ModelID, target.ObservedModelRateLimit)
+		if err != nil {
+			return nil, err
+		}
+		result.ClearedModelRateLimit = cleared
+	}
+	if result.ClearedError || result.ClearedModelRateLimit {
+		s.ResetOpenAI403Counter(ctx, accountID)
+		s.notifyAccountSchedulingBlockCleared(accountID)
+	}
+	return result, nil
 }
 
 func (s *RateLimitService) ClearTempUnschedulable(ctx context.Context, accountID int64) error {
@@ -1835,6 +1923,78 @@ func hasRecoverableRuntimeState(account *Account) bool {
 	}
 	return hasNonEmptyMapValue(account.Extra, "model_rate_limits") ||
 		hasNonEmptyMapValue(account.Extra, "antigravity_quota_scopes")
+}
+
+func hasAccountRecoverableRuntimeState(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	now := time.Now()
+	if (account.RateLimitResetAt != nil && now.Before(*account.RateLimitResetAt)) ||
+		(account.OverloadUntil != nil && now.Before(*account.OverloadUntil)) ||
+		(account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil)) {
+		return true
+	}
+	return hasNonEmptyMapValue(account.Extra, "antigravity_quota_scopes")
+}
+
+func (s *RateLimitService) ErrorRecoveryTargets(ctx context.Context, accountID int64, accountProbeModel string) ([]ErrorRecoveryTarget, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if account.Status != StatusActive && account.Status != StatusError {
+		return nil, nil
+	}
+	if account.Status == StatusActive && !account.Schedulable {
+		return nil, nil
+	}
+	if account.ExpiresAt != nil && !time.Now().Before(*account.ExpiresAt) {
+		return nil, nil
+	}
+	hasAccountState := hasAccountRecoverableRuntimeState(account)
+	if account.Status == StatusError && !hasAccountState {
+		return nil, nil
+	}
+
+	targets := make(map[string]ErrorRecoveryTarget)
+	if limits, ok := account.Extra[modelRateLimitsKey].(map[string]any); ok {
+		for modelID, limit := range limits {
+			if modelID != creditsExhaustedKey &&
+				!isInternalModelRateLimitScope(modelID) &&
+				account.isRateLimitActiveForKey(modelID) {
+				observed, err := json.Marshal(limit)
+				if err != nil {
+					return nil, err
+				}
+				targets[modelID] = ErrorRecoveryTarget{
+					ModelID: modelID, ObservedModelRateLimit: observed, ObservedAccountUpdatedAt: account.UpdatedAt,
+				}
+			}
+		}
+	}
+	if hasAccountState && accountProbeModel != "" && !isInternalModelRateLimitScope(accountProbeModel) {
+		target := targets[accountProbeModel]
+		target.ModelID = accountProbeModel
+		target.ObservedAccountUpdatedAt = account.UpdatedAt
+		target.RecoverAccountState = true
+		targets[accountProbeModel] = target
+	}
+
+	modelIDs := make([]string, 0, len(targets))
+	for modelID := range targets {
+		modelIDs = append(modelIDs, modelID)
+	}
+	sort.Strings(modelIDs)
+	result := make([]ErrorRecoveryTarget, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if targets[modelID].RecoverAccountState {
+			result = append([]ErrorRecoveryTarget{targets[modelID]}, result...)
+			continue
+		}
+		result = append(result, targets[modelID])
+	}
+	return result, nil
 }
 
 func hasNonEmptyMapValue(extra map[string]any, key string) bool {

--- a/backend/internal/service/ratelimit_service_clear_test.go
+++ b/backend/internal/service/ratelimit_service_clear_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -21,6 +22,8 @@ type rateLimitClearRepoStub struct {
 	clearRateLimitCalls       int
 	clearAntigravityCalls     int
 	clearModelRateLimitCalls  int
+	clearModelRateLimitKeys   []string
+	recoverRuntimeCalls       int
 	clearTempUnschedCalls     int
 	clearErrorErr             error
 	clearRateLimitErr         error
@@ -55,6 +58,41 @@ func (r *rateLimitClearRepoStub) ClearAntigravityQuotaScopes(ctx context.Context
 func (r *rateLimitClearRepoStub) ClearModelRateLimits(ctx context.Context, id int64) error {
 	r.clearModelRateLimitCalls++
 	return r.clearModelRateLimitErr
+}
+
+func (r *rateLimitClearRepoStub) ClearModelRateLimit(ctx context.Context, id int64, modelID string) error {
+	r.clearModelRateLimitKeys = append(r.clearModelRateLimitKeys, modelID)
+	return r.clearModelRateLimitErr
+}
+
+func (r *rateLimitClearRepoStub) ClearModelRateLimitIfMatch(_ context.Context, _ int64, modelID string, observed json.RawMessage) (bool, error) {
+	if r.clearModelRateLimitErr != nil || r.getByIDAccount == nil {
+		return false, r.clearModelRateLimitErr
+	}
+	limits, _ := r.getByIDAccount.Extra[modelRateLimitsKey].(map[string]any)
+	current, ok := limits[modelID]
+	if !ok {
+		return false, nil
+	}
+	encoded, err := json.Marshal(current)
+	if err != nil || string(encoded) != string(observed) {
+		return false, err
+	}
+	delete(limits, modelID)
+	r.clearModelRateLimitKeys = append(r.clearModelRateLimitKeys, modelID)
+	r.getByIDAccount.UpdatedAt = r.getByIDAccount.UpdatedAt.Add(time.Nanosecond)
+	return true, nil
+}
+
+func (r *rateLimitClearRepoStub) RecoverAccountRuntimeStateIfUnchanged(_ context.Context, _ int64, observedUpdatedAt time.Time) (bool, error) {
+	if r.getByIDAccount == nil || !r.getByIDAccount.UpdatedAt.Equal(observedUpdatedAt) {
+		return false, nil
+	}
+	r.recoverRuntimeCalls++
+	r.getByIDAccount.Status = StatusActive
+	r.getByIDAccount.Schedulable = true
+	r.getByIDAccount.UpdatedAt = r.getByIDAccount.UpdatedAt.Add(time.Nanosecond)
+	return true, nil
 }
 
 func (r *rateLimitClearRepoStub) ClearTempUnschedulable(ctx context.Context, id int64) error {
@@ -202,6 +240,7 @@ func TestRateLimitService_ClearRateLimit_WithoutTempUnschedCache(t *testing.T) {
 
 func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLimitRelatedState(t *testing.T) {
 	now := time.Now()
+	resetAt := now.Add(time.Hour)
 	repo := &rateLimitClearRepoStub{
 		getByIDAccount: &Account{
 			ID:                     42,
@@ -210,8 +249,14 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLi
 			TempUnschedulableUntil: &now,
 			Extra: map[string]any{
 				"model_rate_limits": map[string]any{
-					"claude-sonnet-4-5": map[string]any{
-						"rate_limit_reset_at": now.Format(time.RFC3339),
+					"gpt-5.6-sol": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+					},
+					"gpt-5.6-luna": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+					},
+					"AICredits": map[string]any{
+						"rate_limit_reset_at": resetAt.Format(time.RFC3339),
 					},
 				},
 				"antigravity_quota_scopes": map[string]any{"gemini": true},
@@ -223,17 +268,19 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLi
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, cache)
 	svc.SetAccountRuntimeBlocker(blocker)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 42)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 42, "gpt-5.6-sol")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.ClearedError)
 	require.True(t, result.ClearedRateLimit)
+	require.True(t, result.ClearedModelRateLimit)
 
 	require.Equal(t, 1, repo.getByIDCalls)
 	require.Equal(t, 1, repo.clearErrorCalls)
 	require.Equal(t, 1, repo.clearRateLimitCalls)
 	require.Equal(t, 1, repo.clearAntigravityCalls)
-	require.Equal(t, 1, repo.clearModelRateLimitCalls)
+	require.Equal(t, 0, repo.clearModelRateLimitCalls)
+	require.Equal(t, []string{"gpt-5.6-sol"}, repo.clearModelRateLimitKeys)
 	require.Equal(t, 1, repo.clearTempUnschedCalls)
 	require.Equal(t, []int64{42}, cache.deletedIDs)
 	require.Equal(t, []int64{42}, blocker.clearedIDs)
@@ -251,17 +298,19 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_NoRecoverableStateIs
 	cache := &tempUnschedCacheRecorder{}
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, cache)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 7)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 7, "gpt-5.6-sol")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.ClearedError)
 	require.False(t, result.ClearedRateLimit)
+	require.False(t, result.ClearedModelRateLimit)
 
 	require.Equal(t, 1, repo.getByIDCalls)
 	require.Equal(t, 0, repo.clearErrorCalls)
 	require.Equal(t, 0, repo.clearRateLimitCalls)
 	require.Equal(t, 0, repo.clearAntigravityCalls)
 	require.Equal(t, 0, repo.clearModelRateLimitCalls)
+	require.Empty(t, repo.clearModelRateLimitKeys)
 	require.Equal(t, 0, repo.clearTempUnschedCalls)
 	require.Empty(t, cache.deletedIDs)
 }
@@ -276,7 +325,7 @@ func TestRateLimitService_RecoverAccountAfterSuccessfulTest_ClearErrorFailed(t *
 	}
 	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 
-	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 9)
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), 9, "gpt-5.6-sol")
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.Equal(t, 1, repo.getByIDCalls)

--- a/backend/internal/service/ratelimit_service_clear_test.go
+++ b/backend/internal/service/ratelimit_service_clear_test.go
@@ -17,7 +17,9 @@ type rateLimitClearRepoStub struct {
 	mockAccountRepoForGemini
 	getByIDAccount            *Account
 	getByIDErr                error
+	getByIDErrAfter           int
 	getByIDCalls              int
+	getByIDHook               func()
 	clearErrorCalls           int
 	clearRateLimitCalls       int
 	clearAntigravityCalls     int
@@ -34,7 +36,10 @@ type rateLimitClearRepoStub struct {
 
 func (r *rateLimitClearRepoStub) GetByID(ctx context.Context, id int64) (*Account, error) {
 	r.getByIDCalls++
-	if r.getByIDErr != nil {
+	if r.getByIDHook != nil {
+		r.getByIDHook()
+	}
+	if r.getByIDErr != nil && (r.getByIDErrAfter == 0 || r.getByIDCalls > r.getByIDErrAfter) {
 		return nil, r.getByIDErr
 	}
 	return r.getByIDAccount, nil
@@ -108,6 +113,133 @@ type tempUnschedCacheRecorder struct {
 type recoverTokenInvalidatorStub struct {
 	accounts []*Account
 	err      error
+}
+
+func TestRateLimitService_RecoverErrorTargetClearsGatewayModelTransientState(t *testing.T) {
+	limit := map[string]any{"rate_limit_reset_at": time.Now().Add(10 * time.Minute).Format(time.RFC3339)}
+	repo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 42, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{modelRateLimitsKey: map[string]any{
+			"gpt-5.6-sol": limit,
+		}},
+	}}
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var initialClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"initial-1", "initial-2", "initial-3"} {
+		initialClaim = state.recordFailure(42, "gpt-5.6-sol", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.finishCircuitPersistence(42, "gpt-5.6-sol", initialClaim.PersistenceGeneration, true)
+	gateway := &OpenAIGatewayService{openaiModelTransient: state}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(gateway)
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), 42, "")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+
+	result, err := svc.RecoverErrorTargetAfterSuccessfulTest(context.Background(), 42, targets[0])
+
+	require.NoError(t, err)
+	require.True(t, result.ClearedModelRateLimit)
+	require.Zero(t, state.size())
+	var rearmedClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"rearmed-1", "rearmed-2", "rearmed-3"} {
+		rearmedClaim = state.recordFailure(42, "gpt-5.6-sol", now.Add(time.Duration(i+3)*time.Millisecond), requestID)
+	}
+	require.True(t, rearmedClaim.OpenCircuit)
+	require.NotEqual(t, initialClaim.PersistenceGeneration, rearmedClaim.PersistenceGeneration)
+}
+
+func TestRateLimitService_RecoverErrorTargetPreservesFailureAfterProbeSnapshot(t *testing.T) {
+	limit := map[string]any{"rate_limit_reset_at": time.Now().Add(10 * time.Minute).Format(time.RFC3339)}
+	account := &Account{
+		ID: 43, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{modelRateLimitsKey: map[string]any{"gpt-5.6-sol": limit}},
+	}
+	repo := &rateLimitClearRepoStub{getByIDAccount: account}
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var claim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"initial-1", "initial-2", "initial-3"} {
+		claim = state.recordFailure(account.ID, "gpt-5.6-sol", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.finishCircuitPersistence(account.ID, "gpt-5.6-sol", claim.PersistenceGeneration, true)
+	gateway := &OpenAIGatewayService{openaiModelTransient: state}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(gateway)
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), account.ID, "")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+
+	state.recordFailure(account.ID, "gpt-5.6-sol", now.Add(4*time.Millisecond), "after-probe-snapshot")
+	result, err := svc.RecoverErrorTargetAfterSuccessfulTest(context.Background(), account.ID, targets[0])
+
+	require.NoError(t, err)
+	require.False(t, result.ClearedModelRateLimit)
+	require.Empty(t, repo.clearModelRateLimitKeys)
+	require.Equal(t, 1, state.size())
+}
+
+func TestRateLimitService_ErrorRecoveryTargetPreservesFailureDuringAccountRead(t *testing.T) {
+	limit := map[string]any{"rate_limit_reset_at": time.Now().Add(10 * time.Minute).Format(time.RFC3339)}
+	account := &Account{
+		ID: 44, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{modelRateLimitsKey: map[string]any{"gpt-5.6-sol": limit}},
+	}
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var claim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"initial-1", "initial-2", "initial-3"} {
+		claim = state.recordFailure(account.ID, "gpt-5.6-sol", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.finishCircuitPersistence(account.ID, "gpt-5.6-sol", claim.PersistenceGeneration, true)
+	repo := &rateLimitClearRepoStub{getByIDAccount: account}
+	repo.getByIDHook = func() {
+		state.recordFailure(account.ID, "gpt-5.6-sol", now.Add(4*time.Millisecond), "during-account-read")
+		repo.getByIDHook = nil
+	}
+	gateway := &OpenAIGatewayService{openaiModelTransient: state}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(gateway)
+
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), account.ID, "")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	result, err := svc.RecoverErrorTargetAfterSuccessfulTest(context.Background(), account.ID, targets[0])
+
+	require.NoError(t, err)
+	require.False(t, result.ClearedModelRateLimit)
+	require.Empty(t, repo.clearModelRateLimitKeys)
+	require.Equal(t, 1, state.size())
+}
+
+func TestRateLimitService_ErrorRecoveryTargetMatchesCanonicalModelCase(t *testing.T) {
+	limit := map[string]any{"rate_limit_reset_at": time.Now().Add(10 * time.Minute).Format(time.RFC3339)}
+	account := &Account{
+		ID: 45, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{modelRateLimitsKey: map[string]any{"GPT-5.6-SOL": limit}},
+	}
+	repo := &rateLimitClearRepoStub{getByIDAccount: account}
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var claim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"initial-1", "initial-2", "initial-3"} {
+		claim = state.recordFailure(account.ID, "GPT-5.6-SOL", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.finishCircuitPersistence(account.ID, "GPT-5.6-SOL", claim.PersistenceGeneration, true)
+	gateway := &OpenAIGatewayService{openaiModelTransient: state}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(gateway)
+
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), account.ID, "")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	result, err := svc.RecoverErrorTargetAfterSuccessfulTest(context.Background(), account.ID, targets[0])
+
+	require.NoError(t, err)
+	require.True(t, result.ClearedModelRateLimit)
+	require.Equal(t, []string{"GPT-5.6-SOL"}, repo.clearModelRateLimitKeys)
+	require.Zero(t, state.size())
 }
 
 func (c *tempUnschedCacheRecorder) SetTempUnsched(ctx context.Context, accountID int64, state *TempUnschedState) error {

--- a/backend/internal/service/scheduled_test_port.go
+++ b/backend/internal/service/scheduled_test_port.go
@@ -7,23 +7,28 @@ import (
 
 // ScheduledTestPlan represents a scheduled test plan domain model.
 type ScheduledTestPlan struct {
-	ID             int64      `json:"id"`
-	AccountID      int64      `json:"account_id"`
-	ModelID        string     `json:"model_id"`
-	CronExpression string     `json:"cron_expression"`
-	Enabled        bool       `json:"enabled"`
-	MaxResults     int        `json:"max_results"`
-	AutoRecover    bool       `json:"auto_recover"`
-	LastRunAt      *time.Time `json:"last_run_at"`
-	NextRunAt      *time.Time `json:"next_run_at"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	ID                   int64      `json:"id"`
+	AccountID            int64      `json:"account_id"`
+	ModelID              string     `json:"model_id"`
+	ModelIDs             []string   `json:"model_ids"`
+	CronExpression       string     `json:"cron_expression"`
+	TriggerMode          string     `json:"trigger_mode"`
+	RetryIntervalMinutes *int       `json:"retry_interval_minutes"`
+	RetryCronExpression  *string    `json:"retry_cron_expression"`
+	Enabled              bool       `json:"enabled"`
+	MaxResults           int        `json:"max_results"`
+	AutoRecover          bool       `json:"auto_recover"`
+	LastRunAt            *time.Time `json:"last_run_at"`
+	NextRunAt            *time.Time `json:"next_run_at"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
 }
 
 // ScheduledTestResult represents a single test execution result.
 type ScheduledTestResult struct {
 	ID           int64     `json:"id"`
 	PlanID       int64     `json:"plan_id"`
+	ModelID      string    `json:"model_id"`
 	Status       string    `json:"status"`
 	ResponseText string    `json:"response_text"`
 	ErrorMessage string    `json:"error_message"`
@@ -42,11 +47,13 @@ type ScheduledTestPlanRepository interface {
 	Update(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error)
 	Delete(ctx context.Context, id int64) error
 	UpdateAfterRun(ctx context.Context, id int64, lastRunAt time.Time, nextRunAt time.Time) error
+	UpdateNextRun(ctx context.Context, id int64, nextRunAt time.Time) error
 }
 
 // ScheduledTestResultRepository defines the data access interface for test results.
 type ScheduledTestResultRepository interface {
 	Create(ctx context.Context, result *ScheduledTestResult) (*ScheduledTestResult, error)
+	Update(ctx context.Context, result *ScheduledTestResult) error
 	ListByPlanID(ctx context.Context, planID int64, limit int) ([]*ScheduledTestResult, error)
-	PruneOldResults(ctx context.Context, planID int64, keepCount int) error
+	PruneOldResults(ctx context.Context, planID int64, modelID string, keepCount int) error
 }

--- a/backend/internal/service/scheduled_test_runner_service.go
+++ b/backend/internal/service/scheduled_test_runner_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -12,17 +13,22 @@ import (
 
 const scheduledTestDefaultMaxWorkers = 10
 
+type scheduledAccountTester interface {
+	RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error)
+}
+
 // ScheduledTestRunnerService periodically scans due test plans and executes them.
 type ScheduledTestRunnerService struct {
 	planRepo       ScheduledTestPlanRepository
 	scheduledSvc   *ScheduledTestService
-	accountTestSvc *AccountTestService
+	accountTestSvc scheduledAccountTester
 	rateLimitSvc   *RateLimitService
 	cfg            *config.Config
 
 	cron      *cron.Cron
 	startOnce sync.Once
 	stopOnce  sync.Once
+	running   sync.Map
 }
 
 // NewScheduledTestRunnerService creates a new runner.
@@ -120,39 +126,147 @@ func (s *ScheduledTestRunnerService) runScheduled() {
 }
 
 func (s *ScheduledTestRunnerService) runOnePlan(ctx context.Context, plan *ScheduledTestPlan) {
-	result, err := s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, plan.ModelID)
-	if err != nil {
-		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d RunTestBackground error: %v", plan.ID, err)
+	if _, loaded := s.running.LoadOrStore(plan.ID, struct{}{}); loaded {
+		return
+	}
+	defer s.running.Delete(plan.ID)
+
+	if plan.TriggerMode == ScheduledTestTriggerErrorRecovery {
+		s.runErrorRecoveryPlan(ctx, plan)
 		return
 	}
 
-	if err := s.scheduledSvc.SaveResult(ctx, plan.ID, plan.MaxResults, result); err != nil {
-		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d SaveResult error: %v", plan.ID, err)
-	}
-
-	// Auto-recover account if test succeeded and auto_recover is enabled.
-	if result.Status == "success" && plan.AutoRecover {
-		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID)
-	}
-
+	s.runModelTest(ctx, plan, plan.ModelID)
 	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d computeNextRun error: %v", plan.ID, err)
 		return
 	}
-
 	if err := s.planRepo.UpdateAfterRun(ctx, plan.ID, time.Now(), nextRun); err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateAfterRun error: %v", plan.ID, err)
 	}
 }
 
+func (s *ScheduledTestRunnerService) runErrorRecoveryPlan(ctx context.Context, plan *ScheduledTestPlan) {
+	if s.rateLimitSvc == nil {
+		return
+	}
+	startedAt := time.Now().Truncate(time.Second)
+	targets, err := s.rateLimitSvc.ErrorRecoveryTargets(ctx, plan.AccountID, plan.ModelID)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d recovery targets error: %v", plan.ID, err)
+		return
+	}
+	if len(targets) == 0 {
+		if err := s.planRepo.UpdateNextRun(ctx, plan.ID, startedAt.Add(time.Minute)); err != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateNextRun error: %v", plan.ID, err)
+		}
+		return
+	}
+
+	for _, target := range targets {
+		if len(plan.ModelIDs) > 0 && !containsModelID(plan.ModelIDs, target.ModelID) && !target.RecoverAccountState {
+			continue
+		}
+		s.runModelTest(ctx, plan, target.ModelID, &target)
+	}
+	nextRun, err := computeRecoveryNextRun(plan, startedAt)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d compute recovery next run error: %v", plan.ID, err)
+		return
+	}
+	if err := s.planRepo.UpdateAfterRun(ctx, plan.ID, time.Now(), nextRun); err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateAfterRun error: %v", plan.ID, err)
+	}
+}
+
+func containsModelID(modelIDs []string, modelID string) bool {
+	for _, candidate := range modelIDs {
+		if candidate == modelID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ScheduledTestRunnerService) runModelTest(ctx context.Context, plan *ScheduledTestPlan, modelID string, recoveryTarget ...*ErrorRecoveryTarget) {
+	startedAt := time.Now()
+	runningResult := &ScheduledTestResult{
+		ModelID:    modelID,
+		Status:     "running",
+		StartedAt:  startedAt,
+		FinishedAt: startedAt,
+	}
+	savedResult, err := s.scheduledSvc.StartResult(ctx, plan.ID, runningResult)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s StartResult error: %v", plan.ID, modelID, err)
+		return
+	}
+
+	result, err := s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, modelID)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s RunTestBackground error: %v", plan.ID, modelID, err)
+		runningResult.ID = savedResult.ID
+		runningResult.Status = "failed"
+		runningResult.ErrorMessage = err.Error()
+		runningResult.FinishedAt = time.Now()
+		runningResult.LatencyMs = runningResult.FinishedAt.Sub(startedAt).Milliseconds()
+		if updateErr := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, runningResult); updateErr != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s failed result update error: %v", plan.ID, modelID, updateErr)
+		}
+		return
+	}
+	if result == nil {
+		runningResult.ID = savedResult.ID
+		runningResult.Status = "failed"
+		runningResult.ErrorMessage = fmt.Sprintf("background test returned no result for model %s", modelID)
+		runningResult.FinishedAt = time.Now()
+		runningResult.LatencyMs = runningResult.FinishedAt.Sub(startedAt).Milliseconds()
+		if updateErr := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, runningResult); updateErr != nil {
+			logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s nil result update error: %v", plan.ID, modelID, updateErr)
+		}
+		return
+	}
+	result.ModelID = modelID
+	result.ID = savedResult.ID
+	if result.StartedAt.IsZero() {
+		result.StartedAt = startedAt
+	}
+	if result.FinishedAt.IsZero() {
+		result.FinishedAt = time.Now()
+	}
+	if err := s.scheduledSvc.UpdateResult(ctx, plan.ID, plan.MaxResults, result); err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d SaveResult error: %v", plan.ID, err)
+	}
+
+	// Auto-recover account if test succeeded and auto_recover is enabled.
+	if result.Status == "success" && plan.AutoRecover {
+		if len(recoveryTarget) > 0 && recoveryTarget[0] != nil {
+			s.tryRecoverErrorTarget(ctx, plan.AccountID, plan.ID, *recoveryTarget[0])
+			return
+		}
+		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID, modelID)
+	}
+}
+
+func (s *ScheduledTestRunnerService) tryRecoverErrorTarget(ctx context.Context, accountID int64, planID int64, target ErrorRecoveryTarget) {
+	recovery, err := s.rateLimitSvc.RecoverErrorTargetAfterSuccessfulTest(ctx, accountID, target)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d conditional auto-recover failed: %v", planID, err)
+		return
+	}
+	if recovery.ClearedModelRateLimit {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d model=%s recovered", planID, accountID, target.ModelID)
+	}
+}
+
 // tryRecoverAccount attempts to recover an account from recoverable runtime state.
-func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64) {
+func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64, modelID string) {
 	if s.rateLimitSvc == nil {
 		return
 	}
 
-	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID)
+	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID, modelID)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover failed: %v", planID, err)
 		return
@@ -166,5 +280,8 @@ func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, acco
 	}
 	if recovery.ClearedRateLimit {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d cleared rate-limit/runtime state", planID, accountID)
+	}
+	if recovery.ClearedModelRateLimit {
+		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover: account=%d model=%s recovered", planID, accountID, modelID)
 	}
 }

--- a/backend/internal/service/scheduled_test_runner_service.go
+++ b/backend/internal/service/scheduled_test_runner_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ const scheduledTestDefaultMaxWorkers = 10
 
 type scheduledAccountTester interface {
 	RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error)
+	RunCanonicalTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error)
 }
 
 // ScheduledTestRunnerService periodically scans due test plans and executes them.
@@ -164,8 +166,9 @@ func (s *ScheduledTestRunnerService) runErrorRecoveryPlan(ctx context.Context, p
 		return
 	}
 
+	allowedModels := s.recoveryPlanTargetIDs(ctx, plan.AccountID, plan.ModelIDs, targets)
 	for _, target := range targets {
-		if len(plan.ModelIDs) > 0 && !containsModelID(plan.ModelIDs, target.ModelID) && !target.RecoverAccountState {
+		if len(plan.ModelIDs) > 0 && !containsModelID(allowedModels, target.ModelID) && !target.RecoverAccountState {
 			continue
 		}
 		s.runModelTest(ctx, plan, target.ModelID, &target)
@@ -178,6 +181,47 @@ func (s *ScheduledTestRunnerService) runErrorRecoveryPlan(ctx context.Context, p
 	if err := s.planRepo.UpdateAfterRun(ctx, plan.ID, time.Now(), nextRun); err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d UpdateAfterRun error: %v", plan.ID, err)
 	}
+}
+
+func (s *ScheduledTestRunnerService) recoveryPlanTargetIDs(ctx context.Context, accountID int64, modelIDs []string, targets []ErrorRecoveryTarget) []string {
+	if len(modelIDs) == 0 {
+		return nil
+	}
+	allowed := make([]string, 0, len(modelIDs))
+	missingExact := make([]string, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if recoveryTargetsContainModel(targets, modelID) {
+			allowed = append(allowed, modelID)
+		} else {
+			missingExact = append(missingExact, modelID)
+		}
+	}
+	if len(missingExact) == 0 {
+		return allowed
+	}
+	if s == nil || s.rateLimitSvc == nil || s.rateLimitSvc.accountRepo == nil {
+		return allowed
+	}
+	account, err := s.rateLimitSvc.accountRepo.GetByID(ctx, accountID)
+	if err != nil || account == nil || account.Platform != PlatformOpenAI {
+		return allowed
+	}
+	for _, modelID := range missingExact {
+		mapped := strings.TrimSpace(account.GetMappedModel(modelID))
+		if mapped != "" && recoveryTargetsContainModel(targets, mapped) && !containsModelID(allowed, mapped) {
+			allowed = append(allowed, mapped)
+		}
+	}
+	return allowed
+}
+
+func recoveryTargetsContainModel(targets []ErrorRecoveryTarget, modelID string) bool {
+	for _, target := range targets {
+		if target.ModelID == modelID {
+			return true
+		}
+	}
+	return false
 }
 
 func containsModelID(modelIDs []string, modelID string) bool {
@@ -203,7 +247,12 @@ func (s *ScheduledTestRunnerService) runModelTest(ctx context.Context, plan *Sch
 		return
 	}
 
-	result, err := s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, modelID)
+	var result *ScheduledTestResult
+	if len(recoveryTarget) > 0 && recoveryTarget[0] != nil {
+		result, err = s.accountTestSvc.RunCanonicalTestBackground(ctx, plan.AccountID, modelID)
+	} else {
+		result, err = s.accountTestSvc.RunTestBackground(ctx, plan.AccountID, modelID)
+	}
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d model=%s RunTestBackground error: %v", plan.ID, modelID, err)
 		runningResult.ID = savedResult.ID

--- a/backend/internal/service/scheduled_test_runner_service_test.go
+++ b/backend/internal/service/scheduled_test_runner_service_test.go
@@ -72,15 +72,25 @@ func (r *scheduledResultRepoStub) PruneOldResults(context.Context, int64, string
 }
 
 type scheduledTesterStub struct {
-	models       []string
-	status       map[string]string
-	err          map[string]error
-	delay        time.Duration
-	beforeReturn func(string)
+	models          []string
+	canonicalModels []string
+	status          map[string]string
+	err             map[string]error
+	delay           time.Duration
+	beforeReturn    func(string)
 }
 
 func (s *scheduledTesterStub) RunTestBackground(_ context.Context, _ int64, modelID string) (*ScheduledTestResult, error) {
 	s.models = append(s.models, modelID)
+	return s.run(modelID)
+}
+
+func (s *scheduledTesterStub) RunCanonicalTestBackground(_ context.Context, _ int64, modelID string) (*ScheduledTestResult, error) {
+	s.canonicalModels = append(s.canonicalModels, modelID)
+	return s.run(modelID)
+}
+
+func (s *scheduledTesterStub) run(modelID string) (*ScheduledTestResult, error) {
 	if s.delay > 0 {
 		time.Sleep(s.delay)
 	}
@@ -144,7 +154,7 @@ func TestScheduledTestRunner_ErrorRecoveryTestsEachModelAndClearsOnlySuccess(t *
 
 	runner.runOnePlan(context.Background(), plan)
 
-	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}, tester.models)
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}, tester.canonicalModels)
 	require.Len(t, resultRepo.results, 3)
 	require.Equal(t, []string{"running", "running", "running"}, resultRepo.createStatuses)
 	require.Equal(t, []string{"failed", "success", "failed"}, resultRepo.updateStatuses)
@@ -172,7 +182,107 @@ func TestScheduledTestRunner_ErrorRecoveryOnlyTestsSelectedFailedModels(t *testi
 		TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
 	})
 
-	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.canonicalModels)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryMapsPlanModelOnceAndProbesCanonicalTarget(t *testing.T) {
+	interval := 5
+	account := &Account{
+		ID:          143,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{"model_mapping": map[string]any{
+			"public-alias": "upstream-a",
+			"upstream-a":   "upstream-b",
+		}},
+		Extra: map[string]any{modelRateLimitsKey: activeModelLimits(time.Now().Add(time.Hour), "upstream-a")},
+	}
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: account}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"upstream-a": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 113, AccountID: account.ID, ModelID: "public-alias", ModelIDs: []string{"public-alias"},
+		TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Empty(t, tester.models)
+	require.Equal(t, []string{"upstream-a"}, tester.canonicalModels)
+	require.Equal(t, []string{"upstream-a"}, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryExactTargetWinsOverMappedSibling(t *testing.T) {
+	interval := 5
+	account := &Account{
+		ID: 144, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+		Credentials: map[string]any{"model_mapping": map[string]any{"upstream-a": "upstream-b"}},
+		Extra: map[string]any{modelRateLimitsKey: activeModelLimits(
+			time.Now().Add(time.Hour), "upstream-a", "upstream-b",
+		)},
+	}
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: account}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"upstream-a": "success", "upstream-b": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 114, AccountID: account.ID, ModelID: "upstream-a", ModelIDs: []string{"upstream-a"},
+		TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"upstream-a"}, tester.canonicalModels)
+	require.Equal(t, []string{"upstream-a"}, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryConstrainedPlanWithNoMatchRunsNothing(t *testing.T) {
+	tests := []struct {
+		name        string
+		modelIDs    []string
+		mapping     map[string]any
+		getByIDFail bool
+	}{
+		{name: "unknown model", modelIDs: []string{"unknown"}},
+		{name: "mapped target missing", modelIDs: []string{"public-alias"}, mapping: map[string]any{"public-alias": "missing-upstream"}},
+		{name: "mapping lookup fails", modelIDs: []string{"public-alias"}, mapping: map[string]any{"public-alias": "upstream-a"}, getByIDFail: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interval := 5
+			account := &Account{
+				ID: 145, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true,
+				Credentials: map[string]any{"model_mapping": tt.mapping},
+				Extra:       map[string]any{modelRateLimitsKey: activeModelLimits(time.Now().Add(time.Hour), "upstream-a")},
+			}
+			repo := &rateLimitClearRepoStub{getByIDAccount: account}
+			if tt.getByIDFail {
+				repo.getByIDErr = context.DeadlineExceeded
+				repo.getByIDErrAfter = 1
+			}
+			planRepo := &scheduledPlanRepoStub{}
+			tester := &scheduledTesterStub{status: map[string]string{"upstream-a": "success"}}
+			runner := &ScheduledTestRunnerService{
+				planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+				accountTestSvc: tester, rateLimitSvc: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+			}
+
+			runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+				ID: 115, AccountID: account.ID, ModelID: tt.modelIDs[0], ModelIDs: tt.modelIDs,
+				TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+			})
+
+			require.Empty(t, tester.canonicalModels)
+			require.Empty(t, repo.clearModelRateLimitKeys)
+		})
+	}
 }
 
 func TestScheduledTestRunner_ErrorRecoveryDoesNotRecoverWhenDisabled(t *testing.T) {
@@ -192,7 +302,7 @@ func TestScheduledTestRunner_ErrorRecoveryDoesNotRecoverWhenDisabled(t *testing.
 		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
 	})
 
-	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.canonicalModels)
 	require.Empty(t, accountRepo.clearModelRateLimitKeys)
 }
 

--- a/backend/internal/service/scheduled_test_runner_service_test.go
+++ b/backend/internal/service/scheduled_test_runner_service_test.go
@@ -1,0 +1,432 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type scheduledPlanRepoStub struct {
+	nextRuns      []time.Time
+	afterRunTimes []time.Time
+}
+
+func (r *scheduledPlanRepoStub) Create(context.Context, *ScheduledTestPlan) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) GetByID(context.Context, int64) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) ListByAccountID(context.Context, int64) ([]*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) ListDue(context.Context, time.Time) ([]*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) Update(context.Context, *ScheduledTestPlan) (*ScheduledTestPlan, error) {
+	panic("unexpected call")
+}
+func (r *scheduledPlanRepoStub) Delete(context.Context, int64) error { panic("unexpected call") }
+func (r *scheduledPlanRepoStub) UpdateAfterRun(_ context.Context, _ int64, _ time.Time, next time.Time) error {
+	r.afterRunTimes = append(r.afterRunTimes, next)
+	return nil
+}
+func (r *scheduledPlanRepoStub) UpdateNextRun(_ context.Context, _ int64, next time.Time) error {
+	r.nextRuns = append(r.nextRuns, next)
+	return nil
+}
+
+type scheduledResultRepoStub struct {
+	results        []*ScheduledTestResult
+	createStatuses []string
+	updateStatuses []string
+}
+
+func (r *scheduledResultRepoStub) Create(_ context.Context, result *ScheduledTestResult) (*ScheduledTestResult, error) {
+	copy := *result
+	copy.ID = int64(len(r.results) + 1)
+	r.results = append(r.results, &copy)
+	r.createStatuses = append(r.createStatuses, result.Status)
+	return &copy, nil
+}
+func (r *scheduledResultRepoStub) Update(_ context.Context, result *ScheduledTestResult) error {
+	r.updateStatuses = append(r.updateStatuses, result.Status)
+	for _, existing := range r.results {
+		if existing.ID == result.ID {
+			*existing = *result
+			return nil
+		}
+	}
+	return nil
+}
+func (r *scheduledResultRepoStub) ListByPlanID(context.Context, int64, int) ([]*ScheduledTestResult, error) {
+	return r.results, nil
+}
+func (r *scheduledResultRepoStub) PruneOldResults(context.Context, int64, string, int) error {
+	return nil
+}
+
+type scheduledTesterStub struct {
+	models       []string
+	status       map[string]string
+	err          map[string]error
+	delay        time.Duration
+	beforeReturn func(string)
+}
+
+func (s *scheduledTesterStub) RunTestBackground(_ context.Context, _ int64, modelID string) (*ScheduledTestResult, error) {
+	s.models = append(s.models, modelID)
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if s.beforeReturn != nil {
+		s.beforeReturn(modelID)
+	}
+	if err := s.err[modelID]; err != nil {
+		return nil, err
+	}
+	return &ScheduledTestResult{ModelID: modelID, Status: s.status[modelID]}, nil
+}
+
+func targetModelIDs(targets []ErrorRecoveryTarget) []string {
+	models := make([]string, 0, len(targets))
+	for _, target := range targets {
+		models = append(models, target.ModelID)
+	}
+	return models
+}
+
+func activeModelLimits(resetAt time.Time, models ...string) map[string]any {
+	limits := make(map[string]any, len(models))
+	for _, modelID := range models {
+		limits[modelID] = map[string]any{
+			"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+			"updated_at":          time.Now().UTC().Format(time.RFC3339Nano),
+		}
+	}
+	return limits
+}
+
+func TestScheduledTestRunner_ErrorRecoveryTestsEachModelAndClearsOnlySuccess(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID:          42,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(
+			time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra",
+			creditsExhaustedKey, antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey,
+		)},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	resultRepo := &scheduledResultRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{
+		"gpt-5.6-luna":  "failed",
+		"gpt-5.6-sol":   "success",
+		"gpt-5.6-terra": "failed",
+	}}
+	rateLimits := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+	runner := &ScheduledTestRunnerService{
+		planRepo:       planRepo,
+		scheduledSvc:   NewScheduledTestService(planRepo, resultRepo),
+		accountTestSvc: tester,
+		rateLimitSvc:   rateLimits,
+	}
+	plan := &ScheduledTestPlan{
+		ID: 7, AccountID: 42, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	}
+
+	runner.runOnePlan(context.Background(), plan)
+
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}, tester.models)
+	require.Len(t, resultRepo.results, 3)
+	require.Equal(t, []string{"running", "running", "running"}, resultRepo.createStatuses)
+	require.Equal(t, []string{"failed", "success", "failed"}, resultRepo.updateStatuses)
+	require.Equal(t, []string{"gpt-5.6-sol"}, accountRepo.clearModelRateLimitKeys)
+	require.Len(t, planRepo.afterRunTimes, 1)
+	require.WithinDuration(t, time.Now().Add(5*time.Minute), planRepo.afterRunTimes[0], 2*time.Second)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryOnlyTestsSelectedFailedModels(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 43, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(
+			time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra",
+		)},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "failed"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 13, AccountID: 43, ModelID: "gpt-5.6-sol", ModelIDs: []string{"gpt-5.6-sol"},
+		TriggerMode: ScheduledTestTriggerErrorRecovery, RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryDoesNotRecoverWhenDisabled(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 44, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 14, AccountID: 44, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-sol"}, tester.models)
+	require.Empty(t, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoverySkipsHealthyAndRunningPlans(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 8, Status: StatusActive, Schedulable: true, Extra: map[string]any{},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{}}
+	runner := &ScheduledTestRunnerService{
+		planRepo:       planRepo,
+		scheduledSvc:   NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester,
+		rateLimitSvc:   NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	plan := &ScheduledTestPlan{
+		ID: 9, AccountID: 8, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	}
+
+	startedAt := time.Now()
+	runner.runOnePlan(context.Background(), plan)
+	require.Empty(t, tester.models)
+	require.Len(t, planRepo.nextRuns, 1)
+	require.Empty(t, planRepo.afterRunTimes)
+	require.WithinDuration(t, startedAt.Add(time.Minute), planRepo.nextRuns[0], time.Second)
+	require.False(t, planRepo.nextRuns[0].After(startedAt.Add(time.Minute)))
+	require.Zero(t, planRepo.nextRuns[0].Nanosecond())
+
+	runner.running.Store(plan.ID, struct{}{})
+	runner.runOnePlan(context.Background(), plan)
+	require.Empty(t, tester.models)
+	require.Len(t, planRepo.nextRuns, 1)
+}
+
+func TestScheduledTestRunner_ErrorRecoverySchedulesFromStartAfterSlowProbe(t *testing.T) {
+	interval := 1
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 15, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{
+		status: map[string]string{"gpt-5.6-sol": "failed"},
+		delay:  200 * time.Millisecond,
+	}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	startedAt := time.Now()
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 15, AccountID: 15, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Len(t, planRepo.afterRunTimes, 1)
+	require.WithinDuration(t, startedAt.Add(time.Minute), planRepo.afterRunTimes[0], time.Second)
+	require.False(t, planRepo.afterRunTimes[0].After(startedAt.Add(time.Minute)))
+	require.Zero(t, planRepo.afterRunTimes[0].Nanosecond(), "next run must not retain sub-second drift past the fixed scheduler tick")
+}
+
+func TestScheduledTestRunner_SavesFailedResultWhenBackgroundTestErrors(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 16, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	resultRepo := &scheduledResultRepoStub{}
+	tester := &scheduledTesterStub{err: map[string]error{"gpt-5.6-sol": context.DeadlineExceeded}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, resultRepo),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 16, AccountID: 16, ModelID: "gpt-5.6-sol", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: false, MaxResults: 100,
+	})
+
+	require.Len(t, resultRepo.results, 1)
+	require.Equal(t, []string{"running"}, resultRepo.createStatuses)
+	require.Equal(t, []string{"failed"}, resultRepo.updateStatuses)
+	require.Equal(t, "failed", resultRepo.results[0].Status)
+	require.Equal(t, context.DeadlineExceeded.Error(), resultRepo.results[0].ErrorMessage)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryClearsTwoSuccessfulModelsInOneRun(t *testing.T) {
+	interval := 5
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 12, Status: StatusActive, Schedulable: true, UpdatedAt: time.Now(),
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(time.Now().Add(time.Hour), "gpt-5.6-luna", "gpt-5.6-sol")},
+	}}
+	planRepo := &scheduledPlanRepoStub{}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-luna": "success", "gpt-5.6-sol": "success"}}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 12, AccountID: 12, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, accountRepo.clearModelRateLimitKeys)
+}
+
+func TestScheduledTestRunner_ErrorRecoveryDoesNotClearNewerModelError(t *testing.T) {
+	interval := 5
+	oldReset := time.Now().Add(time.Hour)
+	accountRepo := &rateLimitClearRepoStub{getByIDAccount: &Account{
+		ID: 10, Status: StatusActive, Schedulable: true, UpdatedAt: time.Now(),
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(oldReset, "gpt-5.6-sol")},
+	}}
+	tester := &scheduledTesterStub{status: map[string]string{"gpt-5.6-sol": "success"}}
+	tester.beforeReturn = func(modelID string) {
+		limits := accountRepo.getByIDAccount.Extra["model_rate_limits"].(map[string]any)
+		limits[modelID].(map[string]any)["updated_at"] = time.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
+	}
+	planRepo := &scheduledPlanRepoStub{}
+	runner := &ScheduledTestRunnerService{
+		planRepo: planRepo, scheduledSvc: NewScheduledTestService(planRepo, &scheduledResultRepoStub{}),
+		accountTestSvc: tester, rateLimitSvc: NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil),
+	}
+	runner.runOnePlan(context.Background(), &ScheduledTestPlan{
+		ID: 10, AccountID: 10, ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true, MaxResults: 100,
+	})
+
+	require.Empty(t, accountRepo.clearModelRateLimitKeys)
+	require.True(t, accountRepo.getByIDAccount.isRateLimitActiveForKey("gpt-5.6-sol"))
+}
+
+func TestRateLimitService_ErrorRecoveryTargetsExcludeManualAndCreditsStates(t *testing.T) {
+	resetAt := time.Now().Add(time.Hour)
+	account := &Account{
+		ID: 11, Status: StatusActive, Schedulable: true,
+		Extra: map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol", creditsExhaustedKey)},
+	}
+	repo := &rateLimitClearRepoStub{getByIDAccount: account}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	targets, err := svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6-sol"}, targetModelIDs(targets))
+
+	account.Schedulable = false
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.Status = StatusError
+	account.Extra = map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol")}
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.UpdatedAt = time.Now()
+	futureWindow := time.Now().Add(time.Hour)
+	account.TempUnschedulableUntil = &futureWindow
+	for _, internalScope := range []string{antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey} {
+		targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, internalScope)
+		require.NoError(t, err)
+		require.Equal(t, []string{"gpt-5.6-sol"}, targetModelIDs(targets))
+	}
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6-luna", "gpt-5.6-sol"}, targetModelIDs(targets))
+	require.True(t, targets[0].RecoverAccountState)
+
+	account.Status = StatusActive
+	account.Schedulable = true
+	account.TempUnschedulableUntil = nil
+	account.Extra = map[string]any{"model_rate_limits": activeModelLimits(resetAt, "gpt-5.6-sol")}
+	expiredAt := time.Now().Add(-time.Minute)
+	account.ExpiresAt = &expiredAt
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+
+	account.ExpiresAt = nil
+	account.Extra = map[string]any{}
+	expiredWindow := time.Now().Add(-time.Minute)
+	account.RateLimitedAt = &expiredWindow
+	account.RateLimitResetAt = &expiredWindow
+	account.OverloadUntil = &expiredWindow
+	account.TempUnschedulableUntil = &expiredWindow
+	targets, err = svc.ErrorRecoveryTargets(context.Background(), 11, "gpt-5.6-luna")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+}
+
+func TestScheduledTestService_ErrorRecoveryScheduleValidation(t *testing.T) {
+	from := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	interval := 5
+	plan := &ScheduledTestPlan{
+		ModelID: "gpt-5.6-luna", TriggerMode: ScheduledTestTriggerErrorRecovery,
+		RetryIntervalMinutes: &interval, AutoRecover: true,
+	}
+	next, err := validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, from, next)
+	require.True(t, plan.AutoRecover)
+
+	plan.AutoRecover = false
+	next, err = validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, from, next)
+	require.False(t, plan.AutoRecover)
+
+	cronExpr := "*/7 * * * *"
+	plan.RetryIntervalMinutes = nil
+	plan.RetryCronExpression = &cronExpr
+	_, err = validateAndComputePlanNextRun(plan, from)
+	require.NoError(t, err)
+	next, err = computeRecoveryNextRun(plan, from)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 8, 1, 10, 7, 0, 0, time.UTC), next)
+
+	plan.RetryIntervalMinutes = &interval
+	_, err = validateAndComputePlanNextRun(plan, from)
+	require.ErrorContains(t, err, "cannot be combined")
+
+	for _, internalScope := range []string{antigravityGeminiModelRateLimitKey, openAIImageGenerationRateLimitKey} {
+		plan.RetryCronExpression = nil
+		plan.ModelID = internalScope
+		plan.ModelIDs = nil
+		_, err = validateAndComputePlanNextRun(plan, from)
+		require.ErrorContains(t, err, "internal rate-limit scope")
+
+		plan.ModelID = "gpt-5.6-luna"
+		plan.ModelIDs = []string{internalScope}
+		_, err = validateAndComputePlanNextRun(plan, from)
+		require.ErrorContains(t, err, "internal rate-limit scope")
+	}
+}

--- a/backend/internal/service/scheduled_test_service.go
+++ b/backend/internal/service/scheduled_test_service.go
@@ -3,12 +3,19 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
 )
 
 var scheduledTestCronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+const (
+	ScheduledTestTriggerScheduled     = "scheduled"
+	ScheduledTestTriggerErrorRecovery = "error_recovery"
+	scheduledTestDefaultCron          = "*/30 * * * *"
+)
 
 // ScheduledTestService provides CRUD operations for scheduled test plans and results.
 type ScheduledTestService struct {
@@ -29,7 +36,7 @@ func NewScheduledTestService(
 
 // CreatePlan validates the cron expression, computes next_run_at, and persists the plan.
 func (s *ScheduledTestService) CreatePlan(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error) {
-	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
+	nextRun, err := validateAndComputePlanNextRun(plan, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("invalid cron expression: %w", err)
 	}
@@ -54,7 +61,7 @@ func (s *ScheduledTestService) ListPlansByAccount(ctx context.Context, accountID
 
 // UpdatePlan validates cron and updates the plan.
 func (s *ScheduledTestService) UpdatePlan(ctx context.Context, plan *ScheduledTestPlan) (*ScheduledTestPlan, error) {
-	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
+	nextRun, err := validateAndComputePlanNextRun(plan, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("invalid cron expression: %w", err)
 	}
@@ -82,7 +89,100 @@ func (s *ScheduledTestService) SaveResult(ctx context.Context, planID int64, max
 	if _, err := s.resultRepo.Create(ctx, result); err != nil {
 		return err
 	}
-	return s.resultRepo.PruneOldResults(ctx, planID, maxResults)
+	return s.resultRepo.PruneOldResults(ctx, planID, result.ModelID, maxResults)
+}
+
+func (s *ScheduledTestService) StartResult(ctx context.Context, planID int64, result *ScheduledTestResult) (*ScheduledTestResult, error) {
+	result.PlanID = planID
+	return s.resultRepo.Create(ctx, result)
+}
+
+func (s *ScheduledTestService) UpdateResult(ctx context.Context, planID int64, maxResults int, result *ScheduledTestResult) error {
+	result.PlanID = planID
+	if err := s.resultRepo.Update(ctx, result); err != nil {
+		return err
+	}
+	return s.resultRepo.PruneOldResults(ctx, planID, result.ModelID, maxResults)
+}
+
+func validateAndComputePlanNextRun(plan *ScheduledTestPlan, from time.Time) (time.Time, error) {
+	plan.ModelID = strings.TrimSpace(plan.ModelID)
+	plan.ModelIDs = normalizeModelIDs(plan.ModelIDs)
+	if plan.TriggerMode == "" {
+		plan.TriggerMode = ScheduledTestTriggerScheduled
+	}
+	if plan.TriggerMode == ScheduledTestTriggerScheduled {
+		plan.RetryIntervalMinutes = nil
+		plan.RetryCronExpression = nil
+		return computeNextRun(plan.CronExpression, from)
+	}
+	if plan.TriggerMode != ScheduledTestTriggerErrorRecovery {
+		return time.Time{}, fmt.Errorf("invalid trigger mode: %s", plan.TriggerMode)
+	}
+	if isInternalModelRateLimitScope(plan.ModelID) {
+		return time.Time{}, fmt.Errorf("internal rate-limit scope cannot be used as a probe model: %s", plan.ModelID)
+	}
+	for _, modelID := range plan.ModelIDs {
+		if isInternalModelRateLimitScope(modelID) {
+			return time.Time{}, fmt.Errorf("internal rate-limit scope cannot be used as a probe model: %s", modelID)
+		}
+	}
+	if len(plan.ModelIDs) > 0 {
+		plan.ModelID = plan.ModelIDs[0]
+	}
+	if plan.ModelID == "" {
+		return time.Time{}, fmt.Errorf("error recovery requires an account probe model")
+	}
+
+	if plan.CronExpression == "" {
+		plan.CronExpression = scheduledTestDefaultCron
+	}
+	if plan.RetryIntervalMinutes != nil {
+		if *plan.RetryIntervalMinutes < 1 || *plan.RetryIntervalMinutes > 1440 || plan.RetryCronExpression != nil {
+			return time.Time{}, fmt.Errorf("retry interval must be 1..1440 minutes and cannot be combined with cron")
+		}
+		return from, nil
+	}
+	if plan.RetryCronExpression == nil || *plan.RetryCronExpression == "" {
+		return time.Time{}, fmt.Errorf("error recovery requires retry interval or cron expression")
+	}
+	if _, err := computeNextRun(*plan.RetryCronExpression, from); err != nil {
+		return time.Time{}, fmt.Errorf("invalid retry cron expression: %w", err)
+	}
+	return from, nil
+}
+
+func normalizeModelIDs(modelIDs []string) []string {
+	if len(modelIDs) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(modelIDs))
+	result := make([]string, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" {
+			continue
+		}
+		if _, ok := seen[modelID]; ok {
+			continue
+		}
+		seen[modelID] = struct{}{}
+		result = append(result, modelID)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func computeRecoveryNextRun(plan *ScheduledTestPlan, from time.Time) (time.Time, error) {
+	if plan.RetryIntervalMinutes != nil {
+		return from.Add(time.Duration(*plan.RetryIntervalMinutes) * time.Minute), nil
+	}
+	if plan.RetryCronExpression == nil {
+		return time.Time{}, fmt.Errorf("missing retry schedule")
+	}
+	return computeNextRun(*plan.RetryCronExpression, from)
 }
 
 func computeNextRun(cronExpr string, from time.Time) (time.Time, error) {

--- a/backend/migrations/192_add_scheduled_test_error_recovery.sql
+++ b/backend/migrations/192_add_scheduled_test_error_recovery.sql
@@ -1,0 +1,28 @@
+-- Add error-triggered scheduled tests while preserving existing cron plans.
+ALTER TABLE scheduled_test_plans
+    ADD COLUMN IF NOT EXISTS trigger_mode VARCHAR(20) NOT NULL DEFAULT 'scheduled',
+    ADD COLUMN IF NOT EXISTS retry_interval_minutes INT,
+    ADD COLUMN IF NOT EXISTS retry_cron_expression VARCHAR(100);
+
+ALTER TABLE scheduled_test_plans DROP CONSTRAINT IF EXISTS chk_stp_trigger_mode;
+ALTER TABLE scheduled_test_plans ADD CONSTRAINT chk_stp_trigger_mode
+    CHECK (trigger_mode IN ('scheduled', 'error_recovery'));
+
+ALTER TABLE scheduled_test_plans DROP CONSTRAINT IF EXISTS chk_stp_recovery_schedule;
+ALTER TABLE scheduled_test_plans ADD CONSTRAINT chk_stp_recovery_schedule CHECK (
+    trigger_mode = 'scheduled' OR
+    ((retry_interval_minutes BETWEEN 1 AND 1440 AND retry_cron_expression IS NULL) OR
+     (retry_interval_minutes IS NULL AND NULLIF(BTRIM(retry_cron_expression), '') IS NOT NULL))
+);
+
+ALTER TABLE scheduled_test_results ADD COLUMN IF NOT EXISTS model_id VARCHAR(100);
+UPDATE scheduled_test_results r
+SET model_id = p.model_id
+FROM scheduled_test_plans p
+WHERE p.id = r.plan_id AND r.model_id IS NULL;
+ALTER TABLE scheduled_test_results ALTER COLUMN model_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_stp_account_error_recovery
+    ON scheduled_test_plans(account_id) WHERE trigger_mode = 'error_recovery';
+CREATE INDEX IF NOT EXISTS idx_str_plan_model_created
+    ON scheduled_test_results(plan_id, model_id, created_at DESC);

--- a/backend/migrations/193_add_scheduled_test_error_model_ids.sql
+++ b/backend/migrations/193_add_scheduled_test_error_model_ids.sql
@@ -1,0 +1,3 @@
+-- 193: Persist the selected failed-model allowlist for error recovery plans.
+ALTER TABLE scheduled_test_plans
+    ADD COLUMN IF NOT EXISTS model_ids TEXT[] NOT NULL DEFAULT '{}';

--- a/backend/migrations/194_add_openai_account_session_sticky_mode.sql
+++ b/backend/migrations/194_add_openai_account_session_sticky_mode.sql
@@ -1,0 +1,21 @@
+-- Keep existing accounts on the historical sticky behavior while allowing an
+-- explicitly configured OpenAI fallback account to yield session_hash affinity.
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS openai_session_sticky_mode VARCHAR(32) NOT NULL DEFAULT 'normal';
+
+UPDATE accounts
+SET openai_session_sticky_mode = 'normal'
+WHERE openai_session_sticky_mode IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'accounts_openai_session_sticky_mode_check'
+    ) THEN
+        ALTER TABLE accounts
+            ADD CONSTRAINT accounts_openai_session_sticky_mode_check
+            CHECK (openai_session_sticky_mode IN ('normal', 'fallback_only'));
+    END IF;
+END $$;

--- a/docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md
+++ b/docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md
@@ -1,0 +1,147 @@
+---
+summary: 让账号按模型自动复测系统记录的临时错误，并在上游恢复后立即精确恢复该模型调度
+doc_kind: spec
+status: active
+review_status: approved
+---
+
+# 模型错误自动复测与精确恢复
+
+执行者只以本 Spec 为任务来源；批准后先进入任务 worktree，创建并持续更新 `PROGRESS.md`，拿不准或前提不符时写 `BLOCKED.md`。中断后先读这两个文件接着做。取舍顺序是：不误恢复仍失败的模型 > 自动尽快恢复 > 设置简单。本文“只允许 / 不许”是验收合同，“建议”可在 `PROGRESS.md` 说明理由后调整。
+
+## 这活为什么干
+
+账号可能仍为正常状态，但 `accounts.extra.model_rate_limits` 同时记录 `gpt-5.6-luna`、`gpt-5.6-sol`、`gpt-5.6-terra` 等模型的临时错误。现在只能等倒计时结束或手工测试；目标是仅在系统自动记录错误后按模型复测，哪个模型恢复就立刻只恢复哪个模型。
+
+## 领导已经拍板
+
+- 错误恢复默认每 5 分钟重试，可输入分钟数；高级模式默认隐藏，可改用 5 字段 Cron。
+- 分钟间隔按测试启动时间计算；同一计划不并发重入，若上一轮超过间隔仍未完成，则在完成后的下一次扫描补跑。
+- 健康账号不测试；手工禁用、手工不可调度、过期等人工或永久状态绝不自动恢复。
+- 多个模型独立重试和恢复；一个模型成功不得清除其他模型的错误。
+- 有结构化来源的账号级自动错误也可恢复；错误恢复计划可多选探测模型，默认全选。模型级错误始终测试实际报错模型；账号级错误使用首个已选模型探测一次。裸 `status=error` 无法区分人工与系统来源，不自动恢复。
+
+## 我替领导拍的板（待确认）
+
+- 每账号只允许 1 个 `error_recovery` 计划，避免重复请求；普通定时计划仍可有多个。
+- 分钟间隔允许 `1..1440`；Cron 使用现有 5 字段解析器。`AICredits` 是额度状态而非模型，排除自动复测和自动清除。
+- 检测到新错误后在下一次每分钟扫描中首次测试；之后按间隔或 Cron 重试，不额外等待一个完整周期。
+
+## 范围与非目标
+
+- 只允许修改 scheduled-test 的 migration、repository/service/handler、API/types、`ScheduledTestsPanel.vue`、中英文文案及对应测试；其他路径只读。
+- 复用现有每分钟 `ScheduledTestRunnerService`、10 worker 上限和账号错误真源；不新增 worker、消息队列、依赖或从错误文本解析模型。
+- 实现与自动测试不写 live 数据；完整验证通过后才允许替换本地 Sub2API app 镜像，保留当前镜像作为回滚点，不重建 PostgreSQL/Redis。真实测试只使用 AIINPUT，CIII 只读且不得恢复。
+- 上游交付使用 feature branch PR；只有发现能脱离 PR 独立追踪的问题时才创建 issue。
+
+## 改完后是什么样
+
+现有普通计划请求保持兼容：
+
+```json
+{"account_id":42,"model_id":"gpt-5.6-luna","cron_expression":"*/30 * * * *","enabled":true,"max_results":100,"auto_recover":true}
+```
+
+新增错误恢复计划请求示例：
+
+```json
+{"account_id":42,"model_id":"gpt-5.6-luna","model_ids":[],"trigger_mode":"error_recovery","retry_interval_minutes":5,"retry_cron_expression":null,"enabled":true,"max_results":100,"auto_recover":true}
+```
+
+`model_ids=[]` 表示全部失败模型，非空数组表示只复测选中的失败模型；`model_id` 保留为账号级错误的 fallback probe model，并由服务端规范化为首个选中模型。历史错误恢复计划没有 `model_ids` 时按全部失败模型处理。
+
+高级模式把 `retry_interval_minutes` 设为 `null`，并写入如 `*/5 * * * *` 的 `retry_cron_expression`。测试结果新增实际执行的 `model_id`，例如：
+
+```json
+{"id":901,"plan_id":7,"model_id":"gpt-5.6-sol","status":"success","response_text":"ok","error_message":"","latency_ms":842}
+```
+
+后台测试开始时先写入同一模型的 `status=running` 结果，完成后原地更新为 `success` 或 `failed`；管理界面仅在展开结果且存在运行项时轮询刷新。超过 runner 5 分钟执行上限仍为 `running` 的历史项显示为“执行中断”，但不据此恢复模型。
+
+错误恢复基础字段由 `192_add_scheduled_test_error_recovery.sql` 提供；模型选择 allowlist 由新增 migration `193_add_scheduled_test_error_model_ids.sql` 提供：
+
+```sql
+ALTER TABLE scheduled_test_plans
+  ADD COLUMN trigger_mode VARCHAR(20) NOT NULL DEFAULT 'scheduled',
+  ADD COLUMN retry_interval_minutes INT,
+  ADD COLUMN retry_cron_expression VARCHAR(100);
+ALTER TABLE scheduled_test_plans
+  ADD CONSTRAINT chk_stp_trigger_mode CHECK (trigger_mode IN ('scheduled', 'error_recovery')),
+  ADD CONSTRAINT chk_stp_recovery_schedule CHECK (
+    trigger_mode = 'scheduled' OR
+    ((retry_interval_minutes BETWEEN 1 AND 1440 AND retry_cron_expression IS NULL) OR
+     (retry_interval_minutes IS NULL AND NULLIF(BTRIM(retry_cron_expression), '') IS NOT NULL))
+  );
+ALTER TABLE scheduled_test_results ADD COLUMN model_id VARCHAR(100);
+UPDATE scheduled_test_results r SET model_id = p.model_id FROM scheduled_test_plans p WHERE p.id = r.plan_id;
+ALTER TABLE scheduled_test_results ALTER COLUMN model_id SET NOT NULL;
+CREATE UNIQUE INDEX uq_stp_account_error_recovery ON scheduled_test_plans(account_id) WHERE trigger_mode = 'error_recovery';
+CREATE INDEX idx_str_plan_model_created ON scheduled_test_results(plan_id, model_id, created_at DESC);
+```
+
+```sql
+ALTER TABLE scheduled_test_plans
+  ADD COLUMN model_ids TEXT[] NOT NULL DEFAULT '{}';
+```
+
+新增字段由 plan API 写入、runner/repository 读取；`result.model_id` 由测试执行写入，所有仍失败的模型共享计划的下一次重试时间，但分别测试和清除。服务端必须校验错误恢复计划只能在“有效分钟间隔”和“有效 Cron”中二选一。历史 plan 通过默认值保持 `scheduled`，历史 result 从所属 plan 回填模型；错误恢复计划的 `max_results` 按 `plan_id + model_id` 分别保留，普通计划继续按 plan 保留。
+
+## 现状与任务 0
+
+- 2026-08-01 实测：runner 每分钟扫描、并发上限 10；手工测试成功调用无 `model_id` 的账号级恢复，`ClearModelRateLimits` 会删除整个 `model_rate_limits`。
+- 基线：`go test ./internal/service ./internal/handler/admin -count=1` 通过；`pnpm --dir frontend exec vitest run src/components/account/__tests__/AccountStatusIndicator.spec.ts` 为 4/4；`pnpm --dir frontend run typecheck` 与 `pnpm --dir frontend run build` 通过。
+- 开工先复跑上述命令并确认 migration 192 不存在；任一不符即停止受影响任务，把证据置顶写入 `BLOCKED.md`。核对后先写不超过 10 行的目标、顺序和最大风险到 `PROGRESS.md`。
+
+## 任务 1：建立按模型恢复合同
+
+- 目标：成功测试 `sol` 时只原子删除 `model_rate_limits.sol`，保留 `luna`、`terra`、`AICredits`；账号级自动状态可同时恢复但不得连带清其他模型。
+- 顺序：先补 repository/service 的失败测试，再实现带 `model_id` 的 targeted recovery，并让手工测试与后台测试共用它。
+- 死规矩：JSON key 删除、scheduler outbox/缓存刷新必须走账号 repository owner；否则 DB 与调度快照会分叉。
+- 验收：`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`；全部通过且新增用例覆盖“只删成功模型、失败不删、兄弟模型保留、AICredits 保留”。
+- 反向验证：临时把 targeted clear 改回全量 clear，确认兄弟模型保留用例失败；还原后全绿。
+
+## 任务 2：只在自动错误存在时独立重试
+
+- 目标：一个账号的 3 个活动模型错误产生 3 个独立测试目标；成功目标停止，失败目标按分钟或 Cron 继续，健康状态执行 0 次。
+- 顺序：在任务 1 的精确恢复后扩展 plan schema、请求校验、结果 `model_id` 和 runner；复用计划的下一次运行时间，不建第二套调度器。
+- 死规矩：只读取结构化 `model_rate_limits` 和现有账号级自动状态，不解析 reason/message；手工状态及 `AICredits` 必须过滤。
+- 验收：`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`；新增 runner 用例机器判定 3 个目标、独立 next run、无重叠执行、健康/手工状态 0 次。
+- 时间语义：分钟间隔从本轮启动时间计算；慢请求不得把固定间隔额外拖长一个完整周期，内部错误也必须把已创建的 `running` 结果更新为 `failed`。
+- 反向验证：移除健康状态过滤，确认“健康账号 0 次”用例失败；还原后全绿。
+
+## 任务 3：交付简单设置界面
+
+- 目标：计划表单提供“定时测试 / 错误恢复”；错误恢复默认显示 5 分钟输入、自动恢复和全部失败模型，探测模型可多选，只有打开高级模式才显示 Cron，并展示每条结果的实际模型。错误恢复旁提供问号说明边界。
+- 顺序：后端合同稳定后更新 API types、表单、列表和中英文文案，避免前端先猜 payload。
+- 死规矩：普通模式不得要求 Cron；高级 Cron 与分钟输入不得同时提交；现有定时计划编辑行为保持不变。
+- 验收：`pnpm --dir frontend run typecheck && pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts && pnpm --dir frontend run build`；组件测试覆盖默认 5 分钟、自动恢复默认勾选、默认全选、子集 payload、问号说明、展开高级、互斥 payload、旧计划回显。
+- 运行可见性：结果展开后显示模型级“执行中”，完成后自动刷新为最终状态；超过 5 分钟的遗留运行项显示“执行中断”，关闭面板或没有运行项时停止轮询。
+- 反向验证：临时恢复“Cron 必填”，确认默认错误恢复提交用例失败；还原后全绿。使用本地测试数据打开账号定时测试面板，确认 console 无错误，并按 selector 截取受影响面板的桌面与移动端截图作为证据。
+
+## 任务 4：安全部署并提交上游
+
+- 目标：先备份当前 app 镜像引用和 Compose 配置摘要，再只替换 `sub2api` app 容器；health、登录页、AIINPUT 测试与错误恢复 UI 全部通过后提交 PR。
+- 顺序：完整测试与独立 review 通过后构建本地镜像；迁移自动执行并验活，PostgreSQL/Redis 容器和数据卷保持不变。
+- 死规矩：不得对 CIII 发测试或恢复请求；任一 health、migration、console 或 AIINPUT 检查失败立即回滚 app 镜像并停止 PR。
+- 验收：`docker compose -f /Users/admin/sub2api/docker-compose.yml ps`、`curl -fsS http://127.0.0.1:8080/health` 与浏览器 AIINPUT 测试成功；截图及容器状态写入 `PROGRESS.md`。
+
+## 规矩
+
+- 不许 skip/todo、删测试、放宽断言、mock 被测恢复 owner、修改验收命令或加 `|| true`；测试数量不得低于开工基线。
+- migration 只能新增，不能改历史文件；不得清洗 live `accounts.extra`。同一验收连续失败 3 次即停止该项；结果比基线差就撤销本任务新增改动并如实记录，不以扩大范围补洞。
+- `BLOCKED.md` 随交付提交，空也写“无”。未经最新用户授权不得部署或创建 PR；当前授权仅涵盖本地 Sub2API 与该功能的上游 PR。
+
+## 完成条件
+
+- 固定样本 `luna=失败、sol=成功、terra=失败、AICredits=存在` 跑一轮后，只消失 `sol`；5 分钟后只重试 `luna/terra`，健康账号和手工禁用账号请求数为 0。
+- 旧定时计划无需迁移操作且行为不变；后端 broad tests、前端 typecheck/build/组件测试全绿，UI 截图无重叠且 console 无错误。
+- 本地部署后 health、AIINPUT 与 UI 通过，CIII 状态未被修改；PR 只包含本功能、测试与 Spec。每条验收必须提交实际命令、红→绿反向证据和证据路径；同一验收连败 3 次则停止并列出缺口。
+
+## Goal
+
+- 验收摘要: 用 `luna/sol/terra + AICredits` 固定样本跑通自动错误发现、按模型复测到精确恢复；看到只清成功模型、失败模型继续重试、健康及手工状态零请求才算通过，且不得写 live 数据。
+- 执行依据: `docs/superpowers/specs/2026-08-01-model-error-auto-recovery.md` 的任务 0 → 4；任务级 RED/GREEN 与反向验证只按正文执行。
+- 真实验收: 固定 4-key 账号样本｜两轮 runner 到精确恢复｜`go test ./internal/service ./internal/repository ./internal/handler/admin -count=1`｜成功=目标独立且只删 `sol`｜证据=`PROGRESS.md`。
+- 真实验收: 错误恢复设置面板｜默认分钟与高级 Cron 互斥｜`pnpm --dir frontend run typecheck && pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts && pnpm --dir frontend run build`｜成功=全绿并产出桌面/移动截图｜证据=`PROGRESS.md` 与截图路径。
+- 非回归: `go test ./internal/service ./internal/handler/admin -count=1 && pnpm --dir frontend exec vitest run src/components/account/__tests__/AccountStatusIndicator.spec.ts`。
+- 边界: 只改白名单路径；完整验证后仅替换本地 app 容器，真实测试只用 AIINPUT，CIII 只读；不满足 schema/基线时写 `BLOCKED.md` 并停止受影响任务。

--- a/docs/superpowers/specs/2026-08-08-openai-account-fallback-only-sticky.md
+++ b/docs/superpowers/specs/2026-08-08-openai-account-fallback-only-sticky.md
@@ -1,0 +1,169 @@
+---
+summary: 为单个 OpenAI 账号增加 fallback-only 会话粘性，使低优先级保底账号不会压住恢复可用的主账号池
+doc_kind: spec
+status: active
+review_status: approved
+---
+
+# OpenAI 单账号 fallback-only sticky
+
+## 这活为什么干
+
+当前 OpenAI `session_hash` sticky 会在账号仍可调度时优先复用原账号，即使该账号只是低优先级 fallback。结果是主池 AI-INPUT 恢复后，已落到官方 Pro 账号的会话仍会持续消耗官方额度。完成后，默认账号继续保持现有 sticky；只有显式配置为 `fallback_only` 的账号会在存在更高优先级、支持当前模型且可立即接单的账号时退出 `session_hash` sticky。
+
+## 领导已经拍板
+
+- 只降低指定官方账号的 sticky，不改变 AI-INPUT 账号之间的正常 sticky。
+- AI-INPUT 支持当前模型且可用时，应优先回到 AI-INPUT；AI-INPUT 不支持模型、限流、不可调度或没有可用并发时，官方账号仍作为 fallback。
+- `previous_response_id` 继续强绑定原账号，避免 OpenAI Responses encrypted context 跨账号后无法验证。
+- 先在隔离 worktree 开发并完成 review-commit 与本地验证，再按 `merge-main` 流程 `ff-only` 合入本地 `main`；随后部署本机 Sub2API、把指定官方账号设置为 `fallback_only` 并做 live 验证；全部通过后才创建上游 issue 和 PR。不 push `main`，不操作 `myclaw`。
+
+## 我替领导拍的板（待确认）
+
+- 新增账号字段 `openai_session_sticky_mode`，取值仅为 `normal`、`fallback_only`，默认 `normal`。选择 enum 而不是任意浮点权重，避免同一目标出现无法解释的概率性行为；猜错代价是如果领导确实需要连续权重，后续要扩 schema 和评分合同。
+- `fallback_only` 只影响 OpenAI `session_hash` 命中，不影响其它平台、`previous_response_id`、已开始的请求或同优先级账号之间的 sticky。
+- “更高优先级可用”定义为：同一调度 group 内，账号支持当前平台、模型、endpoint/transport/compact 能力，状态可调度，未处于账号级或模型级 cooldown，且当前有可立即获取的并发 slot。没有立即可用 slot 时继续使用可用的 fallback，避免为了主池排队而闲置保底容量。
+- live 验证通过后先创建上游 issue；随后从最新 `origin/main` 建独立 public worktree/branch，只移植本功能的公开提交并独立验证，再以 ready-for-review PR 使用 `Closes #<issue>` 关联。PR 未关闭前只保留 public branch/worktree；本地 patches 和私有 Spec 不进入 public branch。
+
+## 范围与非目标
+
+- 允许修改 OpenAI 账号持久化 schema、账号 admin update/list DTO、前端账号编辑控件、scheduler metadata，以及 legacy/advanced OpenAI `session_hash` 调度路径和对应测试。
+- 允许新增一条 versioned migration；历史账号迁移后全部为 `normal`，不改变现有行为。
+- 不修改全局高级调度器默认值，不开启“订阅优先”，不把全局 sticky 权重设为 0。
+- 不弱化 `previous_response_id`、encrypted context、tool continuation 的账号绑定。
+- 允许按 `sub2api-upgrader` 只部署本机 arm64 Sub2API：保留全部 `origin/main..main` local-only patches，只重建 app 容器，保留升级前健康镜像作为回滚点；禁止访问或部署 `myclaw`。
+- 允许通过受控 admin API 把 live 指定官方账号设置为 `fallback_only`，并验证字段 round-trip、账号状态、模型能力、priority 和无 secret 泄露；不直接手改数据库。
+- 不顺手修改 group binding priority、模型映射、账号 concurrency 或其它账号池配置。
+
+## 改完后是什么样
+
+账号更新接口修改前没有该字段：
+
+```json
+{
+  "name": "fallback-owner@example.invalid",
+  "priority": 200
+}
+```
+
+修改后可显式设置账号级策略：
+
+```json
+{
+  "name": "fallback-owner@example.invalid",
+  "priority": 200,
+  "openai_session_sticky_mode": "fallback_only"
+}
+```
+
+账号响应返回同一字段；旧客户端不传时保留现值，新建账号不传时写入 `normal`。数据库新增列：
+
+```sql
+ALTER TABLE accounts
+  ADD COLUMN openai_session_sticky_mode varchar(32) NOT NULL DEFAULT 'normal';
+```
+
+字段 writer 是账号 admin update；reader 是账号 DTO、账号编辑页、scheduler metadata 和 OpenAI session sticky 选择器；当前决策用途仅为判断是否允许低优先级 `session_hash` sticky 覆盖当前可立即接单的高优先级候选。update payload 使用可区分 omitted 的 pointer：不传字段必须保持原值，只传该字段不得修改其它持久化字段。未知值必须在 API 边界拒绝，数据库默认值保证历史行行为不变。
+
+## 现状与任务 0
+
+- 2026-08-08 实测本机 Sub2API：官方账号 `accounts.priority=200`，三个 AI-INPUT 为 `1`；官方账号仍可因 `session_hash`/Responses 连续请求再次承接 Sol/Terra。
+- 当前源码只提供全局 `openai_advanced_scheduler_weight_session_sticky` 与 `...previous_response`，账号 schema 没有 sticky policy 字段。
+- 上游 [#2872](https://github.com/Wei-Shaw/sub2api/pull/2872) 只实现 TTFT/error/concurrency 健康度逃逸；[#3154](https://github.com/Wei-Shaw/sub2api/pull/3154) 修复 Responses session hash；[#2997](https://github.com/Wei-Shaw/sub2api/pull/2997) 固化 HTTP response ID 账号绑定；未发现账号级 fallback-only sticky 实现。
+- 2026-08-08 fetch 后仓库根 `main` 为 `27725215b`，相对 `origin/main` ahead 2 / behind 88，且只有用户已有 `.gitignore` 脏改；执行不得接管或覆盖该改动。该数字只作审核时基线，任务 0 必须重新 fetch 后固定真实 tip/差异。
+
+## 任务 0：前提核验
+
+- 结果：先 fetch 并记录 immutable local main/origin main tip、真实 ahead/behind 和完整 local patch 集，再固定 approved Spec 对应的 immutable integration tip；同时确认工作区 ownership、现有账号 schema、两条 OpenAI sticky 路径和 targeted test 基线。
+- 依赖：无。
+- `write ownership`：默认只读；仅当前提不成立时允许写 integration worktree 根目录的 `BLOCKED.md`，其它路径保持只读。
+- 接口：向任务 1/2 提供固定 tip、字段命名、现有 migration 序号、targeted tests 数量与通过基线。
+- focused verification：`git fetch origin main --tags && git rev-parse main origin/main && git rev-list --left-right --count origin/main...main && git log --reverse --format='%H %s' origin/main..main && git status --short --branch && git worktree list && rg -n "StickyWeighted|tryStickySessionHit|selectBySessionHash|previous_response_id" backend/internal/service backend/internal/handler && cd backend && go test -tags=unit ./internal/service ./internal/handler/admin`；命令存在、测试退出 0、skip/todo 为 0，根工作区已有 `.gitignore` 改动保持不变；ahead/behind、patch 集、write ownership 或 public branch 基线与审核时事实不同且会改变执行合同时，写入 `BLOCKED.md` 并阻断后续任务。
+- 集成顺序：所有后续任务的 ready 前置；失败时阻断全部后续 ready。
+- 失败后果：在 integration worktree 的 `BLOCKED.md` 记录 tip、差异和失败输出，不得继续写生产代码。
+- 反向验证：在测试中先引用尚不存在的 `OpenAISessionStickyModeFallbackOnly`，保存编译失败证据；实现后同一测试转绿。
+
+## 任务 1：后端账号合同与调度行为
+
+- 结果：新增 versioned migration、Ent/account/service/DTO 字段及校验；legacy 与 advanced scheduler 均实现 `fallback_only` 规则；scheduler snapshot 不丢字段；历史账号默认行为不变。
+- 依赖：任务 0。
+- `write ownership`：`backend/ent/schema/account.go`、对应生成的 `backend/ent/**`、新 migration、`backend/internal/service/**`、`backend/internal/repository/**`、`backend/internal/handler/admin/**`、`backend/internal/handler/dto/**` 及这些目录的 focused tests。
+- 接口：读写 `openai_session_sticky_mode`；只在 OpenAI `session_hash` sticky 命中时读取；输出调度 decision/日志能区分 `fallback_only` 逃逸，不输出 secret。
+- focused verification：新增测试必须覆盖 normal 保持 sticky、fallback-only 在高优先级有立即 slot 时逃逸、只有同优先级时保持 sticky、高优先级模型不兼容/限流/满并发时保留 fallback、`previous_response_id` 仍硬绑定、snapshot round-trip；执行 `cd backend && go test -tags=unit ./internal/service ./internal/repository ./internal/handler/admin`，退出 0 且无 skip/todo。
+- 集成顺序：任务 2 可按已批准 API 合同并行；后端先于综合验证集成。
+- 失败后果：任何路径让 `previous_response_id` 跨账号、未知 enum 被静默接受或历史账号默认改变，均 `BLOCK`。
+- 反向验证：把官方测试账号模式改回 `normal` 时，高优先级恢复场景必须重新命中原 sticky；恢复 `fallback_only` 后转绿。
+
+## 任务 2：前端账号编辑设置
+
+- 结果：OpenAI 账号编辑页可选择“正常粘性”或“仅作保底时粘性”并回显当前值；非 OpenAI 账号不显示该控件；API types 与后端字段一致。创建页和批量编辑不新增该设置。
+- 依赖：任务 0，使用本 Spec 已批准的 API 合同。
+- `write ownership`：`frontend/src/api/admin/accounts.ts`、`frontend/src/types/index.ts`、`frontend/src/components/account/EditAccountModal.vue`、该组件现有测试、`frontend/src/i18n/locales/**`。
+- 接口：编辑表单发送 `openai_session_sticky_mode` 并回显服务端值；字段缺失或保存后 round-trip 不一致时按 API 合同失败并提示，不得伪造 normal 或把静默忽略当成功。只有用户提交该编辑表单时才随既有 payload 发送，不产生批量覆盖。
+- focused verification：执行 `cd frontend && pnpm typecheck && pnpm test:run --runInBand`（若仓库 test runner 不接受该参数，任务 0 记录真实命令并只替换参数）；退出 0，相关控件测试覆盖 OpenAI/非 OpenAI 与回显/提交，创建和批量编辑 diff 为零，skip/todo 为 0。
+- 集成顺序：后端之后集成；字段冲突退回本任务 writer，不在父 worktree 临时改合同。
+- 失败后果：字段名漂移、非 OpenAI 显示、默认值导致无意批量覆盖或无法回显均 `BLOCK`。
+- 反向验证：删除 API type 字段时 typecheck 必须失败；恢复后转绿。
+
+## 任务 3：综合验证、review-commit 与本地 main 合入
+
+- 结果：integration worktree 综合验证通过，普通独立 reviewer `PASS`，按 `review-commit` 形成原子提交；随后执行 `merge-main` Gate，rebase 到最新本地 `main`、重新验证和独立 review 后 `ff-only` 合入。
+- 依赖：任务 1、任务 2。
+- `write ownership`：仅允许修复任务 1/2 reviewer 指出的阻塞问题、更新本 Spec/`PROGRESS.md`/`BLOCKED.md` 证据和执行本地 Git cutover；不得 push `main`。
+- 接口：输出 immutable feature tip、commit list、验证证据和本地 `main` 新 tip，供任务 4 构建镜像。
+- focused verification：`git diff --check && cd backend && go test -tags=unit ./... && cd ../frontend && pnpm typecheck && pnpm test:run`，全部退出 0；reviewer `PASS`；提交后 feature worktree clean；`merge-main` 后 `main == feature_tip` 并再次运行同一 broad verification。
+- 集成顺序：任务 1/2 后执行；通过后任务 4 ready。
+- 失败后果：验证、review、rebase 或 ff-only 任一失败时不得部署；保留 branch/worktree 和恢复点继续修复。
+- 反向验证：至少保留任务 1/2 的 RED→GREEN 证据；merge Gate 故意使用旧 tip 做一次 compare-and-swap 检查并证明漂移会阻断，随后用最新 immutable tip 通过。
+
+## 任务 4：部署本机、设置账号与 live 验证
+
+- 结果：按 `sub2api-upgrader` 基于正式 upstream tag 和本地 `main` 全部 local-only patches 构建新的 arm64 image，只切换本机 app 容器；通过 admin API 把指定官方账号设置为 `fallback_only`；真实流量证明 AI-INPUT 可用时新 `session_hash` 请求不再持续命中该官方账号，AI-INPUT 不可用时 fallback 仍成立。
+- 依赖：任务 3。
+- `write ownership`：`/Users/admin/sub2api/docker-compose.yml` 仅允许更新 `services.sub2api.image`；本机 Docker app container/image；本机 Sub2API 指定账号的 `openai_session_sticky_mode`；`docs/sub2api/运行与升级.md` 记录 live image 与回滚镜像。不得修改 PostgreSQL/Redis 容器、其它账号字段或 `myclaw`。
+- 接口：部署输入是任务 3 已验证的本地 `main` tip 与完整 patch manifest；输出新/旧 image、binary version、health、restart count、账号字段 round-trip 和脱敏调度证据。
+- focused verification：按 `sub2api-upgrader` 完成 patch 枚举、targeted tests、frontend build、Linux arm64 binary/image 自检、`/health`、container health/restart count。live 写入前以本地非敏感 account ID 定位目标并 fail closed 断言：唯一记录、platform=openai、type=oauth、priority=200、初始 mode 已记录；不得输出 name/email。admin API GET/PUT/GET 证明仅提交 `openai_session_sticky_mode`，其它字段指纹不变且 mode=`fallback_only`。使用虚构 session 标识的受控 live 请求和 usage/account 只读查询证明主池可用时选择 priority 1；AI-INPUT 不可用时的 fallback 由隔离自动测试证明，不修改生产 AI-INPUT 状态制造故障。
+- 集成顺序：本地 main 合入后执行；live 全部通过后任务 5 ready。
+- 失败后果：容器不健康、migration/API round-trip 失败、local patches 缺失或主路径行为不成立时，立即切回升级前健康 image 并恢复健康。账号 post-write 或调度验证失败时，仅通过 admin API PUT 回已记录的原 mode 并重新 GET/验活；恢复失败立即阻断并保留证据，不得直接改 DB。
+- 反向验证：部署前在旧 live API 上读取新字段/提交新 enum，必须得到字段缺失或不支持的预期 RED；部署后同一路径 GREEN。真实 fallback 失败分支只用自动测试或隔离环境，不破坏 live 主池。
+
+## 任务 5：上游 issue 与 PR
+
+- 结果：live 验证通过后创建不含私有信息的上游 issue；从最新 `origin/main` 创建 public branch，只移植公开功能提交并独立验证，push 到 fork 后创建 ready PR。PR 正文包含问题、行为合同、兼容边界、migration、测试、live 脱敏结论和 `Closes #<issue>`。
+- 依赖：任务 4。
+- `write ownership`：独立 public worktree/branch、GitHub issue、fork public branch、upstream PR；不得 push `main` 或携带 local-only patches。
+- 接口：issue/PR 只引用虚构账号和公开代码，不包含真实邮箱、token、请求体、私有日志或 server_setup 路径。
+- focused verification：`origin/main` 是 `public_tip` 祖先；`origin/main..public_tip` 只含本功能公开提交，路径/commit 来源/Spec/真实邮箱/secret 扫描零异常；在 public worktree 重新运行 backend/frontend broad verification；issue 与 PR URL 可读取，PR head 精确指向 `public_tip`，checks 已启动；仅 public branch/worktree 因开放 PR 保留。
+- 集成顺序：最后。
+- 失败后果：secret/privacy 扫描失败时禁止创建；push/issue/PR 临时失败时保留本地完成结果重试，不回滚已健康部署。
+- 反向验证：创建前对 diff、issue body 和 PR body 运行真实邮箱/secret 模式扫描并要求零命中。
+
+## 协作与集成
+
+- Sol 先创建唯一 integration worktree，并从 approved Spec 固定 immutable integration tip；后端与前端 lane 从同一 tip 创建独立 branch/worktree，分别由 worker 实现并由直接 reviewer 独立审核。
+- `ready = 依赖已完成`；任务 0 通过后任务 1/2 可并行，write ownership 不重叠。Terra `PASS` 前不得集成。
+- 综合验证通过前保留 lane worktree；`merge-main` 只做本地 `ff-only`，不 push `main`。本地 cutover 和部署完成后可按 Gate 清理 integration/lane 资源；上游 PR 未关闭前只保留从 `origin/main` 创建的 public branch/worktree。
+
+## 规矩
+
+- 不得用全局 sticky 权重、关闭 sticky 或“订阅优先”模拟单账号行为。
+- 不得解析日志、prompt 或自由文本决定账号策略；只读 typed account 字段、typed request capability 和 scheduler state。
+- 不得打印 credentials、request body、OAuth token、API key 或真实邮箱；测试使用虚构账号。
+- 不得 skip/todo、放宽断言、mock 掉被测调度器、删除测试、修改验收阈值、使用 `|| true` 或降低测试数。
+- 不新增第三方依赖；同一验收连续失败 3 次停止该路径并记录 `BLOCKED.md`。
+
+## 完成条件
+
+- 对一个 `fallback_only`、priority 200 的测试账号，存在支持模型且有立即 slot 的 priority 1 账号时，下一次 `session_hash` 请求选择 priority 1；priority 1 不可用时选择 fallback；normal 模式与同优先级 sticky 行为不变。
+- `previous_response_id` 全部既有回归测试继续通过；新字段 migration、单字段 omission/round-trip、snapshot round-trip 和前端账号编辑页回显/提交均有自动测试，创建页与批量编辑无改动。
+- broad backend/frontend 验证、独立 reviewer、review-commit、本地 `merge-main` 后复验、本机部署与回滚点、live 账号设置/调度验证、GitHub issue/PR 全部有实际证据；任何一项缺失不得宣称完成。
+- 根工作区原有 `.gitignore` 改动与其它无关 worktree/branch 不被修改或提交；私有 Spec 只保留审核所需的非 secret、脱敏 live 基线且不得进入 public branch；public branch、commit、issue 和 PR 不得包含 secret、真实邮箱、私有路径或 live 数据。
+
+## Goal
+
+- 验收摘要: 自动测试用虚构的 priority 1 主账号与 priority 200 fallback 账号跑 OpenAI session sticky 调度到账号选择边界；随后受控部署本机并只更新目标账号 mode；看到主账号恢复即回切、主账号不可用才保底、normal/previous-response 不回归、live 单字段写入可恢复、公开 PR 不含私有内容才算通过。
+- 执行依据: `docs/superpowers/specs/2026-08-08-openai-account-fallback-only-sticky.md` 的任务 0 → 5。
+- 真实验收: backend scheduler tests｜legacy + advanced 两条路径｜`cd backend && go test -tags=unit ./internal/service ./internal/repository ./internal/handler/admin`｜成功=退出 0 且 RED→GREEN 场景齐全｜证据=`PROGRESS.md`。
+- 真实验收: admin UI/API｜账号编辑页与单字段 round-trip｜`cd frontend && pnpm typecheck && pnpm test:run`｜成功=退出 0、创建/批量编辑无 diff 且无 skip/todo｜证据=`PROGRESS.md`。
+- 非回归: `cd backend && go test -tags=unit ./... && cd ../frontend && pnpm typecheck && pnpm test:run`。
+- 边界: 允许测试、feature push、GitHub issue/PR、本地 ff-only main、本机 app 容器部署和指定账号单字段 admin API 更新；禁止直接改 DB、修改其它账号字段、访问/部署 myclaw 和 push main。

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -19,6 +19,7 @@ import type {
   CodexSessionImportRequest,
   CodexSessionImportResult,
   OpenAICodexPATCreateRequest,
+  OpenAISessionStickyMode,
   CheckMixedChannelRequest,
   CheckMixedChannelResponse,
   UpstreamBillingProbeResult,
@@ -26,6 +27,12 @@ import type {
   OllamaCloudUsageSettings,
   OllamaCloudUsageState
 } from '@/types'
+
+export const OPENAI_SESSION_STICKY_MODES = ['normal', 'fallback_only'] as const
+
+export function isOpenAISessionStickyMode(value: unknown): value is OpenAISessionStickyMode {
+  return OPENAI_SESSION_STICKY_MODES.includes(value as OpenAISessionStickyMode)
+}
 
 /**
  * List all accounts with pagination

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1516,6 +1516,36 @@
         </div>
       </div>
 
+      <!-- OpenAI session sticky policy (account-level; create and bulk edit intentionally omit it) -->
+      <div
+        v-if="account?.platform === 'openai'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+        data-testid="openai-session-sticky-policy"
+      >
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.sessionStickyMode') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.sessionStickyModeDesc') }}
+            </p>
+            <p
+              v-if="openAISessionStickyMode === null"
+              class="mt-2 text-xs text-red-600 dark:text-red-400"
+              data-testid="openai-session-sticky-mode-missing"
+            >
+              {{ t('admin.accounts.openai.sessionStickyModeMissing') }}
+            </p>
+          </div>
+          <div v-if="openAISessionStickyMode !== null" class="w-56 shrink-0">
+            <Select
+              v-model="openAISessionStickyMode"
+              data-testid="openai-session-sticky-mode"
+              :options="openAISessionStickyModeOptions"
+            />
+          </div>
+        </div>
+      </div>
+
       <!-- OpenAI Codex namespace 工具摊平（兼容开关，仅 OAuth） -->
       <div
         v-if="account?.platform === 'openai' && account?.type === 'oauth'"
@@ -2663,6 +2693,7 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import { adminAPI } from '@/api/admin'
+import { isOpenAISessionStickyMode } from '@/api/admin/accounts'
 import { useQuotaNotifyState } from '@/composables/useQuotaNotifyState'
 import type {
   Account,
@@ -2672,6 +2703,7 @@ import type {
   OpenAICompactMode,
   OpenAIResponsesMode,
   OpenAIEndpointCapability,
+  OpenAISessionStickyMode,
   OllamaCloudUsageState
 } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
@@ -2916,6 +2948,7 @@ const openAILongContextBillingEnabled = ref(false)
 const editPlanType = ref<string>('')
 const openAICompactMode = ref<OpenAICompactMode>('auto')
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
+const openAISessionStickyMode = ref<OpenAISessionStickyMode | null>(null)
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
@@ -3049,6 +3082,16 @@ const openAIResponsesModeOptions = computed(() => [
   { value: 'auto', label: t('admin.accounts.openai.responsesModeAuto') },
   { value: 'force_responses', label: t('admin.accounts.openai.responsesModeForceResponses') },
   { value: 'force_chat_completions', label: t('admin.accounts.openai.responsesModeForceChatCompletions') }
+])
+const openAISessionStickyModeOptions = computed(() => [
+  {
+    value: 'normal' as const,
+    label: t('admin.accounts.openai.sessionStickyModeNormal')
+  },
+  {
+    value: 'fallback_only' as const,
+    label: t('admin.accounts.openai.sessionStickyModeFallbackOnly')
+  }
 ])
 const openAITextEndpointCapabilityLabel = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
@@ -3367,6 +3410,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
+  openAISessionStickyMode.value = null
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -3429,6 +3473,11 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     if (compactMappings && typeof compactMappings === 'object') {
       openAICompactModelMappings.value = Object.entries(compactMappings).map(([from, to]) => ({ from, to }))
     }
+  }
+  if (newAccount.platform === 'openai') {
+    openAISessionStickyMode.value = isOpenAISessionStickyMode(newAccount.openai_session_sticky_mode)
+      ? newAccount.openai_session_sticky_mode
+      : null
   }
   if (newAccount.platform === 'anthropic' && newAccount.type === 'apikey') {
     anthropicPassthroughEnabled.value = extra?.anthropic_passthrough === true
@@ -4095,6 +4144,17 @@ const submitUpdateAccount = async (accountID: number, updatePayload: Record<stri
   submitting.value = true
   try {
     const updatedAccount = await adminAPI.accounts.update(accountID, withAntigravityConfirmFlag(updatePayload))
+    if (props.account?.platform === 'openai') {
+      const requestedMode = updatePayload.openai_session_sticky_mode
+      if (
+        !isOpenAISessionStickyMode(requestedMode) ||
+        !isOpenAISessionStickyMode(updatedAccount.openai_session_sticky_mode) ||
+        updatedAccount.openai_session_sticky_mode !== requestedMode
+      ) {
+        appStore.showError(t('admin.accounts.openai.sessionStickyModeRoundTripFailed'))
+        return
+      }
+    }
     appStore.showSuccess(t('admin.accounts.accountUpdated'))
     emit('updated', updatedAccount)
     handleClose()
@@ -4126,6 +4186,13 @@ const handleSubmit = async () => {
 
   const updatePayload: Record<string, unknown> = { ...form }
   try {
+    if (props.account.platform === 'openai') {
+      if (!isOpenAISessionStickyMode(openAISessionStickyMode.value)) {
+        appStore.showError(t('admin.accounts.openai.sessionStickyModeMissing'))
+        return
+      }
+      updatePayload.openai_session_sticky_mode = openAISessionStickyMode.value
+    }
     // 后端期望 proxy_id: 0 表示清除代理，而不是 null
     if (updatePayload.proxy_id === null) {
       updatePayload.proxy_id = 0

--- a/frontend/src/components/account/__tests__/EditAccountModal.grokUpstream.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.grokUpstream.spec.ts
@@ -40,9 +40,13 @@ vi.mock('@/api/admin', () => ({
   }
 }))
 
-vi.mock('@/api/admin/accounts', () => ({
-  getAntigravityDefaultModelMapping: vi.fn()
-}))
+vi.mock('@/api/admin/accounts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/admin/accounts')>()
+  return {
+    ...actual,
+    getAntigravityDefaultModelMapping: vi.fn()
+  }
+})
 
 vi.mock('vue-i18n', async () => {
   const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -2,18 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
 
-const { updateAccountMock, checkMixedChannelRiskMock, authIsSimpleMode } = vi.hoisted(() => ({
+const { updateAccountMock, checkMixedChannelRiskMock, authIsSimpleMode, appStoreMock } = vi.hoisted(() => ({
   updateAccountMock: vi.fn(),
   checkMixedChannelRiskMock: vi.fn(),
-  authIsSimpleMode: { value: true }
-}))
-
-vi.mock('@/stores/app', () => ({
-  useAppStore: () => ({
+  authIsSimpleMode: { value: true },
+  appStoreMock: {
     showError: vi.fn(),
     showSuccess: vi.fn(),
     showInfo: vi.fn()
-  })
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => appStoreMock
 }))
 
 vi.mock('@/stores/auth', () => ({
@@ -41,7 +42,8 @@ vi.mock('@/api/admin', () => ({
 }))
 
 vi.mock('@/api/admin/accounts', () => ({
-  getAntigravityDefaultModelMapping: vi.fn()
+  getAntigravityDefaultModelMapping: vi.fn(),
+  isOpenAISessionStickyMode: (value: unknown) => value === 'normal' || value === 'fallback_only'
 }))
 
 vi.mock('vue-i18n', async () => {
@@ -160,6 +162,7 @@ function buildAccount() {
     priority: 1,
     rate_multiplier: 1,
     status: 'active',
+    openai_session_sticky_mode: 'normal',
     group_ids: [],
     expires_at: null,
     auto_pause_on_expired: false
@@ -314,6 +317,74 @@ function mountModal(account = buildAccount()) {
 describe('EditAccountModal', () => {
   beforeEach(() => {
     authIsSimpleMode.value = true
+    appStoreMock.showError.mockReset()
+    appStoreMock.showSuccess.mockReset()
+    appStoreMock.showInfo.mockReset()
+  })
+
+  it('shows and submits the OpenAI session sticky mode for the current account only', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue({ ...account, openai_session_sticky_mode: 'fallback_only' })
+
+    const wrapper = mountModal(account)
+    const modeSelect = wrapper.get<HTMLSelectElement>('[data-testid="openai-session-sticky-mode"]')
+
+    expect(modeSelect.element.value).toBe('normal')
+    await modeSelect.setValue('fallback_only')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock.mock.calls[0]?.[1]?.openai_session_sticky_mode).toBe('fallback_only')
+  })
+
+  it('does not render or submit the OpenAI session sticky mode for non-OpenAI accounts', async () => {
+    const account = buildVertexAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    expect(wrapper.find('[data-testid="openai-session-sticky-mode"]').exists()).toBe(false)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock.mock.calls[0]?.[1]).not.toHaveProperty('openai_session_sticky_mode')
+  })
+
+  it('fails visibly when the OpenAI sticky mode is missing from the server response', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue({ ...account, openai_session_sticky_mode: undefined })
+
+    const wrapper = mountModal(account)
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(appStoreMock.showError).toHaveBeenCalledWith(
+      'admin.accounts.openai.sessionStickyModeRoundTripFailed'
+    )
+    expect(wrapper.emitted('updated')).toBeUndefined()
+  })
+
+  it('fails visibly before saving when an OpenAI account has no sticky mode field', async () => {
+    const account = { ...buildAccount(), openai_session_sticky_mode: undefined }
+    updateAccountMock.mockReset()
+
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="openai-session-sticky-mode"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="openai-session-sticky-mode-missing"]').exists()).toBe(true)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).not.toHaveBeenCalled()
+    expect(appStoreMock.showError).toHaveBeenCalledWith(
+      'admin.accounts.openai.sessionStickyModeMissing'
+    )
   })
 
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {

--- a/frontend/src/components/admin/account/ModelMultiSelect.vue
+++ b/frontend/src/components/admin/account/ModelMultiSelect.vue
@@ -1,0 +1,104 @@
+<template>
+  <div ref="container" class="relative">
+    <button
+      :id="id"
+      type="button"
+      class="select-trigger w-full"
+      :aria-label="ariaLabel"
+      :aria-expanded="open"
+      :aria-controls="id ? `${id}-options` : undefined"
+      @click="open = !open"
+    >
+      <span class="select-value truncate text-left">{{ summary }}</span>
+      <Icon name="chevronDown" size="md" :class="['transition-transform duration-200', open && 'rotate-180']" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="id ? `${id}-options` : undefined"
+      class="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-lg border border-gray-200 bg-white p-2 shadow-lg dark:border-dark-600 dark:bg-dark-800"
+      role="group"
+      :aria-label="ariaLabel"
+      @click.stop
+    >
+      <div class="mb-2 flex items-center justify-between gap-2 border-b border-gray-100 pb-2 text-xs dark:border-dark-700">
+        <button type="button" class="text-primary-600 hover:underline dark:text-primary-400" @click="selectAll">
+          {{ allLabel }}
+        </button>
+        <button type="button" class="text-gray-500 hover:underline dark:text-gray-400" @click="clearAll">
+          {{ clearLabel }}
+        </button>
+      </div>
+      <label
+        v-for="option in options"
+        :key="String(option.value)"
+        class="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-dark-700"
+      >
+        <input
+          type="checkbox"
+          :checked="selected.has(String(option.value))"
+          :disabled="option.disabled"
+          @change="toggle(String(option.value))"
+        />
+        <span class="truncate">{{ option.label }}</span>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@/components/icons'
+import type { SelectOption } from '@/components/common/Select.vue'
+
+const { t } = useI18n()
+
+const props = withDefaults(defineProps<{
+  modelValue: string[]
+  options: SelectOption[]
+  id?: string
+  ariaLabel?: string
+  placeholder?: string
+  allLabel?: string
+  clearLabel?: string
+}>(), {
+  placeholder: '',
+  id: undefined,
+  ariaLabel: undefined,
+  allLabel: '',
+  clearLabel: ''
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string[]): void
+}>()
+
+const open = ref(false)
+const container = ref<HTMLElement | null>(null)
+const selected = computed(() => new Set(props.modelValue.map(String)))
+const availableValues = computed(() => props.options.map(option => String(option.value)))
+const summary = computed(() => {
+  if (selected.value.size === 0) return props.placeholder || t('common.selectOption')
+  if (selected.value.size === availableValues.value.length && availableValues.value.length > 0) {
+    return props.allLabel || t('admin.scheduledTests.allFailedModels')
+  }
+  return t('admin.scheduledTests.selectedModels', { count: selected.value.size })
+})
+
+const selectAll = () => emit('update:modelValue', [...availableValues.value])
+const clearAll = () => emit('update:modelValue', [])
+const toggle = (modelID: string) => {
+  const next = new Set(selected.value)
+  if (next.has(modelID)) next.delete(modelID)
+  else next.add(modelID)
+  emit('update:modelValue', availableValues.value.filter(value => next.has(value)))
+}
+
+const onDocumentClick = (event: MouseEvent) => {
+  if (container.value && !container.value.contains(event.target as Node)) open.value = false
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick))
+onUnmounted(() => document.removeEventListener('click', onDocumentClick))
+</script>

--- a/frontend/src/components/admin/account/ScheduledTestsPanel.vue
+++ b/frontend/src/components/admin/account/ScheduledTestsPanel.vue
@@ -29,18 +29,69 @@
           {{ t('admin.scheduledTests.addPlan') }}
         </div>
         <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div class="sm:col-span-2">
+            <div class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+              {{ t('admin.scheduledTests.triggerMode') }}
+              <HelpTooltip trigger="click">
+                <template #trigger>
+                  <button
+                    type="button"
+                    :aria-label="t('admin.scheduledTests.errorRecoveryHelpAriaLabel')"
+                    class="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-gray-400/70 text-[10px] font-semibold text-gray-400 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-gray-500 dark:text-gray-500 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                  >
+                    ?
+                  </button>
+                </template>
+                <div class="max-w-xs space-y-1.5">
+                  <p>{{ t('admin.scheduledTests.errorRecoveryTooltipFailedModels') }}</p>
+                  <p>{{ t('admin.scheduledTests.errorRecoveryTooltipBoundaries') }}</p>
+                </div>
+              </HelpTooltip>
+            </div>
+            <div class="inline-flex rounded-lg border border-gray-200 p-0.5 dark:border-dark-500">
+              <button
+                v-for="mode in triggerModes"
+                :key="mode.value"
+                type="button"
+                :aria-pressed="newPlan.trigger_mode === mode.value"
+                :class="[
+                  'rounded-md px-3 py-1.5 text-sm transition-colors',
+                  newPlan.trigger_mode === mode.value
+                    ? 'bg-primary-500 text-white'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-600'
+                ]"
+                @click="setTriggerMode(newPlan, mode.value)"
+              >
+                {{ mode.label }}
+              </button>
+            </div>
+          </div>
           <div>
-            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
-              {{ t('admin.scheduledTests.model') }}
+            <label
+              :for="newPlan.trigger_mode === 'error_recovery' ? 'new-plan-error-models' : undefined"
+              class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+            >
+              {{ t(newPlan.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.probeModel' : 'admin.scheduledTests.model') }}
             </label>
+            <ModelMultiSelect
+              v-if="newPlan.trigger_mode === 'error_recovery'"
+              id="new-plan-error-models"
+              v-model="newPlan.model_ids"
+              :options="modelOptions"
+              :aria-label="t('admin.scheduledTests.probeModel')"
+              :placeholder="t('admin.scheduledTests.selectModels')"
+              :all-label="t('admin.scheduledTests.allFailedModels')"
+              :clear-label="t('admin.scheduledTests.clearSelection')"
+            />
             <Select
+              v-else
               v-model="newPlan.model_id"
               :options="modelOptions"
               :placeholder="t('admin.scheduledTests.model')"
               :searchable="modelOptions.length > 5"
             />
           </div>
-          <div>
+          <div v-if="newPlan.trigger_mode === 'scheduled'">
             <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
               {{ t('admin.scheduledTests.cronExpression') }}
               <HelpTooltip>
@@ -66,6 +117,27 @@
               :hint="t('admin.scheduledTests.cronHelp')"
             />
           </div>
+          <div v-else>
+            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+              {{ newPlan.advanced_cron ? t('admin.scheduledTests.cronExpression') : t('admin.scheduledTests.retryInterval') }}
+            </label>
+            <Input
+              v-if="!newPlan.advanced_cron"
+              v-model="newPlan.retry_interval_minutes"
+              type="number"
+              min="1"
+              max="1440"
+            />
+            <Input
+              v-else
+              v-model="newPlan.retry_cron_expression"
+              :placeholder="'*/5 * * * *'"
+            />
+            <label class="mt-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <Toggle v-model="newPlan.advanced_cron" />
+              {{ t('admin.scheduledTests.advancedCron') }}
+            </label>
+          </div>
           <div>
             <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
               {{ t('admin.scheduledTests.maxResults') }}
@@ -90,7 +162,7 @@
               placeholder="100"
             />
           </div>
-          <div class="flex items-end">
+          <div v-if="newPlan.trigger_mode === 'scheduled'" class="flex items-end">
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
               <Toggle v-model="newPlan.enabled" />
               {{ t('admin.scheduledTests.enabled') }}
@@ -117,7 +189,7 @@
           </button>
           <button
             @click="handleCreate"
-            :disabled="!newPlan.model_id || !newPlan.cron_expression || creating"
+            :disabled="!isPlanFormValid(newPlan) || creating"
             class="flex items-center gap-1.5 rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Icon v-if="creating" name="refresh" size="sm" class="animate-spin" :stroke-width="2" />
@@ -158,11 +230,11 @@
             <div class="flex flex-1 items-center gap-4">
               <!-- Model -->
               <div class="min-w-0">
-                <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {{ plan.model_id }}
+                <div class="truncate text-sm font-medium text-gray-900 dark:text-gray-100" :title="formatPlanModels(plan)">
+                  {{ formatPlanModels(plan) }}
                 </div>
                 <div class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">
-                  {{ plan.cron_expression }}
+                  {{ formatPlanSchedule(plan) }}
                 </div>
               </div>
 
@@ -179,10 +251,10 @@
 
               <!-- Auto Recover Badge -->
               <span
-                v-if="plan.auto_recover"
+                v-if="plan.trigger_mode === 'error_recovery' || plan.auto_recover"
                 class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
               >
-                {{ t('admin.scheduledTests.autoRecover') }}
+                {{ t(plan.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.errorRecoveryMode' : 'admin.scheduledTests.autoRecover') }}
               </span>
             </div>
 
@@ -239,18 +311,69 @@
               {{ t('admin.scheduledTests.editPlan') }}
             </div>
             <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <div class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {{ t('admin.scheduledTests.triggerMode') }}
+                  <HelpTooltip trigger="click">
+                    <template #trigger>
+                      <button
+                        type="button"
+                        :aria-label="t('admin.scheduledTests.errorRecoveryHelpAriaLabel')"
+                        class="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-gray-400/70 text-[10px] font-semibold text-gray-400 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-gray-500 dark:text-gray-500 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                      >
+                        ?
+                      </button>
+                    </template>
+                    <div class="max-w-xs space-y-1.5">
+                      <p>{{ t('admin.scheduledTests.errorRecoveryTooltipFailedModels') }}</p>
+                      <p>{{ t('admin.scheduledTests.errorRecoveryTooltipBoundaries') }}</p>
+                    </div>
+                  </HelpTooltip>
+                </div>
+                <div class="inline-flex rounded-lg border border-gray-200 p-0.5 dark:border-dark-500">
+                  <button
+                    v-for="mode in triggerModes"
+                    :key="mode.value"
+                    type="button"
+                    :aria-pressed="editForm.trigger_mode === mode.value"
+                    :class="[
+                      'rounded-md px-3 py-1.5 text-sm transition-colors',
+                      editForm.trigger_mode === mode.value
+                        ? 'bg-primary-500 text-white'
+                        : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-600'
+                    ]"
+                    @click="setTriggerMode(editForm, mode.value)"
+                  >
+                    {{ mode.label }}
+                  </button>
+                </div>
+              </div>
               <div>
-                <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
-                  {{ t('admin.scheduledTests.model') }}
+                <label
+                  :for="editForm.trigger_mode === 'error_recovery' ? 'edit-plan-error-models' : undefined"
+                  class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                >
+                  {{ t(editForm.trigger_mode === 'error_recovery' ? 'admin.scheduledTests.probeModel' : 'admin.scheduledTests.model') }}
                 </label>
+                <ModelMultiSelect
+                  v-if="editForm.trigger_mode === 'error_recovery'"
+                  id="edit-plan-error-models"
+                  v-model="editForm.model_ids"
+                  :options="modelOptions"
+                  :aria-label="t('admin.scheduledTests.probeModel')"
+                  :placeholder="t('admin.scheduledTests.selectModels')"
+                  :all-label="t('admin.scheduledTests.allFailedModels')"
+                  :clear-label="t('admin.scheduledTests.clearSelection')"
+                />
                 <Select
+                  v-else
                   v-model="editForm.model_id"
                   :options="modelOptions"
                   :placeholder="t('admin.scheduledTests.model')"
                   :searchable="modelOptions.length > 5"
                 />
               </div>
-              <div>
+              <div v-if="editForm.trigger_mode === 'scheduled'">
                 <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
                   {{ t('admin.scheduledTests.cronExpression') }}
                   <HelpTooltip>
@@ -276,6 +399,27 @@
                   :hint="t('admin.scheduledTests.cronHelp')"
                 />
               </div>
+              <div v-else>
+                <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {{ editForm.advanced_cron ? t('admin.scheduledTests.cronExpression') : t('admin.scheduledTests.retryInterval') }}
+                </label>
+                <Input
+                  v-if="!editForm.advanced_cron"
+                  v-model="editForm.retry_interval_minutes"
+                  type="number"
+                  min="1"
+                  max="1440"
+                />
+                <Input
+                  v-else
+                  v-model="editForm.retry_cron_expression"
+                  :placeholder="'*/5 * * * *'"
+                />
+                <label class="mt-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                  <Toggle v-model="editForm.advanced_cron" />
+                  {{ t('admin.scheduledTests.advancedCron') }}
+                </label>
+              </div>
               <div>
                 <label class="mb-1 flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400">
                   {{ t('admin.scheduledTests.maxResults') }}
@@ -300,7 +444,7 @@
                   placeholder="100"
                 />
               </div>
-              <div class="flex items-end">
+              <div v-if="editForm.trigger_mode === 'scheduled'" class="flex items-end">
                 <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                   <Toggle v-model="editForm.enabled" />
                   {{ t('admin.scheduledTests.enabled') }}
@@ -327,7 +471,7 @@
               </button>
               <button
                 @click="handleEdit"
-                :disabled="!editForm.model_id || !editForm.cron_expression || updating"
+                :disabled="!isPlanFormValid(editForm) || updating"
                 class="flex items-center gap-1.5 rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Icon v-if="updating" name="refresh" size="sm" class="animate-spin" :stroke-width="2" />
@@ -368,23 +512,30 @@
               >
                 <div class="flex items-center justify-between">
                   <div class="flex items-center gap-2">
+                    <span class="font-mono text-xs text-gray-600 dark:text-gray-300">
+                      {{ result.model_id }}
+                    </span>
                     <!-- Status Badge -->
                     <span
                       :class="[
                         'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                        result.status === 'success'
+                        displayResultStatus(result) === 'success'
                           ? 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400'
-                          : result.status === 'running'
+                          : displayResultStatus(result) === 'running'
                             ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400'
-                            : 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400'
+                            : displayResultStatus(result) === 'interrupted'
+                              ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400'
+                              : 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400'
                       ]"
                     >
                       {{
-                        result.status === 'success'
+                        displayResultStatus(result) === 'success'
                           ? t('admin.scheduledTests.success')
-                          : result.status === 'running'
+                          : displayResultStatus(result) === 'running'
                             ? t('admin.scheduledTests.running')
-                            : t('admin.scheduledTests.failed')
+                            : displayResultStatus(result) === 'interrupted'
+                              ? t('admin.scheduledTests.interrupted')
+                              : t('admin.scheduledTests.failed')
                       }}
                     </span>
 
@@ -463,19 +614,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue'
+import { computed, ref, reactive, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import HelpTooltip from '@/components/common/HelpTooltip.vue'
 import Select, { type SelectOption } from '@/components/common/Select.vue'
+import ModelMultiSelect from './ModelMultiSelect.vue'
 import Input from '@/components/common/Input.vue'
 import Toggle from '@/components/common/Toggle.vue'
 import { Icon } from '@/components/icons'
 import { adminAPI } from '@/api/admin'
 import { useAppStore } from '@/stores/app'
 import { formatDateTime } from '@/utils/format'
-import type { ScheduledTestPlan, ScheduledTestResult } from '@/types'
+import type { CreateScheduledTestPlanRequest, ScheduledTestPlan, ScheduledTestResult, UpdateScheduledTestPlanRequest } from '@/types'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -498,34 +650,177 @@ const plans = ref<ScheduledTestPlan[]>([])
 const results = ref<ScheduledTestResult[]>([])
 const expandedPlanId = ref<number | null>(null)
 const expandedResultIds = reactive(new Set<number>())
+const resultsStatusNow = ref(Date.now())
+const resultsRefreshIntervalMs = 5000
+const runningResultTimeoutMs = 5 * 60 * 1000
+let resultsRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let resultsRequestGeneration = 0
 const showAddForm = ref(false)
 const showDeleteConfirm = ref(false)
 const deletingPlan = ref<ScheduledTestPlan | null>(null)
 const editingPlanId = ref<number | null>(null)
 const updating = ref(false)
+type TriggerMode = 'scheduled' | 'error_recovery'
+type PlanForm = {
+  model_id: string
+  model_ids: string[]
+  cron_expression: string
+  trigger_mode: TriggerMode
+  retry_interval_minutes: string
+  retry_cron_expression: string
+  advanced_cron: boolean
+  max_results: string
+  enabled: boolean
+  auto_recover: boolean
+}
+
+const triggerModes = computed(() => [
+  { value: 'scheduled' as const, label: t('admin.scheduledTests.scheduledMode') },
+  { value: 'error_recovery' as const, label: t('admin.scheduledTests.errorRecoveryMode') }
+])
+
 const editForm = reactive({
   model_id: '' as string,
+  model_ids: [] as string[],
   cron_expression: '' as string,
+  trigger_mode: 'scheduled' as TriggerMode,
+  retry_interval_minutes: '5' as string,
+  retry_cron_expression: '' as string,
+  advanced_cron: false,
   max_results: '100' as string,
   enabled: true,
-  auto_recover: false
+  auto_recover: true
 })
 
 const newPlan = reactive({
   model_id: '' as string,
-  cron_expression: '' as string,
+  model_ids: props.modelOptions.map(option => String(option.value)),
+  cron_expression: '*/30 * * * *' as string,
+  trigger_mode: 'error_recovery' as TriggerMode,
+  retry_interval_minutes: '5' as string,
+  retry_cron_expression: '' as string,
+  advanced_cron: false,
   max_results: '100' as string,
   enabled: true,
-  auto_recover: false
+  auto_recover: true
 })
 
+const modelOptionIDs = computed(() => props.modelOptions.map(option => String(option.value)))
+
+const allModelsSelected = (modelIDs: string[]) => {
+  const available = modelOptionIDs.value
+  return available.length > 0 && modelIDs.length === available.length && available.every(modelID => modelIDs.includes(modelID))
+}
+
+const canonicalModelIDs = (modelIDs: string[]) => allModelsSelected(modelIDs) ? [] : [...modelIDs]
+
+const setTriggerMode = (form: PlanForm, mode: TriggerMode) => {
+  form.trigger_mode = mode
+  if (mode === 'error_recovery' && form.model_ids.length === 0) {
+    form.model_ids = [...modelOptionIDs.value]
+    form.model_id = form.model_ids[0] || form.model_id
+  }
+}
+
 const resetNewPlan = () => {
-  newPlan.model_id = ''
-  newPlan.cron_expression = ''
+  newPlan.model_ids = [...modelOptionIDs.value]
+  newPlan.model_id = newPlan.model_ids[0] || ''
+  newPlan.cron_expression = '*/30 * * * *'
+  newPlan.trigger_mode = 'error_recovery'
+  newPlan.retry_interval_minutes = '5'
+  newPlan.retry_cron_expression = ''
+  newPlan.advanced_cron = false
   newPlan.max_results = '100'
   newPlan.enabled = true
-  newPlan.auto_recover = false
+  newPlan.auto_recover = true
 }
+
+const isPlanFormValid = (form: PlanForm) => {
+  if (form.trigger_mode === 'error_recovery' && form.model_ids.length === 0) return false
+  if (form.trigger_mode === 'scheduled' && !form.model_id) return false
+  if (form.trigger_mode === 'scheduled') return Boolean(form.cron_expression.trim())
+  if (form.advanced_cron) return Boolean(form.retry_cron_expression.trim())
+  const interval = Number(form.retry_interval_minutes)
+  return Number.isInteger(interval) && interval >= 1 && interval <= 1440
+}
+
+const recoveryFields = (form: PlanForm) => {
+  if (form.trigger_mode === 'scheduled') {
+    return {
+      trigger_mode: 'scheduled' as const,
+      cron_expression: form.cron_expression,
+      retry_interval_minutes: null,
+      retry_cron_expression: null,
+      auto_recover: form.auto_recover,
+      model_ids: []
+    }
+  }
+  return {
+    trigger_mode: 'error_recovery' as const,
+    retry_interval_minutes: form.advanced_cron ? null : Number(form.retry_interval_minutes),
+    retry_cron_expression: form.advanced_cron ? form.retry_cron_expression.trim() : null,
+    auto_recover: form.auto_recover,
+    model_ids: canonicalModelIDs(form.model_ids)
+  }
+}
+
+const formatPlanSchedule = (plan: ScheduledTestPlan) => {
+  if (plan.trigger_mode !== 'error_recovery') return plan.cron_expression
+  if (plan.retry_cron_expression) return plan.retry_cron_expression
+  return t('admin.scheduledTests.everyMinutes', { minutes: plan.retry_interval_minutes ?? 5 })
+}
+
+const formatPlanModels = (plan: ScheduledTestPlan) => {
+  if (plan.trigger_mode !== 'error_recovery') return plan.model_id
+  if (!plan.model_ids?.length) return t('admin.scheduledTests.allFailedModels')
+  return plan.model_ids.join(', ')
+}
+
+const isStaleRunningResult = (result: ScheduledTestResult) => {
+  if (result.status !== 'running') return false
+  const startedAt = Date.parse(result.started_at)
+  return Number.isFinite(startedAt) && resultsStatusNow.value - startedAt > runningResultTimeoutMs
+}
+
+const displayResultStatus = (result: ScheduledTestResult) => {
+  return isStaleRunningResult(result) ? 'interrupted' : result.status
+}
+
+const hasActiveRunningResult = (items: ScheduledTestResult[]) => {
+  return items.some((result) => result.status === 'running' && !isStaleRunningResult(result))
+}
+
+const stopResultsPolling = () => {
+  if (resultsRefreshTimer !== null) {
+    clearTimeout(resultsRefreshTimer)
+    resultsRefreshTimer = null
+  }
+}
+
+const invalidateResultsRequests = () => {
+  resultsRequestGeneration += 1
+}
+
+const startResultsPolling = () => {
+  if (resultsRefreshTimer !== null) return
+  resultsRefreshTimer = setTimeout(async () => {
+    resultsRefreshTimer = null
+    resultsStatusNow.value = Date.now()
+    const planId = expandedPlanId.value
+    if (!planId || !hasActiveRunningResult(results.value)) return
+    await loadResults(planId, false)
+  }, resultsRefreshIntervalMs)
+}
+
+watch(
+  () => props.modelOptions,
+  () => {
+    if (newPlan.trigger_mode === 'error_recovery' && newPlan.model_ids.length === 0) {
+      resetNewPlan()
+    }
+  },
+  { immediate: true, deep: true }
+)
 
 // Load plans when dialog opens
 watch(
@@ -534,6 +829,8 @@ watch(
     if (visible && props.accountId) {
       await loadPlans()
     } else {
+      invalidateResultsRequests()
+      stopResultsPolling()
       plans.value = []
       results.value = []
       expandedPlanId.value = null
@@ -557,18 +854,18 @@ const loadPlans = async () => {
 }
 
 const handleCreate = async () => {
-  if (!props.accountId || !newPlan.model_id || !newPlan.cron_expression) return
+  if (!props.accountId || !isPlanFormValid(newPlan)) return
   creating.value = true
   try {
     const maxResults = Number(newPlan.max_results) || 100
-    await adminAPI.scheduledTests.create({
+    const request: CreateScheduledTestPlanRequest = {
       account_id: props.accountId,
-      model_id: newPlan.model_id,
-      cron_expression: newPlan.cron_expression,
+      model_id: newPlan.trigger_mode === 'error_recovery' ? newPlan.model_ids[0] : newPlan.model_id,
       enabled: newPlan.enabled,
       max_results: maxResults,
-      auto_recover: newPlan.auto_recover
-    })
+      ...recoveryFields(newPlan)
+    }
+    await adminAPI.scheduledTests.create(request)
     appStore.showSuccess(t('admin.scheduledTests.createSuccess'))
     showAddForm.value = false
     resetNewPlan()
@@ -596,7 +893,17 @@ const handleToggleEnabled = async (plan: ScheduledTestPlan, enabled: boolean) =>
 const startEdit = (plan: ScheduledTestPlan) => {
   editingPlanId.value = plan.id
   editForm.model_id = plan.model_id
+  editForm.model_ids = plan.trigger_mode === 'error_recovery'
+    ? (plan.model_ids?.length ? [...plan.model_ids] : [...modelOptionIDs.value])
+    : []
+  if (plan.trigger_mode === 'error_recovery' && editForm.model_ids.length > 0) {
+    editForm.model_id = editForm.model_ids[0]
+  }
   editForm.cron_expression = plan.cron_expression
+  editForm.trigger_mode = plan.trigger_mode || 'scheduled'
+  editForm.retry_interval_minutes = String(plan.retry_interval_minutes ?? 5)
+  editForm.retry_cron_expression = plan.retry_cron_expression || ''
+  editForm.advanced_cron = Boolean(plan.retry_cron_expression)
   editForm.max_results = String(plan.max_results)
   editForm.enabled = plan.enabled
   editForm.auto_recover = plan.auto_recover
@@ -607,16 +914,16 @@ const cancelEdit = () => {
 }
 
 const handleEdit = async () => {
-  if (!editingPlanId.value || !editForm.model_id || !editForm.cron_expression) return
+  if (!editingPlanId.value || !isPlanFormValid(editForm)) return
   updating.value = true
   try {
-    const updated = await adminAPI.scheduledTests.update(editingPlanId.value, {
-      model_id: editForm.model_id,
-      cron_expression: editForm.cron_expression,
+    const request: UpdateScheduledTestPlanRequest = {
+      model_id: editForm.trigger_mode === 'error_recovery' ? editForm.model_ids[0] : editForm.model_id,
       max_results: Number(editForm.max_results) || 100,
       enabled: editForm.enabled,
-      auto_recover: editForm.auto_recover
-    })
+      ...recoveryFields(editForm)
+    }
+    const updated = await adminAPI.scheduledTests.update(editingPlanId.value, request)
     const index = plans.value.findIndex((p) => p.id === editingPlanId.value)
     if (index !== -1) {
       plans.value[index] = updated
@@ -642,6 +949,8 @@ const handleDelete = async () => {
     appStore.showSuccess(t('admin.scheduledTests.deleteSuccess'))
     plans.value = plans.value.filter((p) => p.id !== deletingPlan.value!.id)
     if (expandedPlanId.value === deletingPlan.value.id) {
+      invalidateResultsRequests()
+      stopResultsPolling()
       expandedPlanId.value = null
       results.value = []
     }
@@ -653,25 +962,43 @@ const handleDelete = async () => {
   }
 }
 
+const loadResults = async (planId: number, showLoading = true) => {
+  const requestGeneration = ++resultsRequestGeneration
+  if (showLoading) loadingResults.value = true
+  try {
+    const loaded = await adminAPI.scheduledTests.listResults(planId, 20)
+    if (requestGeneration === resultsRequestGeneration && expandedPlanId.value === planId) {
+      resultsStatusNow.value = Date.now()
+      results.value = loaded
+      if (hasActiveRunningResult(loaded)) startResultsPolling()
+      else stopResultsPolling()
+    }
+  } catch (error: any) {
+    if (requestGeneration !== resultsRequestGeneration || expandedPlanId.value !== planId) return
+    results.value = []
+    stopResultsPolling()
+    appStore.showError(error?.message || 'Failed to load results')
+  } finally {
+    if (showLoading && requestGeneration === resultsRequestGeneration) loadingResults.value = false
+  }
+}
+
 const toggleExpand = async (planId: number) => {
   if (expandedPlanId.value === planId) {
+    invalidateResultsRequests()
+    stopResultsPolling()
     expandedPlanId.value = null
     results.value = []
     expandedResultIds.clear()
     return
   }
 
+  invalidateResultsRequests()
+  stopResultsPolling()
   expandedPlanId.value = planId
   expandedResultIds.clear()
-  loadingResults.value = true
-  try {
-    results.value = await adminAPI.scheduledTests.listResults(planId, 20)
-  } catch (error: any) {
-    appStore.showError(error?.message || 'Failed to load results')
-    results.value = []
-  } finally {
-    loadingResults.value = false
-  }
+  results.value = []
+  await loadResults(planId)
 }
 
 const toggleResultDetail = (resultId: number) => {
@@ -681,4 +1008,9 @@ const toggleResultDetail = (resultId: number) => {
     expandedResultIds.add(resultId)
   }
 }
+
+onUnmounted(() => {
+  invalidateResultsRequests()
+  stopResultsPolling()
+})
 </script>

--- a/frontend/src/components/admin/account/__tests__/ModelMultiSelect.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/ModelMultiSelect.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ModelMultiSelect from '../ModelMultiSelect.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key })
+  }
+})
+
+describe('ModelMultiSelect', () => {
+  it('selects failed models independently and supports all or none', async () => {
+    const wrapper = mount(ModelMultiSelect, {
+      props: {
+        modelValue: ['luna', 'sol'],
+        options: [
+          { value: 'luna', label: 'Luna' },
+          { value: 'sol', label: 'Sol' }
+        ],
+        id: 'failed-models',
+        ariaLabel: 'Failed models',
+        allLabel: 'All failed models',
+        clearLabel: 'Clear'
+      },
+      global: { stubs: { Icon: true } }
+    })
+
+    const trigger = wrapper.get('.select-trigger')
+    expect(trigger.attributes()).toMatchObject({ id: 'failed-models', 'aria-label': 'Failed models' })
+    expect(wrapper.text()).toContain('All failed models')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-controls')).toBe('failed-models-options')
+    expect(wrapper.find('[role="listbox"]').exists()).toBe(false)
+    expect(wrapper.get('[role="group"]').attributes('aria-label')).toBe('Failed models')
+    await wrapper.findAll('input[type="checkbox"]')[0].trigger('change')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['sol']])
+
+    await wrapper.findAll('button').find(button => button.text() === 'Clear')!.trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([[]])
+
+    await wrapper.findAll('button').filter(button => button.text() === 'All failed models').pop()!.trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[2]).toEqual([['luna', 'sol']])
+  })
+})

--- a/frontend/src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/ScheduledTestsPanel.spec.ts
@@ -1,0 +1,397 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ScheduledTestsPanel from '../ScheduledTestsPanel.vue'
+
+const api = vi.hoisted(() => ({
+  listByAccount: vi.fn().mockResolvedValue([]),
+  create: vi.fn().mockResolvedValue({}),
+  update: vi.fn(),
+  delete: vi.fn(),
+  listResults: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({ adminAPI: { scheduledTests: api } }))
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showSuccess: vi.fn(), showError: vi.fn() })
+}))
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string, params?: { minutes?: number }) => params?.minutes ? `${key}:${params.minutes}` : key })
+  }
+})
+
+const stubs = {
+  BaseDialog: { props: ['show'], template: '<div v-if="show"><slot /></div>' },
+  ConfirmDialog: true,
+  HelpTooltip: { template: '<span><slot name="trigger" /><slot /></span>' },
+  Select: {
+    props: ['modelValue', 'options', 'placeholder', 'searchable'],
+    emits: ['update:modelValue'],
+    template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option value=""></option><option value="gpt-5.6-luna">luna</option></select>'
+  },
+  ModelMultiSelect: {
+    props: ['modelValue', 'options', 'placeholder'],
+    emits: ['update:modelValue'],
+    template: '<div data-testid="model-multi-select"><span>{{ modelValue.join(",") }}</span><button data-testid="select-sol-only" @click="$emit(\'update:modelValue\', [\'gpt-5.6-sol\'])">sol only</button></div>'
+  },
+  Input: {
+    props: ['modelValue', 'type', 'min', 'max', 'placeholder', 'hint'],
+    emits: ['update:modelValue'],
+    template: '<input :type="type || \'text\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+  },
+  Toggle: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />'
+  },
+  Icon: true
+}
+
+function mountPanel() {
+  return mount(ScheduledTestsPanel, {
+    props: {
+      show: true,
+      accountId: 42,
+      modelOptions: [
+        { value: 'gpt-5.6-luna', label: 'luna' },
+        { value: 'gpt-5.6-sol', label: 'sol' }
+      ]
+    },
+    global: { stubs }
+  })
+}
+
+async function openForm(wrapper: ReturnType<typeof mountPanel>) {
+  const addButton = wrapper.findAll('button').find(button => button.text().includes('admin.scheduledTests.addPlan'))
+  await addButton!.trigger('click')
+}
+
+async function openScheduledFormAndSelectModel(wrapper: ReturnType<typeof mountPanel>) {
+  await openForm(wrapper)
+  const scheduledButton = wrapper.findAll('button').find(button => button.text() === 'admin.scheduledTests.scheduledMode')
+  await scheduledButton!.trigger('click')
+  await wrapper.find('select').setValue('gpt-5.6-luna')
+}
+
+async function save(wrapper: ReturnType<typeof mountPanel>) {
+  const saveButton = wrapper.findAll('button').find(button => button.text() === 'common.save')
+  await saveButton!.trigger('click')
+  await flushPromises()
+}
+
+beforeEach(() => {
+  api.create.mockClear()
+  api.update.mockClear()
+  api.listByAccount.mockClear()
+  api.listByAccount.mockResolvedValue([])
+  api.listResults.mockReset()
+})
+
+const runningResult = (startedAt = new Date(Date.now() - 1000).toISOString()) => ({
+  id: 1,
+  plan_id: 9,
+  model_id: 'gpt-5.6-sol',
+  status: 'running',
+  response_text: '',
+  error_message: '',
+  latency_ms: 0,
+  started_at: startedAt,
+  finished_at: startedAt,
+  created_at: startedAt
+})
+
+async function openResults(results: object[], refreshResults?: object[]) {
+  const plan = {
+    id: 9,
+    account_id: 42,
+    model_id: 'gpt-5.6-sol',
+    model_ids: [],
+    cron_expression: '*/30 * * * *',
+    trigger_mode: 'error_recovery' as const,
+    retry_interval_minutes: 5,
+    retry_cron_expression: null,
+    enabled: true,
+    max_results: 100,
+    auto_recover: true,
+    last_run_at: null,
+    next_run_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  }
+  api.listByAccount.mockResolvedValue([plan])
+  api.listResults.mockResolvedValueOnce(results)
+  if (refreshResults) api.listResults.mockResolvedValueOnce(refreshResults)
+  const wrapper = mountPanel()
+  await wrapper.setProps({ show: false })
+  await wrapper.setProps({ show: true })
+  await flushPromises()
+  await wrapper.find('[class*="cursor-pointer"][class*="justify-between"]').trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+describe('ScheduledTestsPanel error recovery form', () => {
+  it('defaults to a five-minute error recovery plan', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    expect(wrapper.get('[data-testid="model-multi-select"]').text()).toContain('gpt-5.6-luna,gpt-5.6-sol')
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    expect((autoRecover!.find('input').element as HTMLInputElement).checked).toBe(true)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith({
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      model_ids: [],
+      enabled: true,
+      max_results: 100,
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: 5,
+      retry_cron_expression: null,
+      auto_recover: true
+    })
+  })
+
+  it('uses advanced cron instead of the minute interval', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    const advancedLabel = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.advancedCron'))
+    await advancedLabel!.find('input').setValue(true)
+    const cronInput = wrapper.findAll('input').find(input => input.element.type === 'text')
+    await cronInput!.setValue('*/7 * * * *')
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: null,
+      retry_cron_expression: '*/7 * * * *'
+    }))
+  })
+
+  it('preserves an explicitly disabled auto-recovery setting on create', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    await autoRecover!.find('input').setValue(false)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      auto_recover: false
+    }))
+  })
+
+  it('preserves the existing scheduled cron payload', async () => {
+    const wrapper = mountPanel()
+    await openScheduledFormAndSelectModel(wrapper)
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger_mode: 'scheduled',
+      cron_expression: '*/30 * * * *',
+      retry_interval_minutes: null,
+      retry_cron_expression: null
+    }))
+  })
+
+  it('sends only the selected failed-model subset', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    await wrapper.get('[data-testid="select-sol-only"]').trigger('click')
+    await save(wrapper)
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      model_id: 'gpt-5.6-sol',
+      model_ids: ['gpt-5.6-sol']
+    }))
+  })
+
+  it('explains that error recovery probes the models that actually failed', async () => {
+    const wrapper = mountPanel()
+    await openForm(wrapper)
+    expect(wrapper.text()).toContain('admin.scheduledTests.errorRecoveryTooltipFailedModels')
+    expect(wrapper.get('button[aria-label="admin.scheduledTests.errorRecoveryHelpAriaLabel"]').exists()).toBe(true)
+  })
+
+  it('loads and edits a legacy scheduled plan without recovery fields', async () => {
+    const legacyPlan = {
+      id: 7,
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      cron_expression: '*/17 * * * *',
+      enabled: true,
+      max_results: 100,
+      auto_recover: false,
+      last_run_at: null,
+      next_run_at: null,
+      created_at: '2026-08-01T00:00:00Z',
+      updated_at: '2026-08-01T00:00:00Z'
+    }
+    api.listByAccount.mockResolvedValue([legacyPlan])
+    api.update.mockResolvedValueOnce({ ...legacyPlan, trigger_mode: 'scheduled' })
+    const wrapper = mountPanel()
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find(button => button.attributes('title') === 'admin.scheduledTests.editPlan')
+    await editButton!.trigger('click')
+    expect(wrapper.find('input[value="*/17 * * * *"]').exists()).toBe(true)
+    await save(wrapper)
+
+    expect(api.update).toHaveBeenCalledWith(7, expect.objectContaining({
+      model_id: 'gpt-5.6-luna',
+      trigger_mode: 'scheduled',
+      cron_expression: '*/17 * * * *',
+      retry_interval_minutes: null,
+      retry_cron_expression: null
+    }))
+  })
+
+  it('preserves an explicitly disabled auto-recovery setting on edit', async () => {
+    const plan = {
+      id: 8,
+      account_id: 42,
+      model_id: 'gpt-5.6-luna',
+      model_ids: [],
+      cron_expression: '*/30 * * * *',
+      trigger_mode: 'error_recovery',
+      retry_interval_minutes: 5,
+      retry_cron_expression: null,
+      enabled: true,
+      max_results: 100,
+      auto_recover: true,
+      last_run_at: null,
+      next_run_at: null,
+      created_at: '2026-08-01T00:00:00Z',
+      updated_at: '2026-08-01T00:00:00Z'
+    }
+    api.listByAccount.mockResolvedValue([plan])
+    api.update.mockResolvedValueOnce(plan)
+    const wrapper = mountPanel()
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find(button => button.attributes('title') === 'admin.scheduledTests.editPlan')
+    await editButton!.trigger('click')
+    const autoRecover = wrapper.findAll('label').find(label => label.text().includes('admin.scheduledTests.autoRecover'))
+    await autoRecover!.find('input').setValue(false)
+    await save(wrapper)
+
+    expect(api.update).toHaveBeenCalledWith(8, expect.objectContaining({
+      trigger_mode: 'error_recovery',
+      auto_recover: false
+    }))
+  })
+})
+
+describe('ScheduledTestsPanel running results', () => {
+  it('refreshes expanded results while a test is running', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([runningResult()], [{ ...runningResult(), status: 'success' }])
+
+      expect(api.listResults).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('marks a stale running result as interrupted after the runner timeout', async () => {
+    const wrapper = await openResults([runningResult(new Date(Date.now() - 6 * 60 * 1000).toISOString())])
+
+    expect(wrapper.text()).toContain('admin.scheduledTests.interrupted')
+  })
+
+  it('changes a visible running result to interrupted when it crosses the timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([
+        runningResult(new Date(Date.now() - 5 * 60 * 1000 + 1000).toISOString())
+      ])
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.running')
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.interrupted')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not overlap result polls while the previous request is pending', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolvePoll!: (results: object[]) => void
+      const pendingPoll = new Promise<object[]>((resolve) => { resolvePoll = resolve })
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockReturnValueOnce(pendingPoll)
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      resolvePoll([{ ...runningResult(), status: 'success' }])
+      await flushPromises()
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores an old poll response after the same plan is closed and reopened', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolveOldPoll!: (results: object[]) => void
+      const oldPoll = new Promise<object[]>((resolve) => { resolveOldPoll = resolve })
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockReturnValueOnce(oldPoll)
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      const planHeader = wrapper.find('[class*="cursor-pointer"][class*="justify-between"]')
+      await planHeader.trigger('click')
+      api.listResults.mockResolvedValueOnce([{ ...runningResult(), status: 'success' }])
+      await planHeader.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+
+      resolveOldPoll([runningResult()])
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('admin.scheduledTests.success')
+      expect(wrapper.text()).not.toContain('admin.scheduledTests.running')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops refreshing when a running-result poll fails', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = await openResults([runningResult()])
+      api.listResults.mockRejectedValueOnce(new Error('network unavailable'))
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(5000)
+      await flushPromises()
+
+      expect(api.listResults).toHaveBeenCalledTimes(2)
+      expect(wrapper.exists()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -501,6 +501,13 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        sessionStickyMode: 'Session sticky policy',
+        sessionStickyModeDesc:
+          'Only affects OpenAI session_hash affinity. Normal affinity reuses this account; fallback-only affinity yields to a higher-priority account that supports the request and has an immediate slot. previous_response_id remains bound to its original account.',
+        sessionStickyModeNormal: 'Normal sticky',
+        sessionStickyModeFallbackOnly: 'Sticky only as fallback',
+        sessionStickyModeMissing: 'The server did not return this account session sticky policy, so it cannot be saved safely. Upgrade the backend first.',
+        sessionStickyModeRoundTripFailed: 'The server did not confirm the session sticky policy. The save was rejected; refresh the account and try again.',
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',

--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -5,6 +5,18 @@ export default {
       editPlan: 'Edit Plan',
       deletePlan: 'Delete Plan',
       model: 'Model',
+      probeModel: 'Account Probe Model',
+      selectModels: 'Select failed models',
+      selectedModels: '{count} models selected',
+      allFailedModels: 'All failed models',
+      clearSelection: 'Clear',
+      triggerMode: 'Test Mode',
+      scheduledMode: 'Scheduled',
+      errorRecoveryMode: 'Error Recovery',
+      errorRecoveryHelpAriaLabel: 'Explain error recovery',
+      retryInterval: 'Retry Interval (minutes)',
+      advancedCron: 'Advanced Cron',
+      everyMinutes: 'Every {minutes} minutes',
       cronExpression: 'Cron Expression',
       enabled: 'Enabled',
       lastRun: 'Last Run',
@@ -22,6 +34,7 @@ export default {
       success: 'Success',
       failed: 'Failed',
       running: 'Running',
+      interrupted: 'Execution interrupted',
       schedule: 'Schedule',
       cronHelp: 'Standard 5-field cron expression (e.g., */30 * * * *)',
       cronTooltipTitle: 'Cron expression examples:',
@@ -37,7 +50,9 @@ export default {
       maxResultsTooltipExample: 'For example, 100 means keeping at most the latest 100 test results. When the 101st result is saved, the oldest one is removed.',
       maxResultsTooltipRange: 'Recommended range: usually 20 to 200. Use 20-50 when you only care about recent health status, or 100-200 if you want a longer trend history.',
       autoRecover: 'Auto Recover',
-      autoRecoverHelp: 'Automatically recover account from error/rate-limited state on successful test'
+      autoRecoverHelp: 'Automatically recover account from error/rate-limited state on successful test',
+      errorRecoveryTooltipFailedModels: 'Only structured errors recorded by the system are tested. Each failed model is tested individually; all models are included by default. Account-level errors use the first selected model once.',
+      errorRecoveryTooltipBoundaries: 'AICredits, manually disabled or unschedulable states, and expired accounts are not recovered by this feature.'
     },
 
     // Proxies

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -572,6 +572,13 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        sessionStickyMode: '会话粘性策略',
+        sessionStickyModeDesc:
+          '仅影响 OpenAI session_hash 粘性。正常粘性会复用当前账号；仅作保底时，存在更高优先级且可立即接单的账号时会切回主池。previous_response_id 仍始终绑定原账号。',
+        sessionStickyModeNormal: '正常粘性',
+        sessionStickyModeFallbackOnly: '仅作保底时粘性',
+        sessionStickyModeMissing: '服务端未返回该账号的会话粘性策略，无法安全保存。请先升级后端。',
+        sessionStickyModeRoundTripFailed: '服务端未确认会话粘性策略，保存失败。请刷新账号后重试。',
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -574,7 +574,7 @@ export default {
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
         sessionStickyMode: '会话粘性策略',
         sessionStickyModeDesc:
-          '仅影响 OpenAI session_hash 粘性。正常粘性会复用当前账号；仅作保底时，存在更高优先级且可立即接单的账号时会切回主池。previous_response_id 仍始终绑定原账号。',
+          '此设置只影响 OpenAI 的 session_hash。正常粘性会继续使用当前账号。仅作保底时，只要有优先级更高且能立即处理请求的账号，就会自动切换过去。previous_response_id 仍固定使用原账号，避免上下文失效。',
         sessionStickyModeNormal: '正常粘性',
         sessionStickyModeFallbackOnly: '仅作保底时粘性',
         sessionStickyModeMissing: '服务端未返回该账号的会话粘性策略，无法安全保存。请先升级后端。',

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -5,6 +5,18 @@ export default {
       editPlan: '编辑计划',
       deletePlan: '删除计划',
       model: '模型',
+      probeModel: '账号探测模型',
+      selectModels: '选择失败模型',
+      selectedModels: '已选择 {count} 个模型',
+      allFailedModels: '全部失败模型',
+      clearSelection: '清空',
+      triggerMode: '测试方式',
+      scheduledMode: '定时测试',
+      errorRecoveryMode: '错误恢复',
+      errorRecoveryHelpAriaLabel: '说明错误恢复',
+      retryInterval: '重试间隔（分钟）',
+      advancedCron: '高级 Cron',
+      everyMinutes: '每 {minutes} 分钟',
       cronExpression: 'Cron 表达式',
       enabled: '启用',
       lastRun: '上次运行',
@@ -22,6 +34,7 @@ export default {
       success: '成功',
       failed: '失败',
       running: '运行中',
+      interrupted: '执行中断',
       schedule: '定时测试',
       cronHelp: '标准 5 字段 cron 表达式（例如 */30 * * * *）',
       cronTooltipTitle: 'Cron 表达式示例：',
@@ -37,7 +50,9 @@ export default {
       maxResultsTooltipExample: '例如填写 100，表示最多保存最近 100 次测试结果；第 101 次结果写入后，最早的一条会被清理。',
       maxResultsTooltipRange: '推荐填写范围：一般可填 20 到 200。只关注近期可用性时可填 20-50；需要回看较长时间的波动趋势时可填 100-200。',
       autoRecover: '自动恢复',
-      autoRecoverHelp: '测试成功后自动恢复异常状态的账号'
+      autoRecoverHelp: '测试成功后自动恢复异常状态的账号',
+      errorRecoveryTooltipFailedModels: '只测试系统记录的结构化错误；哪个模型失败就测试哪个模型。默认包含全部模型，也可以缩小范围。账号级错误使用首个已选模型探测一次。',
+      errorRecoveryTooltipBoundaries: 'AICredits、人工禁用或不可调度、过期状态不会通过此功能恢复。'
     },
 
     // Proxies Management

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2247,7 +2247,11 @@ export interface ScheduledTestPlan {
   id: number
   account_id: number
   model_id: string
+  model_ids?: string[]
   cron_expression: string
+  trigger_mode: 'scheduled' | 'error_recovery'
+  retry_interval_minutes: number | null
+  retry_cron_expression: string | null
   enabled: boolean
   max_results: number
   auto_recover: boolean
@@ -2260,6 +2264,7 @@ export interface ScheduledTestPlan {
 export interface ScheduledTestResult {
   id: number
   plan_id: number
+  model_id: string
   status: string
   response_text: string
   error_message: string
@@ -2272,7 +2277,11 @@ export interface ScheduledTestResult {
 export interface CreateScheduledTestPlanRequest {
   account_id: number
   model_id: string
-  cron_expression: string
+  model_ids?: string[]
+  cron_expression?: string
+  trigger_mode?: 'scheduled' | 'error_recovery'
+  retry_interval_minutes?: number | null
+  retry_cron_expression?: string | null
   enabled?: boolean
   max_results?: number
   auto_recover?: boolean
@@ -2280,7 +2289,11 @@ export interface CreateScheduledTestPlanRequest {
 
 export interface UpdateScheduledTestPlanRequest {
   model_id?: string
+  model_ids?: string[]
   cron_expression?: string
+  trigger_mode?: 'scheduled' | 'error_recovery'
+  retry_interval_minutes?: number | null
+  retry_cron_expression?: string | null
   enabled?: boolean
   max_results?: number
   auto_recover?: boolean

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1090,6 +1090,8 @@ export interface Account {
   scheduler_scores?: AccountSchedulerGroupScore[] | null
   priority: number
   rate_multiplier?: number // Account billing multiplier (>=0, 0 means free)
+  // OpenAI account-level session_hash sticky policy; legacy responses may omit it and are rejected by the editor.
+  openai_session_sticky_mode?: OpenAISessionStickyMode
   status: 'active' | 'inactive' | 'error'
   error_message: string | null
   last_used_at: string | null
@@ -1327,6 +1329,7 @@ export interface CodexUsageSnapshot {
 export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'
 export type OpenAIResponsesMode = 'auto' | 'force_responses' | 'force_chat_completions'
 export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings'
+export type OpenAISessionStickyMode = 'normal' | 'fallback_only'
 
 export interface OpenAICompactState {
   openai_compact_mode?: OpenAICompactMode
@@ -1371,6 +1374,7 @@ export interface UpdateAccountRequest {
   load_factor?: number | null
   priority?: number
   rate_multiplier?: number // Account billing multiplier (>=0, 0 means free)
+  openai_session_sticky_mode?: OpenAISessionStickyMode
   schedulable?: boolean
   status?: 'active' | 'inactive' | 'error'
   group_ids?: number[]

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -626,6 +626,20 @@ const ALWAYS_VISIBLE = ['user', 'created_at']
 const DEFAULT_HIDDEN_COLUMNS = ['reasoning_effort', 'user_agent']
 const HIDDEN_COLUMNS_KEY = 'usage-hidden-columns'
 
+const formatTokenSpeed = (_value: unknown, row: AdminUsageLog): string => {
+  if (
+    row.image_count > 0
+    || row.image_output_tokens > 0
+    || !Number.isFinite(row.output_tokens)
+    || row.output_tokens <= 0
+    || !Number.isFinite(row.duration_ms)
+    || row.duration_ms == null
+    || row.duration_ms <= 0
+  ) return '-'
+
+  return (row.output_tokens * 1000 / row.duration_ms).toFixed(2)
+}
+
 const allColumns = computed(() => [
   { key: 'user', label: t('admin.usage.user'), sortable: false },
   { key: 'api_key', label: t('usage.apiKeyFilter'), sortable: false },
@@ -637,6 +651,7 @@ const allColumns = computed(() => [
   { key: 'stream', label: t('usage.type'), sortable: false },
   { key: 'billing_mode', label: t('admin.usage.billingMode'), sortable: false },
   { key: 'tokens', label: t('usage.tokens'), sortable: false },
+  { key: 'token_speed', label: 'Token/s', sortable: false, formatter: formatTokenSpeed },
   { key: 'cost', label: t('usage.cost'), sortable: false },
   { key: 'latency', label: t('usage.latency'), sortable: false },
   { key: 'created_at', label: t('usage.time'), sortable: true },

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -244,6 +244,27 @@ describe('admin UsageView route filters', () => {
     expect(list).toHaveBeenCalledWith(expect.objectContaining({ user_id: 42 }), expect.anything())
     expect(wrapper.find('[data-test="user-filter-label"]').text()).toBe('42')
   })
+
+  it('includes a dedicated Token/s column with safe output throughput formatting', async () => {
+    const wrapper = mountRouteFilteredUsageView()
+    await flushPromises()
+
+    const column = (wrapper.vm as any).allColumns.find((item: { key: string }) => item.key === 'token_speed')
+    expect(column.label).toBe('Token/s')
+    expect(column.formatter(undefined, { output_tokens: 101, duration_ms: 345, image_count: 0 })).toBe('292.75')
+    for (const row of [
+      { output_tokens: 101, duration_ms: -345, image_count: 0 },
+      { output_tokens: 101, duration_ms: 0, image_count: 0 },
+      { output_tokens: 101, duration_ms: null, image_count: 0 },
+      { output_tokens: 101, duration_ms: Number.POSITIVE_INFINITY, image_count: 0 },
+      { output_tokens: 0, duration_ms: 345, image_count: 0 },
+      { output_tokens: Number.POSITIVE_INFINITY, duration_ms: 345, image_count: 0 },
+      { output_tokens: 101, duration_ms: 345, image_count: 1, billing_mode: 'token' },
+      { output_tokens: 101, duration_ms: 345, image_count: 0, image_output_tokens: 1 },
+    ]) {
+      expect(column.formatter(undefined, row)).toBe('-')
+    }
+  })
 })
 
 describe('admin UsageView distribution metric toggles', () => {


### PR DESCRIPTION
## Summary

- persist a 10-minute account-and-model circuit after three distinct requests receive transient upstream failures
- deduplicate retries by request ID and keep transient 400, 401/403, 429/529, and pool-mode handling on their existing paths
- preserve failures that arrive during recovery with a pre-DB generation snapshot plus the existing database value CAS

## Behavior

The durable circuit applies to `500/502/503/504/520/521/522/523/524`, scoped by account ID and canonical model. Internal retries for one request count once. Scheduled recovery clears the circuit only when both the observed database limit and in-memory mutation generation are unchanged.

## Tests

- `go test -tags unit ./internal/service -count=1` (7742 passed)
- focused race tests for transient circuit and recovery paths (28 passed)
- deterministic regression coverage for failures during `GetByID` and canonical model case normalization
- `git diff --check`

## Stack

This PR is stacked on the local patch chain and currently overlaps #5014, #5169, and #5432. The new review boundary is commit `d78f27cb377f0bbddb35c68aff785c5df8dd9762` over `d00f5711a45c38687bb0376fbe097dd891cb3f63`; the cumulative GitHub diff will shrink as those dependencies land.