### PR TITLE
fix(gateway): Composite 分组放行视频生成端点

### DIFF
--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -93,7 +93,10 @@ func RegisterGatewayRoutes(
 		}
 	}
 	videoGenerationHandler := func(c *gin.Context) {
-		if getGroupPlatform(c) == service.PlatformGrok {
+		// Video status/content lookups below already allow Composite groups; keep
+		// task creation aligned so composite keys that route to Grok accounts can
+		// submit video generation jobs.
+		if platform := getGroupPlatform(c); platform == service.PlatformGrok || platform == service.PlatformComposite {
 			h.OpenAIGateway.GrokVideoGeneration(c)
 			return
 		}

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -345,6 +345,18 @@ func TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate(t *testing.T) {
 	}
 }
 
+func TestGatewayRoutesCompositeVideoGenerationAllowed(t *testing.T) {
+	router := newGatewayRoutesTestRouter(service.PlatformComposite)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/videos/generations", strings.NewReader(`{"model":"grok-imagine-video-1.5","prompt":"waves"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusNotFound, w.Code)
+	require.NotContains(t, w.Body.String(), "not supported")
+}
+
 func TestGatewayRoutesCompositeOpenAIOnlyEndpointsRequireOpenAITarget(t *testing.T) {
 	router := newGatewayRoutesTestRouter(service.PlatformComposite)
 


### PR DESCRIPTION
## 问题

Composite 分组后台配好模型路由（如 `MiniMax-H3` → grok）之后，同一把 key 发请求出现这样的现象：

- 对话模型走 chat 全正常
- `GET /v1/videos/:id` 查任务、`GET /v1/videos/:id/content` 取内容都能通
- **唯独发起任务** `POST /v1/videos/generations` 直接 404 `Videos API is not supported for this platform`

问题在 `gateway.go`，三个端点的 gate 判断不一致：

```go
// status / content（两个端点共用一套）：
if platform == service.PlatformGrok || platform == service.PlatformComposite { ... }

// generation（创建）：
if getGroupPlatform(c) == service.PlatformGrok { ... }
```

创建端点少写了 `PlatformComposite`——同组的查和下载都放得进，任务创建的唯一入口却拦着。

## 复现

1. composite 分组挂一个 OpenAI 账号 + 一个 Grok 账号（API Key 类型，base_url 自建中转）
2. 路由表配 `MiniMax-H3` 精确匹配 → grok
3. 该分组 key 发 `POST /v1/videos/generations`，body `{"model":"MiniMax-H3", ...}`

**期望**：转入 Grok 账号通道发起视频任务
**实际**：直接 404，不触达任何账号

## 修复

放行判断补上 `PlatformComposite`，与同文件另外两个端点对齐。其他平台分组仍然 404，行为未变。

新增 `TestGatewayRoutesCompositeVideoGenerationAllowed` 用例；原有 `TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate` 回归用例未动。
