### PR TITLE
fix(anthropic): fail over on upstream transport errors instead of immediate 502

### DIFF
--- a/backend/internal/service/anthropic_upstream_transport_error.go
+++ b/backend/internal/service/anthropic_upstream_transport_error.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// anthropicTransportErrorTempUnschedDuration is how long an account is temporarily
+// unscheduled after a durable transport failure (matches openAITransportErrorTempUnschedDuration).
+const anthropicTransportErrorTempUnschedDuration = 10 * time.Minute
+
+// anthropicTransportFailoverBody is the Anthropic-format error body attached to
+// the failover error for a transport-level failure. Kept identical to the legacy
+// inline 502 body so the client-visible payload is unchanged if failover is
+// ultimately exhausted.
+var anthropicTransportFailoverBody = []byte(`{"type":"error","error":{"type":"upstream_error","message":"Upstream request failed"}}`)
+
+// handleAnthropicUpstreamTransportError handles a transport-level upstream failure
+// on the Anthropic channel (DoWithTLS returned a non-HTTP error: proxy/DNS/TCP/TLS,
+// no HTTP status code received). It mirrors handleOpenAIUpstreamTransportError:
+//  1. records the failure in Ops error logs (status 0, kind=request_error);
+//  2. for durable faults (dead endpoint, DNS/routing failure, rejected proxy
+//     credentials) temporarily unschedules the account so subsequent requests
+//     skip it;
+//  3. returns an error that is *UpstreamFailoverError — so the handler fails
+//     over to a healthy account within the same client request — for all
+//     non-canceled errors, or a plain error for context.Canceled (client gone:
+//     no failover, no eviction).
+//
+// It deliberately does NOT write to the response: the handler owns the response
+// (failover, or a protocol-correct error once failover is exhausted).
+//
+// passthrough tags the Ops error event for the API-key passthrough forward path.
+func (s *GatewayService) handleAnthropicUpstreamTransportError(ctx context.Context, c *gin.Context, account *Account, upstreamURL string, passthrough bool, err error) error {
+	safeErr := sanitizeUpstreamErrorMessage(err.Error())
+	setOpsUpstreamError(c, 0, safeErr, "")
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: 0,
+		UpstreamURL:        upstreamURL,
+		Passthrough:        passthrough,
+		Kind:               "request_error",
+		Message:            safeErr,
+	})
+
+	// Client disconnected: do NOT fail over to another account and do NOT evict
+	// this one — the upstream never had a chance to exhibit a fault.
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+
+	// Transport attempt reached the network path; count as Ollama Cloud activity.
+	scheduleOllamaCloudUsageActivity(s.deferredService, account)
+
+	// The classification (proxy/DNS/TCP failure markers) is channel-agnostic;
+	// reuse the OpenAI-channel classifier.
+	if classifyOpenAITransportError(err).Persistent {
+		s.tempUnscheduleAnthropicTransportError(ctx, account, safeErr)
+	}
+
+	return &UpstreamFailoverError{
+		StatusCode:   http.StatusBadGateway,
+		ResponseBody: anthropicTransportFailoverBody,
+	}
+}
+
+// tempUnscheduleAnthropicTransportError marks an account temporarily
+// unschedulable after a durable transport failure (DB-persisted, matching this
+// channel's other auto-unschedule helpers such as tempUnscheduleEmptyResponse).
+func (s *GatewayService) tempUnscheduleAnthropicTransportError(ctx context.Context, account *Account, safeErr string) {
+	if s == nil || account == nil || s.accountRepo == nil {
+		return
+	}
+	until := time.Now().Add(anthropicTransportErrorTempUnschedDuration)
+	reason := "upstream transport error (proxy/network): " + safeErr
+
+	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openAIAccountStateUpdateTimeout)
+	defer cancel()
+	if err := s.accountRepo.SetTempUnschedulable(bgCtx, account.ID, until, reason); err != nil {
+		logger.L().With(zap.String("component", "service.gateway")).Warn(
+			"anthropic.account_temp_unscheduled_transport_failed",
+			zap.Int64("account_id", account.ID),
+			zap.Error(err),
+		)
+		return
+	}
+	logger.L().With(zap.String("component", "service.gateway")).Warn(
+		"anthropic.account_temp_unscheduled_transport",
+		zap.Int64("account_id", account.ID),
+		zap.String("account_name", account.Name),
+		zap.String("platform", account.Platform),
+		zap.Time("until", until),
+		zap.String("reason", reason),
+	)
+}

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1209,8 +1209,82 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_UpstreamRequest
 	result, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, account, []byte(`{"model":"x"}`), "x", "x", false, time.Now())
 	require.Nil(t, result)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "upstream request failed")
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	// Transport failure must surface as a failover error so the handler can retry
+	// the request on another account (mirrors the OpenAI channel).
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.JSONEq(t, string(anthropicTransportFailoverBody), string(failoverErr.ResponseBody))
+	// The service must NOT write the response itself: the handler owns it
+	// (failover, or a protocol-correct error once failover is exhausted).
+	require.Zero(t, rec.Body.Len())
+}
+
+// anthropicTransportRepoStub records SetTempUnschedulable calls; every other
+// AccountRepository method is inherited from the embedded nil interface and
+// must not be reached in these tests.
+type anthropicTransportRepoStub struct {
+	AccountRepository
+	tempCalls int
+}
+
+func (r *anthropicTransportRepoStub) SetTempUnschedulable(_ context.Context, _ int64, _ time.Time, _ string) error {
+	r.tempCalls++
+	return nil
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_PersistentTransportErrorTempUnschedules(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	repo := &anthropicTransportRepoStub{}
+	upstream := &anthropicHTTPUpstreamRecorder{
+		err: errors.New("dial tcp 203.0.113.7:443: connect: connection refused"),
+	}
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Security: config.SecurityConfig{
+				URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+			},
+		},
+		httpUpstream: upstream,
+		accountRepo:  repo,
+	}
+	account := newAnthropicAPIKeyAccountForTest()
+
+	_, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, account, []byte(`{"model":"x"}`), "x", "x", false, time.Now())
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	// Durable transport fault (connection refused) → account temporarily unscheduled.
+	require.Equal(t, 1, repo.tempCalls)
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_TransientTransportErrorKeepsAccountSchedulable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	repo := &anthropicTransportRepoStub{}
+	upstream := &anthropicHTTPUpstreamRecorder{err: errors.New("dial tcp timeout")}
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Security: config.SecurityConfig{
+				URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+			},
+		},
+		httpUpstream: upstream,
+		accountRepo:  repo,
+	}
+	account := newAnthropicAPIKeyAccountForTest()
+
+	_, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, account, []byte(`{"model":"x"}`), "x", "x", false, time.Now())
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	// Transient blip (timeout) → fail over but keep the account schedulable.
+	require.Zero(t, repo.tempCalls)
 }
 
 func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_EmptyResponseBody(t *testing.T) {

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -114,29 +114,9 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			if !errors.Is(err, context.Canceled) {
-				scheduleOllamaCloudUsageActivity(s.deferredService, account)
-			}
-			safeErr := sanitizeUpstreamErrorMessage(err.Error())
-			setOpsUpstreamError(c, 0, safeErr, "")
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: 0,
-				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-				Passthrough:        true,
-				Kind:               "request_error",
-				Message:            safeErr,
-			})
-			c.JSON(http.StatusBadGateway, gin.H{
-				"type": "error",
-				"error": gin.H{
-					"type":    "upstream_error",
-					"message": "Upstream request failed",
-				},
-			})
-			return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+			// Transport-level failure: return a failover error so the handler can
+			// retry the request on another account (mirrors the OpenAI channel).
+			return nil, s.handleAnthropicUpstreamTransportError(ctx, c, account, safeUpstreamURL(upstreamReq.URL.String()), true, err)
 		}
 
 		// 透传分支禁止 400 请求体降级重试（该重试会改写请求体）

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -381,30 +381,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			// Transport attempt left local validation; count Ollama Cloud activity.
-			if !errors.Is(err, context.Canceled) {
-				scheduleOllamaCloudUsageActivity(s.deferredService, account)
-			}
-			// Ensure the client receives an error response (handlers assume Forward writes on non-failover errors).
-			safeErr := sanitizeUpstreamErrorMessage(err.Error())
-			setOpsUpstreamError(c, 0, safeErr, "")
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: 0,
-				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-				Kind:               "request_error",
-				Message:            safeErr,
-			})
-			c.JSON(http.StatusBadGateway, gin.H{
-				"type": "error",
-				"error": gin.H{
-					"type":    "upstream_error",
-					"message": "Upstream request failed",
-				},
-			})
-			return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+			// Transport-level failure: return a failover error so the handler can
+			// retry the request on another account (mirrors the OpenAI channel).
+			return nil, s.handleAnthropicUpstreamTransportError(ctx, c, account, safeUpstreamURL(upstreamReq.URL.String()), false, err)
 		}
 
 		// 优先检测thinking block签名错误（400）并重试一次


### PR DESCRIPTION
## Problem

On the Anthropic channel, a transport-level upstream failure (connection refused, dial/DNS/TLS error — the HTTP round-trip never completed) is written to the client as an immediate 502 straight from the service layer, and a plain error is returned:

- `backend/internal/service/gateway_anthropic_passthrough.go` (API-key passthrough path)
- `backend/internal/service/gateway_forward.go` (regular forward path)

Because the returned error is not an `*UpstreamFailoverError`, the handler's failover loop never tries the other accounts in the group — even when a healthy account is available. A single dead upstream endpoint (or a dead egress proxy) hard-fails every request routed to that account.

The OpenAI channel already handles this correctly via `handleOpenAIUpstreamTransportError` (returns a failover error, does not write the response, temp-unschedules the account on durable faults). The Anthropic channel simply never got the same treatment.

## Fix

Port the OpenAI pattern to the Anthropic channel (`backend/internal/service/anthropic_upstream_transport_error.go`):

- `handleAnthropicUpstreamTransportError` returns `*UpstreamFailoverError{502}` **without writing the response**, so the handler fails over to a healthy account within the same client request. `context.Canceled` still short-circuits with a plain error (client gone: no failover, no eviction).
- Durable faults (connection refused, no route, network unreachable, DNS failure, rejected proxy credentials — classified by the existing channel-agnostic `classifyOpenAITransportError`) additionally temp-unschedule the account for 10 minutes (DB-persisted, matching this channel's other auto-unschedule helpers), so subsequent requests skip the dead account too.
- Both call sites (passthrough + regular forward) now delegate to the helper. Ops error logging (status 0, `kind=request_error`) and Ollama activity accounting are preserved as-is.

Client-visible behavior when **every** account fails stays identical: the handler's failover-exhausted path emits the same 502 body as before.

## Tests

- Flipped `TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_UpstreamRequestError` to the new contract: transport failure surfaces as `*UpstreamFailoverError{502}` and the service does not write the response.
- New `..._PersistentTransportErrorTempUnschedules`: connection refused → failover error + one `SetTempUnschedulable` call.
- New `..._TransientTransportErrorKeepsAccountSchedulable`: dial timeout → failover error, account stays schedulable.
- Full `./internal/service` (with and without `-tags unit`) and `./internal/handler/...` suites pass.

## Live verification

Verified on a real deployment (two `platform=anthropic, type=apikey` accounts in one group, priorities 10/90): with the primary account's `base_url` pointed at a dead endpoint, the same client request that previously got an instant 502 is now transparently served by the fallback account (HTTP 200), the dead account is temp-unscheduled for 10 minutes with a clear reason, and `gateway.failover_switch_account` shows `switch_count=1`. After restoring the endpoint and the cooldown clearing, traffic returns to the primary account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
