### PR TITLE
fix: MCP 裸工具名 namespace 兜底还原 + 禁用自动更新（自建补丁版）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.5-alpine
+ARG GOLANG_IMAGE=golang:1.26.6-alpine
 ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct

--- a/backend/internal/handler/admin/system_handler.go
+++ b/backend/internal/handler/admin/system_handler.go
@@ -83,6 +83,9 @@ func (h *SystemHandler) CheckUpdates(c *gin.Context) {
 // PerformUpdate downloads and applies the update
 // POST /api/v1/admin/system/update
 func (h *SystemHandler) PerformUpdate(c *gin.Context) {
+	// 自建补丁版（sub2api-shenle）：禁用在线更新，防止补丁被官方版本覆盖。
+	response.Error(c, http.StatusForbidden, "updates are disabled on this build (sub2api-shenle)")
+	return
 	operationID := buildSystemOperationID(c, "update")
 	payload := gin.H{"operation_id": operationID}
 	executeAdminIdempotentJSON(c, "admin.system.update", payload, service.DefaultSystemOperationIdempotencyTTL(), func(ctx context.Context) (any, error) {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -175,6 +175,25 @@ func NamespaceToolNames(tools []ResponsesTool) map[string]NamespacedToolName {
 	return out
 }
 
+// NamespaceToolByBareName 兜底还原：上游模型偶尔会把超长摊平名输出为子工具裸名
+// （如 mcp__sequential_thinking__sequentialthinking -> sequentialthinking）。
+// 裸名跨 namespace 唯一时补 namespace，不唯一（不同 namespace 下同名子工具）则
+// 放弃还原，保持原样交给客户端处理，避免错误路由。
+func NamespaceToolByBareName(namespaceTools map[string]NamespacedToolName, bareName string) (NamespacedToolName, bool) {
+	var found NamespacedToolName
+	matched := false
+	for _, ns := range namespaceTools {
+		if ns.Name == bareName {
+			if matched {
+				return NamespacedToolName{}, false
+			}
+			found = ns
+			matched = true
+		}
+	}
+	return found, matched
+}
+
 // HasToolSearchTool 判断 Responses 请求是否声明了 tool_search 服务端工具。chat 桥
 // 回程时需据此把模型对代理工具的调用还原为 tool_search_call 项：codex 只在该项类型
 // 且 execution=client 时执行 tool search，同名 function_call 会因 payload 不匹配
@@ -1142,6 +1161,20 @@ func chatMessageToResponsesOutput(message ChatMessage, customTools map[string]bo
 			})
 			continue
 		}
+		if ns, ok := NamespaceToolByBareName(namespaceTools, toolCall.Function.Name); ok {
+			// 兜底：模型输出裸子工具名（未带 namespace 前缀）且跨 namespace 唯一时，
+			// 按映射补还原 namespace，避免 codex 客户端判 unsupported call。
+			outputs = append(outputs, ResponsesOutput{
+				Type:      "function_call",
+				ID:        generateItemID(),
+				CallID:    toolCall.ID,
+				Name:      ns.Name,
+				Namespace: ns.Namespace,
+				Arguments: arguments,
+				Status:    "completed",
+			})
+			continue
+		}
 		outputs = append(outputs, ResponsesOutput{
 			Type:      "function_call",
 			ID:        generateItemID(),
@@ -1666,6 +1699,10 @@ func announceChatToolItem(
 	// 还原为裸子工具名 + namespace 字段（codex 按 namespace+name 路由）。
 	itemName, itemNamespace := stored.Function.Name, ""
 	if ns, ok := state.NamespaceTools[stored.Function.Name]; ok && !isCustom && !isToolSearch {
+		state.toolNamespace[idx] = ns
+		itemName, itemNamespace = ns.Name, ns.Namespace
+	} else if ns, ok := NamespaceToolByBareName(state.NamespaceTools, stored.Function.Name); ok && !isCustom && !isToolSearch {
+		// 兜底：模型输出裸子工具名且跨 namespace 唯一时补还原 namespace。
 		state.toolNamespace[idx] = ns
 		itemName, itemNamespace = ns.Name, ns.Namespace
 	}

--- a/backend/internal/pkg/apicompat/namespace_bare_name_patch_test.go
+++ b/backend/internal/pkg/apicompat/namespace_bare_name_patch_test.go
@@ -1,0 +1,36 @@
+package apicompat
+
+import "testing"
+
+func TestNamespaceToolByBareName(t *testing.T) {
+	tools := map[string]NamespacedToolName{
+		"mcp__sequential_thinking__sequentialthinking": {Namespace: "mcp__sequential_thinking", Name: "sequentialthinking"},
+		"mcp__codegraph__codegraph_explore":             {Namespace: "mcp__codegraph", Name: "codegraph_explore"},
+		"mcp__gopls__go_diagnostics":                    {Namespace: "mcp__gopls", Name: "go_diagnostics"},
+	}
+	// 唯一裸名 → 还原
+	ns, ok := NamespaceToolByBareName(tools, "sequentialthinking")
+	if !ok || ns.Namespace != "mcp__sequential_thinking" || ns.Name != "sequentialthinking" {
+		t.Fatalf("unique bare name: got ok=%v ns=%+v", ok, ns)
+	}
+	// 摊平名也算裸名集合外 → 不匹配（摊平名走原 map 分支）
+	if _, ok := NamespaceToolByBareName(tools, "mcp__codegraph__codegraph_explore"); ok {
+		t.Fatal("flattened name should not match bare-name fallback")
+	}
+	// 无匹配
+	if _, ok := NamespaceToolByBareName(tools, "nonexistent"); ok {
+		t.Fatal("unknown name should not match")
+	}
+	// 空 map
+	if _, ok := NamespaceToolByBareName(nil, "sequentialthinking"); ok {
+		t.Fatal("nil map should not match")
+	}
+	// 撞名：两个 namespace 下同名子工具 → 不还原
+	dup := map[string]NamespacedToolName{
+		"ns_a__read": {Namespace: "ns_a", Name: "read"},
+		"ns_b__read": {Namespace: "ns_b", Name: "read"},
+	}
+	if _, ok := NamespaceToolByBareName(dup, "read"); ok {
+		t.Fatal("duplicate bare name should not match")
+	}
+}

--- a/backend/internal/service/update_service.go
+++ b/backend/internal/service/update_service.go
@@ -131,6 +131,13 @@ type GitHubAsset struct {
 
 // CheckUpdate checks for available updates
 func (s *UpdateService) CheckUpdate(ctx context.Context, force bool) (*UpdateInfo, error) {
+	// 自建补丁版（sub2api-shenle）：禁用更新检查，不访问 GitHub，永不提示更新。
+	return &UpdateInfo{
+		CurrentVersion: s.currentVersion,
+		LatestVersion:  s.currentVersion,
+		HasUpdate:      false,
+		BuildType:      "source",
+	}, nil
 	// Try cache first
 	if !force {
 		if cached, err := s.getFromCache(ctx); err == nil && cached != nil {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2,6 +2,10 @@ lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
+  overrides:
+    js-cookie: 3.0.7
+    form-data@<4.0.6: '>=4.0.6'
+    postcss@<8.5.18: '>=8.5.18'
   excludeLinksFromLockfile: false
 
 overrides:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "."
+allowBuilds:
+  esbuild: true
+  vue-demi: true

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -24,8 +24,6 @@
         >
           {{ siteName }}
         </router-link>
-        <!-- Version Badge -->
-        <VersionBadge :version="siteVersion" />
       </div>
     </div>
 
@@ -192,7 +190,6 @@ import { computed, h, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'v
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAdminSettingsStore, useAppStore, useAuthStore, useOnboardingStore } from '@/stores'
-import VersionBadge from '@/components/common/VersionBadge.vue'
 import { sanitizeSvg } from '@/utils/sanitize'
 import { sanitizeUrl } from '@/utils/url'
 import { FeatureFlags, makeSidebarFlag } from '@/utils/featureFlags'
@@ -258,7 +255,6 @@ const expandedGroups = ref<Set<string>>(new Set())
 // Site settings from appStore (cached, no flicker)
 const siteName = computed(() => appStore.siteName)
 const siteLogo = computed(() => sanitizeUrl(appStore.siteLogo || '', { allowRelative: true, allowDataUrl: true }))
-const siteVersion = computed(() => appStore.siteVersion)
 const settingsLoaded = computed(() => appStore.publicSettingsLoaded)
 
 // SVG Icon Components


### PR DESCRIPTION
- chatcompletions_responses_bridge: 模型输出裸子工具名且跨 namespace 唯一时 自动补还原 namespace，修复 codex 客户端 unsupported call 高频失败
- 缓冲/流式双路径接入 + 单元测试
- 禁用在线更新检查（CheckUpdate 固定无更新，不访问 GitHub）
- 管理端更新接口直接 403，前端移除版本徽章
- 构建修复: golang 1.26.6、pnpm lockfile overrides、pnpm-workspace allowBuilds