### PR TITLE
fix(grok): support same-origin video content URLs

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -297,12 +297,32 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 }
 
 func httpClientForUpstreamRequest(client *http.Client, req *http.Request) *http.Client {
-	if client == nil || req == nil || !service.HTTPUpstreamRedirectsDisabled(req.Context()) {
+	if client == nil || req == nil {
+		return client
+	}
+	redirectsDisabled := service.HTTPUpstreamRedirectsDisabled(req.Context())
+	requestChecker := service.HTTPUpstreamRedirectChecker(req.Context())
+	if !redirectsDisabled && requestChecker == nil {
 		return client
 	}
 	clone := *client
-	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
+	baseChecker := client.CheckRedirect
+	clone.CheckRedirect = func(redirectReq *http.Request, via []*http.Request) error {
+		if redirectsDisabled {
+			return http.ErrUseLastResponse
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if requestChecker != nil {
+			if err := requestChecker(redirectReq); err != nil {
+				return err
+			}
+		}
+		if baseChecker != nil {
+			return baseChecker(redirectReq, via)
+		}
+		return nil
 	}
 	return &clone
 }
@@ -590,6 +610,10 @@ func (s *httpUpstreamService) validateRequestHost(req *http.Request) error {
 	if !s.shouldValidateResolvedIP() {
 		return nil
 	}
+	return validateRequestResolvedIP(req)
+}
+
+func validateRequestResolvedIP(req *http.Request) error {
 	if req == nil || req.URL == nil {
 		return errors.New("request url is nil")
 	}

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -50,6 +50,53 @@ func TestHTTPUpstreamDoCanDisableRedirectsPerRequest(t *testing.T) {
 	require.Zero(t, redirectedCalls.Load())
 }
 
+func TestHTTPUpstreamRequestRedirectPolicyPreservesBaseChecker(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	baseErr := errors.New("base redirect policy rejected target")
+	var baseCalls atomic.Int64
+	baseClient := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		baseCalls.Add(1)
+		return baseErr
+	}}
+	ctx := service.WithHTTPUpstreamRedirectChecker(t.Context(), func(*http.Request) error { return nil })
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirector.URL, nil)
+	require.NoError(t, err)
+
+	_, err = httpClientForUpstreamRequest(baseClient, req).Do(req)
+	require.ErrorIs(t, err, baseErr)
+	require.Equal(t, int64(1), baseCalls.Load())
+}
+
+func TestHTTPUpstreamRequestRedirectCheckerRejectsBeforeTargetExecution(t *testing.T) {
+	var targetCalls atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	rejected := errors.New("redirect target rejected")
+	ctx := service.WithHTTPUpstreamRedirectChecker(t.Context(), func(*http.Request) error { return rejected })
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirector.URL, nil)
+	require.NoError(t, err)
+
+	_, err = httpClientForUpstreamRequest(&http.Client{}, req).Do(req)
+	require.ErrorIs(t, err, rejected)
+	require.Zero(t, targetCalls.Load())
+}
+
 func TestHTTPUpstreamDoWithTLSPlainHTTPUsesConfiguredHTTPProxy(t *testing.T) {
 	var upstreamCalls atomic.Int64
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -805,13 +805,12 @@ func (s *OpenAIGatewayService) forwardGrokMediaVideoContent(
 		return nil, err
 	}
 
-	contentURL, err := grokMediaSignedVideoContentURL(statusBody, requestID)
+	contentURL, signedContent, err := grokMediaVideoContentURL(statusBody, requestID, statusURL)
 	if err != nil {
 		SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 		return nil, err
 	}
-	signedContent := contentURL != ""
-	if !signedContent {
+	if contentURL == "" {
 		contentURL, err = buildGrokMediaURL(account, s.cfg, GrokMediaEndpointVideoContent, requestID)
 		if err != nil {
 			SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
@@ -819,8 +818,14 @@ func (s *OpenAIGatewayService) forwardGrokMediaVideoContent(
 		}
 	}
 
+	contentRequestCtx := upstreamCtx
+	if signedContent {
+		contentRequestCtx = WithHTTPUpstreamRedirectChecker(contentRequestCtx, validateGrokMediaSignedVideoRedirect)
+	} else {
+		contentRequestCtx = WithHTTPUpstreamRedirectsDisabled(contentRequestCtx)
+	}
 	contentReq, err := http.NewRequestWithContext(
-		WithHTTPUpstreamRedirectsDisabled(upstreamCtx),
+		contentRequestCtx,
 		http.MethodGet,
 		contentURL,
 		nil,
@@ -881,25 +886,49 @@ func (s *OpenAIGatewayService) forwardGrokMediaVideoContent(
 	return result, nil
 }
 
-func grokMediaSignedVideoContentURL(body []byte, requestID string) (string, error) {
+func grokMediaVideoContentURL(body []byte, requestID, upstreamURL string) (string, bool, error) {
 	rawURL := strings.TrimSpace(gjson.GetBytes(body, "video.url").String())
 	if rawURL == "" {
-		return "", nil
+		return "", false, nil
 	}
 	// An upstream Sub2API rewrites protected content URLs to its own proxy
 	// endpoint. Treat that as an authenticated relay path, not as a signed URL;
 	// the caller will rebuild it against the configured account base URL and
 	// attach the upstream API key.
 	if isGrokMediaVideoContentURL(rawURL, requestID) {
-		return "", nil
+		return "", false, nil
 	}
 	parsed, err := url.Parse(rawURL)
-	if err != nil || !strings.EqualFold(parsed.Scheme, "https") ||
-		!strings.EqualFold(parsed.Hostname(), "vidgen.x.ai") ||
-		(parsed.Port() != "" && parsed.Port() != "443") || parsed.User != nil {
-		return "", fmt.Errorf("grok media status returned an unsupported video content URL")
+	if err != nil || parsed.User != nil || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" {
+		return "", false, fmt.Errorf("grok media status returned an unsupported video content URL")
 	}
-	return parsed.String(), nil
+	if strings.EqualFold(parsed.Hostname(), "vidgen.x.ai") && effectiveHTTPSPort(parsed) == "443" {
+		return parsed.String(), true, nil
+	}
+	upstream, err := url.Parse(upstreamURL)
+	if err == nil && upstream.User == nil && strings.EqualFold(upstream.Scheme, "https") && upstream.Hostname() != "" &&
+		strings.EqualFold(parsed.Hostname(), upstream.Hostname()) &&
+		effectiveHTTPSPort(parsed) == effectiveHTTPSPort(upstream) {
+		return parsed.String(), false, nil
+	}
+	return "", false, fmt.Errorf("grok media status returned an unsupported video content URL")
+}
+
+func effectiveHTTPSPort(parsed *url.URL) string {
+	if parsed.Port() != "" {
+		return parsed.Port()
+	}
+	return "443"
+}
+
+func validateGrokMediaSignedVideoRedirect(req *http.Request) error {
+	if req == nil || req.URL == nil || req.URL.User != nil ||
+		!strings.EqualFold(req.URL.Scheme, "https") ||
+		!strings.EqualFold(req.URL.Hostname(), "vidgen.x.ai") ||
+		effectiveHTTPSPort(req.URL) != "443" {
+		return fmt.Errorf("grok media signed video redirect target is unsupported")
+	}
+	return nil
 }
 
 func isGrokCLIProxyTarget(rawURL string) bool {
@@ -1455,13 +1484,16 @@ func isGrokMediaVideoContentURL(rawURL, requestID string) bool {
 		return false
 	}
 	requestID = strings.Trim(requestID, "/")
-	decodedID, err := url.PathUnescape(segments[len(segments)-2])
-	if err != nil {
-		return false
+	decodedSegments := make([]string, len(segments))
+	for i, segment := range segments {
+		decodedSegments[i], err = url.PathUnescape(segment)
+		if err != nil {
+			return false
+		}
 	}
-	return segments[len(segments)-3] == "videos" &&
-		decodedID == requestID &&
-		segments[len(segments)-1] == "content"
+	return decodedSegments[len(decodedSegments)-3] == "videos" &&
+		decodedSegments[len(decodedSegments)-2] == requestID &&
+		decodedSegments[len(decodedSegments)-1] == "content"
 }
 
 func grokMediaContentProxyURL(c *gin.Context, requestID string) string {

--- a/backend/internal/service/grok_media_content_test.go
+++ b/backend/internal/service/grok_media_content_test.go
@@ -217,13 +217,80 @@ func TestForwardGrokMediaContentFetchesValidatedSignedURLWithoutCredentials(t *t
 	require.Empty(t, upstream.requests[1].Header.Get("Authorization"))
 	require.Empty(t, upstream.requests[1].Header.Get("User-Agent"))
 	require.Equal(t, "bytes=0-12", upstream.requests[1].Header.Get("Range"))
-	require.True(t, HTTPUpstreamRedirectsDisabled(upstream.requests[1].Context()))
+	require.False(t, HTTPUpstreamRedirectsDisabled(upstream.requests[1].Context()))
+	require.NotNil(t, HTTPUpstreamRedirectChecker(upstream.requests[1].Context()))
+}
+
+func TestGrokMediaSignedVideoRedirectPolicy(t *testing.T) {
+	checker := validateGrokMediaSignedVideoRedirect
+	for _, target := range []string{
+		"https://vidgen.x.ai/cdn/video.mp4",
+		"https://vidgen.x.ai:443/cdn/video.mp4",
+	} {
+		t.Run("accept_"+target, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, target, nil)
+			require.NoError(t, err)
+			require.NoError(t, checker(req))
+		})
+	}
+
+	for _, target := range []string{
+		"http://vidgen.x.ai/video.mp4",
+		"https://attacker.invalid/video.mp4",
+		"https://sub.cdn.x.ai/video.mp4",
+		"https://vidgen.x.ai.attacker.invalid/video.mp4",
+		"https://vidgen.x.ai:444/video.mp4",
+		"https://user@vidgen.x.ai/video.mp4",
+		"https://127.0.0.1/video.mp4",
+		"https://169.254.169.254/latest/meta-data",
+		"https://[::1]/video.mp4",
+		"https://[fe80::1]/video.mp4",
+	} {
+		t.Run("reject_"+target, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, target, nil)
+			require.NoError(t, err)
+			require.ErrorContains(t, checker(req), "redirect target is unsupported")
+		})
+	}
+}
+
+func TestIsGrokMediaVideoContentURLDecodesAllPathSegments(t *testing.T) {
+	require.True(t, isGrokMediaVideoContentURL("https://relay.example/%76ideos/task%2D1/%63ontent", "task-1"))
+}
+
+func TestForwardGrokMediaContentFetchesSameOriginNonStandardURLWithCredentials(t *testing.T) {
+	for _, statusURL := range []string{
+		"https://relay.example/custom/video.mp4?token=opaque",
+		"https://relay.example:443/custom/video.mp4?token=opaque",
+	} {
+		t.Run(statusURL, func(t *testing.T) {
+			upstream := &grokMediaContentUpstreamStub{responses: []*http.Response{
+				grokMediaContentStatusResponse(`{"status":"done","video":{"url":"` + statusURL + `"}}`),
+				{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"video/mp4"}}, Body: io.NopCloser(strings.NewReader("video"))},
+			}}
+			account := grokMediaContentTestAccount()
+			account.Credentials[credKeyHeaderOverrideEnabled] = true
+			account.Credentials[credKeyHeaderOverrides] = map[string]any{"user-agent": "private-agent"}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			c, _ := grokMediaContentTestContext(http.MethodGet, "https://api.example/v1/videos/task-1/content", nil)
+
+			_, err := svc.ForwardGrokMedia(context.Background(), c, account, GrokMediaEndpointVideoContent, "task-1", nil, "")
+
+			require.NoError(t, err)
+			require.Len(t, upstream.requests, 2)
+			require.Equal(t, statusURL, upstream.requests[1].URL.String())
+			require.Equal(t, "Bearer upstream-key", upstream.requests[1].Header.Get("Authorization"))
+			require.Equal(t, "private-agent", upstream.requests[1].Header.Get("User-Agent"))
+			require.True(t, HTTPUpstreamRedirectsDisabled(upstream.requests[1].Context()))
+		})
+	}
 }
 
 func TestForwardGrokMediaContentFollowsAuthenticatedSub2APIRelay(t *testing.T) {
 	for _, statusURL := range []string{
 		`/v1/videos/task-1/content`,
 		`https://relay.example/v1/videos/task-1/content`,
+		`https://attacker.invalid/videos/task-1/content?token=deceptive`,
 	} {
 		t.Run(statusURL, func(t *testing.T) {
 			upstream := &grokMediaContentUpstreamStub{
@@ -249,6 +316,7 @@ func TestForwardGrokMediaContentFollowsAuthenticatedSub2APIRelay(t *testing.T) {
 			require.Equal(t, "video-payload", recorder.Body.String())
 			require.Len(t, upstream.requests, 2)
 			require.Equal(t, "https://relay.example/v1/videos/task-1/content", upstream.requests[1].URL.String())
+			require.NotEqual(t, "https://attacker.invalid/videos/task-1/content?token=deceptive", upstream.requests[1].URL.String())
 			require.Equal(t, "Bearer upstream-key", upstream.requests[1].Header.Get("Authorization"))
 		})
 	}
@@ -278,18 +346,24 @@ func TestGrokMediaSignedVideoContentURLRejectsDeceptiveOrigins(t *testing.T) {
 		"https://vidgen.x.ai" + "@attacker.invalid/video.mp4",
 		"https://vidgen.x.ai:444/video.mp4",
 		"http://vidgen.x.ai/video.mp4",
+		"https://relay.example.attacker.invalid/video.mp4",
+		"https://relay.example" + "@attacker.invalid/video.mp4",
+		"https://user@relay.example/video.mp4",
+		"https://relay.example:444/video.mp4",
+		"http://relay.example/video.mp4",
 	} {
 		t.Run(rawURL, func(t *testing.T) {
-			_, err := grokMediaSignedVideoContentURL([]byte(`{"video":{"url":"`+rawURL+`"}}`), "task-1")
+			_, _, err := grokMediaVideoContentURL([]byte(`{"video":{"url":"`+rawURL+`"}}`), "task-1", "https://relay.example/v1/videos/task-1")
 			require.ErrorContains(t, err, "unsupported video content URL")
 		})
 	}
 }
 
 func TestGrokMediaSignedVideoContentURLRejectsDifferentRelayTask(t *testing.T) {
-	_, err := grokMediaSignedVideoContentURL(
+	_, _, err := grokMediaVideoContentURL(
 		[]byte(`{"video":{"url":"/v1/videos/task-2/content"}}`),
 		"task-1",
+		"https://relay.example/v1/videos/task-1",
 	)
 
 	require.ErrorContains(t, err, "unsupported video content URL")

--- a/backend/internal/service/http_upstream_profile.go
+++ b/backend/internal/service/http_upstream_profile.go
@@ -1,6 +1,9 @@
 package service
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 // HTTPUpstreamProfile marks HTTP upstream requests that need provider-specific
 // transport policy.
@@ -13,6 +16,7 @@ const (
 
 type httpUpstreamProfileContextKey struct{}
 type httpUpstreamDisableRedirectsContextKey struct{}
+type httpUpstreamRedirectCheckerContextKey struct{}
 
 // WithHTTPUpstreamProfile injects an upstream transport profile into ctx.
 func WithHTTPUpstreamProfile(ctx context.Context, profile HTTPUpstreamProfile) context.Context {
@@ -53,4 +57,24 @@ func WithHTTPUpstreamRedirectsDisabled(ctx context.Context) context.Context {
 
 func HTTPUpstreamRedirectsDisabled(ctx context.Context) bool {
 	return ctx != nil && ctx.Value(httpUpstreamDisableRedirectsContextKey{}) == true
+}
+
+// WithHTTPUpstreamRedirectChecker applies a request-specific policy to every
+// redirect followed by the shared upstream client.
+func WithHTTPUpstreamRedirectChecker(ctx context.Context, checker func(*http.Request) error) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if checker == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, httpUpstreamRedirectCheckerContextKey{}, checker)
+}
+
+func HTTPUpstreamRedirectChecker(ctx context.Context) func(*http.Request) error {
+	if ctx == nil {
+		return nil
+	}
+	checker, _ := ctx.Value(httpUpstreamRedirectCheckerContextKey{}).(func(*http.Request) error)
+	return checker
 }


### PR DESCRIPTION
## 问题
自定义 Grok 上游的状态响应可能返回与账号上游同源、但不符合标准 `/videos/{id}/content` 路径的视频下载 URL。现有逻辑仅接受标准链式代理地址或 `vidgen.x.ai` 签名地址，导致这类下载返回 502。

## 根因
视频内容 URL 分类没有识别严格同源的自定义 HTTPS 地址；同时，签名 CDN 允许重定向时需要保持无凭据并限制目标来源，避免扩大凭据或请求边界。

## 改动
- 保留标准链式代理 URL 的重建和账号鉴权行为。
- 接受与账号上游协议、主机名和有效端口严格一致的 HTTPS 非标准 URL，保留完整地址并携带账号 Bearer Token 与请求头配置。
- 拒绝 HTTP、userinfo、不同主机/端口和欺骗性来源；带凭据的下载禁止重定向。
- `vidgen.x.ai` 签名下载保持无账号凭据，并将重定向限制为 HTTPS 443 的同一 CDN 主机。
- 增加同源、端口、标准代理编码路径、欺骗来源、凭据和重定向策略回归测试。

## 测试
- `go test ./internal/service -count=1`
- `go test -tags=unit ./internal/service -run TestForwardGrokMediaContent\|TestGrokMediaSignedVideo\|TestIsGrokMediaVideoContentURL -count=1`
- `go test -tags=unit ./internal/repository -run TestHTTPUpstreamDoCanDisableRedirectsPerRequest\|TestHTTPUpstreamRequestRedirectPolicy -count=1`
- `go vet ./internal/service ./internal/repository`
- `git diff --check`

说明：`go test ./internal/repository -count=1` 的 3 个 Aliyun captcha 本地 HTTP 用例在 2 秒等待响应时超时；本次涉及的 repository 精确用例均通过。

Fixes #5678