### PR TITLE
fix(billing): restore Grok long-context pricing on auth cache paths

### DIFF
--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -84,6 +84,8 @@ type APIKeyAuthGroupSnapshot struct {
 	AudioRealtimePricePerMin        *float64                      `json:"audio_realtime_price_per_min,omitempty"`
 	AudioTTSPricePerMillionChars    *float64                      `json:"audio_tts_price_per_million_chars,omitempty"`
 	AudioSTTPricePerHour            *float64                      `json:"audio_stt_price_per_hour,omitempty"`
+	LongContextPricingEnabled       bool                          `json:"long_context_pricing_enabled"`
+	ModelPricing                    []ChannelModelPricing         `json:"model_pricing,omitempty"`
 	ClaudeCodeOnly                  bool                          `json:"claude_code_only"`
 	FallbackGroupID                 *int64                        `json:"fallback_group_id,omitempty"`
 	FallbackGroupIDOnInvalidRequest *int64                        `json:"fallback_group_id_on_invalid_request,omitempty"`

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 19 // v19: group search/audio/video_model_prices billing fields (force refresh of pre-fix snapshots)
+const apiKeyAuthSnapshotVersion = 20 // v20: preserve group long-context and per-model pricing policies
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -406,6 +406,8 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			AudioRealtimePricePerMin:        apiKey.Group.AudioRealtimePricePerMin,
 			AudioTTSPricePerMillionChars:    apiKey.Group.AudioTTSPricePerMillionChars,
 			AudioSTTPricePerHour:            apiKey.Group.AudioSTTPricePerHour,
+			LongContextPricingEnabled:       apiKey.Group.LongContextPricingEnabled,
+			ModelPricing:                    apiKey.Group.ModelPricing,
 			ClaudeCodeOnly:                  apiKey.Group.ClaudeCodeOnly,
 			FallbackGroupID:                 apiKey.Group.FallbackGroupID,
 			FallbackGroupIDOnInvalidRequest: apiKey.Group.FallbackGroupIDOnInvalidRequest,
@@ -501,6 +503,8 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			AudioRealtimePricePerMin:        snapshot.Group.AudioRealtimePricePerMin,
 			AudioTTSPricePerMillionChars:    snapshot.Group.AudioTTSPricePerMillionChars,
 			AudioSTTPricePerHour:            snapshot.Group.AudioSTTPricePerHour,
+			LongContextPricingEnabled:       snapshot.Group.LongContextPricingEnabled,
+			ModelPricing:                    snapshot.Group.ModelPricing,
 			ClaudeCodeOnly:                  snapshot.Group.ClaudeCodeOnly,
 			FallbackGroupID:                 snapshot.Group.FallbackGroupID,
 			FallbackGroupIDOnInvalidRequest: snapshot.Group.FallbackGroupIDOnInvalidRequest,

--- a/backend/internal/service/api_key_auth_cache_pricing_test.go
+++ b/backend/internal/service/api_key_auth_cache_pricing_test.go
@@ -1,0 +1,100 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func authPricingFloat64Ptr(v float64) *float64 { return &v }
+func authPricingIntPtr(v int) *int             { return &v }
+
+func TestAPIKeyAuthSnapshotPreservesGroupPricingPolicy(t *testing.T) {
+	groupID := int64(100)
+	apiKey := &APIKey{
+		ID:      82,
+		UserID:  40,
+		GroupID: &groupID,
+		Status:  StatusActive,
+		User:    &User{ID: 40, Status: StatusActive},
+		Group: &Group{
+			ID:                        groupID,
+			Name:                      "grok-heavy",
+			Platform:                  PlatformGrok,
+			Status:                    StatusActive,
+			RateMultiplier:            1,
+			LongContextPricingEnabled: true,
+			ModelPricing: []ChannelModelPricing{{
+				Platform:    PlatformGrok,
+				Models:      []string{"grok-private"},
+				BillingMode: BillingModeToken,
+				InputPrice:  authPricingFloat64Ptr(3e-6),
+			}},
+		},
+	}
+
+	apiKeyService := &APIKeyService{}
+	snapshot := apiKeyService.snapshotFromAPIKey(context.Background(), apiKey)
+	require.NotNil(t, snapshot)
+
+	payload, err := json.Marshal(&APIKeyAuthCacheEntry{Snapshot: snapshot})
+	require.NoError(t, err)
+	var cached APIKeyAuthCacheEntry
+	require.NoError(t, json.Unmarshal(payload, &cached))
+
+	materialized, used, err := apiKeyService.applyAuthCacheEntry("sk-test", &cached)
+	require.NoError(t, err)
+	require.True(t, used)
+	require.NotNil(t, materialized.Group)
+	require.True(t, materialized.Group.LongContextPricingEnabled)
+	require.Equal(t, apiKey.Group.ModelPricing, materialized.Group.ModelPricing)
+
+	channelPricing := []ChannelModelPricing{{
+		Platform:       PlatformGrok,
+		Models:         []string{"grok-4.6"},
+		BillingMode:    BillingModeToken,
+		InputPrice:     authPricingFloat64Ptr(2e-6),
+		OutputPrice:    authPricingFloat64Ptr(6e-6),
+		CacheReadPrice: authPricingFloat64Ptr(0.5e-6),
+		Intervals: []PricingInterval{
+			{
+				MinTokens: 0, MaxTokens: authPricingIntPtr(199999),
+				InputPrice: authPricingFloat64Ptr(2e-6), OutputPrice: authPricingFloat64Ptr(6e-6),
+				CacheReadPrice: authPricingFloat64Ptr(0.5e-6),
+			},
+			{
+				MinTokens:  199999,
+				InputPrice: authPricingFloat64Ptr(4e-6), OutputPrice: authPricingFloat64Ptr(12e-6),
+				CacheReadPrice: authPricingFloat64Ptr(1e-6),
+			},
+		},
+	}}
+	repo := &mockChannelRepository{
+		listAllFn: func(context.Context) ([]Channel, error) {
+			return []Channel{{
+				ID: 6, Name: "Grok", Status: StatusActive,
+				GroupIDs: []int64{groupID}, ModelPricing: channelPricing,
+			}}, nil
+		},
+		getGroupPlatformsFn: func(context.Context, []int64) (map[int64]string, error) {
+			return map[int64]string{groupID: PlatformGrok}, nil
+		},
+	}
+	billingService := NewBillingService(&config.Config{}, nil)
+	resolver := NewModelPricingResolver(NewChannelService(repo, nil, nil, nil), billingService)
+
+	cost, err := billingService.CalculateCostUnified(CostInput{
+		Ctx: context.Background(), Model: "grok-4.6", GroupID: &groupID, Group: materialized.Group,
+		Tokens:         UsageTokens{InputTokens: 200191, CacheReadTokens: 128, OutputTokens: 1},
+		RateMultiplier: 1, Resolver: resolver,
+	})
+	require.NoError(t, err)
+	require.InDelta(t, 0.800764, cost.InputCost, 1e-12)
+	require.InDelta(t, 0.000128, cost.CacheReadCost, 1e-12)
+	require.InDelta(t, 0.000012, cost.OutputCost, 1e-12)
+}

--- a/backend/internal/service/api_key_auth_cache_profit_test.go
+++ b/backend/internal/service/api_key_auth_cache_profit_test.go
@@ -53,7 +53,7 @@ func TestAPIKeyAuthSnapshotProfitControlRoundtrip(t *testing.T) {
 	snapshot := svc.snapshotFromAPIKey(context.Background(), apiKey)
 	require.NotNil(t, snapshot)
 	require.Equal(t, apiKeyAuthSnapshotVersion, snapshot.Version)
-	require.Equal(t, 19, snapshot.Version, "v19 起认证快照携带 search/audio/video_model_prices 计费字段")
+	require.Equal(t, 20, snapshot.Version, "v20 起认证快照携带分组长上下文和逐模型定价字段")
 
 	// 模拟 L2 缓存的完整 JSON 往返（与 apiKeyCache.SetAuthCache/GetAuthCache 同构）。
 	payload, err := json.Marshal(&APIKeyAuthCacheEntry{Snapshot: snapshot})


### PR DESCRIPTION
## Billing regression

In v0.1.176 and v0.1.177, Grok requests above 200K input tokens can be undercharged on the API key auth hot path. Even when a group has long-context pricing enabled and the channel defines a higher `>=200K` interval, the reconstructed group always carries `LongContextPricingEnabled=false`, so billing falls back to the lower tier.

The same snapshot omission also silently disables group-level per-model pricing for Grok and other platforms: the admin configuration is saved correctly, but gateway billing restores `ModelPricing=nil` and ignores it.

## Root cause

The gateway reconstructs `apiKey.Group` from `APIKeyAuthGroupSnapshot`. That snapshot omitted both `LongContextPricingEnabled` and `ModelPricing`, so L1/L2 auth cache round trips restored their zero values (`false` and `nil`) instead of the database configuration.

## Fix

- preserve `LongContextPricingEnabled` and `ModelPricing` in API key auth snapshots
- bump the auth snapshot version from 19 to 20 so existing incomplete cache entries are evicted after upgrade
- add a regression test covering a JSON cache round trip and Grok pricing with 200,191 input tokens, including cache-read and output costs

## Testing

```bash
go test -tags unit ./internal/service -run '^(TestAPIKeyAuthSnapshotPreservesGroupPricingPolicy|TestAPIKeyAuthSnapshotProfitControlRoundtrip|TestAPIKeyAuthSnapshotOldVersionEvicted)$' -count=1
go test -tags unit ./internal/service -run '^(TestAPIKeyAuth.*|TestAPIKeyService.*)$' -count=1
```

Fixes #5607