### PR TITLE
fix(admin): show category labels in ops error distribution legend

### DIFF
--- a/frontend/src/views/admin/ops/components/OpsErrorDistributionChart.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDistributionChart.vue
@@ -146,7 +146,7 @@ const options = computed(() => ({
           <div class="flex flex-wrap justify-center gap-3">
             <div v-for="item in categories" :key="item.label" class="flex items-center gap-1.5 text-xs">
               <span class="h-2 w-2 rounded-full" :style="{ backgroundColor: item.color }"></span>
-              <span class="text-gray-500 dark:text-gray-400">{{ item.count }}</span>
+              <span class="text-gray-500 dark:text-gray-400">{{ item.label }} {{ item.count }}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 问题

运维监控页「错误分布」饼图的图例项只渲染色点 + 数量(饼图自带 legend 已禁用),多类错误同时存在时图例形如「● 12 ● 5 ● 3」,只能逐个悬停 tooltip 才能分辨上游 / 客户端 / 系统 / 其他。

分类名 `item.label` 在 `categories` 里现成可用(已走 i18n),同页吞吐趋势图的图例也是「色点 + 名称」的形式。

## 修改

图例项补上分类名:`{{ item.count }}` → `{{ item.label }} {{ item.count }}`,一行改动。

## 验证

修复前:
<img width="1498" height="938" alt="image" src="https://github.com/user-attachments/assets/6782a9e6-9da3-4955-828f-73c345f7ebe4" />

修复后:
<img width="1488" height="934" alt="image" src="https://github.com/user-attachments/assets/d4bb1489-2955-4a11-9b7c-7522be63a38d" />
