### PR TITLE
fix(usage): make last-24-hours preset a true rolling window

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -21,15 +21,35 @@ func TestParseTimeRange(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
 	c.Request = req
 
-	start, end := parseTimeRange(c)
-	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), start)
-	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), end)
+	timeRange := parseTimeRange(c)
+	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), timeRange.Start)
+	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), timeRange.End)
+	require.Equal(t, "2024-01-01", timeRange.StartLabel())
+	require.Equal(t, "2024-01-02", timeRange.EndLabel())
 
 	req = httptest.NewRequest(http.MethodGet, "/?start_date=bad&timezone=UTC", nil)
 	c.Request = req
-	start, end = parseTimeRange(c)
-	require.False(t, start.IsZero())
-	require.False(t, end.IsZero())
+	timeRange = parseTimeRange(c)
+	require.False(t, timeRange.Start.IsZero())
+	require.False(t, timeRange.End.IsZero())
+}
+
+func TestParseTimeRange_RFC3339EchoesRealBoundaries(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Second-precision inputs are truncated to the minute so cache keys form stable buckets.
+	req := httptest.NewRequest(http.MethodGet,
+		"/?start_date=2024-01-01T10%3A30%3A45%2B08%3A00&end_date=2024-01-02T10%3A30%3A45%2B08%3A00&timezone=UTC", nil)
+	c.Request = req
+
+	timeRange := parseTimeRange(c)
+	require.True(t, timeRange.StartHasTime)
+	require.True(t, timeRange.EndHasTime)
+	require.True(t, timeRange.Start.Equal(time.Date(2024, 1, 1, 2, 30, 0, 0, time.UTC)))
+	require.True(t, timeRange.End.Equal(time.Date(2024, 1, 2, 2, 30, 0, 0, time.UTC)))
+	require.Equal(t, "2024-01-01T10:30:00+08:00", timeRange.StartLabel())
+	require.Equal(t, "2024-01-02T10:30:00+08:00", timeRange.EndLabel())
 }
 
 func TestParseOpsViewParam(t *testing.T) {

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -42,7 +42,7 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	var startTime, endTime time.Time
 
 	if startDate != "" {
-		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
+		if t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDate, userTZ); err == nil {
 			startTime = t
 		} else {
 			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
@@ -52,8 +52,12 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	}
 
 	if endDate != "" {
-		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
-			endTime = t.Add(24 * time.Hour) // Include the end date
+		if t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDate, userTZ); err == nil {
+			if hasTime {
+				endTime = t
+			} else {
+				endTime = t.Add(24 * time.Hour) // Include the end date
+			}
 		} else {
 			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -31,41 +31,65 @@ func NewDashboardHandler(dashboardService *service.DashboardService, aggregation
 	}
 }
 
+// dashboardTimeRange is a parsed [Start, End) range; the HasTime flags record
+// whether each boundary carried a time-of-day, which decides how it is echoed
+// back in responses.
+type dashboardTimeRange struct {
+	Start        time.Time
+	End          time.Time
+	StartHasTime bool
+	EndHasTime   bool
+}
+
+func (r dashboardTimeRange) StartLabel() string {
+	return timezone.FormatRangeStart(r.Start, r.StartHasTime)
+}
+
+func (r dashboardTimeRange) EndLabel() string {
+	return timezone.FormatRangeEnd(r.End, r.EndHasTime)
+}
+
 // parseTimeRange parses start_date, end_date query parameters
 // Uses user's timezone if provided, otherwise falls back to server timezone
-func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
+func parseTimeRange(c *gin.Context) dashboardTimeRange {
 	userTZ := c.Query("timezone") // Get user's timezone from request
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")
 	endDate := c.Query("end_date")
 
-	var startTime, endTime time.Time
+	var timeRange dashboardTimeRange
 
 	if startDate != "" {
-		if t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDate, userTZ); err == nil {
-			startTime = t
+		if t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(startDate, userTZ); err == nil {
+			timeRange.Start = t
+			timeRange.StartHasTime = hasTime
 		} else {
-			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+			timeRange.Start = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
 		}
 	} else {
-		startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+		timeRange.Start = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
 	}
 
 	if endDate != "" {
-		if t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDate, userTZ); err == nil {
-			if hasTime {
-				endTime = t
-			} else {
-				endTime = t.Add(24 * time.Hour) // Include the end date
-			}
+		if t, hasTime, err := timezone.ParseRangeEndInUserLocation(endDate, userTZ); err == nil {
+			timeRange.End = t
+			timeRange.EndHasTime = hasTime
 		} else {
-			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+			timeRange.End = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}
 	} else {
-		endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+		timeRange.End = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 	}
 
-	return startTime, endTime
+	// 秒级边界会让每个请求的缓存 key 唯一，服务端统一截断到分钟，时间桶不依赖客户端对齐。
+	if timeRange.StartHasTime {
+		timeRange.Start = timeRange.Start.Truncate(time.Minute)
+	}
+	if timeRange.EndHasTime {
+		timeRange.End = timeRange.End.Truncate(time.Minute)
+	}
+
+	return timeRange
 }
 
 func parseOptionalBoolDashboardFilter(c *gin.Context, name string) (*bool, error) {
@@ -207,7 +231,7 @@ func (h *DashboardHandler) GetRealtimeMetrics(c *gin.Context) {
 // GET /api/v1/admin/dashboard/trend
 // Query params: start_date, end_date (YYYY-MM-DD), granularity (day/hour), user_id, api_key_id, model, account_id, group_id, request_type, stream, billing_type
 func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 	granularity := c.DefaultQuery("granularity", "day")
 
 	// Parse optional filter params
@@ -272,7 +296,7 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 		return
 	}
 
-	trend, hit, err := h.getUsageTrendCached(c.Request.Context(), startTime, endTime, granularity, userID, apiKeyID, accountID, groupID, model, requestType, stream, billingType, upstreamModelMismatch)
+	trend, hit, err := h.getUsageTrendCached(c.Request.Context(), timeRange.Start, timeRange.End, granularity, userID, apiKeyID, accountID, groupID, model, requestType, stream, billingType, upstreamModelMismatch)
 	if err != nil {
 		response.Error(c, 500, "Failed to get usage trend")
 		return
@@ -281,8 +305,8 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":  timeRange.StartLabel(),
+		"end_date":    timeRange.EndLabel(),
 		"granularity": granularity,
 	})
 }
@@ -291,7 +315,7 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 // GET /api/v1/admin/dashboard/models
 // Query params: start_date, end_date (YYYY-MM-DD), user_id, api_key_id, account_id, group_id, request_type, stream, billing_type
 func (h *DashboardHandler) GetModelStats(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 
 	// Parse optional filter params
 	var userID, apiKeyID, accountID, groupID int64
@@ -359,7 +383,7 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 		return
 	}
 
-	stats, hit, err := h.getModelStatsCached(c.Request.Context(), startTime, endTime, userID, apiKeyID, accountID, groupID, modelSource, requestType, stream, billingType, upstreamModelMismatch)
+	stats, hit, err := h.getModelStatsCached(c.Request.Context(), timeRange.Start, timeRange.End, userID, apiKeyID, accountID, groupID, modelSource, requestType, stream, billingType, upstreamModelMismatch)
 	if err != nil {
 		response.Error(c, 500, "Failed to get model statistics")
 		return
@@ -368,8 +392,8 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"models":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date": timeRange.StartLabel(),
+		"end_date":   timeRange.EndLabel(),
 	})
 }
 
@@ -377,7 +401,7 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 // GET /api/v1/admin/dashboard/groups
 // Query params: start_date, end_date (YYYY-MM-DD), user_id, api_key_id, account_id, group_id, request_type, stream, billing_type
 func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 
 	var userID, apiKeyID, accountID, groupID int64
 	var requestType *int16
@@ -436,7 +460,7 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 		return
 	}
 
-	stats, hit, err := h.getGroupStatsCached(c.Request.Context(), startTime, endTime, userID, apiKeyID, accountID, groupID, requestType, stream, billingType, upstreamModelMismatch)
+	stats, hit, err := h.getGroupStatsCached(c.Request.Context(), timeRange.Start, timeRange.End, userID, apiKeyID, accountID, groupID, requestType, stream, billingType, upstreamModelMismatch)
 	if err != nil {
 		response.Error(c, 500, "Failed to get group statistics")
 		return
@@ -445,8 +469,8 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"groups":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date": timeRange.StartLabel(),
+		"end_date":   timeRange.EndLabel(),
 	})
 }
 
@@ -454,7 +478,7 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 // GET /api/v1/admin/dashboard/api-keys-trend
 // Query params: start_date, end_date (YYYY-MM-DD), granularity (day/hour), limit (default 5)
 func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 	granularity := c.DefaultQuery("granularity", "day")
 	limitStr := c.DefaultQuery("limit", "5")
 	limit, err := strconv.Atoi(limitStr)
@@ -462,7 +486,7 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 		limit = 5
 	}
 
-	trend, hit, err := h.getAPIKeyUsageTrendCached(c.Request.Context(), startTime, endTime, granularity, limit)
+	trend, hit, err := h.getAPIKeyUsageTrendCached(c.Request.Context(), timeRange.Start, timeRange.End, granularity, limit)
 	if err != nil {
 		response.Error(c, 500, "Failed to get API key usage trend")
 		return
@@ -471,8 +495,8 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":  timeRange.StartLabel(),
+		"end_date":    timeRange.EndLabel(),
 		"granularity": granularity,
 	})
 }
@@ -481,7 +505,7 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 // GET /api/v1/admin/dashboard/users-trend
 // Query params: start_date, end_date (YYYY-MM-DD), granularity (day/hour), limit (default 12)
 func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 	granularity := c.DefaultQuery("granularity", "day")
 	limitStr := c.DefaultQuery("limit", "12")
 	limit, err := strconv.Atoi(limitStr)
@@ -489,7 +513,7 @@ func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
 		limit = 12
 	}
 
-	trend, hit, err := h.getUserUsageTrendCached(c.Request.Context(), startTime, endTime, granularity, limit)
+	trend, hit, err := h.getUserUsageTrendCached(c.Request.Context(), timeRange.Start, timeRange.End, granularity, limit)
 	if err != nil {
 		response.Error(c, 500, "Failed to get user usage trend")
 		return
@@ -498,8 +522,8 @@ func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":  timeRange.StartLabel(),
+		"end_date":    timeRange.EndLabel(),
 		"granularity": granularity,
 	})
 }
@@ -527,7 +551,8 @@ func parseRankingLimit(raw string) int {
 // GetUserSpendingRanking handles getting user spending ranking data.
 // GET /api/v1/admin/dashboard/users-ranking
 func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
+	startTime, endTime := timeRange.Start, timeRange.End
 	limit := parseRankingLimit(c.DefaultQuery("limit", "12"))
 
 	keyRaw, _ := json.Marshal(struct {
@@ -557,8 +582,8 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 		"total_actual_cost": ranking.TotalActualCost,
 		"total_requests":    ranking.TotalRequests,
 		"total_tokens":      ranking.TotalTokens,
-		"start_date":        startTime.Format("2006-01-02"),
-		"end_date":          endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":        timeRange.StartLabel(),
+		"end_date":          timeRange.EndLabel(),
 	}
 	dashboardUsersRankingCache.Set(cacheKey, payload)
 	c.Header("X-Snapshot-Cache", "miss")
@@ -657,7 +682,7 @@ func (h *DashboardHandler) GetBatchAPIKeysUsage(c *gin.Context) {
 // GET /api/v1/admin/dashboard/user-breakdown
 // Query params: start_date, end_date, group_id, model, endpoint, endpoint_type, limit
 func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 
 	dim := usagestats.UserBreakdownDimension{}
 	if v := c.Query("group_id"); v != "" {
@@ -723,7 +748,7 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 	}
 
 	stats, err := h.dashboardService.GetUserBreakdownStats(
-		c.Request.Context(), startTime, endTime, dim, limit,
+		c.Request.Context(), timeRange.Start, timeRange.End, dim, limit,
 	)
 	if err != nil {
 		response.Error(c, 500, "Failed to get user breakdown stats")
@@ -732,7 +757,7 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"users":      stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date": timeRange.StartLabel(),
+		"end_date":   timeRange.EndLabel(),
 	})
 }

--- a/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
+++ b/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
@@ -70,7 +70,7 @@ type dashboardSnapshotV2CacheKey struct {
 }
 
 func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
-	startTime, endTime := parseTimeRange(c)
+	timeRange := parseTimeRange(c)
 	granularity := strings.TrimSpace(c.DefaultQuery("granularity", "day"))
 	if granularity != "hour" {
 		granularity = "day"
@@ -95,8 +95,8 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 	}
 
 	keyRaw, _ := json.Marshal(dashboardSnapshotV2CacheKey{
-		StartTime:             startTime.UTC().Format(time.RFC3339),
-		EndTime:               endTime.UTC().Format(time.RFC3339),
+		StartTime:             timeRange.Start.UTC().Format(time.RFC3339),
+		EndTime:               timeRange.End.UTC().Format(time.RFC3339),
 		Granularity:           granularity,
 		UserID:                filters.UserID,
 		APIKeyID:              filters.APIKeyID,
@@ -119,8 +119,7 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 	cached, hit, err := dashboardSnapshotV2Cache.GetOrLoad(cacheKey, func() (any, error) {
 		return h.buildSnapshotV2Response(
 			c.Request.Context(),
-			startTime,
-			endTime,
+			timeRange,
 			granularity,
 			filters,
 			includeStats,
@@ -149,16 +148,17 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 
 func (h *DashboardHandler) buildSnapshotV2Response(
 	ctx context.Context,
-	startTime, endTime time.Time,
+	timeRange dashboardTimeRange,
 	granularity string,
 	filters *dashboardSnapshotV2Filters,
 	includeStats, includeTrend, includeModels, includeGroups, includeUsersTrend bool,
 	usersTrendLimit int,
 ) (*dashboardSnapshotV2Response, error) {
+	startTime, endTime := timeRange.Start, timeRange.End
 	resp := &dashboardSnapshotV2Response{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		StartDate:   startTime.Format("2006-01-02"),
-		EndDate:     endTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		StartDate:   timeRange.StartLabel(),
+		EndDate:     timeRange.EndLabel(),
 		Granularity: granularity,
 	}
 

--- a/backend/internal/handler/admin/snapshot_cache.go
+++ b/backend/internal/handler/admin/snapshot_cache.go
@@ -64,15 +64,22 @@ func (c *snapshotCache) Set(key string, payload any) snapshotCacheEntry {
 	if c == nil {
 		return snapshotCacheEntry{}
 	}
+	now := time.Now()
 	entry := snapshotCacheEntry{
 		ETag:      buildETagFromAny(payload),
 		Payload:   payload,
-		ExpiresAt: time.Now().Add(c.ttl),
+		ExpiresAt: now.Add(c.ttl),
 	}
 	if key == "" {
 		return entry
 	}
 	c.mu.Lock()
+	// 过期条目未必会被同 key 的 Get 再次触达（key 可能一次性），在写入时统一清扫，避免 items 无界增长。
+	for k, e := range c.items {
+		if now.After(e.ExpiresAt) {
+			delete(c.items, k)
+		}
+	}
 	c.items[key] = entry
 	c.mu.Unlock()
 	return entry

--- a/backend/internal/handler/admin/snapshot_cache_test.go
+++ b/backend/internal/handler/admin/snapshot_cache_test.go
@@ -33,6 +33,22 @@ func TestSnapshotCache_Expiration(t *testing.T) {
 	require.False(t, ok, "expired entry should not be returned")
 }
 
+func TestSnapshotCache_SetSweepsExpired(t *testing.T) {
+	c := newSnapshotCache(1 * time.Millisecond)
+
+	// One-shot keys are never looked up again, so only Set can reclaim them.
+	c.Set("stale1", "value")
+	c.Set("stale2", "value")
+	time.Sleep(5 * time.Millisecond)
+
+	c.Set("fresh", "value")
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	require.Len(t, c.items, 1)
+	require.Contains(t, c.items, "fresh")
+}
+
 func TestSnapshotCache_GetEmptyKey(t *testing.T) {
 	c := newSnapshotCache(5 * time.Second)
 	_, ok := c.Get("")

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -157,22 +157,24 @@ func (h *UsageHandler) List(c *gin.Context) {
 	var startTime, endTime *time.Time
 	userTZ := c.Query("timezone") // Get user's timezone from request
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
 		startTime = &t
 	}
 
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		// Use half-open range [start, end), move to next calendar day start (DST-safe).
-		t = t.AddDate(0, 0, 1)
+		// Use half-open range [start, end); date-only values cover the whole end day (DST-safe).
+		if !hasTime {
+			t = t.AddDate(0, 0, 1)
+		}
 		endTime = &t
 	}
 
@@ -307,18 +309,21 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 
 	if startDateStr != "" && endDateStr != "" {
 		var err error
-		startTime, err = timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		startTime, _, err = timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		endTime, err = timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		var endHasTime bool
+		endTime, endHasTime, err = timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		// 与 SQL 条件 created_at < end 对齐，使用次日 00:00 作为上边界（DST-safe）。
-		endTime = endTime.AddDate(0, 0, 1)
+		// 与 SQL 条件 created_at < end 对齐，纯日期使用次日 00:00 作为上边界（DST-safe）。
+		if !endHasTime {
+			endTime = endTime.AddDate(0, 0, 1)
+		}
 	} else {
 		period := c.DefaultQuery("period", "today")
 		switch period {
@@ -503,17 +508,19 @@ func (h *UsageHandler) CreateCleanupTask(c *gin.Context) {
 		return
 	}
 
-	startTime, err := timezone.ParseInUserLocation("2006-01-02", req.StartDate, req.Timezone)
+	startTime, _, err := timezone.ParseDateOrDateTimeInUserLocation(req.StartDate, req.Timezone)
 	if err != nil {
-		response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+		response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 		return
 	}
-	endTime, err := timezone.ParseInUserLocation("2006-01-02", req.EndDate, req.Timezone)
+	endTime, endHasTime, err := timezone.ParseDateOrDateTimeInUserLocation(req.EndDate, req.Timezone)
 	if err != nil {
-		response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+		response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 		return
 	}
-	endTime = endTime.Add(24*time.Hour - time.Nanosecond)
+	if !endHasTime {
+		endTime = endTime.Add(24*time.Hour - time.Nanosecond)
+	}
 
 	var requestType *int16
 	stream := req.Stream

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -166,14 +166,10 @@ func (h *UsageHandler) List(c *gin.Context) {
 	}
 
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
+		t, _, err := timezone.ParseRangeEndInUserLocation(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
-		}
-		// Use half-open range [start, end); date-only values cover the whole end day (DST-safe).
-		if !hasTime {
-			t = t.AddDate(0, 0, 1)
 		}
 		endTime = &t
 	}
@@ -314,15 +310,10 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		var endHasTime bool
-		endTime, endHasTime, err = timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
+		endTime, _, err = timezone.ParseRangeEndInUserLocation(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
-		}
-		// 与 SQL 条件 created_at < end 对齐，纯日期使用次日 00:00 作为上边界（DST-safe）。
-		if !endHasTime {
-			endTime = endTime.AddDate(0, 0, 1)
 		}
 	} else {
 		period := c.DefaultQuery("period", "today")

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -151,21 +151,25 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 	endDateStr := strings.TrimSpace(c.Query("end_date"))
 
 	if startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
 		startTime = t
 		startPtr = &startTime
 	}
 	if endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
-		endTime = t.AddDate(0, 0, 1)
+		if hasTime {
+			endTime = t
+		} else {
+			endTime = t.AddDate(0, 0, 1)
+		}
 		endPtr = &endTime
 	}
 
@@ -277,20 +281,22 @@ func (h *UsageHandler) ListErrors(c *gin.Context) {
 	// Date range (half-open [start, end)), reuse usage-list semantics.
 	userTZ := c.Query("timezone")
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
 		filter.StartTime = &t
 	}
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		t = t.AddDate(0, 0, 1)
+		if !hasTime {
+			t = t.AddDate(0, 0, 1)
+		}
 		filter.EndTime = &t
 	}
 

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -18,9 +18,19 @@ import (
 )
 
 type userUsageFilters struct {
-	Filters   usagestats.UsageLogFilters
-	StartTime time.Time
-	EndTime   time.Time
+	Filters      usagestats.UsageLogFilters
+	StartTime    time.Time
+	EndTime      time.Time
+	StartHasTime bool
+	EndHasTime   bool
+}
+
+func (f *userUsageFilters) StartLabel() string {
+	return timezone.FormatRangeStart(f.StartTime, f.StartHasTime)
+}
+
+func (f *userUsageFilters) EndLabel() string {
+	return timezone.FormatRangeEnd(f.EndTime, f.EndHasTime)
 }
 
 type userModelStat struct {
@@ -147,29 +157,28 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 	now := timezone.NowInUserLocation(userTZ)
 	var startTime, endTime time.Time
 	var startPtr, endPtr *time.Time
+	var startHasTime, endHasTime bool
 	startDateStr := strings.TrimSpace(c.Query("start_date"))
 	endDateStr := strings.TrimSpace(c.Query("end_date"))
 
 	if startDateStr != "" {
-		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
 		startTime = t
+		startHasTime = hasTime
 		startPtr = &startTime
 	}
 	if endDateStr != "" {
-		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseRangeEndInUserLocation(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
-		if hasTime {
-			endTime = t
-		} else {
-			endTime = t.AddDate(0, 0, 1)
-		}
+		endTime = t
+		endHasTime = hasTime
 		endPtr = &endTime
 	}
 
@@ -211,8 +220,10 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 			StartTime:         startPtr,
 			EndTime:           endPtr,
 		},
-		StartTime: derefTime(startPtr),
-		EndTime:   derefTime(endPtr),
+		StartTime:    derefTime(startPtr),
+		EndTime:      derefTime(endPtr),
+		StartHasTime: startHasTime,
+		EndHasTime:   endHasTime,
 	}, true
 }
 
@@ -289,13 +300,10 @@ func (h *UsageHandler) ListErrors(c *gin.Context) {
 		filter.StartTime = &t
 	}
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
+		t, _, err := timezone.ParseRangeEndInUserLocation(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
-		}
-		if !hasTime {
-			t = t.AddDate(0, 0, 1)
 		}
 		filter.EndTime = &t
 	}
@@ -476,8 +484,8 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"trend":       trend,
-		"start_date":  parsed.StartTime.Format("2006-01-02"),
-		"end_date":    parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":  parsed.StartLabel(),
+		"end_date":    parsed.EndLabel(),
 		"granularity": granularity,
 	})
 }
@@ -504,8 +512,8 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 
 	response.Success(c, gin.H{
 		"models":     userModelStatsFromUsageStats(stats),
-		"start_date": parsed.StartTime.Format("2006-01-02"),
-		"end_date":   parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date": parsed.StartLabel(),
+		"end_date":   parsed.EndLabel(),
 	})
 }
 
@@ -536,8 +544,8 @@ func (h *UsageHandler) DashboardSnapshotV2(c *gin.Context) {
 
 	resp := gin.H{
 		"generated_at": time.Now().UTC().Format(time.RFC3339),
-		"start_date":   parsed.StartTime.Format("2006-01-02"),
-		"end_date":     parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"start_date":   parsed.StartLabel(),
+		"end_date":     parsed.EndLabel(),
 		"granularity":  granularity,
 	}
 

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -140,6 +140,17 @@ func ParseInUserLocation(layout, value, userTZ string) (time.Time, error) {
 	return time.ParseInLocation(layout, value, loc)
 }
 
+// ParseDateOrDateTimeInUserLocation parses value as either an RFC3339 datetime
+// (hasTime=true, offset taken from the value itself) or a date "2006-01-02" in
+// the user's timezone (hasTime=false).
+func ParseDateOrDateTimeInUserLocation(value, userTZ string) (t time.Time, hasTime bool, err error) {
+	if t, err = time.Parse(time.RFC3339, value); err == nil {
+		return t, true, nil
+	}
+	t, err = ParseInUserLocation("2006-01-02", value, userTZ)
+	return t, false, err
+}
+
 // NowInUserLocation returns the current time in the user's timezone.
 // If userTZ is empty or invalid, falls back to the configured server timezone.
 func NowInUserLocation(userTZ string) time.Time {

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -151,6 +151,35 @@ func ParseDateOrDateTimeInUserLocation(value, userTZ string) (t time.Time, hasTi
 	return t, false, err
 }
 
+// ParseRangeEndInUserLocation parses value as a range's exclusive upper bound:
+// an RFC3339 instant is used as-is; a date-only value covers its whole day,
+// yielding the next day's midnight (DST-safe).
+func ParseRangeEndInUserLocation(value, userTZ string) (t time.Time, hasTime bool, err error) {
+	t, hasTime, err = ParseDateOrDateTimeInUserLocation(value, userTZ)
+	if err == nil && !hasTime {
+		t = t.AddDate(0, 0, 1)
+	}
+	return t, hasTime, err
+}
+
+// FormatRangeStart echoes a range start boundary: RFC3339 for precise
+// instants, the original date for whole-day boundaries.
+func FormatRangeStart(t time.Time, hasTime bool) string {
+	if hasTime {
+		return t.Format(time.RFC3339)
+	}
+	return t.Format("2006-01-02")
+}
+
+// FormatRangeEnd echoes a range's exclusive upper bound: RFC3339 for precise
+// instants, the inclusive end date for whole-day boundaries.
+func FormatRangeEnd(t time.Time, hasTime bool) string {
+	if hasTime {
+		return t.Format(time.RFC3339)
+	}
+	return t.AddDate(0, 0, -1).Format("2006-01-02")
+}
+
 // NowInUserLocation returns the current time in the user's timezone.
 // If userTZ is empty or invalid, falls back to the configured server timezone.
 func NowInUserLocation(userTZ string) time.Time {

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -42,8 +42,8 @@
             <label class="date-picker-label">{{ t('dates.startDate') }}</label>
             <input
               type="date"
-              v-model="localStartDate"
-              :max="localEndDate || tomorrow"
+              v-model="startDateInput"
+              :max="endDateInput || tomorrow"
               class="date-picker-input"
               @change="onDateChange"
             />
@@ -55,8 +55,8 @@
             <label class="date-picker-label">{{ t('dates.endDate') }}</label>
             <input
               type="date"
-              v-model="localEndDate"
-              :min="localStartDate"
+              v-model="endDateInput"
+              :min="startDateInput"
               :max="tomorrow"
               class="date-picker-input"
               @change="onDateChange"
@@ -79,6 +79,12 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
+import {
+  getLast24HourRange,
+  hasTimeComponent,
+  parseRangeBoundary,
+  toDateInputValue
+} from '@/utils/dateRange'
 
 interface DatePreset {
   labelKey: string
@@ -155,14 +161,7 @@ const presets: DatePreset[] = [
   {
     labelKey: 'dates.last24Hours',
     value: 'last24Hours',
-    getRange: () => {
-      const end = new Date()
-      const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-      return {
-        start: formatDateToString(start),
-        end: formatDateToString(end)
-      }
-    }
+    getRange: getLast24HourRange
   },
   {
     labelKey: 'dates.last7Days',
@@ -235,10 +234,31 @@ const displayValue = computed(() => {
 })
 
 const formatDate = (dateStr: string): string => {
-  const date = new Date(dateStr + 'T00:00:00')
+  const date = parseRangeBoundary(dateStr)
   const dateLocale = locale.value === 'zh' ? 'zh-CN' : 'en-US'
   return date.toLocaleDateString(dateLocale, { month: 'short', day: 'numeric' })
 }
+
+// Native date inputs only understand YYYY-MM-DD; editing either input
+// normalizes a rolling (datetime) range back to whole days
+const startDateInput = computed({
+  get: () => (localStartDate.value ? toDateInputValue(localStartDate.value) : ''),
+  set: (v: string) => {
+    localStartDate.value = v
+    if (localEndDate.value && hasTimeComponent(localEndDate.value)) {
+      localEndDate.value = toDateInputValue(localEndDate.value)
+    }
+  }
+})
+const endDateInput = computed({
+  get: () => (localEndDate.value ? toDateInputValue(localEndDate.value) : ''),
+  set: (v: string) => {
+    localEndDate.value = v
+    if (localStartDate.value && hasTimeComponent(localStartDate.value)) {
+      localStartDate.value = toDateInputValue(localStartDate.value)
+    }
+  }
+})
 
 const isPresetActive = (preset: DatePreset): boolean => {
   return activePreset.value === preset.value
@@ -252,6 +272,16 @@ const selectPreset = (preset: DatePreset) => {
 }
 
 const onDateChange = () => {
+  // Rolling ranges carry a time component; only the last24Hours preset produces them
+  if (
+    localStartDate.value &&
+    localEndDate.value &&
+    hasTimeComponent(localStartDate.value) &&
+    hasTimeComponent(localEndDate.value)
+  ) {
+    activePreset.value = 'last24Hours'
+    return
+  }
   // Check if current dates match any preset
   activePreset.value = null
   for (const preset of presets) {

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
 import {
@@ -90,6 +90,8 @@ interface DatePreset {
   labelKey: string
   value: string
   getRange: () => { start: string; end: string }
+  /** 自定义识别当前范围是否属于该预设;缺省时按 getRange() 的值精确比较 */
+  matches?: (start: string, end: string) => boolean
 }
 
 interface Props {
@@ -161,7 +163,9 @@ const presets: DatePreset[] = [
   {
     labelKey: 'dates.last24Hours',
     value: 'last24Hours',
-    getRange: getLast24HourRange
+    getRange: getLast24HourRange,
+    // 滚动范围带时间部分;只有本预设会生成这样的边界
+    matches: (start, end) => hasTimeComponent(start) && hasTimeComponent(end)
   },
   {
     labelKey: 'dates.last7Days',
@@ -241,24 +245,16 @@ const formatDate = (dateStr: string): string => {
 
 // Native date inputs only understand YYYY-MM-DD; editing either input
 // normalizes a rolling (datetime) range back to whole days
-const startDateInput = computed({
-  get: () => (localStartDate.value ? toDateInputValue(localStartDate.value) : ''),
-  set: (v: string) => {
-    localStartDate.value = v
-    if (localEndDate.value && hasTimeComponent(localEndDate.value)) {
-      localEndDate.value = toDateInputValue(localEndDate.value)
+const dateInput = (own: Ref<string>, other: Ref<string>) =>
+  computed({
+    get: () => toDateInputValue(own.value),
+    set: (v: string) => {
+      own.value = v
+      other.value = toDateInputValue(other.value)
     }
-  }
-})
-const endDateInput = computed({
-  get: () => (localEndDate.value ? toDateInputValue(localEndDate.value) : ''),
-  set: (v: string) => {
-    localEndDate.value = v
-    if (localStartDate.value && hasTimeComponent(localStartDate.value)) {
-      localStartDate.value = toDateInputValue(localStartDate.value)
-    }
-  }
-})
+  })
+const startDateInput = dateInput(localStartDate, localEndDate)
+const endDateInput = dateInput(localEndDate, localStartDate)
 
 const isPresetActive = (preset: DatePreset): boolean => {
   return activePreset.value === preset.value
@@ -271,26 +267,14 @@ const selectPreset = (preset: DatePreset) => {
   activePreset.value = preset.value
 }
 
+const matchesCurrentRange = (preset: DatePreset): boolean => {
+  if (preset.matches) return preset.matches(localStartDate.value, localEndDate.value)
+  const range = preset.getRange()
+  return range.start === localStartDate.value && range.end === localEndDate.value
+}
+
 const onDateChange = () => {
-  // Rolling ranges carry a time component; only the last24Hours preset produces them
-  if (
-    localStartDate.value &&
-    localEndDate.value &&
-    hasTimeComponent(localStartDate.value) &&
-    hasTimeComponent(localEndDate.value)
-  ) {
-    activePreset.value = 'last24Hours'
-    return
-  }
-  // Check if current dates match any preset
-  activePreset.value = null
-  for (const preset of presets) {
-    const range = preset.getRange()
-    if (range.start === localStartDate.value && range.end === localEndDate.value) {
-      activePreset.value = preset.value
-      break
-    }
-  }
+  activePreset.value = presets.find(matchesCurrentRange)?.value ?? null
 }
 
 const toggle = () => {

--- a/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
+++ b/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
@@ -78,17 +78,18 @@ describe('DateRangePicker', () => {
     await presetButton!.trigger('click')
     await wrapper.find('.date-picker-apply').trigger('click')
 
-    const nowAfterClick = new Date()
-    const yesterdayAfterClick = new Date(nowAfterClick.getTime() - 24 * 60 * 60 * 1000)
-    const expectedStart = formatLocalDate(yesterdayAfterClick)
-    const expectedEnd = formatLocalDate(nowAfterClick)
-
-    expect(wrapper.emitted('update:startDate')?.[0]).toEqual([expectedStart])
-    expect(wrapper.emitted('update:endDate')?.[0]).toEqual([expectedEnd])
+    const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
+    const emittedStart = wrapper.emitted('update:startDate')?.[0]?.[0] as string
+    const emittedEnd = wrapper.emitted('update:endDate')?.[0]?.[0] as string
+    expect(emittedStart).toMatch(RFC3339_RE)
+    expect(emittedEnd).toMatch(RFC3339_RE)
+    expect(new Date(emittedEnd).getTime() - new Date(emittedStart).getTime()).toBe(
+      24 * 60 * 60 * 1000
+    )
     expect(wrapper.emitted('change')?.[0]).toEqual([
       {
-        startDate: expectedStart,
-        endDate: expectedEnd,
+        startDate: emittedStart,
+        endDate: emittedEnd,
         preset: 'last24Hours'
       }
     ])

--- a/frontend/src/utils/__tests__/dateRange.spec.ts
+++ b/frontend/src/utils/__tests__/dateRange.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getLast24HourRange } from '../dateRange'
+
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
+
+describe('getLast24HourRange', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns RFC3339 boundaries aligned to the minute, exactly 24 hours apart', () => {
+    vi.setSystemTime(new Date(2026, 6, 11, 14, 3, 22, 456))
+
+    const { start, end } = getLast24HourRange()
+
+    expect(start).toMatch(RFC3339_RE)
+    expect(end).toMatch(RFC3339_RE)
+    expect(new Date(end).getSeconds()).toBe(0)
+    expect(new Date(end).getMilliseconds()).toBe(0)
+    expect(new Date(end).getTime() - new Date(start).getTime()).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('returns identical boundaries for consecutive calls within the same minute', () => {
+    vi.setSystemTime(new Date(2026, 6, 11, 14, 3, 5))
+    const first = getLast24HourRange()
+
+    vi.setSystemTime(new Date(2026, 6, 11, 14, 3, 55))
+    const second = getLast24HourRange()
+
+    expect(second).toEqual(first)
+  })
+})

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -1,0 +1,40 @@
+/**
+ * 日期范围工具
+ * 后端 start_date/end_date 同时接受 YYYY-MM-DD(整天)和 RFC3339(精确时刻,半开区间上界)
+ */
+
+const pad = (n: number): string => String(n).padStart(2, '0')
+
+/** 本地时区 RFC3339(带偏移),如 2026-07-11T14:03:22+08:00 */
+export function formatDateTimeRFC3339(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMinutes)
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    `${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`
+  )
+}
+
+/** 滚动 24 小时窗口(RFC3339 边界) */
+export function getLast24HourRange(): { start: string; end: string } {
+  const end = new Date()
+  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+  return { start: formatDateTimeRFC3339(start), end: formatDateTimeRFC3339(end) }
+}
+
+/** 范围边界值是否带时间部分(RFC3339) */
+export function hasTimeComponent(value: string): boolean {
+  return value.includes('T')
+}
+
+/** 供 <input type="date"> 显示的日期部分 */
+export function toDateInputValue(value: string): string {
+  return value.slice(0, 10)
+}
+
+/** 解析范围边界(纯日期按本地 00:00) */
+export function parseRangeBoundary(value: string): Date {
+  return hasTimeComponent(value) ? new Date(value) : new Date(`${value}T00:00:00`)
+}

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -6,7 +6,7 @@
 const pad = (n: number): string => String(n).padStart(2, '0')
 
 /** 本地时区 RFC3339(带偏移),如 2026-07-11T14:03:22+08:00 */
-export function formatDateTimeRFC3339(date: Date): string {
+function formatDateTimeRFC3339(date: Date): string {
   const offsetMinutes = -date.getTimezoneOffset()
   const sign = offsetMinutes >= 0 ? '+' : '-'
   const abs = Math.abs(offsetMinutes)
@@ -17,9 +17,10 @@ export function formatDateTimeRFC3339(date: Date): string {
   )
 }
 
-/** 滚动 24 小时窗口(RFC3339 边界) */
+/** 滚动 24 小时窗口(RFC3339 边界);对齐到整分钟,同一分钟内的请求共享后端缓存 key */
 export function getLast24HourRange(): { start: string; end: string } {
   const end = new Date()
+  end.setSeconds(0, 0)
   const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
   return { start: formatDateTimeRFC3339(start), end: formatDateTimeRFC3339(end) }
 }
@@ -37,4 +38,11 @@ export function toDateInputValue(value: string): string {
 /** 解析范围边界(纯日期按本地 00:00) */
 export function parseRangeBoundary(value: string): Date {
   return hasTimeComponent(value) ? new Date(value) : new Date(`${value}T00:00:00`)
+}
+
+/** 范围跨度不超过 1 天用小时粒度,否则用天(按本地时区解析边界) */
+export function getGranularityForRange(start: string, end: string): 'day' | 'hour' {
+  const startTime = parseRangeBoundary(start).getTime()
+  const endTime = parseRangeBoundary(end).getTime()
+  return Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24)) <= 1 ? 'hour' : 'day'
 }

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -363,6 +363,7 @@ import Select from '@/components/common/Select.vue'
 import ModelDistributionChart from '@/components/charts/ModelDistributionChart.vue'
 import TokenUsageTrend from '@/components/charts/TokenUsageTrend.vue'
 import { useBatchImageAccess } from '@/composables/useBatchImageAccess'
+import { getLast24HourRange } from '@/utils/dateRange'
 
 import {
   Chart as ChartJS,
@@ -410,23 +411,9 @@ let usersTrendLoadSeq = 0
 let rankingLoadSeq = 0
 const rankingLimit = 12
 
-// Helper function to format date in local timezone
-const formatLocalDate = (date: Date): string => {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-}
-
-const getLast24HoursRangeDates = (): { start: string; end: string } => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return {
-    start: formatLocalDate(start),
-    end: formatLocalDate(end)
-  }
-}
-
 // Date range
 const granularity = ref<'day' | 'hour'>('hour')
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
 

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -190,7 +190,7 @@ import { useAppStore } from '@/stores/app'; import { adminAPI } from '@/api/admi
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
-import { getLast24HourRange, hasTimeComponent, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
+import { getGranularityForRange, getLast24HourRange, hasTimeComponent, toDateInputValue } from '@/utils/dateRange'
 import AppLayout from '@/components/layout/AppLayout.vue'; import Pagination from '@/components/common/Pagination.vue'; import Select from '@/components/common/Select.vue'; import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import UsageStatsCards from '@/components/admin/usage/UsageStatsCards.vue'; import UsageFilters from '@/components/admin/usage/UsageFilters.vue'
 import UsageTable from '@/components/admin/usage/UsageTable.vue'; import UsageExportProgress from '@/components/admin/usage/UsageExportProgress.vue'
@@ -273,13 +273,6 @@ const handleRankingSelectUser = (userId: number, email: string) => {
 }
 
 const granularityOptions = computed(() => [{ value: 'day', label: t('admin.dashboard.day') }, { value: 'hour', label: t('admin.dashboard.hour') }])
-// Use local timezone to avoid UTC timezone issues
-const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = parseRangeBoundary(start).getTime()
-  const endTime = parseRangeBoundary(end).getTime()
-  const daysDiff = Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24))
-  return daysDiff <= 1 ? 'hour' : 'day'
-}
 const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
@@ -787,11 +780,10 @@ const showErrorModal = ref(false)
 const selectedErrorId = ref<number | null>(null)
 
 // 注意：'YYYY-MM-DDT00:00:00' 无时区后缀，按本地时区解析后再转 UTC——与页面其它日期处理语义一致，刻意如此，勿改成 'T00:00:00Z'
-const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined => {
-  if (!d) return undefined
-  if (hasTimeComponent(d)) return new Date(d).toISOString()
-  return new Date(d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString()
-}
+const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined =>
+  d
+    ? new Date(hasTimeComponent(d) ? d : d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString()
+    : undefined
 
 const loadAdminErrors = async () => {
   errLoading.value = true

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -190,6 +190,7 @@ import { useAppStore } from '@/stores/app'; import { adminAPI } from '@/api/admi
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
+import { getLast24HourRange, hasTimeComponent, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
 import AppLayout from '@/components/layout/AppLayout.vue'; import Pagination from '@/components/common/Pagination.vue'; import Select from '@/components/common/Select.vue'; import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import UsageStatsCards from '@/components/admin/usage/UsageStatsCards.vue'; import UsageFilters from '@/components/admin/usage/UsageFilters.vue'
 import UsageTable from '@/components/admin/usage/UsageTable.vue'; import UsageExportProgress from '@/components/admin/usage/UsageExportProgress.vue'
@@ -273,27 +274,13 @@ const handleRankingSelectUser = (userId: number, email: string) => {
 
 const granularityOptions = computed(() => [{ value: 'day', label: t('admin.dashboard.day') }, { value: 'hour', label: t('admin.dashboard.hour') }])
 // Use local timezone to avoid UTC timezone issues
-const formatLD = (d: Date) => {
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-const getLast24HoursRangeDates = (): { start: string; end: string } => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return {
-    start: formatLD(start),
-    end: formatLD(end)
-  }
-}
 const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = new Date(`${start}T00:00:00`).getTime()
-  const endTime = new Date(`${end}T00:00:00`).getTime()
+  const startTime = parseRangeBoundary(start).getTime()
+  const endTime = parseRangeBoundary(end).getTime()
   const daysDiff = Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24))
   return daysDiff <= 1 ? 'hour' : 'day'
 }
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
 const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
@@ -536,7 +523,7 @@ const refreshData = () => {
   if (rankingMounted.value) rankingRef.value?.reload()
 }
 const resetFilters = () => {
-  const range = getLast24HoursRangeDates()
+  const range = getLast24HourRange()
   startDate.value = range.start
   endDate.value = range.end
   filters.value = { start_date: startDate.value, end_date: endDate.value, request_type: undefined, billing_type: null, billing_mode: undefined }
@@ -616,7 +603,7 @@ const exportToExcel = async () => {
     if(!c.signal.aborted) {
       const wb = XLSX.utils.book_new()
       XLSX.utils.book_append_sheet(wb, ws, 'Usage')
-      saveAs(new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), `usage_${filters.value.start_date}_to_${filters.value.end_date}.xlsx`)
+      saveAs(new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), `usage_${toDateInputValue(filters.value.start_date ?? '')}_to_${toDateInputValue(filters.value.end_date ?? '')}.xlsx`)
       appStore.showSuccess(t('usage.exportSuccess'))
     }
   } catch (error) { console.error('Failed to export:', error); appStore.showError('Export Failed') }
@@ -800,8 +787,11 @@ const showErrorModal = ref(false)
 const selectedErrorId = ref<number | null>(null)
 
 // 注意：'YYYY-MM-DDT00:00:00' 无时区后缀，按本地时区解析后再转 UTC——与页面其它日期处理语义一致，刻意如此，勿改成 'T00:00:00Z'
-const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined =>
-  d ? new Date(d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString() : undefined
+const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined => {
+  if (!d) return undefined
+  if (hasTimeComponent(d)) return new Date(d).toISOString()
+  return new Date(d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString()
+}
 
 const loadAdminErrors = async () => {
   errLoading.value = true

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -43,12 +43,7 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
 
 const createDashboardStats = (): DashboardStats => ({
   total_users: 0,
@@ -133,14 +128,13 @@ describe('admin DashboardView', () => {
 
     await flushPromises()
 
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
-      granularity: 'hour'
-    }))
+    const snapshotParams = getSnapshotV2.mock.calls[0][0]
+    expect(snapshotParams.granularity).toBe('hour')
+    expect(snapshotParams.start_date).toMatch(RFC3339_RE)
+    expect(snapshotParams.end_date).toMatch(RFC3339_RE)
+    expect(
+      new Date(snapshotParams.end_date).getTime() - new Date(snapshotParams.start_date).getTime()
+    ).toBe(24 * 60 * 60 * 1000)
   })
 })

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -41,12 +41,7 @@ const messages: Record<string, string> = {
 	'common.no': 'No',
 }
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
 
 vi.mock('@/api/admin', () => ({
   adminAPI: {
@@ -365,13 +360,13 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-    expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
-      granularity: 'hour'
-    }))
+    const snapshotParams = getSnapshotV2.mock.calls[0][0]
+    expect(snapshotParams.granularity).toBe('hour')
+    expect(snapshotParams.start_date).toMatch(RFC3339_RE)
+    expect(snapshotParams.end_date).toMatch(RFC3339_RE)
+    expect(
+      new Date(snapshotParams.end_date).getTime() - new Date(snapshotParams.start_date).getTime()
+    ).toBe(24 * 60 * 60 * 1000)
 
     const modelChart = wrapper.find('[data-test="model-chart"]')
     const groupChart = wrapper.find('[data-test="group-chart"]')

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -231,7 +231,7 @@ import Icon from '@/components/icons/Icon.vue'
 import UserErrorRequestsTable from '@/components/user/UserErrorRequestsTable.vue'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
-import { getLast24HourRange, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
+import { getGranularityForRange, getLast24HourRange, toDateInputValue } from '@/utils/dateRange'
 import { getBillingModeLabel, getDisplayBillingMode as resolveDisplayBillingMode } from '@/utils/billingMode'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
 import type {
@@ -324,12 +324,6 @@ let abortController: AbortController | null = null
 let chartReqSeq = 0
 let statsReqSeq = 0
 let modelStatsReqSeq = 0
-
-const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = parseRangeBoundary(start).getTime()
-  const endTime = parseRangeBoundary(end).getTime()
-  return Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24)) <= 1 ? 'hour' : 'day'
-}
 
 const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start)

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -231,6 +231,7 @@ import Icon from '@/components/icons/Icon.vue'
 import UserErrorRequestsTable from '@/components/user/UserErrorRequestsTable.vue'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
+import { getLast24HourRange, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
 import { getBillingModeLabel, getDisplayBillingMode as resolveDisplayBillingMode } from '@/utils/billingMode'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
 import type {
@@ -324,22 +325,13 @@ let chartReqSeq = 0
 let statsReqSeq = 0
 let modelStatsReqSeq = 0
 
-const formatLocalDate = (date: Date): string =>
-  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-
-const getLast24HoursRangeDates = () => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return { start: formatLocalDate(start), end: formatLocalDate(end) }
-}
-
 const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = new Date(`${start}T00:00:00`).getTime()
-  const endTime = new Date(`${end}T00:00:00`).getTime()
+  const startTime = parseRangeBoundary(start).getTime()
+  const endTime = parseRangeBoundary(end).getTime()
   return Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24)) <= 1 ? 'hour' : 'day'
 }
 
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
 const granularity = ref<'day' | 'hour'>(getGranularityForRange(startDate.value, endDate.value))
@@ -544,7 +536,7 @@ const refreshData = () => {
 }
 
 const resetFilters = () => {
-  const range = getLast24HoursRangeDates()
+  const range = getLast24HourRange()
   startDate.value = range.start
   endDate.value = range.end
   filters.value = {
@@ -681,7 +673,7 @@ const exportToCSV = async () => {
     const url = window.URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = `usage_${startDate.value}_to_${endDate.value}.csv`
+    link.download = `usage_${toDateInputValue(startDate.value)}_to_${toDateInputValue(endDate.value)}.csv`
     link.click()
     window.URL.revokeObjectURL(url)
     appStore.showSuccess(t('usage.exportSuccess'))


### PR DESCRIPTION
Closes #5688
Closes #4703

> 替代 #4034(同一修复,已在最新 main 上重建并重新验证;原分支与主干冲突故重提)。

## 问题

「近24小时」目前实际查的是「昨天+今天」两个自然日,最长能覆盖到约 48 小时的记录。接近 24 点时查看,数字比真实的 24 小时消费虚高近一倍;一过 0 点,昨天整天的数据瞬间掉出窗口,数字跳崖(#5688 与 #4703 报告的都是这个现象)。

影响面:**用户使用记录页、管理端使用记录页、管理端仪表盘**三个页面的**默认值**都是「近24小时」,打开页面看到的总消费/总请求/图表与显示语义不一致,容易误导用户。

原因是预设算完 now-24h 后把时间部分丢了,只传日期到后端,后端按整数天解析。

## 修改

- 预设改为发送带时区完整时间(RFC3339),任何时刻看到的都是过去 24 小时
- 后端相关解析点(用户/管理端统计、错误日志、清理任务、仪表盘)在原有 `YYYY-MM-DD` 整天语义完全不变的基础上,接受 RFC3339 标准时间;自选日期行为不变
- 三个视图里复制粘贴的 24 小时函数收敛到新的 `utils/dateRange.ts`

## 验证

- 修复前后对比截图见 #4034(修复前显示超过 24 小时的记录,修复后为准确的滚动 24 小时)
- `go test -tags=unit ./...` 全部通过;`pnpm typecheck` 通过
- `DateRangePicker.spec.ts` / `DashboardView.spec.ts` / `UsageView.spec.ts` 共 15 个用例通过
- 本地以跨越多天的测试数据验证:纯日期参数(手选日期)整天语义与之前完全一致