### PR TITLE
fix: persist long_context_pricing_enabled in API key auth snapshot

### DIFF
--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -219,9 +219,9 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 				group.FieldPeakStart,
 				group.FieldPeakEnd,
 				group.FieldPeakRateMultiplier,
-				// 分组利润控制：认证快照是调度门 enable 判定的直接来源，
-				// 漏选会让门静默失效；新增快照分组字段时必须同步本投影，
-				// 集成测试对账兜底。
+				// 分组利润控制 / 长上下文阶梯：认证快照是热路径直接来源，
+				// 漏选会让门或官方 272k/200k 阶梯静默失效；新增快照分组字段
+				// 时必须同步本投影，集成测试对账兜底。
 				group.FieldProfitControlEnabled,
 				group.FieldProfitMinMargin,
 				group.FieldProfitSafetyBuffer,

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -130,6 +130,11 @@ type APIKeyAuthGroupSnapshot struct {
 	ProfitControlEnabled bool    `json:"profit_control_enabled"`
 	ProfitMinMargin      float64 `json:"profit_min_margin"`
 	ProfitSafetyBuffer   float64 `json:"profit_safety_buffer"`
+
+	// 长上下文阶梯：CalculateCostUnified / 定价解析器读的就是这份快照物化出的
+	// Group。漏掉该字段时热路径零值为 false，官方 272k/200k 阶梯会被静默关掉，
+	// 后台分组开关开着也不生效。必须与 GetByKeyForAuth 投影同步。
+	LongContextPricingEnabled bool `json:"long_context_pricing_enabled"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 19 // v19: group search/audio/video_model_prices billing fields (force refresh of pre-fix snapshots)
+const apiKeyAuthSnapshotVersion = 20 // v20: group long_context_pricing_enabled (force refresh of pre-fix snapshots)
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -428,6 +428,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			ProfitControlEnabled:            apiKey.Group.ProfitControlEnabled,
 			ProfitMinMargin:                 apiKey.Group.ProfitMinMargin,
 			ProfitSafetyBuffer:              apiKey.Group.ProfitSafetyBuffer,
+			LongContextPricingEnabled:       apiKey.Group.LongContextPricingEnabled,
 		}
 	}
 	return snapshot
@@ -523,6 +524,7 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			ProfitControlEnabled:            snapshot.Group.ProfitControlEnabled,
 			ProfitMinMargin:                 snapshot.Group.ProfitMinMargin,
 			ProfitSafetyBuffer:              snapshot.Group.ProfitSafetyBuffer,
+			LongContextPricingEnabled:       snapshot.Group.LongContextPricingEnabled,
 		}
 	}
 	s.compileAPIKeyIPRules(apiKey)

--- a/backend/internal/service/api_key_auth_cache_long_context_test.go
+++ b/backend/internal/service/api_key_auth_cache_long_context_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func longContextAuthTestAPIKey(enabled bool) *APIKey {
+	groupID := int64(5)
+	return &APIKey{
+		ID:      13,
+		UserID:  9,
+		GroupID: &groupID,
+		Name:    "long-context-auth-roundtrip",
+		Status:  StatusActive,
+		User: &User{
+			ID:          9,
+			Email:       "long-context@test.local",
+			Status:      StatusActive,
+			Concurrency: 5,
+		},
+		Group: &Group{
+			ID:                        groupID,
+			Name:                      "pro-7",
+			Platform:                  PlatformOpenAI,
+			Status:                    StatusActive,
+			Hydrated:                  true,
+			RateMultiplier:            1,
+			SubscriptionType:          SubscriptionTypeStandard,
+			LongContextPricingEnabled: enabled,
+		},
+	}
+}
+
+func TestAPIKeyAuthSnapshotLongContextPricingRoundtrip(t *testing.T) {
+	svc := &APIKeyService{}
+	apiKey := longContextAuthTestAPIKey(true)
+
+	snapshot := svc.snapshotFromAPIKey(context.Background(), apiKey)
+	require.NotNil(t, snapshot)
+	require.Equal(t, apiKeyAuthSnapshotVersion, snapshot.Version)
+	require.True(t, snapshot.Group.LongContextPricingEnabled)
+
+	payload, err := json.Marshal(&APIKeyAuthCacheEntry{Snapshot: snapshot})
+	require.NoError(t, err)
+	var restored APIKeyAuthCacheEntry
+	require.NoError(t, json.Unmarshal(payload, &restored))
+
+	materialized, used, err := svc.applyAuthCacheEntry(apiKey.Key, &restored)
+	require.NoError(t, err)
+	require.True(t, used)
+	require.NotNil(t, materialized.Group)
+	require.True(t, materialized.Group.LongContextPricingEnabled)
+
+	offKey := longContextAuthTestAPIKey(false)
+	offSnapshot := svc.snapshotFromAPIKey(context.Background(), offKey)
+	offRestored := svc.snapshotToAPIKey(offKey.Key, offSnapshot)
+	require.False(t, offRestored.Group.LongContextPricingEnabled)
+}
+
+func TestAPIKeyAuthSnapshotOldVersionWithoutLongContextIsEvicted(t *testing.T) {
+	svc := &APIKeyService{}
+	snapshot := svc.snapshotFromAPIKey(context.Background(), longContextAuthTestAPIKey(true))
+	require.NotNil(t, snapshot)
+	snapshot.Version = 19
+	snapshot.Group.LongContextPricingEnabled = false
+
+	materialized, used, err := svc.applyAuthCacheEntry("sk-old-longctx", &APIKeyAuthCacheEntry{Snapshot: snapshot})
+	require.NoError(t, err)
+	require.False(t, used, "缺长上下文字段的旧快照必须淘汰回源，避免零值 false 关掉官方阶梯")
+	require.Nil(t, materialized)
+}
+
+func TestAPIKeyAuthSnapshotLongContextRoundtripKeepsOfficialLadder(t *testing.T) {
+	svc := &APIKeyService{}
+	billing := NewBillingService(&config.Config{}, nil)
+	resolver := NewModelPricingResolver(nil, billing)
+	tokens := UsageTokens{InputTokens: 250000, OutputTokens: 1000}
+
+	materialized := svc.snapshotToAPIKey("sk-longctx", svc.snapshotFromAPIKey(context.Background(), longContextAuthTestAPIKey(true)))
+	enabled, err := billing.CalculateCostUnified(CostInput{
+		Model: "grok-4.5", Group: materialized.Group, Tokens: tokens, RateMultiplier: 1, Resolver: resolver,
+	})
+	require.NoError(t, err)
+	require.True(t, enabled.LongContextBillingApplied)
+
+	disabledKey := longContextAuthTestAPIKey(false)
+	disabled := svc.snapshotToAPIKey("sk-shortctx", svc.snapshotFromAPIKey(context.Background(), disabledKey))
+	off, err := billing.CalculateCostUnified(CostInput{
+		Model: "grok-4.5", Group: disabled.Group, Tokens: tokens, RateMultiplier: 1, Resolver: resolver,
+	})
+	require.NoError(t, err)
+	require.False(t, off.LongContextBillingApplied)
+	require.InDelta(t, off.InputCost*2, enabled.InputCost, 1e-12)
+	require.InDelta(t, off.OutputCost*2, enabled.OutputCost, 1e-12)
+}
+
+func TestLegacyAuthSnapshotOmittingLongContextFlagDisablesOfficialLadder(t *testing.T) {
+	// 复现 0.1.176 起的线上事故：快照 JSON 不含该字段时，热路径 Group 零值为 false。
+	legacyJSON := []byte(`{"snapshot":{"version":20,"api_key_id":13,"user_id":9,"group_id":5,"name":"legacy","status":"active","user":{"id":9,"status":"active","role":"","balance":0,"concurrency":0,"email":"","username":"","balance_notify_enabled":false,"balance_notify_threshold_type":"","total_recharged":0,"rpm_limit":0},"group":{"id":5,"name":"pro-7","platform":"openai","is_exclusive":false,"status":"active","subscription_type":"standard","rate_multiplier":1}}}`)
+
+	var entry APIKeyAuthCacheEntry
+	require.NoError(t, json.Unmarshal(legacyJSON, &entry))
+	require.NotNil(t, entry.Snapshot)
+	require.NotNil(t, entry.Snapshot.Group)
+	require.False(t, entry.Snapshot.Group.LongContextPricingEnabled)
+
+	svc := &APIKeyService{}
+	materialized, used, err := svc.applyAuthCacheEntry("sk-legacy", &entry)
+	require.NoError(t, err)
+	require.True(t, used)
+	require.False(t, materialized.Group.LongContextPricingEnabled)
+
+	billing := NewBillingService(&config.Config{}, nil)
+	resolver := NewModelPricingResolver(nil, billing)
+	cost, err := billing.CalculateCostUnified(CostInput{
+		Model: "grok-4.5", Group: materialized.Group, Tokens: UsageTokens{InputTokens: 250000, OutputTokens: 1000}, RateMultiplier: 1, Resolver: resolver,
+	})
+	require.NoError(t, err)
+	require.False(t, cost.LongContextBillingApplied)
+}

--- a/backend/internal/service/api_key_auth_cache_profit_test.go
+++ b/backend/internal/service/api_key_auth_cache_profit_test.go
@@ -53,7 +53,7 @@ func TestAPIKeyAuthSnapshotProfitControlRoundtrip(t *testing.T) {
 	snapshot := svc.snapshotFromAPIKey(context.Background(), apiKey)
 	require.NotNil(t, snapshot)
 	require.Equal(t, apiKeyAuthSnapshotVersion, snapshot.Version)
-	require.Equal(t, 19, snapshot.Version, "v19 起认证快照携带 search/audio/video_model_prices 计费字段")
+	require.Equal(t, 20, snapshot.Version, "v20 起认证快照携带 long_context_pricing_enabled")
 
 	// 模拟 L2 缓存的完整 JSON 往返（与 apiKeyCache.SetAuthCache/GetAuthCache 同构）。
 	payload, err := json.Marshal(&APIKeyAuthCacheEntry{Snapshot: snapshot})


### PR DESCRIPTION
## Problem

#5541 / `f3d949107` added `groups.long_context_pricing_enabled` and made the unified pricing resolver honor `apiKey.Group.LongContextPricingEnabled`. The API key auth cache snapshot was not updated.

Almost all production requests materialize `apiKey.Group` from Redis. The omitted bool becomes Go `false`, so official long-context ladders (OpenAI 272k 2x/1.5x, Grok 200k 2x) are silently disabled even when the admin toggle is on.

This is the same class of leak already documented for profit-control fields on `APIKeyAuthGroupSnapshot`.

## Fix

- Copy `LongContextPricingEnabled` through `snapshotFromAPIKey` / `snapshotToAPIKey`
- Bump `apiKeyAuthSnapshotVersion` to 20 so stale entries are evicted
- Add round-trip tests: preserve on/off, evict v19, and show a JSON-omitted flag disables the official ladder

`GetByKeyForAuth` already selected the column; only the cache snapshot was missing.

## Test

```bash
go test ./internal/service -run 'TestAPIKeyAuthSnapshotLongContext|TestAPIKeyAuthSnapshotOldVersionWithoutLongContext|TestAPIKeyAuthSnapshotLongContextRoundtripKeepsOfficialLadder|TestLegacyAuthSnapshotOmittingLongContextFlagDisablesOfficialLadder|TestAPIKeyAuthSnapshotProfitControlRoundtrip'
```