### PR TITLE
fix(ops): avoid single-insert fallback after batch failure

### DIFF
--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -439,17 +439,8 @@ func (s *OpsService) RecordErrorBatch(ctx context.Context, entries []*OpsInsertE
 	}
 
 	if _, err := s.opsRepo.BatchInsertErrorLogs(ctx, prepared); err != nil {
-		log.Printf("[Ops] RecordErrorBatch failed, fallback to single inserts: %v", err)
-		var firstErr error
-		for _, entry := range prepared {
-			if _, insertErr := s.opsRepo.InsertErrorLog(ctx, entry); insertErr != nil {
-				log.Printf("[Ops] RecordErrorBatch fallback insert failed: %v", insertErr)
-				if firstErr == nil {
-					firstErr = insertErr
-				}
-			}
-		}
-		return firstErr
+		log.Printf("[Ops] RecordErrorBatch failed: %v", err)
+		return err
 	}
 	return nil
 }

--- a/backend/internal/service/ops_service_batch_test.go
+++ b/backend/internal/service/ops_service_batch_test.go
@@ -69,7 +69,7 @@ func TestOpsServiceRecordErrorBatch_SanitizesAndBatches(t *testing.T) {
 	require.False(t, second.CreatedAt.IsZero())
 }
 
-func TestOpsServiceRecordErrorBatch_FallsBackToSingleInsert(t *testing.T) {
+func TestOpsServiceRecordErrorBatch_DoesNotFallbackToSingleInsertsWhenBatchFails(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -92,9 +92,9 @@ func TestOpsServiceRecordErrorBatch_FallsBackToSingleInsert(t *testing.T) {
 		{ErrorMessage: "first"},
 		{ErrorMessage: "second"},
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Equal(t, 1, batchCalls)
-	require.Equal(t, 2, singleCalls)
+	require.Zero(t, singleCalls)
 }
 
 func TestOpsServiceRecordErrorPersistsExplicitAccountAuthStatusZero(t *testing.T) {


### PR DESCRIPTION
## Summary

- stop RecordErrorBatch from retrying every entry individually after a failed batch insert
- preserve and return the original batch error
- add regression coverage proving no single-insert amplification occurs

Fixes #2733.

## Testing

- backend unit and integration tests
- golangci-lint and govulncheck
- frontend lint, typecheck, critical tests, and audit checks
- deployment shell checks