### PR TITLE
fix(frontend): isolate AccountsView helper data loading

### DIFF
--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -2454,12 +2454,19 @@ onMounted(async () => {
 
   load()
   loadUpstreamBillingProbeGlobalState()
-  try {
-    const [p, g] = await Promise.all([adminAPI.proxies.getAll(), adminAPI.groups.getAll()])
-    proxies.value = p
-    groups.value = g
-  } catch (error) {
-    console.error('Failed to load proxies/groups:', error)
+  const [proxiesResult, groupsResult] = await Promise.allSettled([
+    adminAPI.proxies.getAll(),
+    adminAPI.groups.getAll()
+  ])
+  if (proxiesResult.status === 'fulfilled') {
+    proxies.value = proxiesResult.value
+  } else {
+    console.error('Failed to load proxies:', proxiesResult.reason)
+  }
+  if (groupsResult.status === 'fulfilled') {
+    groups.value = groupsResult.value
+  } else {
+    console.error('Failed to load groups:', groupsResult.reason)
   }
   window.addEventListener('scroll', handleScroll, true)
   window.addEventListener('resize', handleViewportResize)

--- a/frontend/src/views/admin/__tests__/AccountsView.usageWindowsHint.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.usageWindowsHint.spec.ts
@@ -101,7 +101,10 @@ function mountView() {
         Pagination: true,
         ConfirmDialog: true,
         AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
-        AccountTableFilters: { template: '<div></div>' },
+        AccountTableFilters: {
+          props: ['groups'],
+          template: '<div data-test="account-filters" :data-group-count="groups.length"></div>'
+        },
         AccountBulkActionsBar: true,
         AccountActionMenu: true,
         ImportDataModal: true,
@@ -153,6 +156,16 @@ describe('admin AccountsView usage windows hint', () => {
     getBatchTodayStats.mockResolvedValue({ stats: {} })
     getAllProxies.mockResolvedValue([])
     getAllGroups.mockResolvedValue([])
+  })
+
+  it('keeps groups available when loading proxies fails', async () => {
+    getAllProxies.mockRejectedValue(new Error('proxy service unavailable'))
+    getAllGroups.mockResolvedValue([{ id: 7, name: 'production' }])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="account-filters"]').attributes('data-group-count')).toBe('1')
   })
 
   it('renders an explanatory tooltip next to the usage windows column header', async () => {


### PR DESCRIPTION
## Summary

- load account proxies and groups independently while preserving parallel requests
- keep successfully loaded groups when the proxy request fails
- log proxy and group loading failures separately
- add regression coverage for the partial-failure scenario

Fixes #3917.

## Testing

- frontend lint and typecheck
- critical Vitest suite: 164 tests passed
- production build
- backend unit and integration tests
- golangci-lint and govulncheck