### PR TITLE
fix(gateway): add safe request body read diagnostics

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -142,8 +142,11 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	defer h.maybeLogCompatibilityFallbackMetrics(reqLog)
 
 	// 读取请求体
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return
@@ -1987,8 +1990,11 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 	defer h.maybeLogCompatibilityFallbackMetrics(reqLog)
 
 	// 读取请求体
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -44,8 +44,11 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	)
 
 	// Read request body
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.chatCompletionsErrorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -44,8 +44,11 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	)
 
 	// Read request body
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.responsesErrorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -49,8 +49,11 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		return
 	}
 
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -17,8 +17,12 @@ import (
 // The route middleware already authenticates the API key and resolves the
 // group; this handler intentionally does not select an account or check billing.
 func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
+	reqLog := requestLogger(c, "handler.openai_gateway.grok_count_tokens")
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.anthropicErrorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return
@@ -34,7 +38,7 @@ func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
 	bodyRef := service.NewRequestBodyRef(body)
 	parsedReq, err := service.ParseGatewayRequest(bodyRef, domain.PlatformAnthropic)
 	if err != nil {
-		logRequestBodyParseFailure(requestLogger(c, "handler.openai_gateway.grok_count_tokens"), body, err)
+		logRequestBodyParseFailure(reqLog, body, err)
 		h.anthropicErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return
 	}
@@ -45,7 +49,7 @@ func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
 
 	estimated, err := service.EstimateGrokCountTokens(parsedReq.Body.Bytes())
 	if err != nil {
-		requestLogger(c, "handler.openai_gateway.grok_count_tokens").Warn("grok_count_tokens.local_estimate_failed", zap.Error(err))
+		reqLog.Warn("grok_count_tokens.local_estimate_failed", zap.Error(err))
 		h.anthropicErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return
 	}
@@ -88,8 +92,11 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 		return
 	}
 
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.anthropicErrorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -277,8 +277,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 
 	// Read request body
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return
@@ -938,8 +941,11 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		return
 	}
 
+	bodyReadMetadata := newRequestBodyReadLogContext(c.Request)
+	bodyReadStartedAt := time.Now()
 	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
 	if err != nil {
+		logRequestBodyReadFailure(reqLog, bodyReadMetadata, err, bodyReadStartedAt)
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.anthropicErrorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
 			return

--- a/backend/internal/handler/request_body_read_log.go
+++ b/backend/internal/handler/request_body_read_log.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"go.uber.org/zap"
+)
+
+const requestBodyBytesReadKindRawTransport = "raw_transport"
+
+type requestBodyReadLogContext struct {
+	contentLength    int64
+	contentEncoding  string
+	transferEncoding string
+}
+
+func newRequestBodyReadLogContext(req *http.Request) requestBodyReadLogContext {
+	if req == nil {
+		return requestBodyReadLogContext{
+			contentLength:    -1,
+			contentEncoding:  "identity",
+			transferEncoding: "unknown",
+		}
+	}
+	return requestBodyReadLogContext{
+		contentLength:    req.ContentLength,
+		contentEncoding:  normalizeRequestBodyContentEncoding(req.Header.Get("Content-Encoding")),
+		transferEncoding: normalizeRequestTransferEncoding(req.TransferEncoding, req.ContentLength),
+	}
+}
+
+func normalizeRequestBodyContentEncoding(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "identity":
+		return "identity"
+	case "gzip", "x-gzip":
+		return "gzip"
+	case "zstd":
+		return "zstd"
+	case "deflate":
+		return "deflate"
+	default:
+		return "other"
+	}
+}
+
+func normalizeRequestTransferEncoding(values []string, contentLength int64) string {
+	if len(values) > 0 {
+		if len(values) == 1 && strings.EqualFold(strings.TrimSpace(values[0]), "chunked") {
+			return "chunked"
+		}
+		return "other"
+	}
+	if contentLength >= 0 {
+		return "content_length"
+	}
+	return "unknown"
+}
+
+// logRequestBodyReadFailure records only bounded classifications and request
+// framing metadata. It deliberately omits body bytes, raw header values, and
+// underlying error text; requestLogger already carries the existing request
+// identity context.
+func logRequestBodyReadFailure(reqLog *zap.Logger, metadata requestBodyReadLogContext, err error, startedAt time.Time) {
+	if reqLog == nil {
+		return
+	}
+	diagnostics := pkghttputil.RequestBodyErrorDiagnosticsFromError(err)
+	elapsedMs := time.Since(startedAt).Milliseconds()
+	if elapsedMs < 0 {
+		elapsedMs = 0
+	}
+
+	reqLog.Warn("request body read failed",
+		zap.String("error_stage", diagnostics.Stage),
+		zap.String("error_class", diagnostics.Class),
+		zap.Int64("bytes_read", diagnostics.BytesRead),
+		zap.String("bytes_read_kind", requestBodyBytesReadKindRawTransport),
+		zap.Int64("content_length", metadata.contentLength),
+		zap.String("content_encoding", metadata.contentEncoding),
+		zap.String("transfer_encoding", metadata.transferEncoding),
+		zap.Int64("elapsed_ms", elapsedMs),
+	)
+}

--- a/backend/internal/handler/request_body_read_log_test.go
+++ b/backend/internal/handler/request_body_read_log_test.go
@@ -1,0 +1,391 @@
+package handler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type diagnosticFailingBody struct {
+	payload []byte
+	err     error
+	read    bool
+}
+
+func (r *diagnosticFailingBody) Read(p []byte) (int, error) {
+	if r.read {
+		if r.err == nil {
+			return 0, io.EOF
+		}
+		return 0, r.err
+	}
+	r.read = true
+	return copy(p, r.payload), r.err
+}
+
+func (r *diagnosticFailingBody) Close() error { return nil }
+
+func diagnosticLogFields(t *testing.T, logs *observer.ObservedLogs) (observer.LoggedEntry, map[string]any) {
+	t.Helper()
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	return entries[0], diagnosticFields(entries[0])
+}
+
+func diagnosticFields(entry observer.LoggedEntry) map[string]any {
+	fields := make(map[string]any, len(entry.Context))
+	for _, field := range entry.Context {
+		switch field.Type {
+		case zapcore.StringType:
+			fields[field.Key] = field.String
+		case zapcore.Int64Type:
+			fields[field.Key] = field.Integer
+		default:
+			fields[field.Key] = field.Interface
+		}
+	}
+	return fields
+}
+
+func diagnosticWarnFields(t *testing.T, logs *observer.ObservedLogs) (observer.LoggedEntry, map[string]any) {
+	t.Helper()
+	entries := logs.FilterLevelExact(zap.WarnLevel).All()
+	require.Len(t, entries, 1)
+	return entries[0], diagnosticFields(entries[0])
+}
+
+func requireNoSensitiveDiagnosticData(t *testing.T, entry observer.LoggedEntry, sensitive ...string) {
+	t.Helper()
+	for _, field := range entry.Context {
+		for _, value := range sensitive {
+			require.NotContains(t, field.String, value)
+			if field.Interface != nil {
+				require.NotContains(t, fmt.Sprint(field.Interface), value)
+			}
+		}
+	}
+}
+
+func newDiagnosticLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.DebugLevel)
+	return zap.New(core), logs
+}
+
+func TestGatewayResponses_LogsRequestBodyReadFailureAndKeepsGeneric400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestLogger, logs := newDiagnosticLogger()
+	bodySecret := "anthropic-body-secret"
+	errorSecret := "anthropic-transport-secret"
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	req.Body = &diagnosticFailingBody{payload: []byte(bodySecret), err: errors.New(errorSecret)}
+	req.ContentLength = 123
+	req.Header.Set("Content-Encoding", "untrusted-secret-encoding")
+	req.TransferEncoding = []string{"chunked"}
+	req = req.WithContext(logger.IntoContext(req.Context(), requestLogger))
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = req
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{ID: 7})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 9})
+
+	(&GatewayHandler{}).Responses(c)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "Failed to read request body")
+	entry, fields := diagnosticLogFields(t, logs)
+	require.Equal(t, zap.WarnLevel, entry.Level)
+	require.Equal(t, "request body read failed", entry.Message)
+	require.Equal(t, "transport_read", fields["error_stage"])
+	require.Equal(t, "read_failed", fields["error_class"])
+	require.Equal(t, int64(len(bodySecret)), fields["bytes_read"])
+	require.Equal(t, "raw_transport", fields["bytes_read_kind"])
+	require.Equal(t, int64(123), fields["content_length"])
+	require.Equal(t, "other", fields["content_encoding"])
+	require.Equal(t, "chunked", fields["transfer_encoding"])
+	require.GreaterOrEqual(t, fields["elapsed_ms"].(int64), int64(0))
+	requireNoSensitiveDiagnosticData(t, entry, bodySecret, errorSecret, "untrusted-secret-encoding")
+}
+
+func TestOpenAIResponses_LogsRequestBodyReadFailureAndKeepsGeneric400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestLogger, logs := newDiagnosticLogger()
+	bodySecret := "openai-body-secret"
+	errorSecret := "openai-transport-secret"
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	req.Body = &diagnosticFailingBody{payload: []byte(bodySecret), err: errors.New(errorSecret)}
+	req.ContentLength = -1
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(logger.IntoContext(req.Context(), requestLogger))
+
+	h := newOpenAIReadDiagnosticHandler(t)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = req
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{ID: 8})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 10})
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "Failed to read request body")
+	entry, fields := diagnosticLogFields(t, logs)
+	require.Equal(t, zap.WarnLevel, entry.Level)
+	require.Equal(t, "request body read failed", entry.Message)
+	require.Equal(t, "transport_read", fields["error_stage"])
+	require.Equal(t, "read_failed", fields["error_class"])
+	require.Equal(t, int64(len(bodySecret)), fields["bytes_read"])
+	require.Equal(t, "raw_transport", fields["bytes_read_kind"])
+	require.Equal(t, int64(-1), fields["content_length"])
+	require.Equal(t, "gzip", fields["content_encoding"])
+	require.Equal(t, "unknown", fields["transfer_encoding"])
+	require.GreaterOrEqual(t, fields["elapsed_ms"].(int64), int64(0))
+	requireNoSensitiveDiagnosticData(t, entry, bodySecret, errorSecret)
+}
+
+func TestGatewayResponses_LogsCorruptedGzipAsDecompressionFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestLogger, logs := newDiagnosticLogger()
+	var compressed bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressed)
+	_, err := gzipWriter.Write([]byte("compressed-body-secret"))
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+	corrupted := compressed.Bytes()[:compressed.Len()-1]
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	req.Body = &diagnosticFailingBody{payload: corrupted, err: nil}
+	req.ContentLength = int64(len(corrupted))
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(logger.IntoContext(req.Context(), requestLogger))
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = req
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{ID: 11})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 12})
+
+	(&GatewayHandler{}).Responses(c)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "Failed to read request body")
+	entry, fields := diagnosticLogFields(t, logs)
+	require.Equal(t, "decompress", fields["error_stage"])
+	require.Equal(t, "decompression_failed", fields["error_class"])
+	require.Equal(t, int64(len(corrupted)), fields["bytes_read"])
+	require.Equal(t, "raw_transport", fields["bytes_read_kind"])
+	require.Equal(t, int64(len(corrupted)), fields["content_length"])
+	require.Equal(t, "gzip", fields["content_encoding"])
+	require.Equal(t, "content_length", fields["transfer_encoding"])
+	requireNoSensitiveDiagnosticData(t, entry, "compressed-body-secret")
+}
+
+func TestLogRequestBodyReadFailure_UsesSafeFramingValues(t *testing.T) {
+	requestLogger, logs := newDiagnosticLogger()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	req.ContentLength = -1
+	req.Header.Set("Content-Encoding", "gzip, secret-header-value")
+	req.TransferEncoding = []string{"secret-transfer-value"}
+
+	logRequestBodyReadFailure(
+		requestLogger,
+		newRequestBodyReadLogContext(req),
+		errors.New("raw-error-secret"),
+		time.Now().Add(-time.Millisecond),
+	)
+
+	entry, fields := diagnosticLogFields(t, logs)
+	require.Equal(t, "transport_read", fields["error_stage"])
+	require.Equal(t, "read_failed", fields["error_class"])
+	require.Equal(t, int64(0), fields["bytes_read"])
+	require.Equal(t, "raw_transport", fields["bytes_read_kind"])
+	require.Equal(t, int64(-1), fields["content_length"])
+	require.Equal(t, "other", fields["content_encoding"])
+	require.Equal(t, "other", fields["transfer_encoding"])
+	requireNoSensitiveDiagnosticData(t, entry, "secret-header-value", "secret-transfer-value", "raw-error-secret")
+}
+
+func TestRequestBodyReadFailureDiagnosticsCoverHighRelevanceEndpoints(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name   string
+		path   string
+		invoke func(*testing.T, *gin.Context)
+	}{
+		{
+			name: "gateway messages",
+			path: "/v1/messages",
+			invoke: func(_ *testing.T, c *gin.Context) {
+				(&GatewayHandler{}).Messages(c)
+			},
+		},
+		{
+			name: "gateway chat completions",
+			path: "/v1/chat/completions",
+			invoke: func(_ *testing.T, c *gin.Context) {
+				(&GatewayHandler{}).ChatCompletions(c)
+			},
+		},
+		{
+			name: "gateway count tokens",
+			path: "/v1/messages/count_tokens",
+			invoke: func(_ *testing.T, c *gin.Context) {
+				(&GatewayHandler{}).CountTokens(c)
+			},
+		},
+		{
+			name: "openai messages",
+			path: "/v1/messages",
+			invoke: func(t *testing.T, c *gin.Context) {
+				newOpenAIReadDiagnosticHandler(t).Messages(c)
+			},
+		},
+		{
+			name: "openai chat completions",
+			path: "/openai/v1/chat/completions",
+			invoke: func(t *testing.T, c *gin.Context) {
+				newOpenAIReadDiagnosticHandler(t).ChatCompletions(c)
+			},
+		},
+		{
+			name: "openai grok count tokens",
+			path: "/v1/messages/count_tokens",
+			invoke: func(t *testing.T, c *gin.Context) {
+				newOpenAIReadDiagnosticHandler(t).GrokCountTokens(c)
+			},
+		},
+		{
+			name: "openai count tokens",
+			path: "/v1/messages/count_tokens",
+			invoke: func(t *testing.T, c *gin.Context) {
+				newOpenAIReadDiagnosticHandler(t).CountTokens(c)
+			},
+		},
+	}
+
+	failures := []struct {
+		name           string
+		err            error
+		status         int
+		class          string
+		responseString string
+	}{
+		{
+			name:           "generic 400",
+			err:            errors.New("high-relevance-raw-error-secret"),
+			status:         http.StatusBadRequest,
+			class:          "read_failed",
+			responseString: "Failed to read request body",
+		},
+		{
+			name:           "max bytes 413",
+			err:            &http.MaxBytesError{Limit: 4},
+			status:         http.StatusRequestEntityTooLarge,
+			class:          "body_too_large",
+			responseString: "Request body too large",
+		},
+	}
+
+	for _, tt := range tests {
+		for _, failure := range failures {
+			t.Run(tt.name+"/"+failure.name, func(t *testing.T) {
+				requestLogger, logs := newDiagnosticLogger()
+				bodySecret := "high-relevance-body-secret"
+				errorSecret := "high-relevance-raw-error-secret"
+				req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+				req.Body = &diagnosticFailingBody{payload: []byte(bodySecret), err: failure.err}
+				req.ContentLength = int64(len(bodySecret) + 3)
+				req.Header.Set("Content-Encoding", "gzip")
+				req.TransferEncoding = []string{"chunked"}
+				req = req.WithContext(logger.IntoContext(req.Context(), requestLogger))
+
+				recorder := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(recorder)
+				c.Request = req
+				c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{ID: 17})
+				c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 19})
+
+				tt.invoke(t, c)
+
+				require.Equal(t, failure.status, recorder.Code)
+				require.Contains(t, recorder.Body.String(), failure.responseString)
+				require.NotContains(t, recorder.Body.String(), bodySecret)
+				require.NotContains(t, recorder.Body.String(), errorSecret)
+
+				entry, fields := diagnosticWarnFields(t, logs)
+				require.Equal(t, zap.WarnLevel, entry.Level)
+				require.Equal(t, "request body read failed", entry.Message)
+				require.Equal(t, "transport_read", fields["error_stage"])
+				require.Equal(t, failure.class, fields["error_class"])
+				require.Equal(t, int64(len(bodySecret)), fields["bytes_read"])
+				require.Equal(t, "raw_transport", fields["bytes_read_kind"])
+				require.Equal(t, int64(len(bodySecret)+3), fields["content_length"])
+				require.Equal(t, "gzip", fields["content_encoding"])
+				require.Equal(t, "chunked", fields["transfer_encoding"])
+				require.GreaterOrEqual(t, fields["elapsed_ms"].(int64), int64(0))
+				requireNoSensitiveDiagnosticData(t, entry, bodySecret, errorSecret)
+			})
+		}
+	}
+}
+
+func newOpenAIReadDiagnosticHandler(t *testing.T) *OpenAIGatewayHandler {
+	t.Helper()
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	concurrencyService := service.NewConcurrencyService(nil)
+	billingCacheService := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCacheService.Stop)
+	apiKeyService := service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg)
+	gatewayService := service.NewOpenAIGatewayService(
+		nil, // accountRepo
+		nil, // usageLogRepo
+		nil, // usageBillingRepo
+		nil, // userRepo
+		nil, // userSubRepo
+		nil, // userGroupRateRepo
+		nil, // cache
+		cfg,
+		nil, // schedulerSnapshot
+		concurrencyService,
+		nil, // billingService
+		nil, // rateLimitService
+		billingCacheService,
+		nil, // httpUpstream
+		nil, // deferredService
+		nil, // openAITokenProvider
+		nil, // grokTokenProvider
+		nil, // resolver
+		nil, // channelService
+		nil, // balanceNotifyService
+		nil, // settingService
+		nil, // userPlatformQuotaRepo
+	)
+	return NewOpenAIGatewayHandler(
+		gatewayService,
+		concurrencyService,
+		billingCacheService,
+		apiKeyService,
+		nil,
+		nil,
+		nil,
+		nil,
+		cfg,
+	)
+}

--- a/backend/internal/pkg/httputil/body.go
+++ b/backend/internal/pkg/httputil/body.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -22,12 +23,138 @@ const (
 	maxDecompressedBodySize = 64 << 20
 )
 
+const (
+	requestBodyErrorStageTransportRead = "transport_read"
+	requestBodyErrorStageDecompress    = "decompress"
+	requestBodyErrorStageNormalize     = "normalize"
+
+	requestBodyErrorClassBodyTooLarge     = "body_too_large"
+	requestBodyErrorClassUnexpectedEOF    = "unexpected_eof"
+	requestBodyErrorClassConnectionReset  = "connection_reset"
+	requestBodyErrorClassContextCanceled  = "context_canceled"
+	requestBodyErrorClassDeadlineExceeded = "deadline_exceeded"
+	requestBodyErrorClassUnsupported      = "unsupported_encoding"
+	requestBodyErrorClassDecompression    = "decompression_failed"
+	requestBodyErrorClassNormalization    = "normalization_failed"
+	requestBodyErrorClassReadFailed       = "read_failed"
+)
+
+var errUnsupportedContentEncoding = errors.New("unsupported content encoding")
+
+// RequestBodyErrorDiagnostics is the bounded, non-sensitive classification of a
+// request body read failure.
+type RequestBodyErrorDiagnostics struct {
+	Stage string
+	Class string
+	// BytesRead always counts raw transport bytes consumed before decompression
+	// or normalization; it is never the decompressed or normalized length.
+	BytesRead int64
+}
+
+// RequestBodyErrorDiagnosticsFromError extracts safe diagnostics without
+// exposing the wrapped error text. Unwrapped errors use conservative defaults.
+func RequestBodyErrorDiagnosticsFromError(err error) RequestBodyErrorDiagnostics {
+	defaultDiagnostics := RequestBodyErrorDiagnostics{
+		Stage:     requestBodyErrorStageTransportRead,
+		Class:     requestBodyErrorClassReadFailed,
+		BytesRead: 0,
+	}
+
+	var diagnosticErr *requestBodyDiagnosticError
+	if errors.As(err, &diagnosticErr) && diagnosticErr != nil {
+		return diagnosticErr.diagnostics
+	}
+	return defaultDiagnostics
+}
+
+type requestBodyDiagnosticError struct {
+	diagnostics RequestBodyErrorDiagnostics
+	err         error
+}
+
+func (e *requestBodyDiagnosticError) Error() string {
+	if e == nil {
+		return "request body operation failed"
+	}
+	switch e.diagnostics.Stage {
+	case requestBodyErrorStageDecompress:
+		return "request body decompression failed"
+	case requestBodyErrorStageNormalize:
+		return "request body normalization failed"
+	default:
+		return "request body read failed"
+	}
+}
+
+func (e *requestBodyDiagnosticError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newRequestBodyDiagnosticError(stage string, bytesRead int64, err error) error {
+	if err == nil {
+		return nil
+	}
+	if bytesRead < 0 {
+		bytesRead = 0
+	}
+	return &requestBodyDiagnosticError{
+		diagnostics: RequestBodyErrorDiagnostics{
+			Stage:     stage,
+			Class:     classifyRequestBodyError(stage, err),
+			BytesRead: bytesRead,
+		},
+		err: err,
+	}
+}
+
+func classifyRequestBodyError(stage string, err error) string {
+	switch stage {
+	case requestBodyErrorStageTransportRead:
+		var maxErr *http.MaxBytesError
+		switch {
+		case errors.As(err, &maxErr):
+			return requestBodyErrorClassBodyTooLarge
+		case errors.Is(err, context.Canceled):
+			return requestBodyErrorClassContextCanceled
+		case errors.Is(err, context.DeadlineExceeded):
+			return requestBodyErrorClassDeadlineExceeded
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			return requestBodyErrorClassUnexpectedEOF
+		case errors.Is(err, syscall.ECONNRESET):
+			return requestBodyErrorClassConnectionReset
+		default:
+			return requestBodyErrorClassReadFailed
+		}
+	case requestBodyErrorStageDecompress:
+		if errors.Is(err, errUnsupportedContentEncoding) {
+			return requestBodyErrorClassUnsupported
+		}
+		return requestBodyErrorClassDecompression
+	case requestBodyErrorStageNormalize:
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return requestBodyErrorClassBodyTooLarge
+		}
+		return requestBodyErrorClassNormalization
+	default:
+		return requestBodyErrorClassReadFailed
+	}
+}
+
 // ReadRequestBodyWithPrealloc reads request body with preallocated buffer based
 // on content length, transparently decoding any Content-Encoding the upstream
 // client used to compress the body (zstd, gzip, deflate).
 func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
+	body, _, err := readRequestBodyWithPrealloc(req)
+	return body, err
+}
+
+func readRequestBodyWithPrealloc(req *http.Request) ([]byte, int64, error) {
 	if req == nil || req.Body == nil {
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	capHint := requestBodyReadInitCap
@@ -43,36 +170,42 @@ func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, capHint))
-	if _, err := io.Copy(buf, req.Body); err != nil {
-		return nil, err
+	n, err := io.Copy(buf, req.Body)
+	if err != nil {
+		return nil, n, newRequestBodyDiagnosticError(requestBodyErrorStageTransportRead, n, err)
 	}
 	raw := buf.Bytes()
+	rawBytesRead := int64(len(raw))
 
 	enc := strings.ToLower(strings.TrimSpace(req.Header.Get("Content-Encoding")))
 	if enc == "" || enc == "identity" {
-		return raw, nil
+		return raw, rawBytesRead, nil
 	}
 
 	decoded, err := decompressRequestBody(enc, raw)
 	if err != nil {
-		return nil, fmt.Errorf("decode Content-Encoding %q: %w", enc, err)
+		return nil, rawBytesRead, newRequestBodyDiagnosticError(requestBodyErrorStageDecompress, rawBytesRead, err)
 	}
 
 	req.Header.Del("Content-Encoding")
 	req.Header.Del("Content-Length")
 	req.ContentLength = int64(len(decoded))
 
-	return decoded, nil
+	return decoded, rawBytesRead, nil
 }
 
 // ReadLenientJSONRequestBodyWithPrealloc reads a request body and normalizes
 // JSON string control bytes before strict validation.
 func ReadLenientJSONRequestBodyWithPrealloc(req *http.Request, maxNormalizedBytes int64) ([]byte, error) {
-	body, err := ReadRequestBodyWithPrealloc(req)
+	body, rawBytesRead, err := readRequestBodyWithPrealloc(req)
 	if err != nil {
 		return nil, err
 	}
-	return NormalizeLenientJSONRequestBody(body, maxNormalizedBytes)
+	normalized, err := NormalizeLenientJSONRequestBody(body, maxNormalizedBytes)
+	if err != nil {
+		return nil, newRequestBodyDiagnosticError(requestBodyErrorStageNormalize, rawBytesRead, err)
+	}
+	return normalized, nil
 }
 
 func decompressRequestBody(encoding string, raw []byte) ([]byte, error) {
@@ -99,7 +232,7 @@ func decompressRequestBody(encoding string, raw []byte) ([]byte, error) {
 		defer func() { _ = zr.Close() }()
 		return io.ReadAll(io.LimitReader(zr, maxDecompressedBodySize))
 	default:
-		return nil, errors.New("unsupported Content-Encoding")
+		return nil, errUnsupportedContentEncoding
 	}
 }
 

--- a/backend/internal/pkg/httputil/body_test.go
+++ b/backend/internal/pkg/httputil/body_test.go
@@ -4,14 +4,35 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
-	"strings"
+	"net/http/httptest"
+	"syscall"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
 )
 
 const samplePayload = `{"model":"gpt-5.5","input":"hi","stream":false}`
+
+type fixedErrorBody struct {
+	payload []byte
+	err     error
+	read    bool
+}
+
+func (r *fixedErrorBody) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, r.err
+	}
+	r.read = true
+	return copy(p, r.payload), r.err
+}
+
+func (r *fixedErrorBody) Close() error { return nil }
 
 func newRequestWithBody(t *testing.T, body []byte, encoding string) *http.Request {
 	t.Helper()
@@ -99,13 +120,21 @@ func TestReadRequestBodyWithPrealloc_DecodesDeflate(t *testing.T) {
 }
 
 func TestReadRequestBodyWithPrealloc_RejectsUnsupportedEncoding(t *testing.T) {
-	req := newRequestWithBody(t, []byte(samplePayload), "br")
+	const unsafeEncoding = "secret-unsupported-encoding"
+	req := newRequestWithBody(t, []byte(samplePayload), unsafeEncoding)
 	_, err := ReadRequestBodyWithPrealloc(req)
 	if err == nil {
 		t.Fatal("expected error for unsupported encoding, got nil")
 	}
-	if !strings.Contains(err.Error(), "br") {
-		t.Fatalf("error should mention encoding, got %v", err)
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Stage != requestBodyErrorStageDecompress {
+		t.Fatalf("stage mismatch: got %q", diagnostics.Stage)
+	}
+	if diagnostics.Class != requestBodyErrorClassUnsupported {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+	if got := err.Error(); got != "request body decompression failed" {
+		t.Fatalf("unexpected unsafe error text: %q", got)
 	}
 }
 
@@ -140,4 +169,202 @@ func TestReadRequestBodyWithPrealloc_RespectsIdentityEncoding(t *testing.T) {
 	if string(got) != samplePayload {
 		t.Fatalf("body mismatch: got %q", got)
 	}
+}
+
+func TestReadRequestBodyWithPrealloc_ReportsTransportUnexpectedEOF(t *testing.T) {
+	payload := []byte("partial-body")
+	req := newRequestWithBody(t, nil, "")
+	req.Body = &fixedErrorBody{payload: payload, err: io.ErrUnexpectedEOF}
+	req.ContentLength = int64(len(payload) + 4)
+
+	_, err := ReadRequestBodyWithPrealloc(req)
+	if err == nil {
+		t.Fatal("expected transport read error, got nil")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("errors.Is did not preserve unexpected EOF: %v", err)
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Stage != requestBodyErrorStageTransportRead {
+		t.Fatalf("stage mismatch: got %q", diagnostics.Stage)
+	}
+	if diagnostics.Class != requestBodyErrorClassUnexpectedEOF {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+	if diagnostics.BytesRead != int64(len(payload)) {
+		t.Fatalf("bytes mismatch: got %d want %d", diagnostics.BytesRead, len(payload))
+	}
+}
+
+func TestReadRequestBodyWithPrealloc_ReportsWrappedConnectionReset(t *testing.T) {
+	payload := []byte("partial-body")
+	resetErr := fmt.Errorf("transport detail: %w", syscall.ECONNRESET)
+	req := newRequestWithBody(t, nil, "")
+	req.Body = &fixedErrorBody{payload: payload, err: resetErr}
+	req.ContentLength = int64(len(payload) + 4)
+
+	_, err := ReadRequestBodyWithPrealloc(req)
+	if err == nil {
+		t.Fatal("expected transport read error, got nil")
+	}
+	if !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("errors.Is did not preserve connection reset: %v", err)
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Class != requestBodyErrorClassConnectionReset {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+	if diagnostics.BytesRead != int64(len(payload)) {
+		t.Fatalf("bytes mismatch: got %d want %d", diagnostics.BytesRead, len(payload))
+	}
+}
+
+func TestReadRequestBodyWithPrealloc_ReportsContextCancellation(t *testing.T) {
+	payload := []byte("partial-body")
+	req := newRequestWithBody(t, nil, "")
+	req.Body = &fixedErrorBody{payload: payload, err: fmt.Errorf("read canceled: %w", context.Canceled)}
+
+	_, err := ReadRequestBodyWithPrealloc(req)
+	if err == nil {
+		t.Fatal("expected transport read error, got nil")
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Class != requestBodyErrorClassContextCanceled {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+}
+
+func TestReadRequestBodyWithPrealloc_ReportsDeadlineExceeded(t *testing.T) {
+	payload := []byte("partial-body")
+	req := newRequestWithBody(t, nil, "")
+	req.Body = &fixedErrorBody{payload: payload, err: fmt.Errorf("deadline reached: %w", context.DeadlineExceeded)}
+
+	_, err := ReadRequestBodyWithPrealloc(req)
+	if err == nil {
+		t.Fatal("expected transport read error, got nil")
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Class != requestBodyErrorClassDeadlineExceeded {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+}
+
+func TestReadRequestBodyWithPrealloc_ReportsTruncatedCompressedBodies(t *testing.T) {
+	for _, encoding := range []string{"gzip", "zstd", "deflate"} {
+		t.Run(encoding, func(t *testing.T) {
+			compressed := compressedPayload(t, encoding)
+			if len(compressed) < 2 {
+				t.Fatal("compressed payload is too short to truncate")
+			}
+			corrupted := compressed[:len(compressed)-1]
+			req := newRequestWithBody(t, corrupted, encoding)
+
+			_, err := ReadRequestBodyWithPrealloc(req)
+			if err == nil {
+				t.Fatal("expected decompression error, got nil")
+			}
+			diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+			if diagnostics.Stage != requestBodyErrorStageDecompress {
+				t.Fatalf("stage mismatch: got %q", diagnostics.Stage)
+			}
+			if diagnostics.Class != requestBodyErrorClassDecompression {
+				t.Fatalf("class mismatch: got %q", diagnostics.Class)
+			}
+			if diagnostics.BytesRead != int64(len(corrupted)) {
+				t.Fatalf("bytes mismatch: got %d want %d", diagnostics.BytesRead, len(corrupted))
+			}
+		})
+	}
+}
+
+func TestReadLenientJSONRequestBodyWithPrealloc_WrapsNormalizationFailure(t *testing.T) {
+	payload := []byte("{\"input\":\"\x00\"}")
+	req := newRequestWithBody(t, payload, "")
+
+	_, err := ReadLenientJSONRequestBodyWithPrealloc(req, int64(len(payload)+4))
+	if err == nil {
+		t.Fatal("expected normalization size error, got nil")
+	}
+	var maxErr *http.MaxBytesError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("expected MaxBytesError through diagnostic wrapper, got %T %v", err, err)
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Stage != requestBodyErrorStageNormalize {
+		t.Fatalf("stage mismatch: got %q", diagnostics.Stage)
+	}
+	if diagnostics.Class != requestBodyErrorClassBodyTooLarge {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+	if diagnostics.BytesRead != int64(len(payload)) {
+		t.Fatalf("bytes mismatch: got %d want %d", diagnostics.BytesRead, len(payload))
+	}
+}
+
+func TestReadRequestBodyWithPrealloc_MaxBytesErrorKeepsClassification(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req := newRequestWithBody(t, []byte("12345678"), "")
+	req.Body = http.MaxBytesReader(recorder, req.Body, 4)
+
+	_, err := ReadRequestBodyWithPrealloc(req)
+	if err == nil {
+		t.Fatal("expected MaxBytesError, got nil")
+	}
+	var maxErr *http.MaxBytesError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("expected MaxBytesError through diagnostic wrapper, got %T %v", err, err)
+	}
+	diagnostics := RequestBodyErrorDiagnosticsFromError(err)
+	if diagnostics.Class != requestBodyErrorClassBodyTooLarge {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+}
+
+func TestRequestBodyErrorDiagnosticsFromError_DefaultsForUnwrappedError(t *testing.T) {
+	diagnostics := RequestBodyErrorDiagnosticsFromError(errors.New("raw secret error"))
+	if diagnostics.Stage != requestBodyErrorStageTransportRead {
+		t.Fatalf("stage mismatch: got %q", diagnostics.Stage)
+	}
+	if diagnostics.Class != requestBodyErrorClassReadFailed {
+		t.Fatalf("class mismatch: got %q", diagnostics.Class)
+	}
+	if diagnostics.BytesRead != 0 {
+		t.Fatalf("bytes mismatch: got %d", diagnostics.BytesRead)
+	}
+}
+
+func compressedPayload(t *testing.T, encoding string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	switch encoding {
+	case "gzip":
+		writer := gzip.NewWriter(&buf)
+		if _, err := writer.Write([]byte(samplePayload)); err != nil {
+			t.Fatalf("gzip write: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+	case "zstd":
+		writer, err := zstd.NewWriter(nil)
+		if err != nil {
+			t.Fatalf("zstd writer: %v", err)
+		}
+		compressed := writer.EncodeAll([]byte(samplePayload), nil)
+		if err := writer.Close(); err != nil {
+			t.Fatalf("zstd close: %v", err)
+		}
+		return compressed
+	case "deflate":
+		writer := zlib.NewWriter(&buf)
+		if _, err := writer.Write([]byte(samplePayload)); err != nil {
+			t.Fatalf("deflate write: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("deflate close: %v", err)
+		}
+	default:
+		t.Fatalf("unsupported test encoding %q", encoding)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
## Background

We encountered an OpenCode/Codex request that reached `/v1/responses` but failed with HTTP 400 `Failed to read request body` before model parsing or upstream forwarding.

The client-facing response is intentionally generic, but the server logs did not preserve enough bounded context to identify where the failure occurred. In practice, the same response could represent very different problems:

- an incomplete or truncated request body (`unexpected EOF`)
- a client or reverse-proxy connection reset while uploading the body
- request cancellation or deadline expiration
- a truncated or corrupted gzip, zstd, or deflate frame
- an unsupported `Content-Encoding`
- the configured request-size limit being exceeded
- failure while normalizing the decoded JSON body

Without the read stage, failure category, consumed byte count, and normalized framing metadata, operators cannot distinguish a transport interruption from a compression problem or a size-limit rejection. There is also no upstream response to inspect because these failures happen before forwarding.

## Why this change

This change keeps the existing safe 400/413 responses while adding enough server-side evidence to diagnose request-body failures. It deliberately avoids logging request contents, raw header values, authentication data, or underlying error strings.

The diagnostics cover the high-relevance endpoints used by OpenCode/Codex clients:

- Responses
- Messages
- Chat Completions
- token-counting endpoints

Both OpenAI and compatible gateway handlers use the same bounded diagnostic format, so the same failure can be compared across protocol entry points.

## Summary

- Preserve request-body read failures as typed, unwrap-compatible diagnostics across transport reads, decompression, and JSON normalization.
- Emit one bounded warning with failure stage/class, raw payload bytes consumed by the helper, normalized framing metadata, and elapsed time.
- Keep existing 400/413 client responses unchanged.
- Preserve `errors.Is` / `errors.As` behavior, including `http.MaxBytesError` extraction.

## Diagnostic fields

- `error_stage`: `transport_read`, `decompress`, or `normalize`
- `error_class`: bounded category such as `unexpected_eof`, `connection_reset`, `body_too_large`, or `decompression_failed`
- `bytes_read`: bytes consumed from the request body before this helper performs decompression or normalization
- `bytes_read_kind`: `raw_transport`
- `content_length`: declared request content length
- `content_encoding`: normalized to `identity`, `gzip`, `zstd`, `deflate`, or `other`
- `transfer_encoding`: normalized to `content_length`, `chunked`, `other`, or `unknown`
- `elapsed_ms`: time spent before the body-read failure was reported

## Example

Before this change, both a truncated upload and a corrupted gzip body result in the same client response with no actionable server-side distinction:

```text
HTTP 400: Failed to read request body
```

After this change, the client response remains the same, while logs can distinguish cases such as:

```text
error_stage=transport_read error_class=unexpected_eof
```

and:

```text
error_stage=decompress error_class=decompression_failed content_encoding=gzip
```

## Verification

- `go test ./internal/pkg/httputil -count=1`
- Focused request-body diagnostics handler tests
- `go test ./internal/handler -count=1`
- `gofmt`
- `git diff --check`

Tests cover partial reads, bounded error classification, gzip/zstd/deflate truncation, 400/413 compatibility, and exclusion of body data, raw header values, and underlying error text from logs.

## Scope and known limits

This does not change request-size limits, successful request processing, decompression algorithms, or client-facing error payloads. A real proxy connection reset was not reproduced end to end; transport failures are covered with injected reader errors.

The change focuses on the OpenCode/Codex request paths listed above. Other request-body readers and the existing 64 MiB decompression `LimitReader` behavior remain separate follow-ups.