### PR TITLE
fix(gemini): support includeServerSideToolInvocations in GeminiToolConfig

### DIFF
--- a/backend/internal/pkg/antigravity/gemini_types.go
+++ b/backend/internal/pkg/antigravity/gemini_types.go
@@ -112,7 +112,8 @@ type GeminiImageSearch struct {
 
 // GeminiToolConfig Gemini 工具配置
 type GeminiToolConfig struct {
-	FunctionCallingConfig *GeminiFunctionCallingConfig `json:"functionCallingConfig,omitempty"`
+	FunctionCallingConfig            *GeminiFunctionCallingConfig `json:"functionCallingConfig,omitempty"`
+	IncludeServerSideToolInvocations *bool                        `json:"includeServerSideToolInvocations,omitempty"`
 }
 
 // GeminiFunctionCallingConfig 函数调用配置

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -156,6 +156,13 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 				Mode: "VALIDATED",
 			},
 		}
+		// 内置工具（googleSearch）与函数调用混用时，上游要求显式开启
+		// includeServerSideToolInvocations，否则返回 400（issue #5709）。
+		// 与 raw 透传路的 enableMixedGeminiToolInvocations 注入保持同一语义。
+		if hasMixedToolInvocations(tools) {
+			enabled := true
+			innerRequest.ToolConfig.IncludeServerSideToolInvocations = &enabled
+		}
 	}
 
 	if systemInstruction != nil {
@@ -701,6 +708,21 @@ func isWebSearchTool(tool ClaudeTool) bool {
 	default:
 		return false
 	}
+}
+
+// hasMixedToolInvocations 判断构建后的工具声明是否同时包含函数声明与内置工具
+// （googleSearch）。仅在两者并存时需要开启 includeServerSideToolInvocations。
+func hasMixedToolInvocations(declarations []GeminiToolDeclaration) bool {
+	hasFunc, hasBuiltin := false, false
+	for _, d := range declarations {
+		if len(d.FunctionDeclarations) > 0 {
+			hasFunc = true
+		}
+		if d.GoogleSearch != nil {
+			hasBuiltin = true
+		}
+	}
+	return hasFunc && hasBuiltin
 }
 
 // buildTools 构建 tools

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -565,3 +565,27 @@ func TestTransformClaudeToGeminiWithOptions_PreservesWebSearchAlongsideFunctions
 	require.Equal(t, "get_weather", req.Request.Tools[0].FunctionDeclarations[0].Name)
 	require.NotNil(t, req.Request.Tools[1].GoogleSearch)
 }
+
+func TestGeminiToolConfig_IncludeServerSideToolInvocations(t *testing.T) {
+	t.Run("serialize and deserialize toolConfig with includeServerSideToolInvocations", func(t *testing.T) {
+		trueVal := true
+		cfg := GeminiToolConfig{
+			FunctionCallingConfig: &GeminiFunctionCallingConfig{
+				Mode: "VALIDATED",
+			},
+			IncludeServerSideToolInvocations: &trueVal,
+		}
+
+		data, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"includeServerSideToolInvocations":true`)
+
+		var decoded GeminiToolConfig
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		require.NotNil(t, decoded.IncludeServerSideToolInvocations)
+		require.True(t, *decoded.IncludeServerSideToolInvocations)
+		require.Equal(t, "VALIDATED", decoded.FunctionCallingConfig.Mode)
+	})
+}
+

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -567,25 +567,57 @@ func TestTransformClaudeToGeminiWithOptions_PreservesWebSearchAlongsideFunctions
 }
 
 func TestGeminiToolConfig_IncludeServerSideToolInvocations(t *testing.T) {
-	t.Run("serialize and deserialize toolConfig with includeServerSideToolInvocations", func(t *testing.T) {
-		trueVal := true
-		cfg := GeminiToolConfig{
-			FunctionCallingConfig: &GeminiFunctionCallingConfig{
-				Mode: "VALIDATED",
+	functionTool := ClaudeTool{
+		Name:        "get_weather",
+		Description: "Get weather information",
+		InputSchema: map[string]any{"type": "object"},
+	}
+	webSearchTool := ClaudeTool{
+		Type: "web_search_20250305",
+		Name: "web_search",
+	}
+
+	transform := func(t *testing.T, tools []ClaudeTool) (V1InternalRequest, string) {
+		t.Helper()
+		body, err := TransformClaudeToGeminiWithOptions(&ClaudeRequest{
+			Model: "claude-3-5-sonnet-latest",
+			Messages: []ClaudeMessage{
+				{
+					Role:    "user",
+					Content: json.RawMessage(`[{"type":"text","text":"hello"}]`),
+				},
 			},
-			IncludeServerSideToolInvocations: &trueVal,
-		}
-
-		data, err := json.Marshal(cfg)
+			Tools: tools,
+		}, "project-1", "gemini-2.5-flash", DefaultTransformOptions())
 		require.NoError(t, err)
-		require.Contains(t, string(data), `"includeServerSideToolInvocations":true`)
 
-		var decoded GeminiToolConfig
-		err = json.Unmarshal(data, &decoded)
-		require.NoError(t, err)
-		require.NotNil(t, decoded.IncludeServerSideToolInvocations)
-		require.True(t, *decoded.IncludeServerSideToolInvocations)
-		require.Equal(t, "VALIDATED", decoded.FunctionCallingConfig.Mode)
+		var req V1InternalRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		return req, string(body)
+	}
+
+	t.Run("mixed builtin and function tools enable server-side tool invocations", func(t *testing.T) {
+		req, raw := transform(t, []ClaudeTool{functionTool, webSearchTool})
+
+		require.NotNil(t, req.Request.ToolConfig)
+		require.NotNil(t, req.Request.ToolConfig.IncludeServerSideToolInvocations)
+		require.True(t, *req.Request.ToolConfig.IncludeServerSideToolInvocations)
+		require.Contains(t, raw, `"includeServerSideToolInvocations":true`)
+	})
+
+	t.Run("function tools only leave the flag unset", func(t *testing.T) {
+		req, raw := transform(t, []ClaudeTool{functionTool})
+
+		require.NotNil(t, req.Request.ToolConfig)
+		require.Nil(t, req.Request.ToolConfig.IncludeServerSideToolInvocations)
+		require.NotContains(t, raw, "includeServerSideToolInvocations")
+	})
+
+	t.Run("web search only leaves the flag unset", func(t *testing.T) {
+		req, raw := transform(t, []ClaudeTool{webSearchTool})
+
+		require.NotNil(t, req.Request.ToolConfig)
+		require.Nil(t, req.Request.ToolConfig.IncludeServerSideToolInvocations)
+		require.NotContains(t, raw, "includeServerSideToolInvocations")
 	})
 }
-


### PR DESCRIPTION
## Summary
- Add `IncludeServerSideToolInvocations` field to `GeminiToolConfig` to prevent dropping client tool settings during request serialization and forwarding.
- Fix HTTP 400 (`Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling.`) when mixing built-in tools (e.g. Google Search) with function calling on Gemini 3.6/3.7 models.

## Changes
- `backend/internal/pkg/antigravity/gemini_types.go`: Added `IncludeServerSideToolInvocations *bool` with `json:"includeServerSideToolInvocations,omitempty"` to `GeminiToolConfig`.
- `backend/internal/pkg/antigravity/request_transformer_test.go`: Added `TestGeminiToolConfig_IncludeServerSideToolInvocations` covering serialization and deserialization preservation.

## Verification
```bash
go test -v ./internal/pkg/antigravity/...
```
All tests pass.

Closes #5709