### PR TITLE
fix(billing): record matching interval billing tier in token usage logs

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -164,6 +164,7 @@ type CostBreakdown struct {
 	TotalCost                 float64
 	ActualCost                float64 // 应用倍率后的实际费用
 	BillingMode               string  // 计费模式（"token"/"per_request"/"image"），由 CalculateCostUnified 填充
+	BillingTier               string  // 计费档位标签（如 token 区间标签或 per_request 档位）
 	LongContextBillingApplied bool
 }
 
@@ -1091,7 +1092,7 @@ func (s *BillingService) CalculateCostUnified(input CostInput) (*CostBreakdown, 
 func (s *BillingService) calculateTokenCost(resolved *ResolvedPricing, input CostInput) (*CostBreakdown, error) {
 	totalContext := input.Tokens.InputTokens + input.Tokens.CacheCreationTokens + input.Tokens.CacheReadTokens
 
-	pricing := input.Resolver.GetIntervalPricing(resolved, totalContext)
+	pricing, tier := input.Resolver.GetIntervalPricingWithTier(resolved, totalContext)
 	if pricing == nil {
 		return nil, fmt.Errorf("no pricing available for model: %s: %w", input.Model, ErrModelPricingUnavailable)
 	}
@@ -1104,7 +1105,11 @@ func (s *BillingService) calculateTokenCost(resolved *ResolvedPricing, input Cos
 		applyLongCtx = applyLongCtx && *input.LongContextBillingEnabled
 	}
 
-	return s.computeTokenBreakdown(pricing, input.Tokens, input.RateMultiplier, input.ServiceTier, applyLongCtx), nil
+	breakdown := s.computeTokenBreakdown(pricing, input.Tokens, input.RateMultiplier, input.ServiceTier, applyLongCtx)
+	if tier != "" {
+		breakdown.BillingTier = tier
+	}
+	return breakdown, nil
 }
 
 // computeTokenBreakdown 是 token 计费的核心逻辑，由 calculateTokenCost 和 calculateCostInternal 共用。

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1743,3 +1743,39 @@ func TestComputeTokenBreakdown_NonExplicitZeroImagePrice_FallsBackToOutput(t *te
 	// textOutputTokens = 200 - 50 = 150
 	require.InDelta(t, 150*15e-6, bd.OutputCost, 1e-12)
 }
+
+func TestCalculateTokenCost_RecordsBillingTier(t *testing.T) {
+	svc := newTestBillingService()
+	resolver := NewModelPricingResolver(&ChannelService{}, svc)
+
+	resolved := &ResolvedPricing{
+		Mode:                   BillingModeToken,
+		BasePricing:            &ModelPricing{InputPricePerToken: 5e-6, OutputPricePerToken: 15e-6},
+		SupportsCacheBreakdown: true,
+		Intervals: []PricingInterval{
+			{MinTokens: 0, MaxTokens: testPtrInt(128000), TierLabel: "short-context", InputPrice: testPtrFloat64(1e-6), OutputPrice: testPtrFloat64(2e-6)},
+			{MinTokens: 128000, MaxTokens: nil, InputPrice: testPtrFloat64(3e-6), OutputPrice: testPtrFloat64(6e-6)},
+		},
+	}
+
+	// 1. Matched labeled tier
+	cost1, err := svc.calculateTokenCost(resolved, CostInput{
+		Model:          "gpt-4o",
+		Tokens:         UsageTokens{InputTokens: 50000, OutputTokens: 1000},
+		RateMultiplier: 1.0,
+		Resolver:       resolver,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "short-context", cost1.BillingTier)
+
+	// 2. Matched unlabeled tier (auto formatted)
+	cost2, err := svc.calculateTokenCost(resolved, CostInput{
+		Model:          "gpt-4o",
+		Tokens:         UsageTokens{InputTokens: 200000, OutputTokens: 1000},
+		RateMultiplier: 1.0,
+		Resolver:       resolver,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "(128000,+inf)", cost2.BillingTier)
+}
+

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -1261,6 +1261,9 @@ func (s *GatewayService) buildRecordUsageLog(
 		usageLog.TotalCost = cost.TotalCost
 		usageLog.ActualCost = cost.ActualCost
 		usageLog.LongContextBillingApplied = cost.LongContextBillingApplied
+		if cost.BillingTier != "" {
+			usageLog.BillingTier = &cost.BillingTier
+		}
 	}
 
 	return usageLog

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 )
@@ -321,16 +322,38 @@ func filterValidIntervals(intervals []PricingInterval) []PricingInterval {
 // GetIntervalPricing 根据 context token 数获取区间定价。
 // 如果有区间列表，找到匹配区间并构造 ModelPricing；否则直接返回 BasePricing。
 func (r *ModelPricingResolver) GetIntervalPricing(resolved *ResolvedPricing, totalContextTokens int) *ModelPricing {
+	pricing, _ := r.GetIntervalPricingWithTier(resolved, totalContextTokens)
+	return pricing
+}
+
+// GetIntervalPricingWithTier 根据 context token 数获取区间定价及命中的档位标签。
+func (r *ModelPricingResolver) GetIntervalPricingWithTier(resolved *ResolvedPricing, totalContextTokens int) (*ModelPricing, string) {
 	if len(resolved.Intervals) == 0 {
-		return resolved.BasePricing
+		return resolved.BasePricing, ""
 	}
 
 	iv := FindMatchingInterval(resolved.Intervals, totalContextTokens)
 	if iv == nil {
-		return resolved.BasePricing
+		return resolved.BasePricing, ""
 	}
 
-	return intervalToModelPricing(iv, resolved.SupportsCacheBreakdown, resolved.channelPricing)
+	tier := iv.TierLabel
+	if tier == "" {
+		tier = FormatIntervalTier(iv)
+	}
+
+	return intervalToModelPricing(iv, resolved.SupportsCacheBreakdown, resolved.channelPricing), tier
+}
+
+// FormatIntervalTier 格式化区间为字符串标签（如 "(0,272000]" 或 "(272000,+inf)"）
+func FormatIntervalTier(iv *PricingInterval) string {
+	if iv == nil {
+		return ""
+	}
+	if iv.MaxTokens == nil {
+		return fmt.Sprintf("(%d,+inf)", iv.MinTokens)
+	}
+	return fmt.Sprintf("(%d,%d]", iv.MinTokens, *iv.MaxTokens)
 }
 
 // intervalToModelPricing 将区间定价转换为 ModelPricing

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -114,6 +114,29 @@ func TestGetIntervalPricing_NoMatch_FallsBackToBase(t *testing.T) {
 	require.Equal(t, basePricing, result)
 }
 
+func TestGetIntervalPricingWithTier(t *testing.T) {
+	bs := newTestBillingServiceForResolver()
+	r := NewModelPricingResolver(&ChannelService{}, bs)
+
+	resolved := &ResolvedPricing{
+		Mode:                   BillingModeToken,
+		BasePricing:            &ModelPricing{InputPricePerToken: 5e-6},
+		SupportsCacheBreakdown: true,
+		Intervals: []PricingInterval{
+			{MinTokens: 0, MaxTokens: testPtrInt(128000), TierLabel: "short-context", InputPrice: testPtrFloat64(1e-6)},
+			{MinTokens: 128000, MaxTokens: nil, InputPrice: testPtrFloat64(3e-6)},
+		},
+	}
+
+	pricing1, tier1 := r.GetIntervalPricingWithTier(resolved, 50000)
+	require.NotNil(t, pricing1)
+	require.Equal(t, "short-context", tier1)
+
+	pricing2, tier2 := r.GetIntervalPricingWithTier(resolved, 200000)
+	require.NotNil(t, pricing2)
+	require.Equal(t, "(128000,+inf)", tier2)
+}
+
 func TestGPT56ExplicitZeroCacheWritePriceIsPreserved(t *testing.T) {
 	bs := &BillingService{}
 	resolver := NewModelPricingResolver(nil, bs)

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -360,6 +360,9 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		usageLog.TotalCost = cost.TotalCost
 		usageLog.ActualCost = cost.ActualCost
 		usageLog.LongContextBillingApplied = cost.LongContextBillingApplied
+		if cost.BillingTier != "" {
+			usageLog.BillingTier = &cost.BillingTier
+		}
 	}
 	if isVideoUsage && (cost == nil || cost.BillingMode != string(BillingModeToken)) {
 		usageLog.RateMultiplier = videoMultiplier


### PR DESCRIPTION
## Summary
- Extract matching pricing interval tier label (or formatted token range, e.g. `(128000,+inf)`) in `GetIntervalPricingWithTier`.
- Populate `BillingTier` on `CostBreakdown` and persist it to `UsageLog.BillingTier`.
- Resolves issue where token mode explicit intervals applied correct pricing but left `billing_tier = NULL` in usage logs, hindering post-hoc billing verification.

## Changes
- `backend/internal/service/model_pricing_resolver.go`: Added `GetIntervalPricingWithTier` and `FormatIntervalTier` to return the matched tier label alongside the resolved pricing.
- `backend/internal/service/billing_service.go`: Added `BillingTier` field on `CostBreakdown` and assigned matched tier in `calculateTokenCost`.
- `backend/internal/service/gateway_usage_billing.go` & `backend/internal/service/openai_gateway_usage.go`: Set `usageLog.BillingTier` from `cost.BillingTier`.
- `backend/internal/service/model_pricing_resolver_test.go` & `backend/internal/service/billing_service_test.go`: Added unit tests verifying interval tier extraction and billing breakdown assignment.

## Verification
```bash
go test -tags unit -v ./internal/service -run "TestGetIntervalPricingWithTier|TestCalculateTokenCost_RecordsBillingTier"
```
All tests pass.

Closes #5694