### PR TITLE
fix(grok): strip all explicit nulls on Responses input items

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -822,14 +822,14 @@ func sanitizeGrokResponsesModelInput(body []byte) ([]byte, error) {
 			filtered = append(filtered, json.RawMessage(item.Raw))
 			continue
 		}
-		itemType := strings.TrimSpace(item.Get("type").String())
-		if itemType != "" {
-			if _, ok := grokResponsesSupportedInputTypes[itemType]; !ok {
-				changed = true
-				continue
-			}
+		converted, convertedChanged, keep := convertGrokUnsupportedResponsesInputItem(item)
+		if convertedChanged {
+			changed = true
 		}
-		sanitized, itemChanged, err := stripExplicitNullsFromJSONValue(item.Value())
+		if !keep {
+			continue
+		}
+		sanitized, itemChanged, err := stripExplicitNullsFromJSONValue(converted)
 		if err != nil {
 			return nil, err
 		}
@@ -850,6 +850,158 @@ func sanitizeGrokResponsesModelInput(body []byte) ([]byte, error) {
 		return nil, err
 	}
 	return sjson.SetRawBytes(body, "input", encoded)
+}
+
+// convertGrokUnsupportedResponsesInputItem lowers Codex-only history into the
+// xAI ModelInput variants. CLIProxyAPI does the same for custom_tool_call*;
+// dropping those items breaks the next tool turn (model can talk, cannot call).
+func convertGrokUnsupportedResponsesInputItem(item gjson.Result) (any, bool, bool) {
+	itemType := strings.TrimSpace(item.Get("type").String())
+	switch itemType {
+	case "custom_tool_call":
+		name := strings.TrimSpace(item.Get("name").String())
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if name == "" || callID == "" {
+			return nil, true, false
+		}
+		converted := map[string]any{
+			"type":      "function_call",
+			"call_id":   callID,
+			"name":      name,
+			"arguments": grokCustomToolCallArguments(item.Get("input")),
+		}
+		if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+			converted["id"] = id
+		}
+		return converted, true, true
+	case "custom_tool_call_output":
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			return nil, true, false
+		}
+		converted := map[string]any{
+			"type":    "function_call_output",
+			"call_id": callID,
+			"output":  grokCustomToolCallOutput(item.Get("output")),
+		}
+		if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+			converted["id"] = id
+		}
+		return converted, true, true
+	case "tool_search_call":
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			return nil, true, false
+		}
+		converted := map[string]any{
+			"type":      "function_call",
+			"call_id":   callID,
+			"name":      "tool_search",
+			"arguments": grokToolSearchCallArguments(item),
+		}
+		if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+			converted["id"] = id
+		}
+		return converted, true, true
+	case "tool_search_output":
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID == "" {
+			return nil, true, false
+		}
+		converted := map[string]any{
+			"type":    "function_call_output",
+			"call_id": callID,
+			"output":  grokCustomToolCallOutput(item.Get("output")),
+		}
+		if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+			converted["id"] = id
+		}
+		return converted, true, true
+	case "item_reference":
+		// xAI has no store/item_reference. Keep the id as a short user note so
+		// later function_call_output items still have conversation context.
+		id := strings.TrimSpace(item.Get("id").String())
+		if id == "" {
+			return nil, true, false
+		}
+		return map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []any{
+				map[string]any{
+					"type": "input_text",
+					"text": "[item_reference " + id + "]",
+				},
+			},
+		}, true, true
+	default:
+		if itemType != "" {
+			if _, ok := grokResponsesSupportedInputTypes[itemType]; !ok {
+				return nil, true, false
+			}
+		}
+		return item.Value(), false, true
+	}
+}
+
+func grokCustomToolCallArguments(input gjson.Result) string {
+	if !input.Exists() || input.Type == gjson.Null {
+		return "{}"
+	}
+	if input.Type == gjson.String {
+		text := input.String()
+		trimmed := strings.TrimSpace(text)
+		if gjson.Valid(trimmed) {
+			parsed := gjson.Parse(trimmed)
+			if parsed.IsObject() {
+				return parsed.Raw
+			}
+		}
+		encoded, err := json.Marshal(map[string]string{"input": text})
+		if err != nil {
+			return "{}"
+		}
+		return string(encoded)
+	}
+	if input.IsObject() {
+		return input.Raw
+	}
+	encoded, err := json.Marshal(map[string]any{"input": input.Value()})
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func grokCustomToolCallOutput(output gjson.Result) string {
+	if !output.Exists() || output.Type == gjson.Null {
+		return ""
+	}
+	if output.Type == gjson.String {
+		return output.String()
+	}
+	return output.Raw
+}
+
+func grokToolSearchCallArguments(item gjson.Result) string {
+	args := item.Get("arguments")
+	if args.Exists() && args.Type != gjson.Null {
+		if args.Type == gjson.String {
+			text := strings.TrimSpace(args.String())
+			if text != "" {
+				return text
+			}
+		} else if args.IsObject() {
+			return args.Raw
+		}
+	}
+	if query := strings.TrimSpace(item.Get("query").String()); query != "" {
+		encoded, err := json.Marshal(map[string]string{"query": query})
+		if err == nil {
+			return string(encoded)
+		}
+	}
+	return "{}"
 }
 
 func stripExplicitNullsFromJSONValue(value any) (any, bool, error) {

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -179,6 +180,13 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 				ResponseHeaders:        resp.Header.Clone(),
 				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
 			}
+		}
+		if isGrokModelInputDeserializeError(resp.StatusCode, respBody) {
+			slog.Error("grok_modelinput_422",
+				"account_id", account.ID,
+				"model", upstreamModel,
+				"input", summarizeGrokResponsesInputForLog(patchedBody),
+			)
 		}
 		return s.handleErrorResponse(ctx, resp, c, account, patchedBody, upstreamModel)
 	}
@@ -772,41 +780,186 @@ func grokResponsesToolDedupKey(tool gjson.Result) string {
 	return "json:" + normalizeCompatSeedJSON(json.RawMessage(tool.Raw))
 }
 
-// sanitizeGrokReasoningNullContent 删除 Responses input 对象上的显式 JSON null。
-// xAI 的 untagged enum ModelInput 拒收这些字段，返回 422。
-// 旧实现只扫 reasoning.content；生产仍有 1MB grok-4.6 请求 422，说明其它 item type / 其它 null 字段也会踩中。
+// sanitizeGrokReasoningNullContent 清洗 Responses input，避免 xAI untagged enum ModelInput 422。
+// 生产 0.1.177-modelinput-hotfix 只删顶层 null 后，~251KB grok-4.6 请求仍 422。
 func sanitizeGrokReasoningNullContent(body []byte) ([]byte, error) {
-	return stripExplicitNullsFromGrokResponsesInput(body)
+	return sanitizeGrokResponsesModelInput(body)
 }
 
-func stripExplicitNullsFromGrokResponsesInput(body []byte) ([]byte, error) {
+var grokResponsesSupportedInputTypes = map[string]struct{}{
+	"message":                {},
+	"reasoning":              {},
+	"function_call":          {},
+	"function_call_output":   {},
+	"web_search_call":        {},
+	"file_search_call":       {},
+	"code_execution_call":    {},
+	"code_interpreter_call":  {},
+	"mcp_call":               {},
+	"mcp_list_tools":         {},
+	"mcp_approval_request":   {},
+	"mcp_approval_response":  {},
+	"image_generation_call":  {},
+	"computer_call":          {},
+	"computer_call_output":   {},
+	"local_shell_call":       {},
+	"local_shell_call_output": {},
+	"shell_call":             {},
+	"shell_call_output":      {},
+}
+
+func sanitizeGrokResponsesModelInput(body []byte) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")
 	if !input.Exists() || !input.IsArray() {
 		return body, nil
 	}
 
-	items := input.Array()
-	var paths []string
-	for i := range items {
-		item := items[i]
+	rawItems := input.Array()
+	filtered := make([]json.RawMessage, 0, len(rawItems))
+	changed := false
+	for _, item := range rawItems {
 		if !item.IsObject() {
+			filtered = append(filtered, json.RawMessage(item.Raw))
 			continue
 		}
-		item.ForEach(func(key, value gjson.Result) bool {
-			if value.Type == gjson.Null {
-				paths = append(paths, fmt.Sprintf("input.%d.%s", i, key.String()))
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType != "" {
+			if _, ok := grokResponsesSupportedInputTypes[itemType]; !ok {
+				changed = true
+				continue
 			}
-			return true
-		})
-	}
-	for _, path := range paths {
-		next, err := sjson.DeleteBytes(body, path)
+		}
+		sanitized, itemChanged, err := stripExplicitNullsFromJSONValue(item.Value())
 		if err != nil {
 			return nil, err
 		}
-		body = next
+		if itemChanged {
+			changed = true
+		}
+		encoded, err := json.Marshal(sanitized)
+		if err != nil {
+			return nil, err
+		}
+		filtered = append(filtered, encoded)
 	}
-	return body, nil
+	if !changed {
+		return body, nil
+	}
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, err
+	}
+	return sjson.SetRawBytes(body, "input", encoded)
+}
+
+func stripExplicitNullsFromJSONValue(value any) (any, bool, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		changed := false
+		for key, child := range typed {
+			if child == nil {
+				delete(typed, key)
+				changed = true
+				continue
+			}
+			next, childChanged, err := stripExplicitNullsFromJSONValue(child)
+			if err != nil {
+				return nil, false, err
+			}
+			if childChanged {
+				typed[key] = next
+				changed = true
+			}
+		}
+		return typed, changed, nil
+	case []any:
+		changed := false
+		for i, child := range typed {
+			if child == nil {
+				continue
+			}
+			next, childChanged, err := stripExplicitNullsFromJSONValue(child)
+			if err != nil {
+				return nil, false, err
+			}
+			if childChanged {
+				typed[i] = next
+				changed = true
+			}
+		}
+		return typed, changed, nil
+	default:
+		return value, false, nil
+	}
+}
+
+func summarizeGrokResponsesInputForLog(body []byte) string {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() {
+		return "input=missing"
+	}
+	if !input.IsArray() {
+		return "input_type=" + input.Type.String()
+	}
+	items := input.Array()
+	typeCounts := make(map[string]int, 8)
+	nullPaths := make([]string, 0, 8)
+	for i, item := range items {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "" {
+			itemType = "<empty>"
+		}
+		typeCounts[itemType]++
+		collectJSONNullPaths(fmt.Sprintf("input.%d", i), item, &nullPaths, 16)
+	}
+	parts := make([]string, 0, len(typeCounts)+2)
+	parts = append(parts, fmt.Sprintf("items=%d", len(items)))
+	for _, itemType := range sortedStringKeys(typeCounts) {
+		parts = append(parts, fmt.Sprintf("%s=%d", itemType, typeCounts[itemType]))
+	}
+	if len(nullPaths) > 0 {
+		parts = append(parts, "nulls="+strings.Join(nullPaths, ","))
+	}
+	return strings.Join(parts, " ")
+}
+
+func collectJSONNullPaths(prefix string, value gjson.Result, out *[]string, limit int) {
+	if out == nil || len(*out) >= limit {
+		return
+	}
+	switch {
+	case value.Type == gjson.Null:
+		*out = append(*out, prefix)
+	case value.IsObject():
+		value.ForEach(func(key, child gjson.Result) bool {
+			collectJSONNullPaths(prefix+"."+key.String(), child, out, limit)
+			return len(*out) < limit
+		})
+	case value.IsArray():
+		for i, child := range value.Array() {
+			collectJSONNullPaths(fmt.Sprintf("%s.%d", prefix, i), child, out, limit)
+			if len(*out) >= limit {
+				return
+			}
+		}
+	}
+}
+
+func sortedStringKeys(values map[string]int) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isGrokModelInputDeserializeError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	msg := strings.ToLower(extractUpstreamErrorMessage(body))
+	return strings.Contains(msg, "untagged enum modelinput") || strings.Contains(msg, "did not match any variant of untagged enum")
 }
 
 var grokResponsesSupportedToolTypes = map[string]struct{}{

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -772,32 +772,40 @@ func grokResponsesToolDedupKey(tool gjson.Result) string {
 	return "json:" + normalizeCompatSeedJSON(json.RawMessage(tool.Raw))
 }
 
-// sanitizeGrokReasoningNullContent 删除 reasoning 项中的 "content": null。
-// xAI 的 untagged enum 反序列化器拒收该字段，返回 422。
+// sanitizeGrokReasoningNullContent 删除 Responses input 对象上的显式 JSON null。
+// xAI 的 untagged enum ModelInput 拒收这些字段，返回 422。
+// 旧实现只扫 reasoning.content；生产仍有 1MB grok-4.6 请求 422，说明其它 item type / 其它 null 字段也会踩中。
 func sanitizeGrokReasoningNullContent(body []byte) ([]byte, error) {
+	return stripExplicitNullsFromGrokResponsesInput(body)
+}
+
+func stripExplicitNullsFromGrokResponsesInput(body []byte) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")
 	if !input.Exists() || !input.IsArray() {
 		return body, nil
 	}
 
 	items := input.Array()
-	changed := false
-	for i := len(items) - 1; i >= 0; i-- {
+	var paths []string
+	for i := range items {
 		item := items[i]
-		if strings.TrimSpace(item.Get("type").String()) != "reasoning" {
+		if !item.IsObject() {
 			continue
 		}
-		contentResult := item.Get("content")
-		if contentResult.Exists() && contentResult.Type == gjson.Null {
-			var err error
-			body, err = sjson.DeleteBytes(body, fmt.Sprintf("input.%d.content", i))
-			if err != nil {
-				return nil, err
+		item.ForEach(func(key, value gjson.Result) bool {
+			if value.Type == gjson.Null {
+				paths = append(paths, fmt.Sprintf("input.%d.%s", i, key.String()))
 			}
-			changed = true
-		}
+			return true
+		})
 	}
-	_ = changed
+	for _, path := range paths {
+		next, err := sjson.DeleteBytes(body, path)
+		if err != nil {
+			return nil, err
+		}
+		body = next
+	}
 	return body, nil
 }
 

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -3327,6 +3327,33 @@ func TestPatchGrokResponsesBody_StripsReasoningContentNull(t *testing.T) {
 	require.Equal(t, "reasoning", reasoning.Get("type").String())
 	require.True(t, reasoning.Get("summary").Exists(), "summary should be preserved")
 	require.False(t, reasoning.Get("content").Exists(), "content: null should be stripped")
+	require.False(t, reasoning.Get("encrypted_content").Exists(), "encrypted_content: null should be stripped")
+}
+
+func TestPatchGrokResponsesBody_StripsExplicitNullsOnNonReasoningItems(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model": "grok-latest",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}],"status":null},
+			{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{}","status":null},
+			{"type":"function_call_output","call_id":"call_1","output":"ok","status":null},
+			{"type":"web_search_call","id":"ws_1","status":null}
+		]
+	}`)
+
+	patched, err := patchGrokResponsesBody(body, "grok-4.6")
+	require.NoError(t, err)
+	require.True(t, json.Valid(patched))
+
+	items := gjson.GetBytes(patched, "input").Array()
+	require.Len(t, items, 4)
+	for i, item := range items {
+		require.Falsef(t, item.Get("status").Exists(), "input.%d.status: null should be stripped", i)
+	}
+	require.Equal(t, "lookup", items[1].Get("name").String())
+	require.Equal(t, "ok", items[2].Get("output").String())
 }
 
 func TestPatchGrokResponsesBody_KeepsReasoningContentNonNull(t *testing.T) {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -3356,6 +3356,50 @@ func TestPatchGrokResponsesBody_StripsExplicitNullsOnNonReasoningItems(t *testin
 	require.Equal(t, "ok", items[2].Get("output").String())
 }
 
+func TestPatchGrokResponsesBody_StripsNestedNullsAndDropsUnknownItems(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model": "grok-latest",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi","extra":null}]},
+			{"type":"item_reference","id":"msg_1"},
+			{"type":"custom_tool_call","call_id":"call_1","name":"lookup","input":"{}"},
+			{"type":"function_call","call_id":"call_2","name":"lookup","arguments":"{}","status":null}
+		]
+	}`)
+
+	patched, err := patchGrokResponsesBody(body, "grok-4.6")
+	require.NoError(t, err)
+	require.True(t, json.Valid(patched))
+
+	items := gjson.GetBytes(patched, "input").Array()
+	require.Len(t, items, 2)
+	require.Equal(t, "message", items[0].Get("type").String())
+	require.False(t, items[0].Get("content.0.extra").Exists(), "nested extra: null should be stripped")
+	require.Equal(t, "hi", items[0].Get("content.0.text").String())
+	require.Equal(t, "function_call", items[1].Get("type").String())
+	require.False(t, items[1].Get("status").Exists())
+}
+
+func TestSummarizeGrokResponsesInputForLog(t *testing.T) {
+	t.Parallel()
+
+	summary := summarizeGrokResponsesInputForLog([]byte(`{
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi","extra":null}]},
+			{"type":"item_reference","id":"msg_1"},
+			{"type":"reasoning","content":null}
+		]
+	}`))
+	require.Contains(t, summary, "items=3")
+	require.Contains(t, summary, "item_reference=1")
+	require.Contains(t, summary, "message=1")
+	require.Contains(t, summary, "reasoning=1")
+	require.Contains(t, summary, "input.0.content.0.extra")
+	require.Contains(t, summary, "input.2.content")
+}
+
 func TestPatchGrokResponsesBody_KeepsReasoningContentNonNull(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -3356,7 +3356,7 @@ func TestPatchGrokResponsesBody_StripsExplicitNullsOnNonReasoningItems(t *testin
 	require.Equal(t, "ok", items[2].Get("output").String())
 }
 
-func TestPatchGrokResponsesBody_StripsNestedNullsAndDropsUnknownItems(t *testing.T) {
+func TestPatchGrokResponsesBody_ConvertsCustomToolHistoryInsteadOfDropping(t *testing.T) {
 	t.Parallel()
 
 	body := []byte(`{
@@ -3364,7 +3364,8 @@ func TestPatchGrokResponsesBody_StripsNestedNullsAndDropsUnknownItems(t *testing
 		"input": [
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi","extra":null}]},
 			{"type":"item_reference","id":"msg_1"},
-			{"type":"custom_tool_call","call_id":"call_1","name":"lookup","input":"{}"},
+			{"type":"custom_tool_call","call_id":"call_1","name":"lookup","input":"{\"q\":\"x\"}"},
+			{"type":"custom_tool_call_output","call_id":"call_1","output":"ok"},
 			{"type":"function_call","call_id":"call_2","name":"lookup","arguments":"{}","status":null}
 		]
 	}`)
@@ -3374,12 +3375,42 @@ func TestPatchGrokResponsesBody_StripsNestedNullsAndDropsUnknownItems(t *testing
 	require.True(t, json.Valid(patched))
 
 	items := gjson.GetBytes(patched, "input").Array()
-	require.Len(t, items, 2)
+	require.Len(t, items, 5)
 	require.Equal(t, "message", items[0].Get("type").String())
 	require.False(t, items[0].Get("content.0.extra").Exists(), "nested extra: null should be stripped")
 	require.Equal(t, "hi", items[0].Get("content.0.text").String())
-	require.Equal(t, "function_call", items[1].Get("type").String())
-	require.False(t, items[1].Get("status").Exists())
+	require.Equal(t, "message", items[1].Get("type").String())
+	require.Contains(t, items[1].Get("content.0.text").String(), "item_reference msg_1")
+	require.Equal(t, "function_call", items[2].Get("type").String())
+	require.Equal(t, "call_1", items[2].Get("call_id").String())
+	require.Equal(t, "lookup", items[2].Get("name").String())
+	require.JSONEq(t, `{"q":"x"}`, items[2].Get("arguments").String())
+	require.Equal(t, "function_call_output", items[3].Get("type").String())
+	require.Equal(t, "ok", items[3].Get("output").String())
+	require.Equal(t, "function_call", items[4].Get("type").String())
+	require.False(t, items[4].Get("status").Exists())
+}
+
+func TestPatchGrokResponsesBody_ConvertsToolSearchHistory(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model": "grok-latest",
+		"input": [
+			{"type":"tool_search_call","call_id":"s1","arguments":{"query":"git"}},
+			{"type":"tool_search_output","call_id":"s1","output":["shell"]}
+		]
+	}`)
+
+	patched, err := patchGrokResponsesBody(body, "grok-4.6")
+	require.NoError(t, err)
+	items := gjson.GetBytes(patched, "input").Array()
+	require.Len(t, items, 2)
+	require.Equal(t, "function_call", items[0].Get("type").String())
+	require.Equal(t, "tool_search", items[0].Get("name").String())
+	require.JSONEq(t, `{"query":"git"}`, items[0].Get("arguments").String())
+	require.Equal(t, "function_call_output", items[1].Get("type").String())
+	require.Equal(t, "s1", items[1].Get("call_id").String())
 }
 
 func TestSummarizeGrokResponsesInputForLog(t *testing.T) {


### PR DESCRIPTION
## Summary
xAI still returns 422 `data did not match any variant of untagged enum ModelInput` on large Grok `/v1/responses` requests after #4239.

#4239 only deleted `content: null` on `type=reasoning`. Production still saw this 422 on `POST /v1/responses` `model=grok-4.6` (account 117) after that sanitizer was already deployed. The remaining failures look like other explicit-null fields on other input item types.

This widens the existing sanitizer to delete every top-level JSON `null` on Responses `input` objects, while keeping non-null values.

## Test plan
- [x] `cd backend && go test -tags=unit ./internal/service -count=1 -run TestPatchGrokResponsesBody`
- [x] Existing reasoning `content: null` cases still pass
- [x] New case: `function_call` / `function_call_output` / `web_search_call` `status: null` is stripped
- [x] Non-null reasoning `content` is preserved

## Notes
This change is AI-assisted.

I have read the CLA Document and I hereby sign the CLA