### PR TITLE
feat(channel): 模型映射与定价支持通配符、多源标签、启停与隐藏

### DIFF
--- a/backend/internal/handler/admin/channel_handler.go
+++ b/backend/internal/handler/admin/channel_handler.go
@@ -27,33 +27,49 @@ func NewChannelHandler(channelService *service.ChannelService, billingService *s
 
 // --- Request / Response types ---
 
+// channelModelMappingEntryRequest 模型映射条目（请求体）
+type channelModelMappingEntryRequest struct {
+	Sources []string `json:"sources"` // 源模型模式列表（支持通配符后缀 *）
+	Target  string   `json:"target"`  // 映射目标（空 = 透传原始模型名）
+	Enabled *bool    `json:"enabled"` // nil 或 true = 启用（默认值）；false = 禁用
+	Hidden  bool     `json:"hidden"`  // true = 隐藏（不在模型列表中显示）
+}
+
+// channelModelMappingEntryResponse 模型映射条目（响应体）
+type channelModelMappingEntryResponse struct {
+	Sources []string `json:"sources"`
+	Target  string   `json:"target"`
+	Enabled bool     `json:"enabled"`
+	Hidden  bool     `json:"hidden"`
+}
+
 type createChannelRequest struct {
-	Name                       string                           `json:"name" binding:"required,max=100"`
-	Description                string                           `json:"description"`
-	GroupIDs                   []int64                          `json:"group_ids"`
-	ModelPricing               []channelModelPricingRequest     `json:"model_pricing"`
-	ModelMapping               map[string]map[string]string     `json:"model_mapping"`
-	BillingModelSource         string                           `json:"billing_model_source" binding:"omitempty,oneof=requested upstream channel_mapped response_model"`
-	RestrictModels             bool                             `json:"restrict_models"`
-	Features                   string                           `json:"features"`
-	FeaturesConfig             map[string]any                   `json:"features_config"`
-	ApplyPricingToAccountStats bool                             `json:"apply_pricing_to_account_stats"`
-	AccountStatsPricingRules   []accountStatsPricingRuleRequest `json:"account_stats_pricing_rules"`
+	Name                       string                                       `json:"name" binding:"required,max=100"`
+	Description                string                                       `json:"description"`
+	GroupIDs                   []int64                                      `json:"group_ids"`
+	ModelPricing               []channelModelPricingRequest                 `json:"model_pricing"`
+	ModelMapping               map[string][]channelModelMappingEntryRequest `json:"model_mapping"`
+	BillingModelSource         string                                       `json:"billing_model_source" binding:"omitempty,oneof=requested upstream channel_mapped response_model"`
+	RestrictModels             bool                                         `json:"restrict_models"`
+	Features                   string                                       `json:"features"`
+	FeaturesConfig             map[string]any                               `json:"features_config"`
+	ApplyPricingToAccountStats bool                                         `json:"apply_pricing_to_account_stats"`
+	AccountStatsPricingRules   []accountStatsPricingRuleRequest             `json:"account_stats_pricing_rules"`
 }
 
 type updateChannelRequest struct {
-	Name                       string                            `json:"name" binding:"omitempty,max=100"`
-	Description                *string                           `json:"description"`
-	Status                     string                            `json:"status" binding:"omitempty,oneof=active disabled"`
-	GroupIDs                   *[]int64                          `json:"group_ids"`
-	ModelPricing               *[]channelModelPricingRequest     `json:"model_pricing"`
-	ModelMapping               map[string]map[string]string      `json:"model_mapping"`
-	BillingModelSource         string                            `json:"billing_model_source" binding:"omitempty,oneof=requested upstream channel_mapped response_model"`
-	RestrictModels             *bool                             `json:"restrict_models"`
-	Features                   *string                           `json:"features"`
-	FeaturesConfig             map[string]any                    `json:"features_config"`
-	ApplyPricingToAccountStats *bool                             `json:"apply_pricing_to_account_stats"`
-	AccountStatsPricingRules   *[]accountStatsPricingRuleRequest `json:"account_stats_pricing_rules"`
+	Name                       string                                       `json:"name" binding:"omitempty,max=100"`
+	Description                *string                                      `json:"description"`
+	Status                     string                                       `json:"status" binding:"omitempty,oneof=active disabled"`
+	GroupIDs                   *[]int64                                     `json:"group_ids"`
+	ModelPricing               *[]channelModelPricingRequest                `json:"model_pricing"`
+	ModelMapping               map[string][]channelModelMappingEntryRequest `json:"model_mapping"`
+	BillingModelSource         string                                       `json:"billing_model_source" binding:"omitempty,oneof=requested upstream channel_mapped response_model"`
+	RestrictModels             *bool                                        `json:"restrict_models"`
+	Features                   *string                                      `json:"features"`
+	FeaturesConfig             map[string]any                               `json:"features_config"`
+	ApplyPricingToAccountStats *bool                                        `json:"apply_pricing_to_account_stats"`
+	AccountStatsPricingRules   *[]accountStatsPricingRuleRequest            `json:"account_stats_pricing_rules"`
 }
 
 type channelModelPricingRequest struct {
@@ -68,6 +84,10 @@ type channelModelPricingRequest struct {
 	ImageOutputPrice *float64                 `json:"image_output_price" binding:"omitempty,min=0"`
 	PerRequestPrice  *float64                 `json:"per_request_price" binding:"omitempty,min=0"`
 	Intervals        []pricingIntervalRequest `json:"intervals"`
+	// Enabled nil 或 true = 启用；false = 停用（等于不存在）
+	Enabled *bool `json:"enabled"`
+	// Hidden true = 隐藏（不在模型列表中显示）
+	Hidden bool `json:"hidden"`
 }
 
 type pricingIntervalRequest struct {
@@ -90,21 +110,21 @@ type accountStatsPricingRuleRequest struct {
 }
 
 type channelResponse struct {
-	ID                         int64                             `json:"id"`
-	Name                       string                            `json:"name"`
-	Description                string                            `json:"description"`
-	Status                     string                            `json:"status"`
-	BillingModelSource         string                            `json:"billing_model_source"`
-	RestrictModels             bool                              `json:"restrict_models"`
-	Features                   string                            `json:"features"`
-	FeaturesConfig             map[string]any                    `json:"features_config"`
-	GroupIDs                   []int64                           `json:"group_ids"`
-	ModelPricing               []channelModelPricingResponse     `json:"model_pricing"`
-	ModelMapping               map[string]map[string]string      `json:"model_mapping"`
-	ApplyPricingToAccountStats bool                              `json:"apply_pricing_to_account_stats"`
-	AccountStatsPricingRules   []accountStatsPricingRuleResponse `json:"account_stats_pricing_rules"`
-	CreatedAt                  string                            `json:"created_at"`
-	UpdatedAt                  string                            `json:"updated_at"`
+	ID                         int64                                         `json:"id"`
+	Name                       string                                        `json:"name"`
+	Description                string                                        `json:"description"`
+	Status                     string                                        `json:"status"`
+	BillingModelSource         string                                        `json:"billing_model_source"`
+	RestrictModels             bool                                          `json:"restrict_models"`
+	Features                   string                                        `json:"features"`
+	FeaturesConfig             map[string]any                                `json:"features_config"`
+	GroupIDs                   []int64                                       `json:"group_ids"`
+	ModelPricing               []channelModelPricingResponse                 `json:"model_pricing"`
+	ModelMapping               map[string][]channelModelMappingEntryResponse `json:"model_mapping"`
+	ApplyPricingToAccountStats bool                                          `json:"apply_pricing_to_account_stats"`
+	AccountStatsPricingRules   []accountStatsPricingRuleResponse             `json:"account_stats_pricing_rules"`
+	CreatedAt                  string                                        `json:"created_at"`
+	UpdatedAt                  string                                        `json:"updated_at"`
 }
 
 type channelModelPricingResponse struct {
@@ -120,6 +140,8 @@ type channelModelPricingResponse struct {
 	ImageOutputPrice *float64                  `json:"image_output_price"`
 	PerRequestPrice  *float64                  `json:"per_request_price"`
 	Intervals        []pricingIntervalResponse `json:"intervals"`
+	Enabled          bool                      `json:"enabled"`
+	Hidden           bool                      `json:"hidden"`
 }
 
 type pricingIntervalResponse struct {
@@ -156,7 +178,6 @@ func channelToResponse(ch *service.Channel) *channelResponse {
 		Features:       ch.Features,
 		FeaturesConfig: ch.FeaturesConfig,
 		GroupIDs:       ch.GroupIDs,
-		ModelMapping:   ch.ModelMapping,
 		CreatedAt:      ch.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:      ch.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
@@ -164,8 +185,19 @@ func channelToResponse(ch *service.Channel) *channelResponse {
 	if resp.GroupIDs == nil {
 		resp.GroupIDs = []int64{}
 	}
-	if resp.ModelMapping == nil {
-		resp.ModelMapping = map[string]map[string]string{}
+	resp.ModelMapping = make(map[string][]channelModelMappingEntryResponse, len(ch.ModelMapping))
+	for platform, entries := range ch.ModelMapping {
+		converted := make([]channelModelMappingEntryResponse, 0, len(entries))
+		for _, entry := range entries {
+			sources := append([]string(nil), entry.Sources...)
+			converted = append(converted, channelModelMappingEntryResponse{
+				Sources: sources,
+				Target:  entry.Target,
+				Enabled: entry.IsEnabled(),
+				Hidden:  entry.Hidden,
+			})
+		}
+		resp.ModelMapping[platform] = converted
 	}
 
 	resp.ModelPricing = make([]channelModelPricingResponse, 0, len(ch.ModelPricing))
@@ -228,6 +260,8 @@ func pricingToResponse(p *service.ChannelModelPricing) channelModelPricingRespon
 		ImageOutputPrice: p.ImageOutputPrice,
 		PerRequestPrice:  p.PerRequestPrice,
 		Intervals:        intervals,
+		Enabled:          p.IsEnabled(),
+		Hidden:           p.Hidden,
 	}
 }
 
@@ -268,6 +302,11 @@ func pricingRequestToService(reqs []channelModelPricingRequest) []service.Channe
 				SortOrder:       iv.SortOrder,
 			})
 		}
+		// Enabled: nil = true (默认启用)
+		enabled := true
+		if r.Enabled != nil {
+			enabled = *r.Enabled
+		}
 		result = append(result, service.ChannelModelPricing{
 			Platform:         platform,
 			Models:           r.Models,
@@ -280,7 +319,30 @@ func pricingRequestToService(reqs []channelModelPricingRequest) []service.Channe
 			ImageOutputPrice: r.ImageOutputPrice,
 			PerRequestPrice:  r.PerRequestPrice,
 			Intervals:        intervals,
+			Enabled:          &enabled,
+			Hidden:           r.Hidden,
 		})
+	}
+	return result
+}
+
+// mappingRequestToService 将请求体中的映射条目转换为服务层类型
+func mappingRequestToService(m map[string][]channelModelMappingEntryRequest) map[string][]service.ModelMappingEntry {
+	if len(m) == 0 {
+		return nil
+	}
+	result := make(map[string][]service.ModelMappingEntry, len(m))
+	for platform, entries := range m {
+		svcEntries := make([]service.ModelMappingEntry, 0, len(entries))
+		for _, e := range entries {
+			svcEntries = append(svcEntries, service.ModelMappingEntry{
+				Sources: e.Sources,
+				Target:  e.Target,
+				Enabled: e.Enabled, // nil = 默认启用
+				Hidden:  e.Hidden,
+			})
+		}
+		result[platform] = svcEntries
 	}
 	return result
 }
@@ -381,7 +443,7 @@ func (h *ChannelHandler) Create(c *gin.Context) {
 		Description:                req.Description,
 		GroupIDs:                   req.GroupIDs,
 		ModelPricing:               pricing,
-		ModelMapping:               req.ModelMapping,
+		ModelMapping:               mappingRequestToService(req.ModelMapping),
 		BillingModelSource:         req.BillingModelSource,
 		RestrictModels:             req.RestrictModels,
 		Features:                   req.Features,
@@ -417,7 +479,7 @@ func (h *ChannelHandler) Update(c *gin.Context) {
 		Description:                req.Description,
 		Status:                     req.Status,
 		GroupIDs:                   req.GroupIDs,
-		ModelMapping:               req.ModelMapping,
+		ModelMapping:               mappingRequestToService(req.ModelMapping),
 		BillingModelSource:         req.BillingModelSource,
 		RestrictModels:             req.RestrictModels,
 		Features:                   req.Features,

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1476,8 +1476,8 @@ func TestOpenAIResponsesWebSocket_PassthroughKeepsTurnMappingSnapshot(t *testing
 				return errors.New("channel service is nil")
 			}
 			_, err := channelSvc.Update(context.Background(), 7701, &service.UpdateChannelInput{
-				ModelMapping: map[string]map[string]string{
-					service.PlatformOpenAI: {"sol": "gpt-5.6-terra"},
+				ModelMapping: map[string][]service.ModelMappingEntry{
+					service.PlatformOpenAI: {{Sources: []string{"sol"}, Target: "gpt-5.6-terra"}},
 				},
 			})
 			return err
@@ -2789,11 +2789,17 @@ func runOpenAIResponsesWebSocketUsageLogCase(t *testing.T, tc openAIResponsesWSU
 	if len(tc.channelMapping) > 0 {
 		channelSvc = service.NewChannelService(&openAIWSUsageHandlerChannelRepoStub{
 			channels: []service.Channel{{
-				ID:                 7701,
-				Name:               "openai-ws-e2e-channel",
-				Status:             service.StatusActive,
-				GroupIDs:           []int64{groupID},
-				ModelMapping:       map[string]map[string]string{service.PlatformOpenAI: tc.channelMapping},
+				ID:       7701,
+				Name:     "openai-ws-e2e-channel",
+				Status:   service.StatusActive,
+				GroupIDs: []int64{groupID},
+				ModelMapping: func() map[string][]service.ModelMappingEntry {
+					entries := make([]service.ModelMappingEntry, 0, len(tc.channelMapping))
+					for source, target := range tc.channelMapping {
+						entries = append(entries, service.ModelMappingEntry{Sources: []string{source}, Target: target})
+					}
+					return map[string][]service.ModelMappingEntry{service.PlatformOpenAI: entries}
+				}(),
 				BillingModelSource: tc.billingModelSource,
 			}},
 			groupPlatforms: map[int64]string{groupID: service.PlatformOpenAI},

--- a/backend/internal/repository/channel_repo.go
+++ b/backend/internal/repository/channel_repo.go
@@ -474,9 +474,9 @@ func (r *channelRepository) GetGroupsInOtherChannels(ctx context.Context, channe
 	return conflicting, nil
 }
 
-// marshalModelMapping 将 model mapping 序列化为嵌套 JSON 字节
-// 格式：{"platform": {"src": "dst"}, ...}
-func marshalModelMapping(m map[string]map[string]string) ([]byte, error) {
+// marshalModelMapping 将 model mapping 序列化为 JSON 字节
+// 新格式：{"platform": [{"sources":["src"],"target":"dst","enabled":null,"hidden":false}], ...}
+func marshalModelMapping(m map[string][]service.ModelMappingEntry) ([]byte, error) {
 	if len(m) == 0 {
 		return []byte("{}"), nil
 	}
@@ -487,16 +487,51 @@ func marshalModelMapping(m map[string]map[string]string) ([]byte, error) {
 	return data, nil
 }
 
-// unmarshalModelMapping 将 JSON 字节反序列化为嵌套 model mapping
-func unmarshalModelMapping(data []byte) map[string]map[string]string {
+// unmarshalModelMapping 将 JSON 字节反序列化为 model mapping，兼容新旧两种格式：
+// 旧格式：{"platform": {"src": "dst"}}
+// 新格式：{"platform": [{"sources":["src"],"target":"dst","enabled":null,"hidden":false}]}
+func unmarshalModelMapping(data []byte) map[string][]service.ModelMappingEntry {
 	if len(data) == 0 {
 		return nil
 	}
-	var m map[string]map[string]string
-	if err := json.Unmarshal(data, &m); err != nil {
+	// 先解析为 platform → raw JSON，再逐平台判断格式
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return nil
 	}
-	return m
+	result := make(map[string][]service.ModelMappingEntry, len(rawMap))
+	for platform, raw := range rawMap {
+		trimmed := strings.TrimSpace(string(raw))
+		if len(trimmed) == 0 {
+			continue
+		}
+		switch trimmed[0] {
+		case '[':
+			// 新格式：条目数组
+			var entries []service.ModelMappingEntry
+			if err := json.Unmarshal(raw, &entries); err != nil {
+				continue
+			}
+			result[platform] = entries
+		case '{':
+			// 旧格式：{src: dst} → 转换为条目数组（每个 src 单独一条，Enabled=nil 即默认启用）
+			var oldMapping map[string]string
+			if err := json.Unmarshal(raw, &oldMapping); err != nil {
+				continue
+			}
+			entries := make([]service.ModelMappingEntry, 0, len(oldMapping))
+			for src, dst := range oldMapping {
+				entries = append(entries, service.ModelMappingEntry{
+					Sources: []string{src},
+					Target:  dst,
+					// Enabled: nil = 默认启用
+					Hidden: false,
+				})
+			}
+			result[platform] = entries
+		}
+	}
+	return result
 }
 
 func marshalFeaturesConfig(m map[string]any) ([]byte, error) {

--- a/backend/internal/repository/channel_repo_pricing.go
+++ b/backend/internal/repository/channel_repo_pricing.go
@@ -16,7 +16,7 @@ import (
 
 func (r *channelRepository) ListModelPricing(ctx context.Context, channelID int64) ([]service.ChannelModelPricing, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price, created_at, updated_at
+		`SELECT id, channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price, enabled, hidden, created_at, updated_at
 		 FROM channel_model_pricing WHERE channel_id = $1 ORDER BY id`, channelID,
 	)
 	if err != nil {
@@ -57,10 +57,11 @@ func (r *channelRepository) UpdateModelPricing(ctx context.Context, pricing *ser
 	}
 	result, err := r.db.ExecContext(ctx,
 		`UPDATE channel_model_pricing
-		 SET models = $1, billing_mode = $2, input_price = $3, output_price = $4, cache_write_price = $5, cache_read_price = $6, image_input_price = $7, image_output_price = $8, per_request_price = $9, platform = $10, updated_at = NOW()
-		 WHERE id = $11`,
+		 SET models = $1, billing_mode = $2, input_price = $3, output_price = $4, cache_write_price = $5, cache_read_price = $6, image_input_price = $7, image_output_price = $8, per_request_price = $9, platform = $10, enabled = $11, hidden = $12, updated_at = NOW()
+		 WHERE id = $13`,
 		modelsJSON, billingMode, pricing.InputPrice, pricing.OutputPrice, pricing.CacheWritePrice, pricing.CacheReadPrice,
-		pricing.ImageInputPrice, pricing.ImageOutputPrice, pricing.PerRequestPrice, pricing.Platform, pricing.ID,
+		pricing.ImageInputPrice, pricing.ImageOutputPrice, pricing.PerRequestPrice, pricing.Platform,
+		pricing.IsEnabled(), pricing.Hidden, pricing.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update model pricing: %w", err)
@@ -91,7 +92,7 @@ func (r *channelRepository) ReplaceModelPricing(ctx context.Context, channelID i
 // batchLoadModelPricing 批量加载多个渠道的模型定价（含区间）
 func (r *channelRepository) batchLoadModelPricing(ctx context.Context, channelIDs []int64) (map[int64][]service.ChannelModelPricing, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price, created_at, updated_at
+		`SELECT id, channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price, enabled, hidden, created_at, updated_at
 		 FROM channel_model_pricing WHERE channel_id = ANY($1) ORDER BY channel_id, id`,
 		pq.Array(channelIDs),
 	)
@@ -172,7 +173,8 @@ func scanModelPricingRows(rows *sql.Rows) ([]service.ChannelModelPricing, []int6
 		if err := rows.Scan(
 			&p.ID, &p.ChannelID, &p.Platform, &modelsJSON, &p.BillingMode,
 			&p.InputPrice, &p.OutputPrice, &p.CacheWritePrice, &p.CacheReadPrice,
-			&p.ImageInputPrice, &p.ImageOutputPrice, &p.PerRequestPrice, &p.CreatedAt, &p.UpdatedAt,
+			&p.ImageInputPrice, &p.ImageOutputPrice, &p.PerRequestPrice,
+			&p.Enabled, &p.Hidden, &p.CreatedAt, &p.UpdatedAt,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan model pricing: %w", err)
 		}
@@ -229,11 +231,12 @@ func createModelPricingExec(ctx context.Context, exec dbExec, pricing *service.C
 		platform = "anthropic"
 	}
 	err = exec.QueryRowContext(ctx,
-		`INSERT INTO channel_model_pricing (channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id, created_at, updated_at`,
+		`INSERT INTO channel_model_pricing (channel_id, platform, models, billing_mode, input_price, output_price, cache_write_price, cache_read_price, image_input_price, image_output_price, per_request_price, enabled, hidden)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id, created_at, updated_at`,
 		pricing.ChannelID, platform, modelsJSON, billingMode,
 		pricing.InputPrice, pricing.OutputPrice, pricing.CacheWritePrice, pricing.CacheReadPrice,
 		pricing.ImageInputPrice, pricing.ImageOutputPrice, pricing.PerRequestPrice,
+		pricing.Enabled, pricing.Hidden,
 	).Scan(&pricing.ID, &pricing.CreatedAt, &pricing.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("insert model pricing: %w", err)

--- a/backend/internal/service/channel.go
+++ b/backend/internal/service/channel.go
@@ -17,6 +17,23 @@ const (
 	BillingModeVideo      BillingMode = "video"       // 视频生成计费（按视频生成次数）
 )
 
+// ModelMappingEntry 渠道模型映射条目（支持多源模式、启用/隐藏）
+type ModelMappingEntry struct {
+	// Sources 源模型模式列表（支持通配符后缀 *，如 "gpt-*"）
+	Sources []string `json:"sources"`
+	// Target 映射目标模型名（空字符串 = 透传，即保持原始模型名）
+	Target string `json:"target"`
+	// Enabled nil 或 true = 启用（默认值）；false = 禁用，该条目不参与路由
+	Enabled *bool `json:"enabled"`
+	// Hidden true = 隐藏：不在可用渠道/返回的模型列表中显示，但路由仍然生效
+	Hidden bool `json:"hidden"`
+}
+
+// IsEnabled 返回此映射条目是否启用（nil 视为 true）
+func (e *ModelMappingEntry) IsEnabled() bool {
+	return e.Enabled == nil || *e.Enabled
+}
+
 // IsValid 检查 BillingMode 是否为合法值
 func (m BillingMode) IsValid() bool {
 	switch m {
@@ -62,8 +79,8 @@ type Channel struct {
 	GroupIDs []int64
 	// 模型定价列表（每条含 Platform 字段）
 	ModelPricing []ChannelModelPricing
-	// 渠道级模型映射（按平台分组：platform → {src→dst}）
-	ModelMapping map[string]map[string]string
+	// 渠道级模型映射（按平台分组：platform → []ModelMappingEntry）
+	ModelMapping map[string][]ModelMappingEntry
 
 	// 账号统计定价
 	ApplyPricingToAccountStats bool                      // 是否应用渠道模型定价到账号统计
@@ -100,8 +117,16 @@ type ChannelModelPricing struct {
 	ImageOutputPrice *float64          `json:"image_output_price"`
 	PerRequestPrice  *float64          `json:"per_request_price"`
 	Intervals        []PricingInterval `json:"intervals"`
-	CreatedAt        time.Time         `json:"created_at,omitempty"`
-	UpdatedAt        time.Time         `json:"updated_at,omitempty"`
+	// Enabled false = 停用（相当于该条目不存在：不参与计费，也不在模型列表中显示）
+	Enabled *bool `json:"enabled"`
+	// Hidden true = 隐藏（不在可用渠道/返回的模型列表中显示，但仍参与计费）
+	Hidden    bool      `json:"hidden"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+func (p ChannelModelPricing) IsEnabled() bool {
+	return p.Enabled == nil || *p.Enabled
 }
 
 // PricingInterval 定价区间（token 区间 / 按次分层 / 图片分辨率分层）
@@ -139,11 +164,15 @@ func (c *Channel) normalizeBillingModelSource() {
 }
 
 // GetModelPricing 根据模型名查找渠道定价，未找到返回 nil。
-// 精确匹配，大小写不敏感。返回值拷贝，不污染缓存。
+// 精确匹配，大小写不敏感。已停用（Enabled=false）的条目被跳过。
+// 返回值拷贝，不污染缓存。
 func (c *Channel) GetModelPricing(model string) *ChannelModelPricing {
 	modelLower := strings.ToLower(model)
 
 	for i := range c.ModelPricing {
+		if !c.ModelPricing[i].IsEnabled() {
+			continue // 停用条目不参与计费
+		}
 		for _, m := range c.ModelPricing[i].Models {
 			if strings.ToLower(m) == modelLower {
 				cp := c.ModelPricing[i].Clone()
@@ -215,13 +244,18 @@ func (c *Channel) Clone() *Channel {
 		}
 	}
 	if c.ModelMapping != nil {
-		cp.ModelMapping = make(map[string]map[string]string, len(c.ModelMapping))
-		for platform, mapping := range c.ModelMapping {
-			inner := make(map[string]string, len(mapping))
-			for k, v := range mapping {
-				inner[k] = v
+		cp.ModelMapping = make(map[string][]ModelMappingEntry, len(c.ModelMapping))
+		for platform, entries := range c.ModelMapping {
+			entriesCopy := make([]ModelMappingEntry, len(entries))
+			for i, e := range entries {
+				ec := e
+				if e.Sources != nil {
+					ec.Sources = make([]string, len(e.Sources))
+					copy(ec.Sources, e.Sources)
+				}
+				entriesCopy[i] = ec
 			}
-			cp.ModelMapping[platform] = inner
+			cp.ModelMapping[platform] = entriesCopy
 		}
 	}
 	if c.FeaturesConfig != nil {
@@ -422,12 +456,16 @@ func splitWildcardSuffix(pattern string) (prefix string, isWildcard bool) {
 
 // GetModelPricingByPlatform 在指定平台下查找精确模型的定价，未找到返回 nil。
 // 与 GetModelPricing 的区别：按 Platform 隔离，避免跨平台同名模型误匹配。
+// 已停用（Enabled=false）的条目被跳过。
 func (c *Channel) GetModelPricingByPlatform(platform, model string) *ChannelModelPricing {
 	if c == nil {
 		return nil
 	}
 	modelLower := strings.ToLower(model)
 	for i := range c.ModelPricing {
+		if !c.ModelPricing[i].IsEnabled() {
+			continue // 停用条目不参与计费
+		}
 		if c.ModelPricing[i].Platform != platform {
 			continue
 		}
@@ -515,7 +553,16 @@ func (c *Channel) SupportedModels() []SupportedModel {
 		return nil
 	}
 
-	idx := buildPricingIndex(c.ModelPricing)
+	// 模型列表只显示 enabled=true && hidden=false 的定价条目
+	visiblePricing := make([]ChannelModelPricing, 0, len(c.ModelPricing))
+	for i := range c.ModelPricing {
+		p := &c.ModelPricing[i]
+		if !p.IsEnabled() || p.Hidden {
+			continue
+		}
+		visiblePricing = append(visiblePricing, *p)
+	}
+	idx := buildPricingIndex(visiblePricing)
 
 	type dedupKey struct {
 		platform string
@@ -549,39 +596,46 @@ func (c *Channel) SupportedModels() []SupportedModel {
 		})
 	}
 
-	// Pass A：从 mapping 展开
-	for platform, mapping := range c.ModelMapping {
-		if len(mapping) == 0 {
+	// Pass A：从 mapping 展开（跳过 disabled 和 hidden 条目）
+	for platform, entries := range c.ModelMapping {
+		if len(entries) == 0 {
 			continue
 		}
 		pidx := idx[platform]
-		for src, target := range mapping {
-			prefix, isWild := splitWildcardSuffix(src)
-			if isWild {
-				if pidx == nil {
-					continue
-				}
-				prefixLower := strings.ToLower(prefix)
-				for _, candidate := range pidx.names {
-					if strings.HasPrefix(strings.ToLower(candidate), prefixLower) {
-						display, pricing := lookup(pidx, candidate)
-						add(platform, display, pricing)
-					}
-				}
+		for _, entry := range entries {
+			// 停用或隐藏的条目不在模型列表中显示
+			if !entry.IsEnabled() || entry.Hidden {
 				continue
 			}
-			// 精确 mapping：定价按 target 查；target 缺失/通配则退化按 src 查
-			pricingKey := target
-			if pricingKey == "" {
-				pricingKey = src
+			for _, src := range entry.Sources {
+				target := entry.Target
+				prefix, isWild := splitWildcardSuffix(src)
+				if isWild {
+					if pidx == nil {
+						continue
+					}
+					prefixLower := strings.ToLower(prefix)
+					for _, candidate := range pidx.names {
+						if strings.HasPrefix(strings.ToLower(candidate), prefixLower) {
+							display, pricing := lookup(pidx, candidate)
+							add(platform, display, pricing)
+						}
+					}
+					continue
+				}
+				// 精确 mapping：定价按 target 查；target 缺失/通配则退化按 src 查
+				pricingKey := target
+				if pricingKey == "" {
+					pricingKey = src
+				}
+				if _, targetWild := splitWildcardSuffix(pricingKey); targetWild {
+					pricingKey = src
+				}
+				_, pricing := lookup(pidx, pricingKey)
+				// 显示名优先用 src 在定价里的原始大小写（若 src 本身是个定价模型名）
+				displayName, _ := lookup(pidx, src)
+				add(platform, displayName, pricing)
 			}
-			if _, targetWild := splitWildcardSuffix(pricingKey); targetWild {
-				pricingKey = src
-			}
-			_, pricing := lookup(pidx, pricingKey)
-			// 显示名优先用 src 在定价里的原始大小写（若 src 本身是个定价模型名）
-			displayName, _ := lookup(pidx, src)
-			add(platform, displayName, pricing)
 		}
 	}
 

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -219,6 +219,9 @@ func newEmptyChannelCache() *channelCache {
 func expandPricingToCache(cache *channelCache, ch *Channel, gid int64, platform string) {
 	for j := range ch.ModelPricing {
 		pricing := &ch.ModelPricing[j]
+		if !pricing.IsEnabled() {
+			continue // 停用条目不参与路由和计费缓存
+		}
 		if !isPlatformPricingMatch(platform, pricing.Platform) {
 			continue // 跳过非本平台的定价
 		}
@@ -244,22 +247,28 @@ func expandPricingToCache(cache *channelCache, ch *Channel, gid int64, platform 
 // 各平台严格独立：antigravity 分组只匹配 antigravity 映射。
 func expandMappingToCache(cache *channelCache, ch *Channel, gid int64, platform string) {
 	for _, mappingPlatform := range matchingPlatforms(platform) {
-		platformMapping, ok := ch.ModelMapping[mappingPlatform]
+		entries, ok := ch.ModelMapping[mappingPlatform]
 		if !ok {
 			continue
 		}
 		// 使用映射条目的原始平台作为缓存 key，防止跨平台同名映射冲突
 		gpKey := channelGroupPlatformKey{groupID: gid, platform: mappingPlatform}
-		for src, dst := range platformMapping {
-			if strings.HasSuffix(src, "*") {
-				prefix := strings.ToLower(strings.TrimSuffix(src, "*"))
-				cache.wildcardMappingByGP[gpKey] = append(cache.wildcardMappingByGP[gpKey], &wildcardMappingEntry{
-					prefix: prefix,
-					target: dst,
-				})
-			} else {
-				key := channelModelKey{groupID: gid, platform: mappingPlatform, model: strings.ToLower(src)}
-				cache.mappingByGroupModel[key] = dst
+		for _, entry := range entries {
+			if !entry.IsEnabled() {
+				continue // 禁用条目不参与路由
+			}
+			for _, src := range entry.Sources {
+				dst := entry.Target
+				if strings.HasSuffix(src, "*") {
+					prefix := strings.ToLower(strings.TrimSuffix(src, "*"))
+					cache.wildcardMappingByGP[gpKey] = append(cache.wildcardMappingByGP[gpKey], &wildcardMappingEntry{
+						prefix: prefix,
+						target: dst,
+					})
+				} else {
+					key := channelModelKey{groupID: gid, platform: mappingPlatform, model: strings.ToLower(src)}
+					cache.mappingByGroupModel[key] = dst
+				}
 			}
 		}
 	}
@@ -630,7 +639,7 @@ func RemovePreviousResponseIDFromBody(body []byte) []byte {
 
 // validateChannelConfig 校验渠道的定价和映射配置（冲突检测 + 区间校验 + 计费模式校验）。
 // Create 和 Update 共用此函数，避免重复。
-func validateChannelConfig(pricing []ChannelModelPricing, mapping map[string]map[string]string) error {
+func validateChannelConfig(pricing []ChannelModelPricing, mapping map[string][]ModelMappingEntry) error {
 	if err := validatePricingEntries(pricing); err != nil {
 		return err
 	}
@@ -1009,13 +1018,18 @@ func validateNoConflictingModels(pricingList []ChannelModelPricing) error {
 }
 
 // validateNoConflictingMappings 检查模型映射中是否有冲突的源模式
-func validateNoConflictingMappings(mapping map[string]map[string]string) error {
-	for platform, platformMapping := range mapping {
-		entries := make([]modelEntry, 0, len(platformMapping))
-		for src := range platformMapping {
-			entries = append(entries, toModelEntry(src))
+func validateNoConflictingMappings(mapping map[string][]ModelMappingEntry) error {
+	for platform, entries := range mapping {
+		modelEntries := make([]modelEntry, 0)
+		for _, e := range entries {
+			if !e.IsEnabled() {
+				continue // 禁用条目不参与冲突检测
+			}
+			for _, src := range e.Sources {
+				modelEntries = append(modelEntries, toModelEntry(src))
+			}
 		}
-		if err := detectConflicts(entries, platform, "MAPPING_PATTERN_CONFLICT", "mapping source patterns"); err != nil {
+		if err := detectConflicts(modelEntries, platform, "MAPPING_PATTERN_CONFLICT", "mapping source patterns"); err != nil {
 			return err
 		}
 	}
@@ -1058,7 +1072,7 @@ type CreateChannelInput struct {
 	Description                string
 	GroupIDs                   []int64
 	ModelPricing               []ChannelModelPricing
-	ModelMapping               map[string]map[string]string // platform → {src→dst}
+	ModelMapping               map[string][]ModelMappingEntry // platform → []ModelMappingEntry
 	BillingModelSource         string
 	RestrictModels             bool
 	Features                   string
@@ -1074,7 +1088,7 @@ type UpdateChannelInput struct {
 	Status                     string
 	GroupIDs                   *[]int64
 	ModelPricing               *[]ChannelModelPricing
-	ModelMapping               map[string]map[string]string // platform → {src→dst}
+	ModelMapping               map[string][]ModelMappingEntry // platform → []ModelMappingEntry
 	BillingModelSource         string
 	RestrictModels             *bool
 	Features                   *string

--- a/backend/internal/service/channel_service_mapping_test.go
+++ b/backend/internal/service/channel_service_mapping_test.go
@@ -1,0 +1,234 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// supportedModelNames 从 []SupportedModel 中提取指定平台的模型名称列表
+func supportedModelNames(models []SupportedModel, platform string) []string {
+	var names []string
+	for _, m := range models {
+		if m.Platform == platform {
+			names = append(names, m.Name)
+		}
+	}
+	return names
+}
+
+// TestMultiSourceMapping 测试多源映射路由：同一 Target 的两个 Source 各自可以命中
+func TestMultiSourceMapping(t *testing.T) {
+	cache := newEmptyChannelCache()
+
+	groupID := int64(1)
+	platform := "openai"
+
+	// 两个 Source 共同映射到同一 Target
+	cache.mappingByGroupModel[channelModelKey{groupID: groupID, platform: platform, model: "gpt-4"}] = "gpt-4o"
+	cache.mappingByGroupModel[channelModelKey{groupID: groupID, platform: platform, model: "gpt-4-turbo"}] = "gpt-4o"
+
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{"first source maps correctly", "gpt-4", "gpt-4o"},
+		{"second source maps correctly", "gpt-4-turbo", "gpt-4o"},
+		{"GPT-4 uppercase maps correctly (case-insensitive)", "GPT-4", "gpt-4o"},
+		{"unmapped model returns empty", "gpt-3.5-turbo", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := lookupMappingAcrossPlatforms(cache, groupID, platform, normalizeChannelPricingModelName(tt.model))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestHiddenMappingRouting 验证隐藏条目仍参与路由，但不出现在 SupportedModels 列表
+func TestHiddenMappingRouting(t *testing.T) {
+	ch := &Channel{
+		ID:     1,
+		Status: StatusActive,
+		ModelMapping: map[string][]ModelMappingEntry{
+			"openai": {
+				{
+					Sources: []string{"gpt-4-deprecated"},
+					Target:  "gpt-4o",
+					Enabled: nil,  // nil = 默认启用
+					Hidden:  true, // 隐藏
+				},
+			},
+		},
+	}
+
+	// 模拟：隐藏条目已被 expandMappingToCache 写入映射缓存（Hidden 不过滤路由缓存）
+	cache := newEmptyChannelCache()
+	cache.groupPlatform[1] = "openai"
+	cache.channelByGroupID[1] = ch
+	cache.byID[1] = ch
+	cache.mappingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4-deprecated"}] = "gpt-4o"
+
+	// 路由：隐藏条目仍可映射
+	mapped := lookupMappingAcrossPlatforms(cache, 1, "openai", "gpt-4-deprecated")
+	require.Equal(t, "gpt-4o", mapped, "hidden mapping should still route")
+
+	// 模型列表：隐藏条目不应出现
+	names := supportedModelNames(ch.SupportedModels(), "openai")
+	require.NotContains(t, names, "gpt-4-deprecated", "hidden mapping should not appear in model list")
+}
+
+// TestDisabledMappingNotInCache 验证停用映射条目不进入路由缓存
+func TestDisabledMappingNotInCache(t *testing.T) {
+	ch := &Channel{
+		ID:     1,
+		Status: StatusActive,
+		ModelMapping: map[string][]ModelMappingEntry{
+			"openai": {
+				{
+					Sources: []string{"gpt-4-old"},
+					Target:  "gpt-4o",
+					Enabled: boolPtr(false), // 停用
+				},
+				{
+					Sources: []string{"gpt-4"},
+					Target:  "gpt-4o",
+					Enabled: nil, // 启用
+				},
+			},
+		},
+	}
+
+	cache := newEmptyChannelCache()
+	cache.groupPlatform[1] = "openai"
+	cache.channelByGroupID[1] = ch
+
+	expandMappingToCache(cache, ch, 1, "openai")
+
+	// 停用条目不应进入缓存
+	_, exists := cache.mappingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4-old"}]
+	require.False(t, exists, "disabled mapping should not be in cache")
+
+	// 启用条目应进入缓存
+	_, existsEnabled := cache.mappingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4"}]
+	require.True(t, existsEnabled, "enabled mapping should be in cache")
+}
+
+// TestDisabledPricingNotInCache 验证停用定价条目不进入计费缓存
+func TestDisabledPricingNotInCache(t *testing.T) {
+	ch := &Channel{
+		ID:     1,
+		Status: StatusActive,
+		ModelPricing: []ChannelModelPricing{
+			{
+				Models:      []string{"gpt-4-deprecated"},
+				Platform:    "openai",
+				BillingMode: BillingModeToken,
+				InputPrice:  float64Ptr(0.01),
+				OutputPrice: float64Ptr(0.03),
+				Enabled:     boolPtr(false), // 停用
+			},
+			{
+				Models:      []string{"gpt-4o"},
+				Platform:    "openai",
+				BillingMode: BillingModeToken,
+				InputPrice:  float64Ptr(0.005),
+				OutputPrice: float64Ptr(0.015),
+				Enabled:     boolPtr(true), // 启用
+			},
+		},
+	}
+
+	cache := newEmptyChannelCache()
+	cache.groupPlatform[1] = "openai"
+	cache.channelByGroupID[1] = ch
+
+	expandPricingToCache(cache, ch, 1, "openai")
+
+	// 停用定价不应进入缓存
+	_, exists := cache.pricingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4-deprecated"}]
+	require.False(t, exists, "disabled pricing should not be in cache")
+
+	// 启用定价应进入缓存，且价格正确
+	pricing, existsEnabled := cache.pricingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4o"}]
+	require.True(t, existsEnabled, "enabled pricing should be in cache")
+	require.NotNil(t, pricing.InputPrice)
+	require.InDelta(t, 0.005, *pricing.InputPrice, 1e-9)
+}
+
+// TestHiddenPricingNotInModelList 验证隐藏定价进入计费缓存但不出现在模型列表
+func TestHiddenPricingNotInModelList(t *testing.T) {
+	ch := &Channel{
+		ID:     1,
+		Status: StatusActive,
+		ModelPricing: []ChannelModelPricing{
+			{
+				Models:      []string{"gpt-4-internal"},
+				Platform:    "openai",
+				BillingMode: BillingModeToken,
+				InputPrice:  float64Ptr(0.01),
+				OutputPrice: float64Ptr(0.03),
+				Enabled:     boolPtr(true), // 启用
+				Hidden:      true,          // 隐藏
+			},
+			{
+				Models:      []string{"gpt-4o"},
+				Platform:    "openai",
+				BillingMode: BillingModeToken,
+				InputPrice:  float64Ptr(0.005),
+				OutputPrice: float64Ptr(0.015),
+				Enabled:     boolPtr(true),
+				Hidden:      false,
+			},
+		},
+	}
+
+	cache := newEmptyChannelCache()
+	cache.groupPlatform[1] = "openai"
+	cache.channelByGroupID[1] = ch
+	cache.byID[1] = ch
+
+	expandPricingToCache(cache, ch, 1, "openai")
+
+	// 隐藏定价应进入缓存（用于计费）
+	pricing, exists := cache.pricingByGroupModel[channelModelKey{groupID: 1, platform: "openai", model: "gpt-4-internal"}]
+	require.True(t, exists, "hidden pricing should be in billing cache")
+	require.NotNil(t, pricing.InputPrice)
+	require.InDelta(t, 0.01, *pricing.InputPrice, 1e-9)
+
+	// 隐藏定价不应出现在模型列表
+	names := supportedModelNames(ch.SupportedModels(), "openai")
+	require.NotContains(t, names, "gpt-4-internal", "hidden pricing should not appear in model list")
+	require.Contains(t, names, "gpt-4o", "visible pricing should appear in model list")
+}
+
+// TestWildcardMappingMultiSource 验证通配符映射的前缀匹配逻辑
+func TestWildcardMappingMultiSource(t *testing.T) {
+	cache := newEmptyChannelCache()
+	gpKey := channelGroupPlatformKey{groupID: 1, platform: "openai"}
+	cache.wildcardMappingByGP[gpKey] = []*wildcardMappingEntry{
+		{prefix: "gpt-4-", target: "gpt-4o"},
+		{prefix: "gpt-3.5-", target: "gpt-3.5-turbo"},
+	}
+	cache.groupPlatform[1] = "openai"
+
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{"gpt-4-turbo matches first wildcard", "gpt-4-turbo", "gpt-4o"},
+		{"gpt-4-vision matches first wildcard", "gpt-4-vision", "gpt-4o"},
+		{"gpt-3.5-turbo-16k matches second wildcard", "gpt-3.5-turbo-16k", "gpt-3.5-turbo"},
+		{"gpt-5 does not match any wildcard", "gpt-5", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := lookupMappingAcrossPlatforms(cache, 1, "openai", normalizeChannelPricingModelName(tt.model))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/internal/service/channel_test.go
+++ b/backend/internal/service/channel_test.go
@@ -294,17 +294,19 @@ func TestChannelClone_EdgeCases(t *testing.T) {
 	t.Run("deep copy model mapping", func(t *testing.T) {
 		original := &Channel{
 			ID: 1,
-			ModelMapping: map[string]map[string]string{
-				"openai": {"gpt-4": "gpt-4-turbo"},
+			ModelMapping: map[string][]ModelMappingEntry{
+				"openai": {{Sources: []string{"gpt-4"}, Target: "gpt-4-turbo"}},
 			},
 		}
 		cloned := original.Clone()
 
-		// Modify the cloned nested map
-		cloned.ModelMapping["openai"]["gpt-4"] = "hacked"
+		// Modify the cloned nested entry and sources slice.
+		cloned.ModelMapping["openai"][0].Target = "hacked"
+		cloned.ModelMapping["openai"][0].Sources[0] = "hacked-source"
 
-		// Original must remain unchanged
-		require.Equal(t, "gpt-4-turbo", original.ModelMapping["openai"]["gpt-4"])
+		// Original must remain unchanged.
+		require.Equal(t, "gpt-4-turbo", original.ModelMapping["openai"][0].Target)
+		require.Equal(t, "gpt-4", original.ModelMapping["openai"][0].Sources[0])
 	})
 }
 
@@ -512,7 +514,6 @@ func TestSupportedModels_WildcardExpandedFromPricing(t *testing.T) {
 		require.NotContains(t, m.Name, "*")
 	}
 }
-
 
 func TestSupportedModels_MissingPricingKeepsNilPricing(t *testing.T) {
 	ch := &Channel{

--- a/backend/migrations/224_channel_pricing_flags.sql
+++ b/backend/migrations/224_channel_pricing_flags.sql
@@ -1,0 +1,6 @@
+-- 渠道模型定价增加 enabled(启用/停用) 和 hidden(显示/隐藏) 标志
+-- enabled=false 表示该定价条目被停用，等价于不存在（不参与计费，也不在模型列表中显示）
+-- hidden=true   表示该定价条目在可用渠道/返回的模型列表中隐藏，但仍参与计费
+ALTER TABLE channel_model_pricing
+	ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE,
+	ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;

--- a/frontend/src/api/admin/channels.ts
+++ b/frontend/src/api/admin/channels.ts
@@ -21,6 +21,13 @@ export interface PricingInterval {
   sort_order: number
 }
 
+export interface ChannelModelMappingEntry {
+  sources: string[]
+  target: string
+  enabled?: boolean
+  hidden: boolean
+}
+
 export interface ChannelModelPricing {
   id?: number
   platform: string
@@ -34,6 +41,8 @@ export interface ChannelModelPricing {
   image_output_price: number | null
   per_request_price: number | null
   intervals: PricingInterval[]
+  enabled?: boolean
+  hidden: boolean
 }
 
 export interface AccountStatsPricingRule {
@@ -54,7 +63,7 @@ export interface Channel {
   features_config?: Record<string, unknown>
   group_ids: number[]
   model_pricing: ChannelModelPricing[]
-  model_mapping: Record<string, Record<string, string>> // platform → {src→dst}
+  model_mapping: Record<string, ChannelModelMappingEntry[]> // platform → mapping rules
   apply_pricing_to_account_stats: boolean
   account_stats_pricing_rules: AccountStatsPricingRule[]
   created_at: string
@@ -66,7 +75,7 @@ export interface CreateChannelRequest {
   description?: string
   group_ids?: number[]
   model_pricing?: ChannelModelPricing[]
-  model_mapping?: Record<string, Record<string, string>>
+  model_mapping?: Record<string, ChannelModelMappingEntry[]>
   billing_model_source?: string
   restrict_models?: boolean
   features_config?: Record<string, unknown>
@@ -80,7 +89,7 @@ export interface UpdateChannelRequest {
   status?: string
   group_ids?: number[]
   model_pricing?: ChannelModelPricing[]
-  model_mapping?: Record<string, Record<string, string>>
+  model_mapping?: Record<string, ChannelModelMappingEntry[]>
   billing_model_source?: string
   restrict_models?: boolean
   features_config?: Record<string, unknown>

--- a/frontend/src/components/admin/channel/PricingEntryCard.vue
+++ b/frontend/src/components/admin/channel/PricingEntryCard.vue
@@ -51,6 +51,23 @@
         {{ t('admin.channels.form.pricingEntry') }}
       </div>
 
+      <div class="flex flex-shrink-0 items-center gap-2" @click.stop>
+        <span class="text-[10px] text-gray-400 dark:text-gray-500" :title="t('admin.channels.form.pricingEnabled', 'Enabled')">
+          {{ entry.enabled ? '' : t('admin.channels.form.disabled', 'OFF') }}
+        </span>
+        <Toggle
+          :modelValue="entry.enabled"
+          @update:modelValue="emit('update', { ...props.entry, enabled: $event })"
+        />
+        <span class="text-[10px] text-gray-400 dark:text-gray-500" :title="t('admin.channels.form.pricingHidden', 'Hidden')">
+          {{ entry.hidden ? t('admin.channels.form.hidden', 'H') : '' }}
+        </span>
+        <Toggle
+          :modelValue="entry.hidden"
+          @update:modelValue="emit('update', { ...props.entry, hidden: $event })"
+        />
+      </div>
+
       <!-- Remove button (always visible, stop propagation) -->
       <button
         type="button"
@@ -235,6 +252,7 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Select from '@/components/common/Select.vue'
+import Toggle from '@/components/common/Toggle.vue'
 import Icon from '@/components/icons/Icon.vue'
 import IntervalRow from './IntervalRow.vue'
 import ModelTagInput from './ModelTagInput.vue'

--- a/frontend/src/components/admin/channel/types.ts
+++ b/frontend/src/components/admin/channel/types.ts
@@ -16,6 +16,8 @@ export interface IntervalFormEntry {
 
 export interface PricingFormEntry {
   models: string[]
+  enabled: boolean
+  hidden: boolean
   billing_mode: BillingMode
   input_price: number | string | null
   output_price: number | string | null

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -378,37 +378,43 @@
                 </button>
               </div>
               <div
-                v-if="Object.keys(section.model_mapping).length === 0"
+                v-if="section.model_mapping.length === 0"
                 class="rounded border border-dashed border-gray-300 p-2 text-center text-xs text-gray-400 dark:border-dark-500"
               >
                 {{ t('admin.channels.form.noMappingRules', 'No mapping rules. Click "Add" to create one.') }}
               </div>
               <div v-else class="space-y-1">
                 <div
-                  v-for="(_, srcModel) in section.model_mapping"
-                  :key="srcModel"
+                  v-for="(entry, mappingIndex) in section.model_mapping"
+                  :key="mappingIndex"
                   class="flex items-center gap-2"
                 >
-                  <input
-                    :value="srcModel"
-                    type="text"
-                    class="input flex-1 text-xs"
-                    :class="platformTextClass(section.platform)"
-                    :placeholder="t('admin.channels.form.mappingSource', 'Source model')"
-                    @change="renameMappingKey(sIdx, srcModel, ($event.target as HTMLInputElement).value)"
+                  <ModelTagInput
+                    :models="entry.sources"
+                    :platform="section.platform"
+                    @update:models="entry.sources = $event"
+                    :placeholder="t('admin.channels.form.mappingSource', 'Source models')"
+                    class="min-w-0 flex-1"
                   />
                   <span class="text-gray-400 text-xs">→</span>
                   <input
-                    :value="section.model_mapping[srcModel]"
+                    v-model="entry.target"
                     type="text"
-                    class="input flex-1 text-xs"
+                    class="input min-w-0 flex-1 text-xs"
                     :class="platformTextClass(section.platform)"
                     :placeholder="t('admin.channels.form.mappingTarget', 'Target model')"
-                    @input="section.model_mapping[srcModel] = ($event.target as HTMLInputElement).value"
+                  />
+                  <Toggle
+                    v-model="entry.enabled"
+                    :title="t('admin.channels.form.mappingEnabled', 'Enabled: when off, this rule is ignored entirely')"
+                  />
+                  <Toggle
+                    v-model="entry.hidden"
+                    :title="t('admin.channels.form.mappingHidden', 'Hidden: rule still works but source models are not listed')"
                   />
                   <button
                     type="button"
-                    @click="removeMappingEntry(sIdx, srcModel)"
+                    @click="removeMappingEntry(sIdx, mappingIndex)"
                     class="rounded p-0.5 text-gray-400 hover:text-red-500"
                   >
                     <Icon name="trash" size="sm" />
@@ -647,6 +653,7 @@ import Select from '@/components/common/Select.vue'
 import Icon from '@/components/icons/Icon.vue'
 import PlatformIcon from '@/components/common/PlatformIcon.vue'
 import Toggle from '@/components/common/Toggle.vue'
+import ModelTagInput from '@/components/admin/channel/ModelTagInput.vue'
 import PricingEntryCard from '@/components/admin/channel/PricingEntryCard.vue'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { useKeyedDebouncedSearch } from '@/composables/useKeyedDebouncedSearch'
@@ -680,7 +687,7 @@ interface PlatformSection {
   enabled: boolean
   collapsed: boolean
   group_ids: number[]
-  model_mapping: Record<string, string>
+  model_mapping: Array<{ sources: string[], target: string, enabled: boolean, hidden: boolean }>
   model_pricing: PricingFormEntry[]
   web_search_emulation: boolean
   codex_image_generation_bridge: boolean
@@ -778,7 +785,7 @@ function addPlatformSection(platform: GroupPlatform) {
     enabled: true,
     collapsed: false,
     group_ids: [],
-    model_mapping: {},
+    model_mapping: [],
     model_pricing: [],
     web_search_emulation: false,
     codex_image_generation_bridge: false,
@@ -851,6 +858,8 @@ function toggleGroupInSection(sectionIdx: number, groupId: number) {
 function addPricingEntry(sectionIdx: number) {
   form.platforms[sectionIdx].model_pricing.push({
     models: [],
+    enabled: true,
+    hidden: false,
     billing_mode: 'token',
     input_price: null,
     output_price: null,
@@ -884,6 +893,8 @@ async function syncLatestModels(sectionIdx: number) {
     // Add new models as a single new pricing entry (user fills in prices)
     form.platforms[sectionIdx].model_pricing.push({
       models: newModels,
+      enabled: true,
+      hidden: false,
       billing_mode: 'token',
       input_price: null,
       output_price: null,
@@ -912,28 +923,11 @@ function removePricingEntry(sectionIdx: number, idx: number) {
 
 // ── Model Mapping helpers ──
 function addMappingEntry(sectionIdx: number) {
-  const mapping = form.platforms[sectionIdx].model_mapping
-  let key = ''
-  let i = 1
-  while (key === '' || key in mapping) {
-    key = `model-${i}`
-    i++
-  }
-  mapping[key] = ''
+  form.platforms[sectionIdx].model_mapping.push({ sources: [], target: '', enabled: true, hidden: false })
 }
 
-function removeMappingEntry(sectionIdx: number, key: string) {
-  delete form.platforms[sectionIdx].model_mapping[key]
-}
-
-function renameMappingKey(sectionIdx: number, oldKey: string, newKey: string) {
-  newKey = newKey.trim()
-  if (!newKey || newKey === oldKey) return
-  const mapping = form.platforms[sectionIdx].model_mapping
-  if (newKey in mapping) return
-  const value = mapping[oldKey]
-  delete mapping[oldKey]
-  mapping[newKey] = value
+function removeMappingEntry(sectionIdx: number, index: number) {
+  form.platforms[sectionIdx].model_mapping.splice(index, 1)
 }
 
 // ── Account Stats Pricing helpers ──
@@ -949,6 +943,8 @@ function addAccountStatsRule(sectionIdx: number) {
 function addRulePricingEntry(sectionIdx: number, ruleIndex: number) {
   form.platforms[sectionIdx].account_stats_pricing_rules[ruleIndex].pricing.push({
     models: [],
+    enabled: true,
+    hidden: false,
     billing_mode: 'token',
     input_price: null,
     output_price: null,
@@ -1082,10 +1078,10 @@ function accountStatsRulesToAPI(): AccountStatsPricingRule[] {
 }
 
 // ── Form ↔ API conversion ──
-function formToAPI(): { group_ids: number[], model_pricing: ChannelModelPricing[], model_mapping: Record<string, Record<string, string>>, features_config: Record<string, unknown> } {
+function formToAPI(): { group_ids: number[], model_pricing: ChannelModelPricing[], model_mapping: Record<string, Array<{ sources: string[], target: string, enabled: boolean, hidden: boolean }>>, features_config: Record<string, unknown> } {
   const group_ids: number[] = []
   const model_pricing: ChannelModelPricing[] = []
-  const model_mapping: Record<string, Record<string, string>> = {}
+  const model_mapping: Record<string, Array<{ sources: string[], target: string, enabled: boolean, hidden: boolean }>> = {}
   // Preserve existing features_config fields not managed by the form
   const featuresConfig: Record<string, unknown> = editingChannel.value?.features_config
     ? { ...editingChannel.value.features_config }
@@ -1096,8 +1092,8 @@ function formToAPI(): { group_ids: number[], model_pricing: ChannelModelPricing[
     group_ids.push(...section.group_ids)
 
     // Model mapping per platform
-    if (Object.keys(section.model_mapping).length > 0) {
-      model_mapping[section.platform] = { ...section.model_mapping }
+    if (section.model_mapping.length > 0) {
+      model_mapping[section.platform] = section.model_mapping.map(entry => ({ ...entry, sources: [...entry.sources] }))
     }
 
     // Model pricing with platform tag
@@ -1114,7 +1110,9 @@ function formToAPI(): { group_ids: number[], model_pricing: ChannelModelPricing[
         image_input_price: mTokToPerToken(entry.image_input_price),
         image_output_price: mTokToPerToken(entry.image_output_price),
         per_request_price: entry.per_request_price != null && entry.per_request_price !== '' ? Number(entry.per_request_price) : null,
-        intervals: formIntervalsToAPI(entry.intervals || [])
+        intervals: formIntervalsToAPI(entry.intervals || []),
+        enabled: entry.enabled,
+        hidden: entry.hidden
       })
     }
   }
@@ -1198,11 +1196,18 @@ function apiToForm(channel: Channel): PlatformSection[] {
       const groupPlatform = groupPlatformMap.get(gid)
       return groupPlatform === platform || groupPlatform === 'composite'
     })
-    const mapping = (channel.model_mapping || {})[platform] || {}
+    const mapping = ((channel.model_mapping || {})[platform] || []).map(entry => ({
+      sources: [...(entry.sources || [])],
+      target: entry.target || '',
+      enabled: entry.enabled !== false,
+      hidden: !!entry.hidden
+    }))
     const pricing = (channel.model_pricing || [])
       .filter(p => (p.platform || 'anthropic') === platform)
       .map(p => ({
         models: p.models || [],
+        enabled: p.enabled !== false,
+        hidden: !!p.hidden,
         billing_mode: p.billing_mode,
         input_price: perTokenToMTok(p.input_price),
         output_price: perTokenToMTok(p.output_price),
@@ -1227,7 +1232,7 @@ function apiToForm(channel: Channel): PlatformSection[] {
       enabled: true,
       collapsed: false,
       group_ids: groupIds,
-      model_mapping: { ...mapping },
+      model_mapping: mapping,
       model_pricing: pricing,
       web_search_emulation: webSearchEnabled,
       codex_image_generation_bridge: codexImageGenerationBridgeEnabled,
@@ -1481,7 +1486,7 @@ async function handleSubmit() {
       return
     }
     // Check model mapping source pattern conflicts
-    const mappingKeys = Object.keys(section.model_mapping)
+    const mappingKeys = section.model_mapping.flatMap(entry => entry.sources)
     if (mappingKeys.length > 0) {
       const mappingConflict = findModelConflict(mappingKeys)
       if (mappingConflict) {


### PR DESCRIPTION
# 模型映射与定价支持通配符、多源标签、启停与隐藏

## 修改背景
- 现有渠道定价/模型映射，无法设置生效还是不生效，并且模型映射后就会在渠道和API中提供，无法隐藏
- 有些情况需要兼容不提供但是用户有请求的模型自动映射到存在模型，不需要在模型列表提供但是用户调用可以映射
- 多上游的情况下，有集中映射到某个模型的需求，因此如果可以多映射，减少维护工作量

## 模型映射
- 映射结构由 platform->{src:dst} 升级为 platform->[]ModelMappingEntry， 支持一行内多个源模型标签（Sources）共同映射到同一目标模型。
- 源模型支持尾部通配符（如 gpt-*），大小写不敏感前缀匹配， 路由时精确映射优先于通配符映射。
- 映射条目支持启用/停用：停用后该条目不参与路由（不进缓存）。
- 映射条目支持显示/隐藏：隐藏后仍可路由，但源模型不出现在 可用渠道/返回的模型列表中。
- 兼容旧格式 model_mapping JSON，读取时自动转换为单源条目。

## 模型定价
- 定价条目新增 enabled/hidden 标志（新增 224 迁移）。
- 停用定价等价于不存在：不参与计费、模型限制与模型列表。
- 隐藏定价仍参与计费，但不出现在模型列表中。
- Enabled 使用可选指针，nil 视为启用，保证旧数据/旧字面量默认启用。

## 分层实现
- Repository: model_mapping 新旧格式序列化兼容、pricing SQL 增加状态列。
- Service: 缓存构建（expandPricing/expandMappingToCache）过滤停用条目， GetModelPricing/SupportedModels 过滤隐藏与停用。
- Handler: 请求/响应 DTO 增加多源映射与定价状态。
- 前端: 映射行改为源标签输入 + 目标 + 启用/隐藏开关， 定价卡片增加启用/隐藏开关，formToAPI/apiToForm 适配新字段。
- 测试: 新增多源映射、隐藏映射路由、停用映射/定价不进缓存、 隐藏定价仍计费等 6 个用例，全部通过。