### PR TITLE
fix: normalize Grok response model audit aliases

### DIFF
--- a/backend/internal/service/upstream_response_model.go
+++ b/backend/internal/service/upstream_response_model.go
@@ -167,8 +167,31 @@ func upstreamModelMismatch(sentModel, responseModel string) *bool {
 		return nil
 	}
 	sentModel = strings.TrimSpace(sentModel)
-	mismatch := sentModel == "" || !strings.EqualFold(sentModel, responseModel)
+	mismatch := sentModel == "" || !upstreamModelsMatchForAudit(sentModel, responseModel)
 	return &mismatch
+}
+
+func upstreamModelsMatchForAudit(sentModel, responseModel string) bool {
+	if strings.EqualFold(sentModel, responseModel) {
+		return true
+	}
+
+	// xAI reports the runtime build ID for these supported public aliases.
+	// Canonicalize only for mismatch auditing; keep the raw response model for
+	// observability and for the separate response-model billing safeguards.
+	sentGrokModel := canonicalGrokBuildRuntimeModel(sentModel)
+	return sentGrokModel != "" && sentGrokModel == canonicalGrokBuildRuntimeModel(responseModel)
+}
+
+func canonicalGrokBuildRuntimeModel(model string) string {
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "grok-4.5", "grok-4.5-latest", "grok-4.5-build":
+		return "grok-4.5-build"
+	case "grok-4.6", "grok-4.6-latest", "grok-4.6-build":
+		return "grok-4.6-build"
+	default:
+		return ""
+	}
 }
 
 func upstreamSentModel(requestedModel, upstreamModel string) string {

--- a/backend/internal/service/upstream_response_model_test.go
+++ b/backend/internal/service/upstream_response_model_test.go
@@ -59,6 +59,77 @@ func TestUpstreamModelMismatchThreeStateAndCaseInsensitiveComparison(t *testing.
 	require.True(t, *mismatched)
 }
 
+func TestUpstreamModelMismatchTreatsGrokBuildRuntimeIDsAsAliases(t *testing.T) {
+	tests := []struct {
+		name          string
+		sentModel     string
+		responseModel string
+	}{
+		{
+			name:          "issue 5634 grok 4.6",
+			sentModel:     "grok-4.6",
+			responseModel: "grok-4.6-build",
+		},
+		{
+			name:          "grok 4.6 latest",
+			sentModel:     "grok-4.6-latest",
+			responseModel: "grok-4.6-build",
+		},
+		{
+			name:          "issue 5647 grok 4.5 latest",
+			sentModel:     "grok-4.5-latest",
+			responseModel: "grok-4.5-build",
+		},
+		{
+			name:          "grok 4.5 canonical",
+			sentModel:     "grok-4.5",
+			responseModel: "GROK-4.5-BUILD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mismatch := upstreamModelMismatch(tt.sentModel, tt.responseModel)
+
+			require.NotNil(t, mismatch)
+			require.False(t, *mismatch)
+		})
+	}
+}
+
+func TestUpstreamModelMismatchDoesNotCollapseDifferentModels(t *testing.T) {
+	tests := []struct {
+		name          string
+		sentModel     string
+		responseModel string
+	}{
+		{
+			name:          "different grok versions",
+			sentModel:     "grok-4.5",
+			responseModel: "grok-4.6-build",
+		},
+		{
+			name:          "unrelated build suffix",
+			sentModel:     "gpt-5.5",
+			responseModel: "gpt-5.5-build",
+		},
+		{
+			name:          "different grok runtime",
+			sentModel:     "grok-build-0.1",
+			responseModel: "grok-4.5-build",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mismatch := upstreamModelMismatch(tt.sentModel, tt.responseModel)
+
+			require.NotNil(t, mismatch)
+			require.True(t, *mismatch)
+		})
+	}
+}
+
 func TestObserveOpenAISSEBodyIgnoresMalformedPayload(t *testing.T) {
 	observer := &upstreamResponseModelObserver{}
 	observeOpenAISSEBody(observer, "data: not-json\n\ndata: {\"type\":\"response.completed\",\"response\":{\"model\":\"gpt-5.4\"}}\n\n")


### PR DESCRIPTION
## Summary

- treat xAI's Grok 4.5 and 4.6 `-build` runtime IDs as equivalent to their matching public aliases for upstream mismatch auditing
- preserve the raw upstream response model and the separate response-model billing safeguards
- add positive coverage for canonical and `-latest` aliases plus negative coverage for cross-version and unrelated build IDs

## Problem

xAI can return `grok-4.5-build` or `grok-4.6-build` after sub2api sends the corresponding public model or `-latest` alias. The audit path compared those strings literally, so successful requests from issues #5634 and #5647 were recorded as upstream model mismatches.

## Reported symptoms

- #5634, **“↳ 上游响应:grok-4.6-build 模型不一致”**:
  > 这个错误是什么意思
- #5647, **“上游响应:grok-4.5-build 模型不一致”**:
  > 上游响应:grok-4.5-build 模型不一致

Both reports show the audit flagging xAI's matching `-build` runtime response ID as a different model from the requested public Grok alias.

## Implementation

The mismatch comparison now canonicalizes only the known Grok 4.5 and 4.6 audit aliases. It does not rewrite the observed response model and does not change billing model selection or response-model billing safeguards.

## Verification

- `go test -tags=unit ./internal/service -run 'Test.*Upstream.*Response.*Model|Test.*Response.*Model' -count=1`
- `git diff --check origin/main...HEAD`
- broader `go test -tags=unit ./internal/service -count=1` reaches one unrelated external comparison failure: OpenAI returns `403 unsupported_country_region_territory`; the same test reproduces unchanged on the unmodified current parent

## Diff

- 2 files changed
- 95 additions, 1 deletion
- production code: 24 additions, 1 deletion
- tests: 71 additions

Base: `ab28a2d10b3e228719d072f8c59376f32c5e0b46`

Candidate: `c46d07ca07ee28413fd1dfa20406722e554a1c7b`

Closes #5634

Closes #5647
