### PR TITLE
fix(openai): 固定 Codex 指纹 turn_started_at_unix_ms 消除时间戳 flaky

### DIFF
--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -143,12 +143,13 @@ func resolveConvergedThreadID(account *Account, clientSessionID string) string {
 // 由 resolveCodexFingerprintIDs 一次性生成，同一个实例在头改写和体改写之间共享，
 // 确保所有载体中的 turn_id 等随机字段一致。
 type codexFingerprintIDs struct {
-	mode           codexFingerprintMode
-	installationID string
-	sessionID      string
-	threadID       string
-	turnID         string
-	windowID       string
+	mode              codexFingerprintMode
+	installationID    string
+	sessionID         string
+	threadID          string
+	turnID            string
+	windowID          string
+	turnStartedAtUnix int64
 }
 
 // resolveCodexFingerprintIDs 按收敛模式计算出站 ID 集合。
@@ -180,6 +181,7 @@ func resolveCodexFingerprintIDs(account *Account, clientSessionID string, mode c
 		}
 		ids.turnID = uuid.Must(uuid.NewV7()).String()
 		ids.windowID = ids.threadID + ":0"
+		ids.turnStartedAtUnix = time.Now().UnixMilli()
 		return ids
 
 	case codexFingerprintFull:
@@ -187,6 +189,7 @@ func resolveCodexFingerprintIDs(account *Account, clientSessionID string, mode c
 		ids.threadID = ids.sessionID
 		ids.turnID = uuid.Must(uuid.NewV7()).String()
 		ids.windowID = ids.threadID + ":0"
+		ids.turnStartedAtUnix = time.Now().UnixMilli()
 		return ids
 	}
 
@@ -252,7 +255,7 @@ func applyCodexFingerprintHeaders(h http.Header, ids *codexFingerprintIDs) {
 		"thread_id":               ids.threadID,
 		"turn_id":                 ids.turnID,
 		"window_id":               ids.windowID,
-		"turn_started_at_unix_ms": time.Now().UnixMilli(),
+		"turn_started_at_unix_ms": ids.turnStartedAtUnix,
 	})
 }
 
@@ -330,7 +333,7 @@ func applyCodexFingerprintToClientMetadataMap(existing map[string]any, ids *code
 		"thread_id":               ids.threadID,
 		"turn_id":                 ids.turnID,
 		"window_id":               ids.windowID,
-		"turn_started_at_unix_ms": time.Now().UnixMilli(),
+		"turn_started_at_unix_ms": ids.turnStartedAtUnix,
 	})
 	return true
 }


### PR DESCRIPTION
## 修复内容

`turn_started_at_unix_ms` 在头改写与体改写路径中各自调用 `time.Now().UnixMilli()`，导致：

1. `TestApplyCodexFingerprintClientMetadataRaw_MatchesMapVariant` 偶发失败（map 版与 raw 版各取一次时间戳，跨 1ms 边界即断言失败）
2. 同一请求的 turn 开始时刻在头与体之间漂移（真实语义不一致）

## 改动

把 `turnStartedAtUnix` 纳入 `codexFingerprintIDs`，在 `resolveCodexFingerprintIDs`（session/full）生成一次，头体改写复用同一值：

- struct 增加字段 `turnStartedAtUnix int64`
- resolve 的 session/full 两分支各赋值一次
- 两处 `time.Now().UnixMilli()` 改为 `ids.turnStartedAtUnix`

device 模式不含该字段，行为不变。

## 验证

- `go build ./internal/service/` 通过
- 原 flaky 测试 `-count=20` 全过
- 全部 fingerprint 相关测试通过

Closes #5743