### PR TITLE
[codex] 修复部分账号 Codex 额度查询 400

### DIFF
--- a/backend/internal/pkg/openai/constants.go
+++ b/backend/internal/pkg/openai/constants.go
@@ -45,6 +45,9 @@ func DefaultModelIDs() []string {
 // DefaultTestModel default model for testing OpenAI accounts
 const DefaultTestModel = "gpt-5.4"
 
+// CodexUsageProbeModel is the model used for OAuth Codex usage probes.
+const CodexUsageProbeModel = "codex-auto-review"
+
 // DefaultInstructions default instructions for non-Codex CLI requests.
 // 内容为真实 Codex CLI 的 GPT-5-Codex base prompt（codex 系模型默认）。
 //

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -830,7 +830,7 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	if accessToken == "" && !account.IsOpenAIAgentIdentity() {
 		return nil, fmt.Errorf("no access token available")
 	}
-	modelID := openaipkg.DefaultTestModel
+	modelID := openaipkg.CodexUsageProbeModel
 	payload := createOpenAITestPayload(modelID, true)
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
## 问题

管理员账号页的“查询/刷新”会调用 active usage 接口，并为 OpenAI OAuth 账号主动发起一次 Codex 用量探测。

探测请求此前复用了全局 `openaipkg.DefaultTestModel`，当前值为 `gpt-5.4`。部分账号（例如没有该模型访问权限的账号）调用 `chatgpt.com/backend-api/codex/responses` 时会收到上游 HTTP 400。由于探测失败不会中断外层用量接口，接口仍可能返回 200，但没有新的额度窗口头或快照写入，前端看起来就像“刷新没有生效”。

## 根因

`gpt-5.4` 并非所有账号类型都可以调用，不适合作为所有 OAuth 账号共用的额度探测模型。账号的模型访问权限存在差异，使用无权限模型会在额度信息返回前直接失败。

## 修复方案

- 为主动 Codex 额度探针增加独立的模型常量，并改用 `codex-auto-review`。
- 保持全局 `DefaultTestModel` 不变，避免影响 API Key 探测及其他测试流程。
- `codex-auto-review` 是当前更通用的选择；`gpt-5.4-mini` 也可以作为后续等价替代，探针模型已独立成常量，便于根据上游可用性调整。

## 影响范围

只改变管理员 active usage 的内部探测请求模型，不改变公开 API、数据库结构或正常请求的模型路由。

## 验证

- `gofmt`
- `git diff --check`
- `go test ./internal/service -run 'Test(ExtractOpenAICodexProbeUpdates|BuildCodexUsageExtraUpdates|ShouldRefreshOpenAICodexSnapshot|GetCodexFingerprintMode|ApplyOpenAICodexBetaFeatures|AccountUsageService)' -count=1`
