### PR TITLE
feat(openai): add API-key tool-call namespace preservation switch

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -2075,6 +2075,21 @@ func (a *Account) IsOpenAIResponsesFlattenNamespacesEnabled() bool {
 	return ok && enabled
 }
 
+// IsOpenAIAPIKeyResponsesKeepToolCallNamespacesEnabled returns whether an
+// OpenAI API Key account should preserve namespace on direct Responses tool
+// call history items. The default is false because the public Responses API
+// may reject the field; enable it only for a compatible upstream that supports
+// Codex namespace tool calls.
+//
+// Field: accounts.extra.openai_apikey_responses_keep_tool_call_namespaces.
+func (a *Account) IsOpenAIAPIKeyResponsesKeepToolCallNamespacesEnabled() bool {
+	if a == nil || !a.IsOpenAIApiKey() || a.Extra == nil {
+		return false
+	}
+	enabled, ok := a.Extra["openai_apikey_responses_keep_tool_call_namespaces"].(bool)
+	return ok && enabled
+}
+
 // IsOpenAIWSAllowStoreRecoveryEnabled 返回账号级 store 恢复开关。
 // 字段：accounts.extra.openai_ws_allow_store_recovery。
 func (a *Account) IsOpenAIWSAllowStoreRecoveryEnabled() bool {

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -77,9 +77,10 @@ func shouldStripOpenAIResponsesInputNamespaces(account *Account, transport OpenA
 //     故 OAuth 非 compact 请求必须保留。
 //   - compact 端点的 schema 不含该字段，携带即 400 `Unknown parameter:
 //     input[N].namespace`（issue #4761 正文），故 compact 一律清理。
-//   - API Key 出口是标准 Responses API（api.openai.com 或自定义 base_url），同样
-//     不认识该字段，维持全量清理；否则只能退化成
-//     openai_responses_rejected_field_retry 的逐项删除，6 次上限根本盖不住长历史。
+//   - API Key 出口默认按标准 Responses API 处理并全量清理。仅当自定义兼容上游
+//     明确支持 Codex namespace 时，账号可通过
+//     openai_apikey_responses_keep_tool_call_namespaces 保留工具调用项；错误开启后会
+//     回退到 openai_responses_rejected_field_retry 的逐项删除，6 次上限盖不住长历史。
 //   - 摊平模式下调用项已被改写成平名，残留 namespace 指向的声明已不存在，一律清理。
 func shouldKeepOpenAIResponsesToolCallNamespaces(
 	account *Account,
@@ -87,10 +88,13 @@ func shouldKeepOpenAIResponsesToolCallNamespaces(
 	passthroughEnabled bool,
 	compactPath bool,
 ) bool {
-	if account == nil || !account.IsOpenAIOAuth() {
+	if account == nil || compactPath {
 		return false
 	}
-	if compactPath {
+	if account.IsOpenAIApiKey() {
+		return account.IsOpenAIAPIKeyResponsesKeepToolCallNamespacesEnabled()
+	}
+	if !account.IsOpenAIOAuth() {
 		return false
 	}
 	return !shouldFlattenOpenAIResponsesNamespaces(account, transport, passthroughEnabled, compactPath)

--- a/backend/internal/service/openai_responses_namespace_forward_test.go
+++ b/backend/internal/service/openai_responses_namespace_forward_test.go
@@ -126,6 +126,54 @@ func TestOpenAIGatewayService_OAuthFlattenFlagRestoresLegacyBehavior(t *testing.
 	)
 }
 
+// API Key 账号默认按标准 Responses API 清理 namespace；指向支持 Codex namespace 的
+// 兼容上游时，账号开关仅保留工具调用项，普通消息上的残留字段仍应清理。
+func TestOpenAIGatewayService_APIKeyKeepToolCallNamespacesFlag(t *testing.T) {
+	body := []byte(codexNamespaceRequestBody)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, namespaceForwardOKResponse),
+	}}
+	c := newOpenAIRejectedFieldTestContext(body)
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Extra["openai_apikey_responses_keep_tool_call_namespaces"] = true
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(), c, account, body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	forwarded := upstream.bodies[0]
+
+	namespaceTool := gjson.GetBytes(forwarded, `tools.#(type=="namespace")`)
+	require.True(t, namespaceTool.Exists(), "namespace 声明必须原样转发")
+	require.Equal(t, "collaboration", gjson.GetBytes(forwarded, "input.0.namespace").String())
+	require.False(t, gjson.GetBytes(forwarded, "input.1.namespace").Exists())
+}
+
+func TestOpenAIGatewayService_APIKeyKeepToolCallNamespacesFlagStillStripsCompact(t *testing.T) {
+	body := []byte(codexNamespaceRequestBody)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, namespaceForwardOKResponse),
+	}}
+	c := newOpenAIRejectedFieldTestContext(body)
+	c.Request.URL.Path = "/v1/responses/compact"
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Extra["openai_apikey_responses_keep_tool_call_namespaces"] = true
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(), c, account, body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	forwarded := upstream.bodies[0]
+	require.False(t, gjson.GetBytes(forwarded, "input.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(forwarded, "input.1.namespace").Exists())
+}
+
 // handler 的 failover 在同一个 *gin.Context 上重试下一个账号；保留 namespace 的账号
 // 不得沿用上一个账号登记的摊平名映射做回程还原。
 func TestOpenAIGatewayService_ForwardClearsStaleNamespaceNames(t *testing.T) {

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -65,6 +65,11 @@ func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
 func TestShouldKeepOpenAIResponsesToolCallNamespaces(t *testing.T) {
 	oauth := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
 	apiKey := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	apiKeyKeepToolCalls := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Extra:    map[string]any{"openai_apikey_responses_keep_tool_call_namespaces": true},
+	}
 	setupToken := &Account{Platform: PlatformOpenAI, Type: AccountTypeSetupToken}
 	flattenOAuth := &Account{
 		Platform: PlatformOpenAI,
@@ -92,8 +97,10 @@ func TestShouldKeepOpenAIResponsesToolCallNamespaces(t *testing.T) {
 		// WSv2 + compact 是唯一「不摊平但仍必须清理」的组合，钉住 compact 判定本身，
 		// 使其不会被误当成可由 shouldFlatten 推导出的冗余分支。
 		{name: "oauth_compact_wsv2_strips", account: oauth, transport: OpenAIUpstreamTransportResponsesWebsocketV2, compactPath: true, want: false},
-		// API Key 出口是标准 Responses API，不认识该字段。
+		// API Key 默认按标准 Responses API 处理，不保留该字段。
 		{name: "apikey_strips", account: apiKey, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+		{name: "apikey_keep_tool_calls_enabled", account: apiKeyKeepToolCalls, transport: OpenAIUpstreamTransportHTTPSSE, want: true},
+		{name: "apikey_keep_tool_calls_enabled_compact_strips", account: apiKeyKeepToolCalls, transport: OpenAIUpstreamTransportHTTPSSE, compactPath: true, want: false},
 		{name: "setup_token_strips", account: setupToken, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
 		{name: "nil_account", account: nil, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
 	}

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -134,6 +134,29 @@ func TestOpenAIGatewayService_APIKeyStripsAllIndexedNamespacesBeforeFirstForward
 	require.False(t, gjson.GetBytes(upstream.bodies[0], "input.1.namespace").Exists())
 }
 
+func TestOpenAIGatewayService_APIKeyKeepToolCallNamespacesRetriesNamespaceRejection(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","name":"first","namespace":"collaboration","arguments":"{}"}]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[0].namespace'.","param":"input[0].namespace","type":"invalid_request_error"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Extra["openai_apikey_responses_keep_tool_call_namespaces"] = true
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		newOpenAIRejectedFieldTestContext(body),
+		account,
+		body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.bodies[0], "input.0.namespace").String())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.0.namespace").Exists())
+}
+
 func TestOpenAIGatewayService_OpenAIHTTPStripsInputNamespacesBeforeFirstForward(t *testing.T) {
 	accounts := []struct {
 		name    string

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2955,6 +2955,37 @@
         </div>
       </div>
 
+      <!-- OpenAI API Key Codex tool-call namespace preservation (compatibility switch) -->
+      <div
+        v-if="form.platform === 'openai' && form.type === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.keepToolCallNamespaces') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.keepToolCallNamespacesDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="create-openai-apikey-keep-tool-call-namespaces-toggle"
+            @click="openaiAPIKeyKeepToolCallNamespacesEnabled = !openaiAPIKeyKeepToolCallNamespacesEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              openaiAPIKeyKeepToolCallNamespacesEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                openaiAPIKeyKeepToolCallNamespacesEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -4094,6 +4125,8 @@ const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+// OpenAI API Key 的兼容上游可显式保留 Codex 工具调用 namespace，默认关闭。
+const openaiAPIKeyKeepToolCallNamespacesEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
@@ -4560,6 +4593,7 @@ watch(
     if (newPlatform !== 'openai') {
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
+      openaiAPIKeyKeepToolCallNamespacesEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -4987,6 +5021,7 @@ const resetForm = () => {
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  openaiAPIKeyKeepToolCallNamespacesEnabled.value = false
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
   openAICompactMode.value = 'auto'
@@ -5077,6 +5112,11 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_responses_flatten_namespaces = true
   } else {
     delete extra.openai_responses_flatten_namespaces
+  }
+  if (form.type === 'apikey' && openaiAPIKeyKeepToolCallNamespacesEnabled.value) {
+    extra.openai_apikey_responses_keep_tool_call_namespaces = true
+  } else {
+    delete extra.openai_apikey_responses_keep_tool_call_namespaces
   }
   extra.openai_long_context_billing_enabled = openAILongContextBillingEnabled.value
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1632,6 +1632,37 @@
         </div>
       </div>
 
+      <!-- OpenAI API Key Codex tool-call namespace preservation (compatibility switch) -->
+      <div
+        v-if="account?.platform === 'openai' && account?.type === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.keepToolCallNamespaces') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.keepToolCallNamespacesDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="edit-openai-apikey-keep-tool-call-namespaces-toggle"
+            @click="openaiAPIKeyKeepToolCallNamespacesEnabled = !openaiAPIKeyKeepToolCallNamespacesEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              openaiAPIKeyKeepToolCallNamespacesEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                openaiAPIKeyKeepToolCallNamespacesEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -3096,6 +3127,8 @@ const customBaseUrl = ref('')
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+// OpenAI API Key 的兼容上游可显式保留 Codex 工具调用 namespace，默认关闭。
+const openaiAPIKeyKeepToolCallNamespacesEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -3571,6 +3604,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  openaiAPIKeyKeepToolCallNamespacesEnabled.value = false
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -3590,6 +3624,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openaiFlattenNamespacesEnabled.value =
       newAccount.type === 'oauth' && extra?.openai_responses_flatten_namespaces === true
+    openaiAPIKeyKeepToolCallNamespacesEnabled.value =
+      newAccount.type === 'apikey' && extra?.openai_apikey_responses_keep_tool_call_namespaces === true
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
     openAILongContextBillingEnabled.value = longContextBillingValue === true
     // plan_type 手动覆盖仅 OAuth 有实际调度语义(IsOpenAIChatGPTSubscription 要求 oauth),故只对 oauth 回填
@@ -4933,6 +4969,11 @@ const handleSubmit = async () => {
         newExtra.openai_responses_flatten_namespaces = true
       } else {
         delete newExtra.openai_responses_flatten_namespaces
+      }
+      if (props.account.type === 'apikey' && openaiAPIKeyKeepToolCallNamespacesEnabled.value) {
+        newExtra.openai_apikey_responses_keep_tool_call_namespaces = true
+      } else {
+        delete newExtra.openai_apikey_responses_keep_tool_call_namespaces
       }
       if (isSparkShadow.value) {
         delete newExtra.openai_long_context_billing_enabled

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -165,9 +165,12 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
 
     expect(createAccountMock).toHaveBeenCalledTimes(1)
     expect(createAccountMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBe(false)
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra).not.toHaveProperty(
+      'openai_apikey_responses_keep_tool_call_namespaces'
+    )
   })
 
-  // namespace 摊平是仅 OAuth 的兼容开关：API Key 走 chat completions 回退桥时由桥自行摊平
+  // namespace 摊平是仅 OAuth 的兼容开关；API Key 使用独立的调用 namespace 保留开关。
   it('shows the Codex namespace flatten toggle only for OpenAI OAuth accounts', async () => {
     const wrapper = mountModal()
     await selectButtonByText(wrapper, 'OpenAI')
@@ -175,11 +178,34 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(wrapper.find('[data-testid="create-openai-flatten-namespaces-toggle"]').exists()).toBe(
       true
     )
+    expect(wrapper.find('[data-testid="create-openai-apikey-keep-tool-call-namespaces-toggle"]').exists()).toBe(
+      false
+    )
 
     await selectButtonByText(wrapper, 'API Key')
     expect(wrapper.find('[data-testid="create-openai-flatten-namespaces-toggle"]').exists()).toBe(
       false
     )
+    expect(wrapper.find('[data-testid="create-openai-apikey-keep-tool-call-namespaces-toggle"]').exists()).toBe(
+      true
+    )
+  })
+
+  it('submits the API key tool-call namespace preservation toggle only when enabled', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI compatible')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+
+    await wrapper.get('[data-testid="create-openai-apikey-keep-tool-call-namespaces-toggle"]').trigger('click')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(
+      createAccountMock.mock.calls[0]?.[0]?.extra?.openai_apikey_responses_keep_tool_call_namespaces
+    ).toBe(true)
   })
 
   it('enables upstream billing probes by default for new OpenAI API key accounts', async () => {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -467,6 +467,55 @@ describe('EditAccountModal', () => {
     )
   })
 
+  it('loads and clears the API key tool-call namespace preservation toggle', async () => {
+    const account = buildAccount()
+    account.extra = {
+      openai_apikey_responses_keep_tool_call_namespaces: true
+    }
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="edit-openai-apikey-keep-tool-call-namespaces-toggle"]')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
+      'openai_apikey_responses_keep_tool_call_namespaces'
+    )
+  })
+
+  it('submits the API key tool-call namespace preservation toggle when switched on', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    await wrapper.get('[data-testid="edit-openai-apikey-keep-tool-call-namespaces-toggle"]').trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_apikey_responses_keep_tool_call_namespaces).toBe(
+      true
+    )
+  })
+
+  it('hides the API key tool-call namespace preservation toggle for OAuth accounts', async () => {
+    const account = buildAccount()
+    account.type = 'oauth'
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="edit-openai-apikey-keep-tool-call-namespaces-toggle"]').exists()).toBe(
+      false
+    )
+  })
+
   it('defaults legacy OpenAI accounts to long-context billing disabled', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -544,6 +544,9 @@ export default {
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',
+        keepToolCallNamespaces: 'Keep Codex tool-call namespaces (compatibility)',
+        keepToolCallNamespacesDesc:
+          'OpenAI API Key accounts only. Disabled by default; enable only when the selected upstream explicitly supports Codex multi-agent tool calls. Tool-call namespaces such as function_call are preserved, while residual fields on ordinary messages are still removed. Compaction requests always remove this field.',
         longContextBilling: 'API long-context pricing',
         longContextBillingDesc:
           'Disabled by default. Enable only when this account\'s upstream charges OpenAI API long-context rates above the model threshold.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -621,6 +621,9 @@ export default {
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',
+        keepToolCallNamespaces: '保留 Codex 工具调用 namespace（兼容）',
+        keepToolCallNamespacesDesc:
+          '仅适用于 OpenAI API Key。默认关闭；仅当当前上游明确支持 Codex 多智能体工具调用时开启。开启后保留 function_call 等工具调用中的 namespace，普通消息中的残留字段仍会清理。压缩（compact）请求始终清理该字段。',
         longContextBilling: 'API 长上下文计费',
         longContextBillingDesc: '默认关闭。仅当该账号的上游会按模型阈值收取 OpenAI API 长上下文费率时开启。',
         responsesWebsocketsV2: 'Responses WebSocket v2',


### PR DESCRIPTION
## Summary

- Add an opt-in account-level switch for compatible OpenAI API-key upstreams that support Codex namespace tool calls.
- Keep the existing default cleanup behavior and always strip namespaces on compact requests.
- Expose the switch in the account create/edit UI with Chinese and English copy.

## Behavior

- Default/off: API-key forwarding behavior is unchanged.
- Enabled on non-compact Responses requests: preserve namespace only on function_call, custom_tool_call, tool_call, and mcp_tool_call history items.
- Message/reasoning residual namespace fields are still removed.
- If an upstream rejects input namespace, the existing rejected-field retry fallback remains active.

## Tests

- go test ./internal/service -count=1
- 63 focused frontend tests passed
- vue-tsc --noEmit
- ESLint on all changed frontend files
- git diff --check

Fixes #5705