### PR TITLE
fix(channels): 渠道定价支持 Kimi/智谱/DeepSeek 平台

### DIFF
--- a/backend/internal/handler/admin/channel_handler.go
+++ b/backend/internal/handler/admin/channel_handler.go
@@ -568,9 +568,12 @@ func (h *ChannelHandler) GetModelDefaultPricing(c *gin.Context) {
 var platformToLiteLLMProvider = map[string]string{
 	service.PlatformAnthropic:   "anthropic",
 	service.PlatformOpenAI:      "openai",
-	service.PlatformGemini:      "google",
+	service.PlatformGemini:      "gemini",
 	service.PlatformAntigravity: "anthropic",
 	service.PlatformGrok:        "xai",
+	service.PlatformKimi:        "moonshot",
+	service.PlatformZhipu:       "zhipu",
+	service.PlatformDeepseek:    "deepseek",
 }
 
 // SyncPricingModels 返回 LiteLLM 定价目录中指定平台的最新模型列表

--- a/backend/internal/handler/admin/channel_handler_test.go
+++ b/backend/internal/handler/admin/channel_handler_test.go
@@ -502,7 +502,7 @@ func TestSyncPricingModels_ValidPlatform_EmptyService(t *testing.T) {
 	svc := service.NewPricingService(nil, nil)
 	router := setupSyncPricingModelsRouter(svc)
 
-	for _, platform := range []string{"anthropic", "openai", "gemini", "antigravity"} {
+	for _, platform := range []string{"anthropic", "openai", "gemini", "antigravity", "grok", "kimi", "zhipu", "deepseek"} {
 		req := httptest.NewRequest(http.MethodGet, "/channels/pricing/sync-models?platform="+platform, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)

--- a/frontend/src/components/admin/channel/types.ts
+++ b/frontend/src/components/admin/channel/types.ts
@@ -368,6 +368,9 @@ export function getPlatformTagClass(platform: string): string {
     case 'gemini': return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
     case 'antigravity': return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
     case 'grok': return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
+    case 'kimi': return 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400'
+    case 'zhipu': return 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
+    case 'deepseek': return 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400'
     default: return 'bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400'
   }
 }
@@ -380,6 +383,9 @@ export function getPlatformTextClass(platform: string): string {
     case 'gemini': return 'text-blue-700 dark:text-blue-400'
     case 'antigravity': return 'text-purple-700 dark:text-purple-400'
     case 'grok': return 'text-slate-700 dark:text-slate-300'
+    case 'kimi': return 'text-pink-700 dark:text-pink-400'
+    case 'zhipu': return 'text-indigo-700 dark:text-indigo-400'
+    case 'deepseek': return 'text-teal-700 dark:text-teal-400'
     default: return ''
   }
 }

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -762,7 +762,10 @@ const form = reactive({
 let abortController: AbortController | null = null
 
 // ── Platform config ──
-const platformOrder: GroupPlatform[] = ['anthropic', 'openai', 'gemini', 'antigravity', 'grok']
+const platformOrder: GroupPlatform[] = ['anthropic', 'openai', 'gemini', 'antigravity', 'grok', 'kimi', 'zhipu', 'deepseek']
+// composite 分组仅覆盖主平台（与后端 isConcreteRequestPlatform / composite-routes target_platform 一致），
+// 不含国产供应商平台。
+const compositePlatforms: GroupPlatform[] = ['anthropic', 'openai', 'gemini', 'antigravity', 'grok']
 
 // ── Helpers ──
 function formatDate(value: string): string {
@@ -801,7 +804,9 @@ function togglePlatform(platform: GroupPlatform) {
 }
 
 function getGroupsForPlatform(platform: GroupPlatform): AdminGroup[] {
-  return allGroups.value.filter(g => g.platform === platform || g.platform === 'composite')
+  return allGroups.value.filter(
+    g => g.platform === platform || (g.platform === 'composite' && compositePlatforms.includes(platform))
+  )
 }
 
 // ── Group helpers ──
@@ -1183,7 +1188,7 @@ function apiToForm(channel: Channel): PlatformSection[] {
   for (const gid of channel.group_ids || []) {
     const p = groupPlatformMap.get(gid)
     if (p === 'composite') {
-      platformOrder.forEach(platform => activePlatforms.add(platform))
+      compositePlatforms.forEach(platform => activePlatforms.add(platform))
     } else if (p) {
       activePlatforms.add(p)
     }
@@ -1202,7 +1207,8 @@ function apiToForm(channel: Channel): PlatformSection[] {
 
     const groupIds = (channel.group_ids || []).filter(gid => {
       const groupPlatform = groupPlatformMap.get(gid)
-      return groupPlatform === platform || groupPlatform === 'composite'
+      return groupPlatform === platform ||
+        (groupPlatform === 'composite' && compositePlatforms.includes(platform))
     })
     const mapping = (channel.model_mapping || {})[platform] || {}
     const pricing = (channel.model_pricing || [])


### PR DESCRIPTION
## 问题

`/admin/channels/pricing` 渠道定价页无法选择 Kimi、智谱 GLM、DeepSeek 三个平台：平台复选框来自 `ChannelsView.vue` 硬编码的 `platformOrder`，只列了 5 个旧平台，没有跟上 #5666 新增的国产供应商平台。后端定价查找本身按平台字符串通用匹配，分组绑定、计费链路均已支持，纯前端清单缺失。

## 修改内容

### 前端 `ChannelsView.vue`（核心修复）
- `platformOrder` 加入 `kimi` / `zhipu` / `deepseek`，平台复选框与 tab 即可选择配置定价；
- 新增 `compositePlatforms`（5 个主平台）：composite 分组的平台展开、分组归属、分组下拉三处保持只覆盖主平台，与后端 `isConcreteRequestPlatform` 及 composite-routes `target_platform` oneof 校验保持一致——composite 分组配出的 CN 平台定价在请求期永远无法匹配，不应展示。

### 后端 `channel_handler.go`（"同步最新模型"按钮）
- `platformToLiteLLMProvider` 增加 `kimi→moonshot`、`zhipu→zhipu`、`deepseek→deepseek`（provider 名与远程价格仓库 Wei-Shaw/model-price-repo 实际目录核对一致）；
- **顺手修复存量 bug**：`gemini` 原映射到 `"google"`，但本地与远程价格目录的 provider 键均为 `"gemini"`，零匹配——此前 Gemini 的同步按钮一直返回空列表并提示"已是最新"。

### 其他
- `channel/types.ts`：定价卡片模型 tag 补 CN 平台配色（kimi 粉 / zhipu 靛 / deepseek 青，与 `platformColors.ts` 同色系，原先落灰色兜底）；
- `channel_handler_test.go`：同步接口测试平台列表扩到全部 8 个平台。

## 已核实无需改动

i18n 中英文平台标签、PlatformIcon、`platformColors.ts`、分组绑定 oneof、计费链路（`GetChannelModelPricing` 按 groupID+模型查找，平台无关）、定价保存（platform 字段无白名单）、规则内账号搜索、`PricingEntryCard`（无平台条件渲染）。

渠道监控的 `provider` oneof 是探针协议方言（CN 供应商走 openai/anthropic 协议即可复用），非本次缺口。

## 验证

- 前端：`vue-tsc --noEmit` 通过、eslint 无告警
- 后端：`go build` / `go vet` / gofmt 干净，`go test -tags unit -run TestSyncPricingModels` 全部通过