### PR TITLE
fix(accounts): route CN provider chat tests correctly

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -285,6 +285,10 @@ func (s *AccountTestService) TestAccountConnection(c *gin.Context, accountID int
 	}
 
 	// Route to platform-specific test method
+	if account.IsCNProvider() && account.GetAPIProtocol() == APIProtocolChatCompletions {
+		return s.testCNProviderChatCompletionsConnection(c, account, modelID, prompt)
+	}
+
 	if account.IsOpenAI() {
 		return s.testOpenAIAccountConnection(c, account, modelID, prompt, normalizeAccountTestMode(mode))
 	}
@@ -302,6 +306,27 @@ func (s *AccountTestService) TestAccountConnection(c *gin.Context, accountID int
 	}
 
 	return s.testClaudeAccountConnection(c, account, modelID)
+}
+
+func (s *AccountTestService) testCNProviderChatCompletionsConnection(c *gin.Context, account *Account, modelID string, prompt string) error {
+	testModelID := strings.TrimSpace(modelID)
+	if testModelID == "" {
+		testModelID = openai.DefaultTestModel
+	}
+	testModelID = account.GetMappedModel(testModelID)
+
+	authToken := strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
+	if authToken == "" {
+		return s.sendErrorAndEnd(c, "No API key available")
+	}
+
+	baseURL := account.GetOpenAIBaseURL()
+	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
+	}
+
+	return s.testOpenAIChatCompletionsConnection(c, account, testModelID, prompt, normalizedBaseURL, authToken)
 }
 
 // testClaudeAccountConnection tests an Anthropic Claude account's connection


### PR DESCRIPTION
## 问题

v0.1.178 新增 Kimi / 智谱 / DeepSeek 供应商后，`TestAccountConnection()` 没有按国产供应商的 `api_protocol` 路由连接测试。

对于默认或显式配置为 `chat_completions` 的 Kimi / Zhipu / DeepSeek APIKey 账号，测试会继续落到 Claude/Anthropic 测试路径，导致 OpenAI-compatible 上游返回 404。

Fixes #5781
Related: #5776

## 修改

保持修改范围最小：仅在 `account_test_service.go` 中对国产供应商的 `chat_completions` 测试增加协议分发，并复用现有 `testOpenAIChatCompletionsConnection()`。

- `chat_completions`：走现有 OpenAI-compatible Chat Completions 测试
- `anthropic`：保持现有行为不变
- `responses`：保持现有行为不变

PR 不包含测试分支使用的临时 workflow 或测试文件。

## 验证

在单独测试分支完成：

- GitHub Actions CI 全部通过：frontend、unit + integration、golangci-lint、shell
- GitHub Actions 云端成功构建 amd64 测试镜像
- 将测试镜像部署到实际 sub2api v0.1.178 环境
- 使用真实 `platform=deepseek`、`api_protocol=chat_completions` 账号连接 AMD OpenAI-compatible 上游
- 修复前该账号测试返回 404
- 修复后实际测试输出：

```text
正在通过 /v1/chat/completions 测试连接
Hello! How can I help you today? 😊
已通过 /v1/chat/completions 验证
test_complete success=true
```

测试分支 CI：https://github.com/UnlastingR/sub2api/actions/runs/32137784291
云构建：https://github.com/UnlastingR/sub2api/actions/runs/32137784290

