### PR TITLE
fix(grok): 修复 Grok 4.6 xhigh 被降级问题 / fix xhigh downgrade for Grok 4.6

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -558,7 +558,7 @@ func normalizeGrokResponsesReasoningEffort(body []byte, upstreamModel string) ([
 		if !value.Exists() {
 			continue
 		}
-		normalized, keep := normalizeGrokReasoningEffortValue(value.String())
+		normalized, keep := normalizeGrokReasoningEffortValue(value.String(), upstreamModel)
 		if !supportsEffort || !keep {
 			out, err = sjson.DeleteBytes(out, field)
 		} else {
@@ -569,7 +569,7 @@ func normalizeGrokResponsesReasoningEffort(body []byte, upstreamModel string) ([
 		}
 	}
 	if camel := gjson.GetBytes(out, "reasoningEffort"); camel.Exists() {
-		normalized, keep := normalizeGrokReasoningEffortValue(camel.String())
+		normalized, keep := normalizeGrokReasoningEffortValue(camel.String(), upstreamModel)
 		out, err = sjson.DeleteBytes(out, "reasoningEffort")
 		if err != nil {
 			return nil, fmt.Errorf("remove Grok reasoningEffort: %w", err)
@@ -595,7 +595,7 @@ func normalizeGrokChatReasoningEffort(body []byte, upstreamModel string) ([]byte
 	if raw == "" {
 		raw = strings.TrimSpace(gjson.GetBytes(body, "reasoningEffort").String())
 	}
-	normalized, keep := normalizeGrokReasoningEffortValue(raw)
+	normalized, keep := normalizeGrokReasoningEffortValue(raw, upstreamModel)
 	keep = keep && grokSupportsReasoningEffort(upstreamModel)
 	out := body
 	var err error
@@ -615,14 +615,20 @@ func normalizeGrokChatReasoningEffort(body []byte, upstreamModel string) ([]byte
 	return out, err
 }
 
-func normalizeGrokReasoningEffortValue(raw string) (string, bool) {
+func normalizeGrokReasoningEffortValue(raw, upstreamModel string) (string, bool) {
 	value := strings.NewReplacer("-", "", "_", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(raw)))
 	switch value {
 	case "none", "low", "medium", "high":
 		return value, true
 	case "minimal":
 		return "low", true
-	case "xhigh", "extrahigh", "max", "ultra":
+	case "xhigh":
+		model := strings.ToLower(xai.StripGrokProviderPrefix(strings.TrimSpace(upstreamModel)))
+		if model == "grok-4.6" || model == "grok-4.6-latest" {
+			return "xhigh", true
+		}
+		return "high", true
+	case "extrahigh", "max", "ultra":
 		return "high", true
 	default:
 		return "", false

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -176,6 +176,29 @@ func TestPatchGrokResponsesBodyNormalizesReasoningEffortAliases(t *testing.T) {
 	}
 }
 
+func TestPatchGrokResponsesBodyPreservesXHighForGrok46(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		body          string
+		upstreamModel string
+		path          string
+	}{
+		{name: "nested", body: `{"input":"hi","reasoning":{"effort":"xhigh"}}`, upstreamModel: "grok-4.6", path: "reasoning.effort"},
+		{name: "flat latest", body: `{"input":"hi","reasoning_effort":"xhigh"}`, upstreamModel: "grok-4.6-latest", path: "reasoning_effort"},
+		{name: "camel provider prefix", body: `{"input":"hi","reasoningEffort":"xhigh"}`, upstreamModel: "xai/grok-4.6", path: "reasoning_effort"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patched, err := patchGrokResponsesBody([]byte(tt.body), tt.upstreamModel)
+			require.NoError(t, err)
+			require.Equal(t, "xhigh", gjson.GetBytes(patched, tt.path).String(), string(patched))
+			require.False(t, gjson.GetBytes(patched, "reasoningEffort").Exists())
+		})
+	}
+}
+
 func TestPatchGrokResponsesBodyAddsDefaultFunctionParameters(t *testing.T) {
 	patched, err := patchGrokResponsesBody(
 		[]byte(`{"input":"hi","tools":[{"type":"function","name":"lookup"},{"type":"function","name":"wait","parameters":null}]}`),
@@ -197,6 +220,10 @@ func TestNormalizeGrokChatReasoningEffort(t *testing.T) {
 	patched, err = normalizeGrokChatReasoningEffort([]byte(`{"reasoning_effort":"high"}`), "grok-composer-2.5-fast")
 	require.NoError(t, err)
 	require.False(t, gjson.GetBytes(patched, "reasoning_effort").Exists())
+
+	patched, err = normalizeGrokChatReasoningEffort([]byte(`{"reasoning_effort":"xhigh"}`), "grok-4.6")
+	require.NoError(t, err)
+	require.Equal(t, "xhigh", gjson.GetBytes(patched, "reasoning_effort").String())
 }
 
 func TestPatchGrokResponsesBodyDropsNestedUnsupportedFields(t *testing.T) {


### PR DESCRIPTION
## 中文

### 背景

`normalizeGrokReasoningEffortValue` 当前不区分上游模型，会将所有
`xhigh` 请求统一降级为 `high`。因此，当客户端调用 Grok 4.6 并明确指定
`reasoning_effort=xhigh` 时，实际发送到上游的值会变成 `high`。

### 修复

- 为 reasoning effort 归一化逻辑传入上游模型。
- 修复 `grok-4.6` 和 `grok-4.6-latest` 的 `xhigh` 被降级问题。
- 支持 `xai/`、`x-ai/` 和 `grok/` 等已有模型前缀。
- Grok 4.5 及其他模型仍保持 `xhigh -> high` 的现有兼容行为。
- `max`、`ultra` 和 `extrahigh` 仍归一化为 `high`，不扩大修改范围。
- 覆盖 Responses API 的嵌套、snake_case、camelCase 字段及 Chat
  Completions 路径。

### 修改范围

本 PR 仅修复 Grok 4.6 明确传入的 `xhigh` 被错误降级问题，不修改
`/v1/models` 的能力声明，也不改变其他 reasoning effort 别名的行为。

## English

### Background

`normalizeGrokReasoningEffortValue` currently normalizes reasoning effort
without considering the upstream model. As a result, an explicit
`reasoning_effort=xhigh` request for Grok 4.6 is downgraded to `high` before
being forwarded upstream.

### Fix

- Pass the upstream model into the reasoning-effort normalizer.
- Fix the incorrect `xhigh` downgrade for `grok-4.6` and
  `grok-4.6-latest`.
- Support the existing `xai/`, `x-ai/`, and `grok/` model prefixes.
- Keep the existing `xhigh -> high` compatibility behavior for Grok 4.5
  and other models.
- Keep `max`, `ultra`, and `extrahigh` normalized to `high`, avoiding
  unrelated behavior changes.
- Cover nested, snake_case, and camelCase Responses API fields, as well as
  the Chat Completions path.

### Scope

This PR only fixes the incorrect downgrade of an explicit `xhigh` value for
Grok 4.6. It does not change `/v1/models` capability advertising or the
behavior of other reasoning-effort aliases.

## 测试 / Tests

- `TestPatchGrokResponsesBodyPreservesXHighForGrok46`
- `TestPatchGrokResponsesBodyNormalizesReasoningEffortAliases`
- `TestNormalizeGrokChatReasoningEffort`

Fixes #5739