### PR TITLE
fix(grok): bill missing chat reasoning tokens

### DIFF
--- a/backend/internal/pkg/openaiusage/json.go
+++ b/backend/internal/pkg/openaiusage/json.go
@@ -1,0 +1,16 @@
+package openaiusage
+
+import (
+	"strconv"
+
+	"github.com/tidwall/gjson"
+)
+
+// JSONNumberInt64 accepts only JSON integer numbers representable by int64.
+func JSONNumberInt64(value gjson.Result) (int64, bool) {
+	if !value.Exists() || value.Type != gjson.Number {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(value.Raw, 10, 64)
+	return n, err == nil
+}

--- a/backend/internal/pkg/openaiusage/reasoning.go
+++ b/backend/internal/pkg/openaiusage/reasoning.go
@@ -1,0 +1,23 @@
+package openaiusage
+
+// OutputTokensWithMissingReasoning adds reasoning tokens only when totalTokens
+// proves that the reported output does not already include them. This supports
+// additive Chat Completions providers without double-counting OpenAI/Responses
+// usage, where reasoning tokens are already part of output tokens.
+func OutputTokensWithMissingReasoning(inputTokens, outputTokens, totalTokens, reasoningTokens int64) int64 {
+	if inputTokens < 0 || outputTokens < 0 || totalTokens < 0 || reasoningTokens <= 0 {
+		return outputTokens
+	}
+	if totalTokens <= inputTokens {
+		return outputTokens
+	}
+	missing := totalTokens - inputTokens
+	if missing <= outputTokens {
+		return outputTokens
+	}
+	missing -= outputTokens
+	if reasoningTokens < missing {
+		missing = reasoningTokens
+	}
+	return outputTokens + missing
+}

--- a/backend/internal/pkg/openaiusage/reasoning_test.go
+++ b/backend/internal/pkg/openaiusage/reasoning_test.go
@@ -1,0 +1,30 @@
+package openaiusage
+
+import "testing"
+
+func TestOutputTokensWithMissingReasoning(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                         string
+		input, output, total, reason int64
+		want                         int64
+	}{
+		{name: "additive xAI usage", input: 10, output: 20, total: 35, reason: 5, want: 25},
+		{name: "bounded by unexplained total", input: 10, output: 20, total: 33, reason: 5, want: 23},
+		{name: "output already includes reasoning", input: 10, output: 25, total: 35, reason: 5, want: 25},
+		{name: "absent total represented as zero", input: 10, output: 20, total: 0, reason: 5, want: 20},
+		{name: "inconsistent total", input: 10, output: 20, total: 25, reason: 5, want: 20},
+		{name: "negative input", input: -1, output: 20, total: 24, reason: 5, want: 20},
+		{name: "negative output", input: 10, output: -1, total: 14, reason: 5, want: -1},
+		{name: "negative total", input: 10, output: 20, total: -1, reason: 5, want: 20},
+		{name: "negative reasoning", input: 10, output: 20, total: 35, reason: -5, want: 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := OutputTokensWithMissingReasoning(tt.input, tt.output, tt.total, tt.reason); got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -130,6 +130,7 @@ func TestGroupUsageRollupTriggerSerializesInsertTransactionAcrossMidnight(t *tes
 	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
 	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
 	_, err := seedTx.ExecContext(ctx, `
+		SET LOCAL TIME ZONE 'Asia/Shanghai';
 		INSERT INTO groups (id) VALUES (10);
 		INSERT INTO users (id) VALUES (1);
 		UPDATE usage_group_rollup_state
@@ -151,6 +152,8 @@ func TestGroupUsageRollupTriggerSerializesInsertTransactionAcrossMidnight(t *tes
 
 	insertTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
 	defer func() { _ = insertTx.Rollback() }()
+	_, err = insertTx.ExecContext(ctx, "SET LOCAL TIME ZONE 'Asia/Shanghai'")
+	require.NoError(t, err)
 	var insertBackendPID int
 	require.NoError(t, insertTx.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&insertBackendPID))
 
@@ -207,6 +210,7 @@ func TestGroupUsageRollupTriggerKeepsWatermarkForTodayInsert(t *testing.T) {
 	tx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
 	defer func() { _ = tx.Rollback() }()
 	_, err := tx.ExecContext(ctx, `
+		SET LOCAL TIME ZONE 'Asia/Shanghai';
 		INSERT INTO groups (id) VALUES (10);
 		INSERT INTO users (id) VALUES (1);
 		UPDATE usage_group_rollup_state

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openaiusage"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -1150,6 +1151,20 @@ func openAIUsageFromGJSON(value gjson.Result) (OpenAIUsage, bool) {
 	outputTokens := value.Get("output_tokens").Int()
 	if outputTokens == 0 {
 		outputTokens = value.Get("completion_tokens").Int()
+	}
+	totalTokens, totalOK := openaiusage.JSONNumberInt64(value.Get("total_tokens"))
+	reasoningResult := value.Get("output_tokens_details.reasoning_tokens")
+	if !reasoningResult.Exists() {
+		reasoningResult = value.Get("completion_tokens_details.reasoning_tokens")
+	}
+	reasoningTokens, reasoningOK := openaiusage.JSONNumberInt64(reasoningResult)
+	if totalOK && reasoningOK {
+		adjusted := openaiusage.OutputTokensWithMissingReasoning(
+			inputTokens, outputTokens, totalTokens, reasoningTokens,
+		)
+		if int64(int(adjusted)) == adjusted {
+			outputTokens = adjusted
+		}
 	}
 	cacheReadTokens := openAICacheReadTokensFromUsage(value)
 	cacheCreationTokens := openAICacheCreationTokensFromUsage(value)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -506,6 +506,41 @@ func TestExtractOpenAIUsage_ReadsClineDataEnvelope(t *testing.T) {
 	require.Equal(t, 4, usage.CacheReadInputTokens)
 }
 
+func TestExtractOpenAIUsage_AddsOnlyMissingReasoningTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"additive chat completions", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":5}}}`, 25},
+		{"already inclusive responses output", `{"usage":{"input_tokens":10,"output_tokens":25,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":5}}}`, 25},
+		{"absent total", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"inconsistent total", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":25,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"negative values", `{"usage":{"prompt_tokens":-1,"completion_tokens":20,"total_tokens":24,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"total numeric string", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":"35","completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"total boolean", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":true,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"total null", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":null,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"total fractional", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35.5,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"total oversized", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":9223372036854775808,"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+		{"reasoning numeric string", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":"5"}}}`, 20},
+		{"reasoning boolean", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":true}}}`, 20},
+		{"reasoning null", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":null}}}`, 20},
+		{"reasoning fractional", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":5.5}}}`, 20},
+		{"reasoning oversized", `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":9223372036854775808}}}`, 20},
+		{"selected reasoning alias wins", `{"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":3},"completion_tokens_details":{"reasoning_tokens":5}}}`, 23},
+		{"malformed selected alias does not fall through", `{"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":"3"},"completion_tokens_details":{"reasoning_tokens":5}}}`, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			usage, ok := extractOpenAIUsageFromJSONBytes([]byte(tt.body))
+			require.True(t, ok)
+			require.Equal(t, tt.want, usage.OutputTokens)
+		})
+	}
+}
+
 func TestExtractOpenAIUsage_ReadsWrappedResponsesDataEnvelope(t *testing.T) {
 	body := []byte(`{"data":{"response":{"usage":{"input_tokens":11,"output_tokens":5,"total_tokens":16,"input_tokens_details":{"cached_tokens":2}}}}}`)
 

--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openaiusage"
 	coderws "github.com/coder/websocket"
 	"github.com/tidwall/gjson"
 )
@@ -947,6 +948,20 @@ func parseUsageAndAccumulate(
 		}
 		// 解析失败时不做部分字段累加，避免计费 usage 出现“半有效”状态。
 		return Usage{}
+	}
+	totalTokens, totalOK := openaiusage.JSONNumberInt64(usageResult.Get("total_tokens"))
+	reasoningResult := usageResult.Get("output_tokens_details.reasoning_tokens")
+	if !reasoningResult.Exists() {
+		reasoningResult = usageResult.Get("completion_tokens_details.reasoning_tokens")
+	}
+	reasoningTokens, reasoningOK := openaiusage.JSONNumberInt64(reasoningResult)
+	if totalOK && reasoningOK {
+		adjusted := openaiusage.OutputTokensWithMissingReasoning(
+			int64(inputTokens), int64(outputTokens), totalTokens, reasoningTokens,
+		)
+		if int64(int(adjusted)) == adjusted {
+			outputTokens = int(adjusted)
+		}
 	}
 	parsedUsage := Usage{
 		InputTokens:              inputTokens,

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_internal_test.go
@@ -341,6 +341,43 @@ func TestParseUsageAndAccumulateAcceptsChatUsageAliases(t *testing.T) {
 	require.Equal(t, got, state.usage)
 }
 
+func TestParseUsageAndAccumulateReasoningTokenParity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		usage string
+		want  int
+	}{
+		{"additive chat completions", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":5}}`, 25},
+		{"already inclusive responses output", `{"input_tokens":10,"output_tokens":25,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":5}}`, 25},
+		{"absent total", `{"prompt_tokens":10,"completion_tokens":20,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"inconsistent total", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":25,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"negative values", `{"prompt_tokens":-1,"completion_tokens":20,"total_tokens":24,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"total numeric string", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":"35","completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"total boolean", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":true,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"total null", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":null,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"total fractional", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35.5,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"total oversized", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":9223372036854775808,"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+		{"reasoning numeric string", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":"5"}}`, 20},
+		{"reasoning boolean", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":true}}`, 20},
+		{"reasoning null", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":null}}`, 20},
+		{"reasoning fractional", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":5.5}}`, 20},
+		{"reasoning oversized", `{"prompt_tokens":10,"completion_tokens":20,"total_tokens":35,"completion_tokens_details":{"reasoning_tokens":9223372036854775808}}`, 20},
+		{"selected reasoning alias wins", `{"input_tokens":10,"output_tokens":20,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":3},"completion_tokens_details":{"reasoning_tokens":5}}`, 23},
+		{"malformed selected alias does not fall through", `{"input_tokens":10,"output_tokens":20,"total_tokens":35,"output_tokens_details":{"reasoning_tokens":"3"},"completion_tokens_details":{"reasoning_tokens":5}}`, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := &relayState{}
+			message := []byte(`{"type":"response.done","response":{"usage":` + tt.usage + `}}`)
+			got := parseUsageAndAccumulate(state, message, "response.done", nil)
+			require.Equal(t, tt.want, got.OutputTokens)
+			require.Equal(t, tt.want, state.usage.OutputTokens)
+		})
+	}
+}
+
 func TestOpenAICacheCreationTokensFromUsageNestedZeroWins(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 问题

Grok 聊天响应在部分 usage 数据中未计入 reasoning tokens，导致用量与计费偏低。

## 根因

不同响应路径返回 reasoning tokens 的字段位置并不一致；现有处理仅覆盖部分格式，遗漏了聊天响应中的相关字段。

## 改动

- 新增统一的 OpenAI usage JSON 解析与 reasoning token 提取逻辑。
- 在 HTTP 网关响应和 WebSocket v2 透传路径中补齐 reasoning tokens。
- 使用守恒规则协调 completion tokens 与 reasoning tokens，确保总量保持一致并防止重复计数。
- 增加对应的单元测试与服务层回归测试。

## 测试

- `go test ./internal/pkg/openaiusage -count=1`
- focused openai_ws_v2 reasoning tests
- focused service usage tests
- go vet on the three touched packages
- `git diff --check`

Fixes #5771