### PR TITLE
fix(openai): 修复 Chat 非流式缓冲读取错误未触发故障转移

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -422,7 +423,7 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai chat_completions buffered", requestID)
 	if err != nil {
-		return nil, err
+		return nil, s.newOpenAICompatBufferedReadFailoverError(c, account, resp, requestID, err)
 	}
 
 	if finalResponse == nil {
@@ -516,6 +517,47 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 		}
 	}
 	return result, nil
+}
+
+func (s *OpenAIGatewayService) newOpenAICompatBufferedReadFailoverError(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	requestID string,
+	err error,
+) error {
+	var readErr *openAICompatBufferedReadError
+	if !errors.As(err, &readErr) || readErr == nil || errors.Is(readErr.cause, bufio.ErrTooLong) {
+		return err
+	}
+	var requestContext context.Context
+	if c != nil && c.Request != nil {
+		requestContext = c.Request.Context()
+	}
+	if !shouldClassifyOpenAIUpstreamStreamReadError(readErr.cause, requestContext) {
+		return err
+	}
+
+	classifiedErr := newOpenAIUpstreamStreamReadError(readErr.cause)
+	code, message, ok := OpenAIUpstreamStreamReadErrorDetails(classifiedErr)
+	if !ok {
+		return err
+	}
+	payload, _ := json.Marshal(gin.H{
+		"error": gin.H{
+			"type":    "upstream_error",
+			"code":    code,
+			"message": message,
+		},
+	})
+	var responseHeaders http.Header
+	if resp != nil {
+		responseHeaders = resp.Header
+	}
+	failoverErr := s.newOpenAIStreamFailoverError(c, account, false, requestID, payload, message, responseHeaders)
+	// 保留稳定错误码，确保重试耗尽后客户端和错误透传规则仍能识别传输故障。
+	failoverErr.ResponseBody = payload
+	return failoverErr
 }
 
 // handleChatStreamingResponse reads Responses SSE events from upstream,

--- a/backend/internal/service/openai_gateway_compat_buffered_read_failover_test.go
+++ b/backend/internal/service/openai_gateway_compat_buffered_read_failover_test.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type openAICompatBufferedReadErrorCloser struct {
+	err error
+}
+
+func (r *openAICompatBufferedReadErrorCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r *openAICompatBufferedReadErrorCloser) Close() error             { return nil }
+
+func TestChatCompletionsBufferedResponsesReadErrorReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	readErrors := []struct {
+		name         string
+		err          error
+		expectedCode string
+	}{
+		{name: "unexpected_eof", err: io.ErrUnexpectedEOF, expectedCode: OpenAIUpstreamStreamReadErrorCode},
+		{name: "http2_reset", err: errors.New("stream error: stream ID 7; INTERNAL_ERROR; received from peer"), expectedCode: OpenAIUpstreamHTTP2StreamErrorCode},
+	}
+
+	for _, readError := range readErrors {
+		t.Run(readError.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"upstream-rid"}},
+				Body:       &openAICompatBufferedReadErrorCloser{err: readError.err},
+			}
+			account := &Account{ID: 40, Name: "openai-oauth", Platform: PlatformOpenAI}
+
+			result, err := (&OpenAIGatewayService{}).handleChatBufferedStreamingResponse(
+				resp, c, account, "gpt-5.6-sol", "gpt-5.6-sol", "gpt-5.6-sol", time.Now(),
+			)
+
+			require.Error(t, err)
+			require.Nil(t, result)
+			var failoverErr *UpstreamFailoverError
+			require.ErrorAs(t, err, &failoverErr)
+			require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+			require.Equal(t, "upstream-rid", failoverErr.ResponseHeaders.Get("x-request-id"))
+			require.Equal(t, readError.expectedCode, gjson.GetBytes(failoverErr.ResponseBody, "error.code").String())
+			require.Empty(t, rec.Body.String())
+			require.False(t, c.Writer.Written())
+		})
+	}
+}
+
+func TestChatCompletionsBufferedResponsesReadErrorDoesNotFailoverAfterClientCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	requestContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(requestContext)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       &openAICompatBufferedReadErrorCloser{err: io.ErrUnexpectedEOF},
+	}
+
+	result, err := (&OpenAIGatewayService{}).handleChatBufferedStreamingResponse(
+		resp,
+		c,
+		&Account{ID: 40, Name: "openai-oauth", Platform: PlatformOpenAI},
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		time.Now(),
+	)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+	require.Empty(t, rec.Body.String())
+}
+
+func TestChatCompletionsBufferedResponsesOversizedLineDoesNotFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       &openAICompatBufferedReadErrorCloser{err: bufio.ErrTooLong},
+	}
+
+	result, err := (&OpenAIGatewayService{}).handleChatBufferedStreamingResponse(
+		resp,
+		c,
+		&Account{ID: 40, Name: "openai-oauth", Platform: PlatformOpenAI},
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		time.Now(),
+	)
+
+	require.ErrorIs(t, err, bufio.ErrTooLong)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+}
+
+func TestAnthropicBufferedResponsesReadErrorKeepsExistingBehavior(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       &openAICompatBufferedReadErrorCloser{err: io.ErrUnexpectedEOF},
+	}
+
+	result, err := (&OpenAIGatewayService{}).handleAnthropicBufferedStreamingResponse(
+		resp,
+		c,
+		&Account{ID: 40, Name: "openai-oauth", Platform: PlatformOpenAI},
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		time.Now(),
+	)
+
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Equal(t, io.ErrUnexpectedEOF, err, "Messages 路径必须保持原始读取错误，不引入 Chat failover 包装")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -553,6 +553,10 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai messages buffered", requestID)
 	if err != nil {
+		var readErr *openAICompatBufferedReadError
+		if errors.As(err, &readErr) && readErr != nil {
+			return nil, readErr.cause
+		}
 		return nil, err
 	}
 
@@ -675,6 +679,15 @@ func isOpenAICompatDoneSentinelLine(line string) bool {
 	return ok && strings.TrimSpace(payload) == "[DONE]"
 }
 
+// openAICompatBufferedReadError 只标记错误发生在上游响应体读取阶段；
+// 具体端点自行决定是否允许重放请求，避免共享读取器扩大重试范围。
+type openAICompatBufferedReadError struct {
+	cause error
+}
+
+func (e *openAICompatBufferedReadError) Error() string { return e.cause.Error() }
+func (e *openAICompatBufferedReadError) Unwrap() error { return e.cause }
+
 func (s *OpenAIGatewayService) readOpenAICompatBufferedTerminal(
 	resp *http.Response,
 	logPrefix string,
@@ -783,7 +796,7 @@ func (s *OpenAIGatewayService) readOpenAICompatBufferedTerminal(
 						zap.String("request_id", requestID),
 					)
 				}
-				return nil, usage, acc, ev.err
+				return nil, usage, acc, &openAICompatBufferedReadError{cause: ev.err}
 			}
 
 			if isOpenAICompatDoneSentinelLine(ev.line) {


### PR DESCRIPTION
## 修复内容

- 将 Chat Completions 非流式 Responses 桥接中的上游响应体读取故障接入现有有界故障转移流程。
- 重试耗尽后保留稳定错误码、上游响应头和请求标识，便于客户端识别、运维关联和错误透传规则匹配。
- 保持客户端取消、请求超时、SSE 单行超限及 Messages 路径的原有行为。

关闭 #5800。

## 根因

当客户端请求 `/v1/chat/completions` 且 `stream=false` 时，Sub2API 会把请求转换成上游 Responses 请求，并强制使用 SSE 流式响应。网关在内存中持续聚合事件，直到收到终止事件，再转换成 Chat JSON 返回客户端。

如果上游已经返回 HTTP 200，但响应体在终止事件到达前发生 `unexpected EOF` 或 HTTP/2 stream reset，共享缓冲读取器会直接返回原始 scanner/read error。handler 只会对 `UpstreamFailoverError` 执行账号重试或切换，因此该错误最终退化成通用 502。

这个路径尚未向客户端写出任何字节，安全条件允许使用现有故障转移机制重放请求。

## 实现方式

- 为共享缓冲 SSE 读取器增加内部错误标记，仅用于确认错误确实发生在上游响应体读取阶段。
- 只在 Chat 非流式调用点复用现有 OpenAI 流读取错误分类器和故障转移错误构造器。
- `unexpected EOF` 等响应流读取故障返回稳定码 `upstream_stream_read_error`。
- HTTP/2 stream reset 返回稳定码 `upstream_http2_stream_error`。
- 保留上游 `x-request-id`、响应头和稳定 JSON 错误体。
- 客户端取消、请求截止时间到达以及 `bufio.ErrTooLong` 不触发请求重放。
- Messages 调用点会还原内部标记并继续返回原始读取错误，确保该端点行为不变。

本次修改没有增加独立重试循环。是否先重试同一账号、何时切换账号以及最大切换次数，仍完全由现有 handler 故障转移策略控制。

## 影响范围

行为发生变化的条件仅限于：

- 入站端点为 `POST /v1/chat/completions`；
- 客户端设置 `stream=false`；
- 请求走 Chat -> Responses 内部协议转换；
- 上游已返回 HTTP 200，但 SSE 响应体在终止事件前读取失败；
- 下游响应尚未提交。

以下路径不受影响：

- Chat 流式请求；
- 原生 `/v1/responses`；
- `/v1/messages`；
- 原生 Chat Completions 直通；
- 图片接口；
- WebSocket。

## 验证结果

- `make test-unit`：通过。
- `go test -race -tags=unit ./internal/service -run "Test(ChatCompletionsBufferedResponses|AnthropicBufferedResponses)" -count=1`：通过。
- `go vet ./...`：通过。
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...`：`0 issues`。
- `git diff --cached --check`：通过。

定向测试覆盖：`unexpected EOF`、HTTP/2 reset 分类、上游响应头保留、故障转移前无下游输出、客户端取消、SSE 单行超限，以及 Messages 原始错误行为不变。

## 集成测试说明

集成测试中的 service 包均通过。唯一失败来自 `internal/pkg/tlsfingerprint` 的外部联网测试：访问 `https://tls.peet.ws/api/all` 时证书验证报错 `x509: certificate signed by unknown authority`，与本次修改的文件和执行路径无关。

## 相关问题

- #4487 / #4520：处理 Chat 流式输出开始后的传输读取错误分类。
- #5400 / #5404：处理 OAuth 图片响应体读取错误的故障转移。
- 本 PR 补齐 Chat 非流式内部缓冲 Responses SSE 的剩余缺口。