### PR TITLE
fix(openai): decouple compact scheduling from ordinary quota

### DIFF
--- a/backend/internal/service/antigravity_quota_scope.go
+++ b/backend/internal/service/antigravity_quota_scope.go
@@ -51,6 +51,26 @@ func (a *Account) IsSchedulableForModelWithContext(ctx context.Context, requeste
 	return true
 }
 
+// IsSchedulableForCompactModelWithContext keeps legacy /responses/compact
+// independent from the ordinary account-wide quota window while retaining
+// lifecycle, overload, temporary-block, and model-level checks.
+func (a *Account) IsSchedulableForCompactModelWithContext(ctx context.Context, requestedModel string) bool {
+	if a == nil || !a.IsActive() || !a.Schedulable {
+		return false
+	}
+	now := time.Now()
+	if a.AutoPauseOnExpired && a.ExpiresAt != nil && !now.Before(*a.ExpiresAt) {
+		return false
+	}
+	if a.OverloadUntil != nil && now.Before(*a.OverloadUntil) {
+		return false
+	}
+	if a.TempUnschedulableUntil != nil && now.Before(*a.TempUnschedulableUntil) {
+		return false
+	}
+	return !a.isModelRateLimitedWithContext(ctx, requestedModel)
+}
+
 // GetRateLimitRemainingTime 获取限流剩余时间（模型级限流）
 // 返回 0 表示未限流或已过期
 func (a *Account) GetRateLimitRemainingTime(requestedModel string) time.Duration {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -549,6 +549,13 @@ func shouldClearStickySession(account *Account, requestedModel string) bool {
 	return false
 }
 
+func shouldClearStickySessionForOpenAIRequest(ctx context.Context, account *Account, requestedModel string, requireCompact bool) bool {
+	if !requireCompact {
+		return shouldClearStickySession(account, requestedModel)
+	}
+	return account != nil && !account.IsSchedulableForCompactModelWithContext(ctx, requestedModel)
+}
+
 type AccountWaitPlan struct {
 	AccountID      int64
 	MaxConcurrency int

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -481,16 +481,12 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		}
 	}
 
-	account, err := s.service.getSchedulableAccount(ctx, accountID)
+	account, err := s.service.getOpenAIAccountForScheduling(ctx, accountID, req.RequireCompact)
 	if err != nil || account == nil {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
-	schedulable := account.IsSchedulable()
-	if req.RequireCompact {
-		schedulable = account.IsSchedulableForCompactModelWithContext(ctx, req.RequestedModel)
-	}
-	if shouldClearStickySession(account, req.RequestedModel) || account.Platform != NormalizeOpenAICompatiblePlatform(req.Platform) || !account.IsOpenAICompatible() || !schedulable {
+	if shouldClearStickySessionForOpenAIRequest(ctx, account, req.RequestedModel, req.RequireCompact) || account.Platform != NormalizeOpenAICompatiblePlatform(req.Platform) || !account.IsOpenAICompatible() {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
@@ -501,8 +497,8 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
-	account = s.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
-	if account == nil || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
+	account = s.service.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
+	if account == nil || (req.RequireCompact && openAICompactSupportTier(account) == 0) || !s.service.openAIAccountMatchesSchedulingGroup(account, req.GroupID) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
@@ -1158,7 +1154,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			continue
 		}
 
-		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
+		fresh := s.service.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1167,7 +1163,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			release(result)
 			break
 		}
-		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
+		fresh = s.service.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1239,14 +1235,14 @@ func (s *defaultOpenAIAccountScheduler) tryFallbackToWeightedSticky(
 				continue
 			}
 		}
-		account, err := s.service.getSchedulableAccount(ctx, accountID)
+		account, err := s.service.getOpenAIAccountForScheduling(ctx, accountID, req.RequireCompact)
 		if err != nil || account == nil {
 			continue
 		}
 		if !s.isAccountRequestCompatible(ctx, account, req) || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 			continue
 		}
-		account = s.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
+		account = s.service.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, account, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
 		if account == nil {
 			if accountID == req.StickyAccountID && strings.TrimSpace(req.SessionHash) != "" {
 				_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, req.SessionHash)
@@ -1670,14 +1666,14 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 					continue
 				}
 			}
-			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
+			fresh := s.service.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
 			if !s.consumeOpenAISelectionDBRecheck(budget) {
 				return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked, filterStats.summary("selection_order_exhausted"))
 			}
-			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
+			fresh = s.service.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, false, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
@@ -2163,6 +2159,9 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	useUpstreamTokenCost bool,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
 	ctx = s.withOpenAIQuotaAutoPauseContext(ctx)
+	if requireCompact {
+		ctx = withOpenAICompactSchedulingContext(ctx)
+	}
 	// 分组利润控制：唯一文本调度入口的防御性装门。handler 文本
 	// 入口已在请求开始经 WithOpenAIRequestPricingContext 装门并固定 pricingAt，
 	// 此处对同分组门直接复用（failover 重入阈值稳定），仅为不经 handler 装配的

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -486,7 +486,11 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
-	if shouldClearStickySession(account, req.RequestedModel) || account.Platform != NormalizeOpenAICompatiblePlatform(req.Platform) || !account.IsOpenAICompatible() || !account.IsSchedulable() {
+	schedulable := account.IsSchedulable()
+	if req.RequireCompact {
+		schedulable = account.IsSchedulableForCompactModelWithContext(ctx, req.RequestedModel)
+	}
+	if shouldClearStickySession(account, req.RequestedModel) || account.Platform != NormalizeOpenAICompatiblePlatform(req.Platform) || !account.IsOpenAICompatible() || !schedulable {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
@@ -1154,7 +1158,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			continue
 		}
 
-		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1163,7 +1167,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			release(result)
 			break
 		}
-		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1355,7 +1359,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	req OpenAIAccountScheduleRequest,
 ) (*AccountSelectionResult, int, int, float64, error) {
 	budget := newOpenAISelectionProbeBudget()
-	accounts, err := s.service.listSchedulableAccounts(ctx, req.GroupID, req.Platform)
+	accounts, err := s.service.listOpenAIAccountCandidates(ctx, req.GroupID, req.Platform, req.RequireCompact)
 	if err != nil {
 		return nil, 0, 0, 0, err
 	}
@@ -1402,7 +1406,12 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 				continue
 			}
 		}
-		if !account.IsSchedulable() {
+		if req.RequireCompact {
+			if !account.IsSchedulableForCompactModelWithContext(ctx, req.RequestedModel) {
+				filterStats.exclude("not_schedulable")
+				continue
+			}
+		} else if !account.IsSchedulable() {
 			filterStats.exclude("not_schedulable")
 			continue
 		}
@@ -1410,7 +1419,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 			filterStats.exclude("platform_mismatch")
 			continue
 		}
-		if s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
+		if !req.RequireCompact && s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
 			filterStats.exclude("runtime_blocked")
 			continue
 		}
@@ -1661,14 +1670,14 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 					continue
 				}
 			}
-			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
 			if !s.consumeOpenAISelectionDBRecheck(budget) {
 				return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked, filterStats.summary("selection_order_exhausted"))
 			}
-			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, req.RequireCompact, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
@@ -1730,7 +1739,7 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx con
 	if account == nil {
 		return false, "account_nil"
 	}
-	if s != nil && s.service != nil && s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
+	if !req.RequireCompact && s != nil && s.service != nil && s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
 		return false, "runtime_blocked"
 	}
 	if s != nil && s.service != nil && s.service.isOpenAIProxyStreamQuarantined(ctx, account) {
@@ -1740,12 +1749,14 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx con
 	// TopK candidate pool can be filled with paused accounts and the later fresh/DB
 	// rechecks won't reach healthy accounts that fell outside TopK — manifesting as
 	// "no available accounts" even though healthy ones exist.
-	if paused, decision := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
-		reason := "quota_auto_pause"
-		if decision.window != "" {
-			reason += "_" + decision.window
+	if !req.RequireCompact {
+		if paused, decision := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
+			reason := "quota_auto_pause"
+			if decision.window != "" {
+				reason += "_" + decision.window
+			}
+			return false, reason
 		}
-		return false, reason
 	}
 	// 母账号健康联动：影子账号的凭据来自母账号，母账号不可调度时影子也不应被选中。
 	// Parent-health gate: shadow borrows the parent's credentials; an unschedulable

--- a/backend/internal/service/openai_account_scheduler_compact_test.go
+++ b/backend/internal/service/openai_account_scheduler_compact_test.go
@@ -133,7 +133,6 @@ func newOpenAICompactionSchedulerTestService(accounts []Account, advanced bool) 
 }
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactUsesPersistentCandidates(t *testing.T) {
-	resetOpenAIAdvancedSchedulerSettingCacheForTest()
 	now := time.Now()
 	resetAt := now.Add(time.Hour)
 	account := Account{
@@ -143,6 +142,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactUsesPersistentCa
 		Status:           StatusActive,
 		Schedulable:      true,
 		Concurrency:      1,
+		GroupIDs:         []int64{91070},
 		RateLimitResetAt: &resetAt,
 		Extra: map[string]any{
 			"openai_compact_supported":   true,
@@ -152,24 +152,158 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactUsesPersistentCa
 			"codex_usage_updated_at":     now.Format(time.RFC3339),
 		},
 	}
-	svc := newOpenAICompactionSchedulerTestService([]Account{account}, true)
-	ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold7d: 0.9})
-	groupID := int64(91070)
+	for _, advanced := range []bool{false, true} {
+		for _, loadBatch := range []bool{false, true} {
+			schedulerMode := "legacy_scheduler"
+			if advanced {
+				schedulerMode = "advanced_scheduler"
+			}
+			loadMode := "load_batch_off"
+			if loadBatch {
+				loadMode = "load_batch_on"
+			}
+			t.Run(schedulerMode+"/"+loadMode, func(t *testing.T) {
+				resetOpenAIAdvancedSchedulerSettingCacheForTest()
+				svc := newOpenAICompactionSchedulerTestService([]Account{account}, advanced)
+				svc.cfg.Gateway.Scheduling.LoadBatchEnabled = loadBatch
+				svc.BlockAccountScheduling(&account, resetAt, "429")
+				ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold7d: 0.9})
+				groupID := int64(91070)
 
-	normalSelection, _, normalErr := svc.SelectAccountWithSchedulerForCapability(
-		ctx, &groupID, "", "", "gpt-5.6-sol", nil,
-		OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityResponses, false, false, false,
+				normalSelection, _, normalErr := svc.SelectAccountWithSchedulerForCapability(
+					ctx, &groupID, "", "", "gpt-5.6-sol", nil,
+					OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityResponses, false, false, false,
+				)
+				require.Error(t, normalErr)
+				require.Nil(t, normalSelection)
+
+				stale := account
+				stale.RateLimitResetAt = nil
+				stale.Extra = map[string]any{
+					"openai_compact_supported":   false,
+					"openai_responses_supported": true,
+				}
+				svc.schedulerSnapshot = &SchedulerSnapshotService{cache: &openAISnapshotCacheStub{
+					snapshotAccounts: []*Account{&stale},
+					accountsByID:     map[int64]*Account{account.ID: &stale},
+				}}
+
+				compactSelection, compactErr := selectOpenAICompactionSchedulerTestAccount(t, svc, groupID, true)
+				require.NoError(t, compactErr)
+				require.NotNil(t, compactSelection)
+				require.NotNil(t, compactSelection.Account)
+				require.Equal(t, account.ID, compactSelection.Account.ID)
+				require.Equal(t, 2, openAICompactSupportTier(compactSelection.Account), "final hydration must not restore stale compact capability")
+				if compactSelection.ReleaseFunc != nil {
+					compactSelection.ReleaseFunc()
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactStickyBypassesOrdinaryBlocks(t *testing.T) {
+	resetAt := time.Now().Add(time.Hour)
+	for _, advanced := range []bool{false, true} {
+		for _, loadBatch := range []bool{false, true} {
+			schedulerMode := "legacy_scheduler"
+			if advanced {
+				schedulerMode = "advanced_scheduler"
+			}
+			loadMode := "load_batch_off"
+			if loadBatch {
+				loadMode = "load_batch_on"
+			}
+			t.Run(schedulerMode+"/"+loadMode, func(t *testing.T) {
+				resetOpenAIAdvancedSchedulerSettingCacheForTest()
+				groupID := int64(91071)
+				account := Account{
+					ID:               71071,
+					Platform:         PlatformOpenAI,
+					Type:             AccountTypeOAuth,
+					Status:           StatusActive,
+					Schedulable:      true,
+					Concurrency:      1,
+					GroupIDs:         []int64{groupID},
+					RateLimitResetAt: &resetAt,
+					Extra: map[string]any{
+						"openai_compact_supported":   true,
+						"openai_responses_supported": true,
+					},
+				}
+				cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:compact_sticky": account.ID}}
+				svc := newOpenAICompactionSchedulerTestService([]Account{account}, advanced)
+				svc.cache = cache
+				svc.cfg.Gateway.Scheduling.LoadBatchEnabled = loadBatch
+				svc.BlockAccountScheduling(&account, resetAt, "429")
+
+				selection, _, err := svc.SelectAccountWithSchedulerForCapability(
+					context.Background(), &groupID, "", "compact_sticky", "gpt-5.6-sol", nil,
+					OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityResponses, true, false, false,
+				)
+				require.NoError(t, err)
+				require.NotNil(t, selection)
+				require.NotNil(t, selection.Account)
+				require.Equal(t, account.ID, selection.Account.ID)
+				require.Equal(t, account.ID, cache.sessionBindings["openai:compact_sticky"])
+				require.Zero(t, cache.deletedSessions["openai:compact_sticky"])
+				if selection.ReleaseFunc != nil {
+					selection.ReleaseFunc()
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_CompactBypassesOrdinaryBlocks(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(91072)
+	resetAt := time.Now().Add(time.Hour)
+	account := Account{
+		ID:               71072,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeAPIKey,
+		Status:           StatusActive,
+		Schedulable:      true,
+		Concurrency:      1,
+		GroupIDs:         []int64{groupID},
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+			"openai_compact_supported":                      true,
+			"openai_responses_supported":                    true,
+		},
+	}
+	stale := account
+	stale.RateLimitResetAt = nil
+	cache := &schedulerTestGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                newSchedulerTestOpenAIWSV2Config(),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		openaiWSStateStore: store,
+		schedulerSnapshot: &SchedulerSnapshotService{cache: &openAISnapshotCacheStub{
+			accountsByID: map[int64]*Account{account.ID: &stale},
+		}},
+	}
+	svc.BlockAccountScheduling(&account, resetAt, "429")
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_compact_blocked", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(
+		ctx, &groupID, "resp_compact_blocked", "gpt-5.6-sol", nil, true,
 	)
-	require.Error(t, normalErr)
-	require.Nil(t, normalSelection)
-
-	compactSelection, compactErr := selectOpenAICompactionSchedulerTestAccount(t, svc, groupID, true)
-	require.NoError(t, compactErr)
-	require.NotNil(t, compactSelection)
-	require.NotNil(t, compactSelection.Account)
-	require.Equal(t, account.ID, compactSelection.Account.ID)
-	if compactSelection.ReleaseFunc != nil {
-		compactSelection.ReleaseFunc()
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, account.ID, selection.Account.ID)
+	require.Equal(t, 2, openAICompactSupportTier(selection.Account))
+	boundAccountID, bindErr := store.GetResponseAccount(ctx, groupID, "resp_compact_blocked")
+	require.NoError(t, bindErr)
+	require.Equal(t, account.ID, boundAccountID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
 	}
 }
 
@@ -269,40 +403,48 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_NativeCompactionRequire
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_LegacyCompactionKeepsCompactEligibility(t *testing.T) {
 	for _, advanced := range []bool{false, true} {
-		t.Run(map[bool]string{false: "legacy_scheduler", true: "advanced_scheduler"}[advanced], func(t *testing.T) {
-			resetOpenAIAdvancedSchedulerSettingCacheForTest()
-			svc := newOpenAICompactionSchedulerTestService([]Account{
-				{
-					ID:          71015,
-					Platform:    PlatformOpenAI,
-					Type:        AccountTypeAPIKey,
-					Status:      StatusActive,
-					Schedulable: true,
-					Concurrency: 1,
-					Extra: map[string]any{
-						"openai_compact_supported":   false,
-						"openai_responses_supported": true,
+		for _, loadBatch := range []bool{false, true} {
+			schedulerMode := map[bool]string{false: "legacy_scheduler", true: "advanced_scheduler"}[advanced]
+			loadMode := map[bool]string{false: "load_batch_off", true: "load_batch_on"}[loadBatch]
+			t.Run(schedulerMode+"/"+loadMode, func(t *testing.T) {
+				resetOpenAIAdvancedSchedulerSettingCacheForTest()
+				resetAt := time.Now().Add(time.Hour)
+				svc := newOpenAICompactionSchedulerTestService([]Account{
+					{
+						ID:               71015,
+						Platform:         PlatformOpenAI,
+						Type:             AccountTypeOAuth,
+						Status:           StatusActive,
+						Schedulable:      true,
+						Concurrency:      1,
+						RateLimitResetAt: &resetAt,
+						Extra: map[string]any{
+							"openai_compact_supported":   false,
+							"openai_responses_supported": true,
+						},
 					},
-				},
-				{
-					ID:          71016,
-					Platform:    PlatformOpenAI,
-					Type:        AccountTypeAPIKey,
-					Status:      StatusActive,
-					Schedulable: true,
-					Concurrency: 1,
-					Extra: map[string]any{
-						"openai_compact_mode":        OpenAICompactModeForceOff,
-						"openai_responses_supported": true,
+					{
+						ID:               71016,
+						Platform:         PlatformOpenAI,
+						Type:             AccountTypeOAuth,
+						Status:           StatusActive,
+						Schedulable:      true,
+						Concurrency:      1,
+						RateLimitResetAt: &resetAt,
+						Extra: map[string]any{
+							"openai_compact_mode":        OpenAICompactModeForceOff,
+							"openai_responses_supported": true,
+						},
 					},
-				},
-			}, advanced)
+				}, advanced)
+				svc.cfg.Gateway.Scheduling.LoadBatchEnabled = loadBatch
 
-			selection, err := selectOpenAICompactionSchedulerTestAccount(t, svc, 91010, true)
-			require.ErrorIs(t, err, ErrNoAvailableCompactAccounts)
-			require.Contains(t, err.Error(), "/responses/compact")
-			require.Nil(t, selection)
-		})
+				selection, err := selectOpenAICompactionSchedulerTestAccount(t, svc, 91010, true)
+				require.ErrorIs(t, err, ErrNoAvailableCompactAccounts)
+				require.Contains(t, err.Error(), "/responses/compact")
+				require.Nil(t, selection)
+			})
+		}
 	}
 }
 

--- a/backend/internal/service/openai_account_scheduler_compact_test.go
+++ b/backend/internal/service/openai_account_scheduler_compact_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
@@ -129,6 +130,47 @@ func newOpenAICompactionSchedulerTestService(accounts []Account, advanced bool) 
 		svc.rateLimitService = newOpenAIAdvancedSchedulerRateLimitService("true")
 	}
 	return svc
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_CompactUsesPersistentCandidates(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	now := time.Now()
+	resetAt := now.Add(time.Hour)
+	account := Account{
+		ID:               71070,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		Concurrency:      1,
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"openai_compact_supported":   true,
+			"openai_responses_supported": true,
+			"codex_7d_used_percent":      100.0,
+			"codex_7d_reset_at":          resetAt.Format(time.RFC3339),
+			"codex_usage_updated_at":     now.Format(time.RFC3339),
+		},
+	}
+	svc := newOpenAICompactionSchedulerTestService([]Account{account}, true)
+	ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold7d: 0.9})
+	groupID := int64(91070)
+
+	normalSelection, _, normalErr := svc.SelectAccountWithSchedulerForCapability(
+		ctx, &groupID, "", "", "gpt-5.6-sol", nil,
+		OpenAIUpstreamTransportAny, OpenAIEndpointCapabilityResponses, false, false, false,
+	)
+	require.Error(t, normalErr)
+	require.Nil(t, normalSelection)
+
+	compactSelection, compactErr := selectOpenAICompactionSchedulerTestAccount(t, svc, groupID, true)
+	require.NoError(t, compactErr)
+	require.NotNil(t, compactSelection)
+	require.NotNil(t, compactSelection.Account)
+	require.Equal(t, account.ID, compactSelection.Account.ID)
+	if compactSelection.ReleaseFunc != nil {
+		compactSelection.ReleaseFunc()
+	}
 }
 
 func selectOpenAICompactionSchedulerTestAccount(t *testing.T, svc *OpenAIGatewayService, groupID int64, requireCompact bool) (*AccountSelectionResult, error) {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -34,6 +34,26 @@ func (r schedulerTestOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (
 	return nil, errors.New("account not found")
 }
 
+func (r schedulerTestOpenAIAccountRepo) ListModelAvailabilityCandidates(_ context.Context, _ *int64, platforms []string, _ bool) ([]Account, error) {
+	platformSet := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		platformSet[platform] = struct{}{}
+	}
+	result := make([]Account, 0, len(r.accounts))
+	for _, account := range r.accounts {
+		if account.Status != StatusActive || !account.Schedulable {
+			continue
+		}
+		if len(platformSet) > 0 {
+			if _, ok := platformSet[account.Platform]; !ok {
+				continue
+			}
+		}
+		result = append(result, account)
+	}
+	return result, nil
+}
+
 func (r schedulerTestOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]Account, error) {
 	var result []Account
 	for _, acc := range r.accounts {
@@ -2671,6 +2691,35 @@ func TestOpenAIAccountScheduler_SkipsAccountBlockedForRequestedModel(t *testing.
 
 	require.False(t, scheduler.isAccountRequestCompatible(context.Background(), account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.5"}))
 	require.True(t, scheduler.isAccountRequestCompatible(context.Background(), account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.6-sol"}))
+}
+
+func TestOpenAICompactScheduling_IgnoresOrdinaryQuotaAndRuntimeBlock(t *testing.T) {
+	now := time.Now()
+	resetAt := now.Add(time.Hour)
+	account := &Account{
+		ID:               21634,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"openai_compact_supported": true,
+			"codex_7d_used_percent":    100.0,
+			"codex_7d_reset_at":        resetAt.Format(time.RFC3339),
+			"codex_usage_updated_at":   now.Format(time.RFC3339),
+		},
+	}
+	ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold7d: 0.9})
+
+	require.False(t, isOpenAICompatibleAccountEligibleForRequest(ctx, account, PlatformOpenAI, "gpt-5.6-sol", false, ""))
+	require.True(t, isOpenAICompatibleAccountEligibleForRequest(ctx, account, PlatformOpenAI, "gpt-5.6-sol", true, ""))
+
+	svc := &OpenAIGatewayService{}
+	svc.BlockAccountScheduling(account, resetAt, "429")
+	scheduler := &defaultOpenAIAccountScheduler{service: svc}
+	require.False(t, scheduler.isAccountRequestCompatible(ctx, account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.6-sol"}))
+	require.True(t, scheduler.isAccountRequestCompatible(ctx, account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.6-sol", RequireCompact: true}))
 }
 
 func TestReportOpenAIAccountScheduleResult_SuccessClearsModelTransientState(t *testing.T) {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -335,10 +335,18 @@ func isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *A
 // profit veto so earlier failures retain their actual reason.
 func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
 	platform = NormalizeOpenAICompatiblePlatform(platform)
-	if account == nil || account.Platform != platform || !account.IsOpenAICompatible() || !account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+	schedulable := false
+	if account != nil {
+		if requireCompact {
+			schedulable = account.IsSchedulableForCompactModelWithContext(ctx, requestedModel)
+		} else {
+			schedulable = account.IsSchedulableForModelWithContext(ctx, requestedModel)
+		}
+	}
+	if account == nil || account.Platform != platform || !account.IsOpenAICompatible() || !schedulable {
 		return false
 	}
-	if account.IsOpenAI() {
+	if account.IsOpenAI() && !requireCompact {
 		if paused, reason := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
 			// Debug level: this fires per-candidate on the scheduling hot path, so Info
 			// would amplify into log spam once several accounts cross the threshold.
@@ -351,7 +359,7 @@ func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context
 			return false
 		}
 	}
-	if account.IsGrok() {
+	if account.IsGrok() && !requireCompact {
 		if paused, reason := shouldAutoPauseGrokAccountByQuota(account); paused {
 			slog.Debug("grok_account_auto_paused_by_quota",
 				"account_id", account.ID,
@@ -1342,6 +1350,27 @@ func (s *OpenAIGatewayService) listSchedulableAccounts(ctx context.Context, grou
 	return accounts, nil
 }
 
+// listOpenAIAccountCandidates returns the normal transient-aware pool unless a
+// legacy /responses/compact request is being scheduled. Compact must be able to
+// inspect accounts temporarily blocked by the ordinary quota window, so it
+// queries the persistent active+schedulable pool directly from the repository.
+func (s *OpenAIGatewayService) listOpenAIAccountCandidates(ctx context.Context, groupID *int64, platform string, requireCompact bool) ([]Account, error) {
+	if !requireCompact {
+		return s.listSchedulableAccounts(ctx, groupID, platform)
+	}
+	if s == nil || s.accountRepo == nil {
+		return nil, ErrSchedulerCacheNotReady
+	}
+	platform = NormalizeOpenAICompatiblePlatform(platform)
+	queryGroupID := groupID
+	includeGrouped := false
+	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		queryGroupID = nil
+		includeGrouped = true
+	}
+	return s.accountRepo.ListModelAvailabilityCandidates(ctx, queryGroupID, []string{platform}, includeGrouped)
+}
+
 func (s *OpenAIGatewayService) tryAcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int) (*AcquireResult, error) {
 	if s.concurrencyService == nil {
 		return &AcquireResult{Acquired: true, ReleaseFunc: func() {}}, nil
@@ -1367,7 +1396,13 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfit(
 	platform = NormalizeOpenAICompatiblePlatform(platform)
 
 	fresh := account
-	if s.schedulerSnapshot != nil {
+	if requireCompact && s.accountRepo != nil {
+		current, err := s.accountRepo.GetByID(ctx, account.ID)
+		if err != nil || current == nil {
+			return nil
+		}
+		fresh = current
+	} else if s.schedulerSnapshot != nil {
 		current, err := s.getSchedulableAccount(ctx, account.ID)
 		if err != nil || current == nil {
 			return nil
@@ -1381,7 +1416,7 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfit(
 	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(fresh, requestedModel) {
+	if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(fresh, requestedModel) {
 		return nil
 	}
 	if s.isOpenAIAccountBlockedBySchedulingThreshold(ctx, fresh) {
@@ -1452,7 +1487,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfit(ct
 	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
+	if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
 		return nil
 	}
 	if s.isOpenAIAccountBlockedBySchedulingThreshold(ctx, latest) {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -319,21 +319,31 @@ func openAICompactSupportTier(account *Account) int {
 // 注意：对 spark 影子账号，调用方还须额外调用 parentHealthyForShadow(account, lookup)
 // 检查母账号凭据可用性；该检查未内置于本函数，以避免注入 DB 依赖。
 func isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
-	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
-		return false
-	}
-	// 分组利润控制：legacy 引擎的粘性/候选循环与 DB recheck 共用
-	// 本判定，任何 fallback 都不能把利润不合格账号重新放回候选。
-	if vetoed, _ := openAIProfitControlVetoReason(ctx, account); vetoed {
-		return false
-	}
-	return true
+	return isOpenAICompatibleAccountEligibleForRequestWithOptions(ctx, account, platform, requestedModel, requireCompact, true, requiredCapability)
 }
 
 // isOpenAICompatibleAccountEligibleForRequestBeforeProfit applies every
 // ordinary scheduling gate. Legacy selection uses it before classifying the
 // profit veto so earlier failures retain their actual reason.
 func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
+	return isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx, account, platform, requestedModel, requireCompact, true, requiredCapability)
+}
+
+// isOpenAICompatibleAccountEligibleForRequestWithOptions lets selection paths
+// defer the compact capability-tier decision until after fresh/DB rechecks.
+// That preserves ErrNoAvailableCompactAccounts classification while still
+// bypassing ordinary quota/runtime gates for the legacy compact request.
+func isOpenAICompatibleAccountEligibleForRequestWithOptions(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) bool {
+	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx, account, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability) {
+		return false
+	}
+	if vetoed, _ := openAIProfitControlVetoReason(ctx, account); vetoed {
+		return false
+	}
+	return true
+}
+
+func isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) bool {
 	platform = NormalizeOpenAICompatiblePlatform(platform)
 	schedulable := false
 	if account != nil {
@@ -380,7 +390,7 @@ func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context
 		}
 		return false
 	}
-	if requireCompact && openAICompactSupportTier(account) == 0 {
+	if requireCompact && enforceCompactCapability && openAICompactSupportTier(account) == 0 {
 		return false
 	}
 	return true
@@ -650,6 +660,23 @@ func readOpenAIQuotaUsedPercent(extra map[string]any, window string) float64 {
 
 type openAIQuotaAutoPauseCtxKey struct{}
 
+type openAICompactSchedulingCtxKey struct{}
+
+func withOpenAICompactSchedulingContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, openAICompactSchedulingCtxKey{}, struct{}{})
+}
+
+func openAICompactSchedulingFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	_, ok := ctx.Value(openAICompactSchedulingCtxKey{}).(struct{})
+	return ok
+}
+
 func withOpenAIQuotaAutoPauseSettings(ctx context.Context, settings OpsOpenAIAccountQuotaAutoPauseSettings) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -757,7 +784,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 
 	// 2. 获取可调度的 OpenAI 账号
 	// Get schedulable OpenAI accounts
-	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	accounts, err := s.listOpenAIAccountCandidates(ctx, groupID, platform, requireCompact)
 	if err != nil {
 		return nil, fmt.Errorf("query accounts failed: %w", err)
 	}
@@ -809,28 +836,28 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		return nil
 	}
 
-	account, err := s.getSchedulableAccount(ctx, accountID)
+	account, err := s.getOpenAIAccountForScheduling(ctx, accountID, requireCompact)
 	if err != nil {
 		return nil
 	}
 
 	// 检查账号是否需要清理粘性会话
 	// Check if sticky session should be cleared
-	if shouldClearStickySession(account, requestedModel) {
+	if shouldClearStickySessionForOpenAIRequest(ctx, account, requestedModel, requireCompact) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
 
 	// 验证账号是否可用于当前请求
 	// Verify account is usable for current request
-	if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
+	if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+	if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
@@ -878,12 +905,12 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 			continue
 		}
 
-		fresh := s.resolveFreshSchedulableOpenAIAccountBeforeProfit(ctx, acc, platform, requestedModel, false, requiredCapability)
+		fresh := s.resolveFreshSchedulableOpenAIAccountBeforeProfitWithOptions(ctx, acc, platform, requestedModel, requireCompact, false, requiredCapability)
 		if fresh == nil {
 			filterStats.exclude("ineligible")
 			continue
 		}
-		fresh = s.recheckSelectedOpenAIAccountFromDBBeforeProfit(ctx, fresh, groupID, platform, requestedModel, false, requiredCapability)
+		fresh = s.recheckSelectedOpenAIAccountFromDBBeforeProfitWithOptions(ctx, fresh, groupID, platform, requestedModel, requireCompact, false, requiredCapability)
 		if fresh == nil {
 			filterStats.exclude("ineligible")
 			continue
@@ -973,6 +1000,9 @@ func (s *OpenAIGatewayService) SelectAccountWithLoadAwareness(ctx context.Contex
 }
 
 func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Context, groupID *int64, platform string, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, requiredCapability OpenAIEndpointCapability, useUpstreamTokenCost bool) (*AccountSelectionResult, error) {
+	if requireCompact {
+		ctx = withOpenAICompactSchedulingContext(ctx)
+	}
 	platform = NormalizeOpenAICompatiblePlatform(platform)
 	if s.checkChannelPricingRestriction(ctx, groupID, requestedModel) {
 		slog.Warn("channel pricing restriction blocked request",
@@ -1018,7 +1048,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		})
 	}
 
-	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	accounts, err := s.listOpenAIAccountCandidates(ctx, groupID, platform, requireCompact)
 	if err != nil {
 		return nil, err
 	}
@@ -1038,19 +1068,19 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if sessionHash != "" {
 		accountID := stickyAccountID
 		if accountID > 0 && !isExcluded(accountID) {
-			account, err := s.getSchedulableAccount(ctx, accountID)
+			account, err := s.getOpenAIAccountForScheduling(ctx, accountID, requireCompact)
 			if err == nil {
-				clearSticky := shouldClearStickySession(account, requestedModel)
+				clearSticky := shouldClearStickySessionForOpenAIRequest(ctx, account, requestedModel, requireCompact)
 				if clearSticky {
 					_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 				}
-				if !clearSticky && isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
+				if !clearSticky && isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
 					account = s.recheckSelectedOpenAIAccountFromDB(ctx, account, groupID, platform, requestedModel, requireCompact, requiredCapability)
 					if account == nil {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if !s.openAIAccountMatchesSchedulingGroup(account, groupID) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
-					} else if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+					} else if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, account, requestedModel, requireCompact) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
@@ -1107,13 +1137,13 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		// Scheduler snapshots can be temporarily stale (bucket rebuild is throttled);
 		// re-check schedulability here so recently rate-limited/overloaded accounts
 		// are not selected again before the bucket is rebuilt.
-		if !isOpenAICompatibleAccountEligibleForRequest(ctx, acc, platform, requestedModel, false, requiredCapability) {
+		if !isOpenAICompatibleAccountEligibleForRequestWithOptions(ctx, acc, platform, requestedModel, requireCompact, false, requiredCapability) {
 			continue
 		}
 		if !parentHealthyForShadow(acc, parentLookupL2) {
 			continue
 		}
-		if s.isOpenAIAccountRequestRuntimeBlocked(acc, requestedModel) {
+		if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(acc, requestedModel) {
 			continue
 		}
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
@@ -1204,12 +1234,15 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		}
 
 		for _, item := range selectionOrder {
-			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, item.account, platform, requestedModel, false, requiredCapability)
+			fresh := s.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, item.account, platform, requestedModel, requireCompact, false, requiredCapability)
 			if fresh == nil {
 				continue
 			}
-			fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
+			fresh = s.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, fresh, groupID, platform, requestedModel, requireCompact, false, requiredCapability)
 			if fresh == nil {
+				continue
+			}
+			if requireCompact && openAICompactSupportTier(fresh) == 0 {
 				continue
 			}
 			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
@@ -1243,12 +1276,15 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			ordered = prioritizeOpenAICompactAccounts(ordered)
 		}
 		for _, acc := range ordered {
-			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+			fresh := s.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, acc, platform, requestedModel, requireCompact, false, requiredCapability)
 			if fresh == nil {
 				continue
 			}
-			fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
+			fresh = s.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, fresh, groupID, platform, requestedModel, requireCompact, false, requiredCapability)
 			if fresh == nil {
+				continue
+			}
+			if requireCompact && openAICompactSupportTier(fresh) == 0 {
 				continue
 			}
 			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
@@ -1293,12 +1329,15 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		candidates = prioritizeOpenAICompactAccounts(candidates)
 	}
 	for _, acc := range candidates {
-		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+		fresh := s.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, acc, platform, requestedModel, requireCompact, false, requiredCapability)
 		if fresh == nil {
 			continue
 		}
-		fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
+		fresh = s.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, fresh, groupID, platform, requestedModel, requireCompact, false, requiredCapability)
 		if fresh == nil {
+			continue
+		}
+		if requireCompact && openAICompactSupportTier(fresh) == 0 {
 			continue
 		}
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
@@ -1379,7 +1418,11 @@ func (s *OpenAIGatewayService) tryAcquireAccountSlot(ctx context.Context, accoun
 }
 
 func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
-	fresh := s.resolveFreshSchedulableOpenAIAccountBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability)
+	return s.resolveFreshSchedulableOpenAIAccountWithOptions(ctx, account, platform, requestedModel, requireCompact, true, requiredCapability)
+}
+
+func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountWithOptions(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) *Account {
+	fresh := s.resolveFreshSchedulableOpenAIAccountBeforeProfitWithOptions(ctx, account, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability)
 	if fresh == nil {
 		return nil
 	}
@@ -1390,6 +1433,10 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.
 }
 
 func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
+	return s.resolveFreshSchedulableOpenAIAccountBeforeProfitWithOptions(ctx, account, platform, requestedModel, requireCompact, true, requiredCapability)
+}
+
+func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfitWithOptions(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) *Account {
 	if account == nil {
 		return nil
 	}
@@ -1410,7 +1457,7 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfit(
 		fresh = current
 	}
 
-	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
+	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx, fresh, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
@@ -1443,7 +1490,11 @@ func (s *OpenAIGatewayService) parentAccountLookup(ctx context.Context) func(int
 }
 
 func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
-	latest := s.recheckSelectedOpenAIAccountFromDBBeforeProfit(ctx, account, groupID, platform, requestedModel, requireCompact, requiredCapability)
+	return s.recheckSelectedOpenAIAccountFromDBWithOptions(ctx, account, groupID, platform, requestedModel, requireCompact, true, requiredCapability)
+}
+
+func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBWithOptions(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) *Account {
+	latest := s.recheckSelectedOpenAIAccountFromDBBeforeProfitWithOptions(ctx, account, groupID, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability)
 	if latest == nil {
 		return nil
 	}
@@ -1454,12 +1505,16 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 }
 
 func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfit(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
+	return s.recheckSelectedOpenAIAccountFromDBBeforeProfitWithOptions(ctx, account, groupID, platform, requestedModel, requireCompact, true, requiredCapability)
+}
+
+func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfitWithOptions(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, enforceCompactCapability bool, requiredCapability OpenAIEndpointCapability) *Account {
 	if account == nil {
 		return nil
 	}
 	platform = NormalizeOpenAICompatiblePlatform(platform)
 	if s.schedulerSnapshot == nil || s.accountRepo == nil {
-		if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
+		if !isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx, account, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability) {
 			return nil
 		}
 		if s.isOpenAIAccountBlockedBySchedulingThreshold(ctx, account) {
@@ -1481,7 +1536,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfit(ct
 	if !s.openAIAccountMatchesSchedulingGroup(latest, groupID) {
 		return nil
 	}
-	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
+	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfitWithOptions(ctx, latest, platform, requestedModel, requireCompact, enforceCompactCapability, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
@@ -1507,11 +1562,17 @@ func (s *OpenAIGatewayService) openAIAccountMatchesSchedulingGroup(account *Acco
 }
 
 func (s *OpenAIGatewayService) getSchedulableAccount(ctx context.Context, accountID int64) (*Account, error) {
+	return s.getOpenAIAccountForScheduling(ctx, accountID, false)
+}
+
+func (s *OpenAIGatewayService) getOpenAIAccountForScheduling(ctx context.Context, accountID int64, requireCompact bool) (*Account, error) {
 	var (
 		account *Account
 		err     error
 	)
-	if s.schedulerSnapshot != nil {
+	if requireCompact && s.accountRepo != nil {
+		account, err = s.accountRepo.GetByID(ctx, accountID)
+	} else if s.schedulerSnapshot != nil {
 		account, err = s.schedulerSnapshot.GetAccount(ctx, accountID)
 	} else {
 		account, err = s.accountRepo.GetByID(ctx, accountID)
@@ -1563,7 +1624,7 @@ func (s *OpenAIGatewayService) isOpenAIAccountBlockedBySchedulingThreshold(ctx c
 }
 
 func (s *OpenAIGatewayService) hydrateSelectedAccount(ctx context.Context, account *Account) (*Account, error) {
-	if account == nil || s.schedulerSnapshot == nil {
+	if account == nil || s.schedulerSnapshot == nil || openAICompactSchedulingFromContext(ctx) {
 		return account, nil
 	}
 	hydrated, err := s.schedulerSnapshot.GetAccount(ctx, account.ID)

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -481,7 +481,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		}
 	}
 
-	account, err := s.getSchedulableAccount(ctx, accountID)
+	account, err := s.getOpenAIAccountForScheduling(ctx, accountID, requireCompact)
 	if err != nil || account == nil {
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
@@ -491,7 +491,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	if s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
 		return 0, nil, "", nil
 	}
-	if shouldClearStickySession(account, requestedModel) || !account.IsOpenAI() || !account.IsSchedulable() {
+	if shouldClearStickySessionForOpenAIRequest(ctx, account, requestedModel, requireCompact) || !account.IsOpenAI() {
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
 	}
@@ -505,11 +505,16 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	if !account.SupportsOpenAIEndpointCapability(requiredCapability) {
 		return 0, nil, "", nil
 	}
-	// Quota auto-pause must also gate the previous_response_id sticky path; otherwise an
-	// account over its 5h/7d threshold keeps serving the same response chain even though
-	// normal scheduling skips it. Pause is transient, so fall through to normal scheduling
-	// without deleting the binding (the window may reset before the next turn).
-	if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
+	// Ordinary requests must honor quota auto-pause on the previous_response_id
+	// sticky path. Legacy compact deliberately bypasses that account-wide quota.
+	// Pause is transient, so keep the binding for reuse after the window resets.
+	if !requireCompact {
+		if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
+			return 0, nil, "", nil
+		}
+	}
+	if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
 	}
 	// 分组利润控制：与 quota auto-pause 同语义——利润不合格是暂时
@@ -524,7 +529,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 			return 0, nil, "", nil
 		}
-		if shouldClearStickySession(latest, requestedModel) || !latest.IsOpenAI() || !latest.IsSchedulable() {
+		if shouldClearStickySessionForOpenAIRequest(ctx, latest, requestedModel, requireCompact) || !latest.IsOpenAI() {
 			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 			return 0, nil, "", nil
 		}
@@ -538,14 +543,16 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		if !latest.SupportsOpenAIEndpointCapability(requiredCapability) {
 			return 0, nil, "", nil
 		}
-		if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, latest); paused {
-			return 0, nil, "", nil
+		if !requireCompact {
+			if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, latest); paused {
+				return 0, nil, "", nil
+			}
 		}
 		// 利润门对最新账号状态复检一次，语义同上：跳过复用、不删绑定。
 		if vetoed, _ := openAIProfitControlVetoReason(ctx, latest); vetoed {
 			return 0, nil, "", nil
 		}
-		if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
+		if !requireCompact && s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
 			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 			return 0, nil, "", nil
 		}


### PR DESCRIPTION
## Summary

Legacy `/responses/compact` requests can be served by an account during the ordinary Codex quota/runtime window. The scheduler previously discarded those accounts before compact capability checks and lost `RequireCompact` across sticky, fresh, database, and `previous_response_id` rechecks.

## Changes

- Keep lifecycle, expiry, overload, temporary-block, model-level rate-limit, endpoint capability, parent-health, channel, threshold, proxy, and profit gates while bypassing ordinary account-wide quota/runtime gates only for compact.
- Query persistent `ListModelAvailabilityCandidates` for compact so transient quota state does not empty the candidate pool.
- Thread compact intent through legacy load-batch/fallback paths, advanced scheduler rechecks, sticky sessions, and `previous_response_id` routing.
- Defer compact-tier filtering until fresh/DB state is available, preserving `ErrNoAvailableCompactAccounts`.
- Avoid stale scheduler snapshot hydration after compact DB selection and add regression coverage across legacy/advanced and load-batch modes.

## Validation

- Targeted service regression: `go test ./internal/service -run 'Test(OpenAIAccountScheduler|OpenAIGatewayService_SelectAccountWithScheduler|OpenAICompact|AdvancedScheduler|OpenAIGatewayService_SelectAccountByPreviousResponseID)' -count=1`\n- The full service package was attempted; an unrelated proxy-quality test requires an IPv6 listener unavailable in the sandbox (`httptest` bind to `[::1]:0`).\n- The runtime block store currently does not retain block reasons, so compact bypasses all in-memory runtime blocks, not only 429; persistent expiry/overload/temp/model-level gates remain enforced.\n\nDownstream edge, anti-ban, branding, and CI changes are intentionally excluded.