### PR TITLE
test(tlsfingerprint): require opt-in for external checks

### DIFF
--- a/backend/internal/pkg/tlsfingerprint/dialer_integration_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_integration_test.go
@@ -46,9 +46,7 @@ func skipIfExternalServiceUnavailable(t *testing.T, err error) {
 // Expected JA3 hash: 44f88fca027f27bab4bb08d4af15f23e (Node.js 24.x)
 // Expected JA4: t13d1714h1_5b57614c22b0_7baf387fc6ff
 func TestJA3Fingerprint(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
+	skipNetworkTest(t)
 
 	profile := &Profile{
 		Name:         "Default Profile Test",
@@ -110,9 +108,7 @@ func TestJA3Fingerprint(t *testing.T) {
 // TestAllProfiles tests multiple TLS fingerprint profiles against tls.peet.ws.
 // Run with: go test -v -tags=integration -run TestAllProfiles ./internal/pkg/tlsfingerprint/...
 func TestAllProfiles(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
+	skipNetworkTest(t)
 
 	// Define all profiles to test with their expected fingerprints
 	// These profiles are from config.yaml gateway.tls_fingerprint.profiles

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -149,15 +148,6 @@ func TestJA3Fingerprint(t *testing.T) {
 		t.Logf("✓ JA3 contains expected extension list: %s", expectedExtensions)
 	} else {
 		t.Logf("Warning: JA3 extension list may differ")
-	}
-}
-
-func skipNetworkTest(t *testing.T) {
-	if testing.Short() {
-		t.Skip("跳过网络测试（short 模式）")
-	}
-	if os.Getenv("TLSFINGERPRINT_NETWORK_TESTS") != "1" {
-		t.Skip("跳过网络测试（需要设置 TLSFINGERPRINT_NETWORK_TESTS=1）")
 	}
 }
 

--- a/backend/internal/pkg/tlsfingerprint/test_types_test.go
+++ b/backend/internal/pkg/tlsfingerprint/test_types_test.go
@@ -1,5 +1,20 @@
 package tlsfingerprint
 
+import (
+	"os"
+	"testing"
+)
+
+func skipNetworkTest(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping external network test in short mode")
+	}
+	if os.Getenv("TLSFINGERPRINT_NETWORK_TESTS") != "1" {
+		t.Skip("skipping external network test: set TLSFINGERPRINT_NETWORK_TESTS=1 to enable")
+	}
+}
+
 // FingerprintResponse represents the response from tls.peet.ws/api/all.
 // 共享测试类型，供 unit 和 integration 测试文件使用。
 type FingerprintResponse struct {


### PR DESCRIPTION
## Summary

- share the existing external-network test gate across unit and integration build tags
- require `TLSFINGERPRINT_NETWORK_TESTS=1` before the TLS fingerprint integration tests contact `tls.peet.ws`

## Why

The integration suite contacted a third-party fingerprint service by default even though these tests are documented as manual network checks. That makes otherwise unrelated integration verification depend on the service's current TLS certificate and availability.

Deterministic ClientHello/profile tests continue to run normally. Explicitly enabling the network checks still performs the real request with normal certificate verification.

## Validation

- `go test -count=1 -tags=unit ./internal/pkg/tlsfingerprint`
- `go test -count=1 -tags=integration ./internal/pkg/tlsfingerprint`
- `git diff --check`

No production code changed, and this does not use `InsecureSkipVerify` or otherwise weaken TLS verification.
