### PR TITLE
test: align group rollup fixture timezone

### DIFF
--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -468,6 +468,8 @@ func beginGroupUsageRollupTriggerTestTx(t *testing.T, ctx context.Context, schem
 	tx, err := integrationDB.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	require.NoError(t, setGroupUsageRollupTriggerSearchPath(ctx, tx, pq.QuoteIdentifier(schema)))
+	_, err = tx.ExecContext(ctx, "SET LOCAL TIME ZONE 'Asia/Shanghai'")
+	require.NoError(t, err)
 	return tx
 }
 


### PR DESCRIPTION
## Summary

- align the group-usage rollup integration fixture's PostgreSQL session timezone with its default `Asia/Shanghai` rollup state
- keep the existing UTC and DST-specific cases free to override the transaction timezone with `SET LOCAL`

## Root cause

The integration harness opens PostgreSQL sessions in UTC, while two rollup-trigger fixtures initialize and assert their watermark using the Shanghai calendar date. During the first eight hours of each Shanghai day, the trigger therefore sees the previous UTC date and the tests fail by one day.

This is a fixture-only correction. Production code, migrations, schema behavior, and TLS/runtime settings are unchanged. The application production connection already sets PostgreSQL `TimeZone` from the configured server timezone.

## Validation

- all `TestGroupUsage` repository integration tests pass, including the two midnight-boundary cases and the DST override case
- related service and repository GroupUsage unit tests pass
- `git diff --check` passes
