### PR TITLE
fix(openai): harden websocket terminal and reconnect flow

### DIFF
--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -45,6 +45,12 @@ const (
 
 	openAIWSIngressStagePreviousResponseNotFound = "previous_response_not_found"
 	openAIWSMaxPrevResponseIDDeletePasses        = 8
+	// A transient proxy path can leave several pooled sockets stale at once and
+	// briefly fail fresh handshakes as well. Keep these retries inside the
+	// server-side retry budget so the client does not need to reconnect once per
+	// stale socket. The initial attempt plus four retries matches the Codex
+	// client's recovery window without allowing an unbounded replay loop.
+	openAIWSIngressTurnRetryMax = 4
 )
 
 var openAIWSLogValueReplacer = strings.NewReplacer(

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -954,7 +954,6 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		)
 		return lease, nil
 	}
-
 	var rejectedFieldRetryState *openAIResponsesRejectedFieldRetryState
 	sendAndRelay := func(turn int, lease *openAIWSConnLease, payload []byte, payloadBytes int, originalModel string, imageBillingModel string, imageSizeTier string, imageInputSize string, requestedReasoningEffort *string) (*OpenAIForwardResult, error) {
 		responseModelObserver := &upstreamResponseModelObserver{}
@@ -1337,6 +1336,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	turn := 1
 	rejectedFieldRetryState = newOpenAIResponsesRejectedFieldRetryState(currentPayload)
 	turnRetry := 0
+	turnRetryStartedAt := time.Time{}
 	turnPrevRecoveryTried := false
 	lastTurnFinishedAt := time.Time{}
 	lastTurnResponseID := ""
@@ -1432,8 +1432,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		skipBeforeTurn = true
 		return true
 	}
-	retryIngressTurn := func(relayErr error, turn int, connID string) bool {
-		if !isOpenAIWSIngressTurnRetryable(relayErr) || turnRetry >= 1 {
+	retryIngressFailure := func(reason string, turn int, connID string) bool {
+		if turnRetry >= openAIWSIngressTurnRetryMax {
+			s.recordOpenAIWSRetryExhausted()
 			return false
 		}
 		if isStrictAffinityTurn(currentPayload) {
@@ -1445,18 +1446,45 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			)
 			return false
 		}
-		turnRetry++
+		if turnRetryStartedAt.IsZero() {
+			turnRetryStartedAt = time.Now()
+		}
+		nextAttempt := turnRetry + 1
+		backoff := s.openAIWSRetryBackoff(nextAttempt)
+		budget := s.openAIWSRetryTotalBudget()
+		if budget > 0 && time.Since(turnRetryStartedAt)+backoff > budget {
+			s.recordOpenAIWSRetryExhausted()
+			return false
+		}
+		if backoff > 0 {
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return false
+			case <-timer.C:
+			}
+		}
+		turnRetry = nextAttempt
+		s.recordOpenAIWSRetryAttempt(backoff)
 		logOpenAIWSModeInfo(
-			"ingress_ws_turn_retry account_id=%d turn=%d retry=%d reason=%s conn_id=%s",
+			"ingress_ws_turn_retry account_id=%d turn=%d retry=%d reason=%s conn_id=%s backoff_ms=%d",
 			account.ID,
 			turn,
 			turnRetry,
-			truncateOpenAIWSLogValue(openAIWSIngressTurnRetryReason(relayErr), openAIWSLogValueMaxLen),
+			truncateOpenAIWSLogValue(reason, openAIWSLogValueMaxLen),
 			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			backoff.Milliseconds(),
 		)
 		resetSessionLease(true)
 		skipBeforeTurn = true
 		return true
+	}
+	retryIngressTurn := func(relayErr error, turn int, connID string) bool {
+		if !isOpenAIWSIngressTurnRetryable(relayErr) {
+			return false
+		}
+		return retryIngressFailure(openAIWSIngressTurnRetryReason(relayErr), turn, connID)
 	}
 	for {
 		if turn > 1 && !skipBeforeTurn && hooks != nil && hooks.BeforeRequest != nil {
@@ -1640,6 +1668,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if sessionLease == nil {
 			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn, turnRetry > 0)
 			if acquireErr != nil {
+				var dialErr *openAIWSDialError
+				if !forcePreferredConn && errors.As(acquireErr, &dialErr) && retryIngressFailure("acquire_upstream", turn, sessionConnID) {
+					continue
+				}
 				return fmt.Errorf("acquire upstream websocket: %w", acquireErr)
 			}
 			sessionLease = acquiredLease
@@ -1811,6 +1843,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			return finalErr
 		}
 		turnRetry = 0
+		turnRetryStartedAt = time.Time{}
 		turnPrevRecoveryTried = false
 		lastTurnFinishedAt = time.Now()
 		lastTurnClean = true

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -3605,7 +3605,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	require.Empty(t, secondWrites, "不能把会触发 No tool call found 的重放请求发到新上游")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeDownstreamRetriesOnce(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeDownstreamRetriesWithinBudget(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -3628,13 +3628,15 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeD
 			[]byte(`{"type":"response.completed","response":{"id":"resp_turn_write_retry_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
 		},
 	}
+	staleConn2 := &openAIWSWriteFailAfterFirstTurnConn{failOnWrite: true}
+	staleConn3 := &openAIWSWriteFailAfterFirstTurnConn{failOnWrite: true}
 	secondConn := &openAIWSCaptureConn{
 		events: [][]byte{
 			[]byte(`{"type":"response.completed","response":{"id":"resp_turn_write_retry_2","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
 		},
 	}
 	dialer := &openAIWSQueueDialer{
-		conns: []openAIWSClientConn{firstConn, secondConn},
+		conns: []openAIWSClientConn{firstConn, staleConn2, staleConn3, secondConn},
 	}
 	pool := newOpenAIWSConnPool(cfg)
 	pool.setClientDialerForTest(dialer)
@@ -3753,7 +3755,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeD
 	case <-time.After(5 * time.Second):
 		t.Fatal("等待 ingress websocket 结束超时")
 	}
-	require.Equal(t, 2, dialer.DialCount(), "第二轮 turn 上游写失败且未写下游时应自动重试并换连")
+	require.Equal(t, 4, dialer.DialCount(), "第二轮 turn 应在预算内连续淘汰多条失效连接")
 	hooksMu.Lock()
 	beforeTurn1 := beforeTurnCalls[1]
 	beforeTurn2 := beforeTurnCalls[2]

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	openaiwsv2 "github.com/Wei-Shaw/sub2api/internal/service/openai_ws_v2"
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 )
 
@@ -336,6 +338,15 @@ func (l *openAIWSPassthroughTurnLifecycle) cancelResponseCreate() {
 	l.mu.Lock()
 	l.inFlight = false
 	l.mu.Unlock()
+}
+
+func (l *openAIWSPassthroughTurnLifecycle) hasInFlightTurn() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inFlight
 }
 
 func (l *openAIWSPassthroughTurnLifecycle) beginTerminalWrite() {
@@ -951,6 +962,13 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	}
 
 	completedTurns := atomic.Int32{}
+	var activeResponseID atomic.Value
+	var capturedSessionModelState atomic.Value
+	capturedSessionModelState.Store(capturedSessionModel)
+	loadCapturedSessionModel := func() string {
+		model, _ := capturedSessionModelState.Load().(string)
+		return model
+	}
 	turnLifecycle := newOpenAIWSPassthroughTurnLifecycle(true)
 	var acceptedTurnStartedAt atomic.Pointer[time.Time]
 	clientFrameConn := &openAIWSClientFrameConn{
@@ -972,10 +990,8 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	}
 	policyClientConn := &openAIWSPolicyEnforcingFrameConn{
 		inner: clientFrameConn,
-		// 注意线程安全：filter 仅在 runClientToUpstream 这一条
-		// goroutine 中被调用（passthrough_relay.go: ReadFrame loop），
-		// capturedSessionModel 的读写都发生在该 goroutine 内，因此无需
-		// 加锁/原子化。
+		// filter and relay callbacks run in different goroutines, so the
+		// session-level model is shared through capturedSessionModelState.
 		filter: func(msgType coderws.MessageType, payload []byte) (out []byte, blocked *OpenAIFastBlockedError, filterErr error) {
 			if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
 				return payload, nil, nil
@@ -1047,7 +1063,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			if isResponseCreate {
 				requestModelForThisFrame = usageMeta.requestModelForFrame(payload)
 				if requestModelForThisFrame == "" {
-					requestModelForThisFrame = capturedSessionModel
+					requestModelForThisFrame = loadCapturedSessionModel()
 				}
 				if hooks != nil && hooks.BeforeRequest != nil {
 					if err := hooks.BeforeRequest(turnNo, payload, requestModelForThisFrame); err != nil {
@@ -1077,7 +1093,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			// 绕过路径。这里只看 session.update 事件中的 session.model
 			// 字段，response.create 自己的 model 仍然由其本帧字段决定。
 			if updated := openAIWSPassthroughPolicyModelFromSessionFrame(account, payload); updated != "" {
-				capturedSessionModel = updated
+				capturedSessionModelState.Store(updated)
 			}
 			usageMeta.updateSessionRequestModel(payload)
 			if requestModelForThisFrame == "" {
@@ -1090,7 +1106,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			// any whitelist and silently fall back to pass.
 			model := openAIWSPassthroughPolicyModelForFrame(account, payload)
 			if model == "" {
-				model = capturedSessionModel
+				model = loadCapturedSessionModel()
 			}
 			if isResponseCreate && model != "" && model != strings.TrimSpace(gjson.GetBytes(payload, "model").String()) {
 				payload = s.ReplaceModelInBody(payload, model)
@@ -1246,6 +1262,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				}
 			},
 			BeforeClientWrite: func(msgType coderws.MessageType, payload []byte) {
+				if msgType == coderws.MessageText {
+					if responseID := openAIWSPassthroughResponseID(payload); responseID != "" {
+						activeResponseID.Store(responseID)
+					}
+				}
 				if msgType == coderws.MessageText && openAIWSPassthroughIsTerminalOutput(payload) {
 					turnLifecycle.beginTerminalWrite()
 				}
@@ -1257,6 +1278,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				}
 				if msgType == coderws.MessageText && openAIWSPassthroughIsTerminalOutput(payload) {
 					turnLifecycle.finishTerminalWrite(writeErr == nil, clientFrameConn.markTurnCompleted)
+					activeResponseID.Store("")
 				}
 			},
 			BeforeRelayCancel: func(exit openaiwsv2.RelayExit) {
@@ -1271,6 +1293,19 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				// frame limit; an oversized reason makes coder/websocket skip the
 				// close frame, leaving the client with EOF instead of the status code.
 				reason = truncateString(reason, 120)
+				// A raw upstream close while a turn is in flight used to make the
+				// client observe a close frame without a Responses terminal event.
+				// Codex treats that as a transport failure and repeatedly reconnects.
+				// Complete the protocol first, then retain the close frame as a
+				// transport-level signal for clients that need to open a new session.
+				if openAIWSPassthroughShouldEmitFailureEvent(exit) && turnLifecycle.hasInFlightTurn() {
+					responseID, _ := activeResponseID.Load().(string)
+					if eventBytes := buildOpenAIWSPassthroughFailureEvent(responseID, loadCapturedSessionModel()); eventBytes != nil {
+						writeCtx, cancelWrite := context.WithTimeout(ctx, s.openAIWSWriteTimeout())
+						_ = clientConn.Write(writeCtx, coderws.MessageText, eventBytes)
+						cancelWrite()
+					}
+				}
 				_ = clientConn.Close(status, reason)
 				_ = clientConn.CloseNow()
 			},
@@ -1283,6 +1318,15 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 					failureAccountSideEffectsApplied = false
 				}
 				if (eventType == "error" || eventType == "response.failed") && markOpenAIWSV2PassthroughCyberPolicy(c, payload) {
+					return nil
+				}
+				if isOpenAIWSTerminalEvent(eventType) {
+					s.handleOpenAIWSTerminalTransientFailure(ctx, account, loadCapturedSessionModel(), handshakeHeaders, payload)
+				}
+				if eventType == "error" {
+					s.handleOpenAIWSErrorEventTransientFailure(ctx, account, loadCapturedSessionModel(), handshakeHeaders, payload)
+				}
+				if wroteDownstream || eventType != "error" {
 					return nil
 				}
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(payload)
@@ -1492,6 +1536,49 @@ func markOpenAIWSV2PassthroughCyberPolicy(c *gin.Context, payload []byte) bool {
 	usage := OpenAIUsage{}
 	parseOpenAIWSResponseUsageFromCompletedEvent(payload, &usage)
 	return markOpenAICyberPolicyEvent(c, payload, http.StatusOK, &usage)
+}
+
+func openAIWSPassthroughShouldEmitFailureEvent(exit openaiwsv2.RelayExit) bool {
+	if exit.Graceful || exit.Stage != "read_upstream" {
+		return false
+	}
+	var closeErr *OpenAIWSClientCloseError
+	return !errors.As(exit.Err, &closeErr)
+}
+
+func openAIWSPassthroughResponseID(payload []byte) string {
+	if responseID := strings.TrimSpace(gjson.GetBytes(payload, "response.id").String()); responseID != "" {
+		return responseID
+	}
+	return strings.TrimSpace(gjson.GetBytes(payload, "response_id").String())
+}
+
+func buildOpenAIWSPassthroughFailureEvent(responseID, model string) []byte {
+	responseID = strings.TrimSpace(responseID)
+	if responseID == "" {
+		responseID = "resp_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	}
+	response := map[string]any{
+		"id":     responseID,
+		"object": "response",
+		"status": "failed",
+		"output": []any{},
+		"error": map[string]string{
+			"code":    "upstream_error",
+			"message": "upstream websocket disconnected before response.completed",
+		},
+	}
+	if model = strings.TrimSpace(model); model != "" {
+		response["model"] = model
+	}
+	payload, err := json.Marshal(map[string]any{
+		"type":     "response.failed",
+		"response": response,
+	})
+	if err != nil {
+		return nil
+	}
+	return payload
 }
 
 func (s *OpenAIGatewayService) mapOpenAIWSPassthroughDialError(

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -638,6 +638,10 @@ func TestPassthroughLifecycle_ActiveTurnInactivityUsesReadTimeout(t *testing.T) 
 	delta, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, "response.output_text.delta", gjson.GetBytes(delta, "type").String())
+	failed, err := readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(failed, "type").String())
+	require.Equal(t, "upstream_error", gjson.GetBytes(failed, "response.error.code").String())
 	_, err = readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
 	var websocketCloseErr coderws.CloseError
 	require.ErrorAs(t, err, &websocketCloseErr)
@@ -845,6 +849,10 @@ func TestPassthroughLifecycle_ResponseCreatedTimeoutClosesWithoutFailover(t *tes
 	created, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, "response.created", gjson.GetBytes(created, "type").String())
+	failed, err := readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(failed, "type").String())
+	require.Equal(t, "upstream_error", gjson.GetBytes(failed, "response.error.code").String())
 	_, err = readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
 	var websocketCloseErr coderws.CloseError
 	require.ErrorAs(t, err, &websocketCloseErr)
@@ -860,6 +868,45 @@ func TestPassthroughLifecycle_ResponseCreatedTimeoutClosesWithoutFailover(t *tes
 		require.Equal(t, "upstream produced no semantic output; please reconnect", closeErr.Reason())
 	case <-time.After(2500 * time.Millisecond):
 		t.Fatal("response.created timeout did not close the passthrough connection")
+	}
+}
+
+func TestPassthroughLifecycle_UpstreamCloseBeforeTerminalEmitsResponseFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream), passthroughLifecycleAccount())
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	require.Equal(t, "response.create", gjson.GetBytes(requirePassthroughUpstreamWrite(t, upstream, 3*time.Second), "type").String())
+	upstream.Send(`{"type":"response.created","response":{"id":"resp_interrupted","model":"gpt-5.1"}}`)
+	created, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.created", gjson.GetBytes(created, "type").String())
+
+	require.NoError(t, upstream.Close())
+	failed, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(failed, "type").String())
+	require.Equal(t, "failed", gjson.GetBytes(failed, "response.status").String())
+	require.Equal(t, "upstream_error", gjson.GetBytes(failed, "response.error.code").String())
+	require.Equal(t, "gpt-5.1", gjson.GetBytes(failed, "response.model").String())
+	require.Equal(t, "resp_interrupted", gjson.GetBytes(failed, "response.id").String())
+
+	_, err = readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	var websocketCloseErr coderws.CloseError
+	require.ErrorAs(t, err, &websocketCloseErr)
+	require.Equal(t, coderws.StatusInternalError, websocketCloseErr.Code)
+	require.Equal(t, "upstream websocket proxy failed", websocketCloseErr.Reason)
+
+	select {
+	case err := <-serverErr:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("upstream close did not terminate the passthrough connection")
 	}
 }
 
@@ -886,6 +933,10 @@ func TestPassthroughLifecycle_SecondTurnTimeoutIsNotFailoverSafe(t *testing.T) {
 	created, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, "response.created", gjson.GetBytes(created, "type").String())
+	failed, err := readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(failed, "type").String())
+	require.Equal(t, "upstream_error", gjson.GetBytes(failed, "response.error.code").String())
 	_, err = readPassthroughLifecycleFrame(t, clientConn, 2500*time.Millisecond)
 	var websocketCloseErr coderws.CloseError
 	require.ErrorAs(t, err, &websocketCloseErr)


### PR DESCRIPTION
## Summary

- emit terminal response events before closing the upstream WebSocket
- keep reconnect error and close handling from racing with terminal state
- cover ingress and passthrough lifecycle behavior with regression tests

## Validation

- `cd backend && go build ./... && go test ./...`
- focused OpenAI WebSocket service tests
