### PR TITLE
fix(ops): align health score with configured thresholds

### DIFF
--- a/backend/internal/service/ops_dashboard.go
+++ b/backend/internal/service/ops_dashboard.go
@@ -65,7 +65,13 @@ func (s *OpsService) GetDashboardOverview(ctx context.Context, filter *OpsDashbo
 		log.Printf("[Ops] ListJobHeartbeats failed: %v", err)
 	}
 
-	overview.HealthScore = computeDashboardHealthScore(time.Now().UTC(), overview)
+	thresholds := defaultOpsMetricThresholds()
+	if loaded, err := s.GetMetricThresholds(ctx); err == nil && loaded != nil {
+		thresholds = loaded
+	} else if err != nil {
+		log.Printf("[Ops] GetMetricThresholds failed: %v", err)
+	}
+	overview.HealthScore = computeDashboardHealthScoreWithThresholds(time.Now().UTC(), overview, thresholds)
 
 	return overview, nil
 }

--- a/backend/internal/service/ops_health_score.go
+++ b/backend/internal/service/ops_health_score.go
@@ -17,6 +17,9 @@ func computeDashboardHealthScoreWithThresholds(now time.Time, overview *OpsDashb
 	if overview == nil {
 		return 0
 	}
+	if thresholds == nil {
+		thresholds = defaultOpsMetricThresholds()
+	}
 
 	// Idle/no-data: avoid showing a "bad" score when there is no traffic.
 	// UI can still render a gray/idle state based on QPS + error rate.
@@ -34,22 +37,29 @@ func computeDashboardHealthScoreWithThresholds(now time.Time, overview *OpsDashb
 
 // computeBusinessHealth calculates business health score (0-100)
 // Components: Error Rate (50%) + TTFT (50%)
-func computeBusinessHealth(overview *OpsDashboardOverview, thresholdArgs ...*OpsMetricThresholds) float64 {
-	var thresholds *OpsMetricThresholds
-	if len(thresholdArgs) > 0 {
-		thresholds = thresholdArgs[0]
-	}
+func computeBusinessHealth(overview *OpsDashboardOverview, thresholds *OpsMetricThresholds) float64 {
 	if thresholds == nil {
 		thresholds = defaultOpsMetricThresholds()
 	}
+	defaults := defaultOpsMetricThresholds()
 
 	// Error rate score scales with configured alert thresholds.
 	// With defaults (5%), this preserves the previous 1% → 100, 10% → 0 curve.
 	errorPct := clampFloat64(overview.ErrorRate*100, 0, 100)
 	upstreamPct := clampFloat64(overview.UpstreamErrorRate*100, 0, 100)
+	requestErrorThreshold := clampFloat64(
+		thresholdOrDefault(thresholds.RequestErrorRatePercentMax, defaults.RequestErrorRatePercentMax),
+		0,
+		100,
+	)
+	upstreamErrorThreshold := clampFloat64(
+		thresholdOrDefault(thresholds.UpstreamErrorRatePercentMax, defaults.UpstreamErrorRatePercentMax),
+		0,
+		100,
+	)
 	errorScore := math.Min(
-		scoreHighIsBad(errorPct, percentThresholdOrDefault(thresholds.RequestErrorRatePercentMax, 5.0)*0.2, percentThresholdOrDefault(thresholds.RequestErrorRatePercentMax, 5.0)*2),
-		scoreHighIsBad(upstreamPct, percentThresholdOrDefault(thresholds.UpstreamErrorRatePercentMax, 5.0)*0.2, percentThresholdOrDefault(thresholds.UpstreamErrorRatePercentMax, 5.0)*2),
+		scoreHighIsBad(errorPct, requestErrorThreshold*0.2, requestErrorThreshold*2),
+		scoreHighIsBad(upstreamPct, upstreamErrorThreshold*0.2, upstreamErrorThreshold*2),
 	)
 
 	// TTFT score scales with configured max threshold.
@@ -57,7 +67,7 @@ func computeBusinessHealth(overview *OpsDashboardOverview, thresholdArgs ...*Ops
 	ttftScore := 100.0
 	if overview.TTFT.P99 != nil {
 		p99 := float64(*overview.TTFT.P99)
-		ttftThreshold := positiveThresholdOrDefault(thresholds.TTFTp99MsMax, 500.0)
+		ttftThreshold := math.Max(0, thresholdOrDefault(thresholds.TTFTp99MsMax, defaults.TTFTp99MsMax))
 		ttftScore = scoreHighIsBad(p99, ttftThreshold*2, ttftThreshold*6)
 	}
 
@@ -67,6 +77,9 @@ func computeBusinessHealth(overview *OpsDashboardOverview, thresholdArgs ...*Ops
 
 func scoreHighIsBad(v float64, goodAtOrBelow float64, zeroAtOrAbove float64) float64 {
 	if zeroAtOrAbove <= goodAtOrBelow {
+		if v >= zeroAtOrAbove {
+			return 0
+		}
 		return 100
 	}
 	if v <= goodAtOrBelow {
@@ -78,16 +91,14 @@ func scoreHighIsBad(v float64, goodAtOrBelow float64, zeroAtOrAbove float64) flo
 	return (zeroAtOrAbove - v) / (zeroAtOrAbove - goodAtOrBelow) * 100
 }
 
-func percentThresholdOrDefault(ptr *float64, fallback float64) float64 {
-	v := positiveThresholdOrDefault(ptr, fallback)
-	return clampFloat64(v, 0.0001, 100)
-}
-
-func positiveThresholdOrDefault(ptr *float64, fallback float64) float64 {
-	if ptr == nil || *ptr <= 0 {
-		return fallback
+func thresholdOrDefault(value *float64, fallback *float64) float64 {
+	if value != nil {
+		return *value
 	}
-	return *ptr
+	if fallback != nil {
+		return *fallback
+	}
+	return 0
 }
 
 // computeInfraHealth calculates infrastructure health score (0-100)

--- a/backend/internal/service/ops_health_score.go
+++ b/backend/internal/service/ops_health_score.go
@@ -36,7 +36,7 @@ func computeDashboardHealthScoreWithThresholds(now time.Time, overview *OpsDashb
 }
 
 // computeBusinessHealth calculates business health score (0-100)
-// Components: Error Rate (50%) + TTFT (50%)
+// Components: Error Rate (40%) + TTFT (40%) + SLA (20%)
 func computeBusinessHealth(overview *OpsDashboardOverview, thresholds *OpsMetricThresholds) float64 {
 	if thresholds == nil {
 		thresholds = defaultOpsMetricThresholds()
@@ -71,8 +71,27 @@ func computeBusinessHealth(overview *OpsDashboardOverview, thresholds *OpsMetric
 		ttftScore = scoreHighIsBad(p99, ttftThreshold*2, ttftThreshold*6)
 	}
 
-	// Weighted combination: 50% error rate + 50% TTFT
-	return errorScore*0.5 + ttftScore*0.5
+	slaScore := 100.0
+	hasSLASample := overview.RequestCountSLA > 0
+	if hasSLASample {
+		slaPercent := clampFloat64(overview.SLA*100, 0, 100)
+		slaThreshold := clampFloat64(
+			thresholdOrDefault(thresholds.SLAPercentMin, defaults.SLAPercentMin),
+			0,
+			100,
+		)
+		// Keep the configured boundary authoritative, while allowing the score
+		// to decay over a small deficit rather than dropping discontinuously.
+		slaZeroDeficit := math.Max(0.1, slaThreshold*0.02)
+		slaScore = scoreHighIsBad(slaThreshold-slaPercent, 0, slaZeroDeficit)
+	}
+
+	if !hasSLASample {
+		// Preserve the historical error/TTFT split when this window has no SLA
+		// sample; otherwise the mere absence of SLA data would rescale both.
+		return errorScore*0.5 + ttftScore*0.5
+	}
+	return errorScore*0.4 + ttftScore*0.4 + slaScore*0.2
 }
 
 func scoreHighIsBad(v float64, goodAtOrBelow float64, zeroAtOrAbove float64) float64 {

--- a/backend/internal/service/ops_health_score.go
+++ b/backend/internal/service/ops_health_score.go
@@ -13,6 +13,10 @@ import (
 // - Avoids double-counting (e.g., DB failure affects both infra and business metrics)
 // - Conservative + stable: penalize clear degradations; avoid overreacting to missing/idle data.
 func computeDashboardHealthScore(now time.Time, overview *OpsDashboardOverview) int {
+	return computeDashboardHealthScoreWithThresholds(now, overview, defaultOpsMetricThresholds())
+}
+
+func computeDashboardHealthScoreWithThresholds(now time.Time, overview *OpsDashboardOverview, thresholds *OpsMetricThresholds) int {
 	if overview == nil {
 		return 0
 	}
@@ -23,7 +27,7 @@ func computeDashboardHealthScore(now time.Time, overview *OpsDashboardOverview) 
 		return 100
 	}
 
-	businessHealth := computeBusinessHealth(overview)
+	businessHealth := computeBusinessHealth(overview, thresholds)
 	infraHealth := computeInfraHealth(now, overview)
 
 	// Weighted combination: 70% business + 30% infrastructure
@@ -33,37 +37,60 @@ func computeDashboardHealthScore(now time.Time, overview *OpsDashboardOverview) 
 
 // computeBusinessHealth calculates business health score (0-100)
 // Components: Error Rate (50%) + TTFT (50%)
-func computeBusinessHealth(overview *OpsDashboardOverview) float64 {
-	// Error rate score: 1% → 100, 10% → 0 (linear)
-	// Combines request errors and upstream errors
-	errorScore := 100.0
-	errorPct := clampFloat64(overview.ErrorRate*100, 0, 100)
-	upstreamPct := clampFloat64(overview.UpstreamErrorRate*100, 0, 100)
-	combinedErrorPct := math.Max(errorPct, upstreamPct) // Use worst case
-	if combinedErrorPct > 1.0 {
-		if combinedErrorPct <= 10.0 {
-			errorScore = (10.0 - combinedErrorPct) / 9.0 * 100
-		} else {
-			errorScore = 0
-		}
+func computeBusinessHealth(overview *OpsDashboardOverview, thresholdArgs ...*OpsMetricThresholds) float64 {
+	var thresholds *OpsMetricThresholds
+	if len(thresholdArgs) > 0 {
+		thresholds = thresholdArgs[0]
+	}
+	if thresholds == nil {
+		thresholds = defaultOpsMetricThresholds()
 	}
 
-	// TTFT score: 1s → 100, 3s → 0 (linear)
-	// Time to first token is critical for user experience
+	// Error rate score scales with configured alert thresholds.
+	// With defaults (5%), this preserves the previous 1% → 100, 10% → 0 curve.
+	errorPct := clampFloat64(overview.ErrorRate*100, 0, 100)
+	upstreamPct := clampFloat64(overview.UpstreamErrorRate*100, 0, 100)
+	errorScore := math.Min(
+		scoreHighIsBad(errorPct, percentThresholdOrDefault(thresholds.RequestErrorRatePercentMax, 5.0)*0.2, percentThresholdOrDefault(thresholds.RequestErrorRatePercentMax, 5.0)*2),
+		scoreHighIsBad(upstreamPct, percentThresholdOrDefault(thresholds.UpstreamErrorRatePercentMax, 5.0)*0.2, percentThresholdOrDefault(thresholds.UpstreamErrorRatePercentMax, 5.0)*2),
+	)
+
+	// TTFT score scales with configured max threshold.
+	// With default (500ms), this preserves the previous 1s → 100, 3s → 0 curve.
 	ttftScore := 100.0
 	if overview.TTFT.P99 != nil {
 		p99 := float64(*overview.TTFT.P99)
-		if p99 > 1000 {
-			if p99 <= 3000 {
-				ttftScore = (3000 - p99) / 2000 * 100
-			} else {
-				ttftScore = 0
-			}
-		}
+		ttftThreshold := positiveThresholdOrDefault(thresholds.TTFTp99MsMax, 500.0)
+		ttftScore = scoreHighIsBad(p99, ttftThreshold*2, ttftThreshold*6)
 	}
 
 	// Weighted combination: 50% error rate + 50% TTFT
 	return errorScore*0.5 + ttftScore*0.5
+}
+
+func scoreHighIsBad(v float64, goodAtOrBelow float64, zeroAtOrAbove float64) float64 {
+	if zeroAtOrAbove <= goodAtOrBelow {
+		return 100
+	}
+	if v <= goodAtOrBelow {
+		return 100
+	}
+	if v >= zeroAtOrAbove {
+		return 0
+	}
+	return (zeroAtOrAbove - v) / (zeroAtOrAbove - goodAtOrBelow) * 100
+}
+
+func percentThresholdOrDefault(ptr *float64, fallback float64) float64 {
+	v := positiveThresholdOrDefault(ptr, fallback)
+	return clampFloat64(v, 0.0001, 100)
+}
+
+func positiveThresholdOrDefault(ptr *float64, fallback float64) float64 {
+	if ptr == nil || *ptr <= 0 {
+		return fallback
+	}
+	return *ptr
 }
 
 // computeInfraHealth calculates infrastructure health score (0-100)

--- a/backend/internal/service/ops_health_score.go
+++ b/backend/internal/service/ops_health_score.go
@@ -5,17 +5,14 @@ import (
 	"time"
 )
 
-// computeDashboardHealthScore computes a 0-100 health score from the metrics returned by the dashboard overview.
+// computeDashboardHealthScoreWithThresholds computes a 0-100 health score from
+// the metrics returned by the dashboard overview.
 //
 // Design goals:
 // - Backend-owned scoring (UI only displays).
 // - Layered scoring: Business Health (70%) + Infrastructure Health (30%)
 // - Avoids double-counting (e.g., DB failure affects both infra and business metrics)
 // - Conservative + stable: penalize clear degradations; avoid overreacting to missing/idle data.
-func computeDashboardHealthScore(now time.Time, overview *OpsDashboardOverview) int {
-	return computeDashboardHealthScoreWithThresholds(now, overview, defaultOpsMetricThresholds())
-}
-
 func computeDashboardHealthScoreWithThresholds(now time.Time, overview *OpsDashboardOverview, thresholds *OpsMetricThresholds) int {
 	if overview == nil {
 		return 0

--- a/backend/internal/service/ops_health_score_test.go
+++ b/backend/internal/service/ops_health_score_test.go
@@ -74,6 +74,7 @@ func TestComputeDashboardHealthScore_UsesConfiguredThresholds(t *testing.T) {
 		ErrorCountTotal:   3,
 		ErrorCountSLA:     3,
 		UpstreamErrorRate: 0.0254,
+		SLA:               0.995,
 		TTFT:              OpsPercentiles{P99: &ttftP99},
 		SystemMetrics: &OpsSystemMetricsSnapshot{
 			DBOK:               boolPtr(true),
@@ -88,10 +89,12 @@ func TestComputeDashboardHealthScore_UsesConfiguredThresholds(t *testing.T) {
 	reqErr := 20.0
 	upstreamErr := 20.0
 	ttftMax := 25_000.0
+	slaMin := 90.0
 	tunedScore := computeDashboardHealthScoreWithThresholds(time.Now().UTC(), ov, &OpsMetricThresholds{
 		RequestErrorRatePercentMax:  &reqErr,
 		UpstreamErrorRatePercentMax: &upstreamErr,
 		TTFTp99MsMax:                &ttftMax,
+		SLAPercentMin:               &slaMin,
 	})
 
 	require.Greater(t, tunedScore, defaultScore)
@@ -194,8 +197,8 @@ func TestComputeDashboardHealthScore_Comprehensive(t *testing.T) {
 					MemoryUsagePercent: float64Ptr(75),
 				},
 			},
-			wantMin: 96,
-			wantMax: 97,
+			wantMin: 80,
+			wantMax: 85,
 		},
 		{
 			name: "DB failure",
@@ -270,8 +273,8 @@ func TestComputeDashboardHealthScore_Comprehensive(t *testing.T) {
 					MemoryUsagePercent: float64Ptr(30),
 				},
 			},
-			wantMin: 84,
-			wantMax: 85,
+			wantMin: 70,
+			wantMax: 75,
 		},
 		{
 			name: "combined failures - business healthy + infra degraded",
@@ -406,6 +409,46 @@ func TestComputeBusinessHealth(t *testing.T) {
 			require.LessOrEqual(t, score, 100.0, "score must be <= 100")
 		})
 	}
+}
+
+func TestComputeBusinessHealthUsesConfiguredSLAThreshold(t *testing.T) {
+	t.Parallel()
+
+	healthyOverview := &OpsDashboardOverview{
+		RequestCountSLA:   100,
+		SLA:               0.995,
+		ErrorRate:         0,
+		UpstreamErrorRate: 0,
+	}
+	require.InDelta(t, 100.0, computeBusinessHealth(healthyOverview, defaultOpsMetricThresholds()), 1e-9)
+
+	belowOverview := &OpsDashboardOverview{
+		RequestCountSLA:   100,
+		SLA:               0.9949,
+		ErrorRate:         0,
+		UpstreamErrorRate: 0,
+	}
+	require.Less(t, computeBusinessHealth(belowOverview, defaultOpsMetricThresholds()), 100.0)
+
+	customThreshold := 90.0
+	custom := &OpsMetricThresholds{
+		SLAPercentMin: &customThreshold,
+	}
+	atCustomOverview := &OpsDashboardOverview{
+		RequestCountSLA:   100,
+		SLA:               0.90,
+		ErrorRate:         0,
+		UpstreamErrorRate: 0,
+	}
+	require.InDelta(t, 100.0, computeBusinessHealth(atCustomOverview, custom), 1e-9)
+
+	belowCustomOverview := &OpsDashboardOverview{
+		RequestCountSLA:   100,
+		SLA:               0.899,
+		ErrorRate:         0,
+		UpstreamErrorRate: 0,
+	}
+	require.Less(t, computeBusinessHealth(belowCustomOverview, custom), 100.0)
 }
 
 func TestComputeInfraHealth(t *testing.T) {

--- a/backend/internal/service/ops_health_score_test.go
+++ b/backend/internal/service/ops_health_score_test.go
@@ -98,6 +98,30 @@ func TestComputeDashboardHealthScore_UsesConfiguredThresholds(t *testing.T) {
 	require.GreaterOrEqual(t, tunedScore, 90)
 }
 
+func TestComputeDashboardHealthScore_ZeroThresholdsRemainEffective(t *testing.T) {
+	t.Parallel()
+
+	zero := 0.0
+	overview := &OpsDashboardOverview{
+		RequestCountTotal: 1,
+		RequestCountSLA:   1,
+		TTFT:              OpsPercentiles{P99: intPtr(1)},
+		SystemMetrics: &OpsSystemMetricsSnapshot{
+			DBOK:               boolPtr(true),
+			RedisOK:            boolPtr(true),
+			CPUUsagePercent:    float64Ptr(1),
+			MemoryUsagePercent: float64Ptr(1),
+		},
+	}
+
+	score := computeDashboardHealthScoreWithThresholds(time.Now().UTC(), overview, &OpsMetricThresholds{
+		TTFTp99MsMax:                &zero,
+		RequestErrorRatePercentMax:  &zero,
+		UpstreamErrorRatePercentMax: &zero,
+	})
+	require.Less(t, score, 100)
+}
+
 func TestComputeDashboardHealthScore_Comprehensive(t *testing.T) {
 	t.Parallel()
 
@@ -375,7 +399,7 @@ func TestComputeBusinessHealth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			score := computeBusinessHealth(tt.overview)
+			score := computeBusinessHealth(tt.overview, defaultOpsMetricThresholds())
 			require.GreaterOrEqual(t, score, tt.wantMin, "score should be >= %.1f", tt.wantMin)
 			require.LessOrEqual(t, score, tt.wantMax, "score should be <= %.1f", tt.wantMax)
 			require.GreaterOrEqual(t, score, 0.0, "score must be >= 0")

--- a/backend/internal/service/ops_health_score_test.go
+++ b/backend/internal/service/ops_health_score_test.go
@@ -12,7 +12,11 @@ import (
 func TestComputeDashboardHealthScore_IdleReturns100(t *testing.T) {
 	t.Parallel()
 
-	score := computeDashboardHealthScore(time.Now().UTC(), &OpsDashboardOverview{})
+	score := computeDashboardHealthScoreWithThresholds(
+		time.Now().UTC(),
+		&OpsDashboardOverview{},
+		defaultOpsMetricThresholds(),
+	)
 	require.Equal(t, 100, score)
 }
 
@@ -50,7 +54,11 @@ func TestComputeDashboardHealthScore_DegradesOnBadSignals(t *testing.T) {
 		},
 	}
 
-	score := computeDashboardHealthScore(time.Now().UTC(), ov)
+	score := computeDashboardHealthScoreWithThresholds(
+		time.Now().UTC(),
+		ov,
+		defaultOpsMetricThresholds(),
+	)
 	require.Less(t, score, 80)
 	require.GreaterOrEqual(t, score, 0)
 }
@@ -264,7 +272,11 @@ func TestComputeDashboardHealthScore_Comprehensive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			score := computeDashboardHealthScore(time.Now().UTC(), tt.overview)
+			score := computeDashboardHealthScoreWithThresholds(
+				time.Now().UTC(),
+				tt.overview,
+				defaultOpsMetricThresholds(),
+			)
 			require.GreaterOrEqual(t, score, tt.wantMin, "score should be >= %d", tt.wantMin)
 			require.LessOrEqual(t, score, tt.wantMax, "score should be <= %d", tt.wantMax)
 			require.GreaterOrEqual(t, score, 0, "score must be >= 0")

--- a/backend/internal/service/ops_health_score_test.go
+++ b/backend/internal/service/ops_health_score_test.go
@@ -55,6 +55,41 @@ func TestComputeDashboardHealthScore_DegradesOnBadSignals(t *testing.T) {
 	require.GreaterOrEqual(t, score, 0)
 }
 
+func TestComputeDashboardHealthScore_UsesConfiguredThresholds(t *testing.T) {
+	t.Parallel()
+
+	ttftP99 := 24_060
+	ov := &OpsDashboardOverview{
+		RequestCountTotal: 118,
+		RequestCountSLA:   118,
+		SuccessCount:      115,
+		ErrorCountTotal:   3,
+		ErrorCountSLA:     3,
+		UpstreamErrorRate: 0.0254,
+		TTFT:              OpsPercentiles{P99: &ttftP99},
+		SystemMetrics: &OpsSystemMetricsSnapshot{
+			DBOK:               boolPtr(true),
+			RedisOK:            boolPtr(true),
+			CPUUsagePercent:    float64Ptr(1),
+			MemoryUsagePercent: float64Ptr(5),
+		},
+	}
+
+	defaultScore := computeDashboardHealthScoreWithThresholds(time.Now().UTC(), ov, defaultOpsMetricThresholds())
+
+	reqErr := 20.0
+	upstreamErr := 20.0
+	ttftMax := 25_000.0
+	tunedScore := computeDashboardHealthScoreWithThresholds(time.Now().UTC(), ov, &OpsMetricThresholds{
+		RequestErrorRatePercentMax:  &reqErr,
+		UpstreamErrorRatePercentMax: &upstreamErr,
+		TTFTp99MsMax:                &ttftMax,
+	})
+
+	require.Greater(t, tunedScore, defaultScore)
+	require.GreaterOrEqual(t, tunedScore, 90)
+}
+
 func TestComputeDashboardHealthScore_Comprehensive(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -546,7 +546,8 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
   }
 
   const ttftP99 = ov.ttft?.p99_ms ?? 0
-  if (ttftP99 > 500) {
+  const ttftThreshold = props.thresholds?.ttft_p99_ms_max ?? 500
+  if (ttftThreshold > 0 && ttftP99 >= ttftThreshold) {
     report.push({
       type: 'warning',
       message: t('admin.ops.diagnosis.ttftHigh', { ttft: ttftP99.toFixed(0) }),
@@ -555,16 +556,18 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
     })
   }
 
-  // Error rate diagnostics (adjusted thresholds)
+  // Error rate diagnostics use the same configurable thresholds as the metric cards.
   const upstreamRatePct = (ov.upstream_error_rate ?? 0) * 100
-  if (upstreamRatePct > 5) {
+  const upstreamRateThreshold = props.thresholds?.upstream_error_rate_percent_max ?? 5
+  const upstreamRateWarningThreshold = upstreamRateThreshold * 0.4
+  if (upstreamRateThreshold > 0 && upstreamRatePct >= upstreamRateThreshold) {
     report.push({
       type: 'critical',
       message: t('admin.ops.diagnosis.upstreamCritical', { rate: upstreamRatePct.toFixed(2) }),
       impact: t('admin.ops.diagnosis.upstreamCriticalImpact'),
       action: t('admin.ops.diagnosis.upstreamCriticalAction')
     })
-  } else if (upstreamRatePct > 2) {
+  } else if (upstreamRateWarningThreshold > 0 && upstreamRatePct >= upstreamRateWarningThreshold) {
     report.push({
       type: 'warning',
       message: t('admin.ops.diagnosis.upstreamHigh', { rate: upstreamRatePct.toFixed(2) }),
@@ -574,14 +577,17 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
   }
 
   const errorPct = (ov.error_rate ?? 0) * 100
-  if (errorPct > 3) {
+  const errorRateThreshold = props.thresholds?.request_error_rate_percent_max ?? 5
+  const errorRateCriticalThreshold = errorRateThreshold * 0.6
+  const errorRateWarningThreshold = errorRateThreshold * 0.1
+  if (errorRateCriticalThreshold > 0 && errorPct >= errorRateCriticalThreshold) {
     report.push({
       type: 'critical',
       message: t('admin.ops.diagnosis.errorHigh', { rate: errorPct.toFixed(2) }),
       impact: t('admin.ops.diagnosis.errorHighImpact'),
       action: t('admin.ops.diagnosis.errorHighAction')
     })
-  } else if (errorPct > 0.5) {
+  } else if (errorRateWarningThreshold > 0 && errorPct >= errorRateWarningThreshold) {
     report.push({
       type: 'warning',
       message: t('admin.ops.diagnosis.errorElevated', { rate: errorPct.toFixed(2) }),

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -546,10 +546,10 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
   }
 
   const ttftP99 = ov.ttft?.p99_ms ?? 0
-  const ttftThreshold = props.thresholds?.ttft_p99_ms_max ?? 500
-  if (ttftThreshold > 0 && ttftP99 >= ttftThreshold) {
+  const ttftLevel = getTTFTThresholdLevel(ttftP99)
+  if (ttftLevel !== 'normal') {
     report.push({
-      type: 'warning',
+      type: ttftLevel,
       message: t('admin.ops.diagnosis.ttftHigh', { ttft: ttftP99.toFixed(0) }),
       impact: t('admin.ops.diagnosis.ttftHighImpact'),
       action: t('admin.ops.diagnosis.ttftHighAction')
@@ -558,16 +558,15 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
 
   // Error rate diagnostics use the same configurable thresholds as the metric cards.
   const upstreamRatePct = (ov.upstream_error_rate ?? 0) * 100
-  const upstreamRateThreshold = props.thresholds?.upstream_error_rate_percent_max ?? 5
-  const upstreamRateWarningThreshold = upstreamRateThreshold * 0.4
-  if (upstreamRateThreshold > 0 && upstreamRatePct >= upstreamRateThreshold) {
+  const upstreamRateLevel = getUpstreamErrorRateThresholdLevel(upstreamRatePct)
+  if (upstreamRateLevel === 'critical') {
     report.push({
       type: 'critical',
       message: t('admin.ops.diagnosis.upstreamCritical', { rate: upstreamRatePct.toFixed(2) }),
       impact: t('admin.ops.diagnosis.upstreamCriticalImpact'),
       action: t('admin.ops.diagnosis.upstreamCriticalAction')
     })
-  } else if (upstreamRateWarningThreshold > 0 && upstreamRatePct >= upstreamRateWarningThreshold) {
+  } else if (upstreamRateLevel === 'warning') {
     report.push({
       type: 'warning',
       message: t('admin.ops.diagnosis.upstreamHigh', { rate: upstreamRatePct.toFixed(2) }),
@@ -577,17 +576,15 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
   }
 
   const errorPct = (ov.error_rate ?? 0) * 100
-  const errorRateThreshold = props.thresholds?.request_error_rate_percent_max ?? 5
-  const errorRateCriticalThreshold = errorRateThreshold * 0.6
-  const errorRateWarningThreshold = errorRateThreshold * 0.1
-  if (errorRateCriticalThreshold > 0 && errorPct >= errorRateCriticalThreshold) {
+  const errorRateLevel = getRequestErrorRateThresholdLevel(errorPct)
+  if (errorRateLevel === 'critical') {
     report.push({
       type: 'critical',
       message: t('admin.ops.diagnosis.errorHigh', { rate: errorPct.toFixed(2) }),
       impact: t('admin.ops.diagnosis.errorHighImpact'),
       action: t('admin.ops.diagnosis.errorHighAction')
     })
-  } else if (errorRateWarningThreshold > 0 && errorPct >= errorRateWarningThreshold) {
+  } else if (errorRateLevel === 'warning') {
     report.push({
       type: 'warning',
       message: t('admin.ops.diagnosis.errorElevated', { rate: errorPct.toFixed(2) }),

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -11,6 +11,7 @@ import type { OpsRequestDetailsPreset } from './OpsRequestDetailsModal.vue'
 import { useAdminSettingsStore } from '@/stores'
 import { formatNumber } from '@/utils/format'
 import { formatMemorySizeMB } from '../utils/opsFormatters'
+import { getSLAProgressPercent, getSLAThresholdLevel } from '../utils/slaThresholds'
 
 type RealtimeWindow = '1min' | '5min' | '30min' | '1h'
 
@@ -221,21 +222,6 @@ function openErrorDetails(kind: 'request' | 'upstream') {
 // --- Threshold checking helpers ---
 type ThresholdLevel = 'normal' | 'warning' | 'critical'
 
-function getSLAThresholdLevel(slaPercent: number | null): ThresholdLevel {
-  if (slaPercent == null) return 'normal'
-  const threshold = props.thresholds?.sla_percent_min
-  if (threshold == null) return 'normal'
-
-  // SLA is "higher is better":
-  // - below threshold => critical
-  // - within +0.1% buffer => warning
-  const warningBuffer = 0.1
-
-  if (slaPercent < threshold) return 'critical'
-  if (slaPercent < threshold + warningBuffer) return 'warning'
-  return 'normal'
-}
-
 function getTTFTThresholdLevel(ttftMs: number | null): ThresholdLevel {
   if (ttftMs == null) return 'normal'
   const threshold = props.thresholds?.ttft_p99_ms_max
@@ -397,6 +383,14 @@ const slaPercent = computed(() => {
   if ((overview.value?.request_count_sla ?? 0) <= 0) return null
   return v * 100
 })
+
+const slaThresholdLevel = computed(() =>
+  getSLAThresholdLevel(slaPercent.value, props.thresholds?.sla_percent_min)
+)
+
+const slaProgressPercent = computed(() =>
+  getSLAProgressPercent(slaPercent.value, props.thresholds?.sla_percent_min)
+)
 
 const errorRatePercent = computed(() => {
   const v = overview.value?.error_rate
@@ -594,18 +588,21 @@ const diagnosisReport = computed<DiagnosisItem[]>(() => {
   }
 
   // SLA diagnostics
-  const slaPct = (ov.sla ?? 0) * 100
-  if (slaPct < 90) {
+  const slaPct =
+    typeof ov.sla === 'number' && (ov.request_count_sla ?? 0) > 0 ? ov.sla * 100 : null
+  const slaLabel = slaPct?.toFixed(2) ?? '-'
+  const slaLevel = getSLAThresholdLevel(slaPct, props.thresholds?.sla_percent_min)
+  if (slaLevel === 'critical') {
     report.push({
       type: 'critical',
-      message: t('admin.ops.diagnosis.slaCritical', { sla: slaPct.toFixed(2) }),
+      message: t('admin.ops.diagnosis.slaCritical', { sla: slaLabel }),
       impact: t('admin.ops.diagnosis.slaCriticalImpact'),
       action: t('admin.ops.diagnosis.slaCriticalAction')
     })
-  } else if (slaPct < 98) {
+  } else if (slaLevel === 'warning') {
     report.push({
       type: 'warning',
-      message: t('admin.ops.diagnosis.slaLow', { sla: slaPct.toFixed(2) }),
+      message: t('admin.ops.diagnosis.slaLow', { sla: slaLabel }),
       impact: t('admin.ops.diagnosis.slaLowImpact'),
       action: t('admin.ops.diagnosis.slaLowAction')
     })
@@ -1256,7 +1253,7 @@ function handleToolbarRefresh() {
             <div class="flex items-center gap-2">
               <span class="text-[10px] font-bold uppercase text-gray-400">{{ t('admin.ops.sla') }}</span>
               <HelpTooltip v-if="!props.fullscreen" :content="t('admin.ops.tooltips.sla')" />
-              <span class="h-1.5 w-1.5 rounded-full" :class="getSLAThresholdLevel(slaPercent) === 'critical' ? 'bg-red-500' : getSLAThresholdLevel(slaPercent) === 'warning' ? 'bg-yellow-500' : 'bg-green-500'"></span>
+              <span class="h-1.5 w-1.5 rounded-full" :class="slaThresholdLevel === 'critical' ? 'bg-red-500' : slaThresholdLevel === 'warning' ? 'bg-yellow-500' : 'bg-green-500'"></span>
             </div>
             <button
               v-if="!props.fullscreen"
@@ -1267,11 +1264,11 @@ function handleToolbarRefresh() {
               {{ t('admin.ops.requestDetails.details') }}
             </button>
           </div>
-          <div class="mt-2 text-3xl font-black" :class="getThresholdColorClass(getSLAThresholdLevel(slaPercent))">
+          <div class="mt-2 text-3xl font-black" :class="getThresholdColorClass(slaThresholdLevel)">
             {{ slaPercent == null ? '-' : `${slaPercent.toFixed(3)}%` }}
           </div>
           <div class="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-dark-700">
-            <div class="h-full transition-all" :class="getSLAThresholdLevel(slaPercent) === 'critical' ? 'bg-red-500' : getSLAThresholdLevel(slaPercent) === 'warning' ? 'bg-yellow-500' : 'bg-green-500'" :style="{ width: `${Math.max((slaPercent ?? 0) - 90, 0) * 10}%` }"></div>
+            <div class="h-full transition-all" :class="slaThresholdLevel === 'critical' ? 'bg-red-500' : slaThresholdLevel === 'warning' ? 'bg-yellow-500' : 'bg-green-500'" :style="{ width: `${slaProgressPercent}%` }"></div>
           </div>
           <div class="mt-3 text-xs">
             <div class="flex justify-between">

--- a/frontend/src/views/admin/ops/utils/__tests__/slaThresholds.spec.ts
+++ b/frontend/src/views/admin/ops/utils/__tests__/slaThresholds.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSLAProgressPercent, getSLAThresholdLevel } from '../slaThresholds'
+
+describe('SLA threshold level', () => {
+  it('uses the configured boundary with a warning buffer', () => {
+    expect(getSLAThresholdLevel(null, 99.5)).toBe('normal')
+    expect(getSLAThresholdLevel(100, null)).toBe('normal')
+    expect(getSLAThresholdLevel(99.49, 99.5)).toBe('critical')
+    expect(getSLAThresholdLevel(99.5, 99.5)).toBe('warning')
+    expect(getSLAThresholdLevel(99.6, 99.5)).toBe('normal')
+  })
+
+  it('supports a custom threshold', () => {
+    expect(getSLAThresholdLevel(89.99, 90)).toBe('critical')
+    expect(getSLAThresholdLevel(90, 90)).toBe('warning')
+    expect(getSLAThresholdLevel(90.11, 90)).toBe('normal')
+  })
+
+  it('derives the progress range from the configured threshold', () => {
+    expect(getSLAProgressPercent(89.9, 90)).toBe(0)
+    expect(getSLAProgressPercent(90, 90)).toBe(0)
+    expect(getSLAProgressPercent(95, 90)).toBe(50)
+    expect(getSLAProgressPercent(100, 90)).toBe(100)
+    expect(getSLAProgressPercent(99.4, 99.5)).toBe(0)
+    expect(getSLAProgressPercent(99.75, 99.5)).toBe(50)
+    expect(getSLAProgressPercent(null, 90)).toBe(0)
+  })
+})

--- a/frontend/src/views/admin/ops/utils/slaThresholds.ts
+++ b/frontend/src/views/admin/ops/utils/slaThresholds.ts
@@ -1,0 +1,28 @@
+export type ThresholdLevel = 'normal' | 'warning' | 'critical'
+
+export function getSLAThresholdLevel(
+  slaPercent: number | null,
+  threshold: number | null | undefined
+): ThresholdLevel {
+  if (slaPercent == null || threshold == null) return 'normal'
+
+  // SLA is higher-is-better: below the configured boundary is critical, and a
+  // 0.1 percentage-point buffer above it remains warning.
+  const warningBuffer = 0.1
+  if (slaPercent < threshold) return 'critical'
+  if (slaPercent < threshold + warningBuffer) return 'warning'
+  return 'normal'
+}
+
+export function getSLAProgressPercent(
+  slaPercent: number | null,
+  threshold: number | null | undefined
+): number {
+  if (slaPercent == null || threshold == null) return 0
+
+  // Map the range from the configured boundary to 100% onto the progress bar.
+  // This keeps the bar and threshold color driven by the same setting.
+  const progressSpan = 100 - threshold
+  if (progressSpan <= 0) return slaPercent >= 100 ? 100 : 0
+  return Math.min(100, Math.max(((slaPercent - threshold) / progressSpan) * 100, 0))
+}


### PR DESCRIPTION
## Summary

- calculate operations health scores from configured thresholds, treating zero as an explicit threshold and using backend defaults as the fallback authority
- align SLA card state, progress, top-level diagnostics, and backend business-score deductions on sla_percent_min
- keep error-rate and TTFT card/diagnostic/score semantics aligned
- add boundary and custom-threshold regression coverage

## Validation

- cd backend && go test -tags unit ./internal/service -run TestCompute -count=1
- cd backend && go test -tags unit ./internal/service -count=1
- cd frontend && pnpm exec vitest run src/views/admin/ops/utils/__tests__/slaThresholds.spec.ts
- cd frontend && pnpm exec vue-tsc --noEmit