### PR TITLE
fix(openai): normalize automation update root unions

### DIFF
--- a/backend/internal/service/openai_responses_tool_schema_test.go
+++ b/backend/internal/service/openai_responses_tool_schema_test.go
@@ -80,6 +80,40 @@ func TestSanitizeOpenAIResponsesToolParameterTypes_ObjectOnlyRootUnion(t *testin
 	require.Equal(t, "string", gjson.GetBytes(sanitized, "tools.0.parameters.oneOf.0.properties.id.type").String())
 }
 
+// issue #5820 的实际形状有四个根 oneOf 分支，其中两个分支继续用无显式
+// type 的 oneOf 表达对象变体。只补齐参数根 type，不能改写 union 及其约束。
+func TestSanitizeOpenAIResponsesToolParameterTypes_Issue5820NestedObjectUnion(t *testing.T) {
+	parameters := `{"$schema":"https://json-schema.org/draft/2020-12/schema","oneOf":[{"type":"object","properties":{"mode":{"type":"string","const":"view"}},"required":["mode"],"additionalProperties":false},{"oneOf":[{"type":"object","properties":{"mode":{"const":"create"},"schedule":{"$ref":"#/$defs/schedule"}},"required":["mode","schedule"],"additionalProperties":false},{"type":"object","properties":{"mode":{"const":"create"},"prompt":{"type":"string"}},"required":["mode","prompt"],"additionalProperties":false}]},{"oneOf":[{"type":"object","properties":{"mode":{"const":"update"},"schedule":{"$ref":"#/$defs/schedule"}},"required":["mode","schedule"],"additionalProperties":false},{"type":"object","properties":{"mode":{"const":"update"},"enabled":{"type":"boolean"}},"required":["mode","enabled"],"additionalProperties":false}]},{"type":"object","properties":{"mode":{"type":"string","const":"delete"}},"required":["mode"],"additionalProperties":false}],"$defs":{"schedule":{"type":"object","properties":{"rrule":{"type":"string"}},"required":["rrule"],"additionalProperties":false}},"required":["mode"]}`
+	wantParameters := `{"type":"object",` + parameters[1:]
+	body := []byte(`{"tools":[{"type":"function","name":"automation_update","strict":true,"parameters":` + parameters + `}],"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"automation_update","strict":true,"parameters":` + parameters + `}]}]}]}`)
+
+	sanitized, changed, err := sanitizeOpenAIResponsesToolParameterTypes(body)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.True(t, json.Valid(sanitized))
+	for _, path := range []string{"tools.0", "input.0.tools.0.tools.0"} {
+		tool := gjson.GetBytes(sanitized, path)
+		require.Equal(t, "true", tool.Get("strict").Raw)
+		require.JSONEq(t, wantParameters, tool.Get("parameters").Raw)
+		require.Len(t, tool.Get("parameters.oneOf").Array(), 4)
+		require.True(t, tool.Get("parameters.oneOf.1.oneOf").IsArray())
+		require.True(t, tool.Get("parameters.oneOf.2.oneOf").IsArray())
+		require.True(t, tool.Get("parameters.$defs.schedule").IsObject())
+		require.Equal(t, "mode", tool.Get("parameters.required.0").String())
+	}
+}
+
+func TestSanitizeOpenAIResponsesToolParameterTypes_Issue5820PreservationBoundaries(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","name":"automation_update","strict":true,"parameters":{"oneOf":[{"type":"object"},{"type":"string"}],"properties":{"keep":{"type":"string"}},"required":["keep"],"$defs":{"keep":{"type":"string"}}}},{"type":"function","name":"automation_update","strict":true,"parameters":{"type":"object","oneOf":[{"type":"object"}],"properties":{"keep":{"type":"string"}},"required":["keep"]}}]}`)
+
+	sanitized, changed, err := sanitizeOpenAIResponsesToolParameterTypes(body)
+
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, body, sanitized)
+}
+
 func TestSanitizeOpenAIResponsesToolParameterTypes_EscapedUnionKeyword(t *testing.T) {
 	body := []byte(`{"tools":[{"type":"function","name":"other","parameters":{"one\u004ff":[{"type":"object"}]}}]}`)
 


### PR DESCRIPTION
## 问题

部分更新类工具的根级联合类型未被正确规范化，导致生成的工具结构在相关场景下不符合预期。

## 根因

现有处理仅覆盖部分结构位置，未统一处理更新类工具根节点上的联合类型。

## 改动

- 补充根级联合类型的规范化处理。
- 增加对应的单元测试与边界场景覆盖。

## 验证

验证结果：

- make test-unit passed
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=30m ./... returned 0 issues
- focused sanitizer tests passed
- go vet -tags=unit ./internal/service passed
- git diff --check passed
- make test-integration 已运行，唯一失败项为既有的 TestCNProviderBalanceCheckRunOnceProbesCodingPlanQuota；该失败在干净的 main 上可原样复现，未发现变更包的集成回归。
- 独立审查已通过，未发现安全或逻辑阻断项。

Fixes #5820