### PR TITLE
test(frontend): align Grok API key placeholder assertion

### DIFF
--- a/frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts
@@ -14,7 +14,8 @@ describe('CreateAccountModal Grok account types', () => {
     expect(source).toContain("newPlatform === 'grok'")
     expect(source).toContain("? 'https://api.x.ai/v1'")
     expect(source).toContain("form.platform === 'grok'")
-    expect(source).toContain("? 'xai-...'")
+    expect(source).toContain(':placeholder="apiKeyValuePlaceholder"')
+    expect(source).toContain("return 'xai-...'")
   })
 
   it('exposes custom upstream URL and header override for the OAuth create flow', () => {


### PR DESCRIPTION
## Summary

- update the Grok account test to assert the computed API-key placeholder wiring
- keep coverage for the `xai-...` placeholder after the component refactor
- no production behavior change

## Validation

- `corepack pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.grok.spec.ts`
- `corepack pnpm test:run` (234 files, 1638 tests)
