### PR TITLE
fix(apicompat): reject malformed tool-call arguments

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -279,6 +279,7 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 	// a user-side item ends the turn and clears it.
 	var lastTurnReasoning string
 	mediaByCallID := make(toolOutputMediaByCallID)
+	invalidFunctionCallIDs := make(map[string]struct{})
 
 	reasoningForAssistant := func() string {
 		if pendingReasoning != "" {
@@ -331,6 +332,20 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 			if strings.TrimSpace(arguments) == "" {
 				arguments = "{}"
 			}
+			callID := rawString(item["call_id"])
+			if !json.Valid([]byte(arguments)) {
+				// A previous streamed turn can leave a truncated function_call in
+				// Codex history (for example after an upstream SSE parse failure or
+				// an output-limit interruption). Do not forward that item to a
+				// Chat Completions provider, which rejects the entire request. Its
+				// matching output is skipped below as well, allowing the next user
+				// turn to self-heal instead of repeatedly replaying the poison.
+				if callID != "" {
+					invalidFunctionCallIDs[callID] = struct{}{}
+				}
+				pendingReasoning = ""
+				continue
+			}
 			name := rawString(item["name"])
 			// namespace 子工具的历史调用带 namespace 字段，需与请求方向的摊平
 			// 命名（namespaceChildrenToChatTools）保持一致。
@@ -338,7 +353,7 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 				name = flattenNamespaceToolName(ns, name)
 			}
 			toolCall := ChatToolCall{
-				ID:   rawString(item["call_id"]),
+				ID:   callID,
 				Type: "function",
 				Function: ChatFunctionCall{
 					Name:      name,
@@ -388,6 +403,10 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 		case "function_call_output", "custom_tool_call_output", "tool_search_output":
 			outputRaw := bytesTrimSpace(item["output"])
 			callID := rawString(item["call_id"])
+			if _, skipped := invalidFunctionCallIDs[callID]; skipped {
+				pendingReasoning = ""
+				continue
+			}
 			delete(mediaByCallID, callID)
 
 			outputText, media, rewritten := extractToolOutputMedia(outputRaw)
@@ -1404,6 +1423,36 @@ func NewChatCompletionsToResponsesStreamState(model string) *ChatCompletionsToRe
 		toolNamespace:    make(map[int]NamespacedToolName),
 		toolAnnounced:    make(map[int]bool),
 	}
+}
+
+// ValidateToolCallArguments checks the accumulated function-call arguments
+// before the stream is finalized. A tool call that ended because the upstream
+// hit its output limit, or whose SSE chunk was lost, must not be emitted as a
+// completed Responses item: Codex will persist it and replay it on the next
+// turn, where a Chat Completions provider rejects the whole request.
+func (state *ChatCompletionsToResponsesStreamState) ValidateToolCallArguments() error {
+	if state == nil {
+		return nil
+	}
+	if state.FinishReason == "length" && len(state.ToolCalls) > 0 {
+		return fmt.Errorf("tool call stream ended at max output length")
+	}
+	for idx, toolCall := range state.ToolCalls {
+		if toolCall == nil {
+			continue
+		}
+		if state.toolIsCustom[idx] || state.toolIsToolSearch[idx] {
+			continue
+		}
+		arguments := strings.TrimSpace(toolCall.Function.Arguments)
+		if arguments == "" {
+			continue
+		}
+		if !json.Valid([]byte(arguments)) {
+			return fmt.Errorf("tool call %q (%s) arguments are invalid JSON", toolCall.ID, toolCall.Function.Name)
+		}
+	}
+	return nil
 }
 
 func (state *ChatCompletionsToResponsesStreamState) allocOutputIndex() int {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -280,6 +280,7 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 	var lastTurnReasoning string
 	mediaByCallID := make(toolOutputMediaByCallID)
 	invalidFunctionCallIDs := make(map[string]struct{})
+	invalidEmptyFunctionCallOutputs := 0
 
 	reasoningForAssistant := func() string {
 		if pendingReasoning != "" {
@@ -342,6 +343,8 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 				// turn to self-heal instead of repeatedly replaying the poison.
 				if callID != "" {
 					invalidFunctionCallIDs[callID] = struct{}{}
+				} else {
+					invalidEmptyFunctionCallOutputs++
 				}
 				pendingReasoning = ""
 				continue
@@ -403,6 +406,11 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 		case "function_call_output", "custom_tool_call_output", "tool_search_output":
 			outputRaw := bytesTrimSpace(item["output"])
 			callID := rawString(item["call_id"])
+			if callID == "" && invalidEmptyFunctionCallOutputs > 0 {
+				invalidEmptyFunctionCallOutputs--
+				pendingReasoning = ""
+				continue
+			}
 			if _, skipped := invalidFunctionCallIDs[callID]; skipped {
 				pendingReasoning = ""
 				continue
@@ -1237,6 +1245,13 @@ func chatMessageToResponsesOutput(message ChatMessage, customTools map[string]bo
 			})
 			continue
 		}
+		// Ordinary Responses function_call arguments must contain valid JSON.
+		// Do not mark a truncated non-streaming Chat tool call as completed;
+		// Codex would persist it and poison the next request in the same way as
+		// the streaming variant guarded by ValidateToolCallArguments.
+		if !json.Valid([]byte(arguments)) {
+			continue
+		}
 		if ns, ok := namespaceTools[toolCall.Function.Name]; ok {
 			outputs = append(outputs, ResponsesOutput{
 				Type:      "function_call",
@@ -1426,16 +1441,13 @@ func NewChatCompletionsToResponsesStreamState(model string) *ChatCompletionsToRe
 }
 
 // ValidateToolCallArguments checks the accumulated function-call arguments
-// before the stream is finalized. A tool call that ended because the upstream
-// hit its output limit, or whose SSE chunk was lost, must not be emitted as a
-// completed Responses item: Codex will persist it and replay it on the next
-// turn, where a Chat Completions provider rejects the whole request.
+// before the stream is finalized. A tool call whose argument stream was
+// truncated must not be emitted as a completed Responses item: Codex will
+// persist it and replay it on the next turn, where a Chat Completions provider
+// rejects the whole request.
 func (state *ChatCompletionsToResponsesStreamState) ValidateToolCallArguments() error {
 	if state == nil {
 		return nil
-	}
-	if state.FinishReason == "length" && len(state.ToolCalls) > 0 {
-		return fmt.Errorf("tool call stream ended at max output length")
 	}
 	for idx, toolCall := range state.ToolCalls {
 		if toolCall == nil {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
@@ -37,6 +37,42 @@ func TestResponsesInputToChatMessages_SkipsInvalidHistoricalFunctionCall(t *test
 	require.Equal(t, "user", messages[2].Role)
 }
 
+func TestResponsesInputToChatMessages_SkipsInvalidEmptyCallIDOutput(t *testing.T) {
+	input := json.RawMessage(`[
+		{"type":"function_call","call_id":"","name":"exec_command","arguments":"{\"cmd\": \"ssh root@HOST"},
+		{"type":"function_call_output","call_id":"","output":"failed to parse function arguments"},
+		{"role":"user","content":"continue"}
+	]`)
+
+	messages, err := responsesInputToChatMessages("", input)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "user", messages[0].Role)
+}
+
+func TestChatCompletionsResponseToResponses_SkipsInvalidFunctionArguments(t *testing.T) {
+	resp := &ChatCompletionsResponse{
+		Model: "deepseek-v4-flash",
+		Choices: []ChatChoice{{
+			Message: ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ChatToolCall{
+					{ID: "call_bad", Type: "function", Function: ChatFunctionCall{Name: "exec_command", Arguments: `{"cmd": "ssh root@HOST`}},
+					{ID: "call_ok", Type: "function", Function: ChatFunctionCall{Name: "exec_command", Arguments: `{}`}},
+				},
+			},
+			FinishReason: "length",
+		}},
+	}
+
+	out := ChatCompletionsResponseToResponses(resp, "deepseek-v4-flash", nil, false, nil)
+	require.Equal(t, "incomplete", out.Status)
+	require.Len(t, out.Output, 1)
+	require.Equal(t, "function_call", out.Output[0].Type)
+	require.Equal(t, "call_ok", out.Output[0].CallID)
+	require.Equal(t, `{}`, out.Output[0].Arguments)
+}
+
 func TestResponsesInputToChatMessages_KeepsChatCompletionRoles(t *testing.T) {
 	input := json.RawMessage(`[
 		{"role":"system","content":"system message"},

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
@@ -17,6 +17,26 @@ func TestResponsesInputToChatMessages_DeveloperRoleMapsToSystem(t *testing.T) {
 	assert.JSONEq(t, `"follow project instructions"`, string(messages[0].Content))
 }
 
+func TestResponsesInputToChatMessages_SkipsInvalidHistoricalFunctionCall(t *testing.T) {
+	input := json.RawMessage(`[
+		{"type":"function_call","call_id":"call_bad","name":"exec_command","arguments":"{\"cmd\": \"ssh root@HOST"},
+		{"type":"function_call_output","call_id":"call_bad","output":"failed to parse function arguments"},
+		{"type":"function_call","call_id":"call_ok","name":"exec_command","arguments":"{}"},
+		{"type":"function_call_output","call_id":"call_ok","output":"ok"},
+		{"role":"user","content":"continue"}
+	]`)
+
+	messages, err := responsesInputToChatMessages("", input)
+	require.NoError(t, err)
+	require.Len(t, messages, 3)
+	require.Equal(t, "assistant", messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 1)
+	require.Equal(t, "call_ok", messages[0].ToolCalls[0].ID)
+	require.Equal(t, "tool", messages[1].Role)
+	require.Equal(t, "call_ok", messages[1].ToolCallID)
+	require.Equal(t, "user", messages[2].Role)
+}
+
 func TestResponsesInputToChatMessages_KeepsChatCompletionRoles(t *testing.T) {
 	input := json.RawMessage(`[
 		{"role":"system","content":"system message"},

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
@@ -243,7 +243,7 @@ func TestStream_InvalidToolArgumentsAreRejectedBeforeFinalize(t *testing.T) {
 	require.ErrorContains(t, err, "invalid JSON")
 }
 
-func TestStream_ToolCallAtOutputLimitIsRejectedBeforeFinalize(t *testing.T) {
+func TestStream_ValidToolCallAtOutputLimitKeepsIncompleteResponse(t *testing.T) {
 	idx := 0
 	state := NewChatCompletionsToResponsesStreamState("deepseek-v4-flash")
 	chunk := &ChatCompletionsChunk{
@@ -269,7 +269,21 @@ func TestStream_ToolCallAtOutputLimitIsRejectedBeforeFinalize(t *testing.T) {
 	ChatCompletionsChunkToResponsesEvents(chunk, state)
 	state.FinishReason = "length"
 
-	require.ErrorContains(t, state.ValidateToolCallArguments(), "max output length")
+	require.NoError(t, state.ValidateToolCallArguments())
+	events := FinalizeChatCompletionsResponsesStream(state)
+	var sawArgsDone, sawIncomplete bool
+	for _, event := range events {
+		switch event.Type {
+		case "response.function_call_arguments.done":
+			sawArgsDone = true
+			require.Equal(t, `{}`, event.Arguments)
+		case "response.completed":
+			require.NotNil(t, event.Response)
+			sawIncomplete = event.Response.Status == "incomplete"
+		}
+	}
+	require.True(t, sawArgsDone)
+	require.True(t, sawIncomplete)
 }
 
 // TestStream_SSEWireComplete drives the full stream through SSE encoding and

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
@@ -214,6 +214,64 @@ func TestStream_ToolCallArgumentsInFirstChunkNotDoubled(t *testing.T) {
 	require.Equal(t, `{"cmd":"ls"}`, argsDelta.String())
 }
 
+func TestStream_InvalidToolArgumentsAreRejectedBeforeFinalize(t *testing.T) {
+	idx := 0
+	state := NewChatCompletionsToResponsesStreamState("deepseek-v4-flash")
+	chunk := &ChatCompletionsChunk{
+		Choices: []ChatChunkChoice{
+			{
+				Index: 0,
+				Delta: ChatDelta{
+					ToolCalls: []ChatToolCall{
+						{
+							Index: &idx,
+							ID:    "call_bad",
+							Type:  "function",
+							Function: ChatFunctionCall{
+								Name:      "exec_command",
+								Arguments: `{"cmd": "ssh root@HOST`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ChatCompletionsChunkToResponsesEvents(chunk, state)
+
+	err := state.ValidateToolCallArguments()
+	require.ErrorContains(t, err, "invalid JSON")
+}
+
+func TestStream_ToolCallAtOutputLimitIsRejectedBeforeFinalize(t *testing.T) {
+	idx := 0
+	state := NewChatCompletionsToResponsesStreamState("deepseek-v4-flash")
+	chunk := &ChatCompletionsChunk{
+		Choices: []ChatChunkChoice{
+			{
+				Index: 0,
+				Delta: ChatDelta{
+					ToolCalls: []ChatToolCall{
+						{
+							Index: &idx,
+							ID:    "call_at_limit",
+							Type:  "function",
+							Function: ChatFunctionCall{
+								Name:      "exec_command",
+								Arguments: `{}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ChatCompletionsChunkToResponsesEvents(chunk, state)
+	state.FinishReason = "length"
+
+	require.ErrorContains(t, state.ValidateToolCallArguments(), "max output length")
+}
+
 // TestStream_SSEWireComplete drives the full stream through SSE encoding and
 // asserts the function_call events carry complete fields on the wire.
 func TestStream_SSEWireComplete(t *testing.T) {

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -281,13 +281,7 @@ func (s *OpenAIGatewayService) scanCCStream(
 				zap.Error(err),
 				zap.String("request_id", requestID),
 			)
-			// A malformed chunk may contain the middle or the tail of a tool-call
-			// argument. Skipping it and finalizing the accumulated state would turn
-			// a truncated function call into a completed Responses item, which then
-			// poisons Codex's next-turn history. Treat the stream as incomplete so
-			// callers skip finalization and surface an upstream-stream error.
-			st.Err = fmt.Errorf("malformed chat stream chunk: %w", err)
-			break
+			continue
 		}
 		if st.FirstTokenMs == nil && !isOpenAIChatUsageOnlyStreamChunk(payload) && chatChunkStartsResponsesOutput(&chunk) {
 			ms := int(time.Since(startTime).Milliseconds())

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -281,7 +281,13 @@ func (s *OpenAIGatewayService) scanCCStream(
 				zap.Error(err),
 				zap.String("request_id", requestID),
 			)
-			continue
+			// A malformed chunk may contain the middle or the tail of a tool-call
+			// argument. Skipping it and finalizing the accumulated state would turn
+			// a truncated function call into a completed Responses item, which then
+			// poisons Codex's next-turn history. Treat the stream as incomplete so
+			// callers skip finalization and surface an upstream-stream error.
+			st.Err = fmt.Errorf("malformed chat stream chunk: %w", err)
+			break
 		}
 		if st.FirstTokenMs == nil && !isOpenAIChatUsageOnlyStreamChunk(payload) && chatChunkStartsResponsesOutput(&chunk) {
 			ms := int(time.Since(startTime).Milliseconds())

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -231,6 +231,20 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 			FirstTokenMs:    scan.FirstTokenMs,
 		}, fmt.Errorf("stream usage incomplete: %w", scan.Err)
 	}
+	if err := state.ValidateToolCallArguments(); err != nil {
+		return &OpenAIForwardResult{
+			RequestID:       requestID,
+			Usage:           scan.Usage,
+			Model:           originalModel,
+			BillingModel:    billingModel,
+			UpstreamModel:   upstreamModel,
+			ReasoningEffort: reasoningEffort,
+			ServiceTier:     serviceTier,
+			Stream:          true,
+			Duration:        time.Since(startTime),
+			FirstTokenMs:    scan.FirstTokenMs,
+		}, fmt.Errorf("invalid tool call arguments from upstream: %w", err)
+	}
 
 	finalEvents := apicompat.FinalizeChatCompletionsResponsesStream(state)
 	s.cacheReasoningItemsFromEvents(finalEvents)

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -148,7 +148,7 @@ func TestForwardResponses_ForceChatCompletionsRoutesStreamingToChatCompletions(t
 	require.NotNil(t, result.FirstTokenMs)
 }
 
-func TestForwardResponses_ChatFallbackDoesNotFinalizeAfterMalformedStreamChunk(t *testing.T) {
+func TestForwardResponses_ChatFallbackRejectsInvalidToolArgumentsAtOutputLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	body := []byte(`{"model":"deepseek-v4-flash","input":"run the command","stream":true}`)
@@ -158,42 +158,7 @@ func TestForwardResponses_ChatFallbackDoesNotFinalizeAfterMalformedStreamChunk(t
 	c.Request.Header.Set("Content-Type", "application/json")
 
 	upstreamBody := strings.Join([]string{
-		`data: {"id":"chatcmpl_bad_stream","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"name":"exec_command","arguments":"{}"}}]},"finish_reason":null}]}`,
-		"",
-		`data: {"id":"chatcmpl_bad_stream","object":"chat.completion.chunk","choices":[`,
-		"",
-		"data: [DONE]",
-		"",
-	}, "\n")
-	upstream := &httpUpstreamRecorder{resp: &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_bad_stream"}},
-		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
-	}}
-	svc := &OpenAIGatewayService{
-		cfg:          rawChatCompletionsTestConfig(),
-		httpUpstream: upstream,
-	}
-
-	result, err := svc.Forward(context.Background(), c, forceChatResponsesFallbackAccount(), body)
-	require.ErrorContains(t, err, "stream usage incomplete")
-	require.NotNil(t, result)
-	require.NotContains(t, rec.Body.String(), "response.function_call_arguments.done")
-	require.NotContains(t, rec.Body.String(), "response.output_item.done")
-	require.NotContains(t, rec.Body.String(), "data: [DONE]")
-}
-
-func TestForwardResponses_ChatFallbackDoesNotCompleteToolCallAtOutputLimit(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	body := []byte(`{"model":"deepseek-v4-flash","input":"run the command","stream":true}`)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
-	c.Request.Header.Set("Content-Type", "application/json")
-
-	upstreamBody := strings.Join([]string{
-		`data: {"id":"chatcmpl_length_tool","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_length","type":"function","function":{"name":"exec_command","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_length_tool","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_length","type":"function","function":{"name":"exec_command","arguments":"{\"cmd\":\"ssh root@HOST"}}]},"finish_reason":null}]}`,
 		"",
 		`data: {"id":"chatcmpl_length_tool","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":4,"completion_tokens":6492,"total_tokens":6496}}`,
 		"",
@@ -211,8 +176,10 @@ func TestForwardResponses_ChatFallbackDoesNotCompleteToolCallAtOutputLimit(t *te
 	}
 
 	result, err := svc.Forward(context.Background(), c, forceChatResponsesFallbackAccount(), body)
-	require.ErrorContains(t, err, "max output length")
+	require.ErrorContains(t, err, "invalid JSON")
 	require.NotNil(t, result)
+	require.Equal(t, 4, result.Usage.InputTokens)
+	require.Equal(t, 6492, result.Usage.OutputTokens)
 	require.NotContains(t, rec.Body.String(), "response.function_call_arguments.done")
 	require.NotContains(t, rec.Body.String(), "response.output_item.done")
 	require.NotContains(t, rec.Body.String(), "data: [DONE]")

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -148,6 +148,76 @@ func TestForwardResponses_ForceChatCompletionsRoutesStreamingToChatCompletions(t
 	require.NotNil(t, result.FirstTokenMs)
 }
 
+func TestForwardResponses_ChatFallbackDoesNotFinalizeAfterMalformedStreamChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"deepseek-v4-flash","input":"run the command","stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_bad_stream","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"name":"exec_command","arguments":"{}"}}]},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_bad_stream","object":"chat.completion.chunk","choices":[`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_bad_stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, forceChatResponsesFallbackAccount(), body)
+	require.ErrorContains(t, err, "stream usage incomplete")
+	require.NotNil(t, result)
+	require.NotContains(t, rec.Body.String(), "response.function_call_arguments.done")
+	require.NotContains(t, rec.Body.String(), "response.output_item.done")
+	require.NotContains(t, rec.Body.String(), "data: [DONE]")
+}
+
+func TestForwardResponses_ChatFallbackDoesNotCompleteToolCallAtOutputLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"deepseek-v4-flash","input":"run the command","stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_length_tool","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_length","type":"function","function":{"name":"exec_command","arguments":"{}"}}]},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_length_tool","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":4,"completion_tokens":6492,"total_tokens":6496}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_length_tool"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, forceChatResponsesFallbackAccount(), body)
+	require.ErrorContains(t, err, "max output length")
+	require.NotNil(t, result)
+	require.NotContains(t, rec.Body.String(), "response.function_call_arguments.done")
+	require.NotContains(t, rec.Body.String(), "response.output_item.done")
+	require.NotContains(t, rec.Body.String(), "data: [DONE]")
+}
+
 func TestForwardResponses_DeepSeekReasoningOnlyStreamProducesVisibleText(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Problem
When `/v1/responses` is downgraded to Chat Completions, an upstream can return a truncated tool-call argument. If the fallback finalizes that argument as a completed Responses `function_call`, Codex persists it and replays it on the next turn. Chat Completions providers then reject the history because `assistant.tool_calls[].function.arguments` is not valid JSON.

## Changes
- Validate ordinary accumulated function-call arguments before finalizing the streaming Chat → Responses fallback.
- Preserve the existing `finish_reason=length` incomplete-response behavior when arguments are valid.
- Skip malformed historical `function_call` items and their matching outputs during Responses → Chat replay, including empty-`call_id` pairs, so poisoned Codex histories can self-heal.
- Filter malformed ordinary function calls from the non-streaming Chat → Responses conversion as well.
- Keep custom tools and tool-search calls on their existing dedicated conversion paths.

The shared Chat SSE scanner and the `/v1/messages` fallback are unchanged.

## Verification
- `go test ./...`
- `go test -tags unit ./internal/pkg/apicompat`
- `go test -tags unit ./internal/service`
