### PR TITLE
fix(openai): strip ChatGPT-internal-unsupported fields at the upstream egress

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -1073,6 +1073,10 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	// previous_response_id，避免携带状态字段被上游拒绝。
 	body = normalizeDeepSeekResponsesRequestBody(account, body)
 
+	// 出口兜底：ChatGPT internal 不支持的顶层字段在此做最后一次清理，防止
+	// 上游任一转换分支遗漏或在清理后重建 body 导致 invalid_parameter 400。
+	body = applyChatGPTInternalEgressStrip(ctx, account, body, openAIEgressForward)
+
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -484,6 +484,11 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	// DeepSeek 原生 Responses 端点为无状态实现（见 normalizeDeepSeekResponsesRequestBody）。
 	body = normalizeDeepSeekResponsesRequestBody(account, body)
 
+	// 出口兜底：见 applyChatGPTInternalEgressStrip。透传路径虽已在
+	// normalizeOpenAIPassthroughOAuthBody 清理过，但其后还有多处 body 重建
+	// （工具适配、指纹改写、模型改写），这里做最终保证。
+	body = applyChatGPTInternalEgressStrip(ctx, account, body, openAIEgressPassthrough)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -17,7 +17,28 @@ const maxOpenAIResponsesRejectedFieldRetries = 6
 var (
 	openAIResponsesRejectedNamespaceParamPattern = regexp.MustCompile(`(?i)^input\[(\d+)\]\.namespace$`)
 	openAIResponsesRejectedMessageParamPattern   = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|input\[\d+\]\.namespace)(?:["']|\b)`)
+	// ChatGPT internal Codex 端点点名拒绝顶层字段时用的是另一种文案，例如
+	// "prompt_cache_retention is not supported on this model"（code 为
+	// invalid_parameter），与上面的 "unknown/unsupported parameter: X" 形态不同。
+	openAIResponsesRejectedUnsupportedOnModelPattern = regexp.MustCompile(`(?i)^([a-z0-9_]+)\s+is\s+not\s+supported\s+(?:on|with|for|by)\s+this\s+model`)
 )
+
+// openAIResponsesStrippableRejectedParams 是被上游以 400 点名拒绝后，可以安全剥离
+// 并重试一次的顶层可选字段。
+//
+// 判据是「删掉它等价于客户端从没发过这个字段」：这些字段只影响提示缓存策略、
+// 调用方标识与用量统计口径，不参与生成语义，剥掉不会改变模型输出。
+//
+// 刻意不含 model / input / instructions / tools / reasoning 等语义关键字段——
+// 那些被拒时必须把错误如实返回客户端，而不是悄悄改写请求再重试。
+var openAIResponsesStrippableRejectedParams = map[string]struct{}{
+	"prompt_cache_retention": {},
+	"prompt_cache_options":   {},
+	"safety_identifier":      {},
+	"stream_options":         {},
+	"metadata":               {},
+	"user":                   {},
+}
 
 type openAIResponsesRejectedFieldRetryState struct {
 	attempts       int
@@ -62,14 +83,27 @@ func normalizeOpenAIResponsesRejectedFieldRetryBody(statusCode int, body, respon
 
 	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(responseBody)))
 	message := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(responseBody)))
-	if !isExplicitOpenAIResponsesFieldRejection(code, message) {
-		return nil, "", false, nil
-	}
 
 	param := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.param").String()))
 	if param == "" {
 		param = openAIResponsesRejectedParamFromMessage(message)
 	}
+
+	// 已知可安全剥离的顶层可选字段：只要上游点名拒绝，就剥掉重试一次。
+	//
+	// 这一支刻意不走 isExplicitOpenAIResponsesFieldRejection 的 code 白名单：
+	// 这类拒绝的 code 并不统一（ChatGPT internal 实测用 invalid_parameter，
+	// 文案为 "X is not supported on this model"），靠 code 判定会漏。安全性由
+	// openAIResponsesStrippableRejectedParams 白名单保证——只有明确无生成语义的
+	// 字段才会被剥离，其余 param（含 model、input[N].name 等）一律不动。
+	if retryBody, reason, changed, err := stripRejectedOptionalParam(body, param); err != nil || changed {
+		return retryBody, reason, changed, err
+	}
+
+	if !isExplicitOpenAIResponsesFieldRejection(code, message) {
+		return nil, "", false, nil
+	}
+
 	if index, ok := openAIResponsesRejectedNamespaceIndex(param); ok {
 		return removeOpenAIResponsesRejectedNamespaceAtIndex(body, index)
 	}
@@ -93,11 +127,43 @@ func isExplicitOpenAIResponsesFieldRejection(code, message string) bool {
 }
 
 func openAIResponsesRejectedParamFromMessage(message string) string {
-	match := openAIResponsesRejectedMessageParamPattern.FindStringSubmatch(strings.TrimSpace(message))
-	if len(match) != 2 {
-		return ""
+	trimmed := strings.TrimSpace(message)
+	if match := openAIResponsesRejectedMessageParamPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return strings.ToLower(strings.TrimSpace(match[1]))
 	}
-	return strings.ToLower(strings.TrimSpace(match[1]))
+	// "X is not supported on this model" 形态：上游通常同时给了 error.param，
+	// 这里只是缺失时的兜底。
+	if match := openAIResponsesRejectedUnsupportedOnModelPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return strings.ToLower(strings.TrimSpace(match[1]))
+	}
+	return ""
+}
+
+// stripRejectedOptionalParam 在 param 命中可剥离白名单且请求体确实带了该字段时，
+// 删除它并返回可用于重试的 body。
+//
+// param 形如 "prompt_cache_options.ttl" 时按其顶层字段处理：上游拒的是该对象的
+// 内容，整体删掉即等价于没发这个对象。非白名单 param（含 "input[74].name" 这类
+// 带下标的路径）一律返回 changed=false，交给后续分支或如实回传客户端。
+func stripRejectedOptionalParam(body []byte, param string) ([]byte, string, bool, error) {
+	if param == "" {
+		return nil, "", false, nil
+	}
+	topLevel := param
+	if idx := strings.IndexByte(topLevel, '.'); idx > 0 {
+		topLevel = topLevel[:idx]
+	}
+	if _, strippable := openAIResponsesStrippableRejectedParams[topLevel]; !strippable {
+		return nil, "", false, nil
+	}
+	if !gjson.GetBytes(body, topLevel).Exists() {
+		return nil, "", false, nil
+	}
+	retryBody, err := sjson.DeleteBytes(body, topLevel)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("delete rejected %s: %w", topLevel, err)
+	}
+	return retryBody, topLevel + " parameter rejection", true, nil
 }
 
 func openAIResponsesRejectedNamespaceIndex(param string) (int, bool) {

--- a/backend/internal/service/openai_upstream_egress_strip.go
+++ b/backend/internal/service/openai_upstream_egress_strip.go
@@ -1,0 +1,106 @@
+package service
+
+// 本文件承载「上游 body 出口兜底清理」：在真正构造发往 ChatGPT internal Codex
+// 端点的 HTTP 请求之前，做最后一道不支持字段的清理与诊断埋点。
+//
+// 背景（#5803）：ChatGPT internal Codex 端点拒绝一批 Platform API 顶层字段，
+// 例如 prompt_cache_retention 会被以
+//
+//	{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model",...}}
+//
+// 拒绝。这类参数错误换账号 failover 也救不了（换号后同样的 body 依旧被拒），
+// 客户端直接吃 400。
+//
+// 现状是各转换分支各自清理：普通 Responses 路径（applyCodexOAuthTransform）、
+// 透传路径（normalizeOpenAIPassthroughOAuthBody）、Chat Completions 的
+// Responses-shape 短路（cursorResponsesUnsupportedFields）以及 grok 路径，
+// 彼此独立且清单需要人工保持同步。分支多、且部分分支会在清理之后重建 body，
+// 任一处遗漏都会让字段重新出现在出口。线上实测确有请求带着该字段到达上游，
+// 但静态定位不到是哪条分支绕过了清理。
+//
+// 因此把清理收敛到唯一出口：无论上游哪条分支如何重建 body，最终发出前必过这里。
+// 出口若真的删掉了字段，说明上游某条分支漏了，按 Warn 记录字段名用于定位——
+// 只记字段名与出口名，不记字段值、不记请求正文（低基数、无敏感内容）。
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
+)
+
+// OpenAI 上游 body 出口名，用于区分埋点来自哪个构造器。
+const (
+	openAIEgressForward     = "forward"
+	openAIEgressPassthrough = "passthrough"
+)
+
+// stripChatGPTInternalUnsupportedFieldsAtEgress 删除 ChatGPT internal Codex 端点
+// 不支持的顶层字段，仅对走该端点的 OpenAI OAuth 账号生效；其余账号（APIKey、
+// 第三方 OpenAI 兼容上游、非 OpenAI 平台）原样返回，避免误删它们合法使用的字段。
+//
+// 返回清理后的 body 与实际被删掉的字段名。字段清单复用
+// openAIChatGPTInternalUnsupportedFields，保持单一事实来源；清单内均为无 "." 的
+// 顶层字段名，可直接作为 gjson/sjson 路径使用。
+func stripChatGPTInternalUnsupportedFieldsAtEgress(account *Account, body []byte) ([]byte, []string) {
+	if account == nil || !account.IsOpenAI() || account.Type != AccountTypeOAuth || len(body) == 0 {
+		return body, nil
+	}
+
+	out := body
+	var stripped []string
+	for _, field := range openAIChatGPTInternalUnsupportedFields {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
+		next, err := sjson.DeleteBytes(out, field)
+		if err != nil {
+			// 单个字段删除失败不影响其余字段：宁可少删一个，也不要因为
+			// 一次 sjson 失败把整个请求打回，出口清理是尽力而为的兜底。
+			continue
+		}
+		out = next
+		stripped = append(stripped, field)
+	}
+	return out, stripped
+}
+
+// logChatGPTInternalEgressStripped 记录出口兜底清理命中的字段。
+//
+// 命中即意味着上游某条转换分支没有清干净，属于需要跟进的实现缺陷，故用 Warn。
+// 只记字段名与出口名，不记字段值、不记请求正文。
+func logChatGPTInternalEgressStripped(ctx context.Context, account *Account, egress string, stripped []string) {
+	if len(stripped) == 0 {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	accountID := int64(0)
+	accountType := ""
+	if account != nil {
+		accountID = account.ID
+		accountType = strings.TrimSpace(string(account.Type))
+	}
+	logger.FromContext(ctx).With(
+		zap.String("component", "service.openai_gateway"),
+		zap.Int64("account_id", accountID),
+		zap.String("account_type", accountType),
+		zap.String("egress", egress),
+		zap.Strings("stripped_fields", stripped),
+	).Warn("OpenAI 出口兜底清理：ChatGPT internal 不支持的顶层字段在构造上游请求前仍然存在")
+}
+
+// applyChatGPTInternalEgressStrip 是 stripChatGPTInternalUnsupportedFieldsAtEgress
+// 与埋点的组合，供各上游请求构造器在 http.NewRequest 之前调用。
+func applyChatGPTInternalEgressStrip(ctx context.Context, account *Account, body []byte, egress string) []byte {
+	strippedBody, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(account, body)
+	if len(stripped) == 0 {
+		return body
+	}
+	logChatGPTInternalEgressStripped(ctx, account, egress, stripped)
+	return strippedBody
+}

--- a/backend/internal/service/openai_upstream_egress_strip_test.go
+++ b/backend/internal/service/openai_upstream_egress_strip_test.go
@@ -11,27 +11,43 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestStripChatGPTInternalUnsupportedFieldsAtEgress(t *testing.T) {
 	oauthAccount := newOpenAIOAuthNamespaceTestAccount()
 
-	t.Run("strips every unsupported top-level field for OAuth", func(t *testing.T) {
-		body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"message","role":"user","content":"hi"}],` +
-			`"prompt_cache_retention":"24h","safety_identifier":"sid","user":"u1",` +
-			`"metadata":{"k":"v"},"stream_options":{"include_usage":true}}`)
+	// 用例跟着 openAIChatGPTInternalUnsupportedFields 走而不是硬编码字段名：该清单是
+	// 单一事实来源，往里加字段时这个用例必须自动覆盖到，否则新字段会静默漏测。
+	t.Run("strips every field in the unsupported list for OAuth", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"message","role":"user","content":"hi"}]}`)
+		for _, field := range openAIChatGPTInternalUnsupportedFields {
+			next, err := sjson.SetBytes(body, field, map[string]any{"probe": field})
+			require.NoError(t, err)
+			body = next
+		}
+		require.NotEmpty(t, openAIChatGPTInternalUnsupportedFields)
 
 		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, body)
 
-		require.ElementsMatch(t,
-			[]string{"user", "metadata", "prompt_cache_retention", "safety_identifier", "stream_options"},
-			stripped)
-		for _, field := range stripped {
+		require.ElementsMatch(t, openAIChatGPTInternalUnsupportedFields, stripped)
+		for _, field := range openAIChatGPTInternalUnsupportedFields {
 			require.False(t, gjson.GetBytes(out, field).Exists(), "field %s must be gone", field)
 		}
 		// 语义字段必须保持原样。
 		require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(out, "model").String())
 		require.Equal(t, "hi", gjson.GetBytes(out, "input.0.content").String())
+	})
+
+	// prompt_cache_retention 是 #5803 的字段，单独钉一个显式用例，避免它哪天被从
+	// 清单里挪走时只有上面那个动态用例跟着一起"通过"。
+	t.Run("always strips prompt_cache_retention for OAuth", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.6-sol","input":"hi","prompt_cache_retention":"24h"}`)
+
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, body)
+
+		require.Contains(t, stripped, "prompt_cache_retention")
+		require.False(t, gjson.GetBytes(out, "prompt_cache_retention").Exists())
 	})
 
 	t.Run("keeps nested occurrences that merely share the field name", func(t *testing.T) {

--- a/backend/internal/service/openai_upstream_egress_strip_test.go
+++ b/backend/internal/service/openai_upstream_egress_strip_test.go
@@ -1,0 +1,269 @@
+package service
+
+// 回归测试：ChatGPT internal 不支持的顶层字段既要在出口被兜底剥离，也要在上游
+// 点名拒绝时被剥掉重试一次。见 openai_upstream_egress_strip.go 头部说明与 #5803。
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestStripChatGPTInternalUnsupportedFieldsAtEgress(t *testing.T) {
+	oauthAccount := newOpenAIOAuthNamespaceTestAccount()
+
+	t.Run("strips every unsupported top-level field for OAuth", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"message","role":"user","content":"hi"}],` +
+			`"prompt_cache_retention":"24h","safety_identifier":"sid","user":"u1",` +
+			`"metadata":{"k":"v"},"stream_options":{"include_usage":true}}`)
+
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, body)
+
+		require.ElementsMatch(t,
+			[]string{"user", "metadata", "prompt_cache_retention", "safety_identifier", "stream_options"},
+			stripped)
+		for _, field := range stripped {
+			require.False(t, gjson.GetBytes(out, field).Exists(), "field %s must be gone", field)
+		}
+		// 语义字段必须保持原样。
+		require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(out, "model").String())
+		require.Equal(t, "hi", gjson.GetBytes(out, "input.0.content").String())
+	})
+
+	t.Run("keeps nested occurrences that merely share the field name", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.6-sol","prompt_cache_retention":"24h",` +
+			`"input":[{"type":"message","role":"user","content":{"prompt_cache_retention":"keep"}}]}`)
+
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, body)
+
+		require.Equal(t, []string{"prompt_cache_retention"}, stripped)
+		require.False(t, gjson.GetBytes(out, "prompt_cache_retention").Exists())
+		require.Equal(t, "keep", gjson.GetBytes(out, "input.0.content.prompt_cache_retention").String())
+	})
+
+	t.Run("no-op when nothing unsupported is present", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.6-sol","input":"hi"}`)
+
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, body)
+
+		require.Empty(t, stripped)
+		require.Equal(t, body, out)
+	})
+
+	// APIKey 账号走 Platform API 或第三方 OpenAI 兼容上游，这些字段在那边是合法的，
+	// 出口不能替它们做决定。
+	t.Run("leaves APIKey accounts untouched", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.5","prompt_cache_retention":"24h","user":"u1"}`)
+
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(newOpenAIRejectedFieldTestAccount(), body)
+
+		require.Empty(t, stripped)
+		require.Equal(t, body, out)
+		require.True(t, gjson.GetBytes(out, "prompt_cache_retention").Exists())
+	})
+
+	t.Run("tolerates nil account and empty body", func(t *testing.T) {
+		out, stripped := stripChatGPTInternalUnsupportedFieldsAtEgress(nil, []byte(`{"prompt_cache_retention":"24h"}`))
+		require.Empty(t, stripped)
+		require.True(t, gjson.GetBytes(out, "prompt_cache_retention").Exists())
+
+		out, stripped = stripChatGPTInternalUnsupportedFieldsAtEgress(oauthAccount, nil)
+		require.Empty(t, stripped)
+		require.Empty(t, out)
+	})
+}
+
+// TestOpenAIGatewayService_EgressStripsPromptCacheRetentionForCodexCLIOAuth 是
+// #5803 的端到端回归：OAuth + Codex CLI + GPT-5.6 + prompt_cache_retention，
+// 断言真正发往上游的 body 不含该字段。
+func TestOpenAIGatewayService_EgressStripsPromptCacheRetentionForCodexCLIOAuth(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"prompt_cache_retention":"24h",` +
+		`"safety_identifier":"sid","input":[{"type":"message","role":"user","content":"hi"}]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusOK,
+			`{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+
+	c := newOpenAIRejectedFieldTestContext(body)
+	c.Request.Header.Set("User-Agent", buildCodexCLIUserAgent("0.148.0"))
+	c.Request.Header.Set("originator", "codex_cli_rs")
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(), c, newOpenAIOAuthNamespaceTestAccount(), body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "prompt_cache_retention").Exists())
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "safety_identifier").Exists())
+}
+
+// buildUpstreamRequest 是出口本身：直接喂一个带字段的 body，模拟「上游所有转换
+// 分支都漏了」的最坏情况，断言出口仍然兜住。
+func TestOpenAIGatewayService_BuildUpstreamRequestStripsUnsupportedFieldsAsLastResort(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hi","prompt_cache_retention":"24h","metadata":{"k":"v"}}`)
+	svc := newOpenAIRejectedFieldTestService(&httpUpstreamRecorder{})
+
+	req, err := svc.buildUpstreamRequest(
+		context.Background(), newOpenAIRejectedFieldTestContext(body),
+		newOpenAIOAuthNamespaceTestAccount(), body, "oauth-token", false, "", true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	sentBody, readErr := readAllUpstreamRequestBody(req)
+	require.NoError(t, readErr)
+	require.False(t, gjson.GetBytes(sentBody, "prompt_cache_retention").Exists())
+	require.False(t, gjson.GetBytes(sentBody, "metadata").Exists())
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(sentBody, "model").String())
+}
+
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyStripsRejectedOptionalParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         []byte
+		responseBody []byte
+		wantReason   string
+		wantGone     string
+	}{
+		{
+			// 线上实测形态：code 是 invalid_parameter，文案是 "is not supported on this model"，
+			// 两者都不在旧的 unknown/unsupported parameter 判定里。
+			name: "invalid_parameter is not supported on this model",
+			body: []byte(`{"model":"gpt-5.6-sol","input":"hi","prompt_cache_retention":"24h"}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter",` +
+				`"message":"prompt_cache_retention is not supported on this model",` +
+				`"param":"prompt_cache_retention","type":"invalid_request_error"}}`),
+			wantReason: "prompt_cache_retention parameter rejection",
+			wantGone:   "prompt_cache_retention",
+		},
+		{
+			name: "nested param strips the whole top-level object",
+			body: []byte(`{"model":"gpt-5.6-sol","input":"hi","prompt_cache_options":{"ttl":"30m"}}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter",` +
+				`"message":"prompt_cache_options.ttl is not supported on this model",` +
+				`"param":"prompt_cache_options.ttl"}}`),
+			wantReason: "prompt_cache_options parameter rejection",
+			wantGone:   "prompt_cache_options",
+		},
+		{
+			name: "falls back to the message when error.param is absent",
+			body: []byte(`{"model":"gpt-5.6-sol","input":"hi","safety_identifier":"sid"}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter",` +
+				`"message":"safety_identifier is not supported on this model"}}`),
+			wantReason: "safety_identifier parameter rejection",
+			wantGone:   "safety_identifier",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(
+				http.StatusBadRequest, tc.body, tc.responseBody)
+
+			require.NoError(t, err)
+			require.True(t, changed)
+			require.Equal(t, tc.wantReason, reason)
+			require.False(t, gjson.GetBytes(retryBody, tc.wantGone).Exists())
+			require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(retryBody, "model").String())
+		})
+	}
+}
+
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyKeepsSemanticParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         []byte
+		responseBody []byte
+	}{
+		{
+			// 语义关键字段被拒时必须如实回传客户端，不能悄悄改写请求再重试。
+			name:         "model rejection is not silently rewritten",
+			body:         []byte(`{"model":"gpt-5.6-sol","input":"hi"}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter","message":"model is not supported on this model","param":"model"}}`),
+		},
+		{
+			// 线上同期真实存在的另一类 400，绝不能被误当成可剥字段。
+			name:         "indexed input param is untouched",
+			body:         []byte(`{"model":"gpt-5.6-sol","input":[{"type":"function_call","name":"bad name"}]}`),
+			responseBody: []byte(`{"error":{"code":"invalid_value","message":"Invalid 'input[74].name': string does not match pattern.","param":"input[74].name"}}`),
+		},
+		{
+			name:         "whitelisted param absent from body yields no retry",
+			body:         []byte(`{"model":"gpt-5.6-sol","input":"hi"}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model","param":"prompt_cache_retention"}}`),
+		},
+		{
+			name:         "non-400 status is ignored",
+			body:         []byte(`{"model":"gpt-5.6-sol","prompt_cache_retention":"24h"}`),
+			responseBody: []byte(`{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model","param":"prompt_cache_retention"}}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := http.StatusBadRequest
+			if tc.name == "non-400 status is ignored" {
+				status = http.StatusInternalServerError
+			}
+
+			retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(
+				status, tc.body, tc.responseBody)
+
+			require.NoError(t, err)
+			require.False(t, changed)
+			require.Empty(t, reason)
+			require.Nil(t, retryBody)
+		})
+	}
+}
+
+// 兜底重试的目标场景：APIKey 账号 + Codex CLI 客户端。
+//
+// 这个组合是现有两处清理的真实盲区——applyCodexOAuthTransform 只对 OAuth 生效，
+// 而 openai_gateway_forward.go 的顶层清理挂在 `if !isCodexCLI` 下，Codex CLI 会
+// 跳过它。字段因此原样到达上游；上游点名拒绝后必须剥掉并同号重试一次，而不是把
+// 400 直接抛给客户端（换号 failover 也救不了参数错误）。
+func TestOpenAIGatewayService_RetriesInvalidParameterRejectionOnce(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"prompt_cache_retention":"24h","input":"hi"}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest,
+			`{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model","param":"prompt_cache_retention","type":"invalid_request_error"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK,
+			`{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+
+	c := newOpenAIRejectedFieldTestContext(body)
+	c.Request.Header.Set("User-Agent", buildCodexCLIUserAgent("0.148.0"))
+	c.Request.Header.Set("originator", "codex_cli_rs")
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		c,
+		newOpenAIRejectedFieldTestAccount(),
+		body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.True(t, gjson.GetBytes(upstream.bodies[0], "prompt_cache_retention").Exists())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_retention").Exists())
+	require.Equal(t, "hi", gjson.GetBytes(upstream.bodies[1], "input").String())
+}
+
+func readAllUpstreamRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(req.Body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
Fixes the 400 reported in #5803.

## What we observed

On one gateway running v0.1.178, **119 distinct client requests in 8 hours** were rejected by
`chatgpt.com/backend-api/codex/responses` with:

```json
{"error":{"code":"invalid_parameter",
          "message":"prompt_cache_retention is not supported on this model",
          "param":"prompt_cache_retention","type":"invalid_request_error"}}
```

That was **61% of all client-visible failures** on that gateway. A parameter rejection cannot be
rescued by switching accounts, so every one of them reached the client as a 400. 109 hit
`/v1/responses` and 10 hit `/v1/chat/completions`.

## Why the existing strips did not catch it

The field lists are not missing anything — that part of #5803's analysis is correct. v0.1.178
already strips this field in five places, most unconditionally, and the affected accounts take a
path that does:

| Site | Gate |
|---|---|
| `openai_codex_transform.go` (`openAICodexOAuthUnsupportedFields`) | OAuth only, unconditional |
| `request_body.go` ← `passthrough.go` | passthrough + OAuth, unconditional |
| `openai_gateway_forward.go` | **inside `if !isCodexCLI`** |
| `chat_completions.go` (`cursorResponsesUnsupportedFields`) | Responses-shape short-circuit |
| `grok.go` | grok |

We also ruled out, on the affected accounts: no `base_url`/`pool_mode` (talking to chatgpt.com
directly, not a second-tier relay), passthrough disabled, and **not a retry-path regression** —
each `client_request_id` logged exactly one 400, so the field was present on the very first
attempt. We also checked the `if requestView.HasPatches()` branch in `Forward` that discards the
decoded map: `HasPatches()` is `!patchesDisabled && len(patches) > 0` and `markDecodedModified()`
calls `disablePatch()`, so the decoded modifications are not lost there.

Request bodies are not persisted, so we could not determine statically which branch let the field
through. Rather than keep guessing at branches, this collapses the cleanup to the one point every
request must pass, and adds a diagnostic so the leaking branch can be identified from production.

## Changes

1. **Egress strip.** `applyChatGPTInternalEgressStrip` is called from both upstream request
   builders (`buildUpstreamRequest` and `buildUpstreamRequestOpenAIPassthrough`) right before
   `http.NewRequest`, next to the existing `normalizeDeepSeekResponsesRequestBody` egress
   normalization. It applies **only to OpenAI OAuth accounts** — API-key accounts talk to the
   Platform API or third-party compatible upstreams where these fields are legal. The field list
   reuses `openAIChatGPTInternalUnsupportedFields` so there is still one source of truth.

2. **Diagnostic.** If the egress actually removes something, an upstream branch leaked, so it logs
   at Warn with the egress name and the field names — **never values and never the request body**.

3. **Retry on `invalid_parameter`.** The rejected-field retry already existed, but
   `isExplicitOpenAIResponsesFieldRejection` only accepts code `unknown_parameter` /
   `unsupported_parameter` or a message containing "unknown/unsupported parameter". The real
   response is `invalid_parameter` with "X is not supported on this model", so both gates missed
   it; and its param handling only knew `max_output_tokens` and `input[N].namespace`. Rejections
   of whitelisted optional fields now retry once regardless of code. Safety comes from the
   whitelist rather than the code: it holds only fields with no generation semantics
   (`prompt_cache_retention`, `prompt_cache_options`, `safety_identifier`, `stream_options`,
   `metadata`, `user`), so a rejected `model` or `input[74].name` is still reported to the client
   verbatim instead of being silently rewritten. A nested param such as
   `prompt_cache_options.ttl` strips the whole top-level object.

Deliberately **not** done: normalizing to `prompt_cache_options.ttl = "30m"`. `forward.go`
historically stripped `prompt_cache_options` alongside `prompt_cache_retention`, which suggests
the internal endpoint rejected it too; adding a new field without confirming internal support
would be an experiment run in production. #5803 makes the same point about the public Platform
API docs not proving internal Codex support.

## Incidental finding

**API-key account + Codex CLI is a real blind spot** in the current cleanup:
`applyCodexOAuthTransform` only covers OAuth, and the `forward.go` strip sits under
`if !isCodexCLI`, so neither covers that combination. This surfaced while writing the retry test —
using a `curl/8.0` UA never reproduced, because that goes down the `!isCodexCLI` branch where the
field is already gone. Reproducing this class of leak requires a Codex CLI user agent. That
combination is now covered by the retry.

## Tests

`openai_upstream_egress_strip_test.go`, 9 cases. The egress case builds its probe body **from
`openAIChatGPTInternalUnsupportedFields` itself**, so adding a field to that list cannot silently
go untested; an explicit `prompt_cache_retention` case is kept pinned alongside it. There is an
end-to-end case for OAuth + Codex CLI + GPT-5.6, a case feeding a dirty body straight into
`buildUpstreamRequest` to simulate "every branch leaked", and negative cases asserting that
semantic params and `input[74].name` are untouched.

`go test ./internal/service/ -run 'OpenAI|Codex|Passthrough|Cursor|Grok'` passes on top of current
main.

## Not covered

WS v2 builds its own upstream target (`buildOpenAIResponsesWSURL` + ws payload) and does not go
through `buildUpstreamRequest`, so the egress strip does not apply there; that path already has a
test asserting the field is stripped. The passthrough path deliberately does not get the retry —
passthrough means proxying the client's request as-is, and rewriting it before retrying would
break that contract; the egress strip already covers OAuth there.
