### PR TITLE
feat: support deleting exhausted quota subscriptions

### DIFF
--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -261,11 +261,18 @@ func (h *SubscriptionHandler) RefreshQuotaAndShorten(c *gin.Context) {
 		Period         string `json:"period"`
 	}{subscriptionID, req.Period}
 	executeAdminIdempotentJSON(c, "admin.subscriptions.refresh_quota", payload, service.DefaultWriteIdempotencyTTL(), func(ctx context.Context) (any, error) {
-		subscription, execErr := h.subscriptionService.RefreshQuotaAndShorten(ctx, subscriptionID, req.Period)
+		result, execErr := h.subscriptionService.RefreshQuotaAndShorten(ctx, subscriptionID, req.Period)
 		if execErr != nil {
 			return nil, execErr
 		}
-		return dto.UserSubscriptionFromServiceAdmin(subscription), nil
+		responsePayload := gin.H{
+			"action":          result.Action,
+			"subscription_id": subscriptionID,
+		}
+		if result.Subscription != nil {
+			responsePayload["subscription"] = dto.UserSubscriptionFromServiceAdmin(result.Subscription)
+		}
+		return responsePayload, nil
 	})
 }
 

--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -57,6 +57,7 @@ type BulkAssignSubscriptionRequest struct {
 
 // RestoreSubscriptionSnapshotRequest represents an exact subscription snapshot restore request.
 type RestoreSubscriptionSnapshotRequest struct {
+	SubscriptionID     int64      `json:"subscription_id"`
 	UserID             int64      `json:"user_id" binding:"required"`
 	GroupID            int64      `json:"group_id" binding:"required"`
 	StartsAt           time.Time  `json:"starts_at" binding:"required"`
@@ -215,6 +216,7 @@ func (h *SubscriptionHandler) RestoreSnapshot(c *gin.Context) {
 	}
 
 	subscription, err := h.subscriptionService.RestoreSubscriptionSnapshot(c.Request.Context(), service.RestoreSubscriptionSnapshotInput{
+		SubscriptionID:     req.SubscriptionID,
 		UserID:             req.UserID,
 		GroupID:            req.GroupID,
 		StartsAt:           req.StartsAt,
@@ -236,6 +238,35 @@ func (h *SubscriptionHandler) RestoreSnapshot(c *gin.Context) {
 	}
 
 	response.Success(c, dto.UserSubscriptionFromServiceAdmin(subscription))
+}
+
+// RefreshQuotaAndShorten resets an exhausted quota window and removes the
+// original full window from the merged subscription duration.
+// POST /api/v1/admin/subscriptions/:id/refresh-quota
+func (h *SubscriptionHandler) RefreshQuotaAndShorten(c *gin.Context) {
+	subscriptionID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid subscription ID")
+		return
+	}
+	var req struct {
+		Period string `json:"period" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	payload := struct {
+		SubscriptionID int64  `json:"subscription_id"`
+		Period         string `json:"period"`
+	}{subscriptionID, req.Period}
+	executeAdminIdempotentJSON(c, "admin.subscriptions.refresh_quota", payload, service.DefaultWriteIdempotencyTTL(), func(ctx context.Context) (any, error) {
+		subscription, execErr := h.subscriptionService.RefreshQuotaAndShorten(ctx, subscriptionID, req.Period)
+		if execErr != nil {
+			return nil, execErr
+		}
+		return dto.UserSubscriptionFromServiceAdmin(subscription), nil
+	})
 }
 
 // Extend handles adjusting a subscription (extend or shorten)

--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -52,6 +53,24 @@ type BulkAssignSubscriptionRequest struct {
 	GroupID      int64   `json:"group_id" binding:"required"`
 	ValidityDays int     `json:"validity_days" binding:"omitempty,max=36500"` // max 100 years
 	Notes        string  `json:"notes"`
+}
+
+// RestoreSubscriptionSnapshotRequest represents an exact subscription snapshot restore request.
+type RestoreSubscriptionSnapshotRequest struct {
+	UserID             int64      `json:"user_id" binding:"required"`
+	GroupID            int64      `json:"group_id" binding:"required"`
+	StartsAt           time.Time  `json:"starts_at" binding:"required"`
+	ExpiresAt          time.Time  `json:"expires_at" binding:"required"`
+	Status             string     `json:"status"`
+	DailyWindowStart   *time.Time `json:"daily_window_start"`
+	WeeklyWindowStart  *time.Time `json:"weekly_window_start"`
+	MonthlyWindowStart *time.Time `json:"monthly_window_start"`
+	DailyUsageUSD      float64    `json:"daily_usage_usd"`
+	WeeklyUsageUSD     float64    `json:"weekly_usage_usd"`
+	MonthlyUsageUSD    float64    `json:"monthly_usage_usd"`
+	AssignedBy         *int64     `json:"assigned_by"`
+	AssignedAt         time.Time  `json:"assigned_at"`
+	Notes              string     `json:"notes"`
 }
 
 // AdjustSubscriptionRequest represents adjust subscription request (extend or shorten)
@@ -184,6 +203,39 @@ func (h *SubscriptionHandler) BulkAssign(c *gin.Context) {
 	}
 
 	response.Success(c, dto.BulkAssignResultFromService(result))
+}
+
+// RestoreSnapshot restores an exact subscription snapshot.
+// POST /api/v1/admin/subscriptions/restore
+func (h *SubscriptionHandler) RestoreSnapshot(c *gin.Context) {
+	var req RestoreSubscriptionSnapshotRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	subscription, err := h.subscriptionService.RestoreSubscriptionSnapshot(c.Request.Context(), service.RestoreSubscriptionSnapshotInput{
+		UserID:             req.UserID,
+		GroupID:            req.GroupID,
+		StartsAt:           req.StartsAt,
+		ExpiresAt:          req.ExpiresAt,
+		Status:             req.Status,
+		DailyWindowStart:   req.DailyWindowStart,
+		WeeklyWindowStart:  req.WeeklyWindowStart,
+		MonthlyWindowStart: req.MonthlyWindowStart,
+		DailyUsageUSD:      req.DailyUsageUSD,
+		WeeklyUsageUSD:     req.WeeklyUsageUSD,
+		MonthlyUsageUSD:    req.MonthlyUsageUSD,
+		AssignedBy:         req.AssignedBy,
+		AssignedAt:         req.AssignedAt,
+		Notes:              req.Notes,
+	})
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.UserSubscriptionFromServiceAdmin(subscription))
 }
 
 // Extend handles adjusting a subscription (extend or shorten)

--- a/backend/internal/handler/admin/subscription_handler_test.go
+++ b/backend/internal/handler/admin/subscription_handler_test.go
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type restoreSnapshotUserSubRepo struct {
+	service.UserSubscriptionRepository
+
+	created *service.UserSubscription
+}
+
+func (r *restoreSnapshotUserSubRepo) Create(_ context.Context, sub *service.UserSubscription) error {
+	cp := *sub
+	cp.ID = 42
+	cp.CreatedAt = time.Date(2026, 5, 7, 10, 30, 0, 0, time.UTC)
+	cp.UpdatedAt = cp.CreatedAt
+	sub.ID = cp.ID
+	sub.CreatedAt = cp.CreatedAt
+	sub.UpdatedAt = cp.UpdatedAt
+	r.created = &cp
+	return nil
+}
+
+func TestSubscriptionHandlerRestoreSnapshotMapsRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &restoreSnapshotUserSubRepo{}
+	svc := service.NewSubscriptionService(nil, repo, nil, nil, nil)
+	handler := NewSubscriptionHandler(svc)
+	router := gin.New()
+	router.POST("/api/v1/admin/subscriptions/restore", handler.RestoreSnapshot)
+
+	body := []byte(`{
+		"user_id": 31,
+		"group_id": 7,
+		"starts_at": "2026-05-01T10:00:00Z",
+		"expires_at": "2026-05-31T10:00:00Z",
+		"status": "active",
+		"daily_window_start": "2026-05-07T00:00:00Z",
+		"weekly_window_start": "2026-05-04T00:00:00Z",
+		"monthly_window_start": "2026-05-01T00:00:00Z",
+		"daily_usage_usd": 1.25,
+		"weekly_usage_usd": 2.5,
+		"monthly_usage_usd": 8.75,
+		"assigned_by": 99,
+		"assigned_at": "2026-05-01T10:01:00Z",
+		"notes": "restore by sales-man after-sales operation op-1"
+	}`)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/subscriptions/restore", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.NotNil(t, repo.created)
+	require.Equal(t, int64(31), repo.created.UserID)
+	require.Equal(t, int64(7), repo.created.GroupID)
+	require.Equal(t, service.SubscriptionStatusActive, repo.created.Status)
+	require.Equal(t, 8.75, repo.created.MonthlyUsageUSD)
+	require.NotNil(t, repo.created.DailyWindowStart)
+	require.Equal(t, time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), *repo.created.DailyWindowStart)
+	require.Contains(t, rec.Body.String(), `"id":42`)
+	require.Contains(t, rec.Body.String(), `"monthly_usage_usd":8.75`)
+}
+
+func TestSubscriptionHandlerRestoreSnapshotRejectsInvalidRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &restoreSnapshotUserSubRepo{}
+	svc := service.NewSubscriptionService(nil, repo, nil, nil, nil)
+	handler := NewSubscriptionHandler(svc)
+	router := gin.New()
+	router.POST("/api/v1/admin/subscriptions/restore", handler.RestoreSnapshot)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/subscriptions/restore", bytes.NewReader([]byte(`{"group_id":7}`)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Nil(t, repo.created)
+}

--- a/backend/internal/repository/user_subscription_repo.go
+++ b/backend/internal/repository/user_subscription_repo.go
@@ -6,6 +6,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/group"
+	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	"github.com/Wei-Shaw/sub2api/ent/usersubscription"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -124,6 +125,49 @@ func (r *userSubscriptionRepository) Update(ctx context.Context, sub *service.Us
 		SetNotes(sub.Notes)
 
 	updated, err := builder.Save(ctx)
+	if err == nil {
+		applyUserSubscriptionEntityToService(sub, updated)
+		return nil
+	}
+	return translatePersistenceError(err, service.ErrSubscriptionNotFound, service.ErrSubscriptionAlreadyExists)
+}
+
+// RestoreSnapshot restores an existing subscription, including one hidden by
+// soft deletion, while preserving its original ID.
+func (r *userSubscriptionRepository) RestoreSnapshot(ctx context.Context, sub *service.UserSubscription) error {
+	if sub == nil {
+		return service.ErrSubscriptionNilInput
+	}
+
+	client := clientFromContext(ctx, r.client)
+	restoreCtx := mixins.SkipSoftDelete(ctx)
+	existing, err := client.UserSubscription.Query().
+		Where(usersubscription.IDEQ(sub.ID)).
+		Only(restoreCtx)
+	if err != nil {
+		return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	}
+	if existing.UserID != sub.UserID || existing.GroupID != sub.GroupID {
+		return service.ErrSubscriptionRestoreMismatch
+	}
+
+	updated, err := client.UserSubscription.UpdateOneID(sub.ID).
+		SetUserID(sub.UserID).
+		SetGroupID(sub.GroupID).
+		SetStartsAt(sub.StartsAt).
+		SetExpiresAt(sub.ExpiresAt).
+		SetStatus(sub.Status).
+		SetNillableDailyWindowStart(sub.DailyWindowStart).
+		SetNillableWeeklyWindowStart(sub.WeeklyWindowStart).
+		SetNillableMonthlyWindowStart(sub.MonthlyWindowStart).
+		SetDailyUsageUsd(sub.DailyUsageUSD).
+		SetWeeklyUsageUsd(sub.WeeklyUsageUSD).
+		SetMonthlyUsageUsd(sub.MonthlyUsageUSD).
+		SetNillableAssignedBy(sub.AssignedBy).
+		SetAssignedAt(sub.AssignedAt).
+		SetNotes(sub.Notes).
+		ClearDeletedAt().
+		Save(restoreCtx)
 	if err == nil {
 		applyUserSubscriptionEntityToService(sub, updated)
 		return nil

--- a/backend/internal/repository/user_subscription_repo.go
+++ b/backend/internal/repository/user_subscription_repo.go
@@ -336,6 +336,26 @@ func (r *userSubscriptionRepository) ResetMonthlyUsage(ctx context.Context, id i
 	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
 }
 
+// RefreshQuotaAndShorten atomically clears one quota window and shortens the
+// subscription to the newly purchased layer. The service validates the
+// eligibility rule before calling this method.
+func (r *userSubscriptionRepository) RefreshQuotaAndShorten(ctx context.Context, id int64, period string, newExpiresAt, newWindowStart time.Time) error {
+	client := clientFromContext(ctx, r.client)
+	query := client.UserSubscription.UpdateOneID(id).SetExpiresAt(newExpiresAt)
+	switch period {
+	case "daily":
+		query.SetDailyUsageUsd(0).SetDailyWindowStart(newWindowStart)
+	case "weekly":
+		query.SetWeeklyUsageUsd(0).SetWeeklyWindowStart(newWindowStart)
+	case "monthly":
+		query.SetMonthlyUsageUsd(0).SetMonthlyWindowStart(newWindowStart)
+	default:
+		return service.ErrInvalidInput
+	}
+	_, err := query.Save(ctx)
+	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+}
+
 // IncrementUsage 原子性地累加订阅用量。
 // 限额检查已在请求前由 BillingCacheService.CheckBillingEligibility 完成，
 // 此处仅负责记录实际消费，确保消费数据的完整性。

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -494,6 +494,7 @@ func registerSubscriptionRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		subscriptions.POST("/restore", h.Admin.Subscription.RestoreSnapshot)
 		subscriptions.POST("/:id/extend", h.Admin.Subscription.Extend)
 		subscriptions.POST("/:id/reset-quota", h.Admin.Subscription.ResetQuota)
+		subscriptions.POST("/:id/refresh-quota", h.Admin.Subscription.RefreshQuotaAndShorten)
 		subscriptions.DELETE("/:id", h.Admin.Subscription.Revoke)
 	}
 

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -491,6 +491,7 @@ func registerSubscriptionRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		subscriptions.GET("/:id/progress", h.Admin.Subscription.GetProgress)
 		subscriptions.POST("/assign", h.Admin.Subscription.Assign)
 		subscriptions.POST("/bulk-assign", h.Admin.Subscription.BulkAssign)
+		subscriptions.POST("/restore", h.Admin.Subscription.RestoreSnapshot)
 		subscriptions.POST("/:id/extend", h.Admin.Subscription.Extend)
 		subscriptions.POST("/:id/reset-quota", h.Admin.Subscription.ResetQuota)
 		subscriptions.DELETE("/:id", h.Admin.Subscription.Revoke)

--- a/backend/internal/service/subscription_quota_refresh_test.go
+++ b/backend/internal/service/subscription_quota_refresh_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type quotaRefreshUserSubRepoStub struct {
+	userSubRepoNoop
+	sub       *UserSubscription
+	refreshed bool
+	period    string
+	newExpiry time.Time
+}
+
+func (r *quotaRefreshUserSubRepoStub) GetByID(_ context.Context, id int64) (*UserSubscription, error) {
+	if r.sub == nil || r.sub.ID != id {
+		return nil, ErrSubscriptionNotFound
+	}
+	cp := *r.sub
+	return &cp, nil
+}
+
+func (r *quotaRefreshUserSubRepoStub) RefreshQuotaAndShorten(_ context.Context, _ int64, period string, newExpiresAt, newWindowStart time.Time) error {
+	r.refreshed = true
+	r.period = period
+	r.newExpiry = newExpiresAt
+	r.sub.ExpiresAt = newExpiresAt
+	r.sub.MonthlyUsageUSD = 0
+	r.sub.MonthlyWindowStart = &newWindowStart
+	return nil
+}
+
+func TestRefreshQuotaAndShortenKeepsRenewalLayer(t *testing.T) {
+	now := time.Now()
+	windowStart := now.Add(-6 * 24 * time.Hour)
+	repo := &quotaRefreshUserSubRepoStub{}
+	repo.sub = &UserSubscription{
+		ID:                 99,
+		UserID:             31,
+		GroupID:            7,
+		Status:             SubscriptionStatusActive,
+		StartsAt:           windowStart,
+		ExpiresAt:          now.Add(54 * 24 * time.Hour),
+		MonthlyWindowStart: &windowStart,
+		MonthlyUsageUSD:    39,
+		Group:              &Group{ID: 7, MonthlyLimitUSD: func() *float64 { v := 39.0; return &v }()},
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+
+	result, err := svc.RefreshQuotaAndShorten(context.Background(), 99, "monthly")
+
+	require.NoError(t, err)
+	require.True(t, repo.refreshed)
+	require.Equal(t, "monthly", repo.period)
+	require.InDelta(t, now.Add(30*24*time.Hour).Unix(), repo.newExpiry.Unix(), 3)
+	require.Equal(t, float64(0), result.MonthlyUsageUSD)
+}
+
+func TestRefreshQuotaAndShortenRejectsQuotaThatIsNotFull(t *testing.T) {
+	now := time.Now()
+	windowStart := now.Add(-6 * 24 * time.Hour)
+	limit := 39.0
+	repo := &quotaRefreshUserSubRepoStub{sub: &UserSubscription{
+		ID:                 99,
+		UserID:             31,
+		GroupID:            7,
+		Status:             SubscriptionStatusActive,
+		ExpiresAt:          now.Add(54 * 24 * time.Hour),
+		MonthlyWindowStart: &windowStart,
+		MonthlyUsageUSD:    38.99,
+		Group:              &Group{ID: 7, MonthlyLimitUSD: &limit},
+	}}
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+
+	_, err := svc.RefreshQuotaAndShorten(context.Background(), 99, "monthly")
+
+	require.Error(t, err)
+	require.False(t, repo.refreshed)
+}

--- a/backend/internal/service/subscription_quota_refresh_test.go
+++ b/backend/internal/service/subscription_quota_refresh_test.go
@@ -12,8 +12,18 @@ type quotaRefreshUserSubRepoStub struct {
 	userSubRepoNoop
 	sub       *UserSubscription
 	refreshed bool
+	deleted   bool
 	period    string
 	newExpiry time.Time
+}
+
+func (r *quotaRefreshUserSubRepoStub) Delete(_ context.Context, id int64) error {
+	if r.sub == nil || r.sub.ID != id {
+		return ErrSubscriptionNotFound
+	}
+	r.deleted = true
+	r.sub = nil
+	return nil
 }
 
 func (r *quotaRefreshUserSubRepoStub) GetByID(_ context.Context, id int64) (*UserSubscription, error) {
@@ -55,9 +65,59 @@ func TestRefreshQuotaAndShortenKeepsRenewalLayer(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, repo.refreshed)
+	require.Equal(t, QuotaRefreshActionRefreshed, result.Action)
+	require.NotNil(t, result.Subscription)
 	require.Equal(t, "monthly", repo.period)
 	require.InDelta(t, now.Add(30*24*time.Hour).Unix(), repo.newExpiry.Unix(), 3)
-	require.Equal(t, float64(0), result.MonthlyUsageUSD)
+	require.Equal(t, float64(0), result.Subscription.MonthlyUsageUSD)
+}
+
+func TestRefreshQuotaAndShortenUsesActualOldWindowRemainder(t *testing.T) {
+	now := time.Now()
+	windowStart := now.Add(-25 * 24 * time.Hour)
+	limit := 39.0
+	repo := &quotaRefreshUserSubRepoStub{sub: &UserSubscription{
+		ID:                 99,
+		UserID:             31,
+		GroupID:            7,
+		Status:             SubscriptionStatusActive,
+		ExpiresAt:          now.Add(95 * 24 * time.Hour),
+		MonthlyWindowStart: &windowStart,
+		MonthlyUsageUSD:    39,
+		Group:              &Group{ID: 7, MonthlyLimitUSD: &limit},
+	}}
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+
+	result, err := svc.RefreshQuotaAndShorten(context.Background(), 99, "monthly")
+
+	require.NoError(t, err)
+	require.Equal(t, QuotaRefreshActionRefreshed, result.Action)
+	require.InDelta(t, now.Add(90*24*time.Hour).Unix(), repo.newExpiry.Unix(), 3)
+}
+
+func TestRefreshQuotaAndShortenDeletesWhenNoRenewalTimeRemains(t *testing.T) {
+	now := time.Now()
+	windowStart := now.Add(-25 * 24 * time.Hour)
+	limit := 39.0
+	repo := &quotaRefreshUserSubRepoStub{sub: &UserSubscription{
+		ID:                 99,
+		UserID:             31,
+		GroupID:            7,
+		Status:             SubscriptionStatusActive,
+		ExpiresAt:          now.Add(5 * 24 * time.Hour),
+		MonthlyWindowStart: &windowStart,
+		MonthlyUsageUSD:    39,
+		Group:              &Group{ID: 7, MonthlyLimitUSD: &limit},
+	}}
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+
+	result, err := svc.RefreshQuotaAndShorten(context.Background(), 99, "monthly")
+
+	require.NoError(t, err)
+	require.Equal(t, QuotaRefreshActionDeleted, result.Action)
+	require.Nil(t, result.Subscription)
+	require.True(t, repo.deleted)
+	require.False(t, repo.refreshed)
 }
 
 func TestRefreshQuotaAndShortenRejectsQuotaThatIsNotFull(t *testing.T) {

--- a/backend/internal/service/subscription_restore_test.go
+++ b/backend/internal/service/subscription_restore_test.go
@@ -11,8 +11,18 @@ import (
 type subscriptionRestoreRepoStub struct {
 	userSubRepoNoop
 
-	nextID  int64
-	created *UserSubscription
+	nextID   int64
+	created  *UserSubscription
+	restored *UserSubscription
+}
+
+func (r *subscriptionRestoreRepoStub) RestoreSnapshot(_ context.Context, sub *UserSubscription) error {
+	if sub == nil {
+		return ErrSubscriptionNilInput
+	}
+	cp := *sub
+	r.restored = &cp
+	return nil
 }
 
 func newSubscriptionRestoreRepoStub() *subscriptionRestoreRepoStub {
@@ -113,4 +123,26 @@ func TestRestoreSubscriptionSnapshotRequiresUserAndGroup(t *testing.T) {
 
 	require.Error(t, err)
 	require.Nil(t, repo.created)
+}
+
+func TestRestoreSubscriptionSnapshotRestoresSoftDeletedID(t *testing.T) {
+	repo := newSubscriptionRestoreRepoStub()
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+	startsAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	expiresAt := startsAt.AddDate(0, 0, 30)
+
+	sub, err := svc.RestoreSubscriptionSnapshot(context.Background(), RestoreSubscriptionSnapshotInput{
+		SubscriptionID: 99,
+		UserID:         41,
+		GroupID:        9,
+		StartsAt:       startsAt,
+		ExpiresAt:      expiresAt,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(99), sub.ID)
+	require.NotNil(t, repo.restored)
+	require.Equal(t, int64(99), repo.restored.ID)
+	require.Equal(t, int64(41), repo.restored.UserID)
+	require.Equal(t, int64(9), repo.restored.GroupID)
 }

--- a/backend/internal/service/subscription_restore_test.go
+++ b/backend/internal/service/subscription_restore_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type subscriptionRestoreRepoStub struct {
+	userSubRepoNoop
+
+	nextID  int64
+	created *UserSubscription
+}
+
+func newSubscriptionRestoreRepoStub() *subscriptionRestoreRepoStub {
+	return &subscriptionRestoreRepoStub{nextID: 1}
+}
+
+func (r *subscriptionRestoreRepoStub) Create(_ context.Context, sub *UserSubscription) error {
+	if sub == nil {
+		return ErrSubscriptionNilInput
+	}
+	cp := *sub
+	if cp.ID == 0 {
+		cp.ID = r.nextID
+		r.nextID++
+	}
+	sub.ID = cp.ID
+	r.created = &cp
+	return nil
+}
+
+func TestRestoreSubscriptionSnapshotCreatesExactSubscription(t *testing.T) {
+	repo := newSubscriptionRestoreRepoStub()
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+	startsAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	expiresAt := time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+	dailyWindow := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	weeklyWindow := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
+	monthlyWindow := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	assignedBy := int64(99)
+	assignedAt := time.Date(2026, 5, 1, 10, 1, 0, 0, time.UTC)
+
+	sub, err := svc.RestoreSubscriptionSnapshot(context.Background(), RestoreSubscriptionSnapshotInput{
+		UserID:             31,
+		GroupID:            7,
+		StartsAt:           startsAt,
+		ExpiresAt:          expiresAt,
+		Status:             SubscriptionStatusActive,
+		DailyWindowStart:   &dailyWindow,
+		WeeklyWindowStart:  &weeklyWindow,
+		MonthlyWindowStart: &monthlyWindow,
+		DailyUsageUSD:      1.25,
+		WeeklyUsageUSD:     2.5,
+		MonthlyUsageUSD:    8.75,
+		AssignedBy:         &assignedBy,
+		AssignedAt:         assignedAt,
+		Notes:              "restore by sales-man after-sales operation op-1",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	require.Equal(t, int64(31), sub.UserID)
+	require.Equal(t, int64(7), sub.GroupID)
+	require.Equal(t, startsAt, sub.StartsAt)
+	require.Equal(t, expiresAt, sub.ExpiresAt)
+	require.Equal(t, SubscriptionStatusActive, sub.Status)
+	require.NotNil(t, sub.DailyWindowStart)
+	require.Equal(t, dailyWindow, *sub.DailyWindowStart)
+	require.NotNil(t, sub.WeeklyWindowStart)
+	require.Equal(t, weeklyWindow, *sub.WeeklyWindowStart)
+	require.NotNil(t, sub.MonthlyWindowStart)
+	require.Equal(t, monthlyWindow, *sub.MonthlyWindowStart)
+	require.Equal(t, 1.25, sub.DailyUsageUSD)
+	require.Equal(t, 2.5, sub.WeeklyUsageUSD)
+	require.Equal(t, 8.75, sub.MonthlyUsageUSD)
+	require.Equal(t, &assignedBy, sub.AssignedBy)
+	require.Equal(t, assignedAt, sub.AssignedAt)
+	require.Equal(t, "restore by sales-man after-sales operation op-1", sub.Notes)
+}
+
+func TestRestoreSubscriptionSnapshotDefaultsStatusAndAssignedAt(t *testing.T) {
+	repo := newSubscriptionRestoreRepoStub()
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+	startsAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	expiresAt := startsAt.AddDate(0, 0, 30)
+
+	sub, err := svc.RestoreSubscriptionSnapshot(context.Background(), RestoreSubscriptionSnapshotInput{
+		UserID:    41,
+		GroupID:   9,
+		StartsAt:  startsAt,
+		ExpiresAt: expiresAt,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, SubscriptionStatusActive, sub.Status)
+	require.False(t, sub.AssignedAt.IsZero())
+	require.Equal(t, startsAt, sub.StartsAt)
+	require.Equal(t, expiresAt, sub.ExpiresAt)
+}
+
+func TestRestoreSubscriptionSnapshotRequiresUserAndGroup(t *testing.T) {
+	repo := newSubscriptionRestoreRepoStub()
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+
+	_, err := svc.RestoreSubscriptionSnapshot(context.Background(), RestoreSubscriptionSnapshotInput{
+		UserID:  0,
+		GroupID: 7,
+	})
+
+	require.Error(t, err)
+	require.Nil(t, repo.created)
+}

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -55,6 +55,10 @@ type SubscriptionService struct {
 	maintenanceQueue *SubscriptionMaintenanceQueue
 }
 
+type quotaRefreshRepository interface {
+	RefreshQuotaAndShorten(ctx context.Context, id int64, period string, newExpiresAt, newWindowStart time.Time) error
+}
+
 // NewSubscriptionService 创建订阅服务
 func NewSubscriptionService(groupRepo GroupRepository, userSubRepo UserSubscriptionRepository, billingCacheService *BillingCacheService, entClient *dbent.Client, cfg *config.Config) *SubscriptionService {
 	svc := &SubscriptionService{
@@ -153,6 +157,7 @@ type AssignSubscriptionInput struct {
 
 // RestoreSubscriptionSnapshotInput restores an exact subscription snapshot for admin rollback.
 type RestoreSubscriptionSnapshotInput struct {
+	SubscriptionID     int64
 	UserID             int64
 	GroupID            int64
 	StartsAt           time.Time
@@ -210,7 +215,19 @@ func (s *SubscriptionService) RestoreSubscriptionSnapshot(ctx context.Context, i
 		sub.AssignedAt = now
 	}
 
-	if err := s.userSubRepo.Create(ctx, sub); err != nil {
+	if input.SubscriptionID > 0 {
+		existing, err := s.userSubRepo.GetByID(ctx, input.SubscriptionID)
+		if err != nil {
+			return nil, err
+		}
+		if existing.UserID != input.UserID || existing.GroupID != input.GroupID {
+			return nil, infraerrors.BadRequest("INVALID_SUBSCRIPTION_RESTORE", "snapshot identity does not match subscription")
+		}
+		sub.ID = input.SubscriptionID
+		if err := s.userSubRepo.Update(ctx, sub); err != nil {
+			return nil, err
+		}
+	} else if err := s.userSubRepo.Create(ctx, sub); err != nil {
 		return nil, err
 	}
 
@@ -220,6 +237,77 @@ func (s *SubscriptionService) RestoreSubscriptionSnapshot(ctx context.Context, i
 	}
 
 	return sub, nil
+}
+
+// RefreshQuotaAndShorten validates and applies the renewal-layer quota refresh
+// as one upstream mutation. Only a quota-exhausted subscription with a
+// non-expired original window and a positive renewal remainder is eligible.
+func (s *SubscriptionService) RefreshQuotaAndShorten(ctx context.Context, subscriptionID int64, period string) (*UserSubscription, error) {
+	if subscriptionID <= 0 {
+		return nil, infraerrors.BadRequest("INVALID_INPUT", "subscription_id is required")
+	}
+	sub, err := s.userSubRepo.GetByID(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	if sub.Group == nil {
+		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "subscription group is missing")
+	}
+	if sub.Status != SubscriptionStatusActive || !sub.ExpiresAt.After(time.Now()) {
+		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "subscription is not active")
+	}
+	var windowStart *time.Time
+	var usage, limit float64
+	var periodDays int
+	switch period {
+	case "daily":
+		windowStart, usage, periodDays = sub.DailyWindowStart, sub.DailyUsageUSD, 1
+		if sub.Group.DailyLimitUSD != nil {
+			limit = *sub.Group.DailyLimitUSD
+		}
+	case "weekly":
+		windowStart, usage, periodDays = sub.WeeklyWindowStart, sub.WeeklyUsageUSD, 7
+		if sub.Group.WeeklyLimitUSD != nil {
+			limit = *sub.Group.WeeklyLimitUSD
+		}
+	case "monthly":
+		windowStart, usage, periodDays = sub.MonthlyWindowStart, sub.MonthlyUsageUSD, 30
+		if sub.Group.MonthlyLimitUSD != nil {
+			limit = *sub.Group.MonthlyLimitUSD
+		}
+	default:
+		return nil, infraerrors.BadRequest("INVALID_INPUT", "period must be daily, weekly, or monthly")
+	}
+	if limit <= 0 || usage < limit || windowStart == nil {
+		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "subscription does not have an exhausted quota window")
+	}
+	now := time.Now()
+	oldRemaining := windowStart.AddDate(0, 0, periodDays).Sub(now)
+	if oldRemaining <= 0 {
+		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "the exhausted quota window has already ended")
+	}
+	totalRemaining := sub.ExpiresAt.Sub(now)
+	newRemaining := totalRemaining - oldRemaining
+	if newRemaining <= 0 {
+		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "no renewal time remains after the original layer")
+	}
+	newExpiresAt := sub.ExpiresAt.Add(-oldRemaining)
+	newWindowStart := startOfDay(now)
+	repo, ok := s.userSubRepo.(quotaRefreshRepository)
+	if !ok {
+		return nil, infraerrors.InternalServer("QUOTA_REFRESH_UNAVAILABLE", "quota refresh repository is unavailable")
+	}
+	if err := repo.RefreshQuotaAndShorten(ctx, sub.ID, period, newExpiresAt, newWindowStart); err != nil {
+		return nil, err
+	}
+	s.InvalidateSubCache(sub.UserID, sub.GroupID)
+	if s.subCacheL1 != nil {
+		s.subCacheL1.Wait()
+	}
+	if s.billingCacheService != nil {
+		_ = s.billingCacheService.InvalidateSubscription(ctx, sub.UserID, sub.GroupID)
+	}
+	return s.userSubRepo.GetByID(ctx, subscriptionID)
 }
 
 // AssignOrExtendSubscription 分配或续期订阅（用于兑换码等场景）

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -25,18 +25,19 @@ var MaxExpiresAt = time.Date(2099, 12, 31, 23, 59, 59, 0, time.UTC)
 const MaxValidityDays = 36500
 
 var (
-	ErrSubscriptionNotFound       = infraerrors.NotFound("SUBSCRIPTION_NOT_FOUND", "subscription not found")
-	ErrSubscriptionExpired        = infraerrors.Forbidden("SUBSCRIPTION_EXPIRED", "subscription has expired")
-	ErrSubscriptionSuspended      = infraerrors.Forbidden("SUBSCRIPTION_SUSPENDED", "subscription is suspended")
-	ErrSubscriptionAlreadyExists  = infraerrors.Conflict("SUBSCRIPTION_ALREADY_EXISTS", "subscription already exists for this user and group")
-	ErrSubscriptionAssignConflict = infraerrors.Conflict("SUBSCRIPTION_ASSIGN_CONFLICT", "subscription exists but request conflicts with existing assignment semantics")
-	ErrGroupNotSubscriptionType   = infraerrors.BadRequest("GROUP_NOT_SUBSCRIPTION_TYPE", "group is not a subscription type")
-	ErrInvalidInput               = infraerrors.BadRequest("INVALID_INPUT", "at least one of resetDaily, resetWeekly, or resetMonthly must be true")
-	ErrDailyLimitExceeded         = infraerrors.TooManyRequests("DAILY_LIMIT_EXCEEDED", "daily usage limit exceeded")
-	ErrWeeklyLimitExceeded        = infraerrors.TooManyRequests("WEEKLY_LIMIT_EXCEEDED", "weekly usage limit exceeded")
-	ErrMonthlyLimitExceeded       = infraerrors.TooManyRequests("MONTHLY_LIMIT_EXCEEDED", "monthly usage limit exceeded")
-	ErrSubscriptionNilInput       = infraerrors.BadRequest("SUBSCRIPTION_NIL_INPUT", "subscription input cannot be nil")
-	ErrAdjustWouldExpire          = infraerrors.BadRequest("ADJUST_WOULD_EXPIRE", "adjustment would result in expired subscription (remaining days must be > 0)")
+	ErrSubscriptionNotFound        = infraerrors.NotFound("SUBSCRIPTION_NOT_FOUND", "subscription not found")
+	ErrSubscriptionExpired         = infraerrors.Forbidden("SUBSCRIPTION_EXPIRED", "subscription has expired")
+	ErrSubscriptionSuspended       = infraerrors.Forbidden("SUBSCRIPTION_SUSPENDED", "subscription is suspended")
+	ErrSubscriptionAlreadyExists   = infraerrors.Conflict("SUBSCRIPTION_ALREADY_EXISTS", "subscription already exists for this user and group")
+	ErrSubscriptionAssignConflict  = infraerrors.Conflict("SUBSCRIPTION_ASSIGN_CONFLICT", "subscription exists but request conflicts with existing assignment semantics")
+	ErrGroupNotSubscriptionType    = infraerrors.BadRequest("GROUP_NOT_SUBSCRIPTION_TYPE", "group is not a subscription type")
+	ErrInvalidInput                = infraerrors.BadRequest("INVALID_INPUT", "at least one of resetDaily, resetWeekly, or resetMonthly must be true")
+	ErrDailyLimitExceeded          = infraerrors.TooManyRequests("DAILY_LIMIT_EXCEEDED", "daily usage limit exceeded")
+	ErrWeeklyLimitExceeded         = infraerrors.TooManyRequests("WEEKLY_LIMIT_EXCEEDED", "weekly usage limit exceeded")
+	ErrMonthlyLimitExceeded        = infraerrors.TooManyRequests("MONTHLY_LIMIT_EXCEEDED", "monthly usage limit exceeded")
+	ErrSubscriptionNilInput        = infraerrors.BadRequest("SUBSCRIPTION_NIL_INPUT", "subscription input cannot be nil")
+	ErrSubscriptionRestoreMismatch = infraerrors.BadRequest("INVALID_SUBSCRIPTION_RESTORE", "snapshot identity does not match subscription")
+	ErrAdjustWouldExpire           = infraerrors.BadRequest("ADJUST_WOULD_EXPIRE", "adjustment would result in expired subscription (remaining days must be > 0)")
 )
 
 // SubscriptionService 订阅服务
@@ -57,6 +58,20 @@ type SubscriptionService struct {
 
 type quotaRefreshRepository interface {
 	RefreshQuotaAndShorten(ctx context.Context, id int64, period string, newExpiresAt, newWindowStart time.Time) error
+}
+
+type subscriptionSnapshotRestorer interface {
+	RestoreSnapshot(ctx context.Context, sub *UserSubscription) error
+}
+
+const (
+	QuotaRefreshActionRefreshed = "refreshed"
+	QuotaRefreshActionDeleted   = "deleted"
+)
+
+type QuotaRefreshResult struct {
+	Action       string
+	Subscription *UserSubscription
 }
 
 // NewSubscriptionService 创建订阅服务
@@ -216,16 +231,22 @@ func (s *SubscriptionService) RestoreSubscriptionSnapshot(ctx context.Context, i
 	}
 
 	if input.SubscriptionID > 0 {
-		existing, err := s.userSubRepo.GetByID(ctx, input.SubscriptionID)
-		if err != nil {
-			return nil, err
-		}
-		if existing.UserID != input.UserID || existing.GroupID != input.GroupID {
-			return nil, infraerrors.BadRequest("INVALID_SUBSCRIPTION_RESTORE", "snapshot identity does not match subscription")
-		}
 		sub.ID = input.SubscriptionID
-		if err := s.userSubRepo.Update(ctx, sub); err != nil {
-			return nil, err
+		if restorer, ok := s.userSubRepo.(subscriptionSnapshotRestorer); ok {
+			if err := restorer.RestoreSnapshot(ctx, sub); err != nil {
+				return nil, err
+			}
+		} else {
+			existing, err := s.userSubRepo.GetByID(ctx, input.SubscriptionID)
+			if err != nil {
+				return nil, err
+			}
+			if existing.UserID != input.UserID || existing.GroupID != input.GroupID {
+				return nil, ErrSubscriptionRestoreMismatch
+			}
+			if err := s.userSubRepo.Update(ctx, sub); err != nil {
+				return nil, err
+			}
 		}
 	} else if err := s.userSubRepo.Create(ctx, sub); err != nil {
 		return nil, err
@@ -240,9 +261,9 @@ func (s *SubscriptionService) RestoreSubscriptionSnapshot(ctx context.Context, i
 }
 
 // RefreshQuotaAndShorten validates and applies the renewal-layer quota refresh
-// as one upstream mutation. Only a quota-exhausted subscription with a
-// non-expired original window and a positive renewal remainder is eligible.
-func (s *SubscriptionService) RefreshQuotaAndShorten(ctx context.Context, subscriptionID int64, period string) (*UserSubscription, error) {
+// as one upstream mutation. If the original exhausted window consumes all
+// remaining time, the subscription is deleted instead.
+func (s *SubscriptionService) RefreshQuotaAndShorten(ctx context.Context, subscriptionID int64, period string) (*QuotaRefreshResult, error) {
 	if subscriptionID <= 0 {
 		return nil, infraerrors.BadRequest("INVALID_INPUT", "subscription_id is required")
 	}
@@ -289,7 +310,17 @@ func (s *SubscriptionService) RefreshQuotaAndShorten(ctx context.Context, subscr
 	totalRemaining := sub.ExpiresAt.Sub(now)
 	newRemaining := totalRemaining - oldRemaining
 	if newRemaining <= 0 {
-		return nil, infraerrors.BadRequest("QUOTA_REFRESH_UNAVAILABLE", "no renewal time remains after the original layer")
+		if err := s.userSubRepo.Delete(ctx, sub.ID); err != nil {
+			return nil, err
+		}
+		s.InvalidateSubCache(sub.UserID, sub.GroupID)
+		if s.subCacheL1 != nil {
+			s.subCacheL1.Wait()
+		}
+		if s.billingCacheService != nil {
+			_ = s.billingCacheService.InvalidateSubscription(ctx, sub.UserID, sub.GroupID)
+		}
+		return &QuotaRefreshResult{Action: QuotaRefreshActionDeleted}, nil
 	}
 	newExpiresAt := sub.ExpiresAt.Add(-oldRemaining)
 	newWindowStart := startOfDay(now)
@@ -307,7 +338,14 @@ func (s *SubscriptionService) RefreshQuotaAndShorten(ctx context.Context, subscr
 	if s.billingCacheService != nil {
 		_ = s.billingCacheService.InvalidateSubscription(ctx, sub.UserID, sub.GroupID)
 	}
-	return s.userSubRepo.GetByID(ctx, subscriptionID)
+	updated, err := s.userSubRepo.GetByID(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	return &QuotaRefreshResult{
+		Action:       QuotaRefreshActionRefreshed,
+		Subscription: updated,
+	}, nil
 }
 
 // AssignOrExtendSubscription 分配或续期订阅（用于兑换码等场景）

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -151,12 +151,74 @@ type AssignSubscriptionInput struct {
 	Notes        string
 }
 
+// RestoreSubscriptionSnapshotInput restores an exact subscription snapshot for admin rollback.
+type RestoreSubscriptionSnapshotInput struct {
+	UserID             int64
+	GroupID            int64
+	StartsAt           time.Time
+	ExpiresAt          time.Time
+	Status             string
+	DailyWindowStart   *time.Time
+	WeeklyWindowStart  *time.Time
+	MonthlyWindowStart *time.Time
+	DailyUsageUSD      float64
+	WeeklyUsageUSD     float64
+	MonthlyUsageUSD    float64
+	AssignedBy         *int64
+	AssignedAt         time.Time
+	Notes              string
+}
+
 // AssignSubscription 分配订阅给用户（不允许重复分配）
 func (s *SubscriptionService) AssignSubscription(ctx context.Context, input *AssignSubscriptionInput) (*UserSubscription, error) {
 	sub, _, err := s.assignSubscriptionWithReuse(ctx, input)
 	if err != nil {
 		return nil, err
 	}
+	return sub, nil
+}
+
+// RestoreSubscriptionSnapshot creates a subscription from an exact snapshot.
+func (s *SubscriptionService) RestoreSubscriptionSnapshot(ctx context.Context, input RestoreSubscriptionSnapshotInput) (*UserSubscription, error) {
+	if input.UserID <= 0 || input.GroupID <= 0 {
+		return nil, infraerrors.BadRequest("INVALID_SUBSCRIPTION_RESTORE", "user_id and group_id are required")
+	}
+
+	now := time.Now()
+	sub := &UserSubscription{
+		UserID:             input.UserID,
+		GroupID:            input.GroupID,
+		StartsAt:           input.StartsAt,
+		ExpiresAt:          input.ExpiresAt,
+		Status:             input.Status,
+		DailyWindowStart:   input.DailyWindowStart,
+		WeeklyWindowStart:  input.WeeklyWindowStart,
+		MonthlyWindowStart: input.MonthlyWindowStart,
+		DailyUsageUSD:      input.DailyUsageUSD,
+		WeeklyUsageUSD:     input.WeeklyUsageUSD,
+		MonthlyUsageUSD:    input.MonthlyUsageUSD,
+		AssignedBy:         input.AssignedBy,
+		AssignedAt:         input.AssignedAt,
+		Notes:              input.Notes,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if sub.Status == "" {
+		sub.Status = SubscriptionStatusActive
+	}
+	if sub.AssignedAt.IsZero() {
+		sub.AssignedAt = now
+	}
+
+	if err := s.userSubRepo.Create(ctx, sub); err != nil {
+		return nil, err
+	}
+
+	s.InvalidateSubCache(sub.UserID, sub.GroupID)
+	if s.billingCacheService != nil {
+		_ = s.billingCacheService.InvalidateSubscription(ctx, sub.UserID, sub.GroupID)
+	}
+
 	return sub, nil
 }
 


### PR DESCRIPTION
Fix quota refresh handling when the original exhausted period consumes all remaining subscription time. Positive remainder refreshes the quota and preserves the renewal layer; zero or negative remainder soft-deletes the subscription. Add exact snapshot restoration for rollback of soft-deleted subscriptions and regression tests.