### PR TITLE
perf(ops): trend 与 api-keys-usage 接入预聚合，system-logs 改封顶计数

### DIFF
--- a/backend/internal/handler/admin/ops_system_log_handler.go
+++ b/backend/internal/handler/admin/ops_system_log_handler.go
@@ -96,7 +96,7 @@ func (h *OpsHandler) ListSystemLogs(c *gin.Context) {
 		response.ErrorFrom(c, err)
 		return
 	}
-	response.Paginated(c, result.Logs, int64(result.Total), result.Page, result.PageSize)
+	response.PaginatedCapped(c, result.Logs, int64(result.Total), result.Page, result.PageSize, result.TotalIsCapped)
 }
 
 // CleanupSystemLogs deletes indexed system logs by filter.

--- a/backend/internal/pkg/response/response.go
+++ b/backend/internal/pkg/response/response.go
@@ -22,11 +22,14 @@ type Response struct {
 
 // PaginatedData 分页数据格式（匹配前端期望）
 type PaginatedData struct {
-	Items    any   `json:"items"`
-	Total    int64 `json:"total"`
-	Page     int   `json:"page"`
-	PageSize int   `json:"page_size"`
-	Pages    int   `json:"pages"`
+	Items any   `json:"items"`
+	Total int64 `json:"total"`
+	// TotalIsCapped 为 true 时 Total 是封顶值，实际命中数 >= Total。
+	// 仅放弃精确计数的接口会置位，其余接口序列化时省略。
+	TotalIsCapped bool `json:"total_is_capped,omitempty"`
+	Page          int  `json:"page"`
+	PageSize      int  `json:"page_size"`
+	Pages         int  `json:"pages"`
 }
 
 // Success 返回成功响应
@@ -122,18 +125,29 @@ func InternalError(c *gin.Context, message string) {
 
 // Paginated 返回分页数据
 func Paginated(c *gin.Context, items any, total int64, page, pageSize int) {
+	Success(c, newPaginatedData(items, total, page, pageSize, false))
+}
+
+// PaginatedCapped 与 Paginated 相同，但声明 total 是封顶值而非精确命中数。
+// 用于超大表上放弃精确 COUNT(*) 的列表接口，前端据此显示「N+」。
+func PaginatedCapped(c *gin.Context, items any, total int64, page, pageSize int, capped bool) {
+	Success(c, newPaginatedData(items, total, page, pageSize, capped))
+}
+
+func newPaginatedData(items any, total int64, page, pageSize int, capped bool) PaginatedData {
 	pages := int(math.Ceil(float64(total) / float64(pageSize)))
 	if pages < 1 {
 		pages = 1
 	}
 
-	Success(c, PaginatedData{
-		Items:    items,
-		Total:    total,
-		Page:     page,
-		PageSize: pageSize,
-		Pages:    pages,
-	})
+	return PaginatedData{
+		Items:         items,
+		Total:         total,
+		TotalIsCapped: capped,
+		Page:          page,
+		PageSize:      pageSize,
+		Pages:         pages,
+	}
 }
 
 // PaginationResult 分页结果（与pagination.PaginationResult兼容）

--- a/backend/internal/repository/custom_group_usage_rollup_repo.go
+++ b/backend/internal/repository/custom_group_usage_rollup_repo.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -17,21 +18,21 @@ func (r *usageLogRepository) getAllGroupUsageSummaryFromRollups(ctx context.Cont
 	todayDate := service.GroupUsageDate(todayStart)
 	yesterdayDate := service.GroupUsageDate(yesterdayStart)
 
+	// 日桶是不可变的历史沉淀：即便原始日志已被保留期清理，
+	// closed_before 以前的桶依旧全部计入累计用量，不随清理缩水。
 	const query = `
 		WITH state_values AS (
 			SELECT
 				COUNT(*) = 1
 					AND MAX(timezone_name) = $3
 					AND MAX(closed_before) <= $4::date AS valid,
-				MAX(closed_before) AS closed_before,
-				MAX(retained_from) AS retained_from
+				MAX(closed_before) AS closed_before
 			FROM usage_group_rollup_state
 			WHERE id = 1
 		),
 		state AS (
 			SELECT
 				CASE WHEN valid THEN closed_before ELSE DATE '1970-01-01' END AS closed_before,
-				CASE WHEN valid THEN retained_from ELSE TIMESTAMPTZ '1970-01-01 00:00:00+00' END AS retained_from,
 				CASE
 					WHEN valid THEN closed_before::timestamp AT TIME ZONE $3::text
 					ELSE TIMESTAMPTZ '1970-01-01 00:00:00+00'
@@ -49,7 +50,6 @@ func (r *usageLogRepository) getAllGroupUsageSummaryFromRollups(ctx context.Cont
 			FROM usage_group_daily_rollups rollup
 			CROSS JOIN state
 			WHERE state.valid
-				AND rollup.bucket_date >= (state.retained_from AT TIME ZONE $3::text)::date
 				AND rollup.bucket_date < state.closed_before
 			GROUP BY rollup.group_id
 		),
@@ -180,9 +180,19 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 	if err != nil {
 		return err
 	}
+	// 重建下界不能早于 retainedDate：更早的原始日志已被清理，
+	// 那段日桶是不可重算的历史沉淀，只能原样保留。
 	rebuildStartDate := retainedDate
 	if !timezoneChanged && closedTime.After(retainedDateTime) {
 		rebuildStartDate = closedBefore
+	}
+	if timezoneChanged && previousRetainedFrom.Before(retainedFrom) {
+		logger.LegacyPrintf(
+			"repository.group_usage_rollup",
+			"[GroupUsageRollup] 时区切换为 %s，%s 以前的日桶因原始日志已归档无法重建，保留旧时区口径",
+			timezoneName,
+			retainedDate,
+		)
 	}
 	rebuildStart, err := service.ParseGroupUsageDate(rebuildStartDate)
 	if err != nil {
@@ -191,10 +201,8 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 
 	if _, err := r.sql.ExecContext(ctx, `
 		DELETE FROM usage_group_daily_rollups
-		WHERE bucket_date < $1::date
-			OR (bucket_date >= $2::date AND bucket_date < $3::date)
-			OR bucket_date >= $3::date
-	`, retainedDate, rebuildStartDate, todayDate); err != nil {
+		WHERE bucket_date >= $1::date
+	`, rebuildStartDate); err != nil {
 		return fmt.Errorf("清理分组用量日桶: %w", err)
 	}
 
@@ -218,10 +226,11 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 		return fmt.Errorf("重建分组用量日桶: %w", err)
 	}
 
+	// 归档屏障只增不减：迟到的历史写入不得把它拉回，否则会解除已归档日桶的保护。
 	if _, err := r.sql.ExecContext(ctx, `
 		UPDATE usage_group_rollup_state
 		SET closed_before = $1::date,
-			retained_from = $2,
+			retained_from = GREATEST(retained_from, $2::timestamptz),
 			timezone_name = $3,
 			updated_at = NOW()
 		WHERE id = 1
@@ -244,16 +253,36 @@ func lockGroupUsageRollupState(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
+// invalidateGroupUsageRollupsAt 把发布水位回退到受影响日期，使该日之后的日桶在下次同步时重建。
+// 回退不会越过归档屏障：retained_from 之前的原始日志已被清理，那段日桶无法重算。
 func invalidateGroupUsageRollupsAt(ctx context.Context, tx *sql.Tx, affectedAt time.Time) error {
 	timezoneName := service.GroupUsageTimezoneName()
 	_, err := tx.ExecContext(ctx, `
 		UPDATE usage_group_rollup_state
 		SET closed_before = LEAST(
 			closed_before,
-			($1::timestamptz AT TIME ZONE $2::text)::date
+			GREATEST(
+				($1::timestamptz AT TIME ZONE $2::text)::date,
+				(retained_from AT TIME ZONE $2::text)::date
+			)
 		),
 			updated_at = NOW()
 		WHERE id = 1
 	`, affectedAt.UTC(), timezoneName)
 	return err
+}
+
+// advanceGroupUsageRetention 推进归档屏障，声明 cutoff 之前的原始日志已被清理。
+// 归档删除必须先调用它再删数据（能用事务时放进同一事务），失效触发器据此跳过水位回退，
+// 从而让已发布的历史日桶保持不变、不被重算。屏障单调递增，可重复调用。
+func advanceGroupUsageRetention(ctx context.Context, exec sqlExecutor, cutoff time.Time) error {
+	if _, err := exec.ExecContext(ctx, `
+		UPDATE usage_group_rollup_state
+		SET retained_from = GREATEST(retained_from, $1::timestamptz),
+			updated_at = NOW()
+		WHERE id = 1
+	`, cutoff.UTC()); err != nil {
+		return fmt.Errorf("推进分组用量归档屏障: %w", err)
+	}
+	return nil
 }

--- a/backend/internal/repository/custom_group_usage_rollup_repo.go
+++ b/backend/internal/repository/custom_group_usage_rollup_repo.go
@@ -256,31 +256,8 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupDayInTx(ctx context
 	}
 	nextClosedDate := service.GroupUsageDate(nextClosed)
 
-	if _, err := r.sql.ExecContext(ctx, `
-		DELETE FROM usage_group_daily_rollups
-		WHERE bucket_date >= $1::date AND bucket_date < $2::date
-	`, rebuildStartDate, nextClosedDate); err != nil {
-		return false, fmt.Errorf("清理分组用量日桶: %w", err)
-	}
-
-	if _, err := r.sql.ExecContext(ctx, `
-		INSERT INTO usage_group_daily_rollups (bucket_date, group_id, actual_cost, computed_at)
-		SELECT
-			(created_at AT TIME ZONE $3::text)::date AS bucket_date,
-			group_id,
-			COALESCE(SUM(actual_cost), 0) AS actual_cost,
-			NOW()
-		FROM usage_logs
-		WHERE group_id IS NOT NULL
-			AND created_at >= $1
-			AND created_at < $2
-		GROUP BY 1, 2
-		ON CONFLICT (bucket_date, group_id)
-		DO UPDATE SET
-			actual_cost = EXCLUDED.actual_cost,
-			computed_at = EXCLUDED.computed_at
-	`, rebuildStart.UTC(), nextClosed.UTC(), timezoneName); err != nil {
-		return false, fmt.Errorf("重建分组用量日桶: %w", err)
+	if err := r.rebuildUsageDailyRollupsForDay(ctx, rebuildStartDate, nextClosedDate, rebuildStart, nextClosed, timezoneName); err != nil {
+		return false, err
 	}
 
 	done := nextClosedDate == todayDate
@@ -294,6 +271,80 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupDayInTx(ctx context
 		return false, err
 	}
 	return done, nil
+}
+
+// rebuildUsageDailyRollupsForDay 重建一个自然日的用量日桶。
+//
+// group 与 api_key 是同一批原始日志的两个维度，因此用一次 GROUPING SETS 扫描同时产出，
+// 避免为 api_key 再扫一遍 usage_logs（大规模部署下是千万行级别）。两张表在同一事务内更新，
+// 共用 usage_group_rollup_state 的水位与归档屏障。
+func (r *dashboardAggregationRepository) rebuildUsageDailyRollupsForDay(
+	ctx context.Context,
+	rebuildStartDate string,
+	nextClosedDate string,
+	rebuildStart time.Time,
+	nextClosed time.Time,
+	timezoneName string,
+) error {
+	if _, err := r.sql.ExecContext(ctx, `
+		DELETE FROM usage_group_daily_rollups
+		WHERE bucket_date >= $1::date AND bucket_date < $2::date
+	`, rebuildStartDate, nextClosedDate); err != nil {
+		return fmt.Errorf("清理分组用量日桶: %w", err)
+	}
+	if _, err := r.sql.ExecContext(ctx, `
+		DELETE FROM usage_apikey_daily_rollups
+		WHERE bucket_date >= $1::date AND bucket_date < $2::date
+	`, rebuildStartDate, nextClosedDate); err != nil {
+		return fmt.Errorf("清理 API Key 用量日桶: %w", err)
+	}
+
+	// 一次扫描出两个维度：GROUPING SETS 的两组分别落到两张表。
+	if _, err := r.sql.ExecContext(ctx, `
+		WITH agg AS (
+			SELECT
+				(created_at AT TIME ZONE $3::text)::date AS bucket_date,
+				-- GROUPING()=1 表示该列在本分组集里被汇总掉了，用它区分
+				-- "被 rollup 置空" 与 "该列本身就是 NULL"。
+				GROUPING(group_id) AS group_rolled_up,
+				GROUPING(api_key_id) AS apikey_rolled_up,
+				group_id,
+				api_key_id,
+				COALESCE(SUM(actual_cost), 0) AS actual_cost,
+				COUNT(*) AS request_count
+			FROM usage_logs
+			WHERE created_at >= $1
+				AND created_at < $2
+			GROUP BY GROUPING SETS (
+				((created_at AT TIME ZONE $3::text)::date, group_id),
+				((created_at AT TIME ZONE $3::text)::date, api_key_id)
+			)
+		),
+		group_rows AS (
+			INSERT INTO usage_group_daily_rollups (bucket_date, group_id, actual_cost, computed_at)
+			SELECT bucket_date, group_id, actual_cost, NOW()
+			FROM agg
+			WHERE group_rolled_up = 0 AND group_id IS NOT NULL
+			ON CONFLICT (bucket_date, group_id)
+			DO UPDATE SET
+				actual_cost = EXCLUDED.actual_cost,
+				computed_at = EXCLUDED.computed_at
+			RETURNING 1
+		)
+		INSERT INTO usage_apikey_daily_rollups (bucket_date, api_key_id, actual_cost, request_count, computed_at)
+		SELECT bucket_date, api_key_id, actual_cost, request_count, NOW()
+		FROM agg
+		WHERE apikey_rolled_up = 0 AND api_key_id IS NOT NULL
+		ON CONFLICT (bucket_date, api_key_id)
+		DO UPDATE SET
+			actual_cost = EXCLUDED.actual_cost,
+			request_count = EXCLUDED.request_count,
+			computed_at = EXCLUDED.computed_at
+	`, rebuildStart.UTC(), nextClosed.UTC(), timezoneName); err != nil {
+		return fmt.Errorf("重建用量日桶: %w", err)
+	}
+
+	return nil
 }
 
 // publishGroupUsageWatermark 推进发布水位。trimFrom 非空时一并删除该日期及以后的日桶。
@@ -311,6 +362,13 @@ func (r *dashboardAggregationRepository) publishGroupUsageWatermark(
 			WHERE bucket_date >= $1::date
 		`, trimFrom); err != nil {
 			return fmt.Errorf("清理今日及以后的分组用量日桶: %w", err)
+		}
+		// api_key 日桶与 group 日桶共用水位，今日的量同样走原始日志尾段。
+		if _, err := r.sql.ExecContext(ctx, `
+			DELETE FROM usage_apikey_daily_rollups
+			WHERE bucket_date >= $1::date
+		`, trimFrom); err != nil {
+			return fmt.Errorf("清理今日及以后的 API Key 用量日桶: %w", err)
 		}
 	}
 	if _, err := r.sql.ExecContext(ctx, `

--- a/backend/internal/repository/custom_group_usage_rollup_repo.go
+++ b/backend/internal/repository/custom_group_usage_rollup_repo.go
@@ -111,28 +111,77 @@ func (r *usageLogRepository) getAllGroupUsageSummaryFromRollups(ctx context.Cont
 	return results, nil
 }
 
+// groupUsageSyncMaxDaysPerRun 限制单次同步推进的天数。
+// 回填/时区切换可能横跨很长区间，分块本身不会阻塞写入，但一轮跑太久会挤占
+// 定时器与 leader 锁；余量走下个周期，水位已持久化因而可以续跑。
+const groupUsageSyncMaxDaysPerRun = 400
+
 // SyncGroupUsageRollups 将服务端配置时区今日以前的用量发布为分组日桶。
+//
+// 发布必须持有 usage_group_rollup_state 的 FOR UPDATE：重建 SELECT 要在拿到锁之后
+// 执行，否则并发的未提交写入既不会被本次重建看见，又会在提交时读到旧水位而不触发
+// 失效，那条用量就丢了。而该锁与 INSERT 触发器的 FOR KEY SHARE 冲突，持锁期间
+// usage_logs 写入全部阻塞——所以这里按自然日分块，一天一个短事务，
+// 把锁持有时间从「整个重建区间」压到「单日重建」，写入在块之间得以通过。
 func (r *dashboardAggregationRepository) SyncGroupUsageRollups(ctx context.Context, todayStart time.Time) error {
 	if r == nil || r.sql == nil {
 		return nil
 	}
 	todayStart = service.GroupUsageTodayStart(todayStart)
-	if db, ok := r.sql.(*sql.DB); ok {
-		tx, err := db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		txRepo := newDashboardAggregationRepositoryWithSQL(tx)
-		if err := txRepo.syncGroupUsageRollupsInTx(ctx, todayStart); err != nil {
-			_ = tx.Rollback()
-			return err
-		}
-		return tx.Commit()
+	db, ok := r.sql.(*sql.DB)
+	if !ok {
+		// 退化路径（已在外层事务中）：无法分块提交，只能一次性完成。
+		_, err := r.syncGroupUsageRollupDayInTx(ctx, todayStart)
+		return err
 	}
-	return r.syncGroupUsageRollupsInTx(ctx, todayStart)
+
+	for range groupUsageSyncMaxDaysPerRun {
+		// 每块提交后状态行锁即释放，积压的 usage_logs 写入得以通过。
+		done, err := syncGroupUsageRollupDay(ctx, db, todayStart)
+		if err != nil {
+			// 超时/取消属于正常中断：已完成的天数都已提交，下个周期从断点续跑。
+			if ctx.Err() != nil {
+				logger.LegacyPrintf(
+					"repository.group_usage_rollup",
+					"[GroupUsageRollup] 同步中断，余量留待下个周期: %v",
+					err,
+				)
+				return nil
+			}
+			return err
+		}
+		if done {
+			return nil
+		}
+	}
+	logger.LegacyPrintf(
+		"repository.group_usage_rollup",
+		"[GroupUsageRollup] 单轮已推进 %d 天仍未追平，余量留待下个周期",
+		groupUsageSyncMaxDaysPerRun,
+	)
+	return nil
 }
 
-func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.Context, todayStart time.Time) error {
+func syncGroupUsageRollupDay(ctx context.Context, db *sql.DB, todayStart time.Time) (bool, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	txRepo := newDashboardAggregationRepositoryWithSQL(tx)
+	done, err := txRepo.syncGroupUsageRollupDayInTx(ctx, todayStart)
+	if err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return done, nil
+}
+
+// syncGroupUsageRollupDayInTx 发布水位所指的那一天，并把水位前推一天。
+// 返回 done=true 表示已追平今日，无需继续分块。
+func (r *dashboardAggregationRepository) syncGroupUsageRollupDayInTx(ctx context.Context, todayStart time.Time) (bool, error) {
 	var closedBefore string
 	var previousRetainedFrom time.Time
 	var stateTimezoneName string
@@ -142,34 +191,33 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 		WHERE id = 1
 		FOR UPDATE
 	`, nil, &closedBefore, &previousRetainedFrom, &stateTimezoneName); err != nil {
-		return fmt.Errorf("读取分组用量汇总水位: %w", err)
+		return false, fmt.Errorf("读取分组用量汇总水位: %w", err)
 	}
 
 	todayDate := service.GroupUsageDate(todayStart)
+	todayDateTime, err := service.ParseGroupUsageDate(todayDate)
+	if err != nil {
+		return false, err
+	}
 	timezoneName := service.GroupUsageTimezoneName()
 	timezoneChanged := stateTimezoneName != timezoneName
 	var closedTime time.Time
 	if !timezoneChanged {
-		var err error
 		closedTime, err = service.ParseGroupUsageDate(closedBefore)
 		if err != nil {
-			return fmt.Errorf("解析分组用量汇总水位 %q: %w", closedBefore, err)
-		}
-		todayDateTime, err := service.ParseGroupUsageDate(todayDate)
-		if err != nil {
-			return err
+			return false, fmt.Errorf("解析分组用量汇总水位 %q: %w", closedBefore, err)
 		}
 		if closedTime.After(todayDateTime) {
-			return fmt.Errorf("分组用量汇总水位位于未来: %s", closedBefore)
+			return false, fmt.Errorf("分组用量汇总水位位于未来: %s", closedBefore)
 		}
 		if closedBefore == todayDate {
-			return nil
+			return true, nil
 		}
 	}
 
 	var earliest sql.NullTime
 	if err := scanSingleRow(ctx, r.sql, "SELECT MIN(created_at) FROM usage_logs", nil, &earliest); err != nil {
-		return fmt.Errorf("读取最早用量记录: %w", err)
+		return false, fmt.Errorf("读取最早用量记录: %w", err)
 	}
 	retainedFrom := todayStart
 	if earliest.Valid {
@@ -178,13 +226,15 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 	retainedDate := service.GroupUsageDate(retainedFrom)
 	retainedDateTime, err := service.ParseGroupUsageDate(retainedDate)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// 重建下界不能早于 retainedDate：更早的原始日志已被清理，
 	// 那段日桶是不可重算的历史沉淀，只能原样保留。
 	rebuildStartDate := retainedDate
+	rebuildStart := retainedDateTime
 	if !timezoneChanged && closedTime.After(retainedDateTime) {
 		rebuildStartDate = closedBefore
+		rebuildStart = closedTime
 	}
 	if timezoneChanged && previousRetainedFrom.Before(retainedFrom) {
 		logger.LegacyPrintf(
@@ -194,16 +244,23 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 			retainedDate,
 		)
 	}
-	rebuildStart, err := service.ParseGroupUsageDate(rebuildStartDate)
-	if err != nil {
-		return err
+	if !rebuildStart.Before(todayDateTime) {
+		// 归档屏障已越过今日：没有可发布的历史日，仅把状态对齐到今日。
+		return true, r.publishGroupUsageWatermark(ctx, todayDate, todayDate, retainedFrom, timezoneName)
 	}
+
+	// 本块只重建 [rebuildStart, nextClosed) 这一个自然日。
+	nextClosed := rebuildStart.AddDate(0, 0, 1)
+	if nextClosed.After(todayDateTime) {
+		nextClosed = todayDateTime
+	}
+	nextClosedDate := service.GroupUsageDate(nextClosed)
 
 	if _, err := r.sql.ExecContext(ctx, `
 		DELETE FROM usage_group_daily_rollups
-		WHERE bucket_date >= $1::date
-	`, rebuildStartDate); err != nil {
-		return fmt.Errorf("清理分组用量日桶: %w", err)
+		WHERE bucket_date >= $1::date AND bucket_date < $2::date
+	`, rebuildStartDate, nextClosedDate); err != nil {
+		return false, fmt.Errorf("清理分组用量日桶: %w", err)
 	}
 
 	if _, err := r.sql.ExecContext(ctx, `
@@ -222,11 +279,40 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 		DO UPDATE SET
 			actual_cost = EXCLUDED.actual_cost,
 			computed_at = EXCLUDED.computed_at
-	`, rebuildStart.UTC(), todayStart.UTC(), timezoneName); err != nil {
-		return fmt.Errorf("重建分组用量日桶: %w", err)
+	`, rebuildStart.UTC(), nextClosed.UTC(), timezoneName); err != nil {
+		return false, fmt.Errorf("重建分组用量日桶: %w", err)
 	}
 
-	// 归档屏障只增不减：迟到的历史写入不得把它拉回，否则会解除已归档日桶的保护。
+	done := nextClosedDate == todayDate
+	// 追平今日时顺带清掉今日及以后的残桶：当天用量走原始日志尾段，
+	// 留着这些桶会与尾段重复计入。
+	trimFrom := ""
+	if done {
+		trimFrom = todayDate
+	}
+	if err := r.publishGroupUsageWatermark(ctx, nextClosedDate, trimFrom, retainedFrom, timezoneName); err != nil {
+		return false, err
+	}
+	return done, nil
+}
+
+// publishGroupUsageWatermark 推进发布水位。trimFrom 非空时一并删除该日期及以后的日桶。
+// 归档屏障只增不减：迟到的历史写入不得把它拉回，否则会解除已归档日桶的保护。
+func (r *dashboardAggregationRepository) publishGroupUsageWatermark(
+	ctx context.Context,
+	closedBefore string,
+	trimFrom string,
+	retainedFrom time.Time,
+	timezoneName string,
+) error {
+	if trimFrom != "" {
+		if _, err := r.sql.ExecContext(ctx, `
+			DELETE FROM usage_group_daily_rollups
+			WHERE bucket_date >= $1::date
+		`, trimFrom); err != nil {
+			return fmt.Errorf("清理今日及以后的分组用量日桶: %w", err)
+		}
+	}
 	if _, err := r.sql.ExecContext(ctx, `
 		UPDATE usage_group_rollup_state
 		SET closed_before = $1::date,
@@ -234,7 +320,7 @@ func (r *dashboardAggregationRepository) syncGroupUsageRollupsInTx(ctx context.C
 			timezone_name = $3,
 			updated_at = NOW()
 		WHERE id = 1
-	`, todayDate, retainedFrom, timezoneName); err != nil {
+	`, closedBefore, retainedFrom, timezoneName); err != nil {
 		return fmt.Errorf("更新分组用量汇总水位: %w", err)
 	}
 	return nil

--- a/backend/internal/repository/dashboard_aggregation_group_usage_test.go
+++ b/backend/internal/repository/dashboard_aggregation_group_usage_test.go
@@ -45,15 +45,8 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsRebuildsWhenTimezone
 			AddRow("2026-03-02", time.Unix(0, 0).UTC(), "Asia/Shanghai"))
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-03-01", "2026-03-02").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
-		WithArgs(retainedFrom, todayStart, "America/New_York").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-03-02").
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDailyRollupRebuild(mock, "2026-03-01", "2026-03-02", retainedFrom, todayStart, "America/New_York")
+	expectRollupWatermarkTrim(mock, "2026-03-02")
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs("2026-03-02", retainedFrom, "America/New_York").
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -77,16 +70,9 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsPublishesWatermarkLa
 			AddRow("2026-08-13", time.Unix(0, 0).UTC(), "Asia/Shanghai"))
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-08-13", "2026-08-14").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
-		WithArgs(rebuildStart, todayStart, "Asia/Shanghai").
-		WillReturnResult(sqlmock.NewResult(0, 2))
+	expectDailyRollupRebuild(mock, "2026-08-13", "2026-08-14", rebuildStart, todayStart, "Asia/Shanghai")
 	// 追平今日时清掉今日残桶，避免与原始日志尾段重复计入。
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-08-14").
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectRollupWatermarkTrim(mock, "2026-08-14")
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs("2026-08-14", retainedFrom, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -122,16 +108,9 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsSplitsRebuildIntoDai
 				AddRow(day.closedBefore, retainedFrom, "Asia/Shanghai"))
 		mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 			WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
-		mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-			WithArgs(day.closedBefore, day.nextClosed).
-			WillReturnResult(sqlmock.NewResult(0, 1))
-		mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
-			WithArgs(day.rebuildStart, day.rebuildStart.Add(24*time.Hour), "Asia/Shanghai").
-			WillReturnResult(sqlmock.NewResult(0, 1))
+		expectDailyRollupRebuild(mock, day.closedBefore, day.nextClosed, day.rebuildStart, day.rebuildStart.Add(24*time.Hour), "Asia/Shanghai")
 		if day.last {
-			mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-				WithArgs("2026-08-14").
-				WillReturnResult(sqlmock.NewResult(0, 0))
+			expectRollupWatermarkTrim(mock, "2026-08-14")
 		}
 		mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 			WithArgs(day.nextClosed, retainedFrom, "Asia/Shanghai").
@@ -233,15 +212,8 @@ func TestDashboardAggregationRepositoryRecomputeRangeSplitsTransactionsToKeepWri
 			AddRow(startDate, time.Unix(0, 0).UTC(), "Asia/Shanghai"))
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(start))
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs(startDate, service.GroupUsageDate(todayStart)).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
-		WithArgs(rebuildStart.UTC(), todayStart.UTC(), "Asia/Shanghai").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs(service.GroupUsageDate(todayStart)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDailyRollupRebuild(mock, startDate, service.GroupUsageDate(todayStart), rebuildStart.UTC(), todayStart.UTC(), "Asia/Shanghai")
+	expectRollupWatermarkTrim(mock, service.GroupUsageDate(todayStart))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs(service.GroupUsageDate(todayStart), start, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -368,4 +340,29 @@ func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionFailureRollsBack
 func setGroupUsageRollupTestTimezone(t *testing.T) {
 	t.Helper()
 	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+}
+
+// expectDailyRollupRebuild 断言一个自然日的日桶重建序列。
+// group 与 api_key 两张表先各自清空该日区间，再由一条 GROUPING SETS 语句同时写入，
+// 使得一天的原始日志只被扫描一次。
+func expectDailyRollupRebuild(mock sqlmock.Sqlmock, fromDate, toDate string, rebuildStart, rebuildEnd time.Time, tz string) {
+	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+		WithArgs(fromDate, toDate).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM usage_apikey_daily_rollups`).
+		WithArgs(fromDate, toDate).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)WITH agg.*INSERT INTO usage_apikey_daily_rollups`).
+		WithArgs(rebuildStart, rebuildEnd, tz).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+}
+
+// expectRollupWatermarkTrim 断言追平当日时对两张表的残桶清理。
+func expectRollupWatermarkTrim(mock sqlmock.Sqlmock, trimFrom string) {
+	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+		WithArgs(trimFrom).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`DELETE FROM usage_apikey_daily_rollups`).
+		WithArgs(trimFrom).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 }

--- a/backend/internal/repository/dashboard_aggregation_group_usage_test.go
+++ b/backend/internal/repository/dashboard_aggregation_group_usage_test.go
@@ -45,7 +45,7 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsRebuildsWhenTimezone
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-03-01", "2026-03-01", "2026-03-09").
+		WithArgs("2026-03-01").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(retainedFrom, todayStart, "America/New_York").
@@ -74,7 +74,7 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsPublishesWatermarkLa
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-05-01", "2026-08-13", "2026-08-14").
+		WithArgs("2026-08-13").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(rebuildStart, todayStart, "Asia/Shanghai").
@@ -164,7 +164,7 @@ func TestDashboardAggregationRepositoryRecomputeRangeRebuildsGroupRollupsBeforeC
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(start))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs(startDate, startDate, service.GroupUsageDate(todayStart)).
+		WithArgs(startDate).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(rebuildStart.UTC(), todayStart.UTC(), "Asia/Shanghai").
@@ -178,50 +178,38 @@ func TestDashboardAggregationRepositoryRecomputeRangeRebuildsGroupRollupsBeforeC
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestDashboardAggregationRepositoryCleanupUsageLogsNonPartitionedInvalidatesEachBatchAndSyncs(t *testing.T) {
+// 归档只推进屏障、删源数据：不回退发布水位，也不触发任何日桶同步/重算。
+func TestDashboardAggregationRepositoryCleanupUsageLogsNonPartitionedAdvancesRetentionWithoutSync(t *testing.T) {
 	setGroupUsageRollupTestTimezone(t)
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
 	cutoff := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
-	earliestDeletedAt := time.Date(2026, 5, 3, 2, 0, 0, 0, time.UTC)
-	fixedNow := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
-	repo.clock = func() time.Time { return fixedNow }
-	todayStart := service.GroupUsageTodayStart(fixedNow)
 
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery(`(?s)DELETE FROM usage_logs.*RETURNING created_at`).
-		WithArgs(cutoff, usageLogsCleanupBatchSize).
-		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).
-			AddRow(earliestDeletedAt.Add(time.Hour)).
-			AddRow(earliestDeletedAt))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(earliestDeletedAt, "Asia/Shanghai").
+	mock.ExpectExec(`(?s)UPDATE usage_group_rollup_state.*retained_from = GREATEST`).
+		WithArgs(cutoff).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectCommit()
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT closed_before::text, retained_from.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"closed_before", "retained_from", "timezone_name"}).
-			AddRow(service.GroupUsageDate(todayStart), time.Unix(0, 0).UTC(), "Asia/Shanghai"))
+	mock.ExpectExec(`(?s)DELETE FROM usage_logs`).
+		WithArgs(cutoff, usageLogsCleanupBatchSize).
+		WillReturnResult(sqlmock.NewResult(0, 2))
 	mock.ExpectCommit()
 
 	require.NoError(t, repo.CleanupUsageLogs(context.Background(), cutoff))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionedSortsAndInvalidatesEachDropBeforeSync(t *testing.T) {
+// 分区归档把屏障推进到分区之后（DROP TABLE 不触发行级失效触发器），同样不做同步。
+func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionedSortsAndAdvancesRetentionWithoutSync(t *testing.T) {
 	setGroupUsageRollupTestTimezone(t)
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
 	cutoff := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
-	aprilStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
-	juneStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	fixedNow := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
-	repo.clock = func() time.Time { return fixedNow }
-	todayStart := service.GroupUsageTodayStart(fixedNow)
+	mayStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	julyStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
@@ -233,49 +221,40 @@ func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionedSortsAndInvali
 			AddRow("usage_logs_202607"))
 
 	for _, partition := range []struct {
-		name  string
-		start time.Time
+		name         string
+		retainedFrom time.Time
 	}{
-		{name: "usage_logs_202604", start: aprilStart},
-		{name: "usage_logs_202606", start: juneStart},
+		{name: "usage_logs_202604", retainedFrom: mayStart},
+		{name: "usage_logs_202606", retainedFrom: julyStart},
 	} {
 		mock.ExpectBegin()
 		mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-		mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-			WithArgs(partition.start, "Asia/Shanghai").
+		mock.ExpectExec(`(?s)UPDATE usage_group_rollup_state.*retained_from = GREATEST`).
+			WithArgs(partition.retainedFrom).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(`DROP TABLE IF EXISTS "` + partition.name + `"`).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectCommit()
 	}
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT closed_before::text, retained_from.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"closed_before", "retained_from", "timezone_name"}).
-			AddRow(service.GroupUsageDate(todayStart), time.Unix(0, 0).UTC(), "Asia/Shanghai"))
-	mock.ExpectCommit()
 
 	require.NoError(t, repo.CleanupUsageLogs(context.Background(), cutoff))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestDashboardAggregationRepositoryCleanupUsageLogsNonPartitionedFailureRollsBackWithoutSync(t *testing.T) {
+func TestDashboardAggregationRepositoryCleanupUsageLogsNonPartitionedFailureRollsBack(t *testing.T) {
 	setGroupUsageRollupTestTimezone(t)
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
 	cutoff := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
-	deletedAt := time.Date(2026, 5, 3, 2, 0, 0, 0, time.UTC)
 
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery(`(?s)SELECT ctid.*ORDER BY created_at ASC, id ASC.*DELETE FROM usage_logs.*RETURNING created_at`).
-		WithArgs(cutoff, usageLogsCleanupBatchSize).
-		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(deletedAt))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(deletedAt, "Asia/Shanghai").
+	mock.ExpectExec(`(?s)UPDATE usage_group_rollup_state.*retained_from = GREATEST`).
+		WithArgs(cutoff).
 		WillReturnError(sql.ErrConnDone)
 	mock.ExpectRollback()
 
@@ -289,7 +268,7 @@ func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionFailureRollsBack
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
 	cutoff := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
-	aprilStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	mayStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	dropErr := errors.New("drop partition failed")
 
 	mock.ExpectQuery(`SELECT EXISTS`).
@@ -301,8 +280,8 @@ func TestDashboardAggregationRepositoryCleanupUsageLogsPartitionFailureRollsBack
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(aprilStart, "Asia/Shanghai").
+	mock.ExpectExec(`(?s)UPDATE usage_group_rollup_state.*retained_from = GREATEST`).
+		WithArgs(mayStart).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`DROP TABLE IF EXISTS "usage_logs_202604"`).
 		WillReturnError(dropErr)

--- a/backend/internal/repository/dashboard_aggregation_group_usage_test.go
+++ b/backend/internal/repository/dashboard_aggregation_group_usage_test.go
@@ -35,23 +35,27 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsRebuildsWhenTimezone
 
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
-	todayStart := time.Date(2026, 3, 9, 4, 0, 0, 0, time.UTC)
+	// 只差一天，单块即可追平；多块分批另见 SplitsRebuildIntoDailyTransactions。
+	todayStart := time.Date(2026, 3, 2, 5, 0, 0, 0, time.UTC)
 	retainedFrom := time.Date(2026, 3, 1, 5, 0, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT closed_before::text, retained_from.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"closed_before", "retained_from", "timezone_name"}).
-			AddRow("2026-03-09", time.Unix(0, 0).UTC(), "Asia/Shanghai"))
+			AddRow("2026-03-02", time.Unix(0, 0).UTC(), "Asia/Shanghai"))
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-03-01").
+		WithArgs("2026-03-01", "2026-03-02").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(retainedFrom, todayStart, "America/New_York").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+		WithArgs("2026-03-02").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs("2026-03-09", retainedFrom, "America/New_York").
+		WithArgs("2026-03-02", retainedFrom, "America/New_York").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -74,15 +78,66 @@ func TestDashboardAggregationRepositorySyncGroupUsageRollupsPublishesWatermarkLa
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs("2026-08-13").
+		WithArgs("2026-08-13", "2026-08-14").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(rebuildStart, todayStart, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	// 追平今日时清掉今日残桶，避免与原始日志尾段重复计入。
+	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+		WithArgs("2026-08-14").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs("2026-08-14", retainedFrom, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
+
+	require.NoError(t, repo.SyncGroupUsageRollups(context.Background(), todayStart))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// 重建跨多天时必须拆成每天一个事务：状态行的 FOR UPDATE 与 usage_logs 的
+// INSERT 触发器冲突，块之间提交才能让积压的写入通过。
+func TestDashboardAggregationRepositorySyncGroupUsageRollupsSplitsRebuildIntoDailyTransactions(t *testing.T) {
+	setGroupUsageRollupTestTimezone(t)
+	db, mock := newSQLMock(t)
+	repo := newDashboardAggregationRepositoryWithSQL(db)
+	todayStart := time.Date(2026, 8, 13, 16, 0, 0, 0, time.UTC)
+	retainedFrom := time.Date(2026, 8, 10, 3, 0, 0, 0, time.UTC)
+
+	// 水位停在 08-11，需要发布 08-11/08-12/08-13 三天。
+	for _, day := range []struct {
+		closedBefore string
+		nextClosed   string
+		rebuildStart time.Time
+		last         bool
+	}{
+		{closedBefore: "2026-08-11", nextClosed: "2026-08-12", rebuildStart: time.Date(2026, 8, 10, 16, 0, 0, 0, time.UTC)},
+		{closedBefore: "2026-08-12", nextClosed: "2026-08-13", rebuildStart: time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC)},
+		{closedBefore: "2026-08-13", nextClosed: "2026-08-14", rebuildStart: time.Date(2026, 8, 12, 16, 0, 0, 0, time.UTC), last: true},
+	} {
+		mock.ExpectBegin()
+		mock.ExpectQuery(`SELECT closed_before::text, retained_from.*FOR UPDATE`).
+			WillReturnRows(sqlmock.NewRows([]string{"closed_before", "retained_from", "timezone_name"}).
+				AddRow(day.closedBefore, retainedFrom, "Asia/Shanghai"))
+		mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
+			WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(retainedFrom))
+		mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+			WithArgs(day.closedBefore, day.nextClosed).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
+			WithArgs(day.rebuildStart, day.rebuildStart.Add(24*time.Hour), "Asia/Shanghai").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		if day.last {
+			mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+				WithArgs("2026-08-14").
+				WillReturnResult(sqlmock.NewResult(0, 0))
+		}
+		mock.ExpectExec(`UPDATE usage_group_rollup_state`).
+			WithArgs(day.nextClosed, retainedFrom, "Asia/Shanghai").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+	}
 
 	require.NoError(t, repo.SyncGroupUsageRollups(context.Background(), todayStart))
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -112,12 +167,15 @@ func TestDashboardAggregationRepositoryRecomputeRangeInvalidatesGroupRollupsBefo
 	start := time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
 
+	// 失效标记走独立短事务并先行提交，仪表盘重建的慢查询不再被状态行锁笼罩。
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs(start, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectBegin()
 	mock.ExpectExec(`DELETE FROM usage_dashboard_hourly`).
 		WillReturnError(sql.ErrConnDone)
 	mock.ExpectRollback()
@@ -127,11 +185,14 @@ func TestDashboardAggregationRepositoryRecomputeRangeInvalidatesGroupRollupsBefo
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestDashboardAggregationRepositoryRecomputeRangeRebuildsGroupRollupsBeforeCommit(t *testing.T) {
+// RecomputeRange 拆成三段独立提交：失效标记、仪表盘重建、分组日桶分块重建。
+// 关键在于慢查询都不在持有 usage_group_rollup_state 行锁的事务里。
+func TestDashboardAggregationRepositoryRecomputeRangeSplitsTransactionsToKeepWritesUnblocked(t *testing.T) {
 	setGroupUsageRollupTestTimezone(t)
 	db, mock := newSQLMock(t)
 	repo := newDashboardAggregationRepositoryWithSQL(db)
-	start := time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)
+	// 起点选在昨天，分组日桶单块即可追平。
+	start := time.Date(2026, 8, 13, 3, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
 	fixedNow := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
 	repo.clock = func() time.Time { return fixedNow }
@@ -140,12 +201,17 @@ func TestDashboardAggregationRepositoryRecomputeRangeRebuildsGroupRollupsBeforeC
 	rebuildStart, err := service.ParseGroupUsageDate(startDate)
 	require.NoError(t, err)
 
+	// 第一段：失效标记，短事务。
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs(start, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	// 第二段：仪表盘重建，独立事务且不碰状态行。
+	mock.ExpectBegin()
 	for _, query := range []string{
 		`DELETE FROM usage_dashboard_hourly WHERE`,
 		`DELETE FROM usage_dashboard_hourly_users WHERE`,
@@ -158,17 +224,24 @@ func TestDashboardAggregationRepositoryRecomputeRangeRebuildsGroupRollupsBeforeC
 	} {
 		mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(0, 1))
 	}
+	mock.ExpectCommit()
+
+	// 第三段：分组日桶按天分块。
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT closed_before::text, retained_from.*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"closed_before", "retained_from", "timezone_name"}).
 			AddRow(startDate, time.Unix(0, 0).UTC(), "Asia/Shanghai"))
 	mock.ExpectQuery(`SELECT MIN\(created_at\) FROM usage_logs`).
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(start))
 	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
-		WithArgs(startDate).
+		WithArgs(startDate, service.GroupUsageDate(todayStart)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO usage_group_daily_rollups`).
 		WithArgs(rebuildStart.UTC(), todayStart.UTC(), "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM usage_group_daily_rollups`).
+		WithArgs(service.GroupUsageDate(todayStart)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
 		WithArgs(service.GroupUsageDate(todayStart), start, "Asia/Shanghai").
 		WillReturnResult(sqlmock.NewResult(0, 1))

--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -133,16 +133,15 @@ func (r *dashboardAggregationRepository) RecomputeRange(ctx context.Context, sta
 
 	// 尽量使用事务保证范围内的一致性（允许在非 *sql.DB 的情况下退化为非事务执行）。
 	if db, ok := r.sql.(*sql.DB); ok {
+		// 三段刻意分开提交，避免 usage_group_rollup_state 的行锁笼罩慢查询：
+		// 该锁与 usage_logs 的 INSERT 触发器冲突，持锁多久写入就阻塞多久。
+		// 1) 短事务标记分组日桶失效——只写状态行，毫秒级。
+		if err := invalidateGroupUsageRollups(ctx, db, start); err != nil {
+			return err
+		}
+		// 2) 仪表盘桶重建，独立事务且不碰状态行，因此不阻塞写入。
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
-			return err
-		}
-		if err := lockGroupUsageRollupState(ctx, tx); err != nil {
-			_ = tx.Rollback()
-			return err
-		}
-		if err := invalidateGroupUsageRollupsAt(ctx, tx, start); err != nil {
-			_ = tx.Rollback()
 			return err
 		}
 		txRepo := newDashboardAggregationRepositoryWithSQL(tx)
@@ -150,13 +149,31 @@ func (r *dashboardAggregationRepository) RecomputeRange(ctx context.Context, sta
 			_ = tx.Rollback()
 			return err
 		}
-		if err := txRepo.syncGroupUsageRollupsInTx(ctx, service.GroupUsageTodayStart(r.now())); err != nil {
-			_ = tx.Rollback()
+		if err := tx.Commit(); err != nil {
 			return err
 		}
-		return tx.Commit()
+		// 3) 分组日桶按天分块重建，每天一个短事务。
+		// 步骤 1 已持久化失效标记，即使这里中断，后续周期同步也会补上。
+		return r.SyncGroupUsageRollups(ctx, service.GroupUsageTodayStart(r.now()))
 	}
 	return r.recomputeRangeInTx(ctx, hourStart, hourEnd, dayStart, dayEnd)
+}
+
+// invalidateGroupUsageRollups 在独立短事务里把发布水位回退到受影响日期。
+func invalidateGroupUsageRollups(ctx context.Context, db *sql.DB, affectedAt time.Time) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := lockGroupUsageRollupState(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := invalidateGroupUsageRollupsAt(ctx, tx, affectedAt); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 func (r *dashboardAggregationRepository) recomputeRangeInTx(ctx context.Context, hourStart, hourEnd, dayStart, dayEnd time.Time) error {

--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -230,26 +230,31 @@ func (r *dashboardAggregationRepository) CleanupAggregates(ctx context.Context, 
 	return nil
 }
 
+// CleanupUsageLogs 归档保留期以外的原始用量日志。
+// 归档只删源数据：cutoff 以前的日期早已发布为分组日桶，那些桶是不可变的历史沉淀，
+// 因此这里既不回退发布水位，也不触发任何重算。
 func (r *dashboardAggregationRepository) CleanupUsageLogs(ctx context.Context, cutoff time.Time) error {
 	isPartitioned, err := r.isUsageLogsPartitioned(ctx)
 	if err != nil {
 		return err
 	}
 	if isPartitioned {
-		if err := r.dropUsageLogsPartitions(ctx, cutoff); err != nil {
-			return err
-		}
-	} else if err := r.cleanupUsageLogsBatches(ctx, cutoff); err != nil {
-		return err
+		return r.dropUsageLogsPartitions(ctx, cutoff)
 	}
-	return r.SyncGroupUsageRollups(ctx, service.GroupUsageTodayStart(r.now()))
+	return r.cleanupUsageLogsBatches(ctx, cutoff)
 }
 
 func (r *dashboardAggregationRepository) cleanupUsageLogsBatches(ctx context.Context, cutoff time.Time) error {
 	db, transactional := r.sql.(*sql.DB)
+	if !transactional {
+		// 无事务可用时至少保证屏障先于删除推进，否则触发器会把这批归档当成数据修正。
+		if err := advanceGroupUsageRetention(ctx, r.sql, cutoff); err != nil {
+			return err
+		}
+	}
 	for {
 		if transactional {
-			affected, err := cleanupUsageLogsBatchWithRollupInvalidation(ctx, db, cutoff)
+			affected, err := cleanupUsageLogsBatchWithRetentionAdvance(ctx, db, cutoff)
 			if err != nil {
 				return err
 			}
@@ -283,7 +288,9 @@ func (r *dashboardAggregationRepository) cleanupUsageLogsBatches(ctx context.Con
 	}
 }
 
-func cleanupUsageLogsBatchWithRollupInvalidation(ctx context.Context, db *sql.DB, cutoff time.Time) (int64, error) {
+// cleanupUsageLogsBatchWithRetentionAdvance 在同一事务内先推进归档屏障再删除，
+// 使失效触发器认出这批删除属于归档，跳过发布水位回退。
+func cleanupUsageLogsBatchWithRetentionAdvance(ctx context.Context, db *sql.DB, cutoff time.Time) (int64, error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
@@ -296,7 +303,10 @@ func cleanupUsageLogsBatchWithRollupInvalidation(ctx context.Context, db *sql.DB
 	if err := lockGroupUsageRollupState(ctx, tx); err != nil {
 		return rollback(err)
 	}
-	rows, err := tx.QueryContext(ctx, `
+	if err := advanceGroupUsageRetention(ctx, tx, cutoff); err != nil {
+		return rollback(err)
+	}
+	res, err := tx.ExecContext(ctx, `
 		WITH victims AS (
 			SELECT ctid
 			FROM usage_logs
@@ -306,36 +316,13 @@ func cleanupUsageLogsBatchWithRollupInvalidation(ctx context.Context, db *sql.DB
 		)
 		DELETE FROM usage_logs
 		WHERE ctid IN (SELECT ctid FROM victims)
-		RETURNING created_at
 	`, cutoff.UTC(), usageLogsCleanupBatchSize)
 	if err != nil {
 		return rollback(err)
 	}
-
-	var affected int64
-	var earliestDeletedAt time.Time
-	for rows.Next() {
-		var deletedAt time.Time
-		if err := rows.Scan(&deletedAt); err != nil {
-			_ = rows.Close()
-			return rollback(err)
-		}
-		affected++
-		if earliestDeletedAt.IsZero() || deletedAt.Before(earliestDeletedAt) {
-			earliestDeletedAt = deletedAt
-		}
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
+	affected, err := res.RowsAffected()
+	if err != nil {
 		return rollback(err)
-	}
-	if err := rows.Close(); err != nil {
-		return rollback(err)
-	}
-	if affected > 0 {
-		if err := invalidateGroupUsageRollupsAt(ctx, tx, earliestDeletedAt); err != nil {
-			return rollback(err)
-		}
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
@@ -629,13 +616,16 @@ func (r *dashboardAggregationRepository) dropUsageLogsPartitions(ctx context.Con
 	})
 	if db, ok := r.sql.(*sql.DB); ok {
 		for _, partition := range partitions {
-			if err := dropUsageLogsPartitionWithRollupInvalidation(ctx, db, partition.name, partition.month); err != nil {
+			if err := dropUsageLogsPartitionWithRetentionAdvance(ctx, db, partition.name, partition.month.AddDate(0, 1, 0)); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
 	for _, partition := range partitions {
+		if err := advanceGroupUsageRetention(ctx, r.sql, partition.month.AddDate(0, 1, 0)); err != nil {
+			return err
+		}
 		if _, err := r.sql.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", pq.QuoteIdentifier(partition.name))); err != nil {
 			return err
 		}
@@ -643,7 +633,10 @@ func (r *dashboardAggregationRepository) dropUsageLogsPartitions(ctx context.Con
 	return nil
 }
 
-func dropUsageLogsPartitionWithRollupInvalidation(ctx context.Context, db *sql.DB, name string, monthStart time.Time) error {
+// dropUsageLogsPartitionWithRetentionAdvance 丢弃整月分区并把归档屏障推进到该分区之后。
+// DROP TABLE 不触发行级失效触发器，因此屏障必须在这里显式推进，
+// 否则后续删除会误以为这段日期仍有原始日志可重建。
+func dropUsageLogsPartitionWithRetentionAdvance(ctx context.Context, db *sql.DB, name string, retainedFrom time.Time) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -656,7 +649,7 @@ func dropUsageLogsPartitionWithRollupInvalidation(ctx context.Context, db *sql.D
 	if err := lockGroupUsageRollupState(ctx, tx); err != nil {
 		return rollback(err)
 	}
-	if err := invalidateGroupUsageRollupsAt(ctx, tx, monthStart); err != nil {
+	if err := advanceGroupUsageRetention(ctx, tx, retainedFrom); err != nil {
 		return rollback(err)
 	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", pq.QuoteIdentifier(name))); err != nil {

--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -50,6 +50,186 @@ func TestGroupUsageRollupTriggerInvalidatesCascadedHistoricalDelete(t *testing.T
 	}
 }
 
+// 保留期清理先推进归档屏障再删源数据，触发器据此跳过水位回退，
+// 已发布的历史日桶原样保留、不被重算。
+func TestGroupUsageRollupTriggerSkipsInvalidationBelowRetentionBarrier(t *testing.T) {
+	for _, partitioned := range []bool{false, true} {
+		name := "ordinary"
+		if partitioned {
+			name = "partitioned"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			schema := createGroupUsageRollupTriggerTestSchema(t, ctx, partitioned)
+			tx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+			defer func() { _ = tx.Rollback() }()
+
+			_, err := tx.ExecContext(ctx, `
+				INSERT INTO groups (id) VALUES (10);
+				INSERT INTO users (id) VALUES (1);
+				INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at)
+				VALUES (1, 1, 10, 1.25, TIMESTAMPTZ '2026-05-01 08:00:00+08');
+				INSERT INTO usage_group_daily_rollups (bucket_date, group_id, actual_cost, computed_at)
+				VALUES (DATE '2026-05-01', 10, 1.25, NOW());
+				UPDATE usage_group_rollup_state
+				SET closed_before = DATE '2026-08-14',
+					retained_from = TIMESTAMPTZ '2026-06-01 00:00:00+08'
+				WHERE id = 1;
+				DELETE FROM usage_logs WHERE id = 1;
+			`)
+			require.NoError(t, err)
+
+			var closedBefore string
+			require.NoError(t, tx.QueryRowContext(ctx, `
+				SELECT closed_before::text
+				FROM usage_group_rollup_state
+				WHERE id = 1
+			`).Scan(&closedBefore))
+			require.Equal(t, "2026-08-14", closedBefore, "归档区间的删除不得回退发布水位")
+
+			var rollupCost float64
+			require.NoError(t, tx.QueryRowContext(ctx, `
+				SELECT actual_cost
+				FROM usage_group_daily_rollups
+				WHERE bucket_date = DATE '2026-05-01' AND group_id = 10
+			`).Scan(&rollupCost))
+			require.InDelta(t, 1.25, rollupCost, 0.0000001, "归档日桶必须原样保留")
+		})
+	}
+}
+
+// 屏障之后的删除仍是数据修正，必须回退水位以便重建。
+func TestGroupUsageRollupTriggerInvalidatesAboveRetentionBarrier(t *testing.T) {
+	ctx := context.Background()
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	tx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at)
+		VALUES (1, 1, 10, 1.25, TIMESTAMPTZ '2026-07-03 08:00:00+08');
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-14',
+			retained_from = TIMESTAMPTZ '2026-06-01 00:00:00+08'
+		WHERE id = 1;
+		DELETE FROM usage_logs WHERE id = 1;
+	`)
+	require.NoError(t, err)
+
+	var closedBefore string
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT closed_before::text
+		FROM usage_group_rollup_state
+		WHERE id = 1
+	`).Scan(&closedBefore))
+	require.Equal(t, "2026-07-03", closedBefore)
+}
+
+// CleanupUsageLogs 的完整归档路径：删掉保留期以外的原始日志后，
+// 发布水位不动、历史日桶一行不少、分组累计用量不变——即「不重新算」。
+func TestCleanupUsageLogsArchivesWithoutRecomputingRollups(t *testing.T) {
+	ctx := context.Background()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	todayStart := time.Date(2026, 8, 13, 16, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	tx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at) VALUES
+			(1, 1, 10, 7, TIMESTAMPTZ '2026-05-20 12:00:00+08'),
+			(2, 1, 10, 2, TIMESTAMPTZ '2026-08-12 12:00:00+08'),
+			(3, 1, 10, 3, TIMESTAMPTZ '2026-08-13 12:00:00+08'),
+			(4, 1, 10, 4, TIMESTAMPTZ '2026-08-14 12:00:00+08');
+		INSERT INTO usage_group_daily_rollups (bucket_date, group_id, actual_cost, computed_at) VALUES
+			(DATE '2026-05-20', 10, 7, NOW()),
+			(DATE '2026-08-12', 10, 2, NOW()),
+			(DATE '2026-08-13', 10, 3, NOW());
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-14',
+			retained_from = TIMESTAMPTZ '2026-05-20 12:00:00+08'
+		WHERE id = 1;
+	`)
+	require.NoError(t, err)
+
+	usageRepo := newUsageLogRepositoryWithSQL(nil, tx)
+	before, err := usageRepo.GetAllGroupUsageSummary(ctx, todayStart)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	require.InDelta(t, 16, before[0].TotalCost, 0.0000001)
+
+	aggRepo := newDashboardAggregationRepositoryWithSQL(tx)
+	require.NoError(t, aggRepo.CleanupUsageLogs(ctx, cutoff))
+
+	var remaining int
+	require.NoError(t, tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM usage_logs").Scan(&remaining))
+	require.Equal(t, 3, remaining, "cutoff 以前的原始日志应被归档")
+
+	var closedBefore string
+	var retainedFrom time.Time
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT closed_before::text, retained_from
+		FROM usage_group_rollup_state
+		WHERE id = 1
+	`).Scan(&closedBefore, &retainedFrom))
+	require.Equal(t, "2026-08-14", closedBefore, "归档不得回退发布水位")
+	require.True(t, retainedFrom.Equal(cutoff), "归档屏障应推进到 cutoff")
+
+	var buckets int
+	require.NoError(t, tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM usage_group_daily_rollups").Scan(&buckets))
+	require.Equal(t, 3, buckets, "历史日桶必须原样保留")
+
+	after, err := usageRepo.GetAllGroupUsageSummary(ctx, todayStart)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.InDelta(t, before[0].TotalCost, after[0].TotalCost, 0.0000001, "累计用量不得因归档缩水")
+	require.InDelta(t, 4, after[0].TodayCost, 0.0000001)
+	require.InDelta(t, 3, after[0].YesterdayCost, 0.0000001)
+}
+
+// 保留期清理后累计用量不缩水：原始日志已不在，日桶依旧全额计入。
+func TestGroupUsageSummaryKeepsArchivedRollupsInTotal(t *testing.T) {
+	ctx := context.Background()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	todayStart := time.Date(2026, 8, 13, 16, 0, 0, 0, time.UTC)
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	tx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	defer func() { _ = tx.Rollback() }()
+
+	// 只有 08-13 起的原始日志还在，08-12 及更早的已被归档，仅剩日桶。
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at) VALUES
+			(2, 1, 10, 3, TIMESTAMPTZ '2026-08-13 12:00:00+08'),
+			(3, 1, 10, 4, TIMESTAMPTZ '2026-08-14 12:00:00+08');
+		INSERT INTO usage_group_daily_rollups (bucket_date, group_id, actual_cost, computed_at) VALUES
+			(DATE '2026-05-20', 10, 11, NOW()),
+			(DATE '2026-08-12', 10, 2, NOW()),
+			(DATE '2026-08-13', 10, 3, NOW());
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-14',
+			retained_from = TIMESTAMPTZ '2026-08-13 00:00:00+08'
+		WHERE id = 1;
+	`)
+	require.NoError(t, err)
+
+	repo := newUsageLogRepositoryWithSQL(nil, tx)
+	result, err := repo.GetAllGroupUsageSummary(ctx, todayStart)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.InDelta(t, 20, result[0].TotalCost, 0.0000001, "归档日桶必须计入累计用量")
+	require.InDelta(t, 4, result[0].TodayCost, 0.0000001)
+	require.InDelta(t, 3, result[0].YesterdayCost, 0.0000001)
+}
+
 func TestGroupUsageRollupTriggerSerializesLateHistoricalInsertWithPublish(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -449,6 +629,7 @@ func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, 
 	for _, migrationName := range []string{
 		"222_group_usage_daily_rollups.sql",
 		"223_group_usage_rollup_timezone.sql",
+		"227_group_usage_rollup_archival.sql",
 	} {
 		migrationSQL, readErr := migrations.FS.ReadFile(migrationName)
 		require.NoError(t, readErr)

--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -35,7 +35,7 @@ func TestGroupUsageRollupTriggerInvalidatesCascadedHistoricalDelete(t *testing.T
 				INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at)
 				VALUES (1, 1, 10, 1.25, TIMESTAMPTZ '2020-01-02 08:00:00+08');
 				UPDATE usage_group_rollup_state
-				SET closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+				SET closed_before = CURRENT_DATE
 				WHERE id = 1;
 				DELETE FROM users WHERE id = 1;
 			`)
@@ -401,7 +401,7 @@ func TestGroupUsageRollupTriggerSerializesLateHistoricalInsertWithPublish(t *tes
 
 	_, err = syncTx.ExecContext(ctx, `
 		UPDATE usage_group_rollup_state
-		SET closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+		SET closed_before = CURRENT_DATE
 		WHERE id = 1
 	`)
 	require.NoError(t, err)
@@ -434,7 +434,7 @@ func TestGroupUsageRollupTriggerSerializesInsertTransactionAcrossMidnight(t *tes
 		INSERT INTO groups (id) VALUES (10);
 		INSERT INTO users (id) VALUES (1);
 		UPDATE usage_group_rollup_state
-		SET closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+		SET closed_before = CURRENT_DATE
 		WHERE id = 1;
 	`)
 	require.NoError(t, err)
@@ -474,7 +474,7 @@ func TestGroupUsageRollupTriggerSerializesInsertTransactionAcrossMidnight(t *tes
 
 	_, err = syncTx.ExecContext(ctx, `
 		UPDATE usage_group_rollup_state
-		SET closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date + 1
+		SET closed_before = CURRENT_DATE + 1
 		WHERE id = 1
 	`)
 	require.NoError(t, err)
@@ -490,7 +490,7 @@ func TestGroupUsageRollupTriggerSerializesInsertTransactionAcrossMidnight(t *tes
 
 	var currentDate string
 	require.NoError(t, integrationDB.QueryRowContext(ctx, `
-		SELECT (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date::text
+		SELECT CURRENT_DATE::text
 	`).Scan(&currentDate))
 	var closedBefore string
 	err = integrationDB.QueryRowContext(ctx, fmt.Sprintf(
@@ -511,7 +511,7 @@ func TestGroupUsageRollupTriggerKeepsWatermarkForTodayInsert(t *testing.T) {
 		INSERT INTO groups (id) VALUES (10);
 		INSERT INTO users (id) VALUES (1);
 		UPDATE usage_group_rollup_state
-		SET closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+		SET closed_before = CURRENT_DATE
 		WHERE id = 1;
 		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at)
 		VALUES (1, 1, 10, 1.25, CURRENT_TIMESTAMP);
@@ -520,7 +520,7 @@ func TestGroupUsageRollupTriggerKeepsWatermarkForTodayInsert(t *testing.T) {
 
 	var unchanged bool
 	err = tx.QueryRowContext(ctx, `
-		SELECT closed_before = (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+		SELECT closed_before = CURRENT_DATE
 		FROM usage_group_rollup_state
 		WHERE id = 1
 	`).Scan(&unchanged)

--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	appTimezone "github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/migrations"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -702,6 +703,205 @@ func TestGroupUsageSummaryUsesConfiguredDSTBoundaries(t *testing.T) {
 	require.InDelta(t, 7, result[0].YesterdayCost, 0.0000001)
 }
 
+// 一次分块日结要同时产出 group 与 api_key 两个维度的日桶，且两者都必须与明细对账。
+// 这条用例同时验证 GROUPING SETS + data-modifying CTE 的组合在真实 PostgreSQL 上成立。
+func TestSyncUsageRollupsProducesGroupAndAPIKeyBucketsInOnePass(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	// 2026-08-12 16:00 UTC = 2026-08-13 00:00 +08，故"今日"为 08-13，只结算 08-12。
+	todayStart := time.Date(2026, 8, 12, 16, 0, 0, 0, time.UTC)
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	_, err := seedTx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10), (20);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, api_key_id, actual_cost, created_at) VALUES
+			(1, 1, 10,  100, 1.5, TIMESTAMPTZ '2026-08-12 09:00:00+08'),
+			(2, 1, 10,  101, 2.5, TIMESTAMPTZ '2026-08-12 10:00:00+08'),
+			(3, 1, 20,  100, 4.0, TIMESTAMPTZ '2026-08-12 11:00:00+08'),
+			-- group_id 为 NULL 的行仍要计入 api_key 维度
+			(4, 1, NULL, 101, 8.0, TIMESTAMPTZ '2026-08-12 12:00:00+08'),
+			-- api_key_id 为 NULL 的行仍要计入 group 维度
+			(5, 1, 10,  NULL, 0.5, TIMESTAMPTZ '2026-08-12 13:00:00+08'),
+			(6, 1, 10,  100, 7.0, TIMESTAMPTZ '2026-08-13 09:00:00+08');
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-12',
+			retained_from = TIMESTAMPTZ '2026-08-12 00:00:00+08'
+		WHERE id = 1;
+	`)
+	require.NoError(t, err)
+	require.NoError(t, seedTx.Commit())
+
+	scopedDB := newGroupUsageRollupSchemaDB(t, schema)
+	repo := newDashboardAggregationRepositoryWithSQL(scopedDB)
+	require.NoError(t, repo.SyncGroupUsageRollups(ctx, todayStart))
+
+	// group 日桶：08-12 的 group 10 = 1.5+2.5+0.5，group 20 = 4.0；group_id 为 NULL 的不入表。
+	groupBuckets := map[int64]float64{}
+	rows, err := scopedDB.QueryContext(ctx, `
+		SELECT group_id, actual_cost FROM usage_group_daily_rollups WHERE bucket_date = DATE '2026-08-12'
+	`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var id int64
+		var cost float64
+		require.NoError(t, rows.Scan(&id, &cost))
+		groupBuckets[id] = cost
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Len(t, groupBuckets, 2)
+	require.InDelta(t, 4.5, groupBuckets[10], 0.0000001)
+	require.InDelta(t, 4.0, groupBuckets[20], 0.0000001)
+
+	// api_key 日桶：key 100 = 1.5+4.0，key 101 = 2.5+8.0；api_key_id 为 NULL 的不入表。
+	type keyBucket struct {
+		cost     float64
+		requests int64
+	}
+	keyBuckets := map[int64]keyBucket{}
+	rows, err = scopedDB.QueryContext(ctx, `
+		SELECT api_key_id, actual_cost, request_count
+		FROM usage_apikey_daily_rollups WHERE bucket_date = DATE '2026-08-12'
+	`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var id int64
+		var b keyBucket
+		require.NoError(t, rows.Scan(&id, &b.cost, &b.requests))
+		keyBuckets[id] = b
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Len(t, keyBuckets, 2)
+	require.InDelta(t, 5.5, keyBuckets[100].cost, 0.0000001)
+	require.Equal(t, int64(2), keyBuckets[100].requests)
+	require.InDelta(t, 10.5, keyBuckets[101].cost, 0.0000001)
+	require.Equal(t, int64(2), keyBuckets[101].requests)
+
+	// 今日（08-13）不应留桶，当天用量走原始日志尾段。
+	var todayBuckets int
+	require.NoError(t, scopedDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM usage_apikey_daily_rollups WHERE bucket_date >= DATE '2026-08-13'
+	`).Scan(&todayBuckets))
+	require.Equal(t, 0, todayBuckets, "今日桶会与尾段重复计入")
+}
+
+// GetBatchAPIKeyUsageStats 必须等于「历史日桶 + 当日明细」，不能因为改走日桶而少算或重复计。
+//
+// 这个用例只能用相对日期：查询里的"今天"取自 timezone.Today()（真实墙钟），
+// 写死日期会让尾段永远落空，从而把 bug 测成通过。
+func TestGetBatchAPIKeyUsageStatsMatchesRawAggregate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	today := appTimezone.Today()
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	_, err := seedTx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+	`)
+	require.NoError(t, err)
+	_, err = seedTx.ExecContext(ctx, `
+		INSERT INTO usage_logs (id, user_id, group_id, api_key_id, actual_cost, created_at) VALUES
+			(1, 1, 10, 100, 3.0, $1),
+			(2, 1, 10, 100, 5.0, $2),
+			(3, 1, 10, 100, 7.0, $3),
+			(4, 1, 10, 101, 2.0, $2)
+	`,
+		today.AddDate(0, 0, -3).Add(9*time.Hour),
+		today.AddDate(0, 0, -2).Add(9*time.Hour),
+		today, // 当天 00:00，既落在尾段又压到 >= 边界上
+	)
+	require.NoError(t, err)
+	_, err = seedTx.ExecContext(ctx, `
+		UPDATE usage_group_rollup_state
+		SET closed_before = ($1::timestamptz AT TIME ZONE 'Asia/Shanghai')::date,
+			retained_from = $1
+		WHERE id = 1
+	`, today.AddDate(0, 0, -3).Add(9*time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, seedTx.Commit())
+
+	scopedDB := newGroupUsageRollupSchemaDB(t, schema)
+	require.NoError(t, newDashboardAggregationRepositoryWithSQL(scopedDB).SyncGroupUsageRollups(ctx, today))
+
+	// 水位追平到今天后，D-3 与 D-2 已入桶，今天仍只在明细里。
+	var closedBefore time.Time
+	require.NoError(t, scopedDB.QueryRowContext(ctx,
+		`SELECT closed_before FROM usage_group_rollup_state WHERE id = 1`).Scan(&closedBefore))
+	require.Equal(t, today.Format("2006-01-02"), closedBefore.Format("2006-01-02"))
+
+	usageRepo := newUsageLogRepositoryWithSQL(nil, scopedDB)
+	stats, err := usageRepo.GetBatchAPIKeyUsageStats(
+		ctx, []int64{100, 101}, today.AddDate(0, 0, -5), today.AddDate(0, 0, 1))
+	require.NoError(t, err)
+	require.Len(t, stats, 2)
+
+	// key 100 = D-3 日桶 3.0 + D-2 日桶 5.0 + 今日尾段 7.0。
+	require.InDelta(t, 15.0, stats[100].TotalActualCost, 0.0000001)
+	require.InDelta(t, 7.0, stats[100].TodayActualCost, 0.0000001)
+	require.InDelta(t, 2.0, stats[101].TotalActualCost, 0.0000001)
+	require.InDelta(t, 0.0, stats[101].TodayActualCost, 0.0000001)
+
+	// 与直接扫明细的口径对账：改造前后总额必须完全一致。
+	rawTotals := map[int64]float64{}
+	rows, err := scopedDB.QueryContext(ctx, `
+		SELECT api_key_id, COALESCE(SUM(actual_cost), 0)
+		FROM usage_logs WHERE api_key_id = ANY($1) AND created_at >= $2 AND created_at < $3
+		GROUP BY api_key_id
+	`, pq.Array([]int64{100, 101}), today.AddDate(0, 0, -5), today.AddDate(0, 0, 1))
+	require.NoError(t, err)
+	for rows.Next() {
+		var id int64
+		var cost float64
+		require.NoError(t, rows.Scan(&id, &cost))
+		rawTotals[id] = cost
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	for id, raw := range rawTotals {
+		require.InDelta(t, raw, stats[id].TotalActualCost, 0.0000001, "api_key %d 日桶口径偏离明细", id)
+	}
+}
+
+// 水位缺失时不能返回 0：宁可退化成全量扫明细（慢但正确）。
+func TestGetBatchAPIKeyUsageStatsFallsBackWhenWatermarkMissing(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	today := appTimezone.Today()
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	_, err := seedTx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+	`)
+	require.NoError(t, err)
+	_, err = seedTx.ExecContext(ctx, `
+		INSERT INTO usage_logs (id, user_id, group_id, api_key_id, actual_cost, created_at) VALUES
+			(1, 1, 10, 100, 3.0, $1),
+			(2, 1, 10, 100, 7.0, $2)
+	`, today.AddDate(0, 0, -3).Add(9*time.Hour), today)
+	require.NoError(t, err)
+	_, err = seedTx.ExecContext(ctx, `DELETE FROM usage_group_rollup_state WHERE id = 1`)
+	require.NoError(t, err)
+	require.NoError(t, seedTx.Commit())
+
+	scopedDB := newGroupUsageRollupSchemaDB(t, schema)
+	usageRepo := newUsageLogRepositoryWithSQL(nil, scopedDB)
+	stats, err := usageRepo.GetBatchAPIKeyUsageStats(
+		ctx, []int64{100}, today.AddDate(0, 0, -5), today.AddDate(0, 0, 1))
+	require.NoError(t, err)
+	require.InDelta(t, 10.0, stats[100].TotalActualCost, 0.0000001)
+	require.InDelta(t, 7.0, stats[100].TodayActualCost, 0.0000001)
+}
+
 func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, partitioned bool) string {
 	t.Helper()
 
@@ -723,6 +923,7 @@ func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, 
 			id BIGINT PRIMARY KEY,
 			user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 			group_id BIGINT REFERENCES groups(id) ON DELETE SET NULL,
+			api_key_id BIGINT,
 			actual_cost NUMERIC(20, 10) NOT NULL,
 			created_at TIMESTAMPTZ NOT NULL
 		);
@@ -733,6 +934,7 @@ func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, 
 				id BIGINT NOT NULL,
 				user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 				group_id BIGINT REFERENCES groups(id) ON DELETE SET NULL,
+				api_key_id BIGINT,
 				actual_cost NUMERIC(20, 10) NOT NULL,
 				created_at TIMESTAMPTZ NOT NULL
 			) PARTITION BY RANGE (created_at);
@@ -750,6 +952,7 @@ func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, 
 		"222_group_usage_daily_rollups.sql",
 		"223_group_usage_rollup_timezone.sql",
 		"227_group_usage_rollup_archival.sql",
+		"229_usage_apikey_daily_rollups.sql",
 	} {
 		migrationSQL, readErr := migrations.FS.ReadFile(migrationName)
 		require.NoError(t, readErr)

--- a/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
+++ b/backend/internal/repository/group_usage_rollup_trigger_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -191,6 +193,124 @@ func TestCleanupUsageLogsArchivesWithoutRecomputingRollups(t *testing.T) {
 	require.InDelta(t, before[0].TotalCost, after[0].TotalCost, 0.0000001, "累计用量不得因归档缩水")
 	require.InDelta(t, 4, after[0].TodayCost, 0.0000001)
 	require.InDelta(t, 3, after[0].YesterdayCost, 0.0000001)
+}
+
+// 多天回填必须按天分块提交：每块结束就释放 usage_group_rollup_state 的行锁，
+// usage_logs 的写入才不会被整段重建挡住。这里用真实并发写入验证。
+func TestSyncGroupUsageRollupsChunksByDayAndReleasesLockBetweenDays(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+	todayStart := time.Date(2026, 8, 13, 16, 0, 0, 0, time.UTC)
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	_, err := seedTx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at) VALUES
+			(1, 1, 10, 1, TIMESTAMPTZ '2026-08-10 12:00:00+08'),
+			(2, 1, 10, 2, TIMESTAMPTZ '2026-08-11 12:00:00+08'),
+			(3, 1, 10, 3, TIMESTAMPTZ '2026-08-12 12:00:00+08'),
+			(4, 1, 10, 4, TIMESTAMPTZ '2026-08-13 12:00:00+08'),
+			(5, 1, 10, 5, TIMESTAMPTZ '2026-08-14 12:00:00+08');
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-10',
+			retained_from = TIMESTAMPTZ '2026-08-10 12:00:00+08'
+		WHERE id = 1;
+	`)
+	require.NoError(t, err)
+	require.NoError(t, seedTx.Commit())
+
+	// 分块跑在真实连接池上，才能观察到块之间锁被释放。
+	scopedDB := newGroupUsageRollupSchemaDB(t, schema)
+	repo := newDashboardAggregationRepositoryWithSQL(scopedDB)
+	require.NoError(t, repo.SyncGroupUsageRollups(ctx, todayStart))
+
+	var closedBefore string
+	require.NoError(t, scopedDB.QueryRowContext(ctx, `
+		SELECT closed_before::text FROM usage_group_rollup_state WHERE id = 1
+	`).Scan(&closedBefore))
+	require.Equal(t, "2026-08-14", closedBefore, "水位应追平今日")
+
+	// 08-10 ~ 08-13 四天各一个桶；今日（08-14）走原始日志尾段，不应留桶。
+	rows, err := scopedDB.QueryContext(ctx, `
+		SELECT bucket_date::text, actual_cost
+		FROM usage_group_daily_rollups
+		WHERE group_id = 10
+		ORDER BY bucket_date
+	`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	buckets := map[string]float64{}
+	for rows.Next() {
+		var date string
+		var cost float64
+		require.NoError(t, rows.Scan(&date, &cost))
+		buckets[date] = cost
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, map[string]float64{
+		"2026-08-10": 1, "2026-08-11": 2, "2026-08-12": 3, "2026-08-13": 4,
+	}, buckets)
+
+	usageRepo := newUsageLogRepositoryWithSQL(nil, scopedDB)
+	result, err := usageRepo.GetAllGroupUsageSummary(ctx, todayStart)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.InDelta(t, 15, result[0].TotalCost, 0.0000001)
+	require.InDelta(t, 5, result[0].TodayCost, 0.0000001)
+	require.InDelta(t, 4, result[0].YesterdayCost, 0.0000001)
+}
+
+// 分块把锁持有压到单日：即便有写入正持有状态行的 KEY SHARE，
+// 同步也只会卡在当前这一天，而非整段区间。
+func TestSyncGroupUsageRollupsResumesFromPersistedWatermark(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	useGroupUsageRepositoryTestTimezone(t, "Asia/Shanghai")
+
+	schema := createGroupUsageRollupTriggerTestSchema(t, ctx, false)
+	seedTx := beginGroupUsageRollupTriggerTestTx(t, ctx, schema)
+	_, err := seedTx.ExecContext(ctx, `
+		INSERT INTO groups (id) VALUES (10);
+		INSERT INTO users (id) VALUES (1);
+		INSERT INTO usage_logs (id, user_id, group_id, actual_cost, created_at) VALUES
+			(1, 1, 10, 1, TIMESTAMPTZ '2026-08-10 12:00:00+08'),
+			(2, 1, 10, 2, TIMESTAMPTZ '2026-08-11 12:00:00+08'),
+			(3, 1, 10, 3, TIMESTAMPTZ '2026-08-12 12:00:00+08');
+		UPDATE usage_group_rollup_state
+		SET closed_before = DATE '2026-08-10',
+			retained_from = TIMESTAMPTZ '2026-08-10 12:00:00+08'
+		WHERE id = 1;
+	`)
+	require.NoError(t, err)
+	require.NoError(t, seedTx.Commit())
+
+	scopedDB := newGroupUsageRollupSchemaDB(t, schema)
+	repo := newDashboardAggregationRepositoryWithSQL(scopedDB)
+
+	// 先只追到 08-12，模拟上一轮被打断在中途。
+	require.NoError(t, repo.SyncGroupUsageRollups(ctx, time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC)))
+	var midWatermark string
+	require.NoError(t, scopedDB.QueryRowContext(ctx, `
+		SELECT closed_before::text FROM usage_group_rollup_state WHERE id = 1
+	`).Scan(&midWatermark))
+	require.Equal(t, "2026-08-12", midWatermark, "中断点应已持久化")
+
+	// 下一轮从持久化水位续跑，不重复已发布的日子。
+	require.NoError(t, repo.SyncGroupUsageRollups(ctx, time.Date(2026, 8, 12, 16, 0, 0, 0, time.UTC)))
+	var finalWatermark string
+	require.NoError(t, scopedDB.QueryRowContext(ctx, `
+		SELECT closed_before::text FROM usage_group_rollup_state WHERE id = 1
+	`).Scan(&finalWatermark))
+	require.Equal(t, "2026-08-13", finalWatermark)
+
+	var total float64
+	require.NoError(t, scopedDB.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(actual_cost), 0) FROM usage_group_daily_rollups WHERE group_id = 10
+	`).Scan(&total))
+	require.InDelta(t, 6, total, 0.0000001, "续跑不得重复或漏算")
 }
 
 // 保留期清理后累计用量不缩水：原始日志已不在，日桶依旧全额计入。
@@ -641,6 +761,23 @@ func createGroupUsageRollupTriggerTestSchema(t *testing.T, ctx context.Context, 
 	require.NoError(t, tx.Commit())
 
 	return schema
+}
+
+// newGroupUsageRollupSchemaDB 返回 search_path 固定在测试 schema 的独立连接池。
+// 分块同步每天开一个新事务，必须有真实的 *sql.DB 才能观察到跨事务行为。
+func newGroupUsageRollupSchemaDB(t *testing.T, schema string) *sql.DB {
+	t.Helper()
+
+	separator := "?"
+	if strings.Contains(integrationDSN, "?") {
+		separator = "&"
+	}
+	scopedDSN := integrationDSN + separator + "options=" + url.QueryEscape("-c search_path="+schema)
+	db, err := sql.Open("postgres", scopedDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.PingContext(context.Background()))
+	return db
 }
 
 func beginGroupUsageRollupTriggerTestTx(t *testing.T, ctx context.Context, schema string) *sql.Tx {

--- a/backend/internal/repository/integration_harness_test.go
+++ b/backend/internal/repository/integration_harness_test.go
@@ -38,6 +38,9 @@ var (
 	integrationDB        *sql.DB
 	integrationEntClient *dbent.Client
 	integrationRedis     *redisclient.Client
+	// integrationDSN 供需要独立连接池的用例开新的 *sql.DB（例如按 schema 隔离、
+	// 或验证跨事务行为——那些场景不能复用共享连接）。
+	integrationDSN string
 
 	redisNamespaceSeq uint64
 )
@@ -91,6 +94,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	integrationDSN = dsn
 	integrationDB, err = openSQLWithRetry(ctx, dsn, 30*time.Second)
 	if err != nil {
 		log.Printf("failed to open sql db: %v", err)

--- a/backend/internal/repository/ops_repo.go
+++ b/backend/internal/repository/ops_repo.go
@@ -16,6 +16,11 @@ type opsRepository struct {
 	db *sql.DB
 }
 
+// opsSystemLogCountCap 是系统日志列表总数的封顶值，超过则只报「>= 该值」。
+// 取 10000：按每页 50 条算是 200 页，远超实际会翻到的深度，
+// 而计数代价从「扫完全部匹配的索引项」降到常数。
+const opsSystemLogCountCap = 10000
+
 const insertOpsErrorLogSQL = `
 INSERT INTO ops_error_logs (
   request_id,
@@ -727,11 +732,24 @@ func (r *opsRepository) BatchInsertSystemLogs(ctx context.Context, inputs []*ser
 }
 
 func (r *opsRepository) ListSystemLogs(ctx context.Context, filter *service.OpsSystemLogFilter) (*service.OpsSystemLogList, error) {
+	return r.listSystemLogsWithCountCap(ctx, filter, opsSystemLogCountCap)
+}
+
+// listSystemLogsWithCountCap 是 ListSystemLogs 的实现，计数上限可注入以便测试
+// （否则要塞进上万行才能触发封顶分支）。
+func (r *opsRepository) listSystemLogsWithCountCap(
+	ctx context.Context,
+	filter *service.OpsSystemLogFilter,
+	countCap int,
+) (*service.OpsSystemLogList, error) {
 	if r == nil || r.db == nil {
 		return nil, fmt.Errorf("nil ops repository")
 	}
 	if filter == nil {
 		filter = &service.OpsSystemLogFilter{}
+	}
+	if countCap <= 0 {
+		countCap = opsSystemLogCountCap
 	}
 
 	page := filter.Page
@@ -747,13 +765,31 @@ func (r *opsRepository) ListSystemLogs(ctx context.Context, filter *service.OpsS
 	}
 
 	where, args, _ := buildOpsSystemLogsWhere(filter)
-	countSQL := "SELECT COUNT(*) FROM ops_system_logs l " + where
+	offset := (page - 1) * pageSize
+
+	// 计数封顶。
+	//
+	// 精确 COUNT(*) 要走完满足条件的全部索引项。ops_system_logs 在高写入部署下可达
+	// 千万行级别，而前端默认 time_range=30d、retention 也是 30 天，默认视图恰好等于
+	// 整张表，精确计数要数十秒。
+	// 这个数字只喂给分页器（「共 N 条」+ 页码按钮 + 跳页上限），千万条对应几十万页，
+	// 既没人翻得到，深翻页的 OFFSET 本身也早已不可用——为它付数十秒不划算。
+	//
+	// 改成先 LIMIT 再数：命中数超过上限时返回上限值并置 TotalIsCapped，前端显示「N+」。
+	// 代价是任意过滤组合下都恒定为 O(cap)。
+	if need := offset + pageSize + 1; need > countCap {
+		// 当前页已经翻过封顶值时要把上限抬上去，否则算出的总页数小于当前页码，分页器会错乱。
+		countCap = need
+	}
+	countArgs := append(append([]any{}, args...), countCap)
+	countSQL := "SELECT COUNT(*) FROM (SELECT 1 FROM ops_system_logs l " + where +
+		" LIMIT $" + itoa(len(countArgs)) + ") capped"
 	var total int
-	if err := r.db.QueryRowContext(ctx, countSQL, args...).Scan(&total); err != nil {
+	if err := r.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
 		return nil, err
 	}
+	totalIsCapped := total >= countCap
 
-	offset := (page - 1) * pageSize
 	argsWithLimit := append(args, pageSize, offset)
 	query := `
 SELECT
@@ -833,10 +869,11 @@ LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
 	}
 
 	return &service.OpsSystemLogList{
-		Logs:     logs,
-		Total:    total,
-		Page:     page,
-		PageSize: pageSize,
+		Logs:          logs,
+		Total:         total,
+		TotalIsCapped: totalIsCapped,
+		Page:          page,
+		PageSize:      pageSize,
 	}, nil
 }
 

--- a/backend/internal/repository/ops_repo_preagg.go
+++ b/backend/internal/repository/ops_repo_preagg.go
@@ -228,6 +228,240 @@ ON CONFLICT (bucket_start, COALESCE(platform, ''), COALESCE(group_id, 0)) DO UPD
 	return err
 }
 
+// opsMinuteDimensionHaving 保证三档 GROUPING SETS 产出的行落在互不相同的唯一键上。
+//
+// ops_metrics_minute 的唯一键是 (bucket_start, COALESCE(platform,”), COALESCE(group_id,0))，
+// 而 GROUPING SETS 里"被卷起的 NULL"和"字段本身就是 NULL"最终折叠成同一个键：
+//
+//	(bucket_start)                      → (b, '', 0)   overall
+//	(bucket_start, platform)            → (b, '', 0)   当 platform 真的是 NULL 时与 overall 撞车
+//	(bucket_start, platform, group_id)  → (b, p,  0)   当 group_id 真的是 NULL 时与 platform 行撞车
+//
+// 撞车会让 ON CONFLICT DO UPDATE 在一条语句里两次命中同一行，PostgreSQL 直接报错
+// "cannot affect row a second time"，整个分钟聚合失败。
+//
+// 丢掉这些行不会少算：真 NULL 的 platform/group 依然计入 overall 行，而 raw 侧的
+// platform / group 过滤本来就排除它们（NULL 不等于任何值），口径一致。
+//
+// UpsertHourlyMetrics 不需要这层保护——它的 usage 侧是 INNER JOIN groups，
+// platform 与 group_id 都不可能为 NULL。
+const opsMinuteDimensionHaving = `HAVING (GROUPING(group_id) = 1 AND (GROUPING(platform) = 1 OR platform IS NOT NULL))
+      OR (GROUPING(group_id) = 0 AND group_id IS NOT NULL)`
+
+// UpsertMinuteMetrics 聚合 [startTime, endTime) 的分钟桶，供 ops trend 查询使用。
+//
+// 与 UpsertHourlyMetrics 的关键差异（刻意为之，不是疏漏）：
+//   - usage 侧用 LEFT JOIN groups/accounts，与 buildUsageWhere 的口径一致；
+//     UpsertHourlyMetrics 用 INNER JOIN groups，会丢掉 group_id IS NULL 的行。
+//     trend 的 preagg 段要和 head/tail 的 raw 段拼接，口径必须一致，否则接缝处数字会跳。
+//   - 额外聚合 switch_count：把原先散落在查询期的 jsonb_array_elements(upstream_errors)
+//     展开挪到写入侧，每分钟只展开一次。
+//   - 不存分位数：分钟粒度的 p50/p90 无意义，且 trend 不需要。
+func (r *opsRepository) UpsertMinuteMetrics(ctx context.Context, startTime, endTime time.Time) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("nil ops repository")
+	}
+	if startTime.IsZero() || endTime.IsZero() || !endTime.After(startTime) {
+		return nil
+	}
+
+	start := startTime.UTC()
+	end := endTime.UTC()
+
+	q := `
+WITH usage_base AS (
+  SELECT
+    date_trunc('minute', ul.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket_start,
+    -- 与 buildUsageWhere 相同：优先 group.platform，回退 account.platform。
+    -- 外层再包一层 NULLIF：唯一键是 COALESCE(platform,'')，'' 与 NULL 同键，
+    -- 不归一的话空串维度行会和 overall 行撞在同一个 ON CONFLICT 目标上。
+    NULLIF(COALESCE(NULLIF(g.platform, ''), a.platform), '') AS platform,
+    ul.group_id AS group_id,
+    (ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens) AS tokens
+  FROM usage_logs ul
+  LEFT JOIN groups g ON g.id = ul.group_id
+  LEFT JOIN accounts a ON a.id = ul.account_id
+  WHERE ul.created_at >= $1 AND ul.created_at < $2
+),
+usage_agg AS (
+  SELECT
+    bucket_start,
+    CASE WHEN GROUPING(platform) = 1 THEN NULL ELSE platform END AS platform,
+    CASE WHEN GROUPING(group_id) = 1 THEN NULL ELSE group_id END AS group_id,
+    COUNT(*) AS success_count,
+    COALESCE(SUM(tokens), 0) AS token_consumed
+  FROM usage_base
+  GROUP BY GROUPING SETS (
+    (bucket_start),
+    (bucket_start, platform),
+    (bucket_start, platform, group_id)
+  )
+  ` + opsMinuteDimensionHaving + `
+),
+error_base AS (
+  SELECT
+    date_trunc('minute', created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket_start,
+    -- platform 在早期阶段错误里可能为 NULL。这里保持 NULL 并由 HAVING 丢掉该维度行，
+    -- 而不是像 UpsertHourlyMetrics 那样映射成 'unknown'：raw 侧的 platform 过滤与
+    -- platform 下钻都排除 NULL platform，造一个假平台会让 preagg 比 raw 多一行。
+    NULLIF(platform, '') AS platform,
+    group_id AS group_id,
+    is_business_limited AS is_business_limited,
+    error_owner AS error_owner,
+    status_code AS client_status_code,
+    COALESCE(upstream_status_code, status_code, 0) AS effective_status_code,
+    upstream_errors AS upstream_errors
+  FROM ops_error_logs
+  -- 与 buildErrorWhere 一致：count_tokens 是探针请求，不计入错误指标。
+  WHERE created_at >= $1 AND created_at < $2
+    AND is_count_tokens = FALSE
+),
+error_agg AS (
+  SELECT
+    bucket_start,
+    CASE WHEN GROUPING(platform) = 1 THEN NULL ELSE platform END AS platform,
+    CASE WHEN GROUPING(group_id) = 1 THEN NULL ELSE group_id END AS group_id,
+    COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400) AS error_count_total,
+    COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400 AND is_business_limited) AS business_limited_count,
+    COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400 AND NOT is_business_limited) AS error_count_sla,
+    COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) NOT IN (429, 529)) AS upstream_error_count_excl_429_529,
+    COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) = 429) AS upstream_429_count,
+    COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) = 529) AS upstream_529_count
+  FROM error_base
+  GROUP BY GROUPING SETS (
+    (bucket_start),
+    (bucket_start, platform),
+    (bucket_start, platform, group_id)
+  )
+  ` + opsMinuteDimensionHaving + `
+),
+switch_agg AS (
+  SELECT
+    bucket_start,
+    CASE WHEN GROUPING(platform) = 1 THEN NULL ELSE platform END AS platform,
+    CASE WHEN GROUPING(group_id) = 1 THEN NULL ELSE group_id END AS group_id,
+    COALESCE(SUM(CASE
+      WHEN split_part(ev->>'kind', ':', 1) IN ('failover', 'retry_exhausted_failover', 'failover_on_400') THEN 1
+      ELSE 0
+    END), 0) AS switch_count
+  FROM error_base
+  CROSS JOIN LATERAL jsonb_array_elements(
+    COALESCE(NULLIF(upstream_errors, 'null'::jsonb), '[]'::jsonb)
+  ) AS ev
+  WHERE upstream_errors IS NOT NULL
+  GROUP BY GROUPING SETS (
+    (bucket_start),
+    (bucket_start, platform),
+    (bucket_start, platform, group_id)
+  )
+  ` + opsMinuteDimensionHaving + `
+),
+combined AS (
+  SELECT
+    COALESCE(u.bucket_start, e.bucket_start, s.bucket_start) AS bucket_start,
+    COALESCE(u.platform, e.platform, s.platform) AS platform,
+    COALESCE(u.group_id, e.group_id, s.group_id) AS group_id,
+
+    COALESCE(u.success_count, 0) AS success_count,
+    COALESCE(e.error_count_total, 0) AS error_count_total,
+    COALESCE(e.business_limited_count, 0) AS business_limited_count,
+    COALESCE(e.error_count_sla, 0) AS error_count_sla,
+    COALESCE(e.upstream_error_count_excl_429_529, 0) AS upstream_error_count_excl_429_529,
+    COALESCE(e.upstream_429_count, 0) AS upstream_429_count,
+    COALESCE(e.upstream_529_count, 0) AS upstream_529_count,
+    COALESCE(u.token_consumed, 0) AS token_consumed,
+    COALESCE(s.switch_count, 0) AS switch_count
+  FROM usage_agg u
+  FULL OUTER JOIN error_agg e
+    ON u.bucket_start = e.bucket_start
+   AND COALESCE(u.platform, '') = COALESCE(e.platform, '')
+   AND COALESCE(u.group_id, 0) = COALESCE(e.group_id, 0)
+  FULL OUTER JOIN switch_agg s
+    ON COALESCE(u.bucket_start, e.bucket_start) = s.bucket_start
+   AND COALESCE(u.platform, e.platform, '') = COALESCE(s.platform, '')
+   AND COALESCE(u.group_id, e.group_id, 0) = COALESCE(s.group_id, 0)
+)
+INSERT INTO ops_metrics_minute (
+  bucket_start,
+  platform,
+  group_id,
+  success_count,
+  error_count_total,
+  business_limited_count,
+  error_count_sla,
+  upstream_error_count_excl_429_529,
+  upstream_429_count,
+  upstream_529_count,
+  token_consumed,
+  switch_count,
+  computed_at
+)
+SELECT
+  bucket_start,
+  NULLIF(platform, '') AS platform,
+  group_id,
+  success_count,
+  error_count_total,
+  business_limited_count,
+  error_count_sla,
+  upstream_error_count_excl_429_529,
+  upstream_429_count,
+  upstream_529_count,
+  token_consumed,
+  switch_count,
+  NOW()
+FROM combined
+WHERE bucket_start IS NOT NULL
+  AND (platform IS NULL OR platform <> '')
+ON CONFLICT (bucket_start, COALESCE(platform, ''), COALESCE(group_id, 0)) DO UPDATE SET
+  success_count = EXCLUDED.success_count,
+  error_count_total = EXCLUDED.error_count_total,
+  business_limited_count = EXCLUDED.business_limited_count,
+  error_count_sla = EXCLUDED.error_count_sla,
+  upstream_error_count_excl_429_529 = EXCLUDED.upstream_error_count_excl_429_529,
+  upstream_429_count = EXCLUDED.upstream_429_count,
+  upstream_529_count = EXCLUDED.upstream_529_count,
+  token_consumed = EXCLUDED.token_consumed,
+  switch_count = EXCLUDED.switch_count,
+  computed_at = NOW()
+`
+
+	_, err := r.db.ExecContext(ctx, q, start, end)
+	return err
+}
+
+// GetLatestMinuteBucketStart 返回分钟表已聚合到的最新桶，用于判断回填缺口。
+func (r *opsRepository) GetLatestMinuteBucketStart(ctx context.Context) (time.Time, bool, error) {
+	if r == nil || r.db == nil {
+		return time.Time{}, false, fmt.Errorf("nil ops repository")
+	}
+
+	var value sql.NullTime
+	if err := r.db.QueryRowContext(ctx, `SELECT MAX(bucket_start) FROM ops_metrics_minute`).Scan(&value); err != nil {
+		return time.Time{}, false, err
+	}
+	if !value.Valid {
+		return time.Time{}, false, nil
+	}
+	return value.Time.UTC(), true, nil
+}
+
+// GetEarliestMinuteBucketStart 返回分钟表最早的桶，用于判断历史回填是否已覆盖目标窗口。
+func (r *opsRepository) GetEarliestMinuteBucketStart(ctx context.Context) (time.Time, bool, error) {
+	if r == nil || r.db == nil {
+		return time.Time{}, false, fmt.Errorf("nil ops repository")
+	}
+
+	var value sql.NullTime
+	if err := r.db.QueryRowContext(ctx, `SELECT MIN(bucket_start) FROM ops_metrics_minute`).Scan(&value); err != nil {
+		return time.Time{}, false, err
+	}
+	if !value.Valid {
+		return time.Time{}, false, nil
+	}
+	return value.Time.UTC(), true, nil
+}
+
 func (r *opsRepository) UpsertDailyMetrics(ctx context.Context, startTime, endTime time.Time) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("nil ops repository")

--- a/backend/internal/repository/ops_repo_system_logs_count_integration_test.go
+++ b/backend/internal/repository/ops_repo_system_logs_count_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// 系统日志列表放弃了精确 COUNT(*)：命中数超过上限时只报上限值。
+// 这组用例钉住三件事——没超上限时仍然精确、超了要置位、深翻页时上限必须跟着抬。
+func TestListSystemLogsCappedCount(t *testing.T) {
+	ctx := context.Background()
+
+	start := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	end := start.Add(time.Hour)
+	cleanup := func() {
+		_, err := integrationDB.ExecContext(context.Background(),
+			`DELETE FROM ops_system_logs WHERE created_at >= $1 AND created_at < $2`, start, end)
+		require.NoError(t, err)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	const seeded = 120
+	repo := NewOpsRepository(integrationDB).(*opsRepository)
+	inputs := make([]*service.OpsInsertSystemLogInput, 0, seeded)
+	for i := range seeded {
+		inputs = append(inputs, &service.OpsInsertSystemLogInput{
+			CreatedAt: start.Add(time.Duration(i) * time.Second),
+			Level:     "info",
+			Component: "capped-count-test",
+			Message:   fmt.Sprintf("entry %d", i),
+		})
+	}
+	_, err := repo.BatchInsertSystemLogs(ctx, inputs)
+	require.NoError(t, err)
+
+	filter := func(page, pageSize int) *service.OpsSystemLogFilter {
+		return &service.OpsSystemLogFilter{
+			StartTime: &start,
+			EndTime:   &end,
+			Component: "capped-count-test",
+			Page:      page,
+			PageSize:  pageSize,
+		}
+	}
+
+	t.Run("未达上限时仍是精确值", func(t *testing.T) {
+		got, err := repo.ListSystemLogs(ctx, filter(1, 50))
+		require.NoError(t, err)
+		require.Equal(t, seeded, got.Total)
+		require.False(t, got.TotalIsCapped)
+		require.Len(t, got.Logs, 50)
+	})
+
+	t.Run("达到上限时置位且不再精确", func(t *testing.T) {
+		// 上限压到 seeded 以下，等价于命中数远超 10000 的情形。
+		// pageSize 必须小于上限，否则会被下面那条"抬上限"的规则顶上去。
+		got, err := repo.listSystemLogsWithCountCap(ctx, filter(1, 10), 30)
+		require.NoError(t, err)
+		require.Equal(t, 30, got.Total)
+		require.True(t, got.TotalIsCapped)
+		require.Len(t, got.Logs, 10, "封顶只影响计数，不该影响当前页数据")
+	})
+
+	t.Run("翻过上限的页码必须把上限抬上去", func(t *testing.T) {
+		// 上限 30、但请求的是 offset=60 的第 3 页：若不抬上限，
+		// 总页数会算成 1，前端分页器直接错乱。
+		got, err := repo.listSystemLogsWithCountCap(ctx, filter(3, 30), 30)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got.Total, 91, "上限至少要抬到 offset+pageSize+1")
+		require.Len(t, got.Logs, 30)
+		// 总数足以让分页器算出第 3 页存在。
+		require.GreaterOrEqual(t, got.Total, (3-1)*30+1)
+	})
+
+	t.Run("空结果不置位", func(t *testing.T) {
+		f := filter(1, 50)
+		f.Component = "no-such-component"
+		got, err := repo.ListSystemLogs(ctx, f)
+		require.NoError(t, err)
+		require.Equal(t, 0, got.Total)
+		require.False(t, got.TotalIsCapped)
+		require.Empty(t, got.Logs)
+	})
+}

--- a/backend/internal/repository/ops_repo_trends.go
+++ b/backend/internal/repository/ops_repo_trends.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,11 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
+// GetThroughputTrend dispatches between the pre-aggregated and raw implementations.
+//
+// Historically this was raw-only, which meant every request scanned usage_logs and
+// ops_error_logs (including a CROSS JOIN LATERAL over the upstream_errors JSONB) and
+// `mode=auto` had no effect here. The preaggregated path is served by ops_metrics_minute.
 func (r *opsRepository) GetThroughputTrend(ctx context.Context, filter *service.OpsDashboardFilter, bucketSeconds int) (*service.OpsThroughputTrendResponse, error) {
 	if r == nil || r.db == nil {
 		return nil, fmt.Errorf("nil ops repository")
@@ -21,14 +27,36 @@ func (r *opsRepository) GetThroughputTrend(ctx context.Context, filter *service.
 		return nil, fmt.Errorf("start_time/end_time required")
 	}
 
-	if bucketSeconds <= 0 {
-		bucketSeconds = 60
-	}
-	if bucketSeconds != 60 && bucketSeconds != 300 && bucketSeconds != 3600 {
-		// Keep a small, predictable set of supported buckets for now.
-		bucketSeconds = 60
+	bucketSeconds = normalizeOpsBucketSeconds(bucketSeconds)
+
+	mode := filter.QueryMode
+	if !mode.IsValid() {
+		mode = service.OpsQueryModeRaw
 	}
 
+	switch mode {
+	case service.OpsQueryModePreagg:
+		return r.getThroughputTrendPreaggregated(ctx, filter, bucketSeconds)
+	case service.OpsQueryModeAuto:
+		out, err := r.getThroughputTrendPreaggregated(ctx, filter, bucketSeconds)
+		if err != nil && errors.Is(err, service.ErrOpsPreaggregatedNotPopulated) {
+			return r.getThroughputTrendRaw(ctx, filter, bucketSeconds)
+		}
+		return out, err
+	default:
+		return r.getThroughputTrendRaw(ctx, filter, bucketSeconds)
+	}
+}
+
+// normalizeOpsBucketSeconds keeps a small, predictable set of supported buckets.
+func normalizeOpsBucketSeconds(bucketSeconds int) int {
+	if bucketSeconds != 60 && bucketSeconds != 300 && bucketSeconds != 3600 {
+		return 60
+	}
+	return bucketSeconds
+}
+
+func (r *opsRepository) getThroughputTrendRaw(ctx context.Context, filter *service.OpsDashboardFilter, bucketSeconds int) (*service.OpsThroughputTrendResponse, error) {
 	start := filter.StartTime.UTC()
 	end := filter.EndTime.UTC()
 
@@ -425,6 +453,8 @@ func fillOpsThroughputBuckets(start, end time.Time, bucketSeconds int, points []
 	return out
 }
 
+// GetErrorTrend dispatches between the pre-aggregated and raw implementations,
+// mirroring GetThroughputTrend. Previously raw-only.
 func (r *opsRepository) GetErrorTrend(ctx context.Context, filter *service.OpsDashboardFilter, bucketSeconds int) (*service.OpsErrorTrendResponse, error) {
 	if r == nil || r.db == nil {
 		return nil, fmt.Errorf("nil ops repository")
@@ -436,13 +466,28 @@ func (r *opsRepository) GetErrorTrend(ctx context.Context, filter *service.OpsDa
 		return nil, fmt.Errorf("start_time/end_time required")
 	}
 
-	if bucketSeconds <= 0 {
-		bucketSeconds = 60
-	}
-	if bucketSeconds != 60 && bucketSeconds != 300 && bucketSeconds != 3600 {
-		bucketSeconds = 60
+	bucketSeconds = normalizeOpsBucketSeconds(bucketSeconds)
+
+	mode := filter.QueryMode
+	if !mode.IsValid() {
+		mode = service.OpsQueryModeRaw
 	}
 
+	switch mode {
+	case service.OpsQueryModePreagg:
+		return r.getErrorTrendPreaggregated(ctx, filter, bucketSeconds)
+	case service.OpsQueryModeAuto:
+		out, err := r.getErrorTrendPreaggregated(ctx, filter, bucketSeconds)
+		if err != nil && errors.Is(err, service.ErrOpsPreaggregatedNotPopulated) {
+			return r.getErrorTrendRaw(ctx, filter, bucketSeconds)
+		}
+		return out, err
+	default:
+		return r.getErrorTrendRaw(ctx, filter, bucketSeconds)
+	}
+}
+
+func (r *opsRepository) getErrorTrendRaw(ctx context.Context, filter *service.OpsDashboardFilter, bucketSeconds int) (*service.OpsErrorTrendResponse, error) {
 	start := filter.StartTime.UTC()
 	end := filter.EndTime.UTC()
 	where, args, _ := buildErrorWhere(filter, start, end, 1)

--- a/backend/internal/repository/ops_repo_trends_preagg.go
+++ b/backend/internal/repository/ops_repo_trends_preagg.go
@@ -1,0 +1,651 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// 分钟预聚合的安全边界：聚合作业按 opsAggMinuteSafeDelay(90s) 落后于当前时间推进，
+// 这里留出更宽的余量，尾部不足一个桶的部分交给 raw 段补齐。
+const opsMinutePreaggSafeLag = 3 * time.Minute
+
+// opsMinutePreaggSafeEnd 返回可以信任分钟预聚合的时间上界。
+func opsMinutePreaggSafeEnd(endTime time.Time) time.Time {
+	cutoff := time.Now().UTC().Add(-opsMinutePreaggSafeLag)
+	if endTime.After(cutoff) {
+		return cutoff
+	}
+	return endTime
+}
+
+func utcFloorToBucket(t time.Time, bucketSeconds int) time.Time {
+	if bucketSeconds <= 0 {
+		bucketSeconds = 60
+	}
+	step := time.Duration(bucketSeconds) * time.Second
+	return t.UTC().Truncate(step)
+}
+
+func utcCeilToBucket(t time.Time, bucketSeconds int) time.Time {
+	u := t.UTC()
+	f := utcFloorToBucket(u, bucketSeconds)
+	if f.Equal(u) {
+		return f
+	}
+	return f.Add(time.Duration(bucketSeconds) * time.Second)
+}
+
+// buildMinutePreaggWhere 把过滤条件映射到 ops_metrics_minute 的三种维度行。
+// 写入侧用 GROUPING SETS 产出 (overall) / (platform) / (platform, group) 三档，
+// 因此这里的匹配规则与 listHourlyMetricsRows 完全一致。
+func buildMinutePreaggWhere(filter *service.OpsDashboardFilter, start, end time.Time) (string, []any) {
+	where := "bucket_start >= $1 AND bucket_start < $2"
+	args := []any{start.UTC(), end.UTC()}
+	idx := 3
+
+	platform := ""
+	groupID := (*int64)(nil)
+	if filter != nil {
+		platform = strings.TrimSpace(strings.ToLower(filter.Platform))
+		groupID = filter.GroupID
+	}
+
+	switch {
+	case groupID != nil && *groupID > 0:
+		where += fmt.Sprintf(" AND group_id = $%d", idx)
+		args = append(args, *groupID)
+		idx++
+		if platform != "" {
+			where += fmt.Sprintf(" AND platform = $%d", idx)
+			args = append(args, platform)
+		}
+	case platform != "":
+		where += fmt.Sprintf(" AND platform = $%d AND group_id IS NULL", idx)
+		args = append(args, platform)
+	default:
+		where += " AND platform IS NULL AND group_id IS NULL"
+	}
+
+	return where, args
+}
+
+// minutePreaggRowsExist 判断给定窗口内分钟表是否已有数据，用于区分
+// 「这段时间本来就没流量」和「预聚合还没跑到」。
+func (r *opsRepository) minutePreaggRowsExist(ctx context.Context, start, end time.Time) (bool, error) {
+	var exists bool
+	err := r.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM ops_metrics_minute
+  WHERE bucket_start >= $1 AND bucket_start < $2
+)`, start.UTC(), end.UTC()).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+type opsThroughputAgg struct {
+	requestCount  int64
+	tokenConsumed int64
+	switchCount   int64
+}
+
+// queryThroughputFromMinutePreagg 按目标桶粒度把分钟行折叠成 trend 点。
+func (r *opsRepository) queryThroughputFromMinutePreagg(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	start, end time.Time,
+	bucketSeconds int,
+) (map[int64]*opsThroughputAgg, error) {
+	where, args := buildMinutePreaggWhere(filter, start, end)
+	args = append(args, bucketSeconds)
+	bucketArg := fmt.Sprintf("$%d", len(args))
+
+	q := `
+SELECT
+  to_timestamp(floor(extract(epoch FROM bucket_start) / ` + bucketArg + `) * ` + bucketArg + `) AS bucket,
+  COALESCE(SUM(success_count + error_count_total), 0) AS request_count,
+  COALESCE(SUM(token_consumed), 0) AS token_consumed,
+  COALESCE(SUM(switch_count), 0) AS switch_count
+FROM ops_metrics_minute
+WHERE ` + where + `
+GROUP BY 1`
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]*opsThroughputAgg, 256)
+	for rows.Next() {
+		var bucket time.Time
+		var requests, tokens, switches int64
+		if err := rows.Scan(&bucket, &requests, &tokens, &switches); err != nil {
+			return nil, err
+		}
+		out[bucket.UTC().Unix()] = &opsThroughputAgg{
+			requestCount:  requests,
+			tokenConsumed: tokens,
+			switchCount:   switches,
+		}
+	}
+	return out, rows.Err()
+}
+
+// queryThroughputFromRaw 直接从明细统计一段（仅用于 preagg 覆盖不到的首尾碎片）。
+func (r *opsRepository) queryThroughputFromRaw(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	start, end time.Time,
+	bucketSeconds int,
+) (map[int64]*opsThroughputAgg, error) {
+	if !start.Before(end) {
+		return map[int64]*opsThroughputAgg{}, nil
+	}
+
+	usageJoin, usageWhere, usageArgs, next := buildUsageWhere(filter, start, end, 1)
+	errorWhere, errorArgs, _ := buildErrorWhere(filter, start, end, next)
+
+	usageBucketExpr := opsBucketExprForUsage(bucketSeconds)
+	errorBucketExpr := opsBucketExprForError(bucketSeconds)
+
+	q := `
+WITH usage_buckets AS (
+  SELECT ` + usageBucketExpr + ` AS bucket,
+         COUNT(*) AS success_count,
+         COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0) AS token_consumed
+  FROM usage_logs ul
+  ` + usageJoin + `
+  ` + usageWhere + `
+  GROUP BY 1
+),
+error_buckets AS (
+  SELECT ` + errorBucketExpr + ` AS bucket,
+         COUNT(*) AS error_count
+  FROM ops_error_logs
+  ` + errorWhere + `
+    AND COALESCE(status_code, 0) >= 400
+  GROUP BY 1
+),
+switch_buckets AS (
+  SELECT ` + errorBucketExpr + ` AS bucket,
+         COALESCE(SUM(CASE
+           WHEN split_part(ev->>'kind', ':', 1) IN ('failover', 'retry_exhausted_failover', 'failover_on_400') THEN 1
+           ELSE 0
+         END), 0) AS switch_count
+  FROM ops_error_logs
+  CROSS JOIN LATERAL jsonb_array_elements(
+    COALESCE(NULLIF(upstream_errors, 'null'::jsonb), '[]'::jsonb)
+  ) AS ev
+  ` + errorWhere + `
+    AND upstream_errors IS NOT NULL
+  GROUP BY 1
+),
+combined AS (
+  SELECT
+    bucket,
+    SUM(success_count) AS success_count,
+    SUM(error_count) AS error_count,
+    SUM(token_consumed) AS token_consumed,
+    SUM(switch_count) AS switch_count
+  FROM (
+    SELECT bucket, success_count, 0 AS error_count, token_consumed, 0 AS switch_count
+    FROM usage_buckets
+    UNION ALL
+    SELECT bucket, 0, error_count, 0, 0
+    FROM error_buckets
+    UNION ALL
+    SELECT bucket, 0, 0, 0, switch_count
+    FROM switch_buckets
+  ) t
+  GROUP BY bucket
+)
+SELECT bucket, (success_count + error_count) AS request_count, token_consumed, switch_count
+FROM combined`
+
+	args := append(usageArgs, errorArgs...)
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]*opsThroughputAgg, 128)
+	for rows.Next() {
+		var bucket time.Time
+		var requests int64
+		var tokens, switches sql.NullInt64
+		if err := rows.Scan(&bucket, &requests, &tokens, &switches); err != nil {
+			return nil, err
+		}
+		out[bucket.UTC().Unix()] = &opsThroughputAgg{
+			requestCount:  requests,
+			tokenConsumed: tokens.Int64,
+			switchCount:   switches.Int64,
+		}
+	}
+	return out, rows.Err()
+}
+
+// getThroughputTrendPreaggregated 用分钟预聚合服务 trend，首尾不足一个稳定桶的部分回落到明细。
+//
+// 三种桶粒度（60/300/3600）统一由 ops_metrics_minute 折叠得出，不混用 ops_metrics_hourly：
+// 后者的 usage 侧是 INNER JOIN groups，会丢掉 group_id IS NULL 的行，与本函数的
+// raw 首尾段口径不一致，拼接处会出现数字跳变。
+func (r *opsRepository) getThroughputTrendPreaggregated(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	bucketSeconds int,
+) (*service.OpsThroughputTrendResponse, error) {
+	start := filter.StartTime.UTC()
+	end := filter.EndTime.UTC()
+
+	aggSafeEnd := opsMinutePreaggSafeEnd(end)
+	aggFullStart := utcCeilToBucket(start, bucketSeconds)
+	aggFullEnd := utcFloorToBucket(aggSafeEnd, bucketSeconds)
+
+	// 窗口太短，凑不出一个完整的稳定桶：直接走明细。
+	if !aggFullStart.Before(aggFullEnd) {
+		return r.getThroughputTrendRaw(ctx, filter, bucketSeconds)
+	}
+
+	preagg, err := r.queryThroughputFromMinutePreagg(ctx, filter, aggFullStart, aggFullEnd, bucketSeconds)
+	if err != nil {
+		return nil, err
+	}
+	if len(preagg) == 0 {
+		// 区分「没有流量」与「预聚合尚未覆盖」。
+		exists, err := r.minutePreaggRowsExist(ctx, aggFullStart, aggFullEnd)
+		if err == nil && !exists {
+			if rawExists, err := r.rawOpsDataExists(ctx, filter, aggFullStart, aggFullEnd); err == nil && rawExists {
+				return nil, service.ErrOpsPreaggregatedNotPopulated
+			}
+		}
+	}
+
+	merged := preagg
+
+	// 首尾碎片走明细：各自最多一个桶的跨度，代价可控。
+	if start.Before(aggFullStart) {
+		head, err := r.queryThroughputFromRaw(ctx, filter, start, minTime(end, aggFullStart), bucketSeconds)
+		if err != nil {
+			return nil, err
+		}
+		mergeThroughputAgg(merged, head)
+	}
+	if aggFullEnd.Before(end) {
+		tail, err := r.queryThroughputFromRaw(ctx, filter, maxTime(start, aggFullEnd), end, bucketSeconds)
+		if err != nil {
+			return nil, err
+		}
+		mergeThroughputAgg(merged, tail)
+	}
+
+	points := make([]*service.OpsThroughputTrendPoint, 0, len(merged))
+	denom := float64(bucketSeconds)
+	if denom <= 0 {
+		denom = 60
+	}
+	for ts, agg := range merged {
+		points = append(points, &service.OpsThroughputTrendPoint{
+			BucketStart:   time.Unix(ts, 0).UTC(),
+			RequestCount:  agg.requestCount,
+			TokenConsumed: agg.tokenConsumed,
+			SwitchCount:   agg.switchCount,
+			QPS:           roundTo1DP(float64(agg.requestCount) / denom),
+			TPS:           roundTo1DP(float64(agg.tokenConsumed) / denom),
+		})
+	}
+	sortThroughputPoints(points)
+	points = fillOpsThroughputBuckets(start, end, bucketSeconds, points)
+
+	byPlatform, topGroups, err := r.throughputBreakdownsPreagg(ctx, filter, aggFullStart, aggFullEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &service.OpsThroughputTrendResponse{
+		Bucket:     opsBucketLabel(bucketSeconds),
+		Points:     points,
+		ByPlatform: byPlatform,
+		TopGroups:  topGroups,
+	}, nil
+}
+
+type opsErrorAgg struct {
+	errorCountTotal      int64
+	businessLimitedCount int64
+	errorCountSLA        int64
+	upstreamExcl429529   int64
+	upstream429Count     int64
+	upstream529Count     int64
+}
+
+// queryErrorFromMinutePreagg 按目标桶粒度折叠分钟表的错误分项。
+func (r *opsRepository) queryErrorFromMinutePreagg(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	start, end time.Time,
+	bucketSeconds int,
+) (map[int64]*opsErrorAgg, error) {
+	where, args := buildMinutePreaggWhere(filter, start, end)
+	args = append(args, bucketSeconds)
+	bucketArg := fmt.Sprintf("$%d", len(args))
+
+	q := `
+SELECT
+  to_timestamp(floor(extract(epoch FROM bucket_start) / ` + bucketArg + `) * ` + bucketArg + `) AS bucket,
+  COALESCE(SUM(error_count_total), 0),
+  COALESCE(SUM(business_limited_count), 0),
+  COALESCE(SUM(error_count_sla), 0),
+  COALESCE(SUM(upstream_error_count_excl_429_529), 0),
+  COALESCE(SUM(upstream_429_count), 0),
+  COALESCE(SUM(upstream_529_count), 0)
+FROM ops_metrics_minute
+WHERE ` + where + `
+GROUP BY 1`
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]*opsErrorAgg, 256)
+	for rows.Next() {
+		var bucket time.Time
+		agg := &opsErrorAgg{}
+		if err := rows.Scan(
+			&bucket,
+			&agg.errorCountTotal,
+			&agg.businessLimitedCount,
+			&agg.errorCountSLA,
+			&agg.upstreamExcl429529,
+			&agg.upstream429Count,
+			&agg.upstream529Count,
+		); err != nil {
+			return nil, err
+		}
+		out[bucket.UTC().Unix()] = agg
+	}
+	return out, rows.Err()
+}
+
+// queryErrorFromRaw 统计一段明细，仅用于 preagg 覆盖不到的首尾碎片。
+func (r *opsRepository) queryErrorFromRaw(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	start, end time.Time,
+	bucketSeconds int,
+) (map[int64]*opsErrorAgg, error) {
+	if !start.Before(end) {
+		return map[int64]*opsErrorAgg{}, nil
+	}
+
+	where, args, _ := buildErrorWhere(filter, start, end, 1)
+	bucketExpr := opsBucketExprForError(bucketSeconds)
+
+	q := `
+SELECT
+  ` + bucketExpr + ` AS bucket,
+  COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400) AS error_total,
+  COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND is_business_limited) AS business_limited,
+  COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND NOT is_business_limited) AS error_sla,
+  COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)) AS upstream_excl,
+  COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 429) AS upstream_429,
+  COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 529) AS upstream_529
+FROM ops_error_logs
+` + where + `
+GROUP BY 1`
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]*opsErrorAgg, 128)
+	for rows.Next() {
+		var bucket time.Time
+		agg := &opsErrorAgg{}
+		if err := rows.Scan(
+			&bucket,
+			&agg.errorCountTotal,
+			&agg.businessLimitedCount,
+			&agg.errorCountSLA,
+			&agg.upstreamExcl429529,
+			&agg.upstream429Count,
+			&agg.upstream529Count,
+		); err != nil {
+			return nil, err
+		}
+		out[bucket.UTC().Unix()] = agg
+	}
+	return out, rows.Err()
+}
+
+// getErrorTrendPreaggregated 与 throughput 版同构：稳定段走分钟预聚合，首尾碎片回落明细。
+func (r *opsRepository) getErrorTrendPreaggregated(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	bucketSeconds int,
+) (*service.OpsErrorTrendResponse, error) {
+	start := filter.StartTime.UTC()
+	end := filter.EndTime.UTC()
+
+	aggSafeEnd := opsMinutePreaggSafeEnd(end)
+	aggFullStart := utcCeilToBucket(start, bucketSeconds)
+	aggFullEnd := utcFloorToBucket(aggSafeEnd, bucketSeconds)
+
+	if !aggFullStart.Before(aggFullEnd) {
+		return r.getErrorTrendRaw(ctx, filter, bucketSeconds)
+	}
+
+	merged, err := r.queryErrorFromMinutePreagg(ctx, filter, aggFullStart, aggFullEnd, bucketSeconds)
+	if err != nil {
+		return nil, err
+	}
+	if len(merged) == 0 {
+		exists, err := r.minutePreaggRowsExist(ctx, aggFullStart, aggFullEnd)
+		if err == nil && !exists {
+			if rawExists, err := r.rawOpsDataExists(ctx, filter, aggFullStart, aggFullEnd); err == nil && rawExists {
+				return nil, service.ErrOpsPreaggregatedNotPopulated
+			}
+		}
+	}
+
+	if start.Before(aggFullStart) {
+		head, err := r.queryErrorFromRaw(ctx, filter, start, minTime(end, aggFullStart), bucketSeconds)
+		if err != nil {
+			return nil, err
+		}
+		mergeErrorAgg(merged, head)
+	}
+	if aggFullEnd.Before(end) {
+		tail, err := r.queryErrorFromRaw(ctx, filter, maxTime(start, aggFullEnd), end, bucketSeconds)
+		if err != nil {
+			return nil, err
+		}
+		mergeErrorAgg(merged, tail)
+	}
+
+	points := make([]*service.OpsErrorTrendPoint, 0, len(merged))
+	for ts, agg := range merged {
+		points = append(points, &service.OpsErrorTrendPoint{
+			BucketStart:                  time.Unix(ts, 0).UTC(),
+			ErrorCountTotal:              agg.errorCountTotal,
+			BusinessLimitedCount:         agg.businessLimitedCount,
+			ErrorCountSLA:                agg.errorCountSLA,
+			UpstreamErrorCountExcl429529: agg.upstreamExcl429529,
+			Upstream429Count:             agg.upstream429Count,
+			Upstream529Count:             agg.upstream529Count,
+		})
+	}
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].BucketStart.Before(points[j].BucketStart)
+	})
+	points = fillOpsErrorTrendBuckets(start, end, bucketSeconds, points)
+
+	return &service.OpsErrorTrendResponse{
+		Bucket: opsBucketLabel(bucketSeconds),
+		Points: points,
+	}, nil
+}
+
+func mergeErrorAgg(dst, src map[int64]*opsErrorAgg) {
+	for ts, agg := range src {
+		cur, ok := dst[ts]
+		if !ok {
+			cur = &opsErrorAgg{}
+			dst[ts] = cur
+		}
+		cur.errorCountTotal += agg.errorCountTotal
+		cur.businessLimitedCount += agg.businessLimitedCount
+		cur.errorCountSLA += agg.errorCountSLA
+		cur.upstreamExcl429529 += agg.upstreamExcl429529
+		cur.upstream429Count += agg.upstream429Count
+		cur.upstream529Count += agg.upstream529Count
+	}
+}
+
+func sortThroughputPoints(points []*service.OpsThroughputTrendPoint) {
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].BucketStart.Before(points[j].BucketStart)
+	})
+}
+
+func mergeThroughputAgg(dst, src map[int64]*opsThroughputAgg) {
+	for ts, agg := range src {
+		if cur, ok := dst[ts]; ok {
+			cur.requestCount += agg.requestCount
+			cur.tokenConsumed += agg.tokenConsumed
+			cur.switchCount += agg.switchCount
+			continue
+		}
+		dst[ts] = &opsThroughputAgg{
+			requestCount:  agg.requestCount,
+			tokenConsumed: agg.tokenConsumed,
+			switchCount:   agg.switchCount,
+		}
+	}
+}
+
+// throughputBreakdownsPreagg 复用分钟表的 platform / group 维度行产出下钻数据。
+func (r *opsRepository) throughputBreakdownsPreagg(
+	ctx context.Context,
+	filter *service.OpsDashboardFilter,
+	start, end time.Time,
+) ([]*service.OpsThroughputPlatformBreakdownItem, []*service.OpsThroughputGroupBreakdownItem, error) {
+	platform := ""
+	groupID := (*int64)(nil)
+	if filter != nil {
+		platform = strings.TrimSpace(strings.ToLower(filter.Platform))
+		groupID = filter.GroupID
+	}
+
+	switch {
+	case platform == "" && (groupID == nil || *groupID <= 0):
+		items, err := r.getThroughputBreakdownByPlatformPreagg(ctx, start, end)
+		return items, nil, err
+	case platform != "" && (groupID == nil || *groupID <= 0):
+		items, err := r.getThroughputTopGroupsByPlatformPreagg(ctx, start, end, platform, 10)
+		return nil, items, err
+	default:
+		return nil, nil, nil
+	}
+}
+
+func (r *opsRepository) getThroughputBreakdownByPlatformPreagg(
+	ctx context.Context,
+	start, end time.Time,
+) ([]*service.OpsThroughputPlatformBreakdownItem, error) {
+	q := `
+SELECT platform,
+       COALESCE(SUM(success_count + error_count_total), 0) AS request_count,
+       COALESCE(SUM(token_consumed), 0) AS token_consumed
+FROM ops_metrics_minute
+WHERE bucket_start >= $1 AND bucket_start < $2
+  AND platform IS NOT NULL AND platform <> ''
+  AND group_id IS NULL
+GROUP BY 1
+ORDER BY request_count DESC`
+
+	rows, err := r.db.QueryContext(ctx, q, start.UTC(), end.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	items := make([]*service.OpsThroughputPlatformBreakdownItem, 0, 8)
+	for rows.Next() {
+		var platform string
+		var requestCount, tokenConsumed int64
+		if err := rows.Scan(&platform, &requestCount, &tokenConsumed); err != nil {
+			return nil, err
+		}
+		items = append(items, &service.OpsThroughputPlatformBreakdownItem{
+			Platform:      platform,
+			RequestCount:  requestCount,
+			TokenConsumed: tokenConsumed,
+		})
+	}
+	return items, rows.Err()
+}
+
+func (r *opsRepository) getThroughputTopGroupsByPlatformPreagg(
+	ctx context.Context,
+	start, end time.Time,
+	platform string,
+	limit int,
+) ([]*service.OpsThroughputGroupBreakdownItem, error) {
+	if strings.TrimSpace(platform) == "" {
+		return nil, nil
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 10
+	}
+
+	q := `
+SELECT m.group_id,
+       COALESCE(g.name, '') AS group_name,
+       COALESCE(SUM(m.success_count + m.error_count_total), 0) AS request_count,
+       COALESCE(SUM(m.token_consumed), 0) AS token_consumed
+FROM ops_metrics_minute m
+LEFT JOIN groups g ON g.id = m.group_id
+WHERE m.bucket_start >= $1 AND m.bucket_start < $2
+  AND m.platform = $3
+  AND m.group_id IS NOT NULL
+GROUP BY 1, 2
+ORDER BY request_count DESC
+LIMIT $4`
+
+	rows, err := r.db.QueryContext(ctx, q, start.UTC(), end.UTC(), platform, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	items := make([]*service.OpsThroughputGroupBreakdownItem, 0, limit)
+	for rows.Next() {
+		var groupID int64
+		var groupName string
+		var requestCount, tokenConsumed int64
+		if err := rows.Scan(&groupID, &groupName, &requestCount, &tokenConsumed); err != nil {
+			return nil, err
+		}
+		items = append(items, &service.OpsThroughputGroupBreakdownItem{
+			GroupID:       groupID,
+			GroupName:     groupName,
+			RequestCount:  requestCount,
+			TokenConsumed: tokenConsumed,
+		})
+	}
+	return items, rows.Err()
+}

--- a/backend/internal/repository/ops_repo_trends_preagg_integration_test.go
+++ b/backend/internal/repository/ops_repo_trends_preagg_integration_test.go
@@ -1,0 +1,269 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// opsTrendPreaggFixture 在一个远离"现在"的窗口里铺一批 usage/error 明细，
+// 并把该窗口聚合进 ops_metrics_minute。
+//
+// 窗口刻意取 4 小时前并对齐到整点：opsMinutePreaggSafeEnd 会把 preagg 段裁到
+// now-3min，只有窗口整体落在安全线之内，preagg 段才等于整个窗口，
+// 从而让 preagg 与 raw 的结果可以逐点比对（否则尾段口径不同是设计使然）。
+type opsTrendPreaggFixture struct {
+	repo    *opsRepository
+	start   time.Time
+	end     time.Time
+	groupID int64
+}
+
+func setupOpsTrendPreaggFixture(t *testing.T, ctx context.Context) *opsTrendPreaggFixture {
+	t.Helper()
+
+	start := time.Now().UTC().Add(-4 * time.Hour).Truncate(time.Hour)
+	end := start.Add(2 * time.Hour)
+
+	// 只清窗口内的数据：整表 TRUNCATE 会波及同包其他用例的 fixture。
+	// 用例结束后必须再清一次——dashboard 那批用例按"今天"全表统计，
+	// 本 fixture 的 4 小时前落在它们的窗口里，留着会把它们的计数顶高。
+	cleanup := func() {
+		for _, stmt := range []string{
+			`DELETE FROM usage_logs WHERE created_at >= $1 AND created_at < $2`,
+			`DELETE FROM ops_error_logs WHERE created_at >= $1 AND created_at < $2`,
+			`DELETE FROM ops_metrics_minute WHERE bucket_start >= $1 AND bucket_start < $2`,
+		} {
+			_, err := integrationDB.ExecContext(context.Background(), stmt, start, end)
+			require.NoError(t, err)
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	user := mustCreateUser(t, integrationEntClient, &service.User{
+		Email:    fmt.Sprintf("ops-trend-%d@example.com", time.Now().UnixNano()),
+		Username: fmt.Sprintf("ops-trend-%d", time.Now().UnixNano()),
+	})
+	group := mustCreateGroup(t, integrationEntClient, &service.Group{
+		Name:     fmt.Sprintf("ops-trend-group-%d", time.Now().UnixNano()),
+		Platform: service.PlatformAnthropic,
+	})
+	account := mustCreateAccount(t, integrationEntClient, &service.Account{
+		Name:     fmt.Sprintf("ops-trend-account-%d", time.Now().UnixNano()),
+		Platform: service.PlatformAnthropic,
+	})
+	apiKey := mustCreateApiKey(t, integrationEntClient, &service.APIKey{UserID: user.ID})
+
+	// usage 明细散落在多个分钟桶里，且跨越 5 分钟 / 1 小时边界。
+	for _, offset := range []time.Duration{
+		1 * time.Minute, 1 * time.Minute, 7 * time.Minute,
+		33 * time.Minute, 61 * time.Minute, 119 * time.Minute,
+	} {
+		_, err := integrationDB.ExecContext(ctx, `
+			INSERT INTO usage_logs
+				(user_id, api_key_id, account_id, group_id, model,
+				 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+				 total_cost, actual_cost, created_at)
+			VALUES ($1, $2, $3, $4, 'claude-test', 10, 20, 5, 3, 0.01, 0.01, $5)
+		`, user.ID, apiKey.ID, account.ID, group.ID, start.Add(offset))
+		require.NoError(t, err)
+	}
+
+	// group_id 为 NULL 的 usage 行：ops_metrics_hourly 的 INNER JOIN 会丢掉它，
+	// 分钟表用 LEFT JOIN 保留，overall 行必须把它算进去。
+	_, err := integrationDB.ExecContext(ctx, `
+		INSERT INTO usage_logs
+			(user_id, api_key_id, account_id, group_id, model,
+			 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			 total_cost, actual_cost, created_at)
+		VALUES ($1, $2, $3, NULL, 'claude-test', 100, 0, 0, 0, 0.01, 0.01, $4)
+	`, user.ID, apiKey.ID, account.ID, start.Add(9*time.Minute))
+	require.NoError(t, err)
+
+	repo := NewOpsRepository(integrationDB).(*opsRepository)
+	upstream529 := 529
+	upstream500 := 500
+	// 仓储层写的是已由 service 侧脱敏序列化好的 UpstreamErrorsJSON，不是 UpstreamErrors。
+	failoverEvents := `[{"kind":"failover","upstream_status_code":500},` +
+		`{"kind":"retry_exhausted_failover:pool","upstream_status_code":500},` +
+		`{"kind":"http_error","upstream_status_code":500}]`
+	countTokensEvents := `[{"kind":"failover"}]`
+	_, err = repo.BatchInsertErrorLogs(ctx, []*service.OpsInsertErrorLogInput{
+		{
+			RequestID: "trend-429", Platform: service.PlatformAnthropic, GroupID: &group.ID,
+			ErrorPhase: "upstream", ErrorType: "upstream_error", Severity: "error",
+			StatusCode: 429, ErrorOwner: "provider", IsBusinessLimited: false,
+			CreatedAt: start.Add(2 * time.Minute),
+		},
+		{
+			RequestID: "trend-429-business", Platform: service.PlatformAnthropic, GroupID: &group.ID,
+			ErrorPhase: "upstream", ErrorType: "quota", Severity: "error",
+			StatusCode: 429, ErrorOwner: "provider", IsBusinessLimited: true,
+			CreatedAt: start.Add(2 * time.Minute),
+		},
+		{
+			RequestID: "trend-529", Platform: service.PlatformAnthropic, GroupID: &group.ID,
+			ErrorPhase: "upstream", ErrorType: "overloaded", Severity: "error",
+			StatusCode: 500, UpstreamStatusCode: &upstream529, ErrorOwner: "provider",
+			CreatedAt: start.Add(35 * time.Minute),
+		},
+		{
+			// 带 failover 事件：switch_count 必须由写入侧展开出 2。
+			RequestID: "trend-failover", Platform: service.PlatformAnthropic, GroupID: &group.ID,
+			ErrorPhase: "upstream", ErrorType: "upstream_error", Severity: "error",
+			StatusCode: 500, UpstreamStatusCode: &upstream500, ErrorOwner: "provider",
+			UpstreamErrorsJSON: &failoverEvents,
+			CreatedAt:          start.Add(65 * time.Minute),
+		},
+		{
+			// count_tokens 探针：两侧都必须排除，否则错误率虚高、切换数虚高。
+			RequestID: "trend-count-tokens", Platform: service.PlatformAnthropic, GroupID: &group.ID,
+			ErrorPhase: "upstream", ErrorType: "upstream_error", Severity: "error",
+			StatusCode: 500, ErrorOwner: "provider", IsCountTokens: true,
+			UpstreamErrorsJSON: &countTokensEvents,
+			CreatedAt:          start.Add(66 * time.Minute),
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.UpsertMinuteMetrics(ctx, start, end))
+
+	return &opsTrendPreaggFixture{repo: repo, start: start, end: end, groupID: group.ID}
+}
+
+// preagg 与 raw 必须逐点相等：两条路径共用同一份口径，任何一侧漂移都会让
+// 面板在 auto fallback 前后跳数字。
+func TestOpsTrendPreaggMatchesRaw(t *testing.T) {
+	ctx := context.Background()
+	fx := setupOpsTrendPreaggFixture(t, ctx)
+
+	filters := map[string]*service.OpsDashboardFilter{
+		"overall":  {StartTime: fx.start, EndTime: fx.end},
+		"platform": {StartTime: fx.start, EndTime: fx.end, Platform: service.PlatformAnthropic},
+		"group":    {StartTime: fx.start, EndTime: fx.end, Platform: service.PlatformAnthropic, GroupID: &fx.groupID},
+	}
+
+	for _, bucketSeconds := range []int{60, 300, 3600} {
+		for name, base := range filters {
+			t.Run(fmt.Sprintf("%s/%ds", name, bucketSeconds), func(t *testing.T) {
+				rawFilter := *base
+				rawFilter.QueryMode = service.OpsQueryModeRaw
+				preaggFilter := *base
+				preaggFilter.QueryMode = service.OpsQueryModePreagg
+
+				rawThroughput, err := fx.repo.GetThroughputTrend(ctx, &rawFilter, bucketSeconds)
+				require.NoError(t, err)
+				preaggThroughput, err := fx.repo.GetThroughputTrend(ctx, &preaggFilter, bucketSeconds)
+				require.NoError(t, err)
+				require.Equal(t, rawThroughput.Bucket, preaggThroughput.Bucket)
+				require.Equal(t, rawThroughput.Points, preaggThroughput.Points)
+				require.Equal(t, rawThroughput.ByPlatform, preaggThroughput.ByPlatform)
+				require.Equal(t, rawThroughput.TopGroups, preaggThroughput.TopGroups)
+
+				rawError, err := fx.repo.GetErrorTrend(ctx, &rawFilter, bucketSeconds)
+				require.NoError(t, err)
+				preaggError, err := fx.repo.GetErrorTrend(ctx, &preaggFilter, bucketSeconds)
+				require.NoError(t, err)
+				require.Equal(t, rawError.Points, preaggError.Points)
+			})
+		}
+	}
+}
+
+// switch_count 从查询期的 JSONB 展开挪到了写入期，口径必须原样保留。
+func TestOpsMinuteMetricsSwitchCountMatchesRawExpansion(t *testing.T) {
+	ctx := context.Background()
+	fx := setupOpsTrendPreaggFixture(t, ctx)
+
+	var preaggSwitch int64
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(switch_count), 0) FROM ops_metrics_minute
+		WHERE bucket_start >= $1 AND bucket_start < $2 AND platform IS NULL AND group_id IS NULL
+	`, fx.start, fx.end).Scan(&preaggSwitch))
+
+	// 与改造前 queryAccountSwitchCount 的展开逻辑逐字一致。
+	var rawSwitch int64
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(CASE
+		  WHEN split_part(ev->>'kind', ':', 1) IN ('failover', 'retry_exhausted_failover', 'failover_on_400') THEN 1
+		  ELSE 0
+		END), 0)
+		FROM ops_error_logs
+		CROSS JOIN LATERAL jsonb_array_elements(
+		  COALESCE(NULLIF(upstream_errors, 'null'::jsonb), '[]'::jsonb)
+		) AS ev
+		WHERE created_at >= $1 AND created_at < $2 AND is_count_tokens = FALSE
+	`, fx.start, fx.end).Scan(&rawSwitch))
+
+	require.Equal(t, int64(2), rawSwitch, "fixture 应产生 2 次切换（count_tokens 那条不计）")
+	require.Equal(t, rawSwitch, preaggSwitch)
+}
+
+// 分钟表尚未覆盖但明细有数据时，preagg 必须报 ErrOpsPreaggregatedNotPopulated，
+// auto 据此回落到 raw —— 否则面板会显示成"这段时间没有流量"。
+func TestOpsTrendAutoFallsBackWhenMinutePreaggEmpty(t *testing.T) {
+	ctx := context.Background()
+	fx := setupOpsTrendPreaggFixture(t, ctx)
+
+	_, err := integrationDB.ExecContext(ctx,
+		`DELETE FROM ops_metrics_minute WHERE bucket_start >= $1 AND bucket_start < $2`, fx.start, fx.end)
+	require.NoError(t, err)
+
+	rawFilter := &service.OpsDashboardFilter{StartTime: fx.start, EndTime: fx.end, QueryMode: service.OpsQueryModeRaw}
+	preaggFilter := &service.OpsDashboardFilter{StartTime: fx.start, EndTime: fx.end, QueryMode: service.OpsQueryModePreagg}
+	autoFilter := &service.OpsDashboardFilter{StartTime: fx.start, EndTime: fx.end, QueryMode: service.OpsQueryModeAuto}
+
+	_, err = fx.repo.GetThroughputTrend(ctx, preaggFilter, 60)
+	require.ErrorIs(t, err, service.ErrOpsPreaggregatedNotPopulated)
+	_, err = fx.repo.GetErrorTrend(ctx, preaggFilter, 60)
+	require.ErrorIs(t, err, service.ErrOpsPreaggregatedNotPopulated)
+
+	want, err := fx.repo.GetThroughputTrend(ctx, rawFilter, 60)
+	require.NoError(t, err)
+	got, err := fx.repo.GetThroughputTrend(ctx, autoFilter, 60)
+	require.NoError(t, err)
+	require.Equal(t, want.Points, got.Points)
+
+	wantErrTrend, err := fx.repo.GetErrorTrend(ctx, rawFilter, 60)
+	require.NoError(t, err)
+	gotErrTrend, err := fx.repo.GetErrorTrend(ctx, autoFilter, 60)
+	require.NoError(t, err)
+	require.Equal(t, wantErrTrend.Points, gotErrTrend.Points)
+}
+
+// 重复聚合同一窗口必须幂等：回填与增量聚合会大量重叠，
+// ON CONFLICT 若写成累加，重叠区的数字就会翻倍。
+func TestUpsertMinuteMetricsIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	fx := setupOpsTrendPreaggFixture(t, ctx)
+
+	snapshot := func() []int64 {
+		var rows, requests, tokens, switches int64
+		require.NoError(t, integrationDB.QueryRowContext(ctx, `
+			SELECT COUNT(*),
+			       COALESCE(SUM(success_count + error_count_total), 0),
+			       COALESCE(SUM(token_consumed), 0),
+			       COALESCE(SUM(switch_count), 0)
+			FROM ops_metrics_minute WHERE bucket_start >= $1 AND bucket_start < $2
+		`, fx.start, fx.end).Scan(&rows, &requests, &tokens, &switches))
+		return []int64{rows, requests, tokens, switches}
+	}
+
+	before := snapshot()
+	require.NotEqual(t, int64(0), before[1], "fixture 应产生非零请求数")
+
+	// 再跑两遍，其中一遍按 30 分钟分段，模拟回填与增量的重叠。
+	require.NoError(t, fx.repo.UpsertMinuteMetrics(ctx, fx.start, fx.end))
+	for at := fx.start; at.Before(fx.end); at = at.Add(30 * time.Minute) {
+		require.NoError(t, fx.repo.UpsertMinuteMetrics(ctx, at, at.Add(30*time.Minute)))
+	}
+
+	require.Equal(t, before, snapshot())
+}

--- a/backend/internal/repository/usage_cleanup_repo.go
+++ b/backend/internal/repository/usage_cleanup_repo.go
@@ -291,9 +291,6 @@ func (r *usageCleanupRepository) DeleteUsageLogsBatch(ctx context.Context, filte
 		return 0, fmt.Errorf("cleanup filters missing time range")
 	}
 	args = append(args, limit)
-	if db, ok := r.sql.(*sql.DB); ok {
-		return r.deleteUsageLogsBatchWithRollupInvalidation(ctx, db, whereClause, args)
-	}
 	query := fmt.Sprintf(`
 		WITH target AS (
 			SELECT id
@@ -304,85 +301,16 @@ func (r *usageCleanupRepository) DeleteUsageLogsBatch(ctx context.Context, filte
 		)
 		DELETE FROM usage_logs
 		WHERE id IN (SELECT id FROM target)
-		RETURNING created_at
 	`, whereClause, len(args))
 
-	rows, err := r.sql.QueryContext(ctx, query, args...)
+	// 管理员主动清理是数据修正，理应反映到分组日桶。
+	// 发布水位的回退交由 usage_logs 的失效触发器完成：它同样覆盖直接 SQL 删除，
+	// 且带归档屏障保护，不会把水位拉进无法重建的已归档区间。
+	res, err := r.sql.ExecContext(ctx, query, args...)
 	if err != nil {
 		return 0, err
 	}
-	defer func() { _ = rows.Close() }()
-
-	var deleted int64
-	for rows.Next() {
-		deleted++
-	}
-	if err := rows.Err(); err != nil {
-		return 0, err
-	}
-	return deleted, nil
-}
-
-func (r *usageCleanupRepository) deleteUsageLogsBatchWithRollupInvalidation(ctx context.Context, db *sql.DB, whereClause string, args []any) (int64, error) {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, err
-	}
-	rollback := func(err error) (int64, error) {
-		_ = tx.Rollback()
-		return 0, err
-	}
-
-	if err := lockGroupUsageRollupState(ctx, tx); err != nil {
-		return rollback(err)
-	}
-	query := fmt.Sprintf(`
-		WITH target AS (
-			SELECT id
-			FROM usage_logs
-			WHERE %s
-			ORDER BY created_at ASC, id ASC
-			LIMIT $%d
-		)
-		DELETE FROM usage_logs
-		WHERE id IN (SELECT id FROM target)
-		RETURNING created_at
-	`, whereClause, len(args))
-	rows, err := tx.QueryContext(ctx, query, args...)
-	if err != nil {
-		return rollback(err)
-	}
-
-	var deleted int64
-	var earliestDeletedAt time.Time
-	for rows.Next() {
-		var deletedAt time.Time
-		if err := rows.Scan(&deletedAt); err != nil {
-			_ = rows.Close()
-			return rollback(err)
-		}
-		deleted++
-		if earliestDeletedAt.IsZero() || deletedAt.Before(earliestDeletedAt) {
-			earliestDeletedAt = deletedAt
-		}
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return rollback(err)
-	}
-	if err := rows.Close(); err != nil {
-		return rollback(err)
-	}
-
-	if deleted > 0 {
-		if err := invalidateGroupUsageRollupsAt(ctx, tx, earliestDeletedAt); err != nil {
-			return rollback(err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, err
-	}
-	return deleted, nil
+	return res.RowsAffected()
 }
 
 func buildUsageCleanupWhere(filters service.UsageCleanupFilters) (string, []any) {

--- a/backend/internal/repository/usage_cleanup_repo_test.go
+++ b/backend/internal/repository/usage_cleanup_repo_test.go
@@ -418,16 +418,9 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatch(t *testing.T) {
 		Model:     &model,
 	}
 
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery("DELETE FROM usage_logs").
+	mock.ExpectExec("DELETE FROM usage_logs").
 		WithArgs(start, end, userID, "gpt-4", 2).
-		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(start.Add(time.Hour)).AddRow(start.Add(2 * time.Hour)))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(start.Add(time.Hour), "Asia/Shanghai").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectCommit()
+		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	deleted, err := repo.DeleteUsageLogsBatch(context.Background(), filters, 2)
 	require.NoError(t, err)
@@ -435,59 +428,24 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatch(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUsageCleanupRepositoryDeleteUsageLogsBatchAtomicallyInvalidatesGroupRollups(t *testing.T) {
+// 管理员清理不再自行回退发布水位，也不再逐行读回 created_at：
+// 水位失效由 usage_logs 的触发器在同一事务内完成，且受归档屏障保护。
+func TestUsageCleanupRepositoryDeleteUsageLogsBatchDelegatesInvalidationToTrigger(t *testing.T) {
 	setUsageCleanupRollupTestTimezone(t)
 	db, mock := newSQLMock(t)
 	repo := &usageCleanupRepository{sql: db}
 
 	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
-	firstDeletedAt := time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)
-	secondDeletedAt := firstDeletedAt.Add(time.Hour)
 	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
 
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery(`(?s)DELETE FROM usage_logs.*RETURNING created_at`).
+	mock.ExpectExec(`(?s)DELETE FROM usage_logs`).
 		WithArgs(start, end, 2).
-		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).
-			AddRow(firstDeletedAt).
-			AddRow(secondDeletedAt))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(firstDeletedAt, "Asia/Shanghai").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectCommit()
+		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	deleted, err := repo.DeleteUsageLogsBatch(context.Background(), filters, 2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), deleted)
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestUsageCleanupRepositoryDeleteUsageLogsBatchRollsBackWhenInvalidationFails(t *testing.T) {
-	setUsageCleanupRollupTestTimezone(t)
-	db, mock := newSQLMock(t)
-	repo := &usageCleanupRepository{sql: db}
-
-	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
-	end := start.Add(24 * time.Hour)
-	deletedAt := time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)
-	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery(`(?s)DELETE FROM usage_logs.*RETURNING created_at`).
-		WithArgs(start, end, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(deletedAt))
-	mock.ExpectExec(`UPDATE usage_group_rollup_state`).
-		WithArgs(deletedAt, "Asia/Shanghai").
-		WillReturnError(sql.ErrConnDone)
-	mock.ExpectRollback()
-
-	_, err := repo.DeleteUsageLogsBatch(context.Background(), filters, 1)
-	require.ErrorIs(t, err, sql.ErrConnDone)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -499,13 +457,9 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatchQueryError(t *testing.T) {
 	end := start.Add(24 * time.Hour)
 	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
 
-	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT id FROM usage_group_rollup_state.*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	mock.ExpectQuery("DELETE FROM usage_logs").
+	mock.ExpectExec("DELETE FROM usage_logs").
 		WithArgs(start, end, 5).
 		WillReturnError(sql.ErrConnDone)
-	mock.ExpectRollback()
 
 	_, err := repo.DeleteUsageLogsBatch(context.Background(), filters, 5)
 	require.Error(t, err)

--- a/backend/internal/repository/usage_log_repo_stats.go
+++ b/backend/internal/repository/usage_log_repo_stats.go
@@ -564,23 +564,71 @@ func (r *usageLogRepository) GetBatchAPIKeyUsageStats(ctx context.Context, apiKe
 	if endTime.IsZero() {
 		endTime = time.Now()
 	}
+	// 历史段按自然日桶结算，因此把起点对齐到当地日边界：
+	// 否则首日会按整天计入，与 startTime 的精确时刻不符。
+	startTime = timezone.StartOfDay(startTime)
 
 	for _, id := range normalizedAPIKeyIDs {
 		result[id] = &BatchAPIKeyUsageStats{APIKeyID: id}
 	}
 
+	// 历史段读日桶、当日段读明细。
+	//
+	// 直接在 usage_logs 上按 api_key_id 聚合 30 天，代价随保留窗口线性增长；热点 key
+	// 往往集中了绝大部分流量，单次请求要聚合千万行级别的数据，需要数十秒。
+	// usage_apikey_daily_rollups 由分块日结产出，
+	// 其发布水位 usage_group_rollup_state.closed_before 之前的日期才是已结算的，
+	// 水位当天及之后仍以原始日志为准，避免与尾段重复计入。
 	query := `
+		WITH state_raw AS (
+			SELECT closed_before, timezone_name
+			FROM usage_group_rollup_state
+			WHERE id = 1
+		),
+		state AS (
+			-- 恒返回一行：水位缺失时退化成 1970，historical 为空、tail 覆盖全窗口，
+			-- 即回落到直接扫明细的旧行为（慢但正确），而不是返回 0。
+			SELECT
+				COALESCE((SELECT closed_before FROM state_raw), DATE '1970-01-01') AS closed_before,
+				COALESCE(
+					(SELECT closed_before::timestamp AT TIME ZONE timezone_name FROM state_raw),
+					TIMESTAMPTZ '1970-01-01 00:00:00+00'
+				) AS tail_start
+		),
+		historical AS (
+			SELECT
+				rollup.api_key_id,
+				COALESCE(SUM(rollup.actual_cost), 0) AS total_cost
+			FROM usage_apikey_daily_rollups rollup
+			CROSS JOIN state
+			WHERE rollup.api_key_id = ANY($1)
+				AND rollup.bucket_date >= ($2::timestamptz AT TIME ZONE $5::text)::date
+				AND rollup.bucket_date < state.closed_before
+			GROUP BY rollup.api_key_id
+		),
+		tail AS (
+			SELECT
+				ul.api_key_id,
+				COALESCE(SUM(ul.actual_cost) FILTER (
+					WHERE ul.created_at >= $2 AND ul.created_at < $3
+				), 0) AS total_cost,
+				COALESCE(SUM(ul.actual_cost) FILTER (WHERE ul.created_at >= $4), 0) AS today_cost
+			FROM usage_logs ul
+			CROSS JOIN state
+			WHERE ul.api_key_id = ANY($1)
+				AND ul.created_at >= GREATEST(state.tail_start, LEAST($2, $4))
+			GROUP BY ul.api_key_id
+		)
 		SELECT
-			api_key_id,
-			COALESCE(SUM(actual_cost) FILTER (WHERE created_at >= $2 AND created_at < $3), 0) as total_cost,
-			COALESCE(SUM(actual_cost) FILTER (WHERE created_at >= $4), 0) as today_cost
-		FROM usage_logs
-		WHERE api_key_id = ANY($1)
-		  AND created_at >= LEAST($2, $4)
-		GROUP BY api_key_id
+			k.api_key_id,
+			COALESCE(historical.total_cost, 0) + COALESCE(tail.total_cost, 0) AS total_cost,
+			COALESCE(tail.today_cost, 0) AS today_cost
+		FROM unnest($1::bigint[]) AS k(api_key_id)
+		LEFT JOIN historical ON historical.api_key_id = k.api_key_id
+		LEFT JOIN tail ON tail.api_key_id = k.api_key_id
 	`
 	today := timezone.Today()
-	rows, err := r.sql.QueryContext(ctx, query, pq.Array(normalizedAPIKeyIDs), startTime, endTime, today)
+	rows, err := r.sql.QueryContext(ctx, query, pq.Array(normalizedAPIKeyIDs), startTime, endTime, today, timezone.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/ops_aggregation_minute_backfill_test.go
+++ b/backend/internal/service/ops_aggregation_minute_backfill_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinuteBackfillRanges(t *testing.T) {
+	safeEnd := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	target := safeEnd.AddDate(0, 0, -30)
+
+	tests := []struct {
+		name     string
+		earliest *time.Time
+		latest   *time.Time
+		want     [][2]time.Time
+	}{
+		{
+			name: "表为空时一次覆盖整个保留窗口",
+			want: [][2]time.Time{{target, safeEnd}},
+		},
+		{
+			name:     "已覆盖整个保留窗口且水位跟得上时无需回填",
+			earliest: opsPtrTime(target.Add(-time.Hour)),
+			latest:   opsPtrTime(safeEnd.Add(-2 * time.Minute)),
+		},
+		{
+			name:     "只缺低端：补到已覆盖的最早桶为止",
+			earliest: opsPtrTime(target.Add(72 * time.Hour)),
+			latest:   opsPtrTime(safeEnd.Add(-2 * time.Minute)),
+			want:     [][2]time.Time{{target, target.Add(72 * time.Hour)}},
+		},
+		{
+			// 增量循环每轮只回看 opsAggMinuteOverlap，停机更久就够不到了。
+			name:     "只缺高端：停机超过 overlap 的部分必须补",
+			earliest: opsPtrTime(target.Add(-time.Hour)),
+			latest:   opsPtrTime(safeEnd.Add(-3 * time.Hour)),
+			want:     [][2]time.Time{{safeEnd.Add(-3 * time.Hour).Add(time.Minute), safeEnd}},
+		},
+		{
+			name:     "停机时间在 overlap 之内则交给增量循环，不重复回填",
+			earliest: opsPtrTime(target.Add(-time.Hour)),
+			latest:   opsPtrTime(safeEnd.Add(-opsAggMinuteOverlap)),
+		},
+		{
+			name:     "两头都缺",
+			earliest: opsPtrTime(target.Add(48 * time.Hour)),
+			latest:   opsPtrTime(safeEnd.Add(-5 * time.Hour)),
+			want: [][2]time.Time{
+				{target, target.Add(48 * time.Hour)},
+				{safeEnd.Add(-5 * time.Hour).Add(time.Minute), safeEnd},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &OpsAggregationService{opsRepo: &opsRepoMock{
+				GetEarliestMinuteBucketStartFn: bucketFn(tc.earliest),
+				GetLatestMinuteBucketStartFn:   bucketFn(tc.latest),
+			}}
+			got, err := svc.minuteBackfillRanges(context.Background(), target, safeEnd)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMinuteBackfillRangesEmptyWindow(t *testing.T) {
+	at := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	svc := &OpsAggregationService{opsRepo: &opsRepoMock{}}
+
+	got, err := svc.minuteBackfillRanges(context.Background(), at, at)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// 读覆盖范围失败时必须上抛：静默返回空会被当成"已经补齐"，缺口永远补不上。
+func TestMinuteBackfillRangesPropagatesError(t *testing.T) {
+	safeEnd := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	target := safeEnd.AddDate(0, 0, -30)
+	boom := errors.New("boom")
+
+	svc := &OpsAggregationService{opsRepo: &opsRepoMock{
+		GetEarliestMinuteBucketStartFn: func(context.Context) (time.Time, bool, error) {
+			return time.Time{}, false, boom
+		},
+	}}
+	_, err := svc.minuteBackfillRanges(context.Background(), target, safeEnd)
+	require.ErrorIs(t, err, boom)
+
+	svc = &OpsAggregationService{opsRepo: &opsRepoMock{
+		GetEarliestMinuteBucketStartFn: bucketFn(opsPtrTime(target.Add(-time.Hour))),
+		GetLatestMinuteBucketStartFn: func(context.Context) (time.Time, bool, error) {
+			return time.Time{}, false, boom
+		},
+	}}
+	_, err = svc.minuteBackfillRanges(context.Background(), target, safeEnd)
+	require.ErrorIs(t, err, boom)
+}
+
+func opsPtrTime(t time.Time) *time.Time { return &t }
+
+func bucketFn(at *time.Time) func(context.Context) (time.Time, bool, error) {
+	if at == nil {
+		return nil
+	}
+	return func(context.Context) (time.Time, bool, error) { return *at, true, nil }
+}

--- a/backend/internal/service/ops_aggregation_service.go
+++ b/backend/internal/service/ops_aggregation_service.go
@@ -16,11 +16,14 @@ import (
 )
 
 const (
-	opsAggHourlyJobName = "ops_preaggregation_hourly"
-	opsAggDailyJobName  = "ops_preaggregation_daily"
+	opsAggHourlyJobName   = "ops_preaggregation_hourly"
+	opsAggDailyJobName    = "ops_preaggregation_daily"
+	opsAggMinuteJobName   = "ops_preaggregation_minute"
+	opsAggBackfillJobName = "ops_preaggregation_minute_backfill"
 
 	opsAggHourlyInterval = 10 * time.Minute
 	opsAggDailyInterval  = 1 * time.Hour
+	opsAggMinuteInterval = 1 * time.Minute
 
 	// Keep in sync with ops retention target (vNext default 30d).
 	opsAggBackfillWindow = 1 * time.Hour
@@ -31,20 +34,39 @@ const (
 
 	opsAggHourlyChunk = 24 * time.Hour
 	opsAggDailyChunk  = 7 * 24 * time.Hour
+	opsAggMinuteChunk = 1 * time.Hour
 
 	// Delay around boundaries (e.g. 10:00..10:05) to avoid aggregating buckets
 	// that may still receive late inserts.
 	opsAggSafeDelay = 5 * time.Minute
 
+	// Minute buckets are consumed by near-real-time trend charts, so the delay is
+	// much shorter than the hourly one. Rows arriving after this point are picked
+	// up by opsAggMinuteOverlap on a later pass, and the trend query stitches the
+	// unaggregated tail from raw logs anyway.
+	opsAggMinuteSafeDelay = 90 * time.Second
+	opsAggMinuteOverlap   = 10 * time.Minute
+
+	// Minute rollups are retained for MinuteMetricsRetentionDays (default 30);
+	// backfill aims to cover the same window so trend queries stay off raw logs.
+	opsAggMinuteBackfillChunk   = 6 * time.Hour
+	opsAggMinuteBackfillMaxDays = 30
+
 	opsAggMaxQueryTimeout = 5 * time.Second
 	opsAggHourlyTimeout   = 5 * time.Minute
 	opsAggDailyTimeout    = 2 * time.Minute
+	opsAggMinuteTimeout   = 50 * time.Second
+	opsAggBackfillTimeout = 30 * time.Minute
 
-	opsAggHourlyLeaderLockKey = "ops:aggregation:hourly:leader"
-	opsAggDailyLeaderLockKey  = "ops:aggregation:daily:leader"
+	opsAggHourlyLeaderLockKey   = "ops:aggregation:hourly:leader"
+	opsAggDailyLeaderLockKey    = "ops:aggregation:daily:leader"
+	opsAggMinuteLeaderLockKey   = "ops:aggregation:minute:leader"
+	opsAggBackfillLeaderLockKey = "ops:aggregation:minute-backfill:leader"
 
-	opsAggHourlyLeaderLockTTL = 15 * time.Minute
-	opsAggDailyLeaderLockTTL  = 10 * time.Minute
+	opsAggHourlyLeaderLockTTL   = 15 * time.Minute
+	opsAggDailyLeaderLockTTL    = 10 * time.Minute
+	opsAggMinuteLeaderLockTTL   = 2 * time.Minute
+	opsAggBackfillLeaderLockTTL = opsAggBackfillTimeout + time.Minute
 )
 
 // OpsAggregationService periodically backfills ops_metrics_hourly / ops_metrics_daily
@@ -66,6 +88,7 @@ type OpsAggregationService struct {
 
 	hourlyMu sync.Mutex
 	dailyMu  sync.Mutex
+	minuteMu sync.Mutex
 
 	skipLogMu sync.Mutex
 	skipLogAt time.Time
@@ -98,6 +121,8 @@ func (s *OpsAggregationService) Start() {
 		}
 		go s.hourlyLoop()
 		go s.dailyLoop()
+		go s.minuteLoop()
+		go s.backfillMinuteHistory()
 	})
 }
 
@@ -144,6 +169,245 @@ func (s *OpsAggregationService) dailyLoop() {
 			return
 		}
 	}
+}
+
+func (s *OpsAggregationService) minuteLoop() {
+	// First run immediately.
+	s.aggregateMinute()
+
+	ticker := time.NewTicker(opsAggMinuteInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.aggregateMinute()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+// aggregateMinute rolls up recent minute buckets for the trend charts.
+// It recomputes a small overlapping window so late-arriving rows (a streaming
+// request can land seconds after its bucket closed) are folded in on a later pass.
+func (s *OpsAggregationService) aggregateMinute() {
+	if s == nil || s.opsRepo == nil {
+		return
+	}
+	if s.cfg != nil {
+		if !s.cfg.Ops.Enabled {
+			return
+		}
+		if !s.cfg.Ops.Aggregation.Enabled {
+			return
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opsAggMinuteTimeout)
+	defer cancel()
+
+	if !s.isMonitoringEnabled(ctx) {
+		return
+	}
+
+	release, ok := s.tryAcquireLeaderLock(ctx, opsAggMinuteLeaderLockKey, opsAggMinuteLeaderLockTTL, "[OpsAggregation][minute]")
+	if !ok {
+		return
+	}
+	if release != nil {
+		defer release()
+	}
+
+	s.minuteMu.Lock()
+	defer s.minuteMu.Unlock()
+
+	startedAt := time.Now().UTC()
+	runAt := startedAt
+
+	end := utcFloorToMinute(time.Now().UTC().Add(-opsAggMinuteSafeDelay))
+	start := end.Add(-opsAggMinuteOverlap)
+
+	// Resume from the latest aggregated bucket, re-covering the overlap window.
+	{
+		ctxMax, cancelMax := context.WithTimeout(context.Background(), opsAggMaxQueryTimeout)
+		latest, ok, err := s.opsRepo.GetLatestMinuteBucketStart(ctxMax)
+		cancelMax()
+		if err != nil {
+			logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute] failed to read latest bucket: %v", err)
+		} else if ok {
+			candidate := latest.Add(-opsAggMinuteOverlap)
+			if candidate.After(start) {
+				start = candidate
+			}
+		}
+	}
+
+	start = utcFloorToMinute(start)
+	if !start.Before(end) {
+		return
+	}
+
+	var aggErr error
+	for cursor := start; cursor.Before(end); cursor = cursor.Add(opsAggMinuteChunk) {
+		chunkEnd := minTime(cursor.Add(opsAggMinuteChunk), end)
+		if err := s.opsRepo.UpsertMinuteMetrics(ctx, cursor, chunkEnd); err != nil {
+			aggErr = err
+			logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute] upsert failed (%s..%s): %v", cursor.Format(time.RFC3339), chunkEnd.Format(time.RFC3339), err)
+			break
+		}
+	}
+
+	s.reportAggregationHeartbeat(opsAggMinuteJobName, runAt, startedAt, start, end, aggErr)
+}
+
+// backfillMinuteHistory fills the minute table back to the retention window on startup,
+// so trend queries over historical windows do not fall back to scanning raw logs.
+// Runs once per process under its own leader lock; chunked so no single statement is long.
+func (s *OpsAggregationService) backfillMinuteHistory() {
+	if s == nil || s.opsRepo == nil {
+		return
+	}
+	if s.cfg != nil {
+		if !s.cfg.Ops.Enabled || !s.cfg.Ops.Aggregation.Enabled {
+			return
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opsAggBackfillTimeout)
+	defer cancel()
+
+	if !s.isMonitoringEnabled(ctx) {
+		return
+	}
+
+	release, ok := s.tryAcquireLeaderLock(ctx, opsAggBackfillLeaderLockKey, opsAggBackfillLeaderLockTTL, "[OpsAggregation][minute-backfill]")
+	if !ok {
+		return
+	}
+	if release != nil {
+		defer release()
+	}
+
+	retentionDays := opsAggMinuteBackfillMaxDays
+	if s.cfg != nil && s.cfg.Ops.Cleanup.MinuteMetricsRetentionDays > 0 {
+		retentionDays = s.cfg.Ops.Cleanup.MinuteMetricsRetentionDays
+	}
+
+	target := utcFloorToMinute(time.Now().UTC().AddDate(0, 0, -retentionDays))
+	safeEnd := utcFloorToMinute(time.Now().UTC().Add(-opsAggMinuteSafeDelay))
+
+	ranges, err := s.minuteBackfillRanges(ctx, target, safeEnd)
+	if err != nil {
+		logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute-backfill] failed to inspect coverage: %v", err)
+		return
+	}
+	if len(ranges) == 0 {
+		return
+	}
+
+	startedAt := time.Now().UTC()
+	runAt := startedAt
+	windowStart, windowEnd := ranges[0][0], ranges[len(ranges)-1][1]
+	logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute-backfill] started (%d range(s), %s..%s)", len(ranges), windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339))
+
+	var aggErr error
+backfill:
+	for _, rng := range ranges {
+		for cursor := rng[0]; cursor.Before(rng[1]); cursor = cursor.Add(opsAggMinuteBackfillChunk) {
+			if ctx.Err() != nil {
+				// Timed out: whatever was committed stays; the next process start resumes the gap.
+				logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute-backfill] interrupted at %s, remaining window resumes on next start", cursor.Format(time.RFC3339))
+				return
+			}
+			chunkEnd := minTime(cursor.Add(opsAggMinuteBackfillChunk), rng[1])
+			if err := s.opsRepo.UpsertMinuteMetrics(ctx, cursor, chunkEnd); err != nil {
+				aggErr = err
+				logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute-backfill] upsert failed (%s..%s): %v", cursor.Format(time.RFC3339), chunkEnd.Format(time.RFC3339), err)
+				break backfill
+			}
+		}
+	}
+
+	if aggErr == nil {
+		logger.LegacyPrintf("service.ops_aggregation", "[OpsAggregation][minute-backfill] done (%s..%s duration=%s)", windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339), time.Since(startedAt))
+	}
+	s.reportAggregationHeartbeat(opsAggBackfillJobName, runAt, startedAt, windowStart, windowEnd, aggErr)
+}
+
+// minuteBackfillRanges 返回分钟表在 [target, safeEnd) 内还缺的时间段。
+//
+// 分两头补：
+//   - 低端：保留窗口起点到已覆盖的最早桶——首次上线或延长 retention 后的缺口。
+//   - 高端：已覆盖的最新桶到当前安全线——停机留下的缺口。增量循环每轮只回看
+//     opsAggMinuteOverlap，停机时间超过这个跨度就再也追不回来，会在 trend 上留下永久空洞。
+//
+// 中段空洞（回填自身被打断留下的）不在这里处理：分块提交后下次启动会从新的
+// earliest/latest 重新算缺口，正常情况下补得回来。
+func (s *OpsAggregationService) minuteBackfillRanges(ctx context.Context, target, safeEnd time.Time) ([][2]time.Time, error) {
+	if !target.Before(safeEnd) {
+		return nil, nil
+	}
+
+	earliest, hasEarliest, err := s.opsRepo.GetEarliestMinuteBucketStart(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !hasEarliest {
+		// 表是空的：一次覆盖整个保留窗口。
+		return [][2]time.Time{{target, safeEnd}}, nil
+	}
+
+	var ranges [][2]time.Time
+	if target.Before(earliest) {
+		ranges = append(ranges, [2]time.Time{target, minTime(earliest, safeEnd)})
+	}
+
+	latest, hasLatest, err := s.opsRepo.GetLatestMinuteBucketStart(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if hasLatest {
+		// 只补增量循环够不到的部分，避免每次启动都重跑最近十分钟。
+		gapStart := latest.Add(time.Minute)
+		if gapStart.Before(safeEnd.Add(-opsAggMinuteOverlap)) {
+			ranges = append(ranges, [2]time.Time{gapStart, safeEnd})
+		}
+	}
+	return ranges, nil
+}
+
+// reportAggregationHeartbeat records the outcome of one aggregation pass.
+// Extracted so the minute/backfill jobs don't duplicate the hourly/daily boilerplate.
+func (s *OpsAggregationService) reportAggregationHeartbeat(jobName string, runAt, startedAt time.Time, windowStart, windowEnd time.Time, aggErr error) {
+	finishedAt := time.Now().UTC()
+	dur := finishedAt.Sub(startedAt).Milliseconds()
+
+	hbCtx, hbCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer hbCancel()
+
+	if aggErr != nil {
+		msg := truncateString(aggErr.Error(), 2048)
+		errAt := finishedAt
+		_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
+			JobName:        jobName,
+			LastRunAt:      &runAt,
+			LastErrorAt:    &errAt,
+			LastError:      &msg,
+			LastDurationMs: &dur,
+		})
+		return
+	}
+
+	successAt := finishedAt
+	result := truncateString(fmt.Sprintf("window=%s..%s", windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339)), 2048)
+	_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
+		JobName:        jobName,
+		LastRunAt:      &runAt,
+		LastSuccessAt:  &successAt,
+		LastDurationMs: &dur,
+		LastResult:     &result,
+	})
 }
 
 func (s *OpsAggregationService) aggregateHourly() {
@@ -214,36 +478,7 @@ func (s *OpsAggregationService) aggregateHourly() {
 		}
 	}
 
-	finishedAt := time.Now().UTC()
-	durationMs := finishedAt.Sub(startedAt).Milliseconds()
-	dur := durationMs
-
-	if aggErr != nil {
-		msg := truncateString(aggErr.Error(), 2048)
-		errAt := finishedAt
-		hbCtx, hbCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer hbCancel()
-		_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
-			JobName:        opsAggHourlyJobName,
-			LastRunAt:      &runAt,
-			LastErrorAt:    &errAt,
-			LastError:      &msg,
-			LastDurationMs: &dur,
-		})
-		return
-	}
-
-	successAt := finishedAt
-	hbCtx, hbCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer hbCancel()
-	result := truncateString(fmt.Sprintf("window=%s..%s", start.Format(time.RFC3339), end.Format(time.RFC3339)), 2048)
-	_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
-		JobName:        opsAggHourlyJobName,
-		LastRunAt:      &runAt,
-		LastSuccessAt:  &successAt,
-		LastDurationMs: &dur,
-		LastResult:     &result,
-	})
+	s.reportAggregationHeartbeat(opsAggHourlyJobName, runAt, startedAt, start, end, aggErr)
 }
 
 func (s *OpsAggregationService) aggregateDaily() {
@@ -312,36 +547,7 @@ func (s *OpsAggregationService) aggregateDaily() {
 		}
 	}
 
-	finishedAt := time.Now().UTC()
-	durationMs := finishedAt.Sub(startedAt).Milliseconds()
-	dur := durationMs
-
-	if aggErr != nil {
-		msg := truncateString(aggErr.Error(), 2048)
-		errAt := finishedAt
-		hbCtx, hbCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer hbCancel()
-		_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
-			JobName:        opsAggDailyJobName,
-			LastRunAt:      &runAt,
-			LastErrorAt:    &errAt,
-			LastError:      &msg,
-			LastDurationMs: &dur,
-		})
-		return
-	}
-
-	successAt := finishedAt
-	hbCtx, hbCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer hbCancel()
-	result := truncateString(fmt.Sprintf("window=%s..%s", start.Format(time.RFC3339), end.Format(time.RFC3339)), 2048)
-	_ = s.opsRepo.UpsertJobHeartbeat(hbCtx, &OpsUpsertJobHeartbeatInput{
-		JobName:        opsAggDailyJobName,
-		LastRunAt:      &runAt,
-		LastSuccessAt:  &successAt,
-		LastDurationMs: &dur,
-		LastResult:     &result,
-	})
+	s.reportAggregationHeartbeat(opsAggDailyJobName, runAt, startedAt, start, end, aggErr)
 }
 
 func (s *OpsAggregationService) isMonitoringEnabled(ctx context.Context) bool {
@@ -428,6 +634,10 @@ func (s *OpsAggregationService) maybeLogSkip(prefix string) {
 		prefix = "[OpsAggregation]"
 	}
 	logger.LegacyPrintf("service.ops_aggregation", "%s leader lock held by another instance; skipping", prefix)
+}
+
+func utcFloorToMinute(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Minute)
 }
 
 func utcFloorToHour(t time.Time) time.Time {

--- a/backend/internal/service/ops_cleanup_executor.go
+++ b/backend/internal/service/ops_cleanup_executor.go
@@ -31,19 +31,21 @@ type opsCleanupDeletedCounts struct {
 	systemLogs     int64
 	logAudits      int64
 	systemMetrics  int64
+	minutePreagg   int64
 	hourlyPreagg   int64
 	dailyPreagg    int64
 }
 
 func (c opsCleanupDeletedCounts) String() string {
 	return fmt.Sprintf(
-		"error_logs=%d ingress_rejects=%d alert_events=%d system_logs=%d log_audits=%d system_metrics=%d hourly_preagg=%d daily_preagg=%d",
+		"error_logs=%d ingress_rejects=%d alert_events=%d system_logs=%d log_audits=%d system_metrics=%d minute_preagg=%d hourly_preagg=%d daily_preagg=%d",
 		c.errorLogs,
 		c.ingressRejects,
 		c.alertEvents,
 		c.systemLogs,
 		c.logAudits,
 		c.systemMetrics,
+		c.minutePreagg,
 		c.hourlyPreagg,
 		c.dailyPreagg,
 	)

--- a/backend/internal/service/ops_cleanup_service.go
+++ b/backend/internal/service/ops_cleanup_service.go
@@ -308,6 +308,7 @@ func (s *OpsCleanupService) runCleanupOnce(ctx context.Context) (opsCleanupDelet
 		{effective.ErrorLogRetentionDays, "ops_system_logs", "created_at", false, &out.systemLogs},
 		{effective.ErrorLogRetentionDays, "ops_system_log_cleanup_audits", "created_at", false, &out.logAudits},
 		{effective.MinuteMetricsRetentionDays, "ops_system_metrics", "created_at", false, &out.systemMetrics},
+		{effective.MinuteMetricsRetentionDays, "ops_metrics_minute", "bucket_start", false, &out.minutePreagg},
 		{effective.HourlyMetricsRetentionDays, "ops_metrics_hourly", "bucket_start", false, &out.hourlyPreagg},
 		{effective.HourlyMetricsRetentionDays, "ops_metrics_daily", "bucket_date", true, &out.dailyPreagg},
 	}

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -59,6 +59,12 @@ type OpsRepository interface {
 	UpsertDailyMetrics(ctx context.Context, startTime, endTime time.Time) error
 	GetLatestHourlyBucketStart(ctx context.Context) (time.Time, bool, error)
 	GetLatestDailyBucketDate(ctx context.Context) (time.Time, bool, error)
+
+	// Minute-level pre-aggregation backing the throughput/error trend charts,
+	// which use 60/300/3600s buckets that hourly rollups cannot serve.
+	UpsertMinuteMetrics(ctx context.Context, startTime, endTime time.Time) error
+	GetLatestMinuteBucketStart(ctx context.Context) (time.Time, bool, error)
+	GetEarliestMinuteBucketStart(ctx context.Context) (time.Time, bool, error)
 }
 
 type OpsInsertErrorLogInput struct {

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -241,10 +241,14 @@ type OpsSystemLogCleanupFilter struct {
 }
 
 type OpsSystemLogList struct {
-	Logs     []*OpsSystemLog `json:"logs"`
-	Total    int             `json:"total"`
-	Page     int             `json:"page"`
-	PageSize int             `json:"page_size"`
+	Logs  []*OpsSystemLog `json:"logs"`
+	Total int             `json:"total"`
+	// TotalIsCapped 表示 Total 是封顶值而非精确命中数（实际命中 >= Total）。
+	// 精确计数要扫完全部索引项，在千万行级别的 ops_system_logs 上要数十秒，
+	// 而这个数字只用于渲染分页器，不值这个代价。
+	TotalIsCapped bool `json:"total_is_capped"`
+	Page          int  `json:"page"`
+	PageSize      int  `json:"page_size"`
 }
 
 type OpsSystemLogCleanupAudit struct {

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -13,6 +13,9 @@ type opsRepoMock struct {
 	ListSystemLogsFn              func(ctx context.Context, filter *OpsSystemLogFilter) (*OpsSystemLogList, error)
 	DeleteSystemLogsFn            func(ctx context.Context, filter *OpsSystemLogCleanupFilter) (int64, error)
 	InsertSystemLogCleanupAuditFn func(ctx context.Context, input *OpsSystemLogCleanupAudit) error
+
+	GetLatestMinuteBucketStartFn   func(ctx context.Context) (time.Time, bool, error)
+	GetEarliestMinuteBucketStartFn func(ctx context.Context) (time.Time, bool, error)
 }
 
 func (m *opsRepoMock) InsertErrorLog(ctx context.Context, input *OpsInsertErrorLogInput) (int64, error) {
@@ -186,6 +189,24 @@ func (m *opsRepoMock) GetLatestHourlyBucketStart(ctx context.Context) (time.Time
 }
 
 func (m *opsRepoMock) GetLatestDailyBucketDate(ctx context.Context) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
+
+func (m *opsRepoMock) UpsertMinuteMetrics(ctx context.Context, startTime, endTime time.Time) error {
+	return nil
+}
+
+func (m *opsRepoMock) GetLatestMinuteBucketStart(ctx context.Context) (time.Time, bool, error) {
+	if m.GetLatestMinuteBucketStartFn != nil {
+		return m.GetLatestMinuteBucketStartFn(ctx)
+	}
+	return time.Time{}, false, nil
+}
+
+func (m *opsRepoMock) GetEarliestMinuteBucketStart(ctx context.Context) (time.Time, bool, error) {
+	if m.GetEarliestMinuteBucketStartFn != nil {
+		return m.GetEarliestMinuteBucketStartFn(ctx)
+	}
 	return time.Time{}, false, nil
 }
 

--- a/backend/migrations/227_group_usage_rollup_archival.sql
+++ b/backend/migrations/227_group_usage_rollup_archival.sql
@@ -1,0 +1,127 @@
+-- 分组日汇总：确立 retained_from 归档屏障，停止在过期清理时重算历史日桶。
+--
+-- 背景：保留期清理删除 usage_logs 老数据时，失效触发器会把 closed_before
+-- 拉回到最老记录的日期，导致后续同步把整个保留窗口的日桶全部删除并重建，
+-- 同时抹掉更早的历史日桶，使分组累计用量随每次清理缩水。
+--
+-- 新不变量：retained_from 之前的日期视为已归档，其日桶是不可变的历史沉淀。
+-- 归档删除必须在同一事务内先推进 retained_from 再删数据，触发器据此跳过失效。
+--
+-- 触发器仍保持 222 迁移的行级/语句级划分（行级覆盖外键级联与直接分区写入），
+-- 只是在取状态行之前先无锁判断归档屏障：retained_from 单调递增，读到旧值只会
+-- 让本次退回原有加锁路径，不会漏掉需要的失效。
+
+COMMENT ON COLUMN usage_group_rollup_state.retained_from IS
+    '归档屏障：早于该时刻的原始日志已被清理，对应日桶冻结为不可变历史，失效触发器不再回退水位。';
+
+CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    affected_date DATE;
+    published_before DATE;
+    archived_before DATE;
+    configured_timezone TEXT := current_setting('TimeZone');
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        affected_date := (OLD.created_at AT TIME ZONE configured_timezone)::date;
+    ELSE
+        IF OLD.group_id IS NULL THEN
+            affected_date := (NEW.created_at AT TIME ZONE configured_timezone)::date;
+        ELSIF NEW.group_id IS NULL THEN
+            affected_date := (OLD.created_at AT TIME ZONE configured_timezone)::date;
+        ELSE
+            affected_date := LEAST(
+                (OLD.created_at AT TIME ZONE configured_timezone)::date,
+                (NEW.created_at AT TIME ZONE configured_timezone)::date
+            );
+        END IF;
+    END IF;
+
+    -- 归档区间的日桶不可变：原始日志已被清理，重建只会得到残缺结果。
+    -- 这里刻意不加锁，让保留期清理的批量删除免于逐行争抢状态行。
+    SELECT (retained_from AT TIME ZONE configured_timezone)::date
+    INTO archived_before
+    FROM usage_group_rollup_state
+    WHERE id = 1;
+
+    IF archived_before IS NOT NULL AND affected_date < archived_before THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    -- 即使当前已发布水位尚未越过受影响日期，也必须先锁行。
+    -- 否则并发关闭作业可能在本事务之后把水位推进，覆盖本次失效。
+    SELECT closed_before
+    INTO published_before
+    FROM usage_group_rollup_state
+    WHERE id = 1
+    FOR UPDATE;
+
+    IF published_before > affected_date THEN
+        UPDATE usage_group_rollup_state
+        SET closed_before = LEAST(closed_before, affected_date),
+            updated_at = NOW()
+        WHERE id = 1;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- INSERT 是网关高频路径。transition table 让每个批量 INSERT 只锁一次状态行；
+-- KEY SHARE 在普通写入之间兼容，但会与关闭作业的 FOR UPDATE 串行化。
+CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state_after_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    affected_date DATE;
+    published_before DATE;
+    archived_before DATE;
+    configured_timezone TEXT := current_setting('TimeZone');
+BEGIN
+    SELECT MIN((created_at AT TIME ZONE configured_timezone)::date)
+    INTO affected_date
+    FROM inserted_usage_logs
+    WHERE group_id IS NOT NULL;
+
+    IF affected_date IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT closed_before, (retained_from AT TIME ZONE configured_timezone)::date
+    INTO published_before, archived_before
+    FROM usage_group_rollup_state
+    WHERE id = 1
+    FOR KEY SHARE;
+
+    -- 迟到写入落在归档区间时同样无法重建，保持水位不动。
+    IF archived_before IS NOT NULL AND affected_date < archived_before THEN
+        RETURN NULL;
+    END IF;
+
+    IF published_before > affected_date THEN
+        UPDATE usage_group_rollup_state
+        SET closed_before = LEAST(closed_before, affected_date),
+            updated_at = NOW()
+        WHERE id = 1;
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+-- 存量修复：把此前被清理拉坏的水位收回到归档屏障之后，
+-- 避免升级后首次同步仍然全量重建保留窗口。
+UPDATE usage_group_rollup_state
+SET closed_before = (retained_from AT TIME ZONE timezone_name)::date,
+    updated_at = NOW()
+WHERE id = 1
+    AND closed_before < (retained_from AT TIME ZONE timezone_name)::date;

--- a/backend/migrations/228_ops_metrics_minute.sql
+++ b/backend/migrations/228_ops_metrics_minute.sql
@@ -1,0 +1,65 @@
+-- ops 面板 trend 查询的分钟级预聚合。
+--
+-- 背景：
+-- ops_metrics_hourly/daily 只服务 overview，GetThroughputTrend / GetErrorTrend 是 raw-only
+-- （见 ops_repo_trends.go），每次请求直扫 usage_logs + ops_error_logs 两张明细表，
+-- 其中 switch_count 还要 CROSS JOIN LATERAL 展开 upstream_errors JSONB。
+-- 在千万行级别的部署下，throughput-trend 与 snapshot-v2 均需数十秒。
+--
+-- trend 使用 60/300/3600 秒桶，小时表撑不起分钟粒度，因此补一张分钟表。
+-- config 的 ops.cleanup.minute_metrics_retention_days（默认 30）早已预留，此前无表可清。
+--
+-- 口径说明（重要）：
+-- 本表刻意对齐 trend 的 raw 口径（buildUsageWhere / buildErrorWhere），而不是照抄
+-- UpsertHourlyMetrics：后者 usage 侧用 INNER JOIN groups，会丢掉 group_id IS NULL 的行。
+-- trend 的 preagg 段与 head/tail raw 段必须同口径，否则拼接处数字会跳。
+-- 因此 trend 的三种桶粒度统一由本表聚合得出，不混用 ops_metrics_hourly。
+
+CREATE TABLE IF NOT EXISTS ops_metrics_minute (
+    id BIGSERIAL PRIMARY KEY,
+
+    bucket_start TIMESTAMPTZ NOT NULL,
+    platform VARCHAR(32),
+    group_id BIGINT,
+
+    success_count BIGINT NOT NULL DEFAULT 0,
+    error_count_total BIGINT NOT NULL DEFAULT 0,
+    business_limited_count BIGINT NOT NULL DEFAULT 0,
+    error_count_sla BIGINT NOT NULL DEFAULT 0,
+
+    upstream_error_count_excl_429_529 BIGINT NOT NULL DEFAULT 0,
+    upstream_429_count BIGINT NOT NULL DEFAULT 0,
+    upstream_529_count BIGINT NOT NULL DEFAULT 0,
+
+    token_consumed BIGINT NOT NULL DEFAULT 0,
+
+    -- 账号切换次数：由写入侧展开 ops_error_logs.upstream_errors 得到，
+    -- 使查询侧不再需要 CROSS JOIN LATERAL jsonb_array_elements。
+    switch_count BIGINT NOT NULL DEFAULT 0,
+
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 与 ops_metrics_hourly 一致：三种维度模式（overall / platform / group）靠 COALESCE 表达式唯一，
+-- 因为 Postgres 的 UNIQUE 把 NULL 视为互不相同。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ops_metrics_minute_unique_dim
+    ON ops_metrics_minute (
+        bucket_start,
+        COALESCE(platform, ''),
+        COALESCE(group_id, 0)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_ops_metrics_minute_bucket
+    ON ops_metrics_minute (bucket_start DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ops_metrics_minute_platform_bucket
+    ON ops_metrics_minute (platform, bucket_start DESC)
+    WHERE platform IS NOT NULL AND platform <> '' AND group_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ops_metrics_minute_group_bucket
+    ON ops_metrics_minute (group_id, bucket_start DESC)
+    WHERE group_id IS NOT NULL AND group_id <> 0;
+
+COMMENT ON TABLE ops_metrics_minute IS 'ops 面板 trend 的分钟级预聚合，口径对齐 buildUsageWhere/buildErrorWhere 的 raw 路径。';
+COMMENT ON COLUMN ops_metrics_minute.switch_count IS '账号切换次数，写入侧展开 upstream_errors 得出，避免查询期解析 JSONB。';

--- a/backend/migrations/229_usage_apikey_daily_rollups.sql
+++ b/backend/migrations/229_usage_apikey_daily_rollups.sql
@@ -1,0 +1,26 @@
+-- 按 API Key 的用量日汇总，支撑 /keys 页面的 api-keys-usage 接口。
+--
+-- 背景：
+-- GetBatchAPIKeyUsageStats（usage_log_repo_stats.go）在 usage_logs 上按 api_key_id 聚合最近 30 天。
+-- usage_logs 在高写入部署下可达千万行级别，而热点 key 往往集中了绝大部分流量，
+-- 单次请求要聚合的行数与保留窗口成正比，实测需要数十秒。
+--
+-- 该表与 usage_group_daily_rollups 同构，并复用后者的水位（usage_group_rollup_state.closed_before）
+-- 与归档屏障：两者都是"按天结算 usage_logs"，在同一个分块事务里用 GROUPING SETS 一次扫描产出，
+-- 因此不需要独立的水位表或调度。
+
+CREATE TABLE IF NOT EXISTS usage_apikey_daily_rollups (
+    bucket_date DATE NOT NULL,
+    api_key_id BIGINT NOT NULL,
+    actual_cost DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    request_count BIGINT NOT NULL DEFAULT 0,
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (bucket_date, api_key_id)
+);
+
+COMMENT ON TABLE usage_apikey_daily_rollups IS '按 API Key 聚合的用量日桶，口径与 usage_group_daily_rollups 一致（服务端配置时区的自然日）。';
+COMMENT ON COLUMN usage_apikey_daily_rollups.bucket_date IS 'usage_group_rollup_state.timezone_name 对应时区的自然日。';
+
+-- 查询侧按 api_key_id 取最近 N 天，故以 api_key_id 前导。
+CREATE INDEX IF NOT EXISTS idx_usage_apikey_daily_rollups_key_date
+    ON usage_apikey_daily_rollups (api_key_id, bucket_date DESC);

--- a/backend/migrations/group_usage_rollup_migration_test.go
+++ b/backend/migrations/group_usage_rollup_migration_test.go
@@ -3,6 +3,7 @@
 package migrations
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -49,4 +50,20 @@ func TestMigration223TracksConfiguredTimezone(t *testing.T) {
 	require.Contains(t, sql, "current_setting('TimeZone')")
 	require.Contains(t, sql, "CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state")
 	require.Contains(t, sql, "CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state_after_insert")
+}
+
+func TestMigration227AddsRetentionBarrier(t *testing.T) {
+	content, err := FS.ReadFile("227_group_usage_rollup_archival.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state")
+	require.Contains(t, sql, "CREATE OR REPLACE FUNCTION invalidate_group_usage_rollup_state_after_insert")
+	// 归档屏障：两个失效函数都必须在回退水位前跳过已归档区间。
+	require.Equal(t, 2, strings.Count(sql, "affected_date < archived_before"))
+	require.Contains(t, sql, "(retained_from AT TIME ZONE configured_timezone)::date")
+	// 屏障判定不加锁，避免批量归档删除逐行争抢状态行。
+	require.Contains(t, sql, "SELECT (retained_from AT TIME ZONE configured_timezone)::date")
+	// 存量修复：把被清理拉坏的水位收回到屏障之后。
+	require.Contains(t, sql, "closed_before < (retained_from AT TIME ZONE timezone_name)::date")
 }

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -842,7 +842,11 @@ export interface OpsSystemLog {
   extra?: Record<string, any>
 }
 
-export type OpsSystemLogListResponse = PaginatedResponse<OpsSystemLog>
+// total_is_capped：系统日志放弃了精确 COUNT(*)（千万行级别下要数十秒），
+// 命中数超过上限时 total 只是下界，前端显示为「N+」。
+export type OpsSystemLogListResponse = PaginatedResponse<OpsSystemLog> & {
+  total_is_capped?: boolean
+}
 
 export interface OpsSystemLogQuery {
   page?: number

--- a/frontend/src/components/common/Pagination.vue
+++ b/frontend/src/components/common/Pagination.vue
@@ -12,11 +12,11 @@
         {{ t('pagination.previous') }}
       </button>
       <span class="text-sm text-gray-700 dark:text-gray-300">
-        {{ t('pagination.pageOf', { page, total: totalPages }) }}
+        {{ t('pagination.pageOf', { page, total: totalPagesLabel }) }}
       </span>
       <button
         @click="goToPage(page + 1)"
-        :disabled="page === totalPages"
+        :disabled="isLastPage"
         class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200 dark:hover:bg-dark-600"
       >
         {{ t('pagination.next') }}
@@ -32,7 +32,7 @@
           {{ t('pagination.to') }}
           <span class="font-medium">{{ toItem }}</span>
           {{ t('pagination.of') }}
-          <span class="font-medium">{{ total }}</span>
+          <span class="font-medium">{{ totalLabel }}</span>
           {{ t('pagination.results') }}
         </p>
 
@@ -106,7 +106,7 @@
         <!-- Next button -->
         <button
           @click="goToPage(page + 1)"
-          :disabled="page === totalPages"
+          :disabled="isLastPage"
           class="relative inline-flex items-center rounded-r-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-400 dark:hover:bg-dark-600"
           :aria-label="t('pagination.next')"
         >
@@ -131,6 +131,11 @@ interface Props {
   total: number
   page: number
   pageSize: number
+  /**
+   * total 是封顶值而非精确命中数（实际 >= total）时置 true，显示为「N+」。
+   * 超大表上放弃精确 COUNT(*) 的列表会带上这个标记。
+   */
+  totalIsCapped?: boolean
   pageSizeOptions?: number[]
   showPageSizeSelector?: boolean
   showJump?: boolean
@@ -142,6 +147,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  totalIsCapped: false,
   pageSizeOptions: () => getConfiguredTablePageSizeOptions(),
   showPageSizeSelector: true,
   showJump: false
@@ -150,6 +156,19 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<Emits>()
 
 const totalPages = computed(() => Math.ceil(props.total / props.pageSize))
+
+// 封顶时实际条数只知道下界，显示成「10000+」而不是谎报成精确值。
+const totalLabel = computed(() => (props.totalIsCapped ? `${props.total}+` : `${props.total}`))
+const totalPagesLabel = computed(() =>
+  props.totalIsCapped ? `${totalPages.value}+` : `${totalPages.value}`
+)
+
+// 封顶时 totalPages 只是下界，后面还有数据，不能把「下一页」锁死在这里。
+// 服务端会随页码把计数上限一起抬高，所以逐页往后翻是成立的。
+const maxPage = computed(() =>
+  props.totalIsCapped ? Number.POSITIVE_INFINITY : totalPages.value
+)
+const isLastPage = computed(() => props.page >= maxPage.value)
 
 const fromItem = computed(() => {
   if (props.total === 0) return 0
@@ -217,7 +236,7 @@ const visiblePages = computed(() => {
 })
 
 const goToPage = (newPage: number) => {
-  if (newPage >= 1 && newPage <= totalPages.value && newPage !== props.page) {
+  if (newPage >= 1 && newPage <= maxPage.value && newPage !== props.page) {
     emit('update:page', newPage)
   }
 }

--- a/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
@@ -25,6 +25,8 @@ const props = withDefaults(defineProps<{
 const loading = ref(false)
 const logs = ref<OpsSystemLog[]>([])
 const total = ref(0)
+// 服务端对系统日志放弃了精确计数，total 可能只是下界。
+const totalIsCapped = ref(false)
 const page = ref(1)
 const pageSize = ref(20)
 
@@ -210,6 +212,7 @@ const fetchLogs = async () => {
     const res = await opsAPI.listSystemLogs(buildQuery())
     logs.value = res.items || []
     total.value = res.total || 0
+    totalIsCapped.value = res.total_is_capped === true
   } catch (err: any) {
     console.error('[OpsSystemLogTable] Failed to fetch logs', err)
     appStore.showError(err?.response?.data?.detail || t('admin.ops.systemLogs.loadFailed'))
@@ -561,6 +564,7 @@ onMounted(async () => {
       </div>
       <Pagination
         :total="total"
+        :total-is-capped="totalIsCapped"
         :page="page"
         :page-size="pageSize"
         @update:page="onPageChange"


### PR DESCRIPTION
Fixes #5858

把 trend 与 api_key 两条线接到预聚合上，并让 system-logs 的分页总数不再付全表扫描的代价。
四块改动互相独立，可分开 review。

## A. 分钟级预聚合 —— trend / snapshot-v2

新增 `ops_metrics_minute`（迁移 228），60/300/3600 三种桶粒度统一由它折叠得出。

- 写入侧 `UpsertMinuteMetrics` 顺带聚合 `switch_count`，把原先散落在查询期的
  `jsonb_array_elements(upstream_errors)` 展开挪到写入侧，每分钟只展开一次；
- **口径刻意对齐 trend 的 raw 路径**（`buildUsageWhere` / `buildErrorWhere`），
  而不是照抄 `UpsertHourlyMetrics` —— 后者 usage 侧是 `INNER JOIN groups`，
  会丢掉 `group_id IS NULL` 的行。trend 的 preagg 段要和 head/tail 的 raw 段拼接，
  口径不一致会让接缝处数字跳变。这也是没有复用小时表的原因；
- 因为改用 `LEFT JOIN`，NULL 维度回来了，三档 GROUPING SETS 会在
  `COALESCE(platform,'')` / `COALESCE(group_id,0)` 唯一键上撞车，触发
  `ON CONFLICT DO UPDATE command cannot affect row a second time`。
  由 `opsMinuteDimensionHaving` 丢掉这些**必然无人查询**的维度行
  （真 NULL 的 platform/group 仍计入 overall 行，raw 侧的过滤本来也排除它们）；
- 查询侧稳定段读预聚合、首尾碎片补明细，`auto` 沿用既有的
  `ErrOpsPreaggregatedNotPopulated` 回落；
- 启动时按 retention（默认 30 天）分块回填，**并补齐停机缺口** —— 增量循环每轮
  只回看 10 分钟，停机更久就会留下增量循环永远够不到的空洞；
- 接上早已存在但无表可清的 `ops.cleanup.minute_metrics_retention_days`。

## B. api_key 用量日汇总 —— api-keys-usage

新增 `usage_apikey_daily_rollups`（迁移 229），与 `usage_group_daily_rollups` 同构。

- **写入并入已有的分块日结**：同一个事务、同一次扫描里用
  `GROUP BY GROUPING SETS ((date, group_id), (date, api_key_id))` 一次产出两个维度，
  分别写两张表。不新增水位表、不新增调度、不增加额外的表扫描；
- 查询改成 historical（日桶）+ tail（当日明细）两段。**水位缺失时退化成 1970**，
  即回落到全量扫明细的旧行为（慢但正确），而不是返回 0；
- 起点对齐到当地日边界，否则首日会按整天计入。

## C. system-logs 封顶计数

```sql
SELECT COUNT(*) FROM (SELECT 1 FROM ops_system_logs l <where> LIMIT 10001) capped
```

超过上限时返回上限值并置 `total_is_capped`，前端显示「10000+」。两个边界：

- 当前页已翻过上限时把上限抬到 `offset + pageSize + 1`，否则算出的总页数小于
  当前页码，分页器会错乱；
- 封顶时不锁死「下一页」——服务端会随页码抬高上限，逐页往后翻仍然成立，
  否则用户会撞上一个没有任何提示的死胡同。

`PaginatedData.TotalIsCapped` 带 `omitempty`，其余分页接口的响应不受影响。

## D. 顺带修掉的两个既有问题

在做 B 的过程中发现分组用量日汇总本身有两个 bug（前两个提交）：

1. **过期清理会让整份历史汇总作废**。`usage_logs` 的行级触发器把删除当成
   "历史数据变了" 而回退水位，于是每次 retention 清理都触发一次全量重算。
   引入归档屏障 `retained_from`：屏障之前的日期已归档，其日桶不可变，
   清理不再作废它们；
2. **重建持有状态行锁贯穿整个区间**。`FOR UPDATE` 与插入触发器的 `FOR KEY SHARE`
   冲突，重建期间所有 `usage_logs` 写入被阻塞（区间大时可达数分钟，导致日志写入
   大面积失败）。改成按天分块提交，每块提交后即释放锁，积压写入得以通过；
   中断后凭水位续跑。

## 测试

单元测试外，新增的集成测试（`-tags integration`，testcontainers 起真实 PostgreSQL）覆盖：

- preagg 与 raw 在 **3 种过滤 × 3 种桶粒度** 下逐点相等（含 `ByPlatform` / `TopGroups`）；
- `switch_count` 与原 `queryAccountSwitchCount` 的展开逻辑对账，`count_tokens` 探针两侧都排除；
- 重复聚合同一窗口幂等（回填与增量必然重叠，`ON CONFLICT` 写成累加就会翻倍）；
- 预聚合未填充时 `auto` 能回落到 raw；
- 回填缺口计算（表空 / 只缺低端 / 只缺高端 / 两头都缺 / 停机在 overlap 之内）；
- api_key 与 group 两个日桶维度分别与明细对账，含 `group_id IS NULL` 与
  `api_key_id IS NULL` 的行；
- 水位缺失时 `GetBatchAPIKeyUsageStats` 退化为全量扫描而非返回 0；
- 封顶计数的四种情形（未达上限 / 达到上限 / 深翻页抬上限 / 空结果）。

`GROUPING SETS` + data-modifying CTE 这类构造 sqlmock 验证不了，必须跑真实 PostgreSQL
—— 上面那条 `ON CONFLICT ... cannot affect row a second time` 就是集成测试发现的。

## 兼容性

- 两条迁移都是纯新增表，不改动既有表结构；
- 新接口字段 `total_is_capped` 带 `omitempty`，旧前端忽略即可；
- trend 的 `mode=raw` 行为完全不变。
