### PR TITLE
fix: preserve Cursor custom tools to apply_patch

### DIFF
--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -306,7 +306,10 @@ type ResponsesTool struct {
 	Name        string          `json:"name,omitempty"`
 	Description string          `json:"description,omitempty"`
 	Parameters  json.RawMessage `json:"parameters,omitempty"`
-	Strict      *bool           `json:"strict,omitempty"`
+	// type=custom 的可选 grammar 约束。Cursor 的 ApplyPatch 会携带该字段；
+	// 必须原样保留到 Responses 上游，不能因内部结构化而静默丢失。
+	Format json.RawMessage `json:"format,omitempty"`
+	Strict *bool           `json:"strict,omitempty"`
 
 	// type=namespace 的子工具列表（tools 与 children 二选一，语义相同）。
 	Tools    []ResponsesTool `json:"tools,omitempty"`

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -95,9 +95,26 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return s.forwardChatCompletionsViaNativeAnthropic(ctx, c, account, body, defaultMappedModel)
 	}
 
+	// Cursor may send a Responses-shaped body (input/tools) to the Chat
+	// Completions URL.  If this API-key account can only reach a Chat
+	// Completions upstream, route it through the existing bidirectional
+	// Responses <-> Chat bridge instead of forwarding the incompatible body
+	// verbatim.  The bridge converts custom tools to ordinary functions for
+	// the upstream and restores custom_tool_call items for Cursor.
+	isResponsesShape := !gjson.GetBytes(body, "messages").Exists() && gjson.GetBytes(body, "input").Exists()
+	isCursorClientRequest := isCursorClientRequest(c)
+
 	// 入口分流：APIKey 账号 + 强制或已探测确认上游不支持 Responses，走 CC 直转。
 	// 自动模式下标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
 	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+		if isResponsesShape && isCursorClientRequest {
+			logger.L().Info("openai chat_completions: bridging Cursor responses-shaped request through chat upstream",
+				zap.Int64("account_id", account.ID),
+				zap.String("model", gjson.GetBytes(body, "model").String()),
+				zap.Bool("stream", gjson.GetBytes(body, "stream").Bool()),
+			)
+			return s.forwardResponsesViaRawChatCompletions(ctx, c, account, body)
+		}
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 
@@ -135,8 +152,6 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	// Detect that shape and forward the raw body as-is, only rewriting `model`
 	// to the resolved upstream model. The downstream codex OAuth transform will
 	// still normalize store/stream/instructions/etc.
-	isResponsesShape := !gjson.GetBytes(body, "messages").Exists() && gjson.GetBytes(body, "input").Exists()
-
 	var (
 		responsesReq  *apicompat.ResponsesRequest
 		responsesBody []byte
@@ -176,6 +191,17 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		responsesReq, err = apicompat.ChatCompletionsToResponses(&chatReq)
 		if err != nil {
 			return nil, fmt.Errorf("convert chat completions to responses: %w", err)
+		}
+		// Cursor combines ordinary nested Chat function tools with a flat
+		// Responses custom tool (ApplyPatch). The standard tools above have
+		// already been converted correctly; append only the flat custom tool.
+		// Replacing the entire slice would erase the nested function payloads.
+		flatCursorCustomTools, hasFlatCursorCustomTools, toolErr := extractFlatCursorCustomToolsFromChatBody(body)
+		if toolErr != nil {
+			return nil, fmt.Errorf("parse Cursor flat custom tools: %w", toolErr)
+		}
+		if isCursorClientRequest && hasFlatCursorCustomTools {
+			responsesReq.Tools = append(responsesReq.Tools, flatCursorCustomTools...)
 		}
 		responsesReq.Model = upstreamModel
 		normalizeResponsesRequestServiceTier(responsesReq)
@@ -351,6 +377,51 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 
 	return result, handleErr
+}
+
+// extractFlatCursorCustomToolsFromChatBody selects only Cursor's top-level
+// custom tools. Standard nested Chat function tools are intentionally left to
+// ChatCompletionsToResponses, which preserves their nested `function` payload.
+func extractFlatCursorCustomToolsFromChatBody(body []byte) ([]apicompat.ResponsesTool, bool, error) {
+	rawTools := gjson.GetBytes(body, "tools")
+	if !rawTools.IsArray() {
+		return nil, false, nil
+	}
+	customTools := make([]apicompat.ResponsesTool, 0)
+	for _, tool := range rawTools.Array() {
+		if !tool.IsObject() || tool.Get("function").Exists() || tool.Get("type").String() != "custom" || tool.Get("name").String() == "" {
+			continue
+		}
+		var customTool apicompat.ResponsesTool
+		if err := json.Unmarshal([]byte(tool.Raw), &customTool); err != nil {
+			return nil, false, err
+		}
+		customTools = append(customTools, customTool)
+	}
+	if len(customTools) == 0 {
+		return nil, false, nil
+	}
+	return customTools, true, nil
+}
+
+// isCursorClientRequest recognizes Cursor by its request headers only.  Tool
+// declarations deliberately do not participate in this decision: a Cursor
+// request that temporarily lacks ApplyPatch must still keep every other flat
+// Responses-style tool, while a non-Cursor client keeps the legacy path.
+func isCursorClientRequest(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	if strings.Contains(strings.ToLower(c.GetHeader("User-Agent")), "cursor") ||
+		strings.Contains(strings.ToLower(c.GetHeader("originator")), "cursor") {
+		return true
+	}
+	for name := range c.Request.Header {
+		if strings.HasPrefix(strings.ToLower(name), "x-cursor-") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeResponsesRequestServiceTier(req *apicompat.ResponsesRequest) {

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -92,6 +94,26 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	}
 	if normalizedBody, normalized := NormalizeGLMOpenAIReasoningEffort(upstreamBody, upstreamModel); normalized {
 		upstreamBody = normalizedBody
+	}
+	// Cursor currently sends a Chat Completions-shaped request, but declares
+	// ApplyPatch as a Responses-only custom tool. Chat-only upstreams ignore
+	// that declaration, making the model believe the tool is unavailable.
+	// Lower client-only tools to the established function-tool representation
+	// before the raw pass-through. A Chat Completions response expresses calls
+	// as function tool_calls, which is the matching wire format for this client
+	// endpoint.
+	if isCursorClientRequest(c) {
+		adaptedBody, clientToolsAdapted, err := adaptRawChatCompletionsClientTools(upstreamBody)
+		if err != nil {
+			writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+			return nil, fmt.Errorf("adapt raw chat client tools: %w", err)
+		}
+		if clientToolsAdapted {
+			upstreamBody = adaptedBody
+			logger.L().Info("openai chat_completions raw: lowered Cursor client-only tools for chat upstream",
+				zap.Int64("account_id", account.ID),
+			)
+		}
 	}
 
 	// 4. Apply OpenAI fast policy on the CC body
@@ -225,6 +247,26 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		result.UpstreamEndpoint = grokChatRawEndpoint
 	}
 	return result, forwardErr
+}
+
+// adaptRawChatCompletionsClientTools reuses the Responses client-tool lowering
+// rules for Cursor's hybrid Chat Completions payloads. It intentionally only
+// rewrites tool declarations/history owned by the client; messages and all
+// ordinary Chat Completions fields remain unchanged.
+func adaptRawChatCompletionsClientTools(body []byte) ([]byte, bool, error) {
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		return body, false, fmt.Errorf("parse request body: %w", err)
+	}
+	_, changed, err := apicompat.AdaptResponsesClientTools(request)
+	if err != nil || !changed {
+		return body, false, err
+	}
+	adapted, err := json.Marshal(request)
+	if err != nil {
+		return body, false, fmt.Errorf("marshal adapted request: %w", err)
+	}
+	return adapted, true, nil
 }
 
 func (s *OpenAIGatewayService) rawChatCompletionsURL(account *Account) (string, error) {

--- a/backend/internal/service/openai_gateway_chat_completions_raw_client_tools_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_client_tools_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestIsCursorClientRequestUsesOnlyClientIdentity(t *testing.T) {
+	newContext := func(userAgent, originator string, cursorHeader bool) *gin.Context {
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		ctx.Request.Header.Set("User-Agent", userAgent)
+		ctx.Request.Header.Set("Originator", originator)
+		if cursorHeader {
+			ctx.Request.Header.Set("X-Cursor-Client-Version", "2.4.0")
+		}
+		return ctx
+	}
+
+	require.True(t, isCursorClientRequest(newContext("Cursor/2.4.0", "", false)))
+	require.True(t, isCursorClientRequest(newContext("", "cursor", false)))
+	require.True(t, isCursorClientRequest(newContext("OpenAI", "", true)))
+	require.False(t, isCursorClientRequest(newContext("OpenAI", "", false)))
+}
+
+func TestAdaptRawChatCompletionsClientToolsLowersCursorApplyPatch(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-test",
+		"messages":[{"role":"user","content":"edit a file"}],
+		"tools":[
+			{"type":"function","name":"Shell","description":"Run a command","parameters":{"type":"object"}},
+			{"type":"custom","name":"ApplyPatch","description":"Apply a unified diff","format":{"type":"grammar"}}
+		]
+	}`)
+
+	adapted, changed, err := adaptRawChatCompletionsClientTools(body)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "function", gjson.GetBytes(adapted, "tools.1.type").String())
+	require.Equal(t, "ApplyPatch", gjson.GetBytes(adapted, "tools.1.name").String())
+	require.Equal(t, "string", gjson.GetBytes(adapted, "tools.1.parameters.properties.input.type").String())
+	require.False(t, gjson.GetBytes(adapted, "tools.1.format").Exists())
+	// Existing flat Cursor function declarations must survive unchanged.
+	require.Equal(t, "Shell", gjson.GetBytes(adapted, "tools.0.name").String())
+}
+
+func TestExtractFlatCursorCustomToolsAppendsWithoutReplacingChatFunctions(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-test",
+		"messages":[{"role":"user","content":"edit a file"}],
+		"tools":[
+			{"type":"function","function":{"name":"Shell","description":"Run a command","parameters":{"type":"object"}}},
+			{"type":"custom","name":"ApplyPatch","description":"Apply a unified diff","format":{"type":"grammar"}}
+		]
+	}`)
+
+	tools, found, err := extractFlatCursorCustomToolsFromChatBody(body)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, tools, 1)
+	require.Equal(t, "custom", tools[0].Type)
+	require.Equal(t, "ApplyPatch", tools[0].Name)
+	encodedCustomTool, err := json.Marshal(tools[0])
+	require.NoError(t, err)
+	require.Equal(t, "grammar", gjson.GetBytes(encodedCustomTool, "format.type").String())
+
+	var chatReq apicompat.ChatCompletionsRequest
+	require.NoError(t, json.Unmarshal(body, &chatReq))
+	responsesReq, err := apicompat.ChatCompletionsToResponses(&chatReq)
+	require.NoError(t, err)
+	// The typed Chat parser converts the standard nested function tool. The
+	// gateway must append, rather than replace it with the flat custom tool.
+	require.Len(t, responsesReq.Tools, 1)
+	require.Equal(t, "Shell", responsesReq.Tools[0].Name)
+	responsesReq.Tools = append(responsesReq.Tools, tools...)
+	require.Len(t, responsesReq.Tools, 2)
+	require.Equal(t, "ApplyPatch", responsesReq.Tools[1].Name)
+}

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -228,6 +228,7 @@ func TestForwardAsChatCompletions_ResponsesShapeForceChatCompletionsRestoresCust
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "Cursor/1.0")
 
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -220,6 +220,38 @@ func TestForwardResponses_AutoSupportedAccountStillUsesResponsesEndpoint(t *test
 	require.Equal(t, "ok", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
 }
 
+func TestForwardAsChatCompletions_ResponsesShapeForceChatCompletionsRestoresCustomToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.5","input":"apply a patch","stream":false,"tools":[{"type":"custom","name":"ApplyPatch","description":"Apply a patch"}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl_patch","object":"chat.completion","model":"gpt-5.5","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_patch","type":"function","function":{"name":"ApplyPatch","arguments":"{\\\"input\\\":\\\"*** Begin Patch\\\\n*** End Patch\\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, forceChatResponsesFallbackAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "http://upstream.example/v1/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "function", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
+	require.Equal(t, "ApplyPatch", gjson.GetBytes(upstream.lastBody, "tools.0.function.name").String())
+	require.Equal(t, "custom_tool_call", gjson.Get(rec.Body.String(), "output.0.type").String())
+	require.Equal(t, "ApplyPatch", gjson.Get(rec.Body.String(), "output.0.name").String())
+	require.Contains(t, gjson.Get(rec.Body.String(), "output.0.input").String(), "*** Begin Patch")
+}
+
 func forceChatResponsesFallbackAccount() *Account {
 	account := rawChatCompletionsTestAccount()
 	account.Extra = map[string]any{

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1601,6 +1601,19 @@
         </div>
       </div>
 
+      <!-- Cursor hybrid Chat/Responses tool compatibility status -->
+      <div
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="rounded-lg border border-sky-100 bg-sky-50/60 px-4 py-3 dark:border-sky-900/50 dark:bg-sky-950/20">
+          <label class="input-label mb-0 text-sky-800 dark:text-sky-200">{{ t('admin.accounts.openai.cursorHybridTools') }}</label>
+          <p class="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-300">
+            {{ t('admin.accounts.openai.cursorHybridToolsDesc') }}
+          </p>
+        </div>
+      </div>
+
       <!-- OpenAI Codex namespace 工具摊平（兼容开关，仅 OAuth） -->
       <div
         v-if="account?.platform === 'openai' && account?.type === 'oauth'"

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -545,6 +545,9 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        cursorHybridTools: 'Cursor Chat tool compatibility',
+        cursorHybridToolsDesc:
+          'Only for requests identified as the Cursor client by request headers: when Cursor sends Chat messages plus flat Responses-style tool declarations to /v1/chat/completions, the gateway preserves every tool for the OpenAI Responses upstream, including custom tools such as ApplyPatch. Other clients are unaffected. This compatibility handling is independent of the auto-passthrough setting above.',
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -622,6 +622,9 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        cursorHybridTools: 'Cursor Chat 工具兼容',
+        cursorHybridToolsDesc:
+          '仅当请求头识别为 Cursor 客户端，且其向 /v1/chat/completions 发送 Chat 消息与扁平 Responses 工具定义的混合请求时，网关才会完整保留工具并转发到 OpenAI Responses 上游；包括 ApplyPatch 等 custom 工具。其他客户端不受影响；此兼容处理独立于上方“自动透传”开关。',
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',


### PR DESCRIPTION
## Problem

Cursor may send standard Chat Completions function tools together with
Responses-style top-level `custom` tools such as `ApplyPatch`.

The previous compatibility path could replace the normal nested function tool
list with the flat custom tool list, causing standard Cursor tools such as
Shell, ReadFile, Delete, TodoWrite, etc. to disappear. On strict
Chat-Completions upstream paths, custom tools could also be dropped.

## Changes

- Enable the compatibility path only for requests identified as Cursor.
- Preserve existing nested function tools.
- Extract and append only top-level `type: custom` Cursor tools.
- Preserve the custom tool `format`/grammar field required by ApplyPatch.
- Lower custom tools to compatible functions when forwarding to a
  Chat-Completions-only upstream.
- Add regression coverage for mixed standard and custom Cursor tools.

## Validation

- Go unit tests passed for Cursor request detection, custom-tool lowering,
  mixed tool preservation, and Responses-to-Chat fallback.
- Frontend production build passed.
- Runtime logging verified that standard Cursor tools and ApplyPatch are
  forwarded together and tool calls return successfully.

## Scope

The special handling is gated by Cursor client identity. Non-Cursor clients
continue using the existing behavior.


fixed result
<img width="1099" height="511" alt="image" src="https://github.com/user-attachments/assets/f42345a7-5fce-4ef8-b04e-3d18779003a1" />
