### PR TITLE
fix(grok): lower Codex tool-search discovery outputs

### DIFF
--- a/backend/internal/pkg/apicompat/responses_client_tools.go
+++ b/backend/internal/pkg/apicompat/responses_client_tools.go
@@ -212,7 +212,7 @@ func rewriteClientToolHistory(value any, adapter *ResponsesClientToolMapping) bo
 				if adapter.ToolSearch {
 					typed["type"] = "function_call_output"
 					dropInvalidLoweredFunctionItemID(typed)
-					normalizeClientToolOutput(typed)
+					normalizeToolSearchOutput(typed)
 					changed = true
 				}
 			}
@@ -254,6 +254,46 @@ func normalizeClientToolOutput(item map[string]any) {
 		return
 	}
 	item["output"] = string(encoded)
+}
+
+// normalizeToolSearchOutput converts both tool_search output wire shapes into
+// the string output required by function_call_output. Older clients send an
+// output field directly; newer Codex clients return discovered definitions in
+// a top-level tools field. Codex treats that field's value as the tool output,
+// so serialize the value directly rather than wrapping it in another object.
+func normalizeToolSearchOutput(item map[string]any) {
+	if output, hasOutput := item["output"]; hasOutput {
+		switch typed := output.(type) {
+		case string:
+			item["output"] = typed
+		case nil:
+			item["output"] = ""
+		default:
+			encoded, err := json.Marshal(typed)
+			if err != nil {
+				return
+			}
+			item["output"] = string(encoded)
+		}
+		dropToolSearchOutputPrivateFields(item)
+		return
+	}
+	tools, hasTools := item["tools"]
+	if !hasTools {
+		return
+	}
+	encoded, err := json.Marshal(tools)
+	if err != nil {
+		return
+	}
+	item["output"] = string(encoded)
+	dropToolSearchOutputPrivateFields(item)
+}
+
+func dropToolSearchOutputPrivateFields(item map[string]any) {
+	delete(item, "tools")
+	delete(item, "status")
+	delete(item, "execution")
 }
 
 func rewriteClientToolChoice(req map[string]any, adapter *ResponsesClientToolMapping) bool {

--- a/backend/internal/pkg/apicompat/responses_client_tools_test.go
+++ b/backend/internal/pkg/apicompat/responses_client_tools_test.go
@@ -66,6 +66,166 @@ func TestAdaptResponsesClientTools_LowersDeclarationsHistoryChoiceAndNamespaces(
 	require.Equal(t, "team__send", namespaceCall["name"])
 }
 
+func TestAdaptResponsesClientTools_LowersDiscoveredToolSearchOutput(t *testing.T) {
+	requestJSON := `{
+		"tools":[{"type":"tool_search"}],
+		"input":[
+			{"type":"tool_search_call","id":"tsc_client","call_id":"call_search","arguments":{"query":"codex app"},"execution":"client","status":"completed"},
+			{"type":"tool_search_output","id":"tso_client","call_id":"call_search","execution":"client","status":"completed","tools":[
+				{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","description":"Load workspace dependencies","parameters":{"type":"object","properties":{},"additionalProperties":false}}]},
+				{"type":"namespace","name":"multi_agent_v1","tools":[{"type":"function","name":"spawn_agent","description":"Spawn an agent","parameters":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}}]}
+			]}
+		]
+	}`
+
+	adapt := func() map[string]any {
+		var req map[string]any
+		require.NoError(t, json.Unmarshal([]byte(requestJSON), &req))
+		_, changed, err := AdaptResponsesClientTools(req)
+		require.NoError(t, err)
+		require.True(t, changed)
+		return req
+	}
+
+	first := adapt()
+	second := adapt()
+	firstInput := requireResponsesClientToolValue[[]any](t, first["input"])
+	secondInput := requireResponsesClientToolValue[[]any](t, second["input"])
+
+	call := requireResponsesClientToolValue[map[string]any](t, firstInput[0])
+	require.Equal(t, "function_call", call["type"])
+	require.Equal(t, toolSearchProxyName, call["name"])
+	require.JSONEq(t, `{"query":"codex app"}`, requireResponsesClientToolValue[string](t, call["arguments"]))
+	require.NotContains(t, call, "execution")
+
+	output := requireResponsesClientToolValue[map[string]any](t, firstInput[1])
+	require.Equal(t, map[string]any{
+		"type":    "function_call_output",
+		"call_id": "call_search",
+		"output":  output["output"],
+	}, output)
+	outputText := requireResponsesClientToolValue[string](t, output["output"])
+	require.JSONEq(t, `[
+		{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","description":"Load workspace dependencies","parameters":{"type":"object","properties":{},"additionalProperties":false}}]},
+		{"type":"namespace","name":"multi_agent_v1","tools":[{"type":"function","name":"spawn_agent","description":"Spawn an agent","parameters":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}}]}
+	]`, outputText)
+	secondOutput := requireResponsesClientToolValue[map[string]any](t, secondInput[1])
+	require.Equal(t, outputText, secondOutput["output"], "tool discovery output encoding must be deterministic")
+}
+
+func TestAdaptResponsesClientTools_ToolSearchOutputEdgeCases(t *testing.T) {
+	unencodableOutput := make(chan struct{})
+	tests := []struct {
+		name             string
+		item             map[string]any
+		wantOutput       any
+		wantOutputExists bool
+		wantPrivateKeys  []string
+		wantExactOutput  bool
+	}{
+		{
+			name:             "absent tools and output remains visibly malformed",
+			item:             map[string]any{"type": "tool_search_output", "call_id": "call_empty", "status": "completed"},
+			wantOutputExists: false,
+			wantPrivateKeys:  []string{"status"},
+		},
+		{
+			name: "preexisting string output wins",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_legacy", "output": "legacy",
+				"tools": []any{map[string]any{"type": "function", "name": "ignored"}}, "execution": "client",
+			},
+			wantOutput:       "legacy",
+			wantOutputExists: true,
+			wantExactOutput:  true,
+		},
+		{
+			name: "preexisting object output remains legacy representation",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_object", "output": map[string]any{"groups": []any{"github"}},
+				"tools": []any{map[string]any{"type": "function", "name": "ignored"}},
+			},
+			wantOutput:       `{"groups":["github"]}`,
+			wantOutputExists: true,
+			wantExactOutput:  true,
+		},
+		{
+			name: "unencodable preexisting output remains visibly malformed",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_bad_output", "output": unencodableOutput,
+				"tools": []any{map[string]any{"type": "function", "name": "retained"}}, "status": "completed", "execution": "client",
+			},
+			wantOutput:       unencodableOutput,
+			wantOutputExists: true,
+			wantPrivateKeys:  []string{"tools", "status", "execution"},
+		},
+		{
+			name: "empty tools array is a valid empty output",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_empty_tools",
+				"tools": []any{}, "status": "completed", "execution": "client",
+			},
+			wantOutput:       `[]`,
+			wantOutputExists: true,
+			wantExactOutput:  true,
+		},
+		{
+			name: "non-array tools value is serialized directly",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_malformed",
+				"tools": map[string]any{"unexpected": true}, "status": "completed", "execution": "client",
+			},
+			wantOutput:       `{"unexpected":true}`,
+			wantOutputExists: true,
+			wantExactOutput:  true,
+		},
+		{
+			name: "unencodable tools remains visibly malformed",
+			item: map[string]any{
+				"type": "tool_search_output", "call_id": "call_unencodable", "tools": make(chan struct{}), "status": "completed",
+			},
+			wantOutputExists: false,
+			wantPrivateKeys:  []string{"tools", "status"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := map[string]any{
+				"tools": []any{map[string]any{"type": "tool_search"}},
+				"input": []any{tt.item},
+			}
+			_, changed, err := AdaptResponsesClientTools(req)
+			require.NoError(t, err)
+			require.True(t, changed)
+			input := requireResponsesClientToolValue[[]any](t, req["input"])
+			output := requireResponsesClientToolValue[map[string]any](t, input[0])
+			require.Equal(t, "function_call_output", output["type"])
+			actualOutput, outputExists := output["output"]
+			require.Equal(t, tt.wantOutputExists, outputExists)
+			if tt.wantOutputExists {
+				require.Equal(t, tt.wantOutput, actualOutput)
+			}
+			if tt.wantExactOutput {
+				require.Equal(t, map[string]any{
+					"type":    "function_call_output",
+					"call_id": output["call_id"],
+					"output":  tt.wantOutput,
+				}, output)
+			}
+			if len(tt.wantPrivateKeys) > 0 {
+				for _, key := range tt.wantPrivateKeys {
+					require.Contains(t, output, key)
+				}
+			} else {
+				require.NotContains(t, output, "tools")
+				require.NotContains(t, output, "status")
+				require.NotContains(t, output, "execution")
+			}
+		})
+	}
+}
+
 func requireResponsesClientToolValue[T any](t *testing.T, value any) T {
 	t.Helper()
 	typed, ok := value.(T)

--- a/backend/internal/service/openai_gateway_grok_tool_protocol_test.go
+++ b/backend/internal/service/openai_gateway_grok_tool_protocol_test.go
@@ -65,6 +65,39 @@ func TestPatchGrokResponsesBodyWithClientToolsLowersCodexProtocol(t *testing.T) 
 	require.False(t, gjson.GetBytes(patched, "input.4.namespace").Exists())
 }
 
+func TestPatchGrokResponsesBodyWithClientToolsLowersDiscoveredToolsOutput(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model":"grok-4.5",
+		"tools":[{"type":"tool_search"}],
+		"input":[
+			{"type":"tool_search_call","id":"tsc_request_74547","call_id":"call_request_74547","arguments":{"query":"subagent"},"execution":"client","status":"completed"},
+			{"type":"tool_search_output","id":"tso_request_74547","call_id":"call_request_74547","execution":"client","status":"completed","tools":[
+				{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","parameters":{"type":"object","properties":{},"additionalProperties":false}}]},
+				{"type":"namespace","name":"multi_agent_v1","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}}]}
+			]}
+		]
+	}`)
+
+	patched, mapping, err := patchGrokResponsesBodyWithClientTools(body, "grok-4.5")
+	require.NoError(t, err)
+	require.True(t, mapping.ToolSearch)
+	require.Equal(t, "function_call", gjson.GetBytes(patched, "input.0.type").String())
+	require.Equal(t, "tool_search", gjson.GetBytes(patched, "input.0.name").String())
+	require.Equal(t, "function_call_output", gjson.GetBytes(patched, "input.1.type").String())
+	require.Equal(t, "call_request_74547", gjson.GetBytes(patched, "input.1.call_id").String())
+	require.Len(t, gjson.GetBytes(patched, "input.1").Map(), 3)
+	require.False(t, gjson.GetBytes(patched, "input.1.tools").Exists())
+	require.False(t, gjson.GetBytes(patched, "input.1.status").Exists())
+	require.False(t, gjson.GetBytes(patched, "input.1.execution").Exists())
+	output := gjson.GetBytes(patched, "input.1.output").String()
+	require.JSONEq(t, `[
+		{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","parameters":{"type":"object","properties":{},"additionalProperties":false}}]},
+		{"type":"namespace","name":"multi_agent_v1","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}}]}
+	]`, output)
+}
+
 func TestPatchGrokResponsesBodyWithClientToolsRewritesEveryToolChoice(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- lower current Codex `tool_search_output.tools` results into the standard `function_call_output.output` string
- remove client-private `tools`, `status`, and `execution` fields after successful normalization
- preserve legacy `output` precedence and keep malformed/unencodable values visible
- add apicompat and Grok patch regressions for nested namespace tools and empty discovery results

## Behavior

A discovery result such as:

```json
{"type":"tool_search_output","call_id":"call_search","tools":[{"type":"namespace","name":"codex_app","tools":[...]}],"status":"completed","execution":"client"}
```

is lowered to:

```json
{"type":"function_call_output","call_id":"call_search","output":"[{\"type\":\"namespace\",\"name\":\"codex_app\",\"tools\":[...]}]"}
```

The raw tools array is serialized directly, matching Codex's tool-result representation. Existing string or JSON-encodable `output` values retain precedence.

## Testing

```text
GOPROXY=off go test ./internal/pkg/apicompat -count=1
ok github.com/Wei-Shaw/sub2api/internal/pkg/apicompat 0.871s
```

A focused offline probe compiled and exercised the actual `adaptGrokResponsesClientTools` Grok boundary:

```text
PASS
ok command-line-arguments 1.284s
```

`gofmt` and `git diff --check` pass. The permanent Grok service regression uses the existing `unit` build tag; the full service package was not run locally because optional captcha modules were not present in the offline module cache, so CI remains the complete service-suite oracle.

Fixes #5867
Refs #4710
Refs #4716
