### PR TITLE
feat(openai): add strict raw Responses forwarding mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Sub2API is an AI API gateway platform designed to distribute and manage API quot
 - **Built-in Payment System** - Supports EasyPay, Alipay, WeChat Pay, and Stripe for user self-service top-up, no separate payment service needed ([Configuration Guide](docs/PAYMENT.md))
 - **Admin Dashboard** - Web interface for monitoring and management
 - **Composite Groups** - Admin routing layer that resolves requested models to concrete providers for multi-provider groups ([Operator Guide](docs/COMPOSITE_GROUPS.md))
+- **Strict Responses Upstreams** - Byte-faithful request and SSE forwarding for upstreams that natively implement OpenAI Responses ([Deployment Guide](docs/openai-strict-responses-upstream.md))
 - **External System Integration** - Embed external systems (e.g. ticketing) via iframe to extend the admin dashboard
 
 ## Ecosystem

--- a/README_CN.md
+++ b/README_CN.md
@@ -195,6 +195,7 @@ Sub2API 是一个 AI API 网关平台，用于分发和管理 AI 产品订阅的
 - **速率限制** - 可配置的请求和 Token 速率限制
 - **内置支付系统** - 支持 EasyPay 易支付、支付宝官方、微信官方、Stripe，用户自助充值，无需独立部署支付服务（[配置指南](docs/PAYMENT_CN.md)）
 - **管理后台** - Web 界面进行监控和管理
+- **严格 Responses 上游** - 面向原生实现 OpenAI Responses 协议的上游，支持请求体与 SSE 忠实转发（[部署指南](docs/openai-strict-responses-upstream.md)）
 - **外部系统集成** - 支持通过 iframe 嵌入外部系统（如工单等），扩展管理后台功能
 
 ## 生态项目

--- a/README_JA.md
+++ b/README_JA.md
@@ -194,6 +194,7 @@ Sub2API は、AI 製品のサブスクリプションから API クォータを�
 - **レート制限** - 設定可能なリクエスト数およびトークンレート制限
 - **内蔵決済システム** - EasyPay、Alipay、WeChat Pay、Stripe に対応。ユーザーのセルフサービスチャージが可能で、別途決済サービスのデプロイは不要（[設定ガイド](docs/PAYMENT.md)）
 - **管理ダッシュボード** - 監視・管理のための Web インターフェース
+- **Strict Responses 上流** - OpenAI Responses をネイティブ実装する上流へのリクエスト本文と SSE の忠実な転送（[運用ガイド](docs/openai-strict-responses-upstream.md)）
 - **外部システム連携** - 外部システム（チケット管理など）を iframe 経由で管理ダッシュボードに埋め込み可能
 
 ## エコシステム

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -650,7 +650,12 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 该判断已排除 Codex 被动 image_gen namespace，避免 CC-only 账号被误过滤（#4476）。
 	needsResponses := nativeV2 || legacyCompact
 	requiredCapability := openAIResponsesRequiredCapabilityForRequest(imageIntent, needsResponses, requestPlatform)
-	if previousResponseID != "" {
+	strictContinuationAccountID, strictOwnerErr := h.gatewayService.StrictHTTPContinuationAccount(c.Request.Context(), apiKey.GroupID, previousResponseID)
+	if strictOwnerErr != nil {
+		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Unable to verify the Responses continuation owner", streamStarted)
+		return
+	}
+	if strictContinuationAccountID > 0 {
 		requiredCapability = service.OpenAIEndpointCapabilityStrictResponses
 	}
 
@@ -693,7 +698,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
-			if previousResponseID != "" {
+			if strictContinuationAccountID > 0 {
 				h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "No available strict Responses account owns this continuation", streamStarted)
 				return
 			}
@@ -719,7 +724,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			return
 		}
 		if selection == nil || selection.Account == nil {
-			if previousResponseID != "" {
+			if strictContinuationAccountID > 0 {
 				h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "No available strict Responses account owns this continuation", streamStarted)
 				return
 			}
@@ -743,6 +748,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			zap.Float64("load_skew", scheduleDecision.LoadSkew),
 		)
 		account := selection.Account
+		if strictContinuationAccountID > 0 && (account.ID != strictContinuationAccountID || !account.IsOpenAIStrictResponsesPassthroughEnabled()) {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "The strict Responses continuation owner is unavailable", streamStarted)
+			return
+		}
 		if previousResponseID != "" && requestPlatform == service.PlatformOpenAI && !account.IsOpenAIApiKey() {
 			// The public Responses HTTP API supports previous_response_id on API-key
 			// accounts. OAuth/SetupToken upstreams do not, so keep searching instead

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -785,7 +785,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		if previousResponseID != "" && account.IsOpenAIStrictResponsesPassthroughEnabled() {
 			strictContinuationPinned := scheduleDecision.StickyPreviousHit ||
-				(explicitSessionHash != "" && scheduleDecision.StickySessionHit)
+				(explicitSessionHash != "" && scheduleDecision.StickySessionHit) ||
+				h.gatewayService.IsOpenAIResponseBoundToAccount(
+					c.Request.Context(),
+					apiKey.GroupID,
+					previousResponseID,
+					account.ID,
+				)
 			if !strictContinuationPinned {
 				if selection.ReleaseFunc != nil {
 					selection.ReleaseFunc()

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -410,7 +410,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 
 	// Read request body
-	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
+	body, strictForwardBody, err := readLenientJSONRequestBodyWithOriginal(c.Request, h.cfg)
 	if err != nil {
 		if maxErr, ok := extractMaxBytesError(err); ok {
 			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
@@ -427,6 +427,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 
 	setOpsRequestContext(c, "", false)
+	// Strict Responses accounts must receive exactly what the authenticated
+	// client sent, before compact promotion, reasoning caps, channel mapping or
+	// any other compatibility rewrite. Normal accounts continue using body.
+	strictInboundPath := c.Request.URL.Path
 	sessionHashBody := body
 	body, ok = h.normalizeOpenAIResponsesCompactRequest(c, reqLog, body)
 	if !ok {
@@ -464,11 +468,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by this OpenAI-compatible endpoint for composite groups")
 		return
 	}
+	reasoningPolicyWouldRewrite := false
 	if cappedBody, changed, err := applyOpenAIReasoningEffortPolicyForRequest(c, apiKey, body); err != nil {
 		respondOpenAIReasoningEffortPolicyError(c, err, h.errorResponse)
 		return
 	} else if changed {
 		body = cappedBody
+		reasoningPolicyWouldRewrite = true
 	}
 	if normalizedBody, changed := normalizeCodexAutomationBootstrap(body); changed {
 		body = normalizedBody
@@ -493,7 +499,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		return
 	}
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
-	previousResponseID := strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String())
+	previousResponseID := strings.TrimSpace(gjson.GetBytes(strictForwardBody, "previous_response_id").String())
 	if previousResponseID != "" {
 		previousResponseIDKind := service.ClassifyOpenAIPreviousResponseIDKind(previousResponseID)
 		reqLog = reqLog.With(
@@ -506,6 +512,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.String("reason", "previous_response_id_looks_like_message_id"),
 			)
 			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*), not a message id")
+			return
+		}
+		if previousResponseIDKind != service.OpenAIPreviousResponseIDKindResponseID {
+			reqLog.Warn("openai.request_validation_failed",
+				zap.String("reason", "previous_response_id_invalid"),
+			)
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*)")
 			return
 		}
 		groupID := int64(0)
@@ -606,7 +619,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		return
 	}
 
-	// Generate session hash (header first; fallback to prompt_cache_key)
+	// Generate session hash (header first; fallback to prompt_cache_key). Keep
+	// whether the client supplied an explicit stable signal separate from the
+	// content fallback: only an explicit signal may recover a strict stateful
+	// continuation when the response-id binding is unavailable.
+	explicitSessionHash := h.gatewayService.GenerateExplicitSessionHash(c, sessionHashBody)
 	sessionHash := h.gatewayService.GenerateSessionHash(c, sessionHashBody)
 	if h.rejectIfCyberSessionBlocked(c, apiKey, sessionHashBody, reqModel, cyberBlockFormatResponses) {
 		return
@@ -633,6 +650,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 该判断已排除 Codex 被动 image_gen namespace，避免 CC-only 账号被误过滤（#4476）。
 	needsResponses := nativeV2 || legacyCompact
 	requiredCapability := openAIResponsesRequiredCapabilityForRequest(imageIntent, needsResponses, requestPlatform)
+	if previousResponseID != "" {
+		requiredCapability = service.OpenAIEndpointCapabilityStrictResponses
+	}
 
 	// 分组利润控制：请求级装配定价上下文——pricingAt 固定本请求的
 	// D 与计费高峰因子，选号、槽位终检与全部 failover 重入共用同一门与阈值。
@@ -673,6 +693,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if previousResponseID != "" {
+				h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "No available strict Responses account owns this continuation", streamStarted)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				if legacyCompact && errors.Is(err, service.ErrNoAvailableCompactAccounts) {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
@@ -695,6 +719,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			return
 		}
 		if selection == nil || selection.Account == nil {
+			if previousResponseID != "" {
+				h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "No available strict Responses account owns this continuation", streamStarted)
+				return
+			}
 			cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, requestPlatform)
 			if !cls.ModelNotFound {
 				markOpsRoutingCapacityLimited(c)
@@ -738,6 +766,39 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			)
 			continue
 		}
+		if account.IsOpenAIStrictResponsesPassthroughEnabled() && (reasoningPolicyWouldRewrite || channelMapping.Mapped) {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			reason := "channel model mapping"
+			if reasoningPolicyWouldRewrite {
+				reason = "reasoning effort policy"
+			}
+			h.handleStreamingAwareError(
+				c,
+				http.StatusBadRequest,
+				"invalid_request_error",
+				"Strict raw Responses cannot apply the configured "+reason+" without rewriting the request",
+				streamStarted,
+			)
+			return
+		}
+		if previousResponseID != "" && account.IsOpenAIStrictResponsesPassthroughEnabled() {
+			strictContinuationPinned := scheduleDecision.StickyPreviousHit ||
+				(explicitSessionHash != "" && scheduleDecision.StickySessionHit)
+			if !strictContinuationPinned {
+				if selection.ReleaseFunc != nil {
+					selection.ReleaseFunc()
+				}
+				reqLog.Warn("openai.strict_responses_continuation_unavailable",
+					zap.Int64("selected_account_id", account.ID),
+					zap.Bool("sticky_previous_hit", scheduleDecision.StickyPreviousHit),
+					zap.Bool("sticky_explicit_session_hit", explicitSessionHash != "" && scheduleDecision.StickySessionHit),
+				)
+				h.handleStreamingAwareError(c, http.StatusConflict, "invalid_request_error", "The strict Responses continuation owner is unavailable", streamStarted)
+				return
+			}
+		}
 		sessionHash = ensureOpenAIPoolModeSessionHash(sessionHash, account)
 		reqLog.Debug("openai.account_selected", zap.Int64("account_id", account.ID), zap.String("account_name", account.Name))
 		setOpsSelectedAccount(c, account.ID, account.Platform)
@@ -766,12 +827,23 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		// 从不可变的 canonical forwardBody 派生本次尝试 body 并整块剔除上游私有的加密
 		// reasoning item（含耦合的 id/summary），避免非透传上游 400 拒绝 Kiro reasoning 形态。
 		attemptBody := h.deriveOpenAIForwardAttemptBody(reqLog, forwardBody, account, &passthroughFailoverState)
+		if account.IsOpenAIStrictResponsesPassthroughEnabled() {
+			attemptBody = strictForwardBody
+			// A transport retry may move a stateless first turn, but it must stay
+			// within the same strict protocol family.
+			requiredCapability = service.OpenAIEndpointCapabilityStrictResponses
+		}
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {
 				if accountReleaseFunc != nil {
 					accountReleaseFunc()
 				}
 			}()
+			pathBeforeAttempt := c.Request.URL.Path
+			if account.IsOpenAIStrictResponsesPassthroughEnabled() {
+				c.Request.URL.Path = strictInboundPath
+			}
+			defer func() { c.Request.URL.Path = pathBeforeAttempt }()
 			return h.gatewayService.Forward(c.Request.Context(), c, account, attemptBody)
 		}()
 		var cyberBlockBodyHTTP []byte
@@ -866,6 +938,14 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 							zap.Int64("account_id", account.ID),
 							zap.Int("upstream_status", failoverErr.StatusCode),
 						)
+						return
+					}
+					if previousResponseID != "" && account.IsOpenAIStrictResponsesPassthroughEnabled() {
+						reqLog.Warn("openai.strict_responses_continuation_failover_blocked",
+							zap.Int64("account_id", account.ID),
+							zap.Int("upstream_status", failoverErr.StatusCode),
+						)
+						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}
 					if !openAIForwardMayFailover(c, writerSizeBeforeForward, failoverErr) {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -952,7 +952,6 @@ func TestOpenAIResponses_RejectsHTTPContinuationOwnedByAnotherUser(t *testing.T)
 	h := newOpenAIHandlerForPreviousResponseIDValidation(t, nil)
 	require.NoError(t, h.gatewayService.BindOpenAIHTTPResponseOwner(context.Background(), groupID, "resp_other_tenant", 1, 101))
 	h.Responses(c)
-
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "previous_response_id is not available for this user")
 }
@@ -3151,6 +3150,25 @@ data: {"type":"response.failed","error":{"message":"This content was flagged"}}
 		reported := openAIForwardErrorAlreadyCommunicated(c, before, errors.New("upstream response failed: This content was flagged"))
 
 		require.True(t, reported)
+	})
+
+	t.Run("strict raw upstream HTTP error stays untouched", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, EndpointResponses, nil)
+		before := c.Writer.Size()
+		c.Data(http.StatusConflict, "application/json", []byte(`{"error":{"message":"continuation state missing"}}`))
+		originalBody := w.Body.String()
+
+		reported := openAIForwardErrorAlreadyCommunicated(
+			c,
+			before,
+			errors.New("upstream response failed: strict Responses upstream returned HTTP 409"),
+		)
+
+		require.True(t, reported)
+		require.Equal(t, http.StatusConflict, w.Code)
+		require.Equal(t, originalBody, w.Body.String())
 	})
 
 	t.Run("no write still needs fallback", func(t *testing.T) {

--- a/backend/internal/handler/openai_strict_continuation_regression_test.go
+++ b/backend/internal/handler/openai_strict_continuation_regression_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newContinuationRegressionHandler(t *testing.T, mode string) (*OpenAIGatewayHandler, *openAIWSFailoverHandlerAccountRepoStub, *openAIHTTPPassthroughAuthFailoverUpstream) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	account := service.Account{ID: 9911, Name: "existing-api-key", Platform: service.PlatformOpenAI,
+		Type: service.AccountTypeAPIKey, Status: service.StatusActive, Schedulable: true,
+		Credentials: map[string]any{"api_key": "sk-test-fixture", "base_url": "https://api.example.test"},
+		Extra:       map[string]any{service.OpenAIResponsesForwardModeExtraKey: mode, "openai_responses_supported": true},
+	}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	repo := &openAIWSFailoverHandlerAccountRepoStub{accounts: []service.Account{account}}
+	upstream := &openAIHTTPPassthroughAuthFailoverUpstream{}
+	billing := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billing.Stop)
+	gateway := service.NewOpenAIGatewayService(repo, nil, nil, nil, nil, nil, nil, cfg, nil, nil,
+		service.NewBillingService(cfg, nil), nil, billing, upstream, &service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil)
+	h := NewOpenAIGatewayHandler(gateway, service.NewConcurrencyService(nil), billing,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg), nil, nil, nil, nil, cfg)
+	return h, repo, upstream
+}
+
+func sendContinuationRegressionRequest(h *OpenAIGatewayHandler, previousID string) *httptest.ResponseRecorder {
+	groupID := int64(4203)
+	body := `{"model":"gpt-5.2","input":"hello","stream":false}`
+	if previousID != "" {
+		body = `{"model":"gpt-5.2","input":"continue","stream":false,"previous_response_id":"` + previousID + `"}`
+	}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{ID: 1803, GroupID: &groupID,
+		User: &service.User{ID: 1703, Status: service.StatusActive}, Group: &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive}})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1703, Concurrency: 0})
+	h.Responses(c)
+	return w
+}
+
+func TestOpenAIResponsesExistingNonStrictHTTPContinuation(t *testing.T) {
+	for _, mode := range []string{"normal", "passthrough"} {
+		t.Run(mode, func(t *testing.T) {
+			h, _, _ := newContinuationRegressionHandler(t, mode)
+			// Preserve pre-existing ownership records even when the scheduler binding
+			// has expired: normal upstream continuation behavior is not strict opt-in.
+			require.NoError(t, h.gatewayService.BindOpenAIHTTPResponseOwner(context.Background(), 4203, "resp_existing", 1703, 1803))
+			w := sendContinuationRegressionRequest(h, "resp_existing")
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		})
+	}
+}
+
+func TestOpenAIResponsesStrictContinuationKeepsItsProtocolOwner(t *testing.T) {
+	for _, transition := range []string{"unchanged", "disabled", "reconfigured", "deleted"} {
+		t.Run(transition, func(t *testing.T) {
+			h, repo, upstream := newContinuationRegressionHandler(t, "strict_raw")
+			first := sendContinuationRegressionRequest(h, "")
+			require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+			require.Contains(t, first.Body.String(), "resp_healthy")
+			require.Len(t, upstream.calls(), 1)
+			fallback := repo.accounts[0]
+			fallback.ID = 9912
+			fallback.Extra = map[string]any{"openai_responses_supported": true}
+			switch transition {
+			case "disabled":
+				repo.accounts[0].Status = service.StatusDisabled
+			case "reconfigured":
+				repo.accounts[0].Extra = map[string]any{"openai_responses_supported": true}
+			case "deleted":
+				repo.accounts = nil
+			}
+			if transition != "unchanged" {
+				repo.accounts = append(repo.accounts, fallback)
+			}
+			next := sendContinuationRegressionRequest(h, "resp_healthy")
+			if transition == "unchanged" {
+				require.Equal(t, http.StatusOK, next.Code, next.Body.String())
+				require.Equal(t, []int64{9911, 9911}, upstream.calls())
+			} else {
+				require.Equal(t, http.StatusConflict, next.Code, next.Body.String())
+				require.Equal(t, []int64{9911}, upstream.calls(), "a strict continuation must not reach a replacement or transforming upstream")
+			}
+		})
+	}
+}

--- a/backend/internal/handler/request_body_limit.go
+++ b/backend/internal/handler/request_body_limit.go
@@ -33,6 +33,18 @@ func readLenientJSONRequestBodyWithPrealloc(req *http.Request, cfg *config.Confi
 	return pkghttputil.ReadLenientJSONRequestBodyWithPrealloc(req, gatewayMaxBodySize(cfg))
 }
 
+func readLenientJSONRequestBodyWithOriginal(req *http.Request, cfg *config.Config) (normalized []byte, original []byte, err error) {
+	original, err = pkghttputil.ReadRequestBodyWithPrealloc(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	normalized, err = pkghttputil.NormalizeLenientJSONRequestBody(original, gatewayMaxBodySize(cfg))
+	if err != nil {
+		return nil, nil, err
+	}
+	return normalized, original, nil
+}
+
 func gatewayMaxBodySize(cfg *config.Config) int64 {
 	if cfg == nil {
 		return 0

--- a/backend/internal/handler/request_body_limit_test.go
+++ b/backend/internal/handler/request_body_limit_test.go
@@ -7,10 +7,23 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReadLenientJSONRequestBodyWithOriginalPreservesStrictBytes(t *testing.T) {
+	raw := []byte{'{', '"', 'v', '"', ':', '"', 'a', '\n', 'b', '"', '}'}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(raw))
+
+	normalized, original, err := readLenientJSONRequestBodyWithOriginal(req, &config.Config{})
+
+	require.NoError(t, err)
+	require.Equal(t, raw, original)
+	require.NotEqual(t, raw, normalized)
+	require.JSONEq(t, `{"v":"a\nb"}`, string(normalized))
+}
 
 func TestRequestBodyLimitTooLarge(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1016,6 +1016,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		// 走网关报 no available accounts"。
 		"openai_passthrough",
 		"openai_oauth_passthrough",
+		service.OpenAIResponsesForwardModeExtraKey,
 		"codex_fingerprint_mode",
 		"codex_fingerprint_seed",
 		"codex_5h_used_percent",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -329,6 +329,24 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestBuildSchedulerMetadataAccount_KeepsStrictResponsesCapability(t *testing.T) {
+	account := service.Account{
+		ID:       420,
+		Platform: service.PlatformOpenAI,
+		Type:     service.AccountTypeAPIKey,
+		Extra: map[string]any{
+			service.OpenAIResponsesForwardModeExtraKey: string(service.OpenAIResponsesForwardModeStrictRaw),
+			"unused_large_field":                       "drop-me",
+		},
+	}
+
+	got := buildSchedulerMetadataAccount(account)
+
+	require.Equal(t, string(service.OpenAIResponsesForwardModeStrictRaw), got.Extra[service.OpenAIResponsesForwardModeExtraKey])
+	require.True(t, got.IsOpenAIStrictResponsesPassthroughEnabled())
+	require.Nil(t, got.Extra["unused_large_field"])
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsGrokMediaEligibility(t *testing.T) {
 	t.Run("explicit override", func(t *testing.T) {
 		account := service.Account{

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -86,6 +86,21 @@ type Account struct {
 
 type OpenAIEndpointCapability string
 
+type OpenAIResponsesForwardMode string
+
+const (
+	OpenAIResponsesForwardModeNormal      OpenAIResponsesForwardMode = "normal"
+	OpenAIResponsesForwardModePassthrough OpenAIResponsesForwardMode = "passthrough"
+	OpenAIResponsesForwardModeStrictRaw   OpenAIResponsesForwardMode = "strict_raw"
+)
+
+const (
+	OpenAIResponsesForwardModeExtraKey  = "openai_responses_forward_mode"
+	OpenAIUpstreamAuthModeCredentialKey = "openai_upstream_auth_mode"
+	OpenAIUpstreamAuthModeBearer        = "bearer"
+	OpenAIUpstreamAuthModeNone          = "none"
+)
+
 const openAILongContextBillingEnabledKey = "openai_long_context_billing_enabled"
 
 const (
@@ -104,6 +119,11 @@ const (
 	// credentials["openai_capabilities"] 配置集。仅用于生图意图的 /v1/responses
 	// 调度，避免把请求调度到会在 forward 阶段被降级为 Chat Completions 的账号（#4417）。
 	OpenAIEndpointCapabilityResponses OpenAIEndpointCapability = "responses"
+	// OpenAIEndpointCapabilityStrictResponses limits scheduling to API-key
+	// accounts that explicitly opted into protocol-faithful HTTP Responses
+	// forwarding. It is used for stateful previous_response_id continuations so
+	// they can never fall through to a normal transforming account.
+	OpenAIEndpointCapabilityStrictResponses OpenAIEndpointCapability = "strict_responses"
 )
 
 const openAIEndpointCapabilitiesCredentialKey = "openai_capabilities"
@@ -853,7 +873,7 @@ func (a *Account) IsModelSupported(requestedModel string) bool {
 	// 该短路必须在 model_mapping 判定之前：账号从"白名单模式"切换到透传后，
 	// credentials 里常残留旧的非空 model_mapping，若不在此放行，透传账号会被
 	// model_mapping 白名单错误排除出候选集，导致 no available accounts / 404（issue #4936）。
-	if a.IsOpenAIPassthroughEnabled() {
+	if a.OpenAIResponsesForwardMode() == OpenAIResponsesForwardModePassthrough {
 		return true
 	}
 	mapping := a.GetModelMapping()
@@ -1860,6 +1880,8 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 		// 支持 Responses 的上游同样需具备 chat 能力：复用下方 chat_completions
 		// 配置集校验。
 		capability = OpenAIEndpointCapabilityChatCompletions
+	case OpenAIEndpointCapabilityStrictResponses:
+		return a.IsOpenAIStrictResponsesPassthroughEnabled()
 	case OpenAIEndpointCapabilityAlphaSearch:
 		// alpha/search 的转发按账号类型分流：OAuth/PAT 走
 		// chatgpt.com/backend-api/codex/alpha/search，API key 走
@@ -2077,22 +2099,59 @@ func (a *Account) IsOveragesEnabled() bool {
 	return false
 }
 
+// OpenAIResponsesForwardMode returns the account's Responses forwarding mode.
+// The string setting is authoritative when valid; existing boolean settings
+// remain fully backward-compatible.
+func (a *Account) OpenAIResponsesForwardMode() OpenAIResponsesForwardMode {
+	if a == nil || !a.IsOpenAI() {
+		return OpenAIResponsesForwardModeNormal
+	}
+	if a.Extra != nil {
+		if raw, ok := a.Extra[OpenAIResponsesForwardModeExtraKey].(string); ok {
+			switch OpenAIResponsesForwardMode(strings.ToLower(strings.TrimSpace(raw))) {
+			case OpenAIResponsesForwardModeNormal:
+				return OpenAIResponsesForwardModeNormal
+			case OpenAIResponsesForwardModePassthrough:
+				return OpenAIResponsesForwardModePassthrough
+			case OpenAIResponsesForwardModeStrictRaw:
+				if a.Type == AccountTypeAPIKey {
+					return OpenAIResponsesForwardModeStrictRaw
+				}
+				return OpenAIResponsesForwardModeNormal
+			}
+		}
+		if enabled, ok := a.Extra["openai_passthrough"].(bool); ok && enabled {
+			return OpenAIResponsesForwardModePassthrough
+		}
+		if enabled, ok := a.Extra["openai_oauth_passthrough"].(bool); ok && enabled {
+			return OpenAIResponsesForwardModePassthrough
+		}
+	}
+	return OpenAIResponsesForwardModeNormal
+}
+
+func (a *Account) IsOpenAIStrictResponsesPassthroughEnabled() bool {
+	return a != nil && a.OpenAIResponsesForwardMode() == OpenAIResponsesForwardModeStrictRaw
+}
+
+// UsesNoOpenAIUpstreamAuth allows an auth-less upstream only for strict raw
+// API-key accounts. Normal and legacy passthrough accounts always retain their
+// existing bearer-auth requirement.
+func (a *Account) UsesNoOpenAIUpstreamAuth() bool {
+	if a == nil || !a.IsOpenAIStrictResponsesPassthroughEnabled() || a.Credentials == nil {
+		return false
+	}
+	mode, _ := a.Credentials[OpenAIUpstreamAuthModeCredentialKey].(string)
+	return strings.EqualFold(strings.TrimSpace(mode), OpenAIUpstreamAuthModeNone)
+}
+
 // IsOpenAIPassthroughEnabled 返回 OpenAI 账号是否启用"自动透传（仅替换认证）"。
 //
 // 新字段：accounts.extra.openai_passthrough。
 // 兼容字段：accounts.extra.openai_oauth_passthrough（历史 OAuth 开关）。
 // 字段缺失或类型不正确时，按 false（关闭）处理。
 func (a *Account) IsOpenAIPassthroughEnabled() bool {
-	if a == nil || !a.IsOpenAI() || a.Extra == nil {
-		return false
-	}
-	if enabled, ok := a.Extra["openai_passthrough"].(bool); ok {
-		return enabled
-	}
-	if enabled, ok := a.Extra["openai_oauth_passthrough"].(bool); ok {
-		return enabled
-	}
-	return false
+	return a != nil && a.OpenAIResponsesForwardMode() == OpenAIResponsesForwardModePassthrough
 }
 
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。

--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -49,6 +49,145 @@ func TestAccount_IsOpenAIPassthroughEnabled(t *testing.T) {
 	})
 }
 
+func TestAccount_OpenAIResponsesForwardMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    OpenAIResponsesForwardMode
+	}{
+		{
+			name:    "missing defaults to normal",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+			want:    OpenAIResponsesForwardModeNormal,
+		},
+		{
+			name: "legacy passthrough remains supported",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+				"openai_passthrough": true,
+			}},
+			want: OpenAIResponsesForwardModePassthrough,
+		},
+		{
+			name: "explicit normal overrides legacy boolean",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+				OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeNormal),
+				"openai_passthrough":               true,
+			}},
+			want: OpenAIResponsesForwardModeNormal,
+		},
+		{
+			name: "strict raw is API key only",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+				OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+			}},
+			want: OpenAIResponsesForwardModeStrictRaw,
+		},
+		{
+			name: "strict raw is rejected for OAuth",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+			}},
+			want: OpenAIResponsesForwardModeNormal,
+		},
+		{
+			name: "unknown mode fails closed",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+				OpenAIResponsesForwardModeExtraKey: "raw-ish",
+			}},
+			want: OpenAIResponsesForwardModeNormal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.OpenAIResponsesForwardMode())
+			require.Equal(t, tt.want == OpenAIResponsesForwardModeStrictRaw, tt.account.IsOpenAIStrictResponsesPassthroughEnabled())
+		})
+	}
+}
+
+func TestAccount_UsesNoOpenAIUpstreamAuth(t *testing.T) {
+	strict := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			OpenAIUpstreamAuthModeCredentialKey: OpenAIUpstreamAuthModeNone,
+		},
+		Extra: map[string]any{
+			OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+		},
+	}
+	require.True(t, strict.UsesNoOpenAIUpstreamAuth())
+
+	legacy := *strict
+	legacy.Extra = map[string]any{"openai_passthrough": true}
+	require.False(t, legacy.UsesNoOpenAIUpstreamAuth())
+
+	bearer := *strict
+	bearer.Credentials = map[string]any{OpenAIUpstreamAuthModeCredentialKey: OpenAIUpstreamAuthModeBearer}
+	require.False(t, bearer.UsesNoOpenAIUpstreamAuth())
+}
+
+func TestAccount_StrictResponsesUsesMappingAsModelAllowlist(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"custom/model": "mapped-but-not-forwarded"},
+		},
+		Extra: map[string]any{
+			OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+		},
+	}
+	require.True(t, account.IsModelSupported("custom/model"))
+	require.False(t, account.IsModelSupported("other/model"))
+}
+
+func TestValidateOpenAIResponsesForwardingAccount(t *testing.T) {
+	strictExtra := map[string]any{
+		OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+	}
+	require.NoError(t, ValidateOpenAIResponsesForwardingAccount(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "sk-upstream",
+		},
+		Extra: strictExtra,
+	}))
+	require.NoError(t, ValidateOpenAIResponsesForwardingAccount(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			OpenAIUpstreamAuthModeCredentialKey: OpenAIUpstreamAuthModeNone,
+		},
+		Extra: strictExtra,
+	}))
+
+	err := ValidateOpenAIResponsesForwardingAccount(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    strictExtra,
+	})
+	require.ErrorContains(t, err, "requires an OpenAI API-key account")
+
+	err = ValidateOpenAIResponsesForwardingAccount(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			OpenAIUpstreamAuthModeCredentialKey: OpenAIUpstreamAuthModeNone,
+		},
+	})
+	require.ErrorContains(t, err, "only allowed for strict raw Responses accounts")
+
+	err = ValidateOpenAIResponsesForwardingAccount(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Extra:    strictExtra,
+	})
+	require.ErrorContains(t, err, "requires an API key")
+}
+
 func TestAccount_IsOpenAIOAuthPassthroughEnabled(t *testing.T) {
 	t.Run("仅OAuth类型允许返回开启", func(t *testing.T) {
 		oauthAccount := &Account{

--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -141,6 +141,8 @@ func TestAccount_StrictResponsesUsesMappingAsModelAllowlist(t *testing.T) {
 	}
 	require.True(t, account.IsModelSupported("custom/model"))
 	require.False(t, account.IsModelSupported("other/model"))
+	require.Equal(t, "custom/model", resolveOpenAIAccountUpstreamModelForRequest(account, "custom/model", false))
+	require.Equal(t, "custom/model", resolveOpenAIAccountUpstreamModelForRequest(account, "custom/model", true))
 }
 
 func TestValidateOpenAIResponsesForwardingAccount(t *testing.T) {

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -763,11 +763,15 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		testModelID = openai.DefaultTestModel
 	}
 
-	// Align test routing with gateway behavior: OpenAI accounts apply normal
+	strictResponses := account.IsOpenAIStrictResponsesPassthroughEnabled()
+	// Align test routing with gateway behavior: normal OpenAI accounts apply
 	// account model mapping. Native remote compaction v2 rides the ordinary
 	// /responses wire and does NOT apply the legacy compact-only mapping
 	// (post-#5641 semantics: compact_model_mapping is /responses/compact-only).
-	testModelID = account.GetMappedModel(testModelID)
+	// Strict raw accounts preserve the administrator-selected model slug.
+	if !strictResponses {
+		testModelID = account.GetMappedModel(testModelID)
+	}
 	if mode == AccountTestModeCompact {
 		return s.testOpenAICompactConnection(c, account, testModelID)
 	}
@@ -813,7 +817,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	} else if credentialAccount.Type == "apikey" {
 		// API Key - use Platform API
 		authToken = credentialAccount.GetOpenAIProtocolAPIKey()
-		if authToken == "" {
+		if authToken == "" && !credentialAccount.UsesNoOpenAIUpstreamAuth() {
 			return s.sendErrorAndEnd(c, "No API key available")
 		}
 
@@ -825,7 +829,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		if !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+		if !strictResponses && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
 			return s.testOpenAIChatCompletionsConnection(c, account, testModelID, prompt, normalizedBaseURL, authToken)
 		}
 		apiURL = buildOpenAIResponsesURLForPlatform(credentialAccount.Platform, normalizedBaseURL)
@@ -853,6 +857,9 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	// restart this probe after registering a replacement task.
 	if !agentIdentityTaskRecoveryWasTried(ctx) {
 		s.sendEvent(c, TestEvent{Type: "test_start", Model: testModelID})
+		if strictResponses {
+			s.sendEvent(c, TestEvent{Type: "status", Text: "Strict raw connection testing sends a Responses inference request"})
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(payloadBytes))
@@ -876,7 +883,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 				req.Header.Add(key, value)
 			}
 		}
-	} else {
+	} else if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -613,6 +613,45 @@ func TestAccountTestService_OpenAIAPIKeyResponsesUnsupportedUsesChatCompletionsP
 	require.NotContains(t, body, "当前测试接口仅支持 Responses API 路径")
 }
 
+func TestAccountTestService_OpenAIStrictNoAuthUsesResponsesAndLabelsInference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, recorder := newTestContext()
+
+	resp := newJSONResponse(http.StatusOK, "")
+	resp.Body = io.NopCloser(strings.NewReader("data: {\"type\":\"response.completed\"}\n\n"))
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          951,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"base_url":                          "https://strict-upstream.example/v1",
+			OpenAIUpstreamAuthModeCredentialKey: OpenAIUpstreamAuthModeNone,
+			"model_mapping": map[string]any{
+				"custom/model": "must-not-map",
+			},
+		},
+		Extra: map[string]any{
+			OpenAIResponsesForwardModeExtraKey:       string(OpenAIResponsesForwardModeStrictRaw),
+			openai_compat.ExtraKeyResponsesSupported: false,
+		},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "custom/model", "hello", "")
+	require.NoError(t, err)
+	require.Len(t, upstream.requests, 1)
+	req := upstream.requests[0]
+	require.Equal(t, "https://strict-upstream.example/v1/responses", req.URL.String())
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, "custom/model", gjson.GetBytes(readRequestBodyForTest(t, req), "model").String())
+	require.Contains(t, recorder.Body.String(), "Strict raw connection testing sends a Responses inference request")
+}
+
 func TestAccountTestService_OpenAIChatCompletionsPathReturns4xx(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, recorder := newTestContext()

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -408,6 +408,46 @@ func normalizeOpenAILongContextBillingUpdateExtra(account *Account, input *Updat
 	return normalized, nil
 }
 
+func ValidateOpenAIResponsesForwardingAccount(account *Account) error {
+	if account == nil || account.Platform != PlatformOpenAI {
+		return nil
+	}
+	if raw, exists := account.Extra[OpenAIResponsesForwardModeExtraKey]; exists {
+		mode, ok := raw.(string)
+		if !ok {
+			return infraerrors.BadRequest("OPENAI_RESPONSES_FORWARD_MODE_INVALID", "openai_responses_forward_mode must be a string")
+		}
+		switch OpenAIResponsesForwardMode(strings.ToLower(strings.TrimSpace(mode))) {
+		case OpenAIResponsesForwardModeNormal, OpenAIResponsesForwardModePassthrough:
+		case OpenAIResponsesForwardModeStrictRaw:
+			if account.Type != AccountTypeAPIKey {
+				return infraerrors.BadRequest("OPENAI_STRICT_RESPONSES_ACCOUNT_TYPE_INVALID", "strict raw Responses forwarding requires an OpenAI API-key account")
+			}
+		default:
+			return infraerrors.BadRequest("OPENAI_RESPONSES_FORWARD_MODE_INVALID", "openai_responses_forward_mode must be normal, passthrough, or strict_raw")
+		}
+	}
+
+	authMode := ""
+	if raw, exists := account.Credentials[OpenAIUpstreamAuthModeCredentialKey]; exists {
+		value, ok := raw.(string)
+		if !ok {
+			return infraerrors.BadRequest("OPENAI_UPSTREAM_AUTH_MODE_INVALID", "openai_upstream_auth_mode must be bearer or none")
+		}
+		authMode = strings.ToLower(strings.TrimSpace(value))
+		if authMode != OpenAIUpstreamAuthModeBearer && authMode != OpenAIUpstreamAuthModeNone {
+			return infraerrors.BadRequest("OPENAI_UPSTREAM_AUTH_MODE_INVALID", "openai_upstream_auth_mode must be bearer or none")
+		}
+	}
+	if authMode == OpenAIUpstreamAuthModeNone && !account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return infraerrors.BadRequest("OPENAI_UPSTREAM_NO_AUTH_REQUIRES_STRICT", "no upstream auth is only allowed for strict raw Responses accounts")
+	}
+	if account.IsOpenAIStrictResponsesPassthroughEnabled() && !account.UsesNoOpenAIUpstreamAuth() && strings.TrimSpace(account.GetOpenAIProtocolAPIKey()) == "" {
+		return infraerrors.BadRequest("OPENAI_STRICT_RESPONSES_API_KEY_REQUIRED", "strict raw Responses bearer auth requires an API key")
+	}
+	return nil
+}
+
 // Grok media eligibility helpers live in account_grok_media_eligibility.go.
 
 func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]any) (*Account, error) {
@@ -431,6 +471,9 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 		Priority:    input.Priority,
 		Status:      StatusActive,
 		Schedulable: true,
+	}
+	if err := ValidateOpenAIResponsesForwardingAccount(account); err != nil {
+		return nil, err
 	}
 	if input.ProbeEnabled != nil && *input.ProbeEnabled {
 		if !isUpstreamBillingProbeAccount(account) {
@@ -819,6 +862,9 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if input.AutoPauseOnExpired != nil {
 		account.AutoPauseOnExpired = *input.AutoPauseOnExpired
 	}
+	if err := ValidateOpenAIResponsesForwardingAccount(account); err != nil {
+		return nil, err
+	}
 
 	// 先验证分组是否存在（在任何写操作之前）
 	if input.GroupIDs != nil {
@@ -916,6 +962,23 @@ func (s *adminServiceImpl) UpdateAccountExtra(ctx context.Context, id int64, upd
 			return err
 		}
 		if err := ValidateOpenAILongContextBillingExtra(account.Platform, updates); err != nil {
+			return err
+		}
+	}
+	if _, exists := updates[OpenAIResponsesForwardModeExtraKey]; exists {
+		account, err := s.accountRepo.GetByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		candidate := *account
+		candidate.Extra = maps.Clone(account.Extra)
+		if candidate.Extra == nil {
+			candidate.Extra = make(map[string]any)
+		}
+		for key, value := range updates {
+			candidate.Extra[key] = value
+		}
+		if err := ValidateOpenAIResponsesForwardingAccount(&candidate); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -2407,6 +2407,9 @@ func (s *OpenAIGatewayService) isOpenAIAccountTransportCompatible(account *Accou
 	if s == nil || account == nil {
 		return false
 	}
+	if account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return false
+	}
 	if requiredTransport == OpenAIUpstreamTransportResponsesWebsocketV2Ingress {
 		if s.cfg == nil || !s.cfg.Gateway.OpenAIWS.ModeRouterV2Enabled {
 			return s.getOpenAIWSProtocolResolver().Resolve(account).Transport == OpenAIUpstreamTransportResponsesWebsocketV2

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -57,6 +57,16 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		})
 		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
 	}
+	// Strict raw mode must branch before every compatibility mutation below.
+	// Authentication, billing, concurrency, routing and client policy checks have
+	// already run; the selected account is now known, so transport can preserve
+	// the authenticated client's original body bytes.
+	if account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		if c != nil {
+			c.Set("openai_strict_responses", true)
+		}
+		return s.forwardOpenAIStrictResponses(ctx, c, account, body, startTime)
+	}
 
 	normalizedBody, normalized, err := normalizeOpenAICodexCompactReasoningEffortForAccount(c, account, body)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -805,6 +805,13 @@ func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedMode
 		return normalizeOpenAIModelForUpstream(account, upstreamModel)
 	}
 
+	// Strict raw uses model_mapping only as a requested-model allowlist. Its
+	// Forward path preserves the original model even for compact requests, so
+	// scheduler cost/availability decisions must use that same model.
+	if account != nil && account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return strings.TrimSpace(requestedModel)
+	}
+
 	// Passthrough accounts only replace authentication. Their Forward path
 	// keeps the channel-mapped model in the request body and does not apply the
 	// account's normal model_mapping. Legacy /responses/compact is the one

--- a/backend/internal/service/openai_gateway_strict_responses.go
+++ b/backend/internal/service/openai_gateway_strict_responses.go
@@ -1,0 +1,367 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+)
+
+const strictResponsesObservationLimit = 8 << 20
+
+var strictResponsesRequestHeaders = map[string]struct{}{
+	"accept":             {},
+	"accept-language":    {},
+	"content-type":       {},
+	"conversation_id":    {},
+	"openai-beta":        {},
+	"originator":         {},
+	"session_id":         {},
+	"user-agent":         {},
+	"x-conversation-id":  {},
+	"x-opencode-session": {},
+	"x-session-affinity": {},
+	"x-session-id":       {},
+}
+
+var strictResponsesBlockedHeaders = map[string]struct{}{
+	"authorization":         {},
+	"connection":            {},
+	"content-length":        {},
+	"cookie":                {},
+	"host":                  {},
+	"keep-alive":            {},
+	"proxy-authenticate":    {},
+	"proxy-authorization":   {},
+	"set-cookie":            {},
+	"te":                    {},
+	"trailer":               {},
+	"transfer-encoding":     {},
+	"upgrade":               {},
+	"x-api-key":             {},
+	"x-codex-api-key":       {},
+	"x-codex-auth":          {},
+	"x-codex-authorization": {},
+	"x-codex-token":         {},
+	"x-goog-api-key":        {},
+}
+
+type openAIStrictResponsesHTTPError struct {
+	status int
+}
+
+func (e *openAIStrictResponsesHTTPError) Error() string {
+	// The handler recognizes this established prefix as an upstream error body
+	// that has already been written and must not append a synthetic SSE failure.
+	return fmt.Sprintf("upstream response failed: strict Responses upstream returned HTTP %d", e.status)
+}
+
+func strictOpenAIResponsesPathSuffix(c *gin.Context) (string, bool) {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return "", false
+	}
+	path := strings.TrimRight(strings.TrimSpace(c.Request.URL.Path), "/")
+	switch path {
+	case "/v1/responses", "/openai/v1/responses", "/responses", "/backend-api/codex/responses":
+		return "", true
+	case "/v1/responses/compact", "/openai/v1/responses/compact", "/responses/compact", "/backend-api/codex/responses/compact":
+		return "/compact", true
+	default:
+		return "", false
+	}
+}
+
+func buildOpenAIStrictResponsesURL(baseURL, suffix string) (string, error) {
+	target := buildOpenAIResponsesURL(baseURL)
+	if suffix == "" {
+		return target, nil
+	}
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("parse strict Responses upstream URL: %w", err)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + suffix
+	return parsed.String(), nil
+}
+
+func isStrictResponsesRequestHeaderAllowed(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	if lower == "" {
+		return false
+	}
+	if isStrictResponsesCredentialOrTransportHeader(lower) {
+		return false
+	}
+	if strings.HasPrefix(lower, "x-codex-") {
+		return true
+	}
+	_, allowed := strictResponsesRequestHeaders[lower]
+	return allowed
+}
+
+func isStrictResponsesCredentialOrTransportHeader(lower string) bool {
+	if _, blocked := strictResponsesBlockedHeaders[lower]; blocked {
+		return true
+	}
+	return strings.Contains(lower, "authorization") ||
+		strings.Contains(lower, "api-key") ||
+		strings.Contains(lower, "cookie") ||
+		strings.Contains(lower, "secret") ||
+		strings.HasSuffix(lower, "-token") ||
+		strings.Contains(lower, "-token-")
+}
+
+func copyOpenAIStrictResponsesRequestHeaders(dst, src http.Header) {
+	for key, values := range src {
+		if !isStrictResponsesRequestHeaderAllowed(key) {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func copyOpenAIStrictResponsesResponseHeaders(dst, src http.Header, filter *responseheaders.CompiledHeaderFilter) {
+	responseheaders.WriteFilteredHeaders(dst, src, filter)
+	for key, values := range src {
+		lower := strings.ToLower(strings.TrimSpace(key))
+		if isStrictResponsesCredentialOrTransportHeader(lower) {
+			continue
+		}
+		if !strings.HasPrefix(lower, "x-codex-") && !strings.HasPrefix(lower, "openai-") {
+			continue
+		}
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func (s *OpenAIGatewayService) buildOpenAIStrictResponsesRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) (*http.Request, error) {
+	if account == nil || !account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return nil, errors.New("strict Responses API-key account is required")
+	}
+	suffix, ok := strictOpenAIResponsesPathSuffix(c)
+	if !ok {
+		return nil, errors.New("strict Responses forwarding only supports /v1/responses and /v1/responses/compact")
+	}
+	baseURL := account.GetOpenAIBaseURL()
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	targetURL, err := buildOpenAIStrictResponsesURL(validatedURL, suffix)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	if c != nil && c.Request != nil {
+		copyOpenAIStrictResponsesRequestHeaders(req.Header, c.Request.Header)
+	}
+	for blocked := range strictResponsesBlockedHeaders {
+		req.Header.Del(blocked)
+	}
+	if !account.UsesNoOpenAIUpstreamAuth() {
+		token, _, tokenErr := s.GetAccessToken(ctx, account)
+		if tokenErr != nil {
+			return nil, tokenErr
+		}
+		authHeaders, authErr := s.buildOpenAIAuthenticationHeaders(ctx, account, token)
+		if authErr != nil {
+			return nil, fmt.Errorf("build strict Responses authentication headers: %w", authErr)
+		}
+		for key, values := range authHeaders {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
+	if _, exists := req.Header["User-Agent"]; !exists {
+		// Suppress net/http's synthetic Go User-Agent. Strict mode only forwards
+		// identity metadata that the authenticated downstream client supplied.
+		req.Header["User-Agent"] = nil
+	}
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// Keep the observed response bytes and Content-Encoding in agreement. Go's
+	// transport otherwise adds gzip automatically and transparently decodes it.
+	req.Header.Set("Accept-Encoding", "identity")
+	account.ApplyHeaderOverrides(req.Header)
+	return req, nil
+}
+
+type openAIStrictResponsesObserver struct {
+	service    *OpenAIGatewayService
+	stream     bool
+	lineBuffer []byte
+	jsonBuffer []byte
+	usage      OpenAIUsage
+	responseID string
+}
+
+func newOpenAIStrictResponsesObserver(s *OpenAIGatewayService, stream bool) *openAIStrictResponsesObserver {
+	return &openAIStrictResponsesObserver{service: s, stream: stream}
+}
+
+func (o *openAIStrictResponsesObserver) observe(chunk []byte) {
+	if len(chunk) == 0 {
+		return
+	}
+	if !o.stream {
+		if len(o.jsonBuffer) < strictResponsesObservationLimit {
+			remaining := strictResponsesObservationLimit - len(o.jsonBuffer)
+			if remaining > len(chunk) {
+				remaining = len(chunk)
+			}
+			o.jsonBuffer = append(o.jsonBuffer, chunk[:remaining]...)
+		}
+		return
+	}
+	o.lineBuffer = append(o.lineBuffer, chunk...)
+	for {
+		idx := bytes.IndexByte(o.lineBuffer, '\n')
+		if idx < 0 {
+			if len(o.lineBuffer) > strictResponsesObservationLimit {
+				o.lineBuffer = o.lineBuffer[:0]
+			}
+			return
+		}
+		line := strings.TrimSuffix(string(o.lineBuffer[:idx]), "\r")
+		o.lineBuffer = o.lineBuffer[idx+1:]
+		data, ok := extractOpenAISSEDataLine(line)
+		if !ok || strings.TrimSpace(data) == "[DONE]" {
+			continue
+		}
+		payload := []byte(data)
+		if o.service != nil {
+			o.service.parseSSEUsageBytes(payload, &o.usage)
+		}
+		if o.responseID == "" {
+			o.responseID = extractOpenAIResponseIDFromJSONBytes(payload)
+		}
+	}
+}
+
+func (o *openAIStrictResponsesObserver) finish() {
+	if o == nil || o.stream || len(o.jsonBuffer) == 0 {
+		return
+	}
+	if usage, ok := extractOpenAIUsageFromJSONBytes(o.jsonBuffer); ok {
+		o.usage = usage
+	}
+	o.responseID = extractOpenAIResponseIDFromJSONBytes(o.jsonBuffer)
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIStrictResponses(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	reqModel, reqStream, _ := extractOpenAIRequestMetaFromBody(body)
+	request, err := s.buildOpenAIStrictResponsesRequest(ctx, c, account, body)
+	if err != nil {
+		return nil, err
+	}
+	SetActualOpenAIUpstreamEndpoint(c, request.URL.Path)
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(request, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, true)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	copyOpenAIStrictResponsesResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	isSSE := isEventStreamResponse(resp.Header)
+	if isSSE {
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("X-Accel-Buffering", "no")
+	}
+	c.Status(resp.StatusCode)
+
+	observer := newOpenAIStrictResponsesObserver(s, isSSE)
+	buffer := make([]byte, 32*1024)
+	var firstTokenMs *int
+	reasoningEffort := extractOpenAIReasoningEffortFromBody(body, reqModel)
+	serviceTier := extractOpenAIServiceTierFromBody(body)
+	resultWithObserver := func(clientDisconnected bool) *OpenAIForwardResult {
+		return &OpenAIForwardResult{
+			RequestID:        resp.Header.Get("x-request-id"),
+			ResponseID:       observer.responseID,
+			Usage:            observer.usage,
+			Model:            reqModel,
+			ServiceTier:      serviceTier,
+			ReasoningEffort:  reasoningEffort,
+			Stream:           reqStream,
+			Duration:         time.Since(startTime),
+			FirstTokenMs:     firstTokenMs,
+			ClientDisconnect: clientDisconnected,
+			ResponseHeaders:  cloneHeader(resp.Header),
+			UpstreamEndpoint: request.URL.Path,
+		}
+	}
+	for {
+		n, readErr := resp.Body.Read(buffer)
+		if n > 0 {
+			chunk := buffer[:n]
+			observer.observe(chunk)
+			if firstTokenMs == nil {
+				ms := int(time.Since(startTime).Milliseconds())
+				firstTokenMs = &ms
+			}
+			written, writeErr := c.Writer.Write(chunk)
+			if writeErr != nil || written != len(chunk) {
+				if writeErr == nil {
+					writeErr = io.ErrShortWrite
+				}
+				return resultWithObserver(true), fmt.Errorf("upstream response failed: write strict Responses downstream: %w", writeErr)
+			}
+			if isSSE {
+				if flusher, ok := c.Writer.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return resultWithObserver(false), fmt.Errorf("upstream response failed: read strict Responses upstream: %w", readErr)
+		}
+	}
+	observer.finish()
+	s.bindHTTPResponseAccount(ctx, c, account, observer.responseID)
+
+	result := resultWithObserver(false)
+	if resp.StatusCode >= http.StatusBadRequest {
+		return result, &openAIStrictResponsesHTTPError{status: resp.StatusCode}
+	}
+	return result, nil
+}

--- a/backend/internal/service/openai_gateway_strict_responses.go
+++ b/backend/internal/service/openai_gateway_strict_responses.go
@@ -357,6 +357,12 @@ func (s *OpenAIGatewayService) forwardOpenAIStrictResponses(
 		}
 	}
 	observer.finish()
+	// Record the strict protocol before publishing continuation ownership. If the
+	// durable binding cannot be saved, a later request must fail ownership checks
+	// rather than silently continue on a normal account in another process.
+	if err := s.getOpenAIWSStateStore().BindStrictHTTPResponseAccount(ctx, getOpenAIGroupIDFromContext(c), observer.responseID, account.ID, s.openAIWSResponseStickyTTL()); err != nil {
+		return resultWithObserver(false), fmt.Errorf("upstream response failed: bind strict Responses continuation: %w", err)
+	}
 	s.bindHTTPResponseAccount(ctx, c, account, observer.responseID)
 
 	result := resultWithObserver(false)

--- a/backend/internal/service/openai_gateway_strict_responses_test.go
+++ b/backend/internal/service/openai_gateway_strict_responses_test.go
@@ -1,0 +1,284 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func strictResponsesTestConfig() *config.Config {
+	return &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+		Enabled: false, AllowInsecureHTTP: true,
+	}}}
+}
+
+func strictResponsesTestAccount(baseURL string, noAuth bool) *Account {
+	credentials := map[string]any{
+		"base_url": baseURL,
+		"api_key":  "UPSTREAM_KEY",
+	}
+	if noAuth {
+		delete(credentials, "api_key")
+		credentials[OpenAIUpstreamAuthModeCredentialKey] = OpenAIUpstreamAuthModeNone
+	}
+	return &Account{
+		ID:          71001,
+		Name:        "strict-responses",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: credentials,
+		Extra: map[string]any{
+			OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+		},
+		Concurrency: 1,
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func strictResponsesTestContext(path string) (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+	return c, recorder
+}
+
+func TestOpenAIGatewayStrictResponsesPreservesBodyAndSafeHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte("{\n  \"model\": \"chatgpt-web/high\",\n  \"reasoning\": {\"effort\": \"minimal\"},\n  \"client_metadata\": {\"cwd\": \"/workspace\"},\n  \"tools\": [{\"type\": \"custom\", \"opaque\": {\"z\": 1}}],\n  \"stream\": false\n}\n")
+	responseBody := []byte(`{"id":"resp_strict_1","object":"response","status":"completed","model":"chatgpt-web/high","output":[],"usage":{"input_tokens":7,"output_tokens":3}}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":         []string{"application/json"},
+			"OpenAI-Processing-Ms": []string{"17"},
+		},
+		Body: io.NopCloser(bytes.NewReader(responseBody)),
+	}}
+	c, recorder := strictResponsesTestContext("/v1/responses")
+	c.Request.Header.Set("Authorization", "Bearer DOWNSTREAM_SUB2API_KEY")
+	c.Request.Header.Set("Proxy-Authorization", "Basic forbidden")
+	c.Request.Header.Set("X-API-Key", "DOWNSTREAM_SUB2API_KEY")
+	c.Request.Header.Set("Cookie", "session=browser-secret")
+	c.Request.Header.Set("Connection", "upgrade")
+	c.Request.Header.Set("Upgrade", "websocket")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/1.2.3")
+	c.Request.Header.Set("originator", "codex_cli_rs")
+	c.Request.Header.Set("X-Session-Id", "session-123")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", "opaque-turn-metadata")
+	c.Request.Header.Set("X-Codex-Future-Signal", "future-value")
+	c.Request.Header.Set("X-Codex-Token", "must-not-forward")
+	c.Request.Header.Set("X-Codex-Session-Token", "must-not-forward-either")
+
+	svc := &OpenAIGatewayService{cfg: strictResponsesTestConfig(), httpUpstream: upstream}
+	account := strictResponsesTestAccount("http://strict.example/v1", false)
+	account.Credentials["model_mapping"] = map[string]any{"chatgpt-web/high": "must-not-map"}
+	result, err := svc.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, body, upstream.lastBody)
+	require.Equal(t, "/v1/responses", upstream.lastReq.URL.Path)
+	require.Equal(t, "Bearer UPSTREAM_KEY", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "identity", upstream.lastReq.Header.Get("Accept-Encoding"))
+	require.Empty(t, upstream.lastReq.Header.Get("Proxy-Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-API-Key"))
+	require.Empty(t, upstream.lastReq.Header.Get("Cookie"))
+	require.Empty(t, upstream.lastReq.Header.Get("Connection"))
+	require.Empty(t, upstream.lastReq.Header.Get("Upgrade"))
+	require.Equal(t, "codex_cli_rs/1.2.3", upstream.lastReq.Header.Get("User-Agent"))
+	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("originator"))
+	require.Equal(t, "session-123", upstream.lastReq.Header.Get("X-Session-Id"))
+	require.Equal(t, "opaque-turn-metadata", upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"))
+	require.Equal(t, "future-value", upstream.lastReq.Header.Get("X-Codex-Future-Signal"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Token"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Session-Token"))
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, responseBody, recorder.Body.Bytes())
+	require.Equal(t, "17", recorder.Header().Get("OpenAI-Processing-Ms"))
+	require.Equal(t, "resp_strict_1", result.ResponseID)
+	require.Equal(t, 7, result.Usage.InputTokens)
+	require.Equal(t, 3, result.Usage.OutputTokens)
+}
+
+func TestOpenAIGatewayStrictResponsesCompactNoAuthPreservesUpstreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"custom/model","input":[{"type":"compaction","encrypted_content":"opaque"}],"stream":false}`)
+	responseBody := []byte(`{"error":{"type":"invalid_request_error","message":"continuation state missing"}}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusConflict,
+		Header: http.Header{
+			"Content-Type":      []string{"application/json"},
+			"Set-Cookie":        []string{"bridge_session=secret"},
+			"OpenAI-Request-ID": []string{"req_strict_conflict"},
+		},
+		Body: io.NopCloser(bytes.NewReader(responseBody)),
+	}}
+	c, recorder := strictResponsesTestContext("/v1/responses/compact")
+	c.Request.Header.Set("Accept", "text/event-stream")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", "compact-metadata")
+
+	svc := &OpenAIGatewayService{cfg: strictResponsesTestConfig(), httpUpstream: upstream}
+	result, err := svc.Forward(context.Background(), c, strictResponsesTestAccount("http://strict.example/v1?tenant=acme", true), body)
+
+	var upstreamErr *openAIStrictResponsesHTTPError
+	require.ErrorAs(t, err, &upstreamErr)
+	require.NotNil(t, result)
+	require.Equal(t, body, upstream.lastBody)
+	require.Equal(t, "/v1/responses/compact", upstream.lastReq.URL.Path)
+	require.Equal(t, "tenant=acme", upstream.lastReq.URL.RawQuery)
+	require.Empty(t, upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "compact-metadata", upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"))
+	require.Equal(t, http.StatusConflict, recorder.Code)
+	require.Equal(t, responseBody, recorder.Body.Bytes())
+	require.Empty(t, recorder.Header().Get("Set-Cookie"))
+	require.Equal(t, "req_strict_conflict", recorder.Header().Get("OpenAI-Request-ID"))
+}
+
+type fragmentedStrictBody struct {
+	fragments [][]byte
+	finalErr  error
+}
+
+func (b *fragmentedStrictBody) Read(p []byte) (int, error) {
+	if len(b.fragments) == 0 {
+		if b.finalErr != nil {
+			err := b.finalErr
+			b.finalErr = nil
+			return 0, err
+		}
+		return 0, io.EOF
+	}
+	fragment := b.fragments[0]
+	b.fragments = b.fragments[1:]
+	return copy(p, fragment), nil
+}
+
+func (b *fragmentedStrictBody) Close() error { return nil }
+
+func TestOpenAIGatewayStrictResponsesStreamsFragmentedSSEByteForByte(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	want := []byte("event: response.created\n" +
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_stream_strict\"}}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_stream_strict\",\"usage\":{\"input_tokens\":4,\"output_tokens\":2}}}\n\n" +
+		"data: [DONE]\n\n")
+	fragments := [][]byte{
+		want[:7], want[7:31], want[31:78], want[78:141], want[141:219], want[219:],
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       &fragmentedStrictBody{fragments: fragments},
+	}}
+	c, recorder := strictResponsesTestContext("/v1/responses")
+	body := []byte(`{"model":"chatgpt-web/high","stream":true}`)
+
+	svc := &OpenAIGatewayService{cfg: strictResponsesTestConfig(), httpUpstream: upstream}
+	result, err := svc.Forward(context.Background(), c, strictResponsesTestAccount("http://strict.example/v1", true), body)
+
+	require.NoError(t, err)
+	require.Equal(t, want, recorder.Body.Bytes())
+	require.Equal(t, "resp_stream_strict", result.ResponseID)
+	require.Equal(t, 4, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+}
+
+func TestOpenAIGatewayStrictResponsesReadErrorKeepsRawPartialStreamAndUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	partial := []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_partial\",\"usage\":{\"input_tokens\":6,\"output_tokens\":1}}}\n\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &fragmentedStrictBody{
+			fragments: [][]byte{partial[:17], partial[17:]},
+			finalErr:  io.ErrUnexpectedEOF,
+		},
+	}}
+	c, recorder := strictResponsesTestContext("/v1/responses")
+	svc := &OpenAIGatewayService{cfg: strictResponsesTestConfig(), httpUpstream: upstream}
+
+	result, err := svc.Forward(
+		context.Background(),
+		c,
+		strictResponsesTestAccount("http://strict.example/v1", true),
+		[]byte(`{"model":"custom/model","stream":true}`),
+	)
+
+	require.ErrorContains(t, err, "upstream response failed: read strict Responses upstream")
+	require.Equal(t, partial, recorder.Body.Bytes())
+	require.NotNil(t, result)
+	require.Equal(t, "resp_partial", result.ResponseID)
+	require.Equal(t, 6, result.Usage.InputTokens)
+	require.Equal(t, 1, result.Usage.OutputTokens)
+}
+
+type cancelAwareStrictUpstream struct {
+	started  chan struct{}
+	canceled chan struct{}
+	once     sync.Once
+}
+
+func (u *cancelAwareStrictUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	close(u.started)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       strictContextBody{ctx: req.Context(), canceled: u.canceled, once: &u.once},
+	}, nil
+}
+
+func (u *cancelAwareStrictUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+type strictContextBody struct {
+	ctx      context.Context
+	canceled chan struct{}
+	once     *sync.Once
+}
+
+func (b strictContextBody) Read(_ []byte) (int, error) {
+	<-b.ctx.Done()
+	b.once.Do(func() { close(b.canceled) })
+	return 0, b.ctx.Err()
+}
+
+func (b strictContextBody) Close() error { return nil }
+
+func TestOpenAIGatewayStrictResponsesCancellationCancelsUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &cancelAwareStrictUpstream{started: make(chan struct{}), canceled: make(chan struct{})}
+	c, _ := strictResponsesTestContext("/v1/responses")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	svc := &OpenAIGatewayService{cfg: strictResponsesTestConfig(), httpUpstream: upstream}
+	go func() {
+		_, err := svc.Forward(ctx, c, strictResponsesTestAccount("http://strict.example/v1", true), []byte(`{"model":"custom/model","stream":true}`))
+		done <- err
+	}()
+
+	select {
+	case <-upstream.started:
+	case <-time.After(time.Second):
+		t.Fatal("strict upstream request did not start")
+	}
+	cancel()
+	select {
+	case <-upstream.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("strict upstream request context was not canceled")
+	}
+	require.Error(t, <-done)
+}

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -48,6 +48,51 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Hit(t *testing.T
 	}
 }
 
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_StrictHTTPHit(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(24)
+	account := Account{
+		ID:          3,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			OpenAIResponsesForwardModeExtraKey: string(OpenAIResponsesForwardModeStrictRaw),
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	// WS is intentionally disabled: strict raw continuation affinity is an
+	// HTTP/SSE feature and must not depend on the WSv2 transport resolver.
+	cfg := &config.Config{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_strict_http", account.ID, time.Hour))
+	selection, err := svc.selectAccountByPreviousResponseIDForCapability(
+		ctx,
+		&groupID,
+		"resp_strict_http",
+		"custom/model",
+		nil,
+		OpenAIEndpointCapabilityStrictResponses,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, account.ID, selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
 func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedMiss(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(23)

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -93,6 +93,19 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_StrictHTTPHit(t 
 	}
 }
 
+func TestOpenAIGatewayService_IsOpenAIResponseBoundToAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(25)
+	store := NewOpenAIWSStateStore(nil)
+	svc := &OpenAIGatewayService{openaiWSStateStore: store}
+
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_strict_owner", 31, time.Hour))
+	require.True(t, svc.IsOpenAIResponseBoundToAccount(ctx, &groupID, "resp_strict_owner", 31))
+	require.False(t, svc.IsOpenAIResponseBoundToAccount(ctx, &groupID, "resp_strict_owner", 32))
+	require.False(t, svc.IsOpenAIResponseBoundToAccount(ctx, nil, "resp_strict_owner", 31))
+	require.False(t, svc.IsOpenAIResponseBoundToAccount(ctx, &groupID, "", 31))
+}
+
 func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedMiss(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(23)

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -520,6 +520,32 @@ func (s *OpenAIGatewayService) ResolveAccountIDByPreviousResponseIDForScheduler(
 	return accountID
 }
 
+// IsOpenAIResponseBoundToAccount verifies the raw response-owner binding
+// without re-running scheduler eligibility filters. The caller must still
+// validate that the selected account is currently strict-capable and
+// schedulable; this only prevents a valid owner selection from being rejected
+// when scheduler decision metadata falls back to the ordinary selection lane.
+func (s *OpenAIGatewayService) IsOpenAIResponseBoundToAccount(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	accountID int64,
+) bool {
+	if s == nil || accountID <= 0 {
+		return false
+	}
+	responseID := strings.TrimSpace(previousResponseID)
+	if responseID == "" {
+		return false
+	}
+	store := s.getOpenAIWSStateStore()
+	if store == nil {
+		return false
+	}
+	boundAccountID, err := store.GetResponseAccount(ctx, derefGroupID(groupID), responseID)
+	return err == nil && boundAccountID == accountID
+}
+
 func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	ctx context.Context,
 	groupID *int64,

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -557,10 +557,11 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		return 0, nil, "", nil
 	}
 	// OAuth/SetupToken continuation state lives on the WSv2 session and cannot
-	// survive an HTTP fallback. Official API-key Responses HTTP requests are
-	// different: previous_response_id is supported by the provider and scoped to
-	// the selected key/project, so the response-id binding must retain that key.
-	if !account.IsOpenAIApiKey() && s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
+	// survive an HTTP fallback. API-key HTTP Responses, including strict raw
+	// mode, retain the binding to the selected key/project.
+	if !account.IsOpenAIApiKey() &&
+		s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 &&
+		!account.IsOpenAIStrictResponsesPassthroughEnabled() {
 		return 0, nil, "", nil
 	}
 	if shouldClearStickySession(account, requestedModel) || !account.IsOpenAI() || !account.IsSchedulable() {

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -520,6 +520,32 @@ func (s *OpenAIGatewayService) ResolveAccountIDByPreviousResponseIDForScheduler(
 	return accountID
 }
 
+// StrictHTTPContinuationAccount returns the strict protocol owner, independently
+// of scheduler eligibility. Older response bindings are recognized from their
+// account's mode until they expire.
+func (s *OpenAIGatewayService) StrictHTTPContinuationAccount(ctx context.Context, groupID *int64, responseID string) (int64, error) {
+	if s == nil || strings.TrimSpace(responseID) == "" {
+		return 0, nil
+	}
+	store := s.getOpenAIWSStateStore()
+	strictID, err := store.GetStrictHTTPResponseAccount(ctx, derefGroupID(groupID), responseID)
+	if err != nil || strictID > 0 {
+		return strictID, err
+	}
+	accountID, err := store.GetResponseAccount(ctx, derefGroupID(groupID), responseID)
+	if err != nil || accountID <= 0 || s.accountRepo == nil {
+		return 0, err
+	}
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return 0, err
+	}
+	if account != nil && account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return accountID, nil
+	}
+	return 0, nil
+}
+
 // IsOpenAIResponseBoundToAccount verifies the raw response-owner binding
 // without re-running scheduler eligibility filters. The caller must still
 // validate that the selected account is currently strict-capable and

--- a/backend/internal/service/openai_ws_protocol_resolver.go
+++ b/backend/internal/service/openai_ws_protocol_resolver.go
@@ -42,6 +42,9 @@ func (r *defaultOpenAIWSProtocolResolver) Resolve(account *Account) OpenAIWSProt
 	if !account.IsOpenAI() {
 		return openAIWSHTTPDecision("platform_not_openai")
 	}
+	if account.IsOpenAIStrictResponsesPassthroughEnabled() {
+		return openAIWSHTTPDecision("strict_responses_http_only")
+	}
 	if account.IsOpenAIWSForceHTTPEnabled() {
 		return openAIWSHTTPDecision("account_force_http")
 	}

--- a/backend/internal/service/openai_ws_protocol_resolver_test.go
+++ b/backend/internal/service/openai_ws_protocol_resolver_test.go
@@ -76,6 +76,21 @@ func TestOpenAIWSProtocolResolver_Resolve(t *testing.T) {
 		require.Equal(t, "ws_v2_enabled", decision.Reason)
 	})
 
+	t.Run("strict Responses is HTTP only", func(t *testing.T) {
+		account := &Account{
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Concurrency: 1,
+			Extra: map[string]any{
+				OpenAIResponsesForwardModeExtraKey:              string(OpenAIResponsesForwardModeStrictRaw),
+				"openai_apikey_responses_websockets_v2_enabled": true,
+			},
+		}
+		decision := NewOpenAIWSProtocolResolver(baseCfg).Resolve(account)
+		require.Equal(t, OpenAIUpstreamTransportHTTPSSE, decision.Transport)
+		require.Equal(t, "strict_responses_http_only", decision.Reason)
+	})
+
 	t.Run("账号级强制HTTP", func(t *testing.T) {
 		account := *openAIOAuthEnabled
 		account.Extra = map[string]any{

--- a/backend/internal/service/openai_ws_state_store.go
+++ b/backend/internal/service/openai_ws_state_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -69,6 +70,8 @@ type OpenAIWSStateStore interface {
 	BindResponseAccount(ctx context.Context, groupID int64, responseID string, accountID int64, ttl time.Duration) error
 	GetResponseAccount(ctx context.Context, groupID int64, responseID string) (int64, error)
 	DeleteResponseAccount(ctx context.Context, groupID int64, responseID string) error
+	BindStrictHTTPResponseAccount(ctx context.Context, groupID int64, responseID string, accountID int64, ttl time.Duration) error
+	GetStrictHTTPResponseAccount(ctx context.Context, groupID int64, responseID string) (int64, error)
 	BindHTTPResponseOwner(ctx context.Context, groupID int64, responseID string, userID, apiKeyID int64, ttl time.Duration) error
 	GetHTTPResponseOwner(ctx context.Context, groupID int64, responseID string) (userID, apiKeyID int64, found bool, err error)
 
@@ -235,7 +238,28 @@ func cleanupExpiredHTTPResponseOwnerBindings(bindings map[string]openAIHTTPRespo
 	}
 }
 
+// Strict protocol bindings survive normal scheduler binding invalidation. This
+// prevents a disabled/reconfigured strict owner from falling through to a
+// transforming account on the next HTTP continuation.
+func (s *defaultOpenAIWSStateStore) BindStrictHTTPResponseAccount(ctx context.Context, groupID int64, responseID string, accountID int64, ttl time.Duration) error {
+	if strings.TrimSpace(responseID) == "" {
+		return nil
+	}
+	return s.BindResponseAccount(ctx, groupID, "strict-http:"+responseID, accountID, ttl)
+}
+
+func (s *defaultOpenAIWSStateStore) GetStrictHTTPResponseAccount(ctx context.Context, groupID int64, responseID string) (int64, error) {
+	if strings.TrimSpace(responseID) == "" {
+		return 0, nil
+	}
+	return s.getResponseAccount(ctx, groupID, "strict-http:"+responseID, false)
+}
+
 func (s *defaultOpenAIWSStateStore) GetResponseAccount(ctx context.Context, groupID int64, responseID string) (int64, error) {
+	return s.getResponseAccount(ctx, groupID, responseID, true)
+}
+
+func (s *defaultOpenAIWSStateStore) getResponseAccount(ctx context.Context, groupID int64, responseID string, ignoreCacheError bool) (int64, error) {
 	id := normalizeOpenAIWSResponseID(responseID)
 	if id == "" {
 		return 0, nil
@@ -262,6 +286,9 @@ func (s *defaultOpenAIWSStateStore) GetResponseAccount(ctx context.Context, grou
 	cacheCtx, cancel := withOpenAIWSStateStoreRedisTimeout(ctx)
 	defer cancel()
 	accountID, err := s.cache.GetSessionAccountID(cacheCtx, groupID, cacheKey)
+	if err != nil && !ignoreCacheError && !errors.Is(err, ErrStickySessionNotFound) {
+		return 0, err
+	}
 	if err != nil || accountID <= 0 {
 		// 缓存读取失败不阻断主流程，按未命中降级。
 		return 0, nil

--- a/backend/internal/service/openai_ws_state_store_test.go
+++ b/backend/internal/service/openai_ws_state_store_test.go
@@ -275,3 +275,47 @@ func TestWithOpenAIWSStateStoreRedisTimeout_WithParentContext(t *testing.T) {
 	_, ok := ctx.Deadline()
 	require.True(t, ok, "应附加短超时")
 }
+
+func TestOpenAIWSStateStoreStrictHTTPBindingSurvivesSchedulerInvalidation(t *testing.T) {
+	cache := &strictScopedGatewayCache{schedulerTestGatewayCache: &schedulerTestGatewayCache{}}
+	ctx := context.Background()
+	writer := NewOpenAIWSStateStore(cache)
+	require.NoError(t, writer.BindResponseAccount(ctx, 7, "resp_strict", 101, time.Minute))
+	require.NoError(t, writer.BindStrictHTTPResponseAccount(ctx, 7, "resp_strict", 101, time.Minute))
+	require.NoError(t, writer.DeleteResponseAccount(ctx, 7, "resp_strict"))
+	reader := NewOpenAIWSStateStore(cache)
+	id, err := reader.GetStrictHTTPResponseAccount(ctx, 7, "resp_strict")
+	require.NoError(t, err)
+	require.Equal(t, int64(101), id)
+	id, err = reader.GetStrictHTTPResponseAccount(ctx, 8, "resp_strict")
+	require.NoError(t, err)
+	require.Zero(t, id, "strict bindings remain group-scoped")
+}
+
+type strictScopedGatewayCache struct {
+	*schedulerTestGatewayCache
+	readErr error
+}
+
+func (c *strictScopedGatewayCache) GetSessionAccountID(ctx context.Context, groupID int64, key string) (int64, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.schedulerTestGatewayCache.GetSessionAccountID(ctx, groupID, fmt.Sprintf("%d:%s", groupID, key))
+}
+func (c *strictScopedGatewayCache) SetSessionAccountID(ctx context.Context, groupID int64, key string, id int64, ttl time.Duration) error {
+	return c.schedulerTestGatewayCache.SetSessionAccountID(ctx, groupID, fmt.Sprintf("%d:%s", groupID, key), id, ttl)
+}
+func (c *strictScopedGatewayCache) DeleteSessionAccountID(ctx context.Context, groupID int64, key string) error {
+	return c.schedulerTestGatewayCache.DeleteSessionAccountID(ctx, groupID, fmt.Sprintf("%d:%s", groupID, key))
+}
+func TestOpenAIWSStateStoreStrictHTTPBindingDistinguishesMissFromCacheFailure(t *testing.T) {
+	cache := &strictScopedGatewayCache{schedulerTestGatewayCache: &schedulerTestGatewayCache{}}
+	store := NewOpenAIWSStateStore(cache)
+	id, err := store.GetStrictHTTPResponseAccount(context.Background(), 7, "resp_normal")
+	require.NoError(t, err)
+	require.Zero(t, id)
+	cache.readErr = errors.New("cache unavailable")
+	_, err = store.GetStrictHTTPResponseAccount(context.Background(), 7, "resp_strict")
+	require.ErrorIs(t, err, cache.readErr)
+}

--- a/docs/openai-strict-responses-upstream.md
+++ b/docs/openai-strict-responses-upstream.md
@@ -1,0 +1,252 @@
+# Strict OpenAI Responses upstreams
+
+Sub2API can forward OpenAI Responses requests to an API-key account without rewriting the request body, SSE frames, or upstream response body. This is intended for upstreams that implement the Responses protocol themselves and need the original Codex request envelope.
+
+One working use case is [`codex-chatgpt-web`](https://github.com/miuuyy/codex-chatgpt-web), an unofficial local bridge that drives a signed-in ChatGPT web session. In that arrangement, Sub2API remains the public API gateway while the browser session stays on a trusted workstation or bridge VM.
+
+## What strict mode forwards
+
+Strict mode supports these HTTP endpoints:
+
+- `POST /v1/responses`
+- `POST /v1/responses/compact`
+
+It preserves the original JSON bytes and SSE data while applying a narrow header policy. Downstream credentials, cookies, hop-by-hop headers, and credential-shaped headers are never copied upstream. The account can either add its own Bearer credential or explicitly select no upstream authentication.
+
+Strict mode does not add browser automation, ChatGPT authentication, cookie handling, or consumer-product logic to Sub2API. Those responsibilities stay in the upstream bridge.
+
+## Recommended topology
+
+```text
+Codex or another Responses client
+              |
+              | HTTPS + Sub2API API key
+              v
+           Sub2API
+              |
+              | HTTPS + private bridge header
+              v
+  private TLS reverse proxy on the Sub2API host
+              |
+              | private reverse tunnel
+              v
+  127.0.0.1:17841 on the bridge workstation or VM
+              |
+              v
+   codex-chatgpt-web + signed-in browser profile
+```
+
+Keep the browser bridge bound to loopback. Do not publish port `17841`, a browser debugging port, browser cookies, or launcher control tokens.
+
+For a workstation proof, a restricted reverse SSH identity can expose one listener only on the remote Docker gateway:
+
+```bash
+ssh \
+  -i /path/to/restricted-key \
+  -o IdentitiesOnly=yes \
+  -o ExitOnForwardFailure=yes \
+  -o ServerAliveInterval=15 \
+  -o ServerAliveCountMax=2 \
+  -NT \
+  -R 172.18.0.1:19090:127.0.0.1:17841 \
+  bridge-forwarder@your-sub2api-host
+```
+
+Restrict that SSH key and user to remote forwarding and the exact `PermitListen` address. Bind the listener to the Docker gateway, not `0.0.0.0` or a public interface. Permit only the TLS proxy container to reach the listener in the host firewall.
+
+## Add guarded TLS in front of the tunnel
+
+A hardened Sub2API deployment may correctly reject an `http://` account base URL. Do not disable URL validation globally. Put the private tunnel behind TLS and require a random bridge header.
+
+The following Caddy pattern reuses an existing valid certificate, adds no public port, and returns 404 when the secret is absent:
+
+```caddyfile
+@codex_chatgpt_web_bridge {
+  path /_internal/codex-chatgpt-web/*
+  header X-Codex-Bridge-Auth {$CODEX_CHATGPT_WEB_BRIDGE_SECRET}
+}
+handle @codex_chatgpt_web_bridge {
+  uri strip_prefix /_internal/codex-chatgpt-web
+  reverse_proxy http://172.18.0.1:19090
+}
+
+@codex_chatgpt_web_bridge_denied path /_internal/codex-chatgpt-web/*
+handle @codex_chatgpt_web_bridge_denied {
+  respond "" 404
+}
+```
+
+Map the TLS hostname to the Compose network gateway only inside the Sub2API container so this hop does not leave the host:
+
+```yaml
+services:
+  sub2api:
+    extra_hosts:
+      - "sub2api.example.com:172.18.0.1"
+```
+
+Use your actual Compose gateway instead of assuming `172.18.0.1`. Store the bridge secret outside version control. Test both outcomes before adding the account:
+
+- the correct header returns the bridge `/healthz` JSON;
+- a missing or incorrect header returns HTTP 404.
+
+## Prepare `codex-chatgpt-web`
+
+1. Install the launcher from the bridge project's official release instructions.
+2. Sign in to ChatGPT inside the launcher-owned browser profile.
+3. Run the launcher browser smoke test.
+4. Install the browser-only models and confirm the bridge doctor reports a healthy loopback Responses proxy.
+5. Keep the launcher running and the host awake.
+
+Use a release containing [the effort-popover recovery fix](https://github.com/miuuyy/codex-chatgpt-web/pull/133). Version 2.1.11 without that fix can intermittently observe the current ChatGPT effort slider and then lose it during a popover rerender. Manually opening the menu is not a reliable deployment procedure.
+
+Browser-only mode exposes these model IDs when the signed-in account supports them:
+
+- `chatgpt-web/light`
+- `chatgpt-web/medium`
+- `chatgpt-web/high`
+- `chatgpt-web/extra-high`
+- `chatgpt-web/pro`
+
+Availability is determined by the signed-in ChatGPT account. Do not advertise a tier that the bridge capability check did not expose.
+
+## Configure the Sub2API group
+
+Create an OpenAI group for the bridge. A conservative first deployment uses:
+
+- concurrency: `1`;
+- a low RPM limit;
+- custom model listing enabled;
+- only the bridge model IDs actually available to the signed-in account.
+
+Custom model listing filters account-discovered models; it does not invent model IDs. Add identity model mappings on the account for every model you want `/v1/models` to advertise:
+
+```json
+{
+  "chatgpt-web/light": "chatgpt-web/light",
+  "chatgpt-web/medium": "chatgpt-web/medium",
+  "chatgpt-web/high": "chatgpt-web/high",
+  "chatgpt-web/extra-high": "chatgpt-web/extra-high",
+  "chatgpt-web/pro": "chatgpt-web/pro"
+}
+```
+
+These identity mappings support discovery only. Strict Responses forwarding branches before model mapping and preserves the request body.
+
+## Configure the strict account
+
+Create an account with:
+
+| Setting | Value |
+| --- | --- |
+| Platform | `openai` |
+| Account type | API key |
+| Base URL | `https://sub2api.example.com/_internal/codex-chatgpt-web` |
+| Responses forwarding mode | `strict_raw` |
+| Upstream authentication | `none` |
+| Concurrency | `1` initially |
+| Header overrides | Enable `X-Codex-Bridge-Auth` with the random proxy secret |
+| Groups | The bridge group created above |
+
+The equivalent account fields are:
+
+```json
+{
+  "platform": "openai",
+  "type": "apikey",
+  "credentials": {
+    "api_key": "unused-because-upstream-auth-is-none",
+    "base_url": "https://sub2api.example.com/_internal/codex-chatgpt-web",
+    "openai_upstream_auth_mode": "none",
+    "header_override_enabled": true,
+    "header_overrides": {
+      "x-codex-bridge-auth": "replace-with-a-random-secret"
+    },
+    "model_mapping": {
+      "chatgpt-web/high": "chatgpt-web/high"
+    }
+  },
+  "extra": {
+    "openai_responses_forward_mode": "strict_raw",
+    "openai_responses_mode": "force_responses",
+    "openai_responses_supported": true
+  }
+}
+```
+
+The placeholder API key satisfies the API-key account shape but is not sent when upstream authentication is `none`. Never reuse the Sub2API downstream API key as this placeholder or bridge header secret.
+
+## Client request envelope
+
+Native Codex requests already include the required turn metadata. A manual curl test must include the same metadata both in `client_metadata` and on the current user message:
+
+```bash
+thread_id="thread_demo_001"
+turn_id="turn_demo_001"
+metadata=$(jq -nc \
+  --arg thread_id "$thread_id" \
+  --arg turn_id "$turn_id" \
+  '{thread_id:$thread_id,turn_id:$turn_id}')
+body=$(jq -nc \
+  --arg metadata "$metadata" \
+  --arg turn_id "$turn_id" \
+  '{
+    model:"chatgpt-web/high",
+    client_metadata:{"x-codex-turn-metadata":$metadata},
+    input:[{
+      type:"message",
+      role:"user",
+      internal_chat_message_metadata_passthrough:{turn_id:$turn_id},
+      content:[{
+        type:"input_text",
+        text:"Reply with exactly: BRIDGE READY"
+      }]
+    }],
+    stream:false
+  }')
+
+curl "$SUB2API_BASE_URL/v1/responses" \
+  -H "Authorization: Bearer $SUB2API_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "x-codex-turn-metadata: $metadata" \
+  --data-binary "$body"
+```
+
+Use `stream: true` to validate SSE. A successful stream includes one `response.created`, one or more `response.output_text.delta` events, one `response.completed`, and the final `data: [DONE]` sentinel.
+
+## Acceptance checklist
+
+Do not call the integration complete until all of these pass through Sub2API:
+
+1. `GET /v1/models` lists the intended `chatgpt-web/*` IDs.
+2. A non-streaming prompt returns HTTP 200 and `status: completed`.
+3. An SSE prompt preserves event framing and the expected final text.
+4. A second request with the first response's `previous_response_id` recalls prior context and stays on the same strict account.
+5. `POST /v1/responses/compact` returns a valid compacted response and preserves an asserted fact.
+6. Disconnecting a long streaming client cancels the upstream browser turn; bridge HTTP and browser turn counters return to zero without `response.completed`.
+7. The TLS bridge path returns 404 without its secret header.
+8. The public Sub2API health check remains green after the proxy and account changes.
+
+The browser-only reference deployment used for this guide passed all eight checks with `chatgpt-web/high`.
+
+## Does this use ChatGPT web allowance?
+
+Yes. For a `chatgpt-web/*` request, the bridge sends the prompt through the signed-in ChatGPT browser session. The ChatGPT plan's web-product availability and limits apply; an OpenAI API key or API credit balance is not used for that upstream turn.
+
+Sub2API still performs its own downstream authentication, usage observation, and any group billing rules you configure. ChatGPT can independently rate-limit the browser account, change available tiers, require sign-in again, or change its UI.
+
+This bridge is unofficial browser automation. Do not use it to evade access controls or usage limits. Prefer one bridge per trusted ChatGPT account or tenant instead of pooling one browser session across unrelated users.
+
+## Tools and full mode
+
+This guide validates browser-only mode. Browser-only responses can use capabilities that ChatGPT itself exposes, but they cannot access the local Codex computer or workspace.
+
+The bridge's optional full mode uses an OpenAI Tunnel and a runtime key to connect a native Codex harness. That is a separate privileged setup with a larger trust boundary; follow the bridge project's instructions and test it independently. It is not required for strict Responses forwarding and was not part of the browser-only acceptance matrix above.
+
+## Operational notes
+
+- Keep the bridge, reverse tunnel, and TLS proxy supervised and restartable.
+- Monitor bridge `/healthz`, tunnel liveness, and Sub2API health separately.
+- A bridge restart loses its local `previous_response_id` replay state; Sub2API affinity cannot reconstruct state the bridge no longer has.
+- Re-run the smoke and acceptance checklist after ChatGPT UI changes or a bridge upgrade.
+- Treat bridge login state, launcher descriptors, control tokens, proxy secrets, SSH keys, and downstream API keys as separate secrets.

--- a/docs/openai-strict-responses-upstream.md
+++ b/docs/openai-strict-responses-upstream.md
@@ -4,6 +4,8 @@ Sub2API can forward OpenAI Responses requests to an API-key account without rewr
 
 One working use case is [`codex-chatgpt-web`](https://github.com/miuuyy/codex-chatgpt-web), an unofficial local bridge that drives a signed-in ChatGPT web session. In that arrangement, Sub2API remains the public API gateway while the browser session stays on a trusted workstation or bridge VM.
 
+If you want the shortest UI-first setup path, start with [OpenAI web bridge quick start](./openai-web-bridge-quickstart.md). Return to this document for the production topology, security rationale, native request envelope, and full acceptance matrix.
+
 ## What strict mode forwards
 
 Strict mode supports these HTTP endpoints:
@@ -100,6 +102,8 @@ Use your actual Compose gateway instead of assuming `172.18.0.1`. Store the brid
 
 Use a release containing [the effort-popover recovery fix](https://github.com/miuuyy/codex-chatgpt-web/pull/133). Version 2.1.11 without that fix can intermittently observe the current ChatGPT effort slider and then lose it during a popover rerender. Manually opening the menu is not a reliable deployment procedure.
 
+That fix is scoped to effort selection. It does not address the separate response-lifecycle failure where ChatGPT removes the active assistant response DOM before the bridge observes terminal completion.
+
 Browser-only mode exposes these model IDs when the signed-in account supports them:
 
 - `chatgpt-web/light`
@@ -174,7 +178,7 @@ The equivalent account fields are:
 }
 ```
 
-The placeholder API key satisfies the API-key account shape but is not sent when upstream authentication is `none`. Never reuse the Sub2API downstream API key as this placeholder or bridge header secret.
+The account uses the API-key account shape, but the current create/edit UI permits the upstream API key to remain blank when upstream authentication is explicitly `none`. Never reuse the Sub2API downstream API key as an upstream key or bridge header secret.
 
 ## Client request envelope
 
@@ -227,7 +231,7 @@ Do not call the integration complete until all of these pass through Sub2API:
 7. The TLS bridge path returns 404 without its secret header.
 8. The public Sub2API health check remains green after the proxy and account changes.
 
-The browser-only reference deployment used for this guide passed all eight checks with `chatgpt-web/high`.
+The browser-only reference deployment passed the full matrix, but later canaries found intermittent ChatGPT response-DOM loss on the High lane. Re-qualify each tier independently after bridge or ChatGPT UI changes. The current user-first quickstart begins with `chatgpt-web/light`, which passed the latest BYOK Chat staging and production exact-marker checks.
 
 ## Does this use ChatGPT web allowance?
 

--- a/docs/openai-strict-responses-upstream.md
+++ b/docs/openai-strict-responses-upstream.md
@@ -63,7 +63,7 @@ The following Caddy pattern reuses an existing valid certificate, adds no public
 ```caddyfile
 @codex_chatgpt_web_bridge {
   path /_internal/codex-chatgpt-web/*
-  header X-Codex-Bridge-Auth {$CODEX_CHATGPT_WEB_BRIDGE_SECRET}
+  header X-Bridge-Secret {$CODEX_CHATGPT_WEB_BRIDGE_SECRET}
 }
 handle @codex_chatgpt_web_bridge {
   uri strip_prefix /_internal/codex-chatgpt-web
@@ -145,7 +145,7 @@ Create an account with:
 | Responses forwarding mode | `strict_raw` |
 | Upstream authentication | `none` |
 | Concurrency | `1` initially |
-| Header overrides | Enable `X-Codex-Bridge-Auth` with the random proxy secret |
+| Header overrides | Enable `X-Bridge-Secret` with the random proxy secret |
 | Groups | The bridge group created above |
 
 The equivalent account fields are:
@@ -160,7 +160,7 @@ The equivalent account fields are:
     "openai_upstream_auth_mode": "none",
     "header_override_enabled": true,
     "header_overrides": {
-      "x-codex-bridge-auth": "replace-with-a-random-secret"
+      "x-bridge-secret": "replace-with-a-random-secret"
     },
     "model_mapping": {
       "chatgpt-web/high": "chatgpt-web/high"

--- a/docs/openai-web-bridge-quickstart.md
+++ b/docs/openai-web-bridge-quickstart.md
@@ -1,0 +1,194 @@
+# OpenAI web bridge quick start
+
+This guide takes a Sub2API operator from a working [`codex-chatgpt-web`](https://github.com/miuuyy/codex-chatgpt-web) browser bridge to a usable `chatgpt-web/*` API group.
+
+The bridge is unofficial browser automation. It sends prompts through a signed-in ChatGPT web session, so the ChatGPT plan's web-product availability and limits apply. It does not convert web allowance into OpenAI API credit.
+
+For the full security rationale, reverse-tunnel configuration, native request envelope, and acceptance matrix, see [Strict OpenAI Responses upstreams](./openai-strict-responses-upstream.md).
+
+## Before you start
+
+You need:
+
+- a Sub2API deployment that includes strict Responses forwarding;
+- a running browser bridge with a signed-in ChatGPT session;
+- an HTTPS route from the Sub2API container to the bridge;
+- a secret header or equivalent private transport protecting that route; and
+- administrator access to create an account, group, and downstream API key.
+
+Keep the bridge bound to loopback. Never expose its browser debugging port, cookies, launcher control token, or loopback Responses port publicly.
+
+## 1. Prove the bridge first
+
+In the bridge launcher:
+
+1. Sign in to ChatGPT using the launcher-owned browser profile.
+2. Install the browser-only models.
+3. Run the authenticated launcher smoke test.
+4. Confirm the bridge health endpoint reports ready and lists the model tiers available to that account.
+
+Start with `chatgpt-web/light` for the first end-to-end test. Higher-effort lanes take longer and are more sensitive to ChatGPT UI lifecycle changes.
+
+Do not continue to Sub2API configuration until the bridge works directly.
+
+## 2. Connect Sub2API to the bridge
+
+The proven reference topology keeps the bridge on a trusted workstation and uses a restricted reverse SSH tunnel to the Sub2API host:
+
+```text
+Client
+  -> HTTPS + Sub2API API key
+Sub2API
+  -> guarded private HTTPS route
+TLS proxy on the Sub2API host
+  -> restricted reverse tunnel
+codex-chatgpt-web on loopback
+  -> signed-in ChatGPT browser session
+```
+
+You may run the bridge on the Sub2API host only if that host can maintain the bridge's supported graphical browser profile and interactive ChatGPT sign-in. A headless VM deployment is not yet the reference setup.
+
+Before creating the account, verify both sides of the guard:
+
+- the correct private header reaches the bridge health endpoint; and
+- a missing or incorrect header returns HTTP 404.
+
+See [Recommended topology](./openai-strict-responses-upstream.md#recommended-topology) and [Add guarded TLS in front of the tunnel](./openai-strict-responses-upstream.md#add-guarded-tls-in-front-of-the-tunnel) for concrete examples.
+
+## 3. Create the bridge group
+
+In **Admin -> Groups**, create an OpenAI group dedicated to the bridge.
+
+Use these initial values:
+
+| Setting | Initial value |
+| --- | --- |
+| Platform | OpenAI |
+| Concurrency | `1` |
+| RPM | Low while validating |
+| Custom models | Enabled |
+| Models | Only tiers reported by the bridge |
+
+Do not advertise a tier that the signed-in account did not expose.
+
+## 4. Create the OpenAI account
+
+In **Admin -> Accounts -> Add account**:
+
+1. Select **OpenAI**.
+2. Select **API Key** as the account shape.
+3. Enter a clear name such as `ChatGPT Web bridge`.
+4. Set **Base URL** to the guarded HTTPS bridge route.
+5. Under **Responses forwarding**, select **Strict raw Responses**.
+6. Enable **No upstream HTTP authentication** when the private route is protected by the tunnel and secret header.
+7. Leave the upstream API key blank in no-auth mode. Do not reuse the downstream Sub2API key.
+8. Enable header overrides and add the private bridge header.
+9. Disable upstream billing probes for the no-auth bridge account.
+10. Keep Responses WebSocket mode off. Strict mode is HTTP/SSE-only.
+11. Add the bridge group created in the previous step.
+
+The stored account fields should resolve to:
+
+```json
+{
+  "platform": "openai",
+  "type": "apikey",
+  "credentials": {
+    "base_url": "https://sub2api.example.com/_internal/codex-chatgpt-web",
+    "openai_upstream_auth_mode": "none",
+    "header_override_enabled": true,
+    "header_overrides": {
+      "x-bridge-secret": "replace-with-a-random-secret"
+    }
+  },
+  "extra": {
+    "openai_responses_forward_mode": "strict_raw",
+    "openai_responses_mode": "force_responses",
+    "openai_responses_supported": true,
+    "openai_apikey_responses_websockets_v2_mode": "off"
+  }
+}
+```
+
+The field values remain generic. Sub2API does not store ChatGPT cookies, browser credentials, or consumer-session tokens.
+
+## 5. Add model mappings
+
+Add an identity mapping for each tier that the account should advertise:
+
+```json
+{
+  "chatgpt-web/light": "chatgpt-web/light",
+  "chatgpt-web/medium": "chatgpt-web/medium",
+  "chatgpt-web/high": "chatgpt-web/high",
+  "chatgpt-web/extra-high": "chatgpt-web/extra-high",
+  "chatgpt-web/pro": "chatgpt-web/pro"
+}
+```
+
+These mappings make the models discoverable. Strict forwarding still preserves the original request body.
+
+## 6. Create the downstream key
+
+In **Admin -> API Keys**, create a key bound to the bridge group.
+
+This is the key clients use with the public Sub2API base URL. Keep it separate from:
+
+- the bridge secret header;
+- the restricted SSH key;
+- launcher control credentials; and
+- any OpenAI API key.
+
+## 7. Connect a client
+
+### BYOK Chat
+
+Use:
+
+| Field | Value |
+| --- | --- |
+| Provider | Custom OpenAI-compatible endpoint |
+| Base URL | `https://your-sub2api.example.com/v1` |
+| API key | The downstream key created above |
+
+Save the profile, fetch models, select `chatgpt-web/light`, and send a short exact-marker prompt.
+
+Current BYOK Chat releases detect `chatgpt-web/*` models and use native `/v1/responses` with the required per-turn metadata. Older releases sent `/v1/chat/completions` and cannot drive this bridge correctly.
+
+### Native Codex clients
+
+Use the public Sub2API base URL and downstream key. Native Codex Responses requests already include the required turn metadata. A hand-written request must include the metadata described in [Client request envelope](./openai-strict-responses-upstream.md#client-request-envelope).
+
+## 8. Verify the complete path
+
+Do not call the setup complete until all of these pass:
+
+1. `GET /v1/models` lists only the intended `chatgpt-web/*` tiers.
+2. A `chatgpt-web/light` request returns HTTP 200, `status: completed`, and the exact marker.
+3. An SSE request includes `response.created`, output deltas, `response.completed`, and `data: [DONE]`.
+4. A continuation using `previous_response_id` stays on the same strict account.
+5. The guarded bridge route returns 404 without its secret header.
+6. Bridge HTTP and browser turn counters return to zero after success and cancellation.
+
+Then test the higher-effort tiers you intend to expose.
+
+## Troubleshooting
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| Model fetch returns the expected model list | Account, group, key, and guarded route are connected | Continue with `chatgpt-web/light` |
+| `Invalid redirect value` in BYOK Chat | The BYOK Chat Worker is older than the edge redirect fix | Refresh after updating BYOK Chat to a current release |
+| `/v1/chat/completions` returns 502 | The client used Chat Completions against a Responses-only bridge | Use a current BYOK Chat release or another native Responses client |
+| `previous_response_not_found` | The bridge restarted or continuation affinity/state was lost | Start a new response chain and inspect bridge restarts |
+| `ChatGPT response DOM disappeared` | The browser bridge lost the active ChatGPT response DOM | Retry with `chatgpt-web/light`, verify the bridge directly, and update the bridge before blaming Sub2API |
+| Models are missing | Group custom models or account model mappings are incomplete | Compare both lists with the bridge health catalog |
+| 401 from Sub2API | The downstream key is wrong or not assigned to the bridge group | Check the client key and group binding |
+| 404 from the private bridge route | The secret header is absent or wrong | Check the account header override and TLS proxy guard |
+
+## Operational boundary
+
+- Keep the bridge host awake and the signed-in browser session healthy.
+- Monitor Sub2API, the TLS proxy, tunnel, bridge process, and browser session separately.
+- Re-run the acceptance checks after any ChatGPT UI, bridge, proxy, or Sub2API update.
+- Use one trusted ChatGPT account per bridge or tenant. Do not pool unrelated users through one browser session.
+- Treat higher-effort tiers as independently qualified capabilities; one passing tier does not prove every tier is stable.

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3059,34 +3059,50 @@
         </p>
       </div>
 
-      <!-- OpenAI 自动透传开关（OAuth/API Key） -->
+      <!-- OpenAI Responses forwarding mode -->
       <div
         v-if="form.platform === 'openai'"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
-        <div class="flex items-center justify-between">
-          <div>
-            <label class="input-label mb-0">{{ t('admin.accounts.openai.oauthPassthrough') }}</label>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.oauthPassthroughDesc') }}
-            </p>
-          </div>
-          <button
-            type="button"
-            @click="openaiPassthroughEnabled = !openaiPassthroughEnabled"
-            :class="[
-              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
-              openaiPassthroughEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
-            ]"
-          >
-            <span
-              :class="[
-                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
-                openaiPassthroughEnabled ? 'translate-x-5' : 'translate-x-0'
-              ]"
-            />
-          </button>
+        <label class="input-label" for="create-openai-responses-forward-mode">
+          {{ t('admin.accounts.openai.forwardMode') }}
+        </label>
+        <select
+          id="create-openai-responses-forward-mode"
+          v-model="openaiResponsesForwardMode"
+          data-testid="create-openai-responses-forward-mode"
+          class="input"
+        >
+          <option v-for="option in openAIResponsesForwardModeOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+        <p class="input-hint">{{ t('admin.accounts.openai.forwardModeDesc') }}</p>
+        <div
+          v-if="openaiResponsesForwardMode === 'strict_raw'"
+          class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200"
+        >
+          {{ t('admin.accounts.openai.forwardModeStrictWarning') }}
         </div>
+        <label
+          v-if="openaiResponsesForwardMode === 'strict_raw' && accountCategory === 'apikey'"
+          class="mt-3 flex items-start gap-3"
+        >
+          <input
+            v-model="openaiStrictNoAuth"
+            data-testid="create-openai-strict-no-auth"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          <span>
+            <span class="block text-sm font-medium text-gray-700 dark:text-gray-200">
+              {{ t('admin.accounts.openai.strictNoAuth') }}
+            </span>
+            <span class="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.strictNoAuthDesc') }}
+            </span>
+          </span>
+        </label>
       </div>
 
       <!-- OpenAI Codex namespace 工具摊平（兼容开关，仅 OAuth） -->
@@ -4424,7 +4440,9 @@ const applyGrokOAuthUpstreamConfig = (credentials: Record<string, unknown>) => {
 }
 const interceptWarmupRequests = ref(false)
 const autoPauseOnExpired = ref(true)
-const openaiPassthroughEnabled = ref(false)
+type OpenAIResponsesForwardMode = 'normal' | 'passthrough' | 'strict_raw'
+const openaiResponsesForwardMode = ref<OpenAIResponsesForwardMode>('normal')
+const openaiStrictNoAuth = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
@@ -4513,6 +4531,16 @@ const openAIResponsesModeOptions = computed(() => [
   { value: 'force_responses', label: t('admin.accounts.openai.responsesModeForceResponses') },
   { value: 'force_chat_completions', label: t('admin.accounts.openai.responsesModeForceChatCompletions') }
 ])
+const openAIResponsesForwardModeOptions = computed(() => {
+  const options = [
+    { value: 'normal' as OpenAIResponsesForwardMode, label: t('admin.accounts.openai.forwardModeNormal') },
+    { value: 'passthrough' as OpenAIResponsesForwardMode, label: t('admin.accounts.openai.forwardModePassthrough') }
+  ]
+  if (accountCategory.value === 'apikey') {
+    options.push({ value: 'strict_raw', label: t('admin.accounts.openai.forwardModeStrictRaw') })
+  }
+  return options
+})
 const openAITextEndpointCapabilityLabel = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
     return t('admin.accounts.openai.capabilityResponses')
@@ -4658,7 +4686,7 @@ const openAIWSModeConcurrencyHintKey = computed(() =>
 )
 
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  form.platform === 'openai' && openaiPassthroughEnabled.value
+  form.platform === 'openai' && openaiResponsesForwardMode.value === 'passthrough'
 )
 
 const mixedChannelWarningMessageText = computed(() => {
@@ -4895,7 +4923,8 @@ watch(
       interceptWarmupRequests.value = false
     }
     if (newPlatform !== 'openai') {
-      openaiPassthroughEnabled.value = false
+      openaiResponsesForwardMode.value = 'normal'
+      openaiStrictNoAuth.value = false
       openaiFlattenNamespacesEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -4929,6 +4958,10 @@ watch(
 watch(
   [accountCategory, () => form.platform],
   ([category, platform]) => {
+    if (platform === 'openai' && category !== 'apikey' && openaiResponsesForwardMode.value === 'strict_raw') {
+      openaiResponsesForwardMode.value = 'normal'
+      openaiStrictNoAuth.value = false
+    }
     if (platform === 'openai' && category !== 'oauth-based') {
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAppServerEnabled.value = false
@@ -5348,7 +5381,8 @@ const resetForm = () => {
   grokOAuthBaseUrl.value = ''
   interceptWarmupRequests.value = false
   autoPauseOnExpired.value = true
-  openaiPassthroughEnabled.value = false
+  openaiResponsesForwardMode.value = 'normal'
+  openaiStrictNoAuth.value = false
   openaiFlattenNamespacesEnabled.value = false
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
@@ -5424,13 +5458,21 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_oauth_responses_websockets_v2_mode = openaiOAuthResponsesWebSocketV2Mode.value
     extra.openai_oauth_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(openaiOAuthResponsesWebSocketV2Mode.value)
   } else if (accountCategory.value === 'apikey') {
-    extra.openai_apikey_responses_websockets_v2_mode = openaiAPIKeyResponsesWebSocketV2Mode.value
-    extra.openai_apikey_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(openaiAPIKeyResponsesWebSocketV2Mode.value)
+    const apiKeyWSMode = openaiResponsesForwardMode.value === 'strict_raw'
+      ? OPENAI_WS_MODE_OFF
+      : openaiAPIKeyResponsesWebSocketV2Mode.value
+    extra.openai_apikey_responses_websockets_v2_mode = apiKeyWSMode
+    extra.openai_apikey_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(apiKeyWSMode)
   }
   // 清理兼容旧键，统一改用分类型开关。
   delete extra.responses_websockets_v2_enabled
   delete extra.openai_ws_enabled
-  if (openaiPassthroughEnabled.value) {
+  delete extra.openai_responses_forward_mode
+  if (openaiResponsesForwardMode.value === 'strict_raw' && accountCategory.value === 'apikey') {
+    extra.openai_responses_forward_mode = 'strict_raw'
+    delete extra.openai_passthrough
+    delete extra.openai_oauth_passthrough
+  } else if (openaiResponsesForwardMode.value === 'passthrough') {
     extra.openai_passthrough = true
   } else {
     delete extra.openai_passthrough
@@ -5757,8 +5799,14 @@ const handleSubmit = async () => {
     return
   }
 
-  // For apikey type, create directly
-  if (!apiKeyValue.value.trim()) {
+  // For apikey type, create directly. Strict raw may deliberately rely on a
+  // private authenticated transport instead of HTTP bearer auth.
+  const strictNoAuth =
+    form.platform === 'openai' &&
+    accountCategory.value === 'apikey' &&
+    openaiResponsesForwardMode.value === 'strict_raw' &&
+    openaiStrictNoAuth.value
+  if (!apiKeyValue.value.trim() && !strictNoAuth) {
     appStore.showError(t('admin.accounts.pleaseEnterApiKey'))
     return
   }
@@ -5775,8 +5823,13 @@ const handleSubmit = async () => {
 
   // Build credentials with optional model mapping
   const credentials: Record<string, unknown> = {
-    base_url: apiKeyBaseUrl.value.trim() || defaultBaseUrl,
-    api_key: apiKeyValue.value.trim()
+    base_url: apiKeyBaseUrl.value.trim() || defaultBaseUrl
+  }
+  if (apiKeyValue.value.trim() && !strictNoAuth) {
+    credentials.api_key = apiKeyValue.value.trim()
+  }
+  if (form.platform === 'openai' && openaiResponsesForwardMode.value === 'strict_raw') {
+    credentials.openai_upstream_auth_mode = strictNoAuth ? 'none' : 'bearer'
   }
   if (form.platform === 'gemini') {
     credentials.tier_id = geminiTierAIStudio.value
@@ -5871,7 +5924,7 @@ const handleSubmit = async () => {
     ...form,
     group_ids: form.group_ids,
     extra: withUpstreamRequestIdHeader(extra),
-    upstream_billing_probe_enabled: upstreamBillingAutoProbeEnabled.value,
+    upstream_billing_probe_enabled: strictNoAuth ? false : upstreamBillingAutoProbeEnabled.value,
     auto_pause_on_expired: autoPauseOnExpired.value
   })
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1739,34 +1739,50 @@
         </p>
       </div>
 
-      <!-- OpenAI 自动透传开关（OAuth/API Key） -->
+      <!-- OpenAI Responses forwarding mode -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
-        <div class="flex items-center justify-between">
-          <div>
-            <label class="input-label mb-0">{{ t('admin.accounts.openai.oauthPassthrough') }}</label>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.oauthPassthroughDesc') }}
-            </p>
-          </div>
-          <button
-            type="button"
-            @click="openaiPassthroughEnabled = !openaiPassthroughEnabled"
-            :class="[
-              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
-              openaiPassthroughEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
-            ]"
-          >
-            <span
-              :class="[
-                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
-                openaiPassthroughEnabled ? 'translate-x-5' : 'translate-x-0'
-              ]"
-            />
-          </button>
+        <label class="input-label" for="edit-openai-responses-forward-mode">
+          {{ t('admin.accounts.openai.forwardMode') }}
+        </label>
+        <select
+          id="edit-openai-responses-forward-mode"
+          v-model="openaiResponsesForwardMode"
+          data-testid="edit-openai-responses-forward-mode"
+          class="input"
+        >
+          <option v-for="option in openAIResponsesForwardModeOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+        <p class="input-hint">{{ t('admin.accounts.openai.forwardModeDesc') }}</p>
+        <div
+          v-if="openaiResponsesForwardMode === 'strict_raw'"
+          class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200"
+        >
+          {{ t('admin.accounts.openai.forwardModeStrictWarning') }}
         </div>
+        <label
+          v-if="openaiResponsesForwardMode === 'strict_raw' && account?.type === 'apikey'"
+          class="mt-3 flex items-start gap-3"
+        >
+          <input
+            v-model="openaiStrictNoAuth"
+            data-testid="edit-openai-strict-no-auth"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          <span>
+            <span class="block text-sm font-medium text-gray-700 dark:text-gray-200">
+              {{ t('admin.accounts.openai.strictNoAuth') }}
+            </span>
+            <span class="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.strictNoAuthDesc') }}
+            </span>
+          </span>
+        </label>
       </div>
 
       <!-- OpenAI Codex namespace 工具摊平（兼容开关，仅 OAuth） -->
@@ -3510,8 +3526,9 @@ const cacheTTLOverrideTarget = ref<string>('5m')
 const customBaseUrlEnabled = ref(false)
 const customBaseUrl = ref('')
 
-// OpenAI 自动透传开关（OAuth/API Key）
-const openaiPassthroughEnabled = ref(false)
+type OpenAIResponsesForwardMode = 'normal' | 'passthrough' | 'strict_raw'
+const openaiResponsesForwardMode = ref<OpenAIResponsesForwardMode>('normal')
+const openaiStrictNoAuth = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
 const openAILongContextBillingEnabled = ref(false)
@@ -3665,6 +3682,16 @@ const openAIResponsesModeOptions = computed(() => [
   { value: 'force_responses', label: t('admin.accounts.openai.responsesModeForceResponses') },
   { value: 'force_chat_completions', label: t('admin.accounts.openai.responsesModeForceChatCompletions') }
 ])
+const openAIResponsesForwardModeOptions = computed(() => {
+  const options = [
+    { value: 'normal' as OpenAIResponsesForwardMode, label: t('admin.accounts.openai.forwardModeNormal') },
+    { value: 'passthrough' as OpenAIResponsesForwardMode, label: t('admin.accounts.openai.forwardModePassthrough') }
+  ]
+  if (props.account?.type === 'apikey') {
+    options.push({ value: 'strict_raw', label: t('admin.accounts.openai.forwardModeStrictRaw') })
+  }
+  return options
+})
 const openAITextEndpointCapabilityLabel = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
     return t('admin.accounts.openai.capabilityResponses')
@@ -3751,7 +3778,7 @@ const normalizeOpenAIResponsesMode = (mode: unknown): OpenAIResponsesMode => {
   return 'auto'
 }
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  props.account?.platform === 'openai' && openaiPassthroughEnabled.value
+  props.account?.platform === 'openai' && openaiResponsesForwardMode.value === 'passthrough'
 )
 const openAIResponsesStatusKey = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
@@ -3914,7 +3941,7 @@ const buildModelRestrictionMapping = () =>
   buildModelMappingObject('combined', allowedModels.value, modelMappings.value)
 
 const applyOpenAIModelMappingCredentials = (credentials: Record<string, unknown>) => {
-  const shouldApplyModelMapping = !openaiPassthroughEnabled.value
+  const shouldApplyModelMapping = openaiResponsesForwardMode.value !== 'passthrough'
 
   if (shouldApplyModelMapping) {
     const modelMapping = buildModelRestrictionMapping()
@@ -3998,7 +4025,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     upstreamBillingAutoProbeEnabled.value && extra?.upstream_billing_rate_sync_enabled === true
 
   // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
-  openaiPassthroughEnabled.value = false
+  openaiResponsesForwardMode.value = 'normal'
+  openaiStrictNoAuth.value = false
   openaiFlattenNamespacesEnabled.value = false
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
@@ -4016,7 +4044,20 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
-    openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
+    const configuredForwardMode = extra?.openai_responses_forward_mode
+    if (newAccount.type === 'apikey' && configuredForwardMode === 'strict_raw') {
+      openaiResponsesForwardMode.value = 'strict_raw'
+      openaiStrictNoAuth.value =
+        (newAccount.credentials as Record<string, unknown> | undefined)?.openai_upstream_auth_mode === 'none'
+    } else if (configuredForwardMode === 'passthrough') {
+      openaiResponsesForwardMode.value = 'passthrough'
+    } else if (configuredForwardMode === 'normal' || configuredForwardMode === 'strict_raw') {
+      openaiResponsesForwardMode.value = 'normal'
+    } else if (extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true) {
+      openaiResponsesForwardMode.value = 'passthrough'
+    } else {
+      openaiResponsesForwardMode.value = 'normal'
+    }
     openaiFlattenNamespacesEnabled.value =
       newAccount.type === 'oauth' && extra?.openai_responses_flatten_namespaces === true
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
@@ -4985,9 +5026,17 @@ const handleSubmit = async () => {
     }
     updatePayload.auto_pause_on_expired = autoPauseOnExpired.value
     if (props.account.type === 'apikey') {
-      updatePayload.upstream_billing_probe_enabled = upstreamBillingAutoProbeEnabled.value
-      updatePayload.upstream_billing_rate_sync_enabled = upstreamBillingRateSyncEnabled.value
-      if (upstreamBillingRateSyncEnabled.value) {
+      const strictPrivateNoAuth =
+        props.account.platform === 'openai' &&
+        openaiResponsesForwardMode.value === 'strict_raw' &&
+        openaiStrictNoAuth.value
+      updatePayload.upstream_billing_probe_enabled = strictPrivateNoAuth
+        ? false
+        : upstreamBillingAutoProbeEnabled.value
+      updatePayload.upstream_billing_rate_sync_enabled = strictPrivateNoAuth
+        ? false
+        : upstreamBillingRateSyncEnabled.value
+      if (!strictPrivateNoAuth && upstreamBillingRateSyncEnabled.value) {
         delete updatePayload.rate_multiplier
       }
     }
@@ -4996,7 +5045,13 @@ const handleSubmit = async () => {
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
       const newBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
-      const shouldApplyModelMapping = !(props.account.platform === 'openai' && openaiPassthroughEnabled.value)
+      const shouldApplyModelMapping = !(
+        props.account.platform === 'openai' && openaiResponsesForwardMode.value === 'passthrough'
+      )
+      const strictNoAuth =
+        props.account.platform === 'openai' &&
+        openaiResponsesForwardMode.value === 'strict_raw' &&
+        openaiStrictNoAuth.value
 
       // Always update credentials for apikey type to handle model mapping changes
       const newCredentials: Record<string, unknown> = {
@@ -5044,11 +5099,16 @@ const handleSubmit = async () => {
       // 两者都无才报错。
       const hasExistingApiKey =
         props.account.credentials_status?.has_api_key ?? Boolean(currentCredentials.api_key)
-      if (editApiKey.value.trim()) {
+      if (editApiKey.value.trim() && !strictNoAuth) {
         newCredentials.api_key = editApiKey.value.trim()
-      } else if (!hasExistingApiKey) {
+      } else if (!hasExistingApiKey && !strictNoAuth) {
         appStore.showError(t('admin.accounts.apiKeyIsRequired'))
         return
+      }
+      if (props.account.platform === 'openai' && openaiResponsesForwardMode.value === 'strict_raw') {
+        newCredentials.openai_upstream_auth_mode = strictNoAuth ? 'none' : 'bearer'
+      } else {
+        delete newCredentials.openai_upstream_auth_mode
       }
 
       // Add model mapping if configured（OpenAI 开启自动透传时保留现有映射，不再编辑）
@@ -5495,12 +5555,20 @@ const handleSubmit = async () => {
         newExtra.openai_oauth_responses_websockets_v2_mode = openaiOAuthResponsesWebSocketV2Mode.value
         newExtra.openai_oauth_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(openaiOAuthResponsesWebSocketV2Mode.value)
       } else if (props.account.type === 'apikey') {
-        newExtra.openai_apikey_responses_websockets_v2_mode = openaiAPIKeyResponsesWebSocketV2Mode.value
-        newExtra.openai_apikey_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(openaiAPIKeyResponsesWebSocketV2Mode.value)
+        const apiKeyWSMode = openaiResponsesForwardMode.value === 'strict_raw'
+          ? OPENAI_WS_MODE_OFF
+          : openaiAPIKeyResponsesWebSocketV2Mode.value
+        newExtra.openai_apikey_responses_websockets_v2_mode = apiKeyWSMode
+        newExtra.openai_apikey_responses_websockets_v2_enabled = isOpenAIWSModeEnabled(apiKeyWSMode)
       }
       delete newExtra.responses_websockets_v2_enabled
       delete newExtra.openai_ws_enabled
-      if (openaiPassthroughEnabled.value) {
+      delete newExtra.openai_responses_forward_mode
+      if (openaiResponsesForwardMode.value === 'strict_raw' && props.account.type === 'apikey') {
+        newExtra.openai_responses_forward_mode = 'strict_raw'
+        delete newExtra.openai_passthrough
+        delete newExtra.openai_oauth_passthrough
+      } else if (openaiResponsesForwardMode.value === 'passthrough') {
         newExtra.openai_passthrough = true
       } else {
         delete newExtra.openai_passthrough

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -398,6 +398,27 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     )
   })
 
+  it('persists strict raw mode with explicit private no-auth and no dummy key', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('Strict upstream')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('must-not-store')
+    await wrapper.get('[data-testid="create-openai-responses-forward-mode"]').setValue('strict_raw')
+    await wrapper.get('[data-testid="create-openai-strict-no-auth"]').setValue(true)
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    const payload = createAccountMock.mock.calls[0]?.[0]
+    expect(payload.extra?.openai_responses_forward_mode).toBe('strict_raw')
+    expect(payload.extra).not.toHaveProperty('openai_passthrough')
+    expect(payload.credentials?.openai_upstream_auth_mode).toBe('none')
+    expect(payload.credentials).not.toHaveProperty('api_key')
+    expect(payload.upstream_billing_probe_enabled).toBe(false)
+    expect(payload.extra?.openai_apikey_responses_websockets_v2_mode).toBe('off')
+  })
+
   // namespace 摊平是仅 OAuth 的兼容开关：API Key 走 chat completions 回退桥时由桥自行摊平
   it('shows the Codex namespace flatten toggle only for OpenAI OAuth accounts', async () => {
     const wrapper = mountModal()

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -418,6 +418,58 @@ describe('EditAccountModal', () => {
     expect(account.group_ids).toEqual([1, 2])
   })
 
+  it('rehydrates and persists strict raw private no-auth mode', async () => {
+    const account = buildAccount()
+    account.credentials = {
+      base_url: 'http://private-relay.internal/v1',
+      openai_upstream_auth_mode: 'none'
+    }
+    account.credentials_status = { has_api_key: false }
+    account.extra = {
+      openai_responses_forward_mode: 'strict_raw',
+      openai_apikey_responses_websockets_v2_mode: 'ctx_pool',
+      openai_apikey_responses_websockets_v2_enabled: true
+    }
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+
+    expect(
+      (wrapper.get('[data-testid="edit-openai-responses-forward-mode"]').element as HTMLSelectElement).value
+    ).toBe('strict_raw')
+    expect(
+      (wrapper.get('[data-testid="edit-openai-strict-no-auth"]').element as HTMLInputElement).checked
+    ).toBe(true)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    const payload = updateAccountMock.mock.calls[0]?.[1]
+    expect(payload.extra?.openai_responses_forward_mode).toBe('strict_raw')
+    expect(payload.extra).not.toHaveProperty('openai_passthrough')
+    expect(payload.extra?.openai_apikey_responses_websockets_v2_mode).toBe('off')
+    expect(payload.extra?.openai_apikey_responses_websockets_v2_enabled).toBe(false)
+    expect(payload.credentials?.openai_upstream_auth_mode).toBe('none')
+    expect(payload.credentials).not.toHaveProperty('api_key')
+    expect(payload.upstream_billing_probe_enabled).toBe(false)
+    expect(payload.upstream_billing_rate_sync_enabled).toBe(false)
+  })
+
+  it('lets an explicit normal mode override stale legacy passthrough flags', () => {
+    const account = buildAccount()
+    account.extra = {
+      openai_responses_forward_mode: 'normal',
+      openai_passthrough: true
+    }
+
+    const wrapper = mountModal(account)
+
+    expect(
+      (wrapper.get('[data-testid="edit-openai-responses-forward-mode"]').element as HTMLSelectElement).value
+    ).toBe('normal')
+  })
+
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -594,6 +594,17 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        forwardMode: 'Responses forwarding',
+        forwardModeDesc:
+          'Normal keeps the existing compatibility transforms. Passthrough keeps the existing auth-only behavior. Strict raw preserves native Responses request and response bytes.',
+        forwardModeNormal: 'Normal (existing behavior)',
+        forwardModePassthrough: 'Passthrough (auth only)',
+        forwardModeStrictRaw: 'Strict raw Responses',
+        forwardModeStrictWarning:
+          'Strict raw is HTTP/SSE-only and intended for trusted Responses-compatible upstreams. It disables semantic request and stream rewrites, so configure supported models and account concurrency explicitly.',
+        strictNoAuth: 'No upstream HTTP authentication',
+        strictNoAuthDesc:
+          'Use only when the upstream is protected by loopback or another authenticated private transport. Never expose an unauthenticated upstream publicly.',
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -681,6 +681,17 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        forwardMode: 'Responses 转发模式',
+        forwardModeDesc:
+          '普通模式保留现有兼容转换；透传模式保留现有仅替换认证行为；严格原始模式会保留原生 Responses 请求与响应字节。',
+        forwardModeNormal: '普通（现有行为）',
+        forwardModePassthrough: '透传（仅替换认证）',
+        forwardModeStrictRaw: '严格原始 Responses',
+        forwardModeStrictWarning:
+          '严格原始模式仅支持 HTTP/SSE，适用于可信的 Responses 兼容上游。该模式禁用语义请求与流改写，请显式配置支持的模型和账号并发数。',
+        strictNoAuth: '上游 HTTP 不使用认证',
+        strictNoAuthDesc:
+          '仅当上游受回环地址或其他已认证私有传输保护时使用；切勿公开暴露无认证上游。',
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',


### PR DESCRIPTION
## Summary

Add an opt-in `strict_raw` mode for OpenAI API-key upstreams on `/v1/responses` and `/v1/responses/compact`. This supports Responses-native upstreams that need the original request and JSON/SSE response bytes preserved, while retaining Sub2API's authentication, scheduling, concurrency and usage handling.

- Branch before compatibility transformations; preserve the requested model and response bytes.
- Support Bearer authentication or an explicit private-upstream `none` setting, with account validation and UI controls.
- Filter downstream credentials, cookies and transport headers; keep strict mode HTTP/SSE-only.
- Observe usage and response IDs without rewriting payloads.
- Preserve existing normal and legacy passthrough HTTP continuations. Strict continuations retain a separate binding to the original strict account and cannot fall through to a different or reconfigured account.

The implementation is generic. Browser sessions, consumer authentication and bridge automation remain outside Sub2API. Setup references: [strict upstream guide](https://github.com/Wei-Shaw/sub2api/blob/33f746fbda14311fb806f57cbba654059b6e7af0/docs/openai-strict-responses-upstream.md) and [web bridge example](https://github.com/Wei-Shaw/sub2api/blob/33f746fbda14311fb806f57cbba654059b6e7af0/docs/openai-web-bridge-quickstart.md).

## Verification

- Regression tests reproduce the previously reported normal/passthrough continuation failure and now pass.
- Handler tests cover a successful strict two-turn flow and reject continuation after owner disable, reconfiguration or deletion without contacting a replacement upstream.
- State-store tests cover persistence across instances, group isolation, scheduler-binding invalidation, cache misses and cache failures.
- Existing strict transport, header filtering, usage, scheduler and tenant-ownership tests remain in place.
- Full upstream CI: unit and integration suites, frontend checks, Go lint, security scans, shell checks and CLA.

Current reviewed head: `33f746fbda14311fb806f57cbba654059b6e7af0`. Runtime deployment is separate from this PR's source and CI verification.
