### PR TITLE
fix(openai): strip unsupported prompt cache retention

### DIFF
--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -183,6 +183,17 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		}
 	}
 
+	// OpenAI API-key Responses upstream does not accept prompt_cache_retention.
+	// Keep prompt_cache_key intact; OAuth retains its existing normalization path.
+	if account != nil && account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey &&
+		gjson.GetBytes(body, "prompt_cache_retention").Exists() {
+		nextBody, deleteErr := sjson.DeleteBytes(body, "prompt_cache_retention")
+		if deleteErr != nil {
+			return nil, fmt.Errorf("remove prompt cache retention from api-key passthrough body: %w", deleteErr)
+		}
+		body = nextBody
+	}
+
 	if account != nil && account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey &&
 		!isOpenAIResponsesCompactPath(c) && needsOpenAIResponsesClientToolAdaptation(body) {
 		adaptedBody, mapping, adaptErr := adaptOpenAIResponsesClientTools(body)

--- a/backend/internal/service/openai_gateway_responses_client_tools_test.go
+++ b/backend/internal/service/openai_gateway_responses_client_tools_test.go
@@ -116,6 +116,29 @@ func TestOpenAIPassthroughAPIKeyRestoresClientToolsNonStreaming(t *testing.T) {
 	require.Equal(t, "*** Begin Patch", gjson.Get(recorder.Body.String(), "output.1.input").String())
 }
 
+func TestOpenAIPassthroughAPIKeyRemovesPromptCacheRetention(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-5.4","input":"fix it","prompt_cache_key":"cache-key","prompt_cache_retention":"24h"}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_cache","status":"completed","output":[],"usage":{}}`)),
+	}}
+	svc := openAIClientToolsTestService(upstream)
+	account := &Account{ID: 5661, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{"api_key": "test-key"}}
+
+	result, err := svc.forwardOpenAIPassthrough(context.Background(), c, account, body, body, "gpt-5.4", false, nil, false, time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_retention").Exists())
+	require.Equal(t, "cache-key", gjson.GetBytes(upstream.lastBody, "prompt_cache_key").String())
+}
+
 func TestOpenAIPassthroughAPIKeyRestoresClientToolsStreaming(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := openAIClientToolsRequest(true)


### PR DESCRIPTION
## Summary
- remove `prompt_cache_retention` from OpenAI API-key Responses passthrough requests
- preserve `prompt_cache_key` and the existing OAuth normalization path
- add a mock-upstream regression test for the affected passthrough path

## Verification
- `go test -tags=unit ./internal/service -run '^(TestOpenAIPassthroughAPIKeyRemovesPromptCacheRetention|TestOpenAIPassthrough|TestAdaptOpenAIResponsesClientTools|TestClearOpenAIResponsesClientToolMapping|TestNormalizeOpenAIPassthroughOAuthBody)$' -count=1`\n- `go test -tags=unit ./internal/service -count=1` *(timed out after 120s without output)*\n\nFixes #5821