### PR TITLE
fix(test): CN 供应商额度探测 fake 加锁消除并发 append 竞态

### DIFF
--- a/backend/internal/service/cn_provider_balance_check_service_test.go
+++ b/backend/internal/service/cn_provider_balance_check_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -14,11 +15,15 @@ import (
 //   - payg 账号不经过额度探测（走余额路径，本测试不放 payg 账号避免真实网络）；
 //   - 非激活账号完全跳过。
 
+// fakeCNQuotaProber 需要并发安全：runOnce 以 cnQuotaProbeConcurrency 并发调用 QueryUsage。
 type fakeCNQuotaProber struct {
+	mu     sync.Mutex
 	probed []int64
 }
 
 func (f *fakeCNQuotaProber) QueryUsage(ctx context.Context, accountID int64) (*CNProviderQuotaProbeResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.probed = append(f.probed, accountID)
 	return &CNProviderQuotaProbeResult{Success: true, Persisted: true}, nil
 }


### PR DESCRIPTION
runOnce 以 cnQuotaProbeConcurrency(4) 并发调用 QueryUsage，测试 fake 无锁 append f.probed，并发写 slice 偶发丢元素，导致 TestCNProviderBalanceCheckRunOnceProbesCodingPlanQuota 在 CI 偶发 "elements differ"（期望 3 个账号只记录到 2 个）。go test -race 必现。