### PR TITLE
fix(deepseek): reject invalid relay balance payloads

### DIFF
--- a/backend/internal/service/cn_provider_balance_service.go
+++ b/backend/internal/service/cn_provider_balance_service.go
@@ -190,9 +190,18 @@ func (s *CNProviderBalanceService) queryBalanceForAccount(ctx context.Context, a
 		}
 		// balance_infos 逐条解析：双币种账号同时返回 CNY + USD（数组顺序即
 		// 主次序，首条为主币种）。
-		gjson.GetBytes(bodyBytes, "balance_infos").ForEach(func(_, info gjson.Result) bool {
+		balanceInfos := gjson.GetBytes(bodyBytes, "balance_infos")
+		if !balanceInfos.Exists() || !balanceInfos.IsArray() {
+			result.Error = "Invalid balance response: missing balance_infos"
+			return result, nil
+		}
+		balanceInfos.ForEach(func(_, info gjson.Result) bool {
 			currency := strings.ToUpper(strings.TrimSpace(info.Get("currency").String()))
-			balance, _ := cnParseF64(info.Get("total_balance").Value())
+			totalBalance := info.Get("total_balance")
+			balance, ok := cnParseF64(totalBalance.Value())
+			if !totalBalance.Exists() || !ok {
+				return true
+			}
 			if currency == "" {
 				currency = "CNY"
 			}
@@ -200,7 +209,8 @@ func (s *CNProviderBalanceService) queryBalanceForAccount(ctx context.Context, a
 			return true
 		})
 		if len(entries) == 0 {
-			entries = append(entries, CNProviderBalanceEntry{Currency: "CNY"})
+			result.Error = "Invalid balance response: no valid balance entries"
+			return result, nil
 		}
 	}
 	result.Balances = entries

--- a/backend/internal/service/cn_provider_balance_service_test.go
+++ b/backend/internal/service/cn_provider_balance_service_test.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/stretchr/testify/require"
+)
+
+type cnBalanceResponseUpstream struct {
+	statusCode int
+	body       string
+}
+
+func (u *cnBalanceResponseUpstream) Do(
+	_ *http.Request,
+	_ string,
+	_ int64,
+	_ int,
+) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: u.statusCode,
+		Body:       io.NopCloser(strings.NewReader(u.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (u *cnBalanceResponseUpstream) DoWithTLS(
+	req *http.Request,
+	proxyURL string,
+	accountID int64,
+	accountConcurrency int,
+	_ *tlsfingerprint.Profile,
+) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+type cnBalanceProbeRepo struct {
+	AccountRepository
+	account     *Account
+	extraWrites []map[string]any
+}
+
+func (r *cnBalanceProbeRepo) GetByID(_ context.Context, _ int64) (*Account, error) {
+	return r.account, nil
+}
+
+func (r *cnBalanceProbeRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
+	r.extraWrites = append(r.extraWrites, updates)
+	return nil
+}
+
+func newDeepSeekBalanceProbeAccount() *Account {
+	return &Account{
+		ID:       42,
+		Platform: PlatformDeepseek,
+		Type:     AccountTypeAPIKey,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"account_mode": AccountModePayG,
+			"api_key":      "sk-test",
+			"base_url":     "https://relay.example.com",
+		},
+	}
+}
+
+func TestCNProviderBalanceService_DeepSeekInvalidBalancePayloadDoesNotBecomeZero(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantError string
+	}{
+		{
+			name:      "missing balance infos",
+			body:      `{"data":{"models":["deepseek-v4-flash"]}}`,
+			wantError: "missing balance_infos",
+		},
+		{
+			name:      "empty balance infos",
+			body:      `{"is_available":true,"balance_infos":[]}`,
+			wantError: "no valid balance entries",
+		},
+		{
+			name:      "invalid balance value",
+			body:      `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"not-a-number"}]}`,
+			wantError: "no valid balance entries",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &cnBalanceProbeRepo{account: newDeepSeekBalanceProbeAccount()}
+			upstream := &cnBalanceResponseUpstream{statusCode: http.StatusOK, body: tt.body}
+			svc := NewCNProviderBalanceService(repo, nil, upstream, nil)
+
+			result, err := svc.QueryBalance(context.Background(), repo.account.ID)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, result.Success)
+			require.Contains(t, result.Error, tt.wantError)
+			require.Empty(t, result.Balances)
+			require.Empty(t, repo.extraWrites, "invalid relay balance payload must not persist a synthetic zero balance")
+		})
+	}
+}
+
+func TestCNProviderBalanceService_DeepSeekValidZeroBalanceRemainsSuccessful(t *testing.T) {
+	repo := &cnBalanceProbeRepo{account: newDeepSeekBalanceProbeAccount()}
+	upstream := &cnBalanceResponseUpstream{
+		statusCode: http.StatusOK,
+		body:       `{"is_available":false,"balance_infos":[{"currency":"CNY","total_balance":"0"}]}`,
+	}
+	svc := NewCNProviderBalanceService(repo, nil, upstream, nil)
+
+	result, err := svc.QueryBalance(context.Background(), repo.account.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Success)
+	require.False(t, result.Available)
+	require.Equal(t, "CNY", result.Currency)
+	require.Zero(t, result.Balance)
+	require.Len(t, result.Balances, 1)
+	require.Len(t, repo.extraWrites, 1, "a valid upstream zero balance must still be persisted")
+}


### PR DESCRIPTION
## Summary

- Treat HTTP 200 relay responses without a valid `balance_infos` array as probe failures instead of synthetic zero balances.
- Ignore entries whose `total_balance` is missing or non-numeric, and fail when no valid balance remains.
- Preserve real zero-balance responses so existing low-balance scheduling behavior still works.

This is a focused follow-up to the DeepSeek balance support already present on `main`. Custom relay endpoints can return unrelated JSON with HTTP 200; interpreting that as `0 CNY` can incorrectly cool down a healthy account.

## Validation

- `go test ./...`
- `git diff --check`

Related: #5273, #5666