### PR TITLE
fix(openai): gate prompt cache fields by capability

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -103,7 +103,8 @@ const (
 	// （openai_responses_supported / openai_responses_mode），而非
 	// credentials["openai_capabilities"] 配置集。仅用于生图意图的 /v1/responses
 	// 调度，避免把请求调度到会在 forward 阶段被降级为 Chat Completions 的账号（#4417）。
-	OpenAIEndpointCapabilityResponses OpenAIEndpointCapability = "responses"
+	OpenAIEndpointCapabilityResponses            OpenAIEndpointCapability = "responses"
+	OpenAIEndpointCapabilityPromptCacheRetention OpenAIEndpointCapability = "prompt_cache_retention"
 )
 
 const openAIEndpointCapabilitiesCredentialKey = "openai_capabilities"
@@ -1794,6 +1795,10 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 		}
 	case OpenAIEndpointCapabilityEmbeddings:
 		if a.Type != AccountTypeAPIKey {
+			return false
+		}
+	case OpenAIEndpointCapabilityPromptCacheRetention:
+		if a.Platform != PlatformOpenAI || a.Type != AccountTypeAPIKey {
 			return false
 		}
 	default:

--- a/backend/internal/service/openai_bulk_account_settings.go
+++ b/backend/internal/service/openai_bulk_account_settings.go
@@ -75,7 +75,7 @@ func normalizeBulkOpenAIEndpointCapabilities(raw any) (any, bool, error) {
 		return nil, true, nil
 	}
 
-	values := make([]string, 0, 2)
+	values := make([]string, 0, 3)
 	switch typed := raw.(type) {
 	case []any:
 		for _, item := range typed {
@@ -91,10 +91,10 @@ func normalizeBulkOpenAIEndpointCapabilities(raw any) (any, bool, error) {
 		return nil, false, invalidBulkOpenAIEndpointCapabilities()
 	}
 
-	selected := make(map[string]bool, 2)
+	selected := make(map[string]bool, 3)
 	for _, value := range values {
 		switch OpenAIEndpointCapability(value) {
-		case OpenAIEndpointCapabilityChatCompletions, OpenAIEndpointCapabilityEmbeddings:
+		case OpenAIEndpointCapabilityChatCompletions, OpenAIEndpointCapabilityEmbeddings, OpenAIEndpointCapabilityPromptCacheRetention:
 			selected[value] = true
 		default:
 			return nil, false, invalidBulkOpenAIEndpointCapabilities()
@@ -105,19 +105,26 @@ func normalizeBulkOpenAIEndpointCapabilities(raw any) (any, bool, error) {
 	}
 
 	includeChat := selected[string(OpenAIEndpointCapabilityChatCompletions)]
-	if includeChat && selected[string(OpenAIEndpointCapabilityEmbeddings)] {
+	if includeChat && selected[string(OpenAIEndpointCapabilityEmbeddings)] && len(selected) == 2 {
 		return nil, true, nil
 	}
-	if includeChat {
-		return []string{string(OpenAIEndpointCapabilityChatCompletions)}, true, nil
+	result := make([]string, 0, len(selected))
+	for _, capability := range []OpenAIEndpointCapability{
+		OpenAIEndpointCapabilityChatCompletions,
+		OpenAIEndpointCapabilityEmbeddings,
+		OpenAIEndpointCapabilityPromptCacheRetention,
+	} {
+		if selected[string(capability)] {
+			result = append(result, string(capability))
+		}
 	}
-	return []string{string(OpenAIEndpointCapabilityEmbeddings)}, false, nil
+	return result, includeChat, nil
 }
 
 func invalidBulkOpenAIEndpointCapabilities() error {
 	return infraerrors.BadRequest(
 		"OPENAI_ENDPOINT_CAPABILITIES_INVALID",
-		"openai_capabilities must contain chat_completions, embeddings, or both",
+		"openai_capabilities must contain chat_completions, embeddings, prompt_cache_retention, or a combination",
 	)
 }
 

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -145,6 +145,7 @@ var openAIChatGPTInternalUnsupportedFields = []string{
 	"user",
 	"metadata",
 	"prompt_cache_retention",
+	"prompt_cache_options",
 	"safety_identifier",
 	"stream_options",
 	"truncation",

--- a/backend/internal/service/openai_fast_policy_ws_test.go
+++ b/backend/internal/service/openai_fast_policy_ws_test.go
@@ -800,11 +800,11 @@ func TestPolicyEnforcingFrameConn_SessionUpdateRotatesCapturedModel(t *testing.T
 	require.NoError(t, err)
 	require.Contains(t, string(payload1), `"service_tier"`, "frame1: gpt-4o miss whitelist → pass keeps service_tier")
 
-	// Frame 2: session.update — not response.create, untouched, but its
-	// side effect updates capturedSessionModel to gpt-5.5.
+	// Frame 2: session.update — not response.create; its side effect updates
+	// capturedSessionModel while nested prompt-cache fields are sanitized.
 	_, payload2, err := wrapper.ReadFrame(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, string(rotate), string(payload2), "session.update frame is forwarded verbatim")
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(payload2, "session.model").String())
 	require.Equal(t, "gpt-5.5", capturedSessionModel, "fix1: session.update must rotate capturedSessionModel")
 
 	// Frame 3: empty model + new captured gpt-5.5 → matches whitelist → filter.

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -526,6 +526,19 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	// Apply the prompt-cache policy only after the final upstream model mapping
+	// and OAuth normalization have completed. Keep the Responses hot path raw
+	// when neither cache-control field is present.
+	if gjson.GetBytes(body, "prompt_cache_retention").Exists() || gjson.GetBytes(body, "prompt_cache_options").Exists() {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if normalizeOpenAIPromptCacheFields(decoded, account, upstreamModel) {
+			markDecodedModified()
+		}
+	}
+
 	if !SupportsVerbosity(upstreamModel) && gjson.GetBytes(body, "text.verbosity").Exists() {
 		markPatchDelete("text.verbosity")
 	}
@@ -568,7 +581,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if gjson.GetBytes(body, "max_completion_tokens").Exists() && (account.Type == AccountTypeAPIKey || account.Platform != PlatformOpenAI) {
 			markPatchDelete("max_completion_tokens")
 		}
-		for _, unsupportedField := range []string{"prompt_cache_retention", "safety_identifier", "prompt_cache_options"} {
+		for _, unsupportedField := range []string{"safety_identifier"} {
 			if gjson.GetBytes(body, unsupportedField).Exists() {
 				markPatchDelete(unsupportedField)
 			}

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -52,6 +52,11 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 	// account has no model_mapping, matching the Chat Completions path and xAI's
 	// actual Responses model IDs.
 	upstreamModel = xai.ResolveGrokTextResponsesModelID(upstreamModel, grokDefaultResponsesModel)
+	if openAIPromptCacheFieldsPresent(body) {
+		if normalized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRaw(body, account, upstreamModel); sanitizeErr == nil && changed {
+			body = normalized
+		}
+	}
 	if isGrokImageGenerationModel(upstreamModel) {
 		return nil, fmt.Errorf("model %s is an image model and is not available on the Responses endpoint; use /v1/images/generations instead", upstreamModel)
 	}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -602,6 +602,11 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 
 	// DeepSeek 原生 Responses 端点为无状态实现（见 normalizeDeepSeekResponsesRequestBody）。
 	body = normalizeDeepSeekResponsesRequestBody(account, body)
+	if openAIPromptCacheFieldsPresent(body) {
+		if normalized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRaw(body, account, gjson.GetBytes(body, "model").String()); sanitizeErr == nil && changed {
+			body = normalized
+		}
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {

--- a/backend/internal/service/openai_prompt_cache_fields.go
+++ b/backend/internal/service/openai_prompt_cache_fields.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+var openAIPromptCacheLegacyModels = map[string]struct{}{
+	"gpt-5.5":             {},
+	"gpt-5.5-pro":         {},
+	"gpt-5.4":             {},
+	"gpt-5.2":             {},
+	"gpt-5.1-codex-max":   {},
+	"gpt-5.1":             {},
+	"gpt-5.1-codex":       {},
+	"gpt-5.1-codex-mini":  {},
+	"gpt-5.1-chat-latest": {},
+	"gpt-5":               {},
+	"gpt-5-codex":         {},
+	"gpt-4.1":             {},
+}
+
+// isOpenAIPromptCacheGPT56OrLater is deliberately numeric rather than an
+// alias lookup: dated/preview GPT-5.6 models and all later major/minor
+// versions must take the new prompt_cache_options branch.
+func isOpenAIPromptCacheGPT56OrLater(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(lastOpenAIModelSegment(model)))
+	if !strings.HasPrefix(model, "gpt-") {
+		return false
+	}
+	version := strings.TrimPrefix(model, "gpt-")
+	dot := strings.IndexByte(version, '.')
+	if dot < 1 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(version[:dot])
+	minorAndSuffix := version[dot+1:]
+	minorEnd := strings.IndexByte(minorAndSuffix, '-')
+	minorText := minorAndSuffix
+	suffix := ""
+	if minorEnd >= 0 {
+		minorText = minorAndSuffix[:minorEnd]
+		suffix = minorAndSuffix[minorEnd:]
+	}
+	minor, errMinor := strconv.Atoi(minorText)
+	if errMajor != nil || errMinor != nil {
+		return false
+	}
+	if suffix != "" && !isOpenAIPromptCacheStructuredSuffix(suffix) {
+		return false
+	}
+	return major > 5 || (major == 5 && minor >= 6)
+}
+
+func isOpenAIPromptCacheStructuredSuffix(suffix string) bool {
+	if suffix == "-sol" || suffix == "-terra" || suffix == "-luna" {
+		return true
+	}
+	if len(suffix) != len("-2026-08-01") || suffix[0] != '-' || !isDigits(suffix[1:5]) || suffix[5] != '-' ||
+		!isDigits(suffix[6:8]) || suffix[8] != '-' || !isDigits(suffix[9:11]) {
+		return false
+	}
+	return true
+}
+
+func isOpenAIPromptCacheLegacyModel(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(lastOpenAIModelSegment(model)))
+	if _, ok := openAIPromptCacheLegacyModels[model]; ok {
+		return true
+	}
+	for legacy := range openAIPromptCacheLegacyModels {
+		suffix := strings.TrimPrefix(model, legacy)
+		if strings.HasPrefix(model, legacy) && len(suffix) == len("-2000-01-01") && suffix[0] == '-' &&
+			isDigits(suffix[1:5]) && suffix[5] == '-' && isDigits(suffix[6:8]) && suffix[8] == '-' && isDigits(suffix[9:11]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// supportsOpenAIPromptCacheRetention is the pure account/model predicate.
+// Unlike endpoint scheduling capabilities, this is an egress field policy:
+// credentials are an explicit default-deny opt-in and no base URL inference is
+// allowed.
+func supportsOpenAIPromptCacheRetention(account *Account, upstreamModel string) bool {
+	if account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	if isOpenAIPromptCacheGPT56OrLater(upstreamModel) || !isOpenAIPromptCacheLegacyModel(upstreamModel) {
+		return false
+	}
+	capabilities, found := account.openAIEndpointCapabilitySet()
+	return found && capabilities[string(OpenAIEndpointCapabilityPromptCacheRetention)]
+}
+
+// normalizeOpenAIPromptCacheFields applies the same final-model policy to a
+// decoded request/frame. prompt_cache_key is intentionally never touched.
+func normalizeOpenAIPromptCacheFields(body map[string]any, account *Account, upstreamModel string) bool {
+	if body == nil {
+		return false
+	}
+	if upstreamModel == "" {
+		upstreamModel, _ = body["model"].(string)
+	}
+	// GPT-5.6+ uses the new cache-options shape. The model-generation rule
+	// takes precedence over an account's legacy-retention capability, including
+	// for OpenAI-compatible upstreams that map to a GPT-5.6+ model.
+	keepOptions := isOpenAIPromptCacheGPT56OrLater(upstreamModel) && account != nil && account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey
+	keepRetention := supportsOpenAIPromptCacheRetention(account, upstreamModel)
+	changed := false
+	if !keepRetention {
+		if _, ok := body["prompt_cache_retention"]; ok {
+			delete(body, "prompt_cache_retention")
+			changed = true
+		}
+	}
+	if !keepOptions {
+		if _, ok := body["prompt_cache_options"]; ok {
+			delete(body, "prompt_cache_options")
+			changed = true
+		}
+	}
+	return changed
+}
+
+func normalizeOpenAIPromptCacheFieldsRaw(body []byte, account *Account, upstreamModel string) ([]byte, bool, error) {
+	return normalizeOpenAIPromptCacheFieldsRawWithSessionModel(body, account, upstreamModel, "")
+}
+
+func openAIPromptCacheFieldsPresent(body []byte) bool {
+	values := gjson.GetManyBytes(body, "prompt_cache_retention", "prompt_cache_options")
+	return values[0].Exists() || values[1].Exists()
+}
+
+func normalizeOpenAIPromptCacheFieldsRawWithSessionModel(body []byte, account *Account, upstreamModel, sessionUpstreamModel string) ([]byte, bool, error) {
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return body, false, err
+	}
+	changed := normalizeOpenAIPromptCacheFields(decoded, account, upstreamModel)
+	if session, ok := decoded["session"].(map[string]any); ok {
+		sessionModel := sessionUpstreamModel
+		if sessionModel == "" {
+			sessionModel, _ = session["model"].(string)
+		}
+		if sessionModel == "" {
+			sessionModel = upstreamModel
+		}
+		if normalizeOpenAIPromptCacheFields(session, account, sessionModel) {
+			changed = true
+		}
+	}
+	if !changed {
+		return body, false, nil
+	}
+	normalized, err := json.Marshal(decoded)
+	return normalized, true, err
+}

--- a/backend/internal/service/openai_prompt_cache_fields_test.go
+++ b/backend/internal/service/openai_prompt_cache_fields_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeOpenAIPromptCacheFields(t *testing.T) {
+	tests := []struct {
+		name, model, platform, accountType string
+		token, retention, options, key     bool
+		wantRetention, wantOptions         bool
+	}{
+		{"legacy token", "gpt-5.5-2026-08-01", PlatformOpenAI, AccountTypeAPIKey, true, true, true, true, true, false},
+		{"legacy default deny", "gpt-5.5", PlatformOpenAI, AccountTypeAPIKey, false, true, true, true, false, false},
+		{"gpt 5.6", "gpt-5.6-2026-08-01", PlatformOpenAI, AccountTypeAPIKey, true, true, true, true, false, true},
+		{"gpt 5.7", "gpt-5.7", PlatformOpenAI, AccountTypeAPIKey, true, true, true, true, false, true},
+		{"gpt 5.6 oauth", "gpt-5.6", PlatformOpenAI, AccountTypeOAuth, true, true, true, true, false, false},
+		{"gpt 5.6 grok", "gpt-5.6", PlatformGrok, AccountTypeAPIKey, true, true, true, true, false, false},
+		{"gpt 5.6 third party keeps options", "gpt-5.6", PlatformOpenAI, AccountTypeAPIKey, false, true, true, true, false, true},
+		{"oauth", "gpt-5.5", PlatformOpenAI, AccountTypeOAuth, true, true, true, true, false, false},
+		{"grok", "gpt-5.5", PlatformGrok, AccountTypeAPIKey, true, true, true, true, false, false},
+		{"unknown", "gpt-5.0-custom", PlatformOpenAI, AccountTypeAPIKey, true, true, true, true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentials := map[string]any{}
+			if tt.token {
+				credentials[openAIEndpointCapabilitiesCredentialKey] = []string{"prompt_cache_retention"}
+			}
+			body := map[string]any{"model": tt.model, "prompt_cache_retention": "24h", "prompt_cache_options": map[string]any{"enabled": true}, "prompt_cache_key": "keep"}
+			changed := normalizeOpenAIPromptCacheFields(body, &Account{Platform: tt.platform, Type: tt.accountType, Credentials: credentials}, tt.model)
+			require.Equal(t, tt.wantRetention, body["prompt_cache_retention"] != nil)
+			require.Equal(t, tt.wantOptions, body["prompt_cache_options"] != nil)
+			require.Equal(t, "keep", body["prompt_cache_key"])
+			require.Equal(t, tt.retention != tt.wantRetention || tt.options != tt.wantOptions, changed)
+		})
+	}
+	t.Run("gpt 5.6 nil account", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-5.6", "prompt_cache_retention": "24h", "prompt_cache_options": map[string]any{"enabled": true}, "prompt_cache_key": "keep"}
+		normalizeOpenAIPromptCacheFields(body, nil, "gpt-5.6")
+		require.NotContains(t, body, "prompt_cache_retention")
+		require.NotContains(t, body, "prompt_cache_options")
+		require.Equal(t, "keep", body["prompt_cache_key"])
+	})
+	for _, model := range []string{"gpt-5.5-2-01", "gpt-5.5--2026-08-01", "gpt-5.5-2026-8-01"} {
+		t.Run("invalid suffix "+model, func(t *testing.T) {
+			a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{openAIEndpointCapabilitiesCredentialKey: []string{"prompt_cache_retention"}}}
+			body := map[string]any{"model": model, "prompt_cache_retention": "24h", "prompt_cache_options": map[string]any{"enabled": true}, "prompt_cache_key": "keep"}
+			normalizeOpenAIPromptCacheFields(body, a, model)
+			require.NotContains(t, body, "prompt_cache_retention")
+			require.NotContains(t, body, "prompt_cache_options")
+			require.Equal(t, "keep", body["prompt_cache_key"])
+		})
+	}
+	for _, model := range []string{"gpt-5.6garbage", "gpt-5.7invalid"} {
+		t.Run("invalid new model "+model, func(t *testing.T) {
+			a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+			body := map[string]any{"model": model, "prompt_cache_retention": "24h", "prompt_cache_options": map[string]any{"enabled": true}}
+			normalizeOpenAIPromptCacheFields(body, a, model)
+			require.NotContains(t, body, "prompt_cache_retention")
+			require.NotContains(t, body, "prompt_cache_options")
+		})
+	}
+	t.Run("session nested fields use captured mapped model when model omitted", func(t *testing.T) {
+		a := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{openAIEndpointCapabilitiesCredentialKey: []string{"prompt_cache_retention"}}}
+		body := []byte(`{"type":"session.update","session":{"prompt_cache_retention":"24h","prompt_cache_options":{"enabled":true},"prompt_cache_key":"keep"}}`)
+		normalized, changed, err := normalizeOpenAIPromptCacheFieldsRawWithSessionModel(body, a, "", "gpt-5.5")
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Contains(t, string(normalized), "prompt_cache_retention")
+		require.NotContains(t, string(normalized), "prompt_cache_options")
+		require.Contains(t, string(normalized), "prompt_cache_key")
+	})
+}

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -390,6 +390,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			normalized = next
 		}
 		SetOpsUpstreamModel(c, upstreamModel)
+		if sanitized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRaw(normalized, account, upstreamModel); sanitizeErr != nil {
+			return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", sanitizeErr)
+		} else if changed {
+			normalized = sanitized
+		}
 		if isCodexCLI && codexImageGenerationExplicitToolPolicy == codexImageGenerationExplicitToolPolicyStrip {
 			if stripped, changed, stripErr := stripOpenAIImageGenerationToolsFromRawPayload(normalized); stripErr != nil {
 				return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", stripErr)

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -780,6 +780,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, blocked.Message, blocked)
 	}
 	firstClientMessage = updatedFirst
+	if sanitized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRaw(firstClientMessage, account, capturedSessionModel); sanitizeErr != nil {
+		return fmt.Errorf("sanitize prompt cache fields on first ws frame: %w", sanitizeErr)
+	} else if changed {
+		firstClientMessage = sanitized
+	}
 
 	// 在 policy filter 之后再提取 service_tier / reasoning_effort 用于
 	// usage 上报：filter
@@ -1074,6 +1079,23 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			}
 			if isResponseCreate && model != "" && model != strings.TrimSpace(gjson.GetBytes(payload, "model").String()) {
 				payload = s.ReplaceModelInBody(payload, model)
+			}
+			if isResponseCreate {
+				if sanitized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRaw(payload, account, model); sanitizeErr != nil {
+					return payload, nil, sanitizeErr
+				} else if changed {
+					payload = sanitized
+				}
+			} else if eventType == "session.update" {
+				mappedSessionModel := openAIWSPassthroughPolicyModelFromSessionFrame(account, payload)
+				if mappedSessionModel == "" {
+					mappedSessionModel = capturedSessionModel
+				}
+				if sanitized, changed, sanitizeErr := normalizeOpenAIPromptCacheFieldsRawWithSessionModel(payload, account, "", mappedSessionModel); sanitizeErr != nil {
+					return payload, nil, sanitizeErr
+				} else if changed {
+					payload = sanitized
+				}
 			}
 			out, blocked, policyErr := s.applyOpenAIFastPolicyToWSResponseCreate(ctx, account, model, payload)
 			// 多轮 passthrough usage：仅在成功（non-block / non-err）

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -1070,7 +1070,7 @@
                 :disabled="!enableOpenAIEndpointCapabilities"
                 class="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-500"
                 :data-testid="`bulk-edit-openai-endpoint-capability-${option.value}`"
-                :checked="openAIEndpointCapabilities.includes(option.value)"
+                :checked="option.value === 'prompt_cache_retention' ? openAIPromptCacheRetentionSupported : openAIEndpointCapabilities.includes(option.value)"
                 @change="toggleOpenAIEndpointCapability(option.value, $event)"
               />
               <span class="text-gray-700 dark:text-gray-200">{{ option.label }}</span>
@@ -1699,6 +1699,7 @@ const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>([
   'chat_completions',
   'embeddings'
 ])
+const openAIPromptCacheRetentionSupported = ref(false)
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
@@ -1785,7 +1786,8 @@ const openAIEndpointCapabilityOptions = computed<
   Array<{ value: OpenAIEndpointCapability; label: string }>
 >(() => [
   { value: 'chat_completions', label: openAITextEndpointCapabilityLabel.value },
-  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') }
+  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') },
+  { value: 'prompt_cache_retention', label: t('admin.accounts.openai.capabilityPromptCacheRetention') }
 ])
 const openAITextGenerationCapabilityEnabled = computed(() =>
   openAIEndpointCapabilities.value.includes('chat_completions')
@@ -1804,6 +1806,10 @@ const toggleOpenAIEndpointCapability = (
   capability: OpenAIEndpointCapability,
   event?: Event
 ) => {
+  if (capability === 'prompt_cache_retention') {
+    openAIPromptCacheRetentionSupported.value = !openAIPromptCacheRetentionSupported.value
+    return
+  }
   if (openAIEndpointCapabilities.value.includes(capability)) {
     if (openAIEndpointCapabilities.value.length <= 1) {
       const input = event?.target as HTMLInputElement | null
@@ -1995,9 +2001,9 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
 
   if (applyOpenAIEndpointCapabilities) {
     credentials.openai_capabilities =
-      openAIEndpointCapabilities.value.length === 2
+      openAIEndpointCapabilities.value.length === 2 && !openAIPromptCacheRetentionSupported.value
         ? null
-        : [...openAIEndpointCapabilities.value]
+        : [...openAIEndpointCapabilities.value, ...(openAIPromptCacheRetentionSupported.value ? ['prompt_cache_retention'] : [])]
     credentialsChanged = true
   }
 
@@ -2373,6 +2379,7 @@ watch(
       openaiFlattenNamespacesEnabled.value = false
       openAILongContextBillingEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
+      openAIPromptCacheRetentionSupported.value = false
       openAIResponsesMode.value = 'auto'
       modelRestrictionMode.value = 'whitelist'
       allowedModels.value = []

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3249,7 +3249,7 @@
                 type="checkbox"
                 class="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-500"
                 :data-testid="`openai-endpoint-capability-${option.value}`"
-                :checked="openAIEndpointCapabilities.includes(option.value)"
+                :checked="option.value === 'prompt_cache_retention' ? openAIPromptCacheRetentionSupported : openAIEndpointCapabilities.includes(option.value)"
                 @change="toggleOpenAIEndpointCapability(option.value, $event)"
               />
               <span class="text-gray-700 dark:text-gray-200">{{ option.label }}</span>
@@ -4167,6 +4167,7 @@ const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
+const openAIPromptCacheRetentionSupported = ref(false)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
@@ -4257,7 +4258,8 @@ const openAITextEndpointCapabilityLabel = computed(() => {
 })
 const openAIEndpointCapabilityOptions = computed<{ value: OpenAIEndpointCapability; label: string }[]>(() => [
   { value: 'chat_completions', label: openAITextEndpointCapabilityLabel.value },
-  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') }
+  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') },
+  { value: 'prompt_cache_retention', label: t('admin.accounts.openai.capabilityPromptCacheRetention') }
 ])
 const openAITextGenerationCapabilityEnabled = computed(() =>
   openAIEndpointCapabilities.value.includes('chat_completions')
@@ -4270,6 +4272,10 @@ const normalizeOpenAIEndpointCapabilities = (values: OpenAIEndpointCapability[])
 }
 
 const toggleOpenAIEndpointCapability = (capability: OpenAIEndpointCapability, event?: Event) => {
+  if (capability === 'prompt_cache_retention') {
+    openAIPromptCacheRetentionSupported.value = !openAIPromptCacheRetentionSupported.value
+    return
+  }
   if (openAIEndpointCapabilities.value.includes(capability)) {
     if (openAIEndpointCapabilities.value.length <= 1) {
       const input = event?.target as HTMLInputElement | null
@@ -4292,11 +4298,13 @@ const toggleOpenAIEndpointCapability = (capability: OpenAIEndpointCapability, ev
 
 const applyOpenAIEndpointCapabilities = (credentials: Record<string, unknown>) => {
   const capabilities = normalizeOpenAIEndpointCapabilities(openAIEndpointCapabilities.value)
-  if (capabilities.length === 2) {
+  if (capabilities.length === 2 && !openAIPromptCacheRetentionSupported.value) {
     delete credentials.openai_capabilities
     return
   }
-  credentials.openai_capabilities = capabilities
+  credentials.openai_capabilities = openAIPromptCacheRetentionSupported.value
+    ? [...capabilities, 'prompt_cache_retention']
+    : capabilities
 }
 
 function buildAntigravityExtra(): Record<string, unknown> | undefined {
@@ -4629,6 +4637,7 @@ watch(
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
+      openAIPromptCacheRetentionSupported.value = false
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       codexCLIOnlyEnabled.value = false
@@ -5061,6 +5070,7 @@ const resetForm = () => {
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
+  openAIPromptCacheRetentionSupported.value = false
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1773,7 +1773,7 @@
                 type="checkbox"
                 class="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-500"
                 :data-testid="`openai-endpoint-capability-${option.value}`"
-                :checked="openAIEndpointCapabilities.includes(option.value)"
+                :checked="option.value === 'prompt_cache_retention' ? openAIPromptCacheRetentionSupported : openAIEndpointCapabilities.includes(option.value)"
                 @change="toggleOpenAIEndpointCapability(option.value, $event)"
               />
               <span class="text-gray-700 dark:text-gray-200">{{ option.label }}</span>
@@ -3227,6 +3227,7 @@ const editPlanType = ref<string>('')
 const openAICompactMode = ref<OpenAICompactMode>('auto')
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
+const openAIPromptCacheRetentionSupported = ref(false)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
@@ -3387,7 +3388,8 @@ const openAITextEndpointCapabilityLabel = computed(() => {
 })
 const openAIEndpointCapabilityOptions = computed<{ value: OpenAIEndpointCapability; label: string }[]>(() => [
   { value: 'chat_completions', label: openAITextEndpointCapabilityLabel.value },
-  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') }
+  { value: 'embeddings', label: t('admin.accounts.openai.capabilityEmbeddings') },
+  { value: 'prompt_cache_retention', label: t('admin.accounts.openai.capabilityPromptCacheRetention') }
 ])
 const openAITextGenerationCapabilityEnabled = computed(() =>
   openAIEndpointCapabilities.value.includes('chat_completions')
@@ -3402,24 +3404,33 @@ const normalizeOpenAIEndpointCapabilities = (values: OpenAIEndpointCapability[])
 const readOpenAIEndpointCapabilities = (credentials?: Record<string, unknown>): OpenAIEndpointCapability[] => {
   const raw = credentials?.openai_capabilities
   if (Array.isArray(raw)) {
-    return normalizeOpenAIEndpointCapabilities(
+    const capabilities = normalizeOpenAIEndpointCapabilities(
       raw.filter((value): value is OpenAIEndpointCapability =>
-        value === 'chat_completions' || value === 'embeddings'
+        value === 'chat_completions' || value === 'embeddings' || value === 'prompt_cache_retention'
       )
     )
+    openAIPromptCacheRetentionSupported.value = raw.includes('prompt_cache_retention')
+    return capabilities
   }
   if (raw !== null && typeof raw === 'object') {
     const capabilityMap = raw as Record<string, unknown>
-    return normalizeOpenAIEndpointCapabilities(
+    const capabilities = normalizeOpenAIEndpointCapabilities(
       openAIEndpointCapabilityOptions.value
         .map((option) => option.value)
         .filter((value) => capabilityMap[value] === true)
     )
+    openAIPromptCacheRetentionSupported.value = capabilityMap.prompt_cache_retention === true
+    return capabilities
   }
+  openAIPromptCacheRetentionSupported.value = false
   return ['chat_completions', 'embeddings']
 }
 
 const toggleOpenAIEndpointCapability = (capability: OpenAIEndpointCapability, event?: Event) => {
+  if (capability === 'prompt_cache_retention') {
+    openAIPromptCacheRetentionSupported.value = !openAIPromptCacheRetentionSupported.value
+    return
+  }
   if (openAIEndpointCapabilities.value.includes(capability)) {
     if (openAIEndpointCapabilities.value.length <= 1) {
       const input = event?.target as HTMLInputElement | null
@@ -3442,11 +3453,13 @@ const toggleOpenAIEndpointCapability = (capability: OpenAIEndpointCapability, ev
 
 const applyOpenAIEndpointCapabilities = (credentials: Record<string, unknown>) => {
   const capabilities = normalizeOpenAIEndpointCapabilities(openAIEndpointCapabilities.value)
-  if (capabilities.length === 2) {
+  if (capabilities.length === 2 && !openAIPromptCacheRetentionSupported.value) {
     delete credentials.openai_capabilities
     return
   }
-  credentials.openai_capabilities = capabilities
+  credentials.openai_capabilities = openAIPromptCacheRetentionSupported.value
+    ? [...capabilities, 'prompt_cache_retention']
+    : capabilities
 }
 const normalizeOpenAIResponsesMode = (mode: unknown): OpenAIResponsesMode => {
   if (mode === 'force_responses' || mode === 'force_chat_completions') {
@@ -3706,6 +3719,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
+  openAIPromptCacheRetentionSupported.value = false
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -507,6 +507,18 @@ describe('BulkEditAccountModal', () => {
     })
   })
 
+  it('选择旧式 prompt_cache_retention 后批量提交 token', async () => {
+    const wrapper = mountModal({ selectedPlatforms: ['openai'], selectedTypes: ['apikey'] })
+    await wrapper.get('#bulk-edit-openai-endpoint-capabilities-enabled').setValue(true)
+    await wrapper.get('[data-testid="bulk-edit-openai-endpoint-capability-prompt_cache_retention"]').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      credentials: { openai_capabilities: ['chat_completions', 'embeddings', 'prompt_cache_retention'] }
+    })
+  })
+
   it('Responses 路由独立启用，auto 提交 null，强制模式提交明确值', async () => {
     const autoWrapper = mountModal({
       selectedPlatforms: ['openai'],

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -234,6 +234,22 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
 
     expect(createAccountMock).toHaveBeenCalledTimes(1)
     expect(createAccountMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBe(false)
+    expect(createAccountMock.mock.calls[0]?.[0]?.credentials).not.toHaveProperty('openai_capabilities')
+  })
+
+  it('submits prompt_cache_retention only when selected for an OpenAI API Key', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('[data-testid="openai-endpoint-capability-prompt_cache_retention"]').setValue(true)
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI account')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock.mock.calls[0]?.[0]?.credentials?.openai_capabilities).toContain(
+      'prompt_cache_retention'
+    )
   })
 
   // namespace 摊平是仅 OAuth 的兼容开关：API Key 走 chat completions 回退桥时由桥自行摊平

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -992,6 +992,28 @@ describe('EditAccountModal', () => {
     ])
   })
 
+  it('echoes and preserves the legacy prompt_cache_retention capability token', async () => {
+    const account = buildAccount()
+    account.credentials.openai_capabilities = ['chat_completions', 'prompt_cache_retention']
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const checkbox = wrapper.get<HTMLInputElement>(
+      '[data-testid="openai-endpoint-capability-prompt_cache_retention"]'
+    )
+    expect(checkbox.element.checked).toBe(true)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials?.openai_capabilities).toEqual([
+      'chat_completions',
+      'prompt_cache_retention'
+    ])
+  })
+
 	it('submits OpenAI quota auto-pause thresholds in extra', async () => {
 	  const account = buildAccount()
 	  account.extra = {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -597,6 +597,7 @@ export default {
         capabilityChatCompletions: 'Chat Completions',
         capabilityChatCompletionsAuto: 'Chat Completions (auto probe)',
         capabilityEmbeddings: 'Embeddings',
+        capabilityPromptCacheRetention: 'Upstream supports legacy prompt_cache_retention',
         responsesStatusAutoSupported: 'Auto probe: Responses',
         responsesStatusAutoUnsupported: 'Auto probe: Chat Completions',
         responsesStatusAutoUnknown: 'Auto probe: unknown',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -678,6 +678,7 @@ export default {
         capabilityChatCompletions: 'Chat Completions',
         capabilityChatCompletionsAuto: 'Chat Completions（自动探测）',
         capabilityEmbeddings: 'Embeddings',
+        capabilityPromptCacheRetention: '上游支持旧式 prompt_cache_retention',
         responsesStatusAutoSupported: '自动探测：Responses',
         responsesStatusAutoUnsupported: '自动探测：Chat Completions',
         responsesStatusAutoUnknown: '自动探测：未探测',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1406,7 +1406,7 @@ export interface CodexUsageSnapshot {
 
 export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'
 export type OpenAIResponsesMode = 'auto' | 'force_responses' | 'force_chat_completions'
-export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings'
+export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings' | 'prompt_cache_retention'
 
 export interface OpenAICompactState {
   openai_compact_mode?: OpenAICompactMode


### PR DESCRIPTION
## Background

Issue #5821 reports upstream rejections for `prompt_cache_retention`. The field cannot be globally stripped: legacy OpenAI models and GPT-5.6+ use different cache-control shapes, while OAuth/Codex, Grok, and unknown compatibility upstreams must not receive unsupported fields.

## What changed

### Field compatibility policy

The gateway now evaluates the **final mapped upstream model** at every Responses egress boundary. `prompt_cache_key` is never changed.

| Upstream/account condition | `prompt_cache_retention` | `prompt_cache_options` |
| --- | --- | --- |
| OpenAI API Key + explicit `prompt_cache_retention` capability + supported legacy model | Preserve | Strip |
| OpenAI API Key + GPT-5.6 or newer | Strip | Preserve client value |
| OAuth/Codex, Grok, unknown model, unsupported account, or missing capability | Strip | Strip |

The legacy allowlist is intentionally narrow and accepts only documented model families plus strict `YYYY-MM-DD` snapshots. GPT-5.6+ is parsed numerically with structured suffix validation, so arbitrary aliases are not mistaken for supported models.

### Account configuration

- Adds `prompt_cache_retention` to `credentials.openai_capabilities`.
- This is an explicit, default-deny opt-in for OpenAI API Key accounts using a legacy supported model.
- No database migration is required; existing accounts keep their previous filtering behavior.
- Adds the default-off setting to account create, edit, and bulk-edit UI.

### Request-path coverage

Applies the shared final-model sanitizer to:

- standard and passthrough HTTP Responses requests;
- Grok Responses and WebSocket HTTP bridge requests;
- raw WebSocket ingress;
- WebSocket passthrough initial and follow-up `response.create` frames;
- nested `session.update` fields, including frames that inherit the current mapped session model.

The HTTP hot paths keep raw request bytes unless one of the cache-control fields is actually present.

## Tests

- `go test -tags=unit ./internal/service -count=1`
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.spec.ts src/components/account/__tests__/EditAccountModal.spec.ts src/components/account/__tests__/BulkEditAccountModal.spec.ts`

The backend coverage includes legacy/token default-deny behavior, GPT-5.6+, OAuth/Grok/nil/unknown accounts, strict model suffixes, `prompt_cache_key` preservation, HTTP hot paths, WebSocket initial/follow-up frames, and session-model changes.

Fixes #5821