### PR TITLE
feat(payment): add Alipay refund status query

### DIFF
--- a/backend/internal/payment/provider/alipay.go
+++ b/backend/internal/payment/provider/alipay.go
@@ -22,9 +22,10 @@ const (
 
 // Alipay response constants.
 const (
-	alipayFundChangeYes    = "Y"
-	alipayErrTradeNotExist = "ACQ.TRADE_NOT_EXIST"
-	alipayRefundSuffix     = "-refund"
+	alipayFundChangeYes       = "Y"
+	alipayRefundStatusSuccess = "REFUND_SUCCESS"
+	alipayErrTradeNotExist    = "ACQ.TRADE_NOT_EXIST"
+	alipayRefundSuffix        = "-refund"
 )
 
 var (
@@ -36,6 +37,12 @@ var (
 	}
 	alipayTradePagePay = func(client *alipay.Client, param alipay.TradePagePay) (*url.URL, error) {
 		return client.TradePagePay(param)
+	}
+	alipayTradeRefund = func(ctx context.Context, client *alipay.Client, param alipay.TradeRefund) (*alipay.TradeRefundRsp, error) {
+		return client.TradeRefund(ctx, param)
+	}
+	alipayTradeFastPayRefundQuery = func(ctx context.Context, client *alipay.Client, param alipay.TradeFastPayRefundQuery) (*alipay.TradeFastPayRefundQueryRsp, error) {
+		return client.TradeFastPayRefundQuery(ctx, param)
 	}
 )
 
@@ -338,11 +345,12 @@ func (a *Alipay) Refund(ctx context.Context, req payment.RefundRequest) (*paymen
 		return nil, err
 	}
 
-	result, err := client.TradeRefund(ctx, alipay.TradeRefund{
+	outRequestNo := fmt.Sprintf("%s-refund-%d", req.OrderID, time.Now().UnixNano())
+	result, err := alipayTradeRefund(ctx, client, alipay.TradeRefund{
 		OutTradeNo:   req.OrderID,
 		RefundAmount: req.Amount,
 		RefundReason: req.Reason,
-		OutRequestNo: fmt.Sprintf("%s-refund-%d", req.OrderID, time.Now().UnixNano()),
+		OutRequestNo: outRequestNo,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("alipay TradeRefund: %w", err)
@@ -353,15 +361,69 @@ func (a *Alipay) Refund(ctx context.Context, req payment.RefundRequest) (*paymen
 		refundStatus = payment.ProviderStatusSuccess
 	}
 
-	refundID := result.TradeNo
-	if refundID == "" {
-		refundID = req.OrderID + alipayRefundSuffix
-	}
-
+	// Alipay refund queries identify a refund by the original out_request_no,
+	// not by the payment trade number. Preserve the exact request number so a
+	// pending refund can be queried later.
 	return &payment.RefundResponse{
-		RefundID: refundID,
+		RefundID: outRequestNo,
 		Status:   refundStatus,
 	}, nil
+}
+
+// QueryRefund queries the status of a previously requested Alipay refund.
+func (a *Alipay) QueryRefund(ctx context.Context, req payment.RefundQueryRequest) (*payment.RefundResponse, error) {
+	client, err := a.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	refundID := strings.TrimSpace(req.RefundID)
+	if refundID == "" {
+		if orderID := strings.TrimSpace(req.OrderID); orderID != "" {
+			refundID = orderID + alipayRefundSuffix
+		}
+	}
+	if refundID == "" {
+		return nil, fmt.Errorf("alipay query refund: missing refund request number")
+	}
+
+	param := alipay.TradeFastPayRefundQuery{
+		OutRequestNo: refundID,
+	}
+	// Alipay accepts either the merchant order number or the Alipay trade
+	// number. Prefer the latter when it is available because it is immutable
+	// across merchant-side order identifiers.
+	if tradeNo := strings.TrimSpace(req.TradeNo); tradeNo != "" {
+		param.TradeNo = tradeNo
+	} else if orderID := strings.TrimSpace(req.OrderID); orderID != "" {
+		param.OutTradeNo = orderID
+	} else {
+		return nil, fmt.Errorf("alipay query refund: missing trade number")
+	}
+
+	result, err := alipayTradeFastPayRefundQuery(ctx, client, param)
+	if err != nil {
+		return nil, fmt.Errorf("alipay TradeFastPayRefundQuery: %w", err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("alipay TradeFastPayRefundQuery: empty response")
+	}
+	if result.Code != "" && result.IsFailure() {
+		return nil, fmt.Errorf("alipay TradeFastPayRefundQuery: %w", result.Error)
+	}
+
+	status := payment.ProviderStatusPending
+	switch strings.ToUpper(strings.TrimSpace(result.RefundStatus)) {
+	case alipayRefundStatusSuccess:
+		status = payment.ProviderStatusSuccess
+	case "REFUND_FAILED", "REFUND_CLOSED":
+		status = payment.ProviderStatusFailed
+	}
+
+	if queriedRefundID := strings.TrimSpace(result.OutRequestNo); queriedRefundID != "" {
+		refundID = queriedRefundID
+	}
+	return &payment.RefundResponse{RefundID: refundID, Status: status}, nil
 }
 
 // CancelPayment closes a pending trade on Alipay.
@@ -405,6 +467,7 @@ func parseAlipayAmount(values ...string) (float64, error) {
 // Ensure interface compliance.
 var (
 	_ payment.Provider                 = (*Alipay)(nil)
+	_ payment.RefundQueryProvider      = (*Alipay)(nil)
 	_ payment.CancelableProvider       = (*Alipay)(nil)
 	_ payment.MerchantIdentityProvider = (*Alipay)(nil)
 )

--- a/backend/internal/payment/provider/alipay_test.go
+++ b/backend/internal/payment/provider/alipay_test.go
@@ -414,6 +414,106 @@ func TestCreateTradeUsesPrecreateForDesktopWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestAlipayRefundReturnsRequestNumberForLaterQueries(t *testing.T) {
+	origRefund := alipayTradeRefund
+	t.Cleanup(func() { alipayTradeRefund = origRefund })
+
+	var gotParam alipay.TradeRefund
+	alipayTradeRefund = func(_ context.Context, _ *alipay.Client, param alipay.TradeRefund) (*alipay.TradeRefundRsp, error) {
+		gotParam = param
+		return &alipay.TradeRefundRsp{FundChange: "N"}, nil
+	}
+
+	provider := &Alipay{client: &alipay.Client{}}
+	resp, err := provider.Refund(context.Background(), payment.RefundRequest{
+		OrderID: "sub2_refund_request",
+		Amount:  "10.00",
+		Reason:  "customer request",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(gotParam.OutRequestNo, "sub2_refund_request-refund-") {
+		t.Fatalf("out_request_no = %q, want generated request number", gotParam.OutRequestNo)
+	}
+	if resp.RefundID != gotParam.OutRequestNo {
+		t.Fatalf("refund_id = %q, want out_request_no %q", resp.RefundID, gotParam.OutRequestNo)
+	}
+	if resp.Status != payment.ProviderStatusPending {
+		t.Fatalf("status = %q, want pending", resp.Status)
+	}
+}
+
+func TestAlipayQueryRefund(t *testing.T) {
+	tests := []struct {
+		name         string
+		refundStatus string
+		wantStatus   string
+	}{
+		{name: "success", refundStatus: "REFUND_SUCCESS", wantStatus: payment.ProviderStatusSuccess},
+		{name: "failed", refundStatus: "REFUND_FAILED", wantStatus: payment.ProviderStatusFailed},
+		{name: "pending when status is absent", refundStatus: "", wantStatus: payment.ProviderStatusPending},
+		{name: "unknown status remains pending", refundStatus: "REFUND_PROCESSING", wantStatus: payment.ProviderStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origQuery := alipayTradeFastPayRefundQuery
+			t.Cleanup(func() { alipayTradeFastPayRefundQuery = origQuery })
+
+			var gotParam alipay.TradeFastPayRefundQuery
+			alipayTradeFastPayRefundQuery = func(_ context.Context, _ *alipay.Client, param alipay.TradeFastPayRefundQuery) (*alipay.TradeFastPayRefundQueryRsp, error) {
+				gotParam = param
+				return &alipay.TradeFastPayRefundQueryRsp{
+					Error:        alipay.Error{Code: alipay.CodeSuccess},
+					OutRequestNo: "refund-request-123",
+					RefundStatus: tt.refundStatus,
+				}, nil
+			}
+
+			provider := &Alipay{client: &alipay.Client{}}
+			resp, err := provider.QueryRefund(context.Background(), payment.RefundQueryRequest{
+				TradeNo:  "2026082022001425151434353291",
+				OrderID:  "sub2_20260820uUvtfx1F",
+				RefundID: "refund-request-123",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotParam.TradeNo != "2026082022001425151434353291" || gotParam.OutTradeNo != "" {
+				t.Fatalf("trade identifiers = trade_no %q, out_trade_no %q", gotParam.TradeNo, gotParam.OutTradeNo)
+			}
+			if gotParam.OutRequestNo != "refund-request-123" {
+				t.Fatalf("out_request_no = %q, want %q", gotParam.OutRequestNo, "refund-request-123")
+			}
+			if resp.RefundID != "refund-request-123" {
+				t.Fatalf("refund_id = %q, want %q", resp.RefundID, "refund-request-123")
+			}
+			if resp.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", resp.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAlipayQueryRefundReturnsUpstreamErrors(t *testing.T) {
+	origQuery := alipayTradeFastPayRefundQuery
+	t.Cleanup(func() { alipayTradeFastPayRefundQuery = origQuery })
+
+	alipayTradeFastPayRefundQuery = func(context.Context, *alipay.Client, alipay.TradeFastPayRefundQuery) (*alipay.TradeFastPayRefundQueryRsp, error) {
+		return nil, errors.New("gateway unavailable")
+	}
+
+	provider := &Alipay{client: &alipay.Client{}}
+	_, err := provider.QueryRefund(context.Background(), payment.RefundQueryRequest{
+		TradeNo:  "alipay-trade-123",
+		RefundID: "refund-request-123",
+	})
+	if err == nil || !strings.Contains(err.Error(), "alipay TradeFastPayRefundQuery: gateway unavailable") {
+		t.Fatalf("error = %v, want wrapped upstream error", err)
+	}
+}
+
 func TestAlipayMerchantIdentityMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add Alipay refund status query via `alipay.trade.fastpay.refund.query`
- preserve the generated `out_request_no` in `RefundResponse.RefundID` so pending refunds can be queried later
- map Alipay refund statuses to the provider status values and cover upstream error handling

## Tests
- `go test -tags=unit ./internal/payment/provider`
- `git diff --cached --check`

Only the following files are included in this PR:
- `backend/internal/payment/provider/alipay.go`
- `backend/internal/payment/provider/alipay_test.go`
