### PR TITLE
fix(openai): gate Responses optional fields by official host

### DIFF
--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -443,13 +443,12 @@ func openAIAlphaSearchInboundHeader(c *gin.Context, key string) string {
 	return strings.TrimSpace(c.GetHeader(key))
 }
 
-var openAIAlphaSearchUnsupportedBodyFields = [...]string{
+var openAIAlphaSearchUnsupportedBodyFields = append([]string{
 	// Codex alpha/search 是 SearchRequest 独立协议，不是 /responses 子请求。
 	// 新版 Codex/第三方代理可能把 Responses 公共字段误带到搜索请求里；ChatGPT
 	// alpha/search 会对这些字段返回 Unknown parameter（例如 prompt_cache_key）。
 	"prompt_cache_key",
-	"prompt_cache_retention",
-}
+}, openAIResponsesOptionalFields...)
 
 func sanitizeOpenAIAlphaSearchBody(body []byte) ([]byte, error) {
 	if len(body) == 0 {

--- a/backend/internal/service/openai_alpha_search_test.go
+++ b/backend/internal/service/openai_alpha_search_test.go
@@ -101,7 +101,9 @@ func TestForwardAlphaSearchPATUsesResponsesWebSearchFallback(t *testing.T) {
 		"model":"gpt-5.6-sol",
 		"commands":{"search_query":[{"q":"OpenAI news"}]},
 		"prompt_cache_key":"responses-cache-key",
-		"prompt_cache_retention":"24h"
+		"prompt_cache_retention":"24h",
+		"safety_identifier":"sid",
+		"prompt_cache_options":{"ttl":"30m"}
 	}`)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -163,11 +165,26 @@ func TestForwardAlphaSearchPATUsesResponsesWebSearchFallback(t *testing.T) {
 	require.Empty(t, upstream.lastReq.Header.Get("Accept-Language"))
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_retention").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "safety_identifier").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_options").Exists())
 	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Bool())
 	require.Equal(t, "web_search", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
 	require.Contains(t, gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String(), `"search_query"`)
+}
+
+func TestSanitizeOpenAIAlphaSearchBodyStripsResponsesOptionalFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","prompt_cache_key":"cache-key","prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"commands":{}}`)
+
+	sanitized, err := sanitizeOpenAIAlphaSearchBody(body)
+
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(sanitized, "prompt_cache_key").Exists())
+	for _, field := range openAIResponsesOptionalFields {
+		require.False(t, gjson.GetBytes(sanitized, field).Exists(), field)
+	}
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(sanitized, "model").String())
 }
 
 func TestForwardAlphaSearchPATBackfillsMissingChatGPTAccountMetadata(t *testing.T) {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -123,13 +123,11 @@ const (
 	codexSparkImageUnsupportedText   = codexSparkImageUnsupportedMarker + "\nThe current model is gpt-5.3-codex-spark, which does not support image generation, image editing, image input, the `image_generation` tool, or Codex `image_gen`/`$imagegen` workflows. If the user asks for image generation or image editing, clearly explain this model limitation and ask them to switch to a non-Spark Codex model such as gpt-5.3-codex or gpt-5.4. Do not claim that the local environment merely lacks image_gen tooling, and do not suggest CLI fallback as the primary fix while the model remains Spark.\n</sub2api-codex-spark-image-unsupported>"
 )
 
-var openAIChatGPTInternalUnsupportedFields = []string{
+var openAIChatGPTInternalUnsupportedFields = append([]string{
 	"user",
 	"metadata",
-	"prompt_cache_retention",
-	"safety_identifier",
 	"stream_options",
-}
+}, openAIResponsesOptionalFields...)
 
 var openAICodexOAuthUnsupportedFields = append([]string{
 	"max_output_tokens",

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1655,6 +1655,7 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 		"metadata":               map[string]any{"trace_id": "abc"},
 		"prompt_cache_retention": "24h",
 		"safety_identifier":      "sid",
+		"prompt_cache_options":   map[string]any{"ttl": "30m"},
 		"stream_options":         map[string]any{"include_usage": true},
 		"input": []any{
 			map[string]any{"role": "user", "content": "hi"},
@@ -1667,6 +1668,7 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 	for _, field := range openAIChatGPTInternalUnsupportedFields {
 		require.NotContains(t, reqBody, field)
 	}
+	require.NotContains(t, reqBody, "prompt_cache_options")
 }
 
 func TestApplyCodexOAuthTransform_ExtractsSystemMessages(t *testing.T) {

--- a/backend/internal/service/openai_cursor_warmup_pipeline_test.go
+++ b/backend/internal/service/openai_cursor_warmup_pipeline_test.go
@@ -154,46 +154,47 @@ func TestCursorMixedShape_JSONRoundtrip(t *testing.T) {
 	require.Len(t, inputArr, 1)
 }
 
-// TestCursorMixedShape_StripsUnsupportedFields mirrors the strip loop in
-// ForwardAsChatCompletions (isResponsesShape branch). Cursor cloud sends
-// prompt_cache_retention, safety_identifier, metadata and stream_options
-// as top-level Responses API parameters, which Codex upstreams reject with
-// "Unsupported parameter: ...". The fix must remove them from the raw body
-// before it is forwarded, for BOTH OAuth and API Key account types.
-func TestCursorMixedShape_StripsUnsupportedFields(t *testing.T) {
+func TestSanitizeCursorResponsesShapeBodyUsesOfficialHostPolicy(t *testing.T) {
 	cursorBody := []byte(`{
 		"model": "gpt-5.4",
 		"stream": true,
 		"prompt_cache_retention": "24h",
 		"safety_identifier": "cursor-user-xyz",
+		"prompt_cache_options": {"ttl":"30m"},
 		"metadata": {"trace_id":"abc","caller":"cursor"},
 		"stream_options": {"include_usage": true},
 		"input": [{"role":"user","content":"hi"}]
 	}`)
-
-	// Sanity: the test fixture contains every field the production code strips.
-	for _, field := range cursorResponsesUnsupportedFields {
-		require.True(t, gjson.GetBytes(cursorBody, field).Exists(),
-			"test fixture must contain %s", field)
+	tests := []struct {
+		name             string
+		account          *Account
+		preserveOfficial bool
+	}{
+		{
+			name:             "official OpenAI API key",
+			account:          &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+			preserveOfficial: true,
+		},
+		{
+			name: "custom compatible API key",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"base_url": "https://compat.example/v1",
+			}},
+			preserveOfficial: false,
+		},
 	}
 
-	// Run the exact same loop as the production code.
-	result := cursorBody
-	for _, field := range cursorResponsesUnsupportedFields {
-		if stripped, err := sjson.DeleteBytes(result, field); err == nil {
-			result = stripped
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sanitizeCursorResponsesShapeBody(tt.account, cursorBody)
+			require.NoError(t, err)
+			for _, field := range openAIResponsesOptionalFields {
+				require.Equal(t, tt.preserveOfficial, gjson.GetBytes(result, field).Exists(), field)
+			}
+			require.Equal(t, tt.preserveOfficial, gjson.GetBytes(result, "metadata").Exists())
+			require.False(t, gjson.GetBytes(result, "stream_options").Exists())
+			require.Equal(t, "gpt-5.4", gjson.GetBytes(result, "model").String())
+			require.True(t, gjson.GetBytes(result, "input").IsArray())
+		})
 	}
-
-	// All unsupported fields must be gone.
-	for _, field := range cursorResponsesUnsupportedFields {
-		assert.False(t, gjson.GetBytes(result, field).Exists(),
-			"%s must be stripped", field)
-	}
-
-	// Everything else must survive intact.
-	assert.Equal(t, "gpt-5.4", gjson.GetBytes(result, "model").String())
-	assert.Equal(t, true, gjson.GetBytes(result, "stream").Bool())
-	assert.True(t, gjson.GetBytes(result, "input").IsArray())
-	assert.Equal(t, "user", gjson.GetBytes(result, "input.0.role").String())
 }

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -27,14 +27,33 @@ import (
 // short-circuit in ForwardAsChatCompletions (see isResponsesShape branch).
 // The normal Chat Completions → Responses conversion path is unaffected
 // because ChatCompletionsRequest has no fields for these parameters — unknown
-// fields are dropped naturally by json.Unmarshal. Kept semantically in sync
-// with the list in openai_gateway_service.go:2034 used by the /v1/responses
-// passthrough path.
-var cursorResponsesUnsupportedFields = []string{
-	"prompt_cache_retention",
-	"safety_identifier",
+// fields are dropped naturally by json.Unmarshal.
+var cursorResponsesUnsupportedFields = append([]string{
 	"metadata",
 	"stream_options",
+}, openAIResponsesOptionalFields...)
+
+var cursorOfficialOpenAIResponsesUnsupportedFields = []string{
+	"stream_options",
+}
+
+func sanitizeCursorResponsesShapeBody(account *Account, body []byte) ([]byte, error) {
+	fields := cursorResponsesUnsupportedFields
+	if shouldPreserveOpenAIResponsesOptionalFields(account) {
+		fields = cursorOfficialOpenAIResponsesUnsupportedFields
+	}
+	out := body
+	for _, field := range fields {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
+		stripped, err := sjson.DeleteBytes(out, field)
+		if err != nil {
+			return body, fmt.Errorf("strip Cursor Responses field %s: %w", field, err)
+		}
+		out = stripped
+	}
+	return out, nil
 }
 
 // ForwardAsChatCompletions accepts a Chat Completions request body, converts it
@@ -179,15 +198,12 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		if err != nil {
 			return nil, fmt.Errorf("rewrite model in responses-shape body: %w", err)
 		}
-		// Strip Responses API parameters that no Codex upstream accepts.
-		// Because this branch forwards the raw body (the normal path rebuilds
-		// it from ChatCompletionsRequest and drops unknown fields naturally),
-		// we must filter these fields explicitly here — otherwise the upstream
-		// rejects the request with "Unsupported parameter: ...".
-		for _, field := range cursorResponsesUnsupportedFields {
-			if stripped, derr := sjson.DeleteBytes(responsesBody, field); derr == nil {
-				responsesBody = stripped
-			}
+		// The raw Responses-shaped body bypasses struct conversion. Preserve
+		// official Responses fields only for the official Platform API; internal
+		// and compatible upstreams keep the stricter unsupported-field filter.
+		responsesBody, err = sanitizeCursorResponsesShapeBody(account, responsesBody)
+		if err != nil {
+			return nil, err
 		}
 		responsesBody, normalizedServiceTier, err := normalizeResponsesBodyServiceTier(responsesBody)
 		if err != nil {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -20,6 +20,11 @@ import (
 // Forward forwards request to OpenAI API
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	filteredBody, filterErr := filterOpenAIResponsesOptionalFieldsForAccount(account, body)
+	if filterErr != nil {
+		return nil, filterErr
+	}
+	body = filteredBody
 	clearGrokResponsesClientToolMapping(c)
 	clearOpenAIResponsesClientToolMapping(c)
 	clearOpenAIResponsesNamespaceNames(c)
@@ -494,11 +499,6 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		if gjson.GetBytes(body, "max_completion_tokens").Exists() && (account.Type == AccountTypeAPIKey || account.Platform != PlatformOpenAI) {
 			markPatchDelete("max_completion_tokens")
-		}
-		for _, unsupportedField := range []string{"prompt_cache_retention", "safety_identifier", "prompt_cache_options"} {
-			if gjson.GetBytes(body, unsupportedField).Exists() {
-				markPatchDelete(unsupportedField)
-			}
 		}
 	}
 	if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 && gjson.GetBytes(body, "previous_response_id").Exists() {

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -455,7 +455,7 @@ func patchGrokResponsesBodyBase(body []byte, upstreamModel string) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	for _, unsupportedField := range []string{"prompt_cache_retention", "safety_identifier"} {
+	for _, unsupportedField := range openAIResponsesOptionalFields {
 		if gjson.GetBytes(out, unsupportedField).Exists() {
 			out, err = sjson.DeleteBytes(out, unsupportedField)
 			if err != nil {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -31,6 +31,7 @@ func TestPatchGrokResponsesBodySetsMappedModelAndDropsUnsupportedFields(t *testi
 		"input": "hello",
 		"prompt_cache_retention": "24h",
 		"safety_identifier": "user-1",
+		"prompt_cache_options": {"ttl":"30m"},
 		"reasoning": {"effort": "high"}
 	}`)
 
@@ -40,6 +41,7 @@ func TestPatchGrokResponsesBodySetsMappedModelAndDropsUnsupportedFields(t *testi
 	require.Equal(t, "grok-4.3", gjson.GetBytes(patched, "model").String())
 	require.False(t, gjson.GetBytes(patched, "prompt_cache_retention").Exists())
 	require.False(t, gjson.GetBytes(patched, "safety_identifier").Exists())
+	require.False(t, gjson.GetBytes(patched, "prompt_cache_options").Exists())
 	require.Equal(t, "high", gjson.GetBytes(patched, "reasoning.effort").String())
 }
 

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -55,6 +55,56 @@ func buildOpenAIResponsesURLForPlatform(platform string, base string) string {
 	return buildOpenAIResponsesURL(base)
 }
 
+// openAIResponsesOptionalFields are valid top-level OpenAI Responses fields
+// that some compatible or internal upstreams do not implement.
+var openAIResponsesOptionalFields = []string{
+	"prompt_cache_retention",
+	"safety_identifier",
+	"prompt_cache_options",
+}
+
+func stripOpenAIResponsesOptionalFields(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	out := body
+	for _, field := range openAIResponsesOptionalFields {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
+		next, err := sjson.DeleteBytes(out, field)
+		if err != nil {
+			return body, fmt.Errorf("strip %s: %w", field, err)
+		}
+		out = next
+	}
+	return out, nil
+}
+
+func deleteOpenAIResponsesOptionalFieldsFromObject(body map[string]any) {
+	if body == nil {
+		return
+	}
+	for _, field := range openAIResponsesOptionalFields {
+		delete(body, field)
+	}
+}
+
+func shouldPreserveOpenAIResponsesOptionalFields(account *Account) bool {
+	if account == nil || !account.IsOpenAIApiKey() {
+		return false
+	}
+	baseURL := strings.TrimSpace(account.GetCredential("base_url"))
+	return baseURL == "" || isOfficialOpenAIModelsBaseURL(baseURL)
+}
+
+func filterOpenAIResponsesOptionalFieldsForAccount(account *Account, body []byte) ([]byte, error) {
+	if shouldPreserveOpenAIResponsesOptionalFields(account) {
+		return body, nil
+	}
+	return stripOpenAIResponsesOptionalFields(body)
+}
+
 // normalizeDeepSeekResponsesRequestBody 适配 DeepSeek 无状态 Responses 端点：
 // 强制 store=false 并清除 previous_response_id（官方 /responses 不支持服务端
 // 状态存储，携带这些字段会被拒绝）。非 deepseek responses 协议账号原样返回。

--- a/backend/internal/service/openai_gateway_request_body_reasoning_test.go
+++ b/backend/internal/service/openai_gateway_request_body_reasoning_test.go
@@ -199,3 +199,69 @@ func TestTrimOpenAIEncryptedReasoningItems_ContentNullDropsBareSkeleton(t *testi
 	_, hasInput := reqBody["input"]
 	assert.False(t, hasInput, "bare reasoning skeleton should be dropped, emptying input")
 }
+
+func TestStripOpenAIResponsesOptionalFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"input":"hi"}`)
+	stripped, err := stripOpenAIResponsesOptionalFields(body)
+	require.NoError(t, err)
+	for _, field := range openAIResponsesOptionalFields {
+		require.False(t, gjson.GetBytes(stripped, field).Exists(), field)
+	}
+	require.Equal(t, "gpt-5.4", gjson.GetBytes(stripped, "model").String())
+	require.Equal(t, "hi", gjson.GetBytes(stripped, "input").String())
+
+	unchanged, err := stripOpenAIResponsesOptionalFields([]byte(`{"model":"gpt-5.4","input":"hi"}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"model":"gpt-5.4","input":"hi"}`, string(unchanged))
+}
+
+func TestShouldPreserveOpenAIResponsesOptionalFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name:    "official OpenAI API key",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+			want:    true,
+		},
+		{
+			name: "explicit official OpenAI API key endpoint",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"base_url": "https://api.openai.com/v1",
+			}},
+			want: true,
+		},
+		{
+			name: "custom OpenAI-compatible API key endpoint",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"base_url": "https://example.com/v1",
+			}},
+			want: false,
+		},
+		{
+			name: "OpenAI lookalike host",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"base_url": "https://api.openai.com.example/v1",
+			}},
+			want: false,
+		},
+		{
+			name:    "OpenAI OAuth internal endpoint",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+			want:    false,
+		},
+		{name: "Grok API key", account: &Account{Platform: PlatformGrok, Type: AccountTypeAPIKey}, want: false},
+		{name: "Kimi API key", account: &Account{Platform: PlatformKimi, Type: AccountTypeAPIKey}, want: false},
+		{name: "Zhipu API key", account: &Account{Platform: PlatformZhipu, Type: AccountTypeAPIKey}, want: false},
+		{name: "DeepSeek API key", account: &Account{Platform: PlatformDeepseek, Type: AccountTypeAPIKey}, want: false},
+		{name: "missing account", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldPreserveOpenAIResponsesOptionalFields(tt.account))
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -238,6 +238,71 @@ func TestOpenAIGatewayService_Forward_NormalizesMaxTokensAndStripsPromptCacheOpt
 	})
 }
 
+func TestOpenAIGatewayService_Forward_FiltersResponsesOptionalFieldsByOfficialHost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name          string
+		baseURL       string
+		codexClient   bool
+		preserveField bool
+	}{
+		{
+			name:          "official OpenAI endpoint preserves fields for regular clients",
+			preserveField: true,
+		},
+		{
+			name:          "custom compatible endpoint strips fields for Codex clients",
+			baseURL:       "https://compat.example/v1",
+			codexClient:   true,
+			preserveField: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+			}}
+			cfg := &config.Config{}
+			cfg.Security.URLAllowlist.Enabled = false
+			svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+			credentials := map[string]any{"api_key": "sk-test"}
+			if tt.baseURL != "" {
+				credentials["base_url"] = tt.baseURL
+			}
+			account := &Account{
+				ID:          41,
+				Name:        "openai-apikey",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: credentials,
+				Extra:       map[string]any{"openai_responses_supported": true},
+			}
+			body := []byte(`{"model":"gpt-5.4","stream":false,"prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"input":"hi"}`)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			if tt.codexClient {
+				c.Request.Header.Set("User-Agent", codexCLIUserAgent)
+				c.Request.Header.Set("Originator", "codex_cli_rs")
+			}
+			SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, upstream.bodies, 1)
+			for _, field := range []string{"prompt_cache_retention", "safety_identifier", "prompt_cache_options"} {
+				require.Equal(t, tt.preserveField, gjson.GetBytes(upstream.bodies[0], field).Exists(), field)
+			}
+		})
+	}
+}
+
 func TestOpenAIGatewayService_Forward_MappedImageModelUsesImageGate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	upstream := &httpUpstreamRecorder{

--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -16,7 +16,7 @@ const maxOpenAIResponsesRejectedFieldRetries = 6
 
 var (
 	openAIResponsesRejectedNamespaceParamPattern = regexp.MustCompile(`(?i)^input\[(\d+)\]\.namespace$`)
-	openAIResponsesRejectedMessageParamPattern   = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|input\[\d+\]\.namespace)(?:["']|\b)`)
+	openAIResponsesRejectedMessageParamPattern   = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|prompt_cache_retention|safety_identifier|prompt_cache_options|input\[\d+\]\.namespace)(?:["']|\b)`)
 )
 
 type openAIResponsesRejectedFieldRetryState struct {
@@ -62,13 +62,17 @@ func normalizeOpenAIResponsesRejectedFieldRetryBody(statusCode int, body, respon
 
 	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(responseBody)))
 	message := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(responseBody)))
-	if !isExplicitOpenAIResponsesFieldRejection(code, message) {
+	param := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.param").String()))
+	optionalField := openAIResponsesRejectedOptionalField(param, message)
+	modelUnsupported := optionalField != "" && strings.Contains(message, optionalField+" is not supported")
+	if !isExplicitOpenAIResponsesFieldRejection(code, message) && !modelUnsupported {
 		return nil, "", false, nil
 	}
-
-	param := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.param").String()))
 	if param == "" {
 		param = openAIResponsesRejectedParamFromMessage(message)
+	}
+	if optionalField == "" {
+		optionalField = openAIResponsesRejectedOptionalField(param, message)
 	}
 	if index, ok := openAIResponsesRejectedNamespaceIndex(param); ok {
 		return removeOpenAIResponsesRejectedNamespaceAtIndex(body, index)
@@ -79,6 +83,13 @@ func normalizeOpenAIResponsesRejectedFieldRetryBody(statusCode int, body, respon
 			return nil, "", false, fmt.Errorf("delete rejected max_output_tokens: %w", err)
 		}
 		return retryBody, "max_output_tokens parameter rejection", true, nil
+	}
+	if optionalField != "" && gjson.GetBytes(body, optionalField).Exists() {
+		retryBody, err := sjson.DeleteBytes(body, optionalField)
+		if err != nil {
+			return nil, "", false, fmt.Errorf("delete rejected %s: %w", optionalField, err)
+		}
+		return retryBody, optionalField + " parameter rejection", true, nil
 	}
 	return nil, "", false, nil
 }
@@ -98,6 +109,20 @@ func openAIResponsesRejectedParamFromMessage(message string) string {
 		return ""
 	}
 	return strings.ToLower(strings.TrimSpace(match[1]))
+}
+
+func openAIResponsesRejectedOptionalField(param, message string) string {
+	for _, field := range openAIResponsesOptionalFields {
+		if param == field {
+			return field
+		}
+		if strings.Contains(message, field+" is not supported") ||
+			strings.Contains(message, "unsupported parameter: "+field) ||
+			strings.Contains(message, "unknown parameter: "+field) {
+			return field
+		}
+	}
+	return ""
 }
 
 func openAIResponsesRejectedNamespaceIndex(param string) (int, bool) {

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -114,6 +114,59 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyBindsMaxOutputTokensToRej
 	require.False(t, gjson.GetBytes(retryBody, "max_output_tokens").Exists())
 }
 
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyStripsRejectedOptionalField(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","prompt_cache_retention":"24h","safety_identifier":"sid","input":[{"type":"message","content":{"prompt_cache_retention":"keep"}}]}`)
+	responseBody := []byte(`{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model","param":"prompt_cache_retention","type":"invalid_request_error"}}`)
+
+	retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Contains(t, reason, "prompt_cache_retention")
+	require.False(t, gjson.GetBytes(retryBody, "prompt_cache_retention").Exists())
+	require.Equal(t, "sid", gjson.GetBytes(retryBody, "safety_identifier").String())
+	require.Equal(t, "keep", gjson.GetBytes(retryBody, "input.0.content.prompt_cache_retention").String())
+}
+
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyIgnoresOtherModelUnsupportedFields(t *testing.T) {
+	body := []byte(`{"temperature":0.2,"prompt_cache_retention":"24h"}`)
+	responseBody := []byte(`{"error":{"message":"temperature is not supported on this model","param":"temperature","type":"invalid_request_error"}}`)
+
+	retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, retryBody)
+}
+
+func TestOpenAIGatewayService_OfficialResponsesEndpointRetriesRejectedOptionalField(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"input":"hello"}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"invalid_parameter","message":"prompt_cache_retention is not supported on this model","param":"prompt_cache_retention","type":"invalid_request_error"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Name = "official-openai"
+	delete(account.Credentials, "base_url")
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		newOpenAIRejectedFieldTestContext(body),
+		account,
+		body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "24h", gjson.GetBytes(upstream.bodies[0], "prompt_cache_retention").String())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_retention").Exists())
+	for _, forwardedBody := range upstream.bodies {
+		require.Equal(t, "sid", gjson.GetBytes(forwardedBody, "safety_identifier").String())
+		require.Equal(t, "30m", gjson.GetBytes(forwardedBody, "prompt_cache_options.ttl").String())
+	}
+}
+
 func TestOpenAIGatewayService_APIKeyStripsAllIndexedNamespacesBeforeFirstForward(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","name":"first","namespace":"remove-first","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove-second","input":"{}"}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -393,6 +393,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			)
 		}
 		normalized = policyApplied
+		filteredFields, filterFieldsErr := filterOpenAIResponsesOptionalFieldsForAccount(account, normalized)
+		if filterFieldsErr != nil {
+			return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", filterFieldsErr)
+		}
+		normalized = filteredFields
 		ingressSessionOriginalModel = originalModel
 
 		return openAIWSClientPayload{

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -958,6 +958,23 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_DedicatedModeDoe
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeRelaysByCaddyAdapter(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseURL    string
+		wantFields bool
+	}{
+		{name: "official OpenAI endpoint", wantFields: true},
+		{name: "custom OpenAI-compatible endpoint", baseURL: "https://compat.example/v1", wantFields: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testOpenAIResponsesWebSocketPassthroughOptionalFields(t, tt.baseURL, tt.wantFields)
+		})
+	}
+}
+
+func testOpenAIResponsesWebSocketPassthroughOptionalFields(t *testing.T, baseURL string, wantFields bool) {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -988,6 +1005,10 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeR
 		openaiWSPassthroughDialer: captureDialer,
 	}
 
+	credentials := map[string]any{"api_key": "sk-test"}
+	if baseURL != "" {
+		credentials["base_url"] = baseURL
+	}
 	account := &Account{
 		ID:          452,
 		Name:        "openai-ingress-passthrough",
@@ -996,9 +1017,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeR
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
-		Credentials: map[string]any{
-			"api_key": "sk-test",
-		},
+		Credentials: credentials,
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_mode": OpenAIWSIngressModePassthrough,
 		},
@@ -1058,7 +1077,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeR
 	}()
 
 	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
-	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"service_tier":"fast","reasoning":{"effort":"HIGH"}}`))
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"service_tier":"fast","prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"reasoning":{"effort":"HIGH"}}`))
 	cancelWrite()
 	require.NoError(t, err)
 
@@ -1099,6 +1118,16 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeR
 
 	require.Equal(t, 1, captureDialer.DialCount(), "passthrough 模式应直接建立上游 websocket")
 	require.Len(t, upstreamConn.writes, 1, "passthrough 模式应透传首条 response.create")
+	forwarded := requestToJSONString(upstreamConn.writes[0])
+	if wantFields {
+		require.Equal(t, "24h", gjson.Get(forwarded, "prompt_cache_retention").String())
+		require.Equal(t, "sid", gjson.Get(forwarded, "safety_identifier").String())
+		require.Equal(t, "30m", gjson.Get(forwarded, "prompt_cache_options.ttl").String())
+		return
+	}
+	require.False(t, gjson.Get(forwarded, "prompt_cache_retention").Exists())
+	require.False(t, gjson.Get(forwarded, "safety_identifier").Exists())
+	require.False(t, gjson.Get(forwarded, "prompt_cache_options").Exists())
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughHeadersUsePromptCacheAndTurnState(t *testing.T) {

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -115,7 +115,7 @@ func (s *OpenAIGatewayService) shouldBridgeOpenAIWSHTTP(account *Account, payloa
 	return threshold > 0 && int64(payloadBytes) >= threshold
 }
 
-func prepareOpenAIWSHTTPBridgeBody(payload []byte) ([]byte, error) {
+func prepareOpenAIWSHTTPBridgeBody(account *Account, payload []byte) ([]byte, error) {
 	var body map[string]any
 	if err := json.Unmarshal(payload, &body); err != nil {
 		return nil, err
@@ -126,6 +126,9 @@ func prepareOpenAIWSHTTPBridgeBody(payload []byte) ([]byte, error) {
 	delete(body, "type")
 	delete(body, "generate")
 	delete(body, "previous_response_id")
+	if !shouldPreserveOpenAIResponsesOptionalFields(account) {
+		deleteOpenAIResponsesOptionalFieldsFromObject(body)
+	}
 	body["stream"] = true
 	return json.Marshal(body)
 }
@@ -268,7 +271,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 	}
 	responseModelObserver := &upstreamResponseModelObserver{}
 
-	body, err := prepareOpenAIWSHTTPBridgeBody(payload)
+	body, err := prepareOpenAIWSHTTPBridgeBody(account, payload)
 	if err != nil {
 		return nil, fmt.Errorf("prepare http bridge body: %w", err)
 	}
@@ -675,7 +678,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 }
 
 func resolveGrokWSCacheIdentity(c *gin.Context, account *Account, seedPayload, currentPayload []byte, originalModel string) (string, error) {
-	body, err := prepareOpenAIWSHTTPBridgeBody(seedPayload)
+	body, err := prepareOpenAIWSHTTPBridgeBody(account, seedPayload)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/service/openai_ws_http_bridge_test.go
+++ b/backend/internal/service/openai_ws_http_bridge_test.go
@@ -31,14 +31,49 @@ func TestResolveOpenAIWSClientFirstMessageTimeout(t *testing.T) {
 }
 
 func TestPrepareOpenAIWSHTTPBridgeBodyStripsWSFields(t *testing.T) {
-	body, err := prepareOpenAIWSHTTPBridgeBody([]byte(`{"type":"response.create","generate":true,"model":"gpt-5","stream":false,"previous_response_id":"resp_prev","input":"hi"}`))
+	body, err := prepareOpenAIWSHTTPBridgeBody(&Account{Platform: PlatformGrok, Type: AccountTypeAPIKey}, []byte(`{"type":"response.create","generate":true,"model":"gpt-5","stream":false,"previous_response_id":"resp_prev","prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"input":"hi"}`))
 	require.NoError(t, err)
 	require.False(t, gjson.GetBytes(body, "type").Exists())
 	require.False(t, gjson.GetBytes(body, "generate").Exists())
 	require.False(t, gjson.GetBytes(body, "previous_response_id").Exists())
+	for _, field := range openAIResponsesOptionalFields {
+		require.False(t, gjson.GetBytes(body, field).Exists(), field)
+	}
 	require.Equal(t, "gpt-5", gjson.GetBytes(body, "model").String())
 	require.True(t, gjson.GetBytes(body, "stream").Bool())
 	require.Equal(t, "hi", gjson.GetBytes(body, "input").String())
+}
+
+func TestPrepareOpenAIWSHTTPBridgeBodyUsesOfficialHostPolicy(t *testing.T) {
+	payload := []byte(`{"type":"response.create","model":"gpt-5","prompt_cache_retention":"24h","safety_identifier":"sid","prompt_cache_options":{"ttl":"30m"},"input":"hi"}`)
+	tests := []struct {
+		name     string
+		account  *Account
+		preserve bool
+	}{
+		{
+			name:     "official default base URL",
+			account:  &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+			preserve: true,
+		},
+		{
+			name: "custom compatible base URL",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"base_url": "https://compat.example/v1",
+			}},
+			preserve: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := prepareOpenAIWSHTTPBridgeBody(tt.account, payload)
+			require.NoError(t, err)
+			for _, field := range openAIResponsesOptionalFields {
+				require.Equal(t, tt.preserve, gjson.GetBytes(body, field).Exists(), field)
+			}
+		})
+	}
 }
 
 func TestProxyOpenAIWSHTTPBridgeTurnAPIKeyAdaptsClientTools(t *testing.T) {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -752,6 +752,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, blocked.Message, blocked)
 	}
 	firstClientMessage = updatedFirst
+	filteredFirst, filterFirstErr := filterOpenAIResponsesOptionalFieldsForAccount(account, firstClientMessage)
+	if filterFirstErr != nil {
+		return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", filterFirstErr)
+	}
+	firstClientMessage = filteredFirst
 
 	// 在 policy filter 之后再提取 service_tier / reasoning_effort 用于
 	// usage 上报：filter
@@ -1022,6 +1027,13 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				payload = s.ReplaceModelInBody(payload, model)
 			}
 			out, blocked, policyErr := s.applyOpenAIFastPolicyToWSResponseCreate(ctx, account, model, payload)
+			if policyErr == nil && blocked == nil && isResponseCreate {
+				filtered, filterErr := filterOpenAIResponsesOptionalFieldsForAccount(account, out)
+				if filterErr != nil {
+					return payload, nil, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", filterErr)
+				}
+				out = filtered
+			}
 			// 多轮 passthrough usage：仅在成功（non-block / non-err）
 			// 的 response.create 帧上更新 usageMeta，使用
 			// filter 处理后的 payload，与首帧 policy-after-extract 语义


### PR DESCRIPTION
## Problem

Responses optional fields currently sit on both sides of an incompatible boundary:

- Official OpenAI Platform API requests may legitimately use `prompt_cache_retention`, `safety_identifier`, and `prompt_cache_options`.
- ChatGPT internal, Grok, DeepSeek, Kimi, Zhipu, and arbitrary OpenAI-compatible endpoints may reject one or more of them.

The original global strip ran before account/upstream routing, so official API-key requests silently lost supported cache and safety metadata. Replacing that with a check for `PlatformOpenAI + APIKey` is still too broad because a custom `base_url` account has exactly the same platform and credential type while targeting a third-party endpoint.

After removing the global strip, several default HTTP and WebSocket paths also had no proactive cleanup. Relying on a 400 retry is not equivalent: error wording varies, one retry only removes one named field, and the first failure can interrupt streaming behavior.

## Root cause

Account type does not identify the actual trust boundary. The missing discriminator is the final upstream host:

- empty `base_url` means the official default;
- `api.openai.com` is official;
- every other host is an OpenAI-compatible upstream and must be treated as potentially incompatible.

Field cleanup was also spread across passthrough, OAuth, Grok, and WebSocket branches, leaving default forwarding and mixed-shape paths inconsistent.

## What changed

- Centralize the three Responses optional fields and official-host predicate.
- Preserve them only for OpenAI API-key accounts whose `base_url` is empty or has host `api.openai.com`.
- Strip all three before the first upstream request for custom OpenAI-compatible addresses and non-OpenAI/internal accounts.
- Apply the same policy to standard HTTP forwarding, raw WebSocket ingress, WS v2 initial/follow-up `response.create` frames, WS-to-HTTP bridge requests, and Cursor Responses-shaped bodies.
- Keep OAuth/Codex, Grok, and `/alpha/search` unsupported-field lists synchronized, including `prompt_cache_options` and `safety_identifier` where previously omitted.
- Retain bounded retry for official model-specific 400 responses, deleting only the explicitly rejected top-level optional field and preserving the others.

## Related open work

- #5848 protects ChatGPT OAuth HTTP egress and expands rejected-field retry. This PR additionally covers API-key/custom-host classification, compatible providers, Cursor, alpha search, and WebSocket boundaries.
- #5914 introduces model/capability-based prompt-cache handling. This PR addresses a separate endpoint-identity boundary and includes all three optional fields. In particular, #5914 currently keeps `prompt_cache_options` for a third-party `PlatformOpenAI + APIKey` account, while this change intentionally strips optional fields for any non-`api.openai.com` host before the first request.

## Tests

- `go test ./...`
- `go test -tags=unit ./internal/service`
- `go build ./cmd/server`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Regression coverage includes official/default and explicit official hosts, custom and lookalike hosts, Grok/Kimi/Zhipu/DeepSeek, OAuth transforms, Cursor mixed-shape requests, alpha search, normal and passthrough WebSockets, the WS HTTP bridge, and bounded single-field retry.