### PR TITLE
fix(openai): hide image generators from Codex model picker

### DIFF
--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -567,10 +567,10 @@ var apiKeyCodexModelsWithoutResponsesLite = map[string]struct{}{
 	"gpt-5.6-luna":  {},
 }
 
-// adjustAPIKeyCodexModelsManifest prevents Codex from selecting Responses
-// Lite for custom API key providers. Those clients do not install web.run in
-// Lite mode, so the affected model manifests must advertise the full Responses
-// path. Return the original body when no targeted true value is present.
+// adjustAPIKeyCodexModelsManifest removes dedicated image-generation models
+// from the Codex agent picker and prevents Codex from selecting Responses Lite
+// for custom API key providers. Return the original body when no adjustment is
+// needed.
 func adjustAPIKeyCodexModelsManifest(body []byte) ([]byte, error) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(body, &envelope); err != nil {
@@ -582,20 +582,29 @@ func adjustAPIKeyCodexModelsManifest(body []byte) ([]byte, error) {
 	}
 
 	changed := false
-	for i, rawModel := range models {
+	adjustedModels := make([]json.RawMessage, 0, len(models))
+	for _, rawModel := range models {
 		var model map[string]json.RawMessage
 		if err := json.Unmarshal(rawModel, &model); err != nil || model == nil {
+			adjustedModels = append(adjustedModels, rawModel)
 			continue
 		}
 		var slug string
 		if err := json.Unmarshal(model["slug"], &slug); err != nil {
+			adjustedModels = append(adjustedModels, rawModel)
+			continue
+		}
+		if IsGPTImageGenerationModel(slug) {
+			changed = true
 			continue
 		}
 		if _, targeted := apiKeyCodexModelsWithoutResponsesLite[slug]; !targeted {
+			adjustedModels = append(adjustedModels, rawModel)
 			continue
 		}
 		var useResponsesLite bool
 		if err := json.Unmarshal(model["use_responses_lite"], &useResponsesLite); err != nil || !useResponsesLite {
+			adjustedModels = append(adjustedModels, rawModel)
 			continue
 		}
 		model["use_responses_lite"] = json.RawMessage("false")
@@ -603,18 +612,18 @@ func adjustAPIKeyCodexModelsManifest(body []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("encode model %q: %w", slug, err)
 		}
-		models[i] = adjusted
+		adjustedModels = append(adjustedModels, adjusted)
 		changed = true
 	}
 	if !changed {
 		return body, nil
 	}
 
-	adjustedModels, err := json.Marshal(models)
+	encodedModels, err := json.Marshal(adjustedModels)
 	if err != nil {
 		return nil, fmt.Errorf("encode top-level models array: %w", err)
 	}
-	envelope["models"] = adjustedModels
+	envelope["models"] = encodedModels
 	adjusted, err := json.Marshal(envelope)
 	if err != nil {
 		return nil, fmt.Errorf("encode JSON object: %w", err)

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -472,7 +472,7 @@ func TestFetchCodexModelsManifestAPIKeyCustomUpstream(t *testing.T) {
 }
 
 func TestFetchCodexModelsManifestAPIKeyConvertsStandardOpenAIModelList(t *testing.T) {
-	upstreamBody := `{"object":"list","data":[{"id":"gpt-5.6","object":"model"},{"id":"  ","object":"model"},{"id":"gpt-5.6-codex","object":"model"}]}`
+	upstreamBody := `{"object":"list","data":[{"id":"gpt-5.6","object":"model"},{"id":"gpt-image-2","object":"model"},{"id":"  ","object":"model"},{"id":"gpt-5.6-codex","object":"model"}]}`
 	upstream := &codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 		header := make(http.Header)
 		header.Set("ETag", `W/"openai-list"`)
@@ -521,6 +521,11 @@ func TestAdjustAPIKeyCodexModelsManifest(t *testing.T) {
 			body: `{"models":[{"slug":"gpt-5.6-sol","use_responses_lite":false},{"slug":"gpt-5.6-terra"},null,"gpt-5.6-luna",{"slug":17,"use_responses_lite":true}]}`,
 			want: `{"models":[{"slug":"gpt-5.6-sol","use_responses_lite":false},{"slug":"gpt-5.6-terra"},null,"gpt-5.6-luna",{"slug":17,"use_responses_lite":true}]}`,
 		},
+		{
+			name: "dedicated image models removed while unknown fields and entries remain",
+			body: `{"models":[{"slug":"gpt-image-1","unknown_model":{"enabled":true}},{"slug":"gpt-5.6","unknown_model":{"enabled":true}},null,"alternate-entry",{"slug":"gpt-image-2-codex"}],"unknown_top":{"version":1}}`,
+			want: `{"models":[{"slug":"gpt-5.6","unknown_model":{"enabled":true}},null,"alternate-entry"],"unknown_top":{"version":1}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -533,7 +538,7 @@ func TestAdjustAPIKeyCodexModelsManifest(t *testing.T) {
 }
 
 func TestFetchCodexModelsManifestAPIKeyDisablesResponsesLiteForAffectedModels(t *testing.T) {
-	const upstreamBody = `{"models":[{"slug":"gpt-5.6-sol","use_responses_lite":true},{"slug":"gpt-5.6-codex","use_responses_lite":true}],"metadata":{"version":1}}`
+	const upstreamBody = `{"models":[{"slug":"gpt-5.6-sol","use_responses_lite":true},{"slug":"gpt-image-2"},{"slug":"gpt-5.6-codex","use_responses_lite":true}],"metadata":{"version":1}}`
 	upstream := &codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -555,8 +560,8 @@ func TestFetchCodexModelsManifestAPIKeyDisablesResponsesLiteForAffectedModels(t 
 	require.Equal(t, manifest.ETag, notModified.ETag)
 }
 
-func TestFetchCodexModelsManifestOAuthPreservesResponsesLite(t *testing.T) {
-	const manifestBody = ` {"models":[{"slug":"gpt-5.6-sol","use_responses_lite":true}]} `
+func TestFetchCodexModelsManifestOAuthPreservesAPIKeySpecificFieldsAndModels(t *testing.T) {
+	const manifestBody = ` {"models":[{"slug":"gpt-5.6-sol","use_responses_lite":true},{"slug":"gpt-image-2"}]} `
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(manifestBody))
 	}))


### PR DESCRIPTION
## Why

Custom OpenAI API key upstreams may return text models and dedicated image-generation models from the same `/v1/models` endpoint. The Codex conversion currently treats every returned ID as an agent model, so `gpt-image-*` entries appear in `/model` even though Codex cannot use them as text/agent models.

## What changed

- Filter `gpt-image-*` slugs while adjusting API-key Codex model manifests.
- Preserve malformed/unknown manifest entries and unknown fields.
- Keep OAuth ChatGPT manifests unchanged.
- Leave ordinary `/v1/models`, Images API, and Responses image tools unchanged.
- Reuse the adjusted body for the client ETag while retaining the upstream ETag for revalidation.

This PR is independent of #5926 and is based directly on the current `upstream/main`.

## Validation

- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=30m ./...` (`0 issues`)
- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm run test:run` (237 files, 1666 tests)
- `make build`