### PR TITLE
fix(antigravity): 支持已验证的 Gemini 3.7 Flash tiered 模型 / support verified Gemini 3.7 tiered model

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -144,6 +144,10 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"gemini-3.6-flash-low":    "gemini-3.6-flash-low",
 	"gemini-3.6-flash-medium": "gemini-3.6-flash-medium",
 	"gemini-3.6-flash-tiered": "gemini-3.6-flash-tiered",
+	// Gemini 3.7 Flash. The current upstream catalog exposes only the tiered
+	// wire ID; keep the bare name as a stable client-facing alias.
+	"gemini-3.7-flash":        "gemini-3.7-flash-tiered",
+	"gemini-3.7-flash-tiered": "gemini-3.7-flash-tiered",
 	// Gemini 3 image 兼容映射（向 3.1 image 迁移）
 	"gemini-3-pro-image":         "gemini-3.1-flash-image",
 	"gemini-3-pro-image-preview": "gemini-3.1-flash-image",

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDefaultAntigravityModelMapping_ImageCompatibilityAliases(t *testing.T) {
 	t.Parallel()
@@ -70,6 +73,30 @@ func TestDefaultAntigravityModelMapping_Gemini36FlashModels(t *testing.T) {
 		if got := DefaultAntigravityModelMapping[model]; got != model {
 			t.Fatalf("expected %s to map to itself, got %q", model, got)
 		}
+	}
+}
+
+func TestDefaultAntigravityModelMapping_Gemini37FlashModels(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"gemini-3.7-flash":        "gemini-3.7-flash-tiered",
+		"gemini-3.7-flash-tiered": "gemini-3.7-flash-tiered",
+	}
+	for from, want := range cases {
+		if got := DefaultAntigravityModelMapping[from]; got != want {
+			t.Fatalf("unexpected Gemini 3.7 mapping for %q: got %q want %q", from, got, want)
+		}
+	}
+
+	count := 0
+	for model := range DefaultAntigravityModelMapping {
+		if strings.HasPrefix(model, "gemini-3.7-flash") {
+			count++
+		}
+	}
+	if count != len(cases) {
+		t.Fatalf("expected exactly %d authoritative Gemini 3.7 mappings, got %d", len(cases), count)
 	}
 }
 

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -323,6 +323,48 @@ func TestAccountHandlerGetAvailableModels_GeminiGoogleOneUsesConservativeCatalog
 	require.NotContains(t, ids, "gemini-2.5-flash-image")
 }
 
+func TestAccountHandlerGetAvailableModels_AntigravityIncludesGemini37TieredOnly(t *testing.T) {
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       46,
+			Name:     "antigravity",
+			Platform: service.PlatformAntigravity,
+			Type:     service.AccountTypeOAuth,
+			Status:   service.StatusActive,
+		},
+	}
+	router := setupAvailableModelsRouter(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/46/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ids := make([]string, 0, len(resp.Data))
+	for _, model := range resp.Data {
+		ids = append(ids, model.ID)
+	}
+	for _, expectedID := range []string{"gemini-3.7-flash", "gemini-3.7-flash-tiered"} {
+		count := 0
+		for _, id := range ids {
+			if id == expectedID {
+				count++
+			}
+		}
+		require.Equalf(t, 1, count, "expected model %q exactly once", expectedID)
+	}
+	require.NotContains(t, ids, "gemini-3.7-flash-high")
+	require.NotContains(t, ids, "gemini-3.7-flash-medium")
+	require.NotContains(t, ids, "gemini-3.7-flash-low")
+}
+
 func TestAccountHandlerSyncUpstreamModels_ConfigErrorReturnsBadRequest(t *testing.T) {
 	svc := &availableModelsAdminService{
 		stubAdminService: newStubAdminService(),

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -183,6 +183,8 @@ var geminiModels = []modelDef{
 	{ID: "gemini-3.6-flash-low", DisplayName: "Gemini 3.6 Flash Low", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.6-flash-medium", DisplayName: "Gemini 3.6 Flash Medium", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.6-flash-tiered", DisplayName: "Gemini 3.6 Flash", CreatedAt: "2026-07-21T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.7-flash", DisplayName: "Gemini 3.7 Flash", CreatedAt: "2026-08-13T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.7-flash-tiered", DisplayName: "Gemini 3.7 Flash Tiered", CreatedAt: "2026-08-13T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-pro-preview", DisplayName: "Gemini 3 Pro Preview", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-pro-image", DisplayName: "Gemini 3 Pro Image", CreatedAt: "2025-06-01T00:00:00Z"},
 }

--- a/backend/internal/pkg/antigravity/claude_types_test.go
+++ b/backend/internal/pkg/antigravity/claude_types_test.go
@@ -33,3 +33,32 @@ func TestDefaultModels_ContainsNewAndLegacyImageModels(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultModels_ContainsGemini37Tiered(t *testing.T) {
+	t.Parallel()
+
+	models := DefaultModels()
+	byID := make(map[string]ClaudeModel, len(models))
+	counts := make(map[string]int, len(models))
+	for _, model := range models {
+		byID[model.ID] = model
+		counts[model.ID]++
+	}
+	want := map[string]string{
+		"gemini-3.7-flash":        "Gemini 3.7 Flash",
+		"gemini-3.7-flash-tiered": "Gemini 3.7 Flash Tiered",
+	}
+	for id, displayName := range want {
+		if counts[id] != 1 {
+			t.Fatalf("expected Antigravity model %q exactly once, got %d", id, counts[id])
+		}
+		if byID[id].DisplayName != displayName {
+			t.Fatalf("unexpected display name for %q: got %q want %q", id, byID[id].DisplayName, displayName)
+		}
+	}
+	for _, id := range []string{"gemini-3.7-flash-high", "gemini-3.7-flash-medium", "gemini-3.7-flash-low"} {
+		if counts[id] != 0 {
+			t.Fatalf("did not expect unverified Antigravity model %q, got %d entries", id, counts[id])
+		}
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -662,8 +662,10 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 				"gemini-3.6-flash-low",
 				"gemini-3.6-flash-medium",
 				"gemini-3.6-flash-tiered",
+				"gemini-3.7-flash-tiered",
 			})
 			applyAntigravityGemini31ProAliases(result)
+			applyAntigravityDefaultAlias(result, "gemini-3.7-flash", "gemini-3.7-flash-tiered", "gemini-3.7-flash")
 		}
 		return result
 	}
@@ -731,6 +733,29 @@ func ensureAntigravityDefaultPassthroughs(mapping map[string]string, models []st
 	for _, model := range models {
 		ensureAntigravityDefaultPassthrough(mapping, model)
 	}
+}
+
+func applyAntigravityDefaultAlias(mapping map[string]string, model, targetModel string, legacyTargets ...string) {
+	if mapping == nil || model == "" || targetModel == "" {
+		return
+	}
+	target := strings.TrimSpace(mapping[targetModel])
+	if target == "" {
+		target = targetModel
+	}
+	if current, exists := mapping[model]; exists {
+		for _, legacy := range legacyTargets {
+			if current == legacy {
+				mapping[model] = target
+				return
+			}
+		}
+		return
+	}
+	if mappingHasWildcardForModel(mapping, model) {
+		return
+	}
+	mapping[model] = target
 }
 
 func applyAntigravityGemini31ProAliases(mapping map[string]string) {

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -583,6 +583,59 @@ func TestAccountGetModelMapping_GoogleOnePreservesExplicitMapping(t *testing.T) 
 	}
 }
 
+func TestAccountGetModelMapping_AntigravityNormalizesGemini37Alias(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gemini-3.7-flash": "gemini-3.7-flash",
+			},
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	if mapping["gemini-3.7-flash"] != "gemini-3.7-flash-tiered" {
+		t.Fatalf("expected Gemini 3.7 alias to normalize to tiered, got %q", mapping["gemini-3.7-flash"])
+	}
+	if mapping["gemini-3.7-flash-tiered"] != "gemini-3.7-flash-tiered" {
+		t.Fatalf("expected Gemini 3.7 tiered passthrough, got %q", mapping["gemini-3.7-flash-tiered"])
+	}
+}
+
+func TestAccountGetModelMapping_AntigravityPreservesGemini37Override(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gemini-3.7-flash": "custom-gemini-3.7",
+			},
+		},
+	}
+
+	if got := account.GetModelMapping()["gemini-3.7-flash"]; got != "custom-gemini-3.7" {
+		t.Fatalf("expected explicit Gemini 3.7 override to survive, got %q", got)
+	}
+}
+
+func TestAccountGetModelMapping_AntigravityGemini37AliasRespectsWildcard(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gemini-3.7*": "custom-gemini-3.7",
+			},
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	if _, exists := mapping["gemini-3.7-flash"]; exists {
+		t.Fatal("did not expect a concrete alias when a wildcard already handles Gemini 3.7")
+	}
+	if got := account.GetMappedModel("gemini-3.7-flash"); got != "custom-gemini-3.7" {
+		t.Fatalf("expected wildcard mapping to remain effective, got %q", got)
+	}
+}
+
 func TestAccountGetModelMapping_AntigravityRespectsWildcardOverride(t *testing.T) {
 	account := &Account{
 		Platform: PlatformAntigravity,

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -343,6 +343,14 @@ func (s *BillingService) initFallbackPricing() {
 		SupportsCacheBreakdown: false,
 	}
 
+	// Gemini 3.7 Flash introductory pricing through 2026-12-31.
+	s.fallbackPrices["gemini-3.7-flash"] = &ModelPricing{
+		InputPricePerToken:     0.75e-6,
+		OutputPricePerToken:    3.75e-6,
+		CacheReadPricePerToken: 0.075e-6,
+		SupportsCacheBreakdown: false,
+	}
+
 	// OpenAI GPT-5.4（业务指定价格）
 	s.fallbackPrices["gpt-5.4"] = &ModelPricing{
 		InputPricePerToken:             2.5e-6,  // $2.5 per MTok
@@ -793,6 +801,9 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	}
 	if strings.Contains(modelLower, "gemini-3.6-flash") || strings.Contains(modelLower, "gemini-3-6-flash") {
 		return s.fallbackPrices["gemini-3.6-flash"]
+	}
+	if strings.Contains(modelLower, "gemini-3.7-flash") || strings.Contains(modelLower, "gemini-3-7-flash") {
+		return s.fallbackPrices["gemini-3.7-flash"]
 	}
 
 	// DeepSeek V4 系列：仅匹配已知 V4 Pro/Flash 与官方兼容别名

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -802,6 +802,10 @@ func normalizeModelNameForPricing(model string) string {
 // behavior, not the published token rate, so this keeps -high/-low/-medium and
 // -tiered requests on the same price card as gemini-3.6-flash.
 func normalizeGeminiThinkingTierAlias(model string) string {
+	if model == "gemini-3.7-flash-tiered" {
+		return "gemini-3.7-flash"
+	}
+
 	const baseModel = "gemini-3.6-flash"
 	for _, tier := range []string{"-high", "-low", "-medium", "-tiered"} {
 		if model == baseModel+tier {

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -477,6 +478,20 @@ func TestPricingService_Gemini36FlashThinkingTiersUseBasePricing(t *testing.T) {
 	}
 }
 
+func TestPricingService_Gemini37TieredUsesBasePricing(t *testing.T) {
+	basePricing := &LiteLLMModelPricing{
+		InputCostPerToken:       0.75e-6,
+		OutputCostPerToken:      3.75e-6,
+		CacheReadInputTokenCost: 0.075e-6,
+	}
+	svc := &PricingService{pricingData: map[string]*LiteLLMModelPricing{
+		"gemini-3.7-flash": basePricing,
+	}}
+
+	require.Same(t, basePricing, svc.GetModelPricing("gemini-3.7-flash"))
+	require.Same(t, basePricing, svc.GetModelPricing("gemini-3.7-flash-tiered"))
+}
+
 func TestPricingService_Gemini36FlashTierSpecificPricingTakesPrecedence(t *testing.T) {
 	basePricing := &LiteLLMModelPricing{InputCostPerToken: 1.5e-6}
 	tierPricing := &LiteLLMModelPricing{InputCostPerToken: 2e-6}
@@ -510,6 +525,22 @@ func TestBillingService_Gemini36FlashThinkingTierFallbacksAreBillable(t *testing
 	}
 }
 
+func TestBillingService_Gemini37TieredFallbackIsBillable(t *testing.T) {
+	svc := NewBillingService(&config.Config{}, nil)
+	tokens := UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheReadTokens: 1_000_000}
+
+	for _, model := range []string{"gemini-3.7-flash", "gemini-3.7-flash-tiered"} {
+		t.Run(model, func(t *testing.T) {
+			cost, err := svc.CalculateCost(model, tokens, 1)
+			require.NoError(t, err)
+			require.InDelta(t, 0.75, cost.InputCost, 1e-12)
+			require.InDelta(t, 3.75, cost.OutputCost, 1e-12)
+			require.InDelta(t, 0.075, cost.CacheReadCost, 1e-12)
+			require.InDelta(t, 4.575, cost.TotalCost, 1e-12)
+		})
+	}
+}
+
 func TestDefaultPricingIncludesGemini36FlashRates(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "resources", "model-pricing", "model_prices_and_context_window.json"))
 	require.NoError(t, err)
@@ -527,6 +558,29 @@ func TestDefaultPricingIncludesGemini36FlashRates(t *testing.T) {
 			require.InDelta(t, 1.5e-6, pricing.InputPricePerToken, 1e-12)
 			require.InDelta(t, 7.5e-6, pricing.OutputPricePerToken, 1e-12)
 			require.InDelta(t, 0.15e-6, pricing.CacheReadPricePerToken, 1e-12)
+		})
+	}
+}
+
+func TestDefaultPricingIncludesGemini37FlashRates(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "resources", "model-pricing", "model_prices_and_context_window.json"))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(data), `"gemini-3.7-flash":`))
+	require.Equal(t, 0, strings.Count(string(data), `"gemini-3.7-flash-tiered":`))
+
+	pricingSvc := &PricingService{}
+	pricingData, err := pricingSvc.parsePricingData(data)
+	require.NoError(t, err)
+	pricingSvc.pricingData = pricingData
+	billingSvc := NewBillingService(&config.Config{}, pricingSvc)
+
+	for _, model := range []string{"gemini-3.7-flash", "gemini-3.7-flash-tiered"} {
+		t.Run(model, func(t *testing.T) {
+			pricing, err := billingSvc.GetModelPricing(model)
+			require.NoError(t, err)
+			require.InDelta(t, 0.75e-6, pricing.InputPricePerToken, 1e-12)
+			require.InDelta(t, 3.75e-6, pricing.OutputPricePerToken, 1e-12)
+			require.InDelta(t, 0.075e-6, pricing.CacheReadPricePerToken, 1e-12)
 		})
 	}
 }

--- a/backend/resources/model-pricing/model_prices_and_context_window.json
+++ b/backend/resources/model-pricing/model_prices_and_context_window.json
@@ -2345,6 +2345,20 @@
     "supports_reasoning": true,
     "supports_service_tier": true
   },
+  "gemini-3.7-flash": {
+    "cache_read_input_token_cost": 7.5e-08,
+    "input_cost_per_token": 7.5e-07,
+    "litellm_provider": "vertex_ai-language-models",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "max_tokens": 65536,
+    "mode": "chat",
+    "output_cost_per_token": 3.75e-06,
+    "source": "https://ai.google.dev/gemini-api/docs/latest-model",
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_service_tier": true
+  },
   "gemini-embedding-001": {
     "input_cost_per_token": 1.5e-07,
     "litellm_provider": "vertex_ai-embedding-models",

--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -293,7 +293,7 @@ const openAITestModeOptions = computed(() => [
   { value: 'compact', label: t('admin.accounts.openai.testModeCompact') }
 ])
 const previewImageUrl = ref('')
-const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
+const prioritizedGeminiModels = ['gemini-3.7-flash-tiered', 'gemini-3.7-flash', 'gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gemini-') || !modelID.includes('-image')) return false
@@ -353,7 +353,7 @@ const loadAvailableModels = async () => {
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      if (props.account.platform === 'gemini' || props.account.platform === 'antigravity') {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -437,7 +437,7 @@ const grokTestModeOptions = computed(() => [
   { value: 'stt', label: t('admin.accounts.grok.testModeSTT') },
   { value: 'realtime', label: t('admin.accounts.grok.testModeRealtime') }
 ])
-const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
+const prioritizedGeminiModels = ['gemini-3.7-flash-tiered', 'gemini-3.7-flash', 'gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gemini-') || !modelID.includes('-image')) return false
@@ -772,7 +772,7 @@ const loadAvailableModels = async () => {
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      if (props.account.platform === 'gemini' || props.account.platform === 'antigravity') {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -148,6 +148,40 @@ describe('AccountTestModal', () => {
     expect(preview.attributes('src')).toBe('data:image/png;base64,QUJD')
   })
 
+  it('Antigravity 默认优先选择已验证的 Gemini 3.7 tiered 模型', async () => {
+    getAvailableModels.mockResolvedValue([
+      { id: 'gemini-2.5-flash-image', display_name: 'Gemini 2.5 Flash Image' },
+      { id: 'gemini-3.7-flash', display_name: 'Gemini 3.7 Flash' },
+      { id: 'gemini-3.7-flash-tiered', display_name: 'Gemini 3.7 Flash Tiered' }
+    ])
+    global.fetch = vi.fn().mockResolvedValue(
+      createStreamResponse([
+        'data: {"type":"test_complete","success":true}\n'
+      ])
+    ) as any
+
+    const wrapper = mountModal({
+      id: 14,
+      name: 'Antigravity OAuth',
+      platform: 'antigravity',
+      type: 'oauth',
+      status: 'active'
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const startButton = wrapper.findAll('button').find((button) => button.text().includes('admin.accounts.startTest'))
+    expect(startButton).toBeTruthy()
+    await startButton!.trigger('click')
+    await flushPromises()
+
+    const [, request] = (global.fetch as any).mock.calls[0]
+    expect(JSON.parse(request.body)).toEqual({
+      model_id: 'gemini-3.7-flash-tiered',
+      prompt: ''
+    })
+  })
+
   it('grok 账号测试默认选择 Grok 模型', async () => {
     getAvailableModels.mockResolvedValue([
       { id: 'grok-4.3', display_name: 'Grok 4.3' },

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -104,6 +104,16 @@ describe('useModelWhitelist', () => {
     expect(models).toContain('gemini-3.1-pro')
   })
 
+  it('antigravity 模型列表包含已验证的 Gemini 3.7 tiered 模型', () => {
+    const models = getModelsByPlatform('antigravity')
+
+    expect(models.filter(model => model === 'gemini-3.7-flash')).toHaveLength(1)
+    expect(models.filter(model => model === 'gemini-3.7-flash-tiered')).toHaveLength(1)
+    expect(models).not.toContain('gemini-3.7-flash-high')
+    expect(models).not.toContain('gemini-3.7-flash-medium')
+    expect(models).not.toContain('gemini-3.7-flash-low')
+  })
+
   it('whitelist 模式会忽略通配符条目', () => {
     const mapping = buildModelMappingObject('whitelist', ['claude-*', 'gemini-3.1-flash-image'], [])
     expect(mapping).toEqual({

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -81,6 +81,9 @@ const antigravityModels = [
   'gemini-3.1-pro-high',
   'gemini-3.1-pro-low',
   'gemini-3-pro-image',
+  // Gemini 3.7 Flash: current upstream catalog exposes tiered only.
+  'gemini-3.7-flash',
+  'gemini-3.7-flash-tiered',
   // 其他
   'gpt-oss-120b-medium',
   'tab_flash_lite_preview'


### PR DESCRIPTION
## 中文

### 背景

Antigravity 当前 prod 目录不返回 Gemini 3.7，daily 目录只返回已验证的 `gemini-3.7-flash-tiered`。裸 `gemini-3.7-flash` 不是实际 wire ID，而 `high`、`medium`、`low` 变体目前也没有出现在上游目录中。

### 修复

- 加入当前已验证的 `gemini-3.7-flash-tiered` 模型。
- 将客户端友好名称 `gemini-3.7-flash` 映射到 tiered wire ID。
- 明确不静态展示尚未验证的 `high`、`medium`、`low` IDs。
- 加入官方阶段价格，并让账号测试优先使用 tiered。

### 兼容性

- 不涉及数据库迁移或持久化格式变化。
- 用户显式 mapping 和 wildcard mapping 保持优先。
- Gemini 3.6 的现有行为保持不变。

### 验证

- 基础 alias、模型目录、mapping 优先级与计价相关 Go 回归测试通过。
- `golangci-lint v2.9.0`：0 issues。
- 前端 Vitest：20/20 通过。
- 前端 `vue-tsc --noEmit` 与 ESLint 通过。
- 裸 alias 与显式 tiered 均通过 staging 网关链路。

## English

### Summary

- Add the currently verified `gemini-3.7-flash-tiered` Antigravity model.
- Map the client-facing `gemini-3.7-flash` alias to the tiered wire ID.
- Intentionally do not advertise unverified `high`, `medium`, or `low` IDs.
- Add official introductory pricing and make account tests prefer tiered.

### Upstream evidence

- Current prod catalog: no Gemini 3.7 entry.
- Current daily catalog: `gemini-3.7-flash-tiered` only.
- Official pricing through 2026-12-31: $0.75 input, $3.75 output, and $0.075 cached input per 1M tokens.

### Compatibility

- No migrations or persisted-format changes.
- Explicit and wildcard mappings retain priority.
- Existing Gemini 3.6 behavior is unchanged.

### Verification

- Focused Go regression tests for aliasing, catalogs, mapping precedence, and pricing.
- `golangci-lint v2.9.0`: 0 issues.
- Frontend Vitest: 20/20 passed.
- Frontend `vue-tsc --noEmit` and ESLint passed.
- Both the bare alias and explicit tiered model passed the staging gateway path.

Fixes #5932
