### PR TITLE
fix(antigravity): 恢复有序 URL fallback / restore ordered URL fallback

### DIFF
--- a/backend/internal/service/antigravity_gateway_retry.go
+++ b/backend/internal/service/antigravity_gateway_retry.go
@@ -46,28 +46,22 @@ type antigravityRetryLoopResult struct {
 	resp *http.Response
 }
 
-// resolveAntigravityForwardBaseURL 解析转发用 base URL。
-//
-// 默认使用生产端点 cloudcode-pa.googleapis.com（antigravity.BaseURLs 的首个地址，
-// 与账号 OAuth 登录/测试连接所用的 antigravity.BaseURL 一致）。
-//
-// 历史上这里改用 ForwardBaseURLs()（把 daily/sandbox 排到首位）并默认取首个地址，
-// 导致网关把带生产 OAuth token 的请求发到 daily-cloudcode-pa.sandbox.googleapis.com，
-// 上游拒绝 → 账号被 401「Invalid bearer token」/502 打入临时不可调度且无法恢复
-// （见 #3611 / #2962）。后台「测试连接」用的是生产端点，所以「测试成功但网关 401」。
-//
-// daily/sandbox 端点仅供内部联调，需显式设置
-// GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily（或 sandbox）才启用。
-func resolveAntigravityForwardBaseURL() string {
+// resolveAntigravityForwardBaseURLs returns forwarding endpoints in priority
+// order. Production remains the default first choice; daily is retained as a
+// fallback for URL-level throttling and model-catalog lag.
+func resolveAntigravityForwardBaseURLs() []string {
 	baseURLs := antigravity.BaseURLs
 	if len(baseURLs) == 0 {
-		return ""
+		return nil
 	}
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv(antigravityForwardBaseURLEnv)))
 	if (mode == "daily" || mode == "sandbox") && len(baseURLs) > 1 {
-		return baseURLs[1]
+		return []string{baseURLs[1]}
 	}
-	return baseURLs[0]
+	if mode == "prod" || mode == "production" {
+		return []string{baseURLs[0]}
+	}
+	return append([]string(nil), baseURLs...)
 }
 
 // smartRetryAction 智能重试的处理结果
@@ -488,11 +482,10 @@ func (s *AntigravityGatewayService) antigravityRetryLoop(p antigravityRetryLoopP
 		}
 	}
 
-	baseURL := resolveAntigravityForwardBaseURL()
-	if baseURL == "" {
+	availableURLs := resolveAntigravityForwardBaseURLs()
+	if len(availableURLs) == 0 {
 		return nil, errors.New("no antigravity forward base url configured")
 	}
-	availableURLs := []string{baseURL}
 
 	var resp *http.Response
 	var usedBaseURL string
@@ -561,6 +554,17 @@ urlFallbackLoop:
 			if resp.StatusCode >= 400 {
 				respBody := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
+
+				// Production may lag daily for newly released Gemini 3.7
+				// models. Keep this endpoint fallback scoped to that family so
+				// ordinary model-not-found responses retain model fallback
+				// semantics.
+				if resp.StatusCode == http.StatusNotFound &&
+					strings.HasPrefix(strings.TrimSpace(p.requestedModel), "gemini-3.7-flash") &&
+					urlIdx < len(availableURLs)-1 {
+					logger.LegacyPrintf("service.antigravity_gateway", "%s URL fallback (404): %s -> %s", p.prefix, baseURL, availableURLs[urlIdx+1])
+					continue urlFallbackLoop
+				}
 
 				if overagesInjected && shouldMarkCreditsExhausted(resp, respBody, nil) {
 					modelKey := resolveCreditsOveragesModelKey(p.ctx, p.account, "", p.requestedModel)

--- a/backend/internal/service/antigravity_rate_limit_test.go
+++ b/backend/internal/service/antigravity_rate_limit_test.go
@@ -23,9 +23,11 @@ var _ AccountRepository = (*stubAntigravityAccountRepo)(nil)
 var _ SchedulerCache = (*stubSchedulerCache)(nil)
 
 type stubAntigravityUpstream struct {
-	firstBase  string
-	secondBase string
-	calls      []string
+	firstBase   string
+	secondBase  string
+	firstStatus int
+	firstBody   string
+	calls       []string
 }
 
 type recordingOKUpstream struct {
@@ -49,10 +51,18 @@ func (s *stubAntigravityUpstream) Do(req *http.Request, proxyURL string, account
 	url := req.URL.String()
 	s.calls = append(s.calls, url)
 	if strings.HasPrefix(url, s.firstBase) {
+		status := s.firstStatus
+		if status == 0 {
+			status = http.StatusTooManyRequests
+		}
+		body := s.firstBody
+		if body == "" {
+			body = `{"error":{"message":"Resource has been exhausted"}}`
+		}
 		return &http.Response{
-			StatusCode: http.StatusTooManyRequests,
+			StatusCode: status,
 			Header:     http.Header{},
-			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"Resource has been exhausted"}}`)),
+			Body:       io.NopCloser(strings.NewReader(body)),
 		}, nil
 	}
 	return &http.Response{
@@ -104,7 +114,7 @@ func (s *stubAntigravityAccountRepo) UpdateExtra(ctx context.Context, id int64, 
 	return nil
 }
 
-func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) {
+func TestAntigravityRetryLoop_URLLevel429FallsBackToNextURL(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "")
 
 	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
@@ -151,16 +161,106 @@ func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) 
 	require.NotNil(t, result)
 	require.NotNil(t, result.resp)
 	defer func() { _ = result.resp.Body.Close() }()
-	require.Equal(t, http.StatusTooManyRequests, result.resp.StatusCode)
-	require.True(t, handleErrorCalled)
-	require.Len(t, upstream.calls, antigravityMaxRetries)
-	for _, callURL := range upstream.calls {
-		require.True(t, strings.HasPrefix(callURL, base1))
-	}
+	require.Equal(t, http.StatusOK, result.resp.StatusCode)
+	require.False(t, handleErrorCalled)
+	require.Equal(t, []string{
+		base1 + "/v1internal:generateContent",
+		base2 + "/v1internal:generateContent",
+	}, upstream.calls)
 
 	available := antigravity.DefaultURLAvailability.GetAvailableURLs()
 	require.NotEmpty(t, available)
-	require.Equal(t, base1, available[0])
+	require.Equal(t, base2, available[0])
+}
+
+func TestAntigravityRetryLoop_Gemini37Model404FallsBackToNextURL(t *testing.T) {
+	t.Setenv(antigravityForwardBaseURLEnv, "")
+
+	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
+	oldAvailability := antigravity.DefaultURLAvailability
+	defer func() {
+		antigravity.BaseURLs = oldBaseURLs
+		antigravity.DefaultURLAvailability = oldAvailability
+	}()
+
+	prodURL := "https://prod.test"
+	dailyURL := "https://daily.test"
+	antigravity.BaseURLs = []string{prodURL, dailyURL}
+	antigravity.DefaultURLAvailability = antigravity.NewURLAvailability(time.Minute)
+
+	upstream := &stubAntigravityUpstream{
+		firstBase:   prodURL,
+		secondBase:  dailyURL,
+		firstStatus: http.StatusNotFound,
+		firstBody:   `{"error":{"code":404,"message":"Requested entity was not found.","status":"NOT_FOUND"}}`,
+	}
+	account := &Account{ID: 1, Name: "acc-1", Platform: PlatformAntigravity, Schedulable: true, Status: StatusActive, Concurrency: 1}
+	svc := &AntigravityGatewayService{}
+	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
+		prefix:         "[test]",
+		ctx:            context.Background(),
+		account:        account,
+		accessToken:    "token",
+		action:         "generateContent",
+		body:           []byte(`{"input":"test"}`),
+		httpUpstream:   upstream,
+		requestedModel: "gemini-3.7-flash-tiered",
+		handleError: func(context.Context, string, *Account, int, http.Header, []byte, string, int64, string, bool) *handleModelRateLimitResult {
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer func() { _ = result.resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, result.resp.StatusCode)
+	require.Equal(t, []string{
+		prodURL + "/v1internal:generateContent",
+		dailyURL + "/v1internal:generateContent",
+	}, upstream.calls)
+}
+
+func TestAntigravityRetryLoop_OtherModel404DoesNotFallbackURL(t *testing.T) {
+	t.Setenv(antigravityForwardBaseURLEnv, "")
+
+	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
+	oldAvailability := antigravity.DefaultURLAvailability
+	defer func() {
+		antigravity.BaseURLs = oldBaseURLs
+		antigravity.DefaultURLAvailability = oldAvailability
+	}()
+
+	prodURL := "https://prod.test"
+	dailyURL := "https://daily.test"
+	antigravity.BaseURLs = []string{prodURL, dailyURL}
+	antigravity.DefaultURLAvailability = antigravity.NewURLAvailability(time.Minute)
+
+	upstream := &stubAntigravityUpstream{
+		firstBase:   prodURL,
+		secondBase:  dailyURL,
+		firstStatus: http.StatusNotFound,
+		firstBody:   `{"error":{"code":404,"message":"Requested entity was not found.","status":"NOT_FOUND"}}`,
+	}
+	svc := &AntigravityGatewayService{}
+	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
+		prefix:         "[test]",
+		ctx:            context.Background(),
+		account:        &Account{ID: 1, Name: "acc-1", Platform: PlatformAntigravity, Schedulable: true, Status: StatusActive, Concurrency: 1},
+		accessToken:    "token",
+		action:         "generateContent",
+		body:           []byte(`{"input":"test"}`),
+		httpUpstream:   upstream,
+		requestedModel: "gemini-3.6-flash-tiered",
+		handleError: func(context.Context, string, *Account, int, http.Header, []byte, string, int64, string, bool) *handleModelRateLimitResult {
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer func() { _ = result.resp.Body.Close() }()
+	require.Equal(t, http.StatusNotFound, result.resp.StatusCode)
+	require.Equal(t, []string{prodURL + "/v1internal:generateContent"}, upstream.calls)
 }
 
 // TestHandleUpstreamError_429_ModelRateLimit 测试 429 模型限流场景
@@ -1009,7 +1109,7 @@ func TestIsAntigravityAccountSwitchError(t *testing.T) {
 	}
 }
 
-func TestResolveAntigravityForwardBaseURL_DefaultDaily(t *testing.T) {
+func TestResolveAntigravityForwardBaseURLs_DefaultPreservesFallbackOrder(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "")
 
 	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
@@ -1019,10 +1119,38 @@ func TestResolveAntigravityForwardBaseURL_DefaultDaily(t *testing.T) {
 
 	prodURL := "https://prod.test"
 	dailyURL := "https://daily.test"
-	antigravity.BaseURLs = []string{dailyURL, prodURL}
+	antigravity.BaseURLs = []string{prodURL, dailyURL}
 
-	resolved := resolveAntigravityForwardBaseURL()
-	require.Equal(t, dailyURL, resolved)
+	resolved := resolveAntigravityForwardBaseURLs()
+	require.Equal(t, []string{prodURL, dailyURL}, resolved)
+}
+
+func TestResolveAntigravityForwardBaseURLs_ExplicitModesDisableFallback(t *testing.T) {
+	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
+	defer func() {
+		antigravity.BaseURLs = oldBaseURLs
+	}()
+
+	prodURL := "https://prod.test"
+	dailyURL := "https://daily.test"
+	antigravity.BaseURLs = []string{prodURL, dailyURL}
+
+	t.Run("prod", func(t *testing.T) {
+		t.Setenv(antigravityForwardBaseURLEnv, "prod")
+		require.Equal(t, []string{prodURL}, resolveAntigravityForwardBaseURLs())
+	})
+	t.Run("production", func(t *testing.T) {
+		t.Setenv(antigravityForwardBaseURLEnv, "production")
+		require.Equal(t, []string{prodURL}, resolveAntigravityForwardBaseURLs())
+	})
+	t.Run("daily", func(t *testing.T) {
+		t.Setenv(antigravityForwardBaseURLEnv, "daily")
+		require.Equal(t, []string{dailyURL}, resolveAntigravityForwardBaseURLs())
+	})
+	t.Run("sandbox", func(t *testing.T) {
+		t.Setenv(antigravityForwardBaseURLEnv, "sandbox")
+		require.Equal(t, []string{dailyURL}, resolveAntigravityForwardBaseURLs())
+	})
 }
 
 func TestAntigravityAccountSwitchError_Error(t *testing.T) {


### PR DESCRIPTION
## 中文

### 背景

Antigravity 已有 URL 级 429 fallback 分支，但 retry loop 会先把 resolver 结果折叠为单个 URL，导致默认模式下 fallback 实际不可达。类似地，Gemini 3.7 在 prod 返回 catalog 404、daily 已可用时也无法进行端点级回退。

### 修复

- 保留 Antigravity resolver 返回的有序端点列表，不再折叠为单个 URL。
- 默认仍以 production 为第一端点。
- 让已有的 URL 级 429 fallback 实际可达。
- 仅为 Gemini 3.7 增加定向 catalog-404 fallback，普通模型的 404 行为保持不变。

### 兼容性

- 显式 `prod/production` 与 `daily/sandbox` 模式仍为单端点。
- account/model quota 429 的处理保持不变。
- 非 3.7 的普通 404 不切换 URL。
- 不涉及数据库迁移或配置格式变化。

### 验证

- prod URL 级 429 → daily 200。
- Gemini 3.7 catalog 404 → 下一端点。
- 非 3.7 的 404 → 不切换 URL。
- 显式端点模式 → 不生成 fallback 列表。
- 相关 Go 测试通过，`golangci-lint v2.9.0`：0 issues。
- 真实账号测试和网关日志确认 prod 429 → daily 后成功。

## English

### Summary

- Preserve the ordered Antigravity endpoint list instead of collapsing it to one URL.
- Keep production as the default first endpoint.
- Make the existing URL-level 429 fallback reachable.
- Add a narrowly scoped Gemini 3.7 catalog-404 fallback while preserving ordinary model fallback behavior.

### Compatibility

- Explicit `prod/production` and `daily/sandbox` modes remain single-endpoint.
- Account/model quota 429 handling is unchanged.
- Ordinary non-3.7 404 responses do not switch URLs.
- No migrations or configuration-format changes.

### Verification

- prod URL-level 429 → daily 200.
- Gemini 3.7 catalog 404 → next URL.
- non-3.7 404 → no URL switch.
- explicit endpoint modes → no fallback list.
- Focused Go tests passed; `golangci-lint v2.9.0`: 0 issues.
- Real account-test and gateway logs confirm prod 429 → daily success.

Fixes #5933
