### PR TITLE
fix(gemini): 限制 Google One OAuth 模型目录 / constrain Google One model catalog

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2614,8 +2614,14 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 
 	// Handle Gemini accounts
 	if account.IsGemini() {
-		// For OAuth accounts: return default Gemini models
+		// Consumer Google One OAuth still uses the legacy Gemini CLI / Code
+		// Assist channel. Do not advertise newer 3.x or image models that the
+		// channel cannot serve.
 		if account.IsOAuth() {
+			if account.IsGeminiGoogleOne() {
+				response.Success(c, geminicli.GoogleOneModels)
+				return
+			}
 			response.Success(c, geminicli.DefaultModels)
 			return
 		}

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -287,6 +287,42 @@ func TestAccountHandlerGetAvailableModels_OpenAISparkShadowReturnsMappingModels(
 	}, ids, "影子可用模型由 model_mapping 派生（非写死）")
 }
 
+func TestAccountHandlerGetAvailableModels_GeminiGoogleOneUsesConservativeCatalog(t *testing.T) {
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       45,
+			Name:     "google-one",
+			Platform: service.PlatformGemini,
+			Type:     service.AccountTypeOAuth,
+			Status:   service.StatusActive,
+			Credentials: map[string]any{
+				"oauth_type": "google_one",
+			},
+		},
+	}
+	router := setupAvailableModelsRouter(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/45/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ids := make([]string, 0, len(resp.Data))
+	for _, model := range resp.Data {
+		ids = append(ids, model.ID)
+	}
+	require.ElementsMatch(t, []string{"gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro"}, ids)
+	require.NotContains(t, ids, "gemini-3.5-flash")
+	require.NotContains(t, ids, "gemini-2.5-flash-image")
+}
+
 func TestAccountHandlerSyncUpstreamModels_ConfigErrorReturnsBadRequest(t *testing.T) {
 	svc := &availableModelsAdminService{
 		stubAdminService: newStubAdminService(),

--- a/backend/internal/pkg/geminicli/models.go
+++ b/backend/internal/pkg/geminicli/models.go
@@ -22,5 +22,24 @@ var DefaultModels = []Model{
 	{ID: "gemini-3.1-flash-image", Type: "model", DisplayName: "Gemini 3.1 Flash Image", CreatedAt: ""},
 }
 
+// GoogleOneModels is the conservative model set exposed for legacy Google One
+// OAuth accounts. Newer subscription models are served through Antigravity
+// OAuth rather than the retired consumer Gemini CLI / Code Assist channel.
+var GoogleOneModels = []Model{
+	{ID: "gemini-2.5-flash", Type: "model", DisplayName: "Gemini 2.5 Flash", CreatedAt: ""},
+	{ID: "gemini-2.5-pro", Type: "model", DisplayName: "Gemini 2.5 Pro", CreatedAt: ""},
+	{ID: "gemini-2.0-flash", Type: "model", DisplayName: "Gemini 2.0 Flash", CreatedAt: ""},
+}
+
+// GoogleOneModelMapping returns a new whitelist map for each account so callers
+// cannot mutate the package-level catalog.
+func GoogleOneModelMapping() map[string]string {
+	mapping := make(map[string]string, len(GoogleOneModels))
+	for _, model := range GoogleOneModels {
+		mapping[model.ID] = model.ID
+	}
+	return mapping
+}
+
 // DefaultTestModel is the default model to preselect in test flows.
 const DefaultTestModel = "gemini-2.0-flash"

--- a/backend/internal/pkg/geminicli/models_test.go
+++ b/backend/internal/pkg/geminicli/models_test.go
@@ -21,3 +21,24 @@ func TestDefaultModels_ContainsImageModels(t *testing.T) {
 		}
 	}
 }
+
+func TestGoogleOneModels_ExcludeUnsupportedNewAndImageModels(t *testing.T) {
+	t.Parallel()
+
+	mapping := GoogleOneModelMapping()
+	for _, id := range []string{"gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro"} {
+		if mapping[id] != id {
+			t.Fatalf("expected Google One model %q to map to itself", id)
+		}
+	}
+	for _, id := range []string{"gemini-2.5-flash-image", "gemini-3.1-flash-image", "gemini-3.5-flash"} {
+		if _, ok := mapping[id]; ok {
+			t.Fatalf("did not expect unsupported Google One model %q", id)
+		}
+	}
+
+	mapping["gemini-2.5-flash"] = "mutated"
+	if GoogleOneModelMapping()["gemini-2.5-flash"] != "gemini-2.5-flash" {
+		t.Fatal("GoogleOneModelMapping must return a defensive copy")
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 )
@@ -324,6 +325,12 @@ func (a *Account) IsGeminiCodeAssist() bool {
 	return oauthType == "code_assist"
 }
 
+// IsGeminiGoogleOne reports whether this account uses the legacy consumer
+// Gemini CLI / Code Assist OAuth channel.
+func (a *Account) IsGeminiGoogleOne() bool {
+	return a.Platform == PlatformGemini && a.Type == AccountTypeOAuth && a.GeminiOAuthType() == "google_one"
+}
+
 func (a *Account) CanGetUsage() bool {
 	return a.Type == AccountTypeOAuth
 }
@@ -625,6 +632,9 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 		return nil
 	}
 	if len(rawMapping) == 0 {
+		if a.IsGeminiGoogleOne() {
+			return geminicli.GoogleOneModelMapping()
+		}
 		// Antigravity 平台使用默认映射
 		if a.Platform == domain.PlatformAntigravity {
 			return domain.DefaultAntigravityModelMapping
@@ -659,6 +669,9 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 	}
 
 	// Antigravity 平台使用默认映射
+	if a.IsGeminiGoogleOne() {
+		return geminicli.GoogleOneModelMapping()
+	}
 	if a.Platform == domain.PlatformAntigravity {
 		return domain.DefaultAntigravityModelMapping
 	}

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -537,6 +537,52 @@ func TestAccountGetModelMapping_AntigravityEnsuresGeminiDefaultPassthroughs(t *t
 	}
 }
 
+func TestAccountGetModelMapping_GoogleOneUsesConservativeDefaults(t *testing.T) {
+	account := &Account{
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"oauth_type": "google_one",
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	for _, model := range []string{"gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro"} {
+		if mapping[model] != model {
+			t.Fatalf("expected Google One model %q to map to itself, got %q", model, mapping[model])
+		}
+	}
+	for _, model := range []string{"gemini-2.5-flash-image", "gemini-3.1-flash-image", "gemini-3.5-flash"} {
+		if _, ok := mapping[model]; ok {
+			t.Fatalf("did not expect unsupported Google One model %q", model)
+		}
+	}
+	if account.IsModelSupported("gemini-3.5-flash") {
+		t.Fatal("Google One defaults must not treat unsupported models as eligible")
+	}
+}
+
+func TestAccountGetModelMapping_GoogleOnePreservesExplicitMapping(t *testing.T) {
+	account := &Account{
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"oauth_type": "google_one",
+			"model_mapping": map[string]any{
+				"custom-model": "gemini-2.5-flash",
+			},
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	if mapping["custom-model"] != "gemini-2.5-flash" {
+		t.Fatalf("expected explicit Google One mapping to be preserved, got %v", mapping)
+	}
+	if _, ok := mapping["gemini-2.5-flash"]; ok {
+		t.Fatalf("did not expect defaults to overwrite an explicit mapping: %v", mapping)
+	}
+}
+
 func TestAccountGetModelMapping_AntigravityRespectsWildcardOverride(t *testing.T) {
 	account := &Account{
 		Platform: PlatformAntigravity,


### PR DESCRIPTION
## 中文

### 背景

`platform=gemini`、`type=oauth`、`oauth_type=google_one` 账号当前沿用通用 Gemini 模型目录。账号没有自定义 mapping 时，管理员界面和调度资格会包含旧通道实际不支持的 3.x/image 模型，导致账号先被选中、再在上游返回 403/404。

### 修复

- 将 `google_one` 与其他 Gemini OAuth 账号类型区分处理。
- 为旧通道提供独立、保守的默认模型目录。
- 默认账号 mapping 使用同一目录，使调度 eligibility 与管理员界面保持一致。
- 保持用户显式 mapping 的优先级。

### 兼容性

- 不涉及数据库迁移或 OAuth 凭据格式变化。
- 非 Google One 的 Gemini OAuth/API Key 行为保持不变。
- 用户显式 mapping 仍然具有最高优先级。

### 验证

- 相关 package、handler 与账号 mapping 测试通过。
- `golangci-lint v2.9.0`：0 issues。
- 默认目录排除 3.x 和 image 模型。
- 空 mapping 不再表示支持任意模型。
- 回归测试覆盖显式 mapping 优先级。

## English

### Summary

- Distinguish `google_one` from other Gemini OAuth account types.
- Expose a conservative legacy-channel model catalog.
- Use the same catalog as the default account mapping so scheduler eligibility matches the UI.
- Preserve user-provided explicit mappings.

### Compatibility

- No migrations or credential-format changes.
- Non-Google-One Gemini OAuth/API Key behavior is unchanged.
- Explicit mappings remain authoritative.

### Verification

- Focused package, handler, and account-mapping tests passed.
- `golangci-lint v2.9.0`: 0 issues.
- The default catalog excludes 3.x and image models.
- Empty mapping no longer means arbitrary-model eligibility.
- Explicit mapping precedence is covered by regression tests.

Fixes #5934
