### PR TITLE
fix: classify account balance errors in channel monitor

### DIFF
--- a/backend/internal/repository/channel_monitor_v2_aggregation.go
+++ b/backend/internal/repository/channel_monitor_v2_aggregation.go
@@ -279,7 +279,7 @@ WITH dedup AS (
     WHEN text LIKE ANY(ARRAY['%failed to deserialize%','%missing required parameter%','%invalid request%','%invalid_request%','%tool_choice%']) THEN 'invalid_request'
     WHEN text LIKE ANY(ARRAY['%does not support the requested model%','%not supported by any configured account%','%model not supported%','%unsupported model%']) THEN 'model_unsupported'
     WHEN text LIKE ANY(ARRAY['%group not allowed%','%group_not_allowed%','%group access%']) THEN 'group_access'
-    WHEN text LIKE ANY(ARRAY['%run out of credits%','%insufficient balance%','%insufficient quota%','%subscription%','%quota exceeded%','%billing hard limit%']) THEN 'quota_or_balance'
+    WHEN text LIKE ANY(ARRAY['%run out of credits%','%insufficient balance%','%insufficient account balance%','%insufficient quota%','%subscription%','%quota exceeded%','%billing hard limit%']) THEN 'quota_or_balance'
     WHEN text LIKE ANY(ARRAY['%no available accounts%','%no healthy account%','%no healthy upstream account%','%failover budget exhausted%','%account pool%']) THEN 'account_pool_unavailable'
     WHEN status_code = 429 OR upstream_status_code = 429 OR text LIKE ANY(ARRAY['%rate limit%','%rate_limit%','%high demand%','%overloaded%','%concurrency limit%','%capacity%']) THEN 'rate_or_capacity'
     WHEN status_code IN (408,504) OR text LIKE ANY(ARRAY['%timeout%','%deadline exceeded%','%error code: 524%','%gateway time-out%','%gateway timeout%']) THEN 'timeout'

--- a/backend/internal/repository/channel_monitor_v2_repo_test.go
+++ b/backend/internal/repository/channel_monitor_v2_repo_test.go
@@ -196,6 +196,7 @@ func TestChannelMonitorV2SQLTaxonomyContainsGoNeedles(t *testing.T) {
 		"invalid_request",
 		"model not supported",
 		"billing hard limit",
+		"insufficient account balance",
 		"no healthy upstream account",
 		"rate_limit",
 		"gateway timeout",

--- a/backend/internal/service/channel_monitor_v2_error_taxonomy.go
+++ b/backend/internal/service/channel_monitor_v2_error_taxonomy.go
@@ -36,7 +36,7 @@ func ClassifyChannelMonitorV2Error(input ChannelMonitorV2ErrorInput) string {
 	if channelMonitorV2ContainsAny(text, "group not allowed", "group_not_allowed", "group access") {
 		return "group_access"
 	}
-	if channelMonitorV2ContainsAny(text, "run out of credits", "insufficient balance", "insufficient quota", "subscription", "quota exceeded", "billing hard limit") {
+	if channelMonitorV2ContainsAny(text, "run out of credits", "insufficient balance", "insufficient account balance", "insufficient quota", "subscription", "quota exceeded", "billing hard limit") {
 		return "quota_or_balance"
 	}
 	if channelMonitorV2ContainsAny(text, "no available accounts", "no healthy account", "no healthy upstream account", "failover budget exhausted", "account pool") {

--- a/backend/internal/service/channel_monitor_v2_test.go
+++ b/backend/internal/service/channel_monitor_v2_test.go
@@ -191,6 +191,7 @@ func TestChannelMonitorV2ErrorTaxonomyPriority(t *testing.T) {
 		{"auth before forbidden", ChannelMonitorV2ErrorInput{StatusCode: 403, Message: "invalid API key"}, "authentication"},
 		{"context", ChannelMonitorV2ErrorInput{Message: "maximum prompt length exceeded"}, "context_limit"},
 		{"unsupported", ChannelMonitorV2ErrorInput{Message: "not supported by any configured account"}, "model_unsupported"},
+		{"account balance before forbidden", ChannelMonitorV2ErrorInput{StatusCode: 403, Message: "Insufficient account balance"}, "quota_or_balance"},
 		{"pool", ChannelMonitorV2ErrorInput{Message: "No available accounts"}, "account_pool_unavailable"},
 		{"timeout", ChannelMonitorV2ErrorInput{Message: "error code: 524"}, "timeout"},
 		{"upstream", ChannelMonitorV2ErrorInput{ErrorOwner: "provider", StatusCode: 502, UpstreamStatusCode: 502}, "upstream_5xx"},


### PR DESCRIPTION
## Summary

- classify `Insufficient account balance` as `quota_or_balance` before the generic HTTP 403 fallback
- keep the Go drilldown classifier and SQL aggregation classifier in lockstep
- add regression coverage for the exact message emitted by API key authentication

## Root cause

API key authentication emits HTTP 403 with `INSUFFICIENT_BALANCE` and the message `Insufficient account balance`. The channel monitor taxonomy only matched the non-contiguous phrase `insufficient balance`, so these client balance failures fell through to `upstream_forbidden` and affected channel health even though `quota_or_balance` is ignored by default.

## Validation

- `go test ./internal/service -run TestChannelMonitorV2ErrorTaxonomyPriority -count=1`
- `go test ./internal/repository -run TestChannelMonitorV2SQLTaxonomyContainsGoNeedles -count=1`
- `make test-unit`
- `make test-integration`

No schema migration is required; normal channel-monitor recomputation rewrites recent aggregate windows with the corrected category.