### PR TITLE
feat: 泛化 Token 统计并修正 OpenAI Fast 策略作用域

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -59,7 +59,7 @@ func TestParseOpsDuration(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestParseOpsOpenAITokenStatsDuration(t *testing.T) {
+func TestParseOpsTokenStatsDuration(t *testing.T) {
 	tests := []struct {
 		input string
 		want  time.Duration
@@ -74,20 +74,20 @@ func TestParseOpsOpenAITokenStatsDuration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, ok := parseOpsOpenAITokenStatsDuration(tt.input)
+		got, ok := parseOpsTokenStatsDuration(tt.input)
 		require.Equal(t, tt.ok, ok, "input=%s", tt.input)
 		require.Equal(t, tt.want, got, "input=%s", tt.input)
 	}
 }
 
-func TestParseOpsOpenAITokenStatsFilter_Defaults(t *testing.T) {
+func TestParseOpsTokenStatsFilter_Defaults(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 
 	before := time.Now().UTC()
-	filter, err := parseOpsOpenAITokenStatsFilter(c)
+	filter, err := parseOpsTokenStatsFilter(c)
 	after := time.Now().UTC()
 
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestParseOpsOpenAITokenStatsFilter_Defaults(t *testing.T) {
 	require.WithinDuration(t, after, filter.EndTime, 2*time.Second)
 }
 
-func TestParseOpsOpenAITokenStatsFilter_WithTopN(t *testing.T) {
+func TestParseOpsTokenStatsFilter_WithTopN(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -113,7 +113,7 @@ func TestParseOpsOpenAITokenStatsFilter_WithTopN(t *testing.T) {
 		nil,
 	)
 
-	filter, err := parseOpsOpenAITokenStatsFilter(c)
+	filter, err := parseOpsTokenStatsFilter(c)
 	require.NoError(t, err)
 	require.Equal(t, "1h", filter.TimeRange)
 	require.Equal(t, "openai", filter.Platform)
@@ -124,7 +124,7 @@ func TestParseOpsOpenAITokenStatsFilter_WithTopN(t *testing.T) {
 	require.Equal(t, 0, filter.PageSize)
 }
 
-func TestParseOpsOpenAITokenStatsFilter_InvalidParams(t *testing.T) {
+func TestParseOpsTokenStatsFilter_InvalidParams(t *testing.T) {
 	tests := []string{
 		"/?time_range=7d",
 		"/?group_id=0",
@@ -144,7 +144,7 @@ func TestParseOpsOpenAITokenStatsFilter_InvalidParams(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, rawURL, nil)
 
-		_, err := parseOpsOpenAITokenStatsFilter(c)
+		_, err := parseOpsTokenStatsFilter(c)
 		require.Error(t, err, "url=%s", rawURL)
 	}
 }

--- a/backend/internal/handler/admin/ops_dashboard_handler.go
+++ b/backend/internal/handler/admin/ops_dashboard_handler.go
@@ -219,9 +219,9 @@ func (h *OpsHandler) GetDashboardErrorDistribution(c *gin.Context) {
 	response.Success(c, data)
 }
 
-// GetDashboardOpenAITokenStats returns OpenAI token efficiency stats grouped by model.
-// GET /api/v1/admin/ops/dashboard/openai-token-stats
-func (h *OpsHandler) GetDashboardOpenAITokenStats(c *gin.Context) {
+// GetDashboardTokenStats returns platform token efficiency stats grouped by model.
+// GET /api/v1/admin/ops/dashboard/token-stats
+func (h *OpsHandler) GetDashboardTokenStats(c *gin.Context) {
 	if h.opsService == nil {
 		response.Error(c, http.StatusServiceUnavailable, "Ops service not available")
 		return
@@ -231,13 +231,13 @@ func (h *OpsHandler) GetDashboardOpenAITokenStats(c *gin.Context) {
 		return
 	}
 
-	filter, err := parseOpsOpenAITokenStatsFilter(c)
+	filter, err := parseOpsTokenStatsFilter(c)
 	if err != nil {
 		response.BadRequest(c, err.Error())
 		return
 	}
 
-	data, err := h.opsService.GetOpenAITokenStats(c.Request.Context(), filter)
+	data, err := h.opsService.GetTokenStats(c.Request.Context(), filter)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
@@ -245,7 +245,7 @@ func (h *OpsHandler) GetDashboardOpenAITokenStats(c *gin.Context) {
 	response.Success(c, data)
 }
 
-func parseOpsOpenAITokenStatsFilter(c *gin.Context) (*service.OpsOpenAITokenStatsFilter, error) {
+func parseOpsTokenStatsFilter(c *gin.Context) (*service.OpsTokenStatsFilter, error) {
 	if c == nil {
 		return nil, fmt.Errorf("invalid request")
 	}
@@ -254,14 +254,14 @@ func parseOpsOpenAITokenStatsFilter(c *gin.Context) (*service.OpsOpenAITokenStat
 	if timeRange == "" {
 		timeRange = "30d"
 	}
-	dur, ok := parseOpsOpenAITokenStatsDuration(timeRange)
+	dur, ok := parseOpsTokenStatsDuration(timeRange)
 	if !ok {
 		return nil, fmt.Errorf("invalid time_range")
 	}
 	end := time.Now().UTC()
 	start := end.Add(-dur)
 
-	filter := &service.OpsOpenAITokenStatsFilter{
+	filter := &service.OpsTokenStatsFilter{
 		TimeRange: timeRange,
 		StartTime: start,
 		EndTime:   end,
@@ -311,7 +311,7 @@ func parseOpsOpenAITokenStatsFilter(c *gin.Context) (*service.OpsOpenAITokenStat
 	return filter, nil
 }
 
-func parseOpsOpenAITokenStatsDuration(v string) (time.Duration, bool) {
+func parseOpsTokenStatsDuration(v string) (time.Duration, bool) {
 	switch strings.TrimSpace(v) {
 	case "30m":
 		return 30 * time.Minute, true

--- a/backend/internal/repository/ops_repo_openai_token_stats.go
+++ b/backend/internal/repository/ops_repo_openai_token_stats.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-func (r *opsRepository) GetOpenAITokenStats(ctx context.Context, filter *service.OpsOpenAITokenStatsFilter) (*service.OpsOpenAITokenStatsResponse, error) {
+func (r *opsRepository) GetTokenStats(ctx context.Context, filter *service.OpsTokenStatsFilter) (*service.OpsTokenStatsResponse, error) {
 	if r == nil || r.db == nil {
 		return nil, fmt.Errorf("nil ops repository")
 	}
@@ -27,17 +28,27 @@ func (r *opsRepository) GetOpenAITokenStats(ctx context.Context, filter *service
 	dashboardFilter := &service.OpsDashboardFilter{
 		StartTime: filter.StartTime.UTC(),
 		EndTime:   filter.EndTime.UTC(),
-		Platform:  strings.TrimSpace(strings.ToLower(filter.Platform)),
 		GroupID:   filter.GroupID,
 	}
 
 	join, where, baseArgs, next := buildUsageWhere(dashboardFilter, dashboardFilter.StartTime, dashboardFilter.EndTime, 1)
-	where += " AND ul.model LIKE 'gpt%'"
+	join += " LEFT JOIN groups g ON g.id = ul.group_id LEFT JOIN accounts a ON a.id = ul.account_id"
+	platformExpr := "LOWER(TRIM(" + usageLogEffectivePlatformExpr + "))"
+	modelExpr := resolveModelDimensionExpressionWithAlias(usagestats.ModelSourceRequested, "ul")
+	platform := strings.TrimSpace(strings.ToLower(filter.Platform))
+	if platform != "" {
+		baseArgs = append(baseArgs, platform)
+		where += fmt.Sprintf(" AND %s = $%d", platformExpr, next)
+		next++
+	}
+	where += " AND NULLIF(TRIM(COALESCE(" + usageLogEffectivePlatformExpr + ", '')), '') IS NOT NULL"
+	where += " AND (ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens) > 0"
 
 	baseCTE := `
-WITH stats AS (
-  SELECT
-    ul.model AS model,
+	WITH stats AS (
+	  SELECT
+	    ` + platformExpr + ` AS platform,
+	    ` + modelExpr + ` AS model,
     COUNT(*)::bigint AS request_count,
     ROUND(
       AVG(
@@ -55,7 +66,7 @@ WITH stats AS (
   FROM usage_logs ul
   ` + join + `
   ` + where + `
-  GROUP BY ul.model
+	  GROUP BY ` + platformExpr + `, ` + modelExpr + `
 )
 `
 
@@ -67,7 +78,8 @@ WITH stats AS (
 
 	querySQL := baseCTE + `
 SELECT
-  model,
+	  platform,
+	  model,
   request_count,
   avg_tokens_per_sec,
   avg_first_token_ms,
@@ -75,7 +87,7 @@ SELECT
   avg_duration_ms,
   requests_with_first_token
 FROM stats
-ORDER BY request_count DESC, model ASC`
+ORDER BY request_count DESC, platform ASC, model ASC`
 
 	args := make([]any, 0, len(baseArgs)+2)
 	args = append(args, baseArgs...)
@@ -95,12 +107,13 @@ ORDER BY request_count DESC, model ASC`
 	}
 	defer func() { _ = rows.Close() }()
 
-	items := make([]*service.OpsOpenAITokenStatsItem, 0, 32)
+	items := make([]*service.OpsTokenStatsItem, 0, 32)
 	for rows.Next() {
-		item := &service.OpsOpenAITokenStatsItem{}
+		item := &service.OpsTokenStatsItem{}
 		var avgTPS sql.NullFloat64
 		var avgFirstToken sql.NullFloat64
 		if err := rows.Scan(
+			&item.Platform,
 			&item.Model,
 			&item.RequestCount,
 			&avgTPS,
@@ -125,11 +138,11 @@ ORDER BY request_count DESC, model ASC`
 		return nil, err
 	}
 
-	resp := &service.OpsOpenAITokenStatsResponse{
+	resp := &service.OpsTokenStatsResponse{
 		TimeRange: strings.TrimSpace(filter.TimeRange),
 		StartTime: dashboardFilter.StartTime,
 		EndTime:   dashboardFilter.EndTime,
-		Platform:  dashboardFilter.Platform,
+		Platform:  platform,
 		GroupID:   dashboardFilter.GroupID,
 		Items:     items,
 		Total:     total,

--- a/backend/internal/repository/ops_repo_openai_token_stats_test.go
+++ b/backend/internal/repository/ops_repo_openai_token_stats_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
+func TestOpsRepositoryGetTokenStats_PaginationMode(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &opsRepository{db: db}
 
@@ -18,7 +18,7 @@ func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
 	end := start.Add(24 * time.Hour)
 	groupID := int64(9)
 
-	filter := &service.OpsOpenAITokenStatsFilter{
+	filter := &service.OpsTokenStatsFilter{
 		TimeRange: "1d",
 		StartTime: start,
 		EndTime:   end,
@@ -33,6 +33,7 @@ func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(3)))
 
 	rows := sqlmock.NewRows([]string{
+		"platform",
 		"model",
 		"request_count",
 		"avg_tokens_per_sec",
@@ -41,14 +42,14 @@ func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
 		"avg_duration_ms",
 		"requests_with_first_token",
 	}).
-		AddRow("gpt-4o-mini", int64(20), 21.56, 120.34, int64(3000), int64(850), int64(18)).
-		AddRow("gpt-4.1", int64(20), 10.2, 240.0, int64(2500), int64(900), int64(20))
+		AddRow("openai", "gpt-4o-mini", int64(20), 21.56, 120.34, int64(3000), int64(850), int64(18)).
+		AddRow("openai", "o3", int64(20), 10.2, 240.0, int64(2500), int64(900), int64(20))
 
-	mock.ExpectQuery(`ORDER BY request_count DESC, model ASC\s+LIMIT \$5 OFFSET \$6`).
+	mock.ExpectQuery(`(?s)LOWER\(TRIM\(CASE WHEN g\.platform = 'composite' THEN a\.platform ELSE COALESCE\(NULLIF\(g\.platform,''\), a\.platform\) END\)\) = \$4.*NULLIF\(TRIM\(COALESCE\(CASE WHEN.*IS NOT NULL.*ul\.input_tokens.*> 0.*GROUP BY LOWER\(TRIM\(CASE WHEN.*COALESCE\(NULLIF\(TRIM\(ul\.requested_model\), ''\), ul\.model\).*ORDER BY request_count DESC, platform ASC, model ASC\s+LIMIT \$5 OFFSET \$6`).
 		WithArgs(start, end, groupID, "openai", 10, 10).
 		WillReturnRows(rows)
 
-	resp, err := repo.GetOpenAITokenStats(context.Background(), filter)
+	resp, err := repo.GetTokenStats(context.Background(), filter)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, int64(3), resp.Total)
@@ -59,6 +60,7 @@ func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
 	require.NotNil(t, resp.GroupID)
 	require.Equal(t, groupID, *resp.GroupID)
 	require.Len(t, resp.Items, 2)
+	require.Equal(t, "openai", resp.Items[0].Platform)
 	require.Equal(t, "gpt-4o-mini", resp.Items[0].Model)
 	require.NotNil(t, resp.Items[0].AvgTokensPerSec)
 	require.InDelta(t, 21.56, *resp.Items[0].AvgTokensPerSec, 0.0001)
@@ -68,13 +70,13 @@ func TestOpsRepositoryGetOpenAITokenStats_PaginationMode(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestOpsRepositoryGetOpenAITokenStats_TopNMode(t *testing.T) {
+func TestOpsRepositoryGetTokenStats_TopNMode(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &opsRepository{db: db}
 
 	start := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
-	filter := &service.OpsOpenAITokenStatsFilter{
+	filter := &service.OpsTokenStatsFilter{
 		TimeRange: "1h",
 		StartTime: start,
 		EndTime:   end,
@@ -86,6 +88,7 @@ func TestOpsRepositoryGetOpenAITokenStats_TopNMode(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
 
 	rows := sqlmock.NewRows([]string{
+		"platform",
 		"model",
 		"request_count",
 		"avg_tokens_per_sec",
@@ -94,13 +97,13 @@ func TestOpsRepositoryGetOpenAITokenStats_TopNMode(t *testing.T) {
 		"avg_duration_ms",
 		"requests_with_first_token",
 	}).
-		AddRow("gpt-4o", int64(5), nil, nil, int64(0), int64(0), int64(0))
+		AddRow("deepseek", "custom-chat-alias", int64(5), nil, nil, int64(7), int64(0), int64(0))
 
-	mock.ExpectQuery(`ORDER BY request_count DESC, model ASC\s+LIMIT \$3`).
+	mock.ExpectQuery(`(?s)COALESCE\(NULLIF\(TRIM\(ul\.requested_model\), ''\), ul\.model\) AS model.*NULLIF\(TRIM\(COALESCE\(CASE WHEN.*IS NOT NULL.*ORDER BY request_count DESC, platform ASC, model ASC\s+LIMIT \$3`).
 		WithArgs(start, end, 5).
 		WillReturnRows(rows)
 
-	resp, err := repo.GetOpenAITokenStats(context.Background(), filter)
+	resp, err := repo.GetTokenStats(context.Background(), filter)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.TopN)
@@ -108,19 +111,21 @@ func TestOpsRepositoryGetOpenAITokenStats_TopNMode(t *testing.T) {
 	require.Equal(t, 0, resp.Page)
 	require.Equal(t, 0, resp.PageSize)
 	require.Len(t, resp.Items, 1)
+	require.Equal(t, "deepseek", resp.Items[0].Platform)
+	require.Equal(t, "custom-chat-alias", resp.Items[0].Model)
 	require.Nil(t, resp.Items[0].AvgTokensPerSec)
 	require.Nil(t, resp.Items[0].AvgFirstTokenMs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestOpsRepositoryGetOpenAITokenStats_EmptyResult(t *testing.T) {
+func TestOpsRepositoryGetTokenStats_EmptyResult(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &opsRepository{db: db}
 
 	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	end := start.Add(30 * time.Minute)
-	filter := &service.OpsOpenAITokenStatsFilter{
+	filter := &service.OpsTokenStatsFilter{
 		TimeRange: "30m",
 		StartTime: start,
 		EndTime:   end,
@@ -132,9 +137,10 @@ func TestOpsRepositoryGetOpenAITokenStats_EmptyResult(t *testing.T) {
 		WithArgs(start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 
-	mock.ExpectQuery(`ORDER BY request_count DESC, model ASC\s+LIMIT \$3 OFFSET \$4`).
+	mock.ExpectQuery(`ORDER BY request_count DESC, platform ASC, model ASC\s+LIMIT \$3 OFFSET \$4`).
 		WithArgs(start, end, 20, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
+			"platform",
 			"model",
 			"request_count",
 			"avg_tokens_per_sec",
@@ -144,7 +150,7 @@ func TestOpsRepositoryGetOpenAITokenStats_EmptyResult(t *testing.T) {
 			"requests_with_first_token",
 		}))
 
-	resp, err := repo.GetOpenAITokenStats(context.Background(), filter)
+	resp, err := repo.GetTokenStats(context.Background(), filter)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, int64(0), resp.Total)

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -274,7 +274,7 @@ func registerOpsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		ops.GET("/dashboard/latency-histogram", h.Admin.Ops.GetDashboardLatencyHistogram)
 		ops.GET("/dashboard/error-trend", h.Admin.Ops.GetDashboardErrorTrend)
 		ops.GET("/dashboard/error-distribution", h.Admin.Ops.GetDashboardErrorDistribution)
-		ops.GET("/dashboard/openai-token-stats", h.Admin.Ops.GetDashboardOpenAITokenStats)
+		ops.GET("/dashboard/token-stats", h.Admin.Ops.GetDashboardTokenStats)
 	}
 }
 

--- a/backend/internal/server/routes/ops_token_stats_routes_test.go
+++ b/backend/internal/server/routes/ops_token_stats_routes_test.go
@@ -1,0 +1,28 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/handler"
+	adminhandler "github.com/Wei-Shaw/sub2api/internal/handler/admin"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpsTokenStatsRoutesExposeOnlyCurrentEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handlers := &handler.Handlers{Admin: &handler.AdminHandlers{Ops: adminhandler.NewOpsHandler(nil)}}
+	registerOpsRoutes(router.Group("/api/v1/admin"), handlers)
+
+	registeredGET := make(map[string]bool)
+	for _, route := range router.Routes() {
+		if route.Method == http.MethodGet {
+			registeredGET[route.Path] = true
+		}
+	}
+
+	require.True(t, registeredGET["/api/v1/admin/ops/dashboard/token-stats"])
+	require.False(t, registeredGET["/api/v1/admin/ops/dashboard/openai-token-stats"])
+}

--- a/backend/internal/service/openai_fast_policy_test.go
+++ b/backend/internal/service/openai_fast_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -13,7 +14,8 @@ import (
 )
 
 type openAIFastPolicyRepoStub struct {
-	values map[string]string
+	values        map[string]string
+	getValueCalls atomic.Int64
 }
 
 func (s *openAIFastPolicyRepoStub) Get(ctx context.Context, key string) (*Setting, error) {
@@ -21,6 +23,7 @@ func (s *openAIFastPolicyRepoStub) Get(ctx context.Context, key string) (*Settin
 }
 
 func (s *openAIFastPolicyRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	s.getValueCalls.Add(1)
 	if v, ok := s.values[key]; ok {
 		return v, nil
 	}
@@ -262,6 +265,137 @@ func TestApplyOpenAIFastPolicyToBody_ForcePriorityRewritesKnownTier(t *testing.T
 	}
 }
 
+func TestApplyOpenAIFastPolicyToBody_ForcePriorityInjectsMissingTier(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierPriority,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	}
+	svc := newOpenAIGatewayServiceWithSettings(t, settings)
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	body := []byte(`{"model":"gpt-5.5","messages":[]}`)
+
+	updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestApplyOpenAIFastPolicyToBody_ForcePriorityFallbackInjectsMissingTier(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier:    OpenAIFastTierPriority,
+			Action:         BetaPolicyActionPass,
+			Scope:          BetaPolicyScopeAll,
+			ModelWhitelist: []string{"gpt-5.5"},
+			FallbackAction: OpenAIFastPolicyActionForcePriority,
+		}},
+	}
+	svc := newOpenAIGatewayServiceWithSettings(t, settings)
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	body := []byte(`{"model":"gpt-4.1","messages":[]}`)
+
+	updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-4.1", body)
+	require.NoError(t, err)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestApplyOpenAIFastPolicyToBody_CachesPolicyForMissingTierHotPath(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierAny,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	}
+	raw, err := json.Marshal(settings)
+	require.NoError(t, err)
+	repo := &openAIFastPolicyRepoStub{values: map[string]string{
+		SettingKeyOpenAIFastPolicySettings: string(raw),
+	}}
+	svc := &OpenAIGatewayService{
+		settingService: NewSettingService(repo, &config.Config{}),
+	}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	body := []byte(`{"model":"gpt-5.5"}`)
+
+	for range 5 {
+		updated, applyErr := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+		require.NoError(t, applyErr)
+		require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+	}
+	require.Equal(t, int64(1), repo.getValueCalls.Load())
+}
+
+func TestSetOpenAIFastPolicySettingsRefreshesHotPathCache(t *testing.T) {
+	repo := &openAIFastPolicyRepoStub{values: map[string]string{}}
+	settingSvc := NewSettingService(repo, &config.Config{})
+	svc := &OpenAIGatewayService{settingService: settingSvc}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	body := []byte(`{"model":"gpt-5.5"}`)
+
+	updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+	require.Equal(t, int64(1), repo.getValueCalls.Load())
+
+	err = settingSvc.SetOpenAIFastPolicySettings(context.Background(), &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierPriority,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	})
+	require.NoError(t, err)
+
+	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+	require.Equal(t, int64(1), repo.getValueCalls.Load(), "写入后应直接使用刷新后的内存快照")
+}
+
+func TestApplyOpenAIFastPolicyToBody_NonOpenAIPlatformsBypassPolicy(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierAny,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	}
+	raw, err := json.Marshal(settings)
+	require.NoError(t, err)
+	repo := &openAIFastPolicyRepoStub{values: map[string]string{
+		SettingKeyOpenAIFastPolicySettings: string(raw),
+	}}
+	svc := &OpenAIGatewayService{
+		settingService: NewSettingService(repo, &config.Config{}),
+	}
+
+	for _, platform := range []string{
+		PlatformAnthropic,
+		PlatformGemini,
+		PlatformAntigravity,
+		PlatformGrok,
+		PlatformKimi,
+		PlatformZhipu,
+		PlatformDeepseek,
+	} {
+		t.Run(platform, func(t *testing.T) {
+			account := &Account{Platform: platform, Type: AccountTypeAPIKey}
+			for _, body := range [][]byte{
+				[]byte(`{"model":"provider-model"}`),
+				[]byte(`{"model":"provider-model","service_tier":"fast"}`),
+			} {
+				updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "provider-model", body)
+				require.NoError(t, err)
+				require.Equal(t, string(body), string(updated))
+			}
+		})
+	}
+	require.Equal(t, int64(0), repo.getValueCalls.Load(), "非 OpenAI 上游不应读取或应用 OpenAI fast policy")
+}
+
 // TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule 验证默认配置
 // 下客户端显式发送的 OpenAI 官方合法 tier 能透传到上游而不被静默剥离。
 func TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule(t *testing.T) {
@@ -407,7 +541,7 @@ func TestSetOpenAIFastPolicySettings_Validation(t *testing.T) {
 	got, err := svc.GetOpenAIFastPolicySettings(context.Background())
 	require.NoError(t, err)
 	require.Len(t, got.Rules, 1)
-	require.Equal(t, OpenAIFastTierPriority, got.Rules[0].ServiceTier)
+	require.Equal(t, OpenAIFastTierAny, got.Rules[0].ServiceTier)
 	require.Equal(t, OpenAIFastPolicyActionForcePriority, got.Rules[0].Action)
 	require.Equal(t, []int64{42, 43}, got.Rules[0].UserIDs)
 }

--- a/backend/internal/service/openai_fast_policy_ws_test.go
+++ b/backend/internal/service/openai_fast_policy_ws_test.go
@@ -122,6 +122,50 @@ func TestWSResponseCreate_ForcePriorityRewritesKnownTier(t *testing.T) {
 	}
 }
 
+func TestWSResponseCreate_ForcePriorityInjectsMissingTier(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierPriority,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	}
+	svc := newOpenAIGatewayServiceWithSettings(t, settings)
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	frame := []byte(`{"type":"response.create","model":"gpt-5.5","input":[]}`)
+
+	updated, blocked, err := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "gpt-5.5", frame)
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestWSResponseCreate_NonOpenAIPlatformsBypassPolicy(t *testing.T) {
+	settings := &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierAny,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	}
+	svc := newOpenAIGatewayServiceWithSettings(t, settings)
+
+	for _, platform := range []string{PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		t.Run(platform, func(t *testing.T) {
+			account := &Account{Platform: platform, Type: AccountTypeAPIKey}
+			for _, frame := range [][]byte{
+				[]byte(`{"type":"response.create","model":"provider-model","input":[]}`),
+				[]byte(`{"type":"response.create","model":"provider-model","service_tier":"fast"}`),
+			} {
+				updated, blocked, err := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "provider-model", frame)
+				require.NoError(t, err)
+				require.Nil(t, blocked)
+				require.Equal(t, string(frame), string(updated))
+			}
+		})
+	}
+}
+
 func TestWSResponseCreate_FlexPassThrough(t *testing.T) {
 	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -301,6 +301,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return nil, policyErr
 	}
 	responsesBody = updatedBody
+	responsesReq.ServiceTier = normalizedOpenAIServiceTierValue(gjson.GetBytes(responsesBody, "service_tier").String())
 
 	// 5. Get access token
 	token, _, err := s.GetAccessToken(ctx, account)

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -92,17 +92,19 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		upstreamBody = normalizedBody
 	}
 
-	// 4. Apply OpenAI fast policy on the CC body
-	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, upstreamBody)
-	if policyErr != nil {
-		var blocked *OpenAIFastBlockedError
-		if errors.As(policyErr, &blocked) {
-			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
-			writeChatCompletionsError(c, http.StatusForbidden, "permission_error", blocked.Message)
+	// 4. Apply the OpenAI fast policy only when the final upstream is OpenAI.
+	if openAIFastPolicyAppliesToAccount(account) {
+		updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, upstreamBody)
+		if policyErr != nil {
+			var blocked *OpenAIFastBlockedError
+			if errors.As(policyErr, &blocked) {
+				MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+				writeChatCompletionsError(c, http.StatusForbidden, "permission_error", blocked.Message)
+			}
+			return nil, policyErr
 		}
-		return nil, policyErr
+		upstreamBody = updatedBody
 	}
-	upstreamBody = updatedBody
 	// 计费兜底 tier = 最终出站 body（policy filter/force 后）里的 tier；
 	// 最终值由 resolvedOpenAIUpstreamServiceTier 决定（上游回显优先）。
 	serviceTier := extractOpenAIServiceTierFromBody(upstreamBody)

--- a/backend/internal/service/openai_gateway_chat_completions_raw_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_test.go
@@ -123,6 +123,40 @@ func TestForwardAsRawChatCompletions_ForcesStreamUsageUpstreamAndPassesUsageDown
 	require.Contains(t, rec.Body.String(), "data: [DONE]")
 }
 
+func TestForwardAsRawChatCompletions_ForcePriorityUpdatesUpstreamAndBillingTier(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl_fast","object":"chat.completion","model":"gpt-5.4","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		)),
+	}}
+	svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierPriority,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	})
+	svc.cfg = rawChatCompletionsTestConfig()
+	svc.httpUpstream = upstream
+
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, rawChatCompletionsTestAccount(), body, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(upstream.lastBody, "service_tier").String())
+	require.NotNil(t, result.ServiceTier)
+	require.Equal(t, OpenAIFastTierPriority, *result.ServiceTier)
+}
+
 func TestForwardAsChatCompletions_OpenAICompatibleGrokRawMissingUsageFailsBeforeWrite(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -275,6 +309,42 @@ func TestForwardAsRawChatCompletions_PreservesMappedGPT56MaxEffort(t *testing.T)
 	require.Equal(t, "max", gjson.GetBytes(upstream.lastBody, "reasoning_effort").String())
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "max", *result.ReasoningEffort)
+}
+
+func TestForwardAsRawChatCompletions_NonOpenAIBypassesFastPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"provider-model","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl_policy","object":"chat.completion","model":"provider-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		)),
+	}}
+	svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierAny,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	})
+	svc.cfg = rawChatCompletionsTestConfig()
+	svc.httpUpstream = upstream
+	account := rawChatCompletionsTestAccount()
+	account.Platform = PlatformDeepseek
+
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, account, body, "")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+	require.Nil(t, result.ReasoningEffort)
 }
 
 func TestForwardAsRawChatCompletions_NonStreamingCapturesCacheWriteUsage(t *testing.T) {

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -238,6 +238,68 @@ func TestForwardAsChatCompletions_APIKeyPropagatesPromptCacheKeyInResponsesBody(
 	require.Equal(t, generateSessionUUID(isolateOpenAISessionID(99, "cache-key-123")), upstream.lastReq.Header.Get("session_id"))
 }
 
+func TestForwardAsChatCompletions_DeepSeekResponsesPathsBypassForcePriority(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name     string
+		protocol string
+		body     []byte
+	}{
+		{
+			name:     "fixed responses chat body",
+			protocol: APIProtocolResponses,
+			body:     []byte(`{"model":"deepseek-v4-pro","messages":[{"role":"user","content":"hello"}],"stream":false}`),
+		},
+		{
+			name:     "adaptive responses-shaped body",
+			protocol: APIProtocolAdaptive,
+			body:     []byte(`{"model":"deepseek-v4-pro","input":"hello","stream":false}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop after request capture"}}`)),
+			}}
+			svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+				Rules: []OpenAIFastPolicyRule{{
+					ServiceTier: OpenAIFastTierAny,
+					Action:      OpenAIFastPolicyActionForcePriority,
+					Scope:       BetaPolicyScopeAll,
+				}},
+			})
+			svc.cfg = &config.Config{}
+			svc.httpUpstream = upstream
+			account := &Account{
+				ID:          101,
+				Name:        "deepseek-responses",
+				Platform:    PlatformDeepseek,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":      "sk-test",
+					"api_protocol": tt.protocol,
+				},
+			}
+
+			result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, tt.body, "", "")
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+		})
+	}
+}
+
 func TestForwardAsChatCompletions_OAuthDoesNotInjectDefaultInstructions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -588,9 +588,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	if rawTier := requestView.ServiceTier; rawTier != "" {
-		if normTier := normalizedOpenAIServiceTierValue(rawTier); normTier != "" {
-			action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
+	if openAIFastPolicyAppliesToAccount(account) {
+		rawTier := requestView.ServiceTier
+		normTier := normalizedOpenAIServiceTierValue(rawTier)
+		action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
+		if normTier != "" || action == OpenAIFastPolicyActionForcePriority {
 			switch action {
 			case BetaPolicyActionBlock:
 				msg := errMsg

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -663,6 +663,7 @@ func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(
 			result.RequestID = firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id"))
 		}
 		result.ReasoningEffort = extractOpenAIReasoningEffortFromBody(body, upstreamModel, billingModel, originalModel)
+		result.ServiceTier = extractOpenAIServiceTierFromBody(responsesBody)
 	}
 	return result, err
 }

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -131,8 +131,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	responsesReq.Stream = true
 	isStream := true
 
-	// 3b. Handle BetaFastMode → service_tier: "priority"
-	if containsBetaToken(c.GetHeader("anthropic-beta"), claude.BetaFastMode) {
+	// 3b. Handle BetaFastMode → service_tier: "priority" only for OpenAI upstreams.
+	if openAIFastPolicyAppliesToAccount(account) && containsBetaToken(c.GetHeader("anthropic-beta"), claude.BetaFastMode) {
 		responsesReq.ServiceTier = "priority"
 	}
 
@@ -287,6 +287,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		return nil, policyErr
 	}
 	responsesBody = updatedBody
+	responsesReq.ServiceTier = normalizedOpenAIServiceTierValue(gjson.GetBytes(responsesBody, "service_tier").String())
 	grokCacheIdentity := ""
 	if account.Platform == PlatformGrok {
 		grokIntentBody := responsesBody

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -63,6 +65,9 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	chatReq.Model = upstreamModel
 	chatReq.ReasoningEffort = openAICompatAnthropicReasoningEffort(&anthropicReq, upstreamModel, chatReq.ReasoningEffort)
 	chatReq.Stream = clientStream
+	if openAIFastPolicyAppliesToAccount(account) && containsBetaToken(c.GetHeader("anthropic-beta"), claude.BetaFastMode) {
+		chatReq.ServiceTier = OpenAIFastTierPriority
+	}
 	if clientStream {
 		chatReq.StreamOptions = &apicompat.ChatStreamOptions{IncludeUsage: true}
 	}
@@ -70,7 +75,6 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	convertedEffort := chatReq.ReasoningEffort
 	reasoningEffort := &convertedEffort
 	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, body, billingModel)
-	serviceTier := extractOpenAIServiceTierFromBody(body)
 
 	chatBody, err := json.Marshal(chatReq)
 	if err != nil {
@@ -87,10 +91,18 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 			}
 		}
 	}
-	// Unlike forwardResponsesViaRawChatCompletions, applyOpenAIFastPolicyToBody
-	// is intentionally skipped: Anthropic Messages bodies carry no service_tier,
-	// so the converted Chat Completions body never contains one and the policy
-	// would always be a no-op on this path.
+	if openAIFastPolicyAppliesToAccount(account) {
+		chatBody, err = s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, chatBody)
+		if err != nil {
+			var blocked *OpenAIFastBlockedError
+			if errors.As(err, &blocked) {
+				MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+				writeAnthropicError(c, http.StatusForbidden, "forbidden_error", blocked.Message)
+			}
+			return nil, err
+		}
+	}
+	serviceTier := extractOpenAIServiceTierFromBody(chatBody)
 
 	logger.L().Debug("openai messages: forwarding via raw chat completions",
 		zap.Int64("account_id", account.ID),

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -163,6 +164,122 @@ func TestForwardAsAnthropic_ForceChatCompletionsNonStreaming(t *testing.T) {
 	require.Equal(t, 2, result.Usage.OutputTokens)
 	require.Equal(t, 1, result.Usage.CacheReadInputTokens)
 	require.False(t, result.Stream)
+}
+
+func TestForwardAsAnthropic_ForceChatCompletionsAppliesForcePriorityPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl_fast","object":"chat.completion","model":"gpt-5.4","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		)),
+	}}
+	svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+		Rules: []OpenAIFastPolicyRule{{
+			ServiceTier: OpenAIFastTierPriority,
+			Action:      OpenAIFastPolicyActionForcePriority,
+			Scope:       BetaPolicyScopeAll,
+		}},
+	})
+	svc.cfg = rawChatCompletionsTestConfig()
+	svc.httpUpstream = upstream
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(upstream.lastBody, "service_tier").String())
+	require.NotNil(t, result.ServiceTier)
+	require.Equal(t, OpenAIFastTierPriority, *result.ServiceTier)
+}
+
+func TestForwardAsAnthropic_NonOpenAIResponsesBypassFastPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, platform := range []string{PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		t.Run(platform, func(t *testing.T) {
+			body := []byte(`{"model":"provider-model","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Header.Set("anthropic-beta", claude.BetaFastMode)
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop after request capture"}}`)),
+			}}
+			svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+				Rules: []OpenAIFastPolicyRule{{
+					ServiceTier: OpenAIFastTierAny,
+					Action:      OpenAIFastPolicyActionForcePriority,
+					Scope:       BetaPolicyScopeAll,
+				}},
+			})
+			svc.cfg = rawChatCompletionsTestConfig()
+			svc.httpUpstream = upstream
+			account := rawChatCompletionsTestAccount()
+			account.Platform = platform
+			account.Credentials["api_protocol"] = APIProtocolResponses
+			account.Extra = map[string]any{
+				openai_compat.ExtraKeyResponsesMode: string(openai_compat.ResponsesSupportModeForceResponses),
+			}
+
+			result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+		})
+	}
+}
+
+func TestForwardAnthropicViaRawChatCompletions_NonOpenAIBypassesFastPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, platform := range []string{PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		t.Run(platform, func(t *testing.T) {
+			body := []byte(`{"model":"provider-model","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Header.Set("anthropic-beta", claude.BetaFastMode)
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"chatcmpl_non_openai","object":"chat.completion","model":"provider-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+				)),
+			}}
+			svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+				Rules: []OpenAIFastPolicyRule{{
+					ServiceTier: OpenAIFastTierAny,
+					Action:      OpenAIFastPolicyActionForcePriority,
+					Scope:       BetaPolicyScopeAll,
+				}},
+			})
+			svc.cfg = rawChatCompletionsTestConfig()
+			svc.httpUpstream = upstream
+			account := forceChatMessagesFallbackAccount()
+			account.Platform = platform
+
+			result, err := svc.forwardAnthropicViaRawChatCompletions(context.Background(), c, account, body, "")
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+			require.Nil(t, result.ServiceTier)
+		})
+	}
 }
 
 // Covers the fully-new streaming composition: text block is still open when

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1299,15 +1299,21 @@ type OpenAIFastBlockedError struct {
 
 func (e *OpenAIFastBlockedError) Error() string { return e.Message }
 
+func openAIFastPolicyAppliesToAccount(account *Account) bool {
+	return account != nil && account.Platform == PlatformOpenAI
+}
+
 // evaluateOpenAIFastPolicy returns the action and error message that should be
 // applied for a request with the given account/model/service_tier. When the
-// policy service is unavailable or no rule matches, it returns
+// final upstream is not OpenAI, the policy service is unavailable, or no rule
+// matches, it returns
 // (BetaPolicyActionPass, "") so callers can short-circuit safely.
 //
 // Matching rules:
 //   - Scope filters by account type (all / oauth / apikey / bedrock)
 //   - UserIDs, when present, filters by the trusted Sub2API user that owns the API key
-//   - ServiceTier must be empty (= any), "all", or equal the normalized tier
+//   - Non-force actions require ServiceTier to be empty (= any), "all", or
+//     equal the normalized tier; force_priority ignores the incoming tier
 //   - ModelWhitelist narrows the rule to specific models; FallbackAction
 //     handles the non-matching case (default: pass)
 //   - User-specific rules take precedence over global rules; each group keeps
@@ -1322,20 +1328,13 @@ func (e *OpenAIFastBlockedError) Error() string { return e.Message }
 //     发生重叠，admin 可通过规则顺序明确意图。因此采用 first-match 而
 //     非 BetaPolicy 那样的"block 覆盖 filter 覆盖 pass"语义。
 func (s *OpenAIGatewayService) evaluateOpenAIFastPolicy(ctx context.Context, account *Account, model, serviceTier string) (action, errMsg string) {
-	if s == nil || s.settingService == nil {
+	if !openAIFastPolicyAppliesToAccount(account) || s == nil || s.settingService == nil {
 		return BetaPolicyActionPass, ""
 	}
 	tier := strings.ToLower(strings.TrimSpace(serviceTier))
-	if tier == "" {
-		return BetaPolicyActionPass, ""
-	}
 	settings := openAIFastPolicySettingsFromContext(ctx)
 	if settings == nil {
-		fetched, err := s.settingService.GetOpenAIFastPolicySettings(ctx)
-		if err != nil || fetched == nil {
-			return BetaPolicyActionPass, ""
-		}
-		settings = fetched
+		settings = s.settingService.GetOpenAIFastPolicySettingsCached(ctx)
 	}
 	return evaluateOpenAIFastPolicyWithSettings(settings, openAIFastPolicyUserID(ctx), account, model, tier)
 }
@@ -1361,10 +1360,6 @@ func evaluateOpenAIFastPolicyWithSettings(settings *OpenAIFastPolicySettings, us
 			if !betaPolicyScopeMatches(rule.Scope, isOAuth, isBedrock) {
 				continue
 			}
-			ruleTier := strings.ToLower(strings.TrimSpace(rule.ServiceTier))
-			if ruleTier != "" && ruleTier != OpenAIFastTierAny && ruleTier != tier {
-				continue
-			}
 			eff := BetaPolicyRule{
 				Action:               rule.Action,
 				ErrorMessage:         rule.ErrorMessage,
@@ -1372,7 +1367,14 @@ func evaluateOpenAIFastPolicyWithSettings(settings *OpenAIFastPolicySettings, us
 				FallbackAction:       rule.FallbackAction,
 				FallbackErrorMessage: rule.FallbackErrorMessage,
 			}
-			return resolveRuleAction(eff, model)
+			resolvedAction, resolvedMessage := resolveRuleAction(eff, model)
+			ruleTier := strings.ToLower(strings.TrimSpace(rule.ServiceTier))
+			tierIndependent := rule.Action == OpenAIFastPolicyActionForcePriority || resolvedAction == OpenAIFastPolicyActionForcePriority
+			if !tierIndependent &&
+				(tier == "" || (ruleTier != "" && ruleTier != OpenAIFastTierAny && ruleTier != tier)) {
+				continue
+			}
+			return resolvedAction, resolvedMessage
 		}
 	}
 	return BetaPolicyActionPass, ""
@@ -1435,7 +1437,7 @@ func openAIFastPolicySettingsFromContext(ctx context.Context) *OpenAIFastPolicyS
 // body. When action=filter it removes the service_tier field; when
 // action=block it returns (body, *OpenAIFastBlockedError). On pass it
 // normalizes the service_tier value (e.g. client alias "fast" → "priority").
-// action=force_priority rewrites any matched known tier to "priority".
+// action=force_priority writes "priority" even when the field is absent.
 //
 // Rationale for normalize-on-pass: chat-completions / messages 入口在调用本
 // 函数之前已经通过 normalizeResponsesBodyServiceTier 把 service_tier 归一化
@@ -1446,15 +1448,17 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToBody(ctx context.Context, 
 	if len(body) == 0 {
 		return body, nil
 	}
+	// service_tier 是 OpenAI 上游语义。统一按最终选中的账号平台收口，
+	// 避免 Composite 路由到 Grok/CN 等非 OpenAI 上游时注入 priority。
+	if !openAIFastPolicyAppliesToAccount(account) {
+		return body, nil
+	}
 	rawTier := gjson.GetBytes(body, "service_tier").String()
-	if rawTier == "" {
-		return body, nil
-	}
 	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
+	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
+	if normTier == "" && action != OpenAIFastPolicyActionForcePriority {
 		return body, nil
 	}
-	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
 	switch action {
 	case BetaPolicyActionBlock:
 		msg := errMsg
@@ -1517,7 +1521,7 @@ func writeOpenAIFastPolicyBlockedResponse(c *gin.Context, err *OpenAIFastBlocked
 //
 //   - pass: keeps service_tier, normalizing aliases such as "fast" to "priority"
 //   - filter: returns a copy with top-level service_tier removed
-//   - force_priority: keeps service_tier and rewrites it to "priority"
+//   - force_priority: writes service_tier="priority", including when absent
 //   - block: returns (frame, *OpenAIFastBlockedError)
 //
 // Only frames whose "type" field strictly equals "response.create" are
@@ -1544,6 +1548,9 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToWSResponseCreate(
 	if len(frame) == 0 {
 		return frame, nil, nil
 	}
+	if !openAIFastPolicyAppliesToAccount(account) {
+		return frame, nil, nil
+	}
 	if !gjson.ValidBytes(frame) {
 		return frame, nil, nil
 	}
@@ -1558,14 +1565,11 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToWSResponseCreate(
 		return frame, nil, nil
 	}
 	rawTier := gjson.GetBytes(frame, "service_tier").String()
-	if rawTier == "" {
-		return frame, nil, nil
-	}
 	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
+	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
+	if normTier == "" && action != OpenAIFastPolicyActionForcePriority {
 		return frame, nil, nil
 	}
-	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
 	switch action {
 	case BetaPolicyActionBlock:
 		msg := errMsg

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -79,13 +79,15 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	if err != nil {
 		return nil, fmt.Errorf("marshal chat completions fallback request: %w", err)
 	}
-	chatBody, err = s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, chatBody)
-	if err != nil {
-		var blocked *OpenAIFastBlockedError
-		if errors.As(err, &blocked) {
-			writeOpenAIFastPolicyBlockedResponse(c, blocked)
+	if openAIFastPolicyAppliesToAccount(account) {
+		chatBody, err = s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, chatBody)
+		if err != nil {
+			var blocked *OpenAIFastBlockedError
+			if errors.As(err, &blocked) {
+				writeOpenAIFastPolicyBlockedResponse(c, blocked)
+			}
+			return nil, err
 		}
-		return nil, err
 	}
 	// 计费兜底 tier = 最终出站 body（policy filter/force 后）里的 tier；最终值由
 	// resolvedOpenAIUpstreamServiceTier 决定（上游回显优先）。filter 删掉字段后

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -103,6 +103,53 @@ func TestOpenAIRequestView_HasPatches(t *testing.T) {
 	require.False(t, view.HasPatches())
 }
 
+func TestOpenAIGatewayService_Forward_NonOpenAIPlatformsBypassFastPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, platform := range []string{PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		t.Run(platform, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+			}}
+			cfg := &config.Config{}
+			cfg.Security.URLAllowlist.Enabled = false
+			svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{
+				Rules: []OpenAIFastPolicyRule{{
+					ServiceTier: OpenAIFastTierAny,
+					Action:      OpenAIFastPolicyActionForcePriority,
+					Scope:       BetaPolicyScopeAll,
+				}},
+			})
+			svc.cfg = cfg
+			svc.httpUpstream = upstream
+			account := &Account{
+				ID:          1,
+				Name:        platform + "-responses",
+				Platform:    platform,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":      "sk-test",
+					"base_url":     "https://example.com",
+					"api_protocol": APIProtocolResponses,
+				},
+			}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+			SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+			result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"provider-model","stream":false,"input":"hello"}`))
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+		})
+	}
+}
+
 func TestOpenAIGatewayService_Forward_HTTPPatchPathKeepsLargeInputRaw(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	upstream := &httpUpstreamRecorder{

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -96,10 +96,8 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	// 预取一次 OpenAI Fast Policy settings，绑定到 ctx，让该 WS session
 	// 内所有帧的 evaluateOpenAIFastPolicy 调用复用同一份快照，避免每帧
 	// 进入 DB / settingRepo。Trade-off 见 withOpenAIFastPolicyContext 注释。
-	if s.settingService != nil {
-		if settings, err := s.settingService.GetOpenAIFastPolicySettings(ctx); err == nil && settings != nil {
-			ctx = withOpenAIFastPolicyContext(ctx, settings)
-		}
+	if s.settingService != nil && openAIFastPolicyAppliesToAccount(account) {
+		ctx = withOpenAIFastPolicyContext(ctx, s.settingService.GetOpenAIFastPolicySettingsCached(ctx))
 	}
 
 	// The handler normally owns this registration across retry attempts. Direct

--- a/backend/internal/service/ops_openai_token_stats.go
+++ b/backend/internal/service/ops_openai_token_stats.go
@@ -2,11 +2,12 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
 
-func (s *OpsService) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAITokenStatsFilter) (*OpsOpenAITokenStatsResponse, error) {
+func (s *OpsService) GetTokenStats(ctx context.Context, filter *OpsTokenStatsFilter) (*OpsTokenStatsResponse, error) {
 	if err := s.RequireMonitoringEnabled(ctx); err != nil {
 		return nil, err
 	}
@@ -22,6 +23,11 @@ func (s *OpsService) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAIT
 	if filter.StartTime.After(filter.EndTime) {
 		return nil, infraerrors.BadRequest("OPS_TIME_RANGE_INVALID", "start_time must be <= end_time")
 	}
+	platform := strings.ToLower(strings.TrimSpace(filter.Platform))
+	if platform != "" && !isConcreteRequestPlatform(platform) {
+		return nil, infraerrors.BadRequest("OPS_TOKEN_STATS_PLATFORM_INVALID", "platform is not supported")
+	}
+	filter.Platform = platform
 
 	if filter.GroupID != nil && *filter.GroupID <= 0 {
 		return nil, infraerrors.BadRequest("OPS_GROUP_ID_INVALID", "group_id must be > 0")
@@ -51,5 +57,5 @@ func (s *OpsService) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAIT
 		}
 	}
 
-	return s.opsRepo.GetOpenAITokenStats(ctx, filter)
+	return s.opsRepo.GetTokenStats(ctx, filter)
 }

--- a/backend/internal/service/ops_openai_token_stats_models.go
+++ b/backend/internal/service/ops_openai_token_stats_models.go
@@ -2,7 +2,7 @@ package service
 
 import "time"
 
-type OpsOpenAITokenStatsFilter struct {
+type OpsTokenStatsFilter struct {
 	TimeRange string
 	StartTime time.Time
 	EndTime   time.Time
@@ -18,11 +18,12 @@ type OpsOpenAITokenStatsFilter struct {
 	TopN int
 }
 
-func (f *OpsOpenAITokenStatsFilter) IsTopNMode() bool {
+func (f *OpsTokenStatsFilter) IsTopNMode() bool {
 	return f != nil && f.TopN > 0
 }
 
-type OpsOpenAITokenStatsItem struct {
+type OpsTokenStatsItem struct {
+	Platform               string   `json:"platform"`
 	Model                  string   `json:"model"`
 	RequestCount           int64    `json:"request_count"`
 	AvgTokensPerSec        *float64 `json:"avg_tokens_per_sec"`
@@ -32,7 +33,7 @@ type OpsOpenAITokenStatsItem struct {
 	RequestsWithFirstToken int64    `json:"requests_with_first_token"`
 }
 
-type OpsOpenAITokenStatsResponse struct {
+type OpsTokenStatsResponse struct {
 	TimeRange string    `json:"time_range"`
 	StartTime time.Time `json:"start_time"`
 	EndTime   time.Time `json:"end_time"`
@@ -40,9 +41,9 @@ type OpsOpenAITokenStatsResponse struct {
 	Platform string `json:"platform,omitempty"`
 	GroupID  *int64 `json:"group_id,omitempty"`
 
-	Items []*OpsOpenAITokenStatsItem `json:"items"`
+	Items []*OpsTokenStatsItem `json:"items"`
 
-	// Total model rows before pagination/topN trimming.
+	// Total platform/model rows before pagination/topN trimming.
 	Total int64 `json:"total"`
 
 	// Pagination mode metadata.

--- a/backend/internal/service/ops_openai_token_stats_test.go
+++ b/backend/internal/service/ops_openai_token_stats_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type openAITokenStatsRepoStub struct {
+type tokenStatsRepoStub struct {
 	OpsRepository
-	resp     *OpsOpenAITokenStatsResponse
+	resp     *OpsTokenStatsResponse
 	err      error
-	captured *OpsOpenAITokenStatsFilter
+	captured *OpsTokenStatsFilter
 }
 
-func (s *openAITokenStatsRepoStub) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAITokenStatsFilter) (*OpsOpenAITokenStatsResponse, error) {
+func (s *tokenStatsRepoStub) GetTokenStats(ctx context.Context, filter *OpsTokenStatsFilter) (*OpsTokenStatsResponse, error) {
 	s.captured = filter
 	if s.err != nil {
 		return nil, s.err
@@ -24,15 +24,15 @@ func (s *openAITokenStatsRepoStub) GetOpenAITokenStats(ctx context.Context, filt
 	if s.resp != nil {
 		return s.resp, nil
 	}
-	return &OpsOpenAITokenStatsResponse{}, nil
+	return &OpsTokenStatsResponse{}, nil
 }
 
-func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
+func TestOpsServiceGetTokenStats_Validation(t *testing.T) {
 	now := time.Now().UTC()
 
 	tests := []struct {
 		name       string
-		filter     *OpsOpenAITokenStatsFilter
+		filter     *OpsTokenStatsFilter
 		wantCode   int
 		wantReason string
 	}{
@@ -44,7 +44,7 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 		},
 		{
 			name: "start_time/end_time 必填",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: time.Time{},
 				EndTime:   now,
 			},
@@ -53,7 +53,7 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 		},
 		{
 			name: "start_time 不能晚于 end_time",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: now,
 				EndTime:   now.Add(-1 * time.Minute),
 			},
@@ -62,7 +62,7 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 		},
 		{
 			name: "group_id 必须大于 0",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: now.Add(-time.Hour),
 				EndTime:   now,
 				GroupID:   int64Ptr(0),
@@ -71,8 +71,18 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 			wantReason: "OPS_GROUP_ID_INVALID",
 		},
 		{
+			name: "platform 必须是具体平台",
+			filter: &OpsTokenStatsFilter{
+				StartTime: now.Add(-time.Hour),
+				EndTime:   now,
+				Platform:  PlatformComposite,
+			},
+			wantCode:   400,
+			wantReason: "OPS_TOKEN_STATS_PLATFORM_INVALID",
+		},
+		{
 			name: "top_n 与分页参数互斥",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: now.Add(-time.Hour),
 				EndTime:   now,
 				TopN:      10,
@@ -83,7 +93,7 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 		},
 		{
 			name: "top_n 参数越界",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: now.Add(-time.Hour),
 				EndTime:   now,
 				TopN:      101,
@@ -93,7 +103,7 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 		},
 		{
 			name: "page_size 参数越界",
-			filter: &OpsOpenAITokenStatsFilter{
+			filter: &OpsTokenStatsFilter{
 				StartTime: now.Add(-time.Hour),
 				EndTime:   now,
 				Page:      1,
@@ -107,10 +117,10 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := &OpsService{
-				opsRepo: &openAITokenStatsRepoStub{},
+				opsRepo: &tokenStatsRepoStub{},
 			}
 
-			_, err := svc.GetOpenAITokenStats(context.Background(), tt.filter)
+			_, err := svc.GetTokenStats(context.Background(), tt.filter)
 			require.Error(t, err)
 			require.Equal(t, tt.wantCode, infraerrors.Code(err))
 			require.Equal(t, tt.wantReason, infraerrors.Reason(err))
@@ -118,11 +128,11 @@ func TestOpsServiceGetOpenAITokenStats_Validation(t *testing.T) {
 	}
 }
 
-func TestOpsServiceGetOpenAITokenStats_DefaultPagination(t *testing.T) {
+func TestOpsServiceGetTokenStats_DefaultPagination(t *testing.T) {
 	now := time.Now().UTC()
-	repo := &openAITokenStatsRepoStub{
-		resp: &OpsOpenAITokenStatsResponse{
-			Items: []*OpsOpenAITokenStatsItem{
+	repo := &tokenStatsRepoStub{
+		resp: &OpsTokenStatsResponse{
+			Items: []*OpsTokenStatsItem{
 				{Model: "gpt-4o-mini", RequestCount: 10},
 			},
 			Total: 1,
@@ -130,25 +140,42 @@ func TestOpsServiceGetOpenAITokenStats_DefaultPagination(t *testing.T) {
 	}
 	svc := &OpsService{opsRepo: repo}
 
-	filter := &OpsOpenAITokenStatsFilter{
+	filter := &OpsTokenStatsFilter{
 		TimeRange: "30d",
 		StartTime: now.Add(-30 * 24 * time.Hour),
 		EndTime:   now,
 	}
-	resp, err := svc.GetOpenAITokenStats(context.Background(), filter)
+	resp, err := svc.GetTokenStats(context.Background(), filter)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, repo.captured)
 	require.Equal(t, 1, repo.captured.Page)
 	require.Equal(t, 20, repo.captured.PageSize)
 	require.Equal(t, 0, repo.captured.TopN)
+	require.Equal(t, "", repo.captured.Platform)
 }
 
-func TestOpsServiceGetOpenAITokenStats_RepoUnavailable(t *testing.T) {
+func TestOpsServiceGetTokenStats_NormalizesConcretePlatform(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &tokenStatsRepoStub{}
+	svc := &OpsService{opsRepo: repo}
+
+	_, err := svc.GetTokenStats(context.Background(), &OpsTokenStatsFilter{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now,
+		Platform:  " DeepSeek ",
+		TopN:      10,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repo.captured)
+	require.Equal(t, PlatformDeepseek, repo.captured.Platform)
+}
+
+func TestOpsServiceGetTokenStats_RepoUnavailable(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &OpsService{}
 
-	_, err := svc.GetOpenAITokenStats(context.Background(), &OpsOpenAITokenStatsFilter{
+	_, err := svc.GetTokenStats(context.Background(), &OpsTokenStatsFilter{
 		TimeRange: "1h",
 		StartTime: now.Add(-time.Hour),
 		EndTime:   now,

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -28,7 +28,7 @@ type OpsRepository interface {
 	GetLatencyHistogram(ctx context.Context, filter *OpsDashboardFilter) (*OpsLatencyHistogramResponse, error)
 	GetErrorTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsErrorTrendResponse, error)
 	GetErrorDistribution(ctx context.Context, filter *OpsDashboardFilter) (*OpsErrorDistributionResponse, error)
-	GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAITokenStatsFilter) (*OpsOpenAITokenStatsResponse, error)
+	GetTokenStats(ctx context.Context, filter *OpsTokenStatsFilter) (*OpsTokenStatsResponse, error)
 
 	InsertSystemMetrics(ctx context.Context, input *OpsInsertSystemMetricsInput) error
 	GetLatestSystemMetrics(ctx context.Context, windowMinutes int) (*OpsSystemMetricsSnapshot, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -101,8 +101,8 @@ func (m *opsRepoMock) GetErrorDistribution(ctx context.Context, filter *OpsDashb
 	return &OpsErrorDistributionResponse{}, nil
 }
 
-func (m *opsRepoMock) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAITokenStatsFilter) (*OpsOpenAITokenStatsResponse, error) {
-	return &OpsOpenAITokenStatsResponse{}, nil
+func (m *opsRepoMock) GetTokenStats(ctx context.Context, filter *OpsTokenStatsFilter) (*OpsTokenStatsResponse, error) {
+	return &OpsTokenStatsResponse{}, nil
 }
 
 func (m *opsRepoMock) InsertSystemMetrics(ctx context.Context, input *OpsInsertSystemMetricsInput) error {

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -101,10 +101,11 @@ type OpsAdvancedSettings struct {
 	// Deprecated compatibility field. It is always normalized to true.
 	IgnoreInvalidApiKeyErrors       bool `json:"ignore_invalid_api_key_errors"`
 	IgnoreInsufficientBalanceErrors bool `json:"ignore_insufficient_balance_errors"`
-	DisplayOpenAITokenStats         bool `json:"display_openai_token_stats"`
-	DisplayAlertEvents              bool `json:"display_alert_events"`
-	AutoRefreshEnabled              bool `json:"auto_refresh_enabled"`
-	AutoRefreshIntervalSec          int  `json:"auto_refresh_interval_seconds"`
+	// DisplayOpenAITokenStats keeps the legacy wire key while controlling the generic token stats card.
+	DisplayOpenAITokenStats bool `json:"display_openai_token_stats"`
+	DisplayAlertEvents      bool `json:"display_alert_events"`
+	AutoRefreshEnabled      bool `json:"auto_refresh_enabled"`
+	AutoRefreshIntervalSec  int  `json:"auto_refresh_interval_seconds"`
 }
 
 type OpsOpenAIAccountQuotaAutoPauseSettings struct {

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -941,7 +941,19 @@ func (s *SettingService) SetBetaPolicySettings(ctx context.Context, settings *Be
 	return s.settingRepo.Set(ctx, SettingKeyBetaPolicySettings, string(data))
 }
 
-// GetOpenAIFastPolicySettings 获取 OpenAI fast 策略配置
+const (
+	openAIFastPolicyCacheTTL  = 60 * time.Second
+	openAIFastPolicyErrorTTL  = 5 * time.Second
+	openAIFastPolicyDBTimeout = 5 * time.Second
+)
+
+type cachedOpenAIFastPolicySettings struct {
+	settings  *OpenAIFastPolicySettings
+	expiresAt int64
+}
+
+// GetOpenAIFastPolicySettings 获取 OpenAI fast 策略配置。
+// 管理端读路径直读 DB；网关热路径使用 GetOpenAIFastPolicySettingsCached。
 func (s *SettingService) GetOpenAIFastPolicySettings(ctx context.Context) (*OpenAIFastPolicySettings, error) {
 	value, err := s.settingRepo.GetValue(ctx, SettingKeyOpenAIFastPolicySettings)
 	if err != nil {
@@ -964,8 +976,85 @@ func (s *SettingService) GetOpenAIFastPolicySettings(ctx context.Context) (*Open
 			"key", SettingKeyOpenAIFastPolicySettings)
 		return DefaultOpenAIFastPolicySettings(), nil
 	}
+	canonicalizeOpenAIFastPolicySettings(&settings)
 
 	return &settings, nil
+}
+
+// GetOpenAIFastPolicySettingsCached 返回供网关热路径使用的进程内策略快照。
+// 当前节点写入后立即生效；多节点部署通过 60s TTL 收敛。缓存过期时由
+// singleflight 合并并发查询，DB 异常则短暂沿用最近一次有效快照。
+func (s *SettingService) GetOpenAIFastPolicySettingsCached(ctx context.Context) *OpenAIFastPolicySettings {
+	if s == nil || s.settingRepo == nil {
+		return DefaultOpenAIFastPolicySettings()
+	}
+	if cached, ok := s.openAIFastPolicyCache.Load().(*cachedOpenAIFastPolicySettings); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.settings
+		}
+	}
+
+	result, _, _ := s.openAIFastPolicySF.Do("openai_fast_policy_settings", func() (any, error) {
+		if cached, ok := s.openAIFastPolicyCache.Load().(*cachedOpenAIFastPolicySettings); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.settings, nil
+			}
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openAIFastPolicyDBTimeout)
+		defer cancel()
+
+		settings, err := s.GetOpenAIFastPolicySettings(dbCtx)
+		if err != nil {
+			slog.Warn("failed to get cached openai fast policy settings", "error", err)
+			fallback := DefaultOpenAIFastPolicySettings()
+			if prior, ok := s.openAIFastPolicyCache.Load().(*cachedOpenAIFastPolicySettings); ok && prior != nil {
+				fallback = prior.settings
+			}
+			return s.storeOpenAIFastPolicyCache(fallback, openAIFastPolicyErrorTTL), nil
+		}
+
+		return s.storeOpenAIFastPolicyCache(settings, openAIFastPolicyCacheTTL), nil
+	})
+	if settings, ok := result.(*OpenAIFastPolicySettings); ok && settings != nil {
+		return settings
+	}
+	return DefaultOpenAIFastPolicySettings()
+}
+
+func (s *SettingService) storeOpenAIFastPolicyCache(settings *OpenAIFastPolicySettings, ttl time.Duration) *OpenAIFastPolicySettings {
+	snapshot := cloneOpenAIFastPolicySettings(settings)
+	s.openAIFastPolicyCache.Store(&cachedOpenAIFastPolicySettings{
+		settings:  snapshot,
+		expiresAt: time.Now().Add(ttl).UnixNano(),
+	})
+	return snapshot
+}
+
+func cloneOpenAIFastPolicySettings(settings *OpenAIFastPolicySettings) *OpenAIFastPolicySettings {
+	if settings == nil {
+		return DefaultOpenAIFastPolicySettings()
+	}
+	out := &OpenAIFastPolicySettings{Rules: make([]OpenAIFastPolicyRule, len(settings.Rules))}
+	copy(out.Rules, settings.Rules)
+	for i := range out.Rules {
+		out.Rules[i].UserIDs = append([]int64(nil), settings.Rules[i].UserIDs...)
+		out.Rules[i].ModelWhitelist = append([]string(nil), settings.Rules[i].ModelWhitelist...)
+	}
+	return out
+}
+
+func canonicalizeOpenAIFastPolicySettings(settings *OpenAIFastPolicySettings) {
+	if settings == nil {
+		return
+	}
+	for i := range settings.Rules {
+		if settings.Rules[i].Action == OpenAIFastPolicyActionForcePriority {
+			settings.Rules[i].ServiceTier = OpenAIFastTierAny
+		}
+	}
 }
 
 // SetOpenAIFastPolicySettings 设置 OpenAI fast 策略配置
@@ -992,6 +1081,9 @@ func (s *SettingService) SetOpenAIFastPolicySettings(ctx context.Context, settin
 		}
 		if !validTiers[tier] {
 			return fmt.Errorf("rule[%d]: invalid service_tier %q", i, rule.ServiceTier)
+		}
+		if rule.Action == OpenAIFastPolicyActionForcePriority {
+			tier = OpenAIFastTierAny
 		}
 		settings.Rules[i].ServiceTier = tier
 		if !validActions[rule.Action] {
@@ -1027,7 +1119,11 @@ func (s *SettingService) SetOpenAIFastPolicySettings(ctx context.Context, settin
 		return fmt.Errorf("marshal openai fast policy settings: %w", err)
 	}
 
-	return s.settingRepo.Set(ctx, SettingKeyOpenAIFastPolicySettings, string(data))
+	if err := s.settingRepo.Set(ctx, SettingKeyOpenAIFastPolicySettings, string(data)); err != nil {
+		return err
+	}
+	s.storeOpenAIFastPolicyCache(settings, openAIFastPolicyCacheTTL)
+	return nil
 }
 
 // SetStreamTimeoutSettings 设置流超时处理配置

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -132,6 +132,8 @@ type SettingService struct {
 	openAICodexVersionSF        singleflight.Group
 	codexRestrictionPolicyCache atomic.Value // *cachedCodexRestrictionPolicy
 	codexRestrictionPolicySF    singleflight.Group
+	openAIFastPolicyCache       atomic.Value // *cachedOpenAIFastPolicySettings
+	openAIFastPolicySF          singleflight.Group
 
 	cyberSessionBlockRuntimeCache atomic.Value // *cachedCyberSessionBlockRuntime
 	cyberSessionBlockRuntimeSF    singleflight.Group

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -664,8 +664,9 @@ const (
 	OpenAIFastTierPriority = "priority" // 仅匹配 fast（priority）
 	OpenAIFastTierFlex     = "flex"     // 仅匹配 flex
 
-	// OpenAIFastPolicyActionForcePriority 会保留 service_tier 字段并强制写成
-	// priority，用于把 flex/auto/default/scale 等已识别 tier 收敛为 fast。
+	// OpenAIFastPolicyActionForcePriority 会强制写入 service_tier=priority，
+	// 包括请求未携带 service_tier 的情况。该动作不再按入站 tier 过滤，
+	// 保存时会把 ServiceTier 规范化为 all。
 	OpenAIFastPolicyActionForcePriority = "force_priority"
 )
 

--- a/frontend/src/api/__tests__/admin.ops.tokenStats.spec.ts
+++ b/frontend/src/api/__tests__/admin.ops.tokenStats.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { apiClient } from '@/api/client'
+import {
+  getTokenStats,
+  type OpsTokenStatsParams,
+  type OpsTokenStatsResponse,
+} from '@/api/admin/ops'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('admin ops token stats API', () => {
+  it('uses the generic endpoint and preserves token-stat filters', async () => {
+    const response: OpsTokenStatsResponse = {
+      time_range: '1h',
+      start_time: '2026-08-15T00:00:00Z',
+      end_time: '2026-08-15T01:00:00Z',
+      platform: 'deepseek',
+      group_id: 7,
+      items: [{
+        platform: 'deepseek',
+        model: 'deepseek-v4-pro',
+        request_count: 2,
+        avg_tokens_per_sec: 12.5,
+        avg_first_token_ms: 80,
+        total_output_tokens: 100,
+        avg_duration_ms: 4000,
+        requests_with_first_token: 2,
+      }],
+      total: 1,
+      top_n: 20,
+    }
+    const get = vi.spyOn(apiClient, 'get').mockResolvedValue({ data: response })
+    const controller = new AbortController()
+    const params: OpsTokenStatsParams = {
+      time_range: '1h',
+      platform: 'deepseek',
+      group_id: 7,
+      top_n: 20,
+    }
+
+    await expect(getTokenStats(params, { signal: controller.signal })).resolves.toEqual(response)
+
+    expect(get).toHaveBeenCalledWith('/admin/ops/dashboard/token-stats', {
+      params,
+      signal: controller.signal,
+    })
+  })
+})

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -210,9 +210,10 @@ export interface OpsDashboardSnapshotV2Response {
   error_trend: OpsErrorTrendResponse
 }
 
-export type OpsOpenAITokenStatsTimeRange = '30m' | '1h' | '1d' | '15d' | '30d'
+export type OpsTokenStatsTimeRange = '30m' | '1h' | '1d' | '15d' | '30d'
 
-export interface OpsOpenAITokenStatsItem {
+export interface OpsTokenStatsItem {
+  platform: string
   model: string
   request_count: number
   avg_tokens_per_sec?: number | null
@@ -222,21 +223,21 @@ export interface OpsOpenAITokenStatsItem {
   requests_with_first_token: number
 }
 
-export interface OpsOpenAITokenStatsResponse {
-  time_range: OpsOpenAITokenStatsTimeRange
+export interface OpsTokenStatsResponse {
+  time_range: OpsTokenStatsTimeRange
   start_time: string
   end_time: string
   platform?: string
   group_id?: number | null
-  items: OpsOpenAITokenStatsItem[]
+  items: OpsTokenStatsItem[]
   total: number
   page?: number
   page_size?: number
   top_n?: number | null
 }
 
-export interface OpsOpenAITokenStatsParams {
-  time_range?: OpsOpenAITokenStatsTimeRange
+export interface OpsTokenStatsParams {
+  time_range?: OpsTokenStatsTimeRange
   platform?: string
   group_id?: number | null
   page?: number
@@ -1068,11 +1069,11 @@ export async function getErrorDistribution(
   return data
 }
 
-export async function getOpenAITokenStats(
-  params: OpsOpenAITokenStatsParams,
+export async function getTokenStats(
+  params: OpsTokenStatsParams,
   options: OpsRequestOptions = {}
-): Promise<OpsOpenAITokenStatsResponse> {
-  const { data } = await apiClient.get<OpsOpenAITokenStatsResponse>('/admin/ops/dashboard/openai-token-stats', {
+): Promise<OpsTokenStatsResponse> {
+  const { data } = await apiClient.get<OpsTokenStatsResponse>('/admin/ops/dashboard/token-stats', {
     params,
     signal: options.signal
   })
@@ -1312,7 +1313,7 @@ export const opsAPI = {
   getLatencyHistogram,
   getErrorTrend,
   getErrorDistribution,
-  getOpenAITokenStats,
+  getTokenStats,
   getConcurrencyStats,
   getUserConcurrencyStats,
   getAccountAvailabilityStats,

--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -153,17 +153,18 @@ export default {
         startTime: 'Start Time',
         endTime: 'End Time'
       },
-      openaiTokenStats: {
-        title: 'OpenAI Token Request Stats',
+      tokenStats: {
+        title: 'Token Request Stats',
         viewModeTopN: 'TopN',
         viewModePagination: 'Pagination',
         prevPage: 'Previous',
         nextPage: 'Next',
         pageInfo: 'Page {page}/{total}',
-        totalModels: 'Total models: {total}',
-        failedToLoad: 'Failed to load OpenAI token stats',
-        empty: 'No OpenAI token stats for the current filters',
+        totalRows: 'Total platform/model rows: {total}',
+        failedToLoad: 'Failed to load token stats',
+        empty: 'No token stats for the current filters',
         table: {
+          platform: 'Platform',
           model: 'Model',
           requestCount: 'Requests',
           avgTokensPerSec: 'Avg Tokens/sec',
@@ -733,8 +734,8 @@ export default {
         dashboardCards: 'Dashboard Cards',
         displayAlertEvents: 'Display alert events',
         displayAlertEventsHint: 'Show or hide the recent alert events card on the ops dashboard. Enabled by default.',
-        displayOpenAITokenStats: 'Display OpenAI token request stats',
-        displayOpenAITokenStatsHint: 'Show or hide the OpenAI token request stats card on the ops dashboard. Hidden by default.',
+        displayOpenAITokenStats: 'Display token request stats',
+        displayOpenAITokenStatsHint: 'Show or hide the token request stats card on the ops dashboard. Hidden by default.',
         autoRefreshCountdown: 'Auto refresh: {seconds}s',
         validation: {
           title: 'Please fix the following issues',

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -149,17 +149,18 @@ export default {
         '30d': '近30天',
         custom: '自定义'
       },
-      openaiTokenStats: {
-        title: 'OpenAI Token 请求统计',
+      tokenStats: {
+        title: 'Token 请求统计',
         viewModeTopN: 'TopN',
         viewModePagination: '分页',
         prevPage: '上一页',
         nextPage: '下一页',
         pageInfo: '第 {page}/{total} 页',
-        totalModels: '模型总数：{total}',
-        failedToLoad: '加载 OpenAI Token 统计失败',
-        empty: '当前筛选条件下暂无 OpenAI Token 请求统计数据',
+        totalRows: '平台/模型统计项总数：{total}',
+        failedToLoad: '加载 Token 统计失败',
+        empty: '当前筛选条件下暂无 Token 请求统计数据',
         table: {
+          platform: '平台',
           model: '模型',
           requestCount: '请求数',
           avgTokensPerSec: '平均 Tokens/秒',
@@ -734,8 +735,8 @@ export default {
         dashboardCards: '仪表盘卡片',
         displayAlertEvents: '展示告警事件',
         displayAlertEventsHint: '控制运维监控仪表盘中告警事件卡片是否显示，默认开启。',
-        displayOpenAITokenStats: '展示 OpenAI Token 请求统计',
-        displayOpenAITokenStatsHint: '控制运维监控仪表盘中 OpenAI Token 请求统计卡片是否显示，默认关闭。',
+        displayOpenAITokenStats: '展示 Token 请求统计',
+        displayOpenAITokenStatsHint: '控制运维监控仪表盘中 Token 请求统计卡片是否显示，默认关闭。',
         autoRefreshCountdown: '自动刷新：{seconds}s',
         validation: {
           title: '请先修正以下问题',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -1199,11 +1199,7 @@
                     <Select
                       :modelValue="rule.action"
                       @update:modelValue="
-                        rule.action = $event as
-                          | 'pass'
-                          | 'filter'
-                          | 'block'
-                          | 'force_priority'
+                        updateOpenAIFastPolicyAction(rule, $event)
                       "
                       :options="openaiFastPolicyActionOptions"
                     />
@@ -12103,6 +12099,16 @@ function addOpenAIFastPolicyRule() {
 
 function removeOpenAIFastPolicyRule(index: number) {
   openaiFastPolicyForm.rules.splice(index, 1);
+}
+
+function updateOpenAIFastPolicyAction(
+  rule: OpenAIFastPolicyRule,
+  action: unknown,
+) {
+  rule.action = action as OpenAIFastPolicyRule["action"];
+  if (rule.action === "force_priority") {
+    rule.service_tier = "all";
+  }
 }
 
 function addOpenAIFastPolicyModelPattern(rule: OpenAIFastPolicyRule) {

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -84,9 +84,9 @@
         />
       </div>
 
-      <!-- Row: OpenAI Token Stats -->
-      <div v-if="opsEnabled && showOpenAITokenStats && !(loading && !hasLoadedOnce)" class="grid grid-cols-1 gap-6">
-        <OpsOpenAITokenStatsCard
+      <!-- Row: Token Stats -->
+      <div v-if="opsEnabled && showTokenStats && !(loading && !hasLoadedOnce)" class="grid grid-cols-1 gap-6">
+        <OpsTokenStatsCard
           :platform-filter="platform"
           :group-id-filter="groupId"
           :refresh-token="dashboardRefreshToken"
@@ -168,7 +168,7 @@ import OpsLatencyChart from './components/OpsLatencyChart.vue'
 import OpsThroughputTrendChart from './components/OpsThroughputTrendChart.vue'
 import OpsSwitchRateTrendChart from './components/OpsSwitchRateTrendChart.vue'
 import OpsAlertEventsCard from './components/OpsAlertEventsCard.vue'
-import OpsOpenAITokenStatsCard from './components/OpsOpenAITokenStatsCard.vue'
+import OpsTokenStatsCard from './components/OpsTokenStatsCard.vue'
 import OpsSystemLogTable from './components/OpsSystemLogTable.vue'
 import OpsRequestDetailsModal, { type OpsRequestDetailsPreset } from './components/OpsRequestDetailsModal.vue'
 import OpsSettingsDialog from './components/OpsSettingsDialog.vue'
@@ -393,7 +393,7 @@ applyRouteQueryToState()
 
 // Auto refresh settings
 const showAlertEvents = ref(true)
-const showOpenAITokenStats = ref(false)
+const showTokenStats = ref(false)
 const autoRefreshEnabled = ref(false)
 const autoRefreshIntervalMs = ref(30000) // default 30 seconds
 const autoRefreshCountdown = ref(0)
@@ -426,14 +426,14 @@ async function loadDashboardAdvancedSettings() {
   try {
     const settings = await opsAPI.getAdvancedSettings()
     showAlertEvents.value = settings.display_alert_events
-    showOpenAITokenStats.value = settings.display_openai_token_stats
+    showTokenStats.value = settings.display_openai_token_stats
     autoRefreshEnabled.value = settings.auto_refresh_enabled
     autoRefreshIntervalMs.value = settings.auto_refresh_interval_seconds * 1000
     autoRefreshCountdown.value = settings.auto_refresh_interval_seconds
   } catch (err) {
     console.error('[OpsDashboard] Failed to load dashboard advanced settings', err)
     showAlertEvents.value = true
-    showOpenAITokenStats.value = false
+    showTokenStats.value = false
     autoRefreshEnabled.value = false
     autoRefreshIntervalMs.value = 30000
     autoRefreshCountdown.value = 0

--- a/frontend/src/views/admin/ops/__tests__/OpsDashboard.tokenStats.spec.ts
+++ b/frontend/src/views/admin/ops/__tests__/OpsDashboard.tokenStats.spec.ts
@@ -1,0 +1,138 @@
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import OpsDashboard from '../OpsDashboard.vue'
+
+const mocks = vi.hoisted(() => ({
+  route: { query: {} as Record<string, string> },
+  routerReplace: vi.fn(),
+  displayTokenStats: true,
+  fetchAdminSettings: vi.fn(),
+  getAdvancedSettings: vi.fn(),
+  getMetricThresholds: vi.fn(),
+  getDashboardSnapshotV2: vi.fn(),
+  getThroughputTrend: vi.fn(),
+  getLatencyHistogram: vi.fn(),
+  getErrorDistribution: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => ({ replace: mocks.routerReplace }),
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return { ...actual, useI18n: () => ({ t: (key: string) => key }) }
+})
+
+vi.mock('@/stores', () => ({
+  useAppStore: () => ({ showError: vi.fn() }),
+  useAdminSettingsStore: () => ({
+    opsMonitoringEnabled: true,
+    opsQueryModeDefault: 'auto',
+    fetch: mocks.fetchAdminSettings,
+  }),
+}))
+
+vi.mock('@/api/admin/ops', () => {
+  const opsAPI = {
+    getAdvancedSettings: mocks.getAdvancedSettings,
+    getMetricThresholds: mocks.getMetricThresholds,
+    getDashboardSnapshotV2: mocks.getDashboardSnapshotV2,
+    getThroughputTrend: mocks.getThroughputTrend,
+    getLatencyHistogram: mocks.getLatencyHistogram,
+    getErrorDistribution: mocks.getErrorDistribution,
+  }
+  return { opsAPI, default: opsAPI }
+})
+
+const AppLayoutStub = defineComponent({ template: '<main><slot /></main>' })
+const TokenStatsCardStub = defineComponent({
+  name: 'OpsTokenStatsCard',
+  props: {
+    platformFilter: { type: String, default: '' },
+    groupIdFilter: { type: Number, default: null },
+    refreshToken: { type: Number, required: true },
+  },
+  template: '<div data-testid="token-stats-card" :data-platform="platformFilter" />',
+})
+
+function mountDashboard() {
+  return mount(OpsDashboard, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        BaseDialog: true,
+        OpsDashboardHeader: true,
+        OpsDashboardSkeleton: true,
+        OpsConcurrencyCard: true,
+        OpsSwitchRateTrendChart: true,
+        OpsThroughputTrendChart: true,
+        OpsLatencyChart: true,
+        OpsErrorDistributionChart: true,
+        OpsErrorTrendChart: true,
+        OpsAlertEventsCard: true,
+        OpsTokenStatsCard: TokenStatsCardStub,
+        OpsSystemLogTable: true,
+        OpsSettingsDialog: true,
+        OpsAlertRulesCard: true,
+        OpsErrorDetailsModal: true,
+        OpsErrorDetailModal: true,
+        OpsRequestDetailsModal: true,
+      },
+    },
+  })
+}
+
+describe('OpsDashboard token stats card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.route.query = {}
+    mocks.displayTokenStats = true
+    mocks.fetchAdminSettings.mockResolvedValue(undefined)
+    mocks.getAdvancedSettings.mockImplementation(async () => ({
+      display_alert_events: false,
+      display_openai_token_stats: mocks.displayTokenStats,
+      auto_refresh_enabled: false,
+      auto_refresh_interval_seconds: 30,
+    }))
+    mocks.getMetricThresholds.mockResolvedValue({})
+    mocks.getDashboardSnapshotV2.mockResolvedValue({
+      overview: null,
+      throughput_trend: { points: [] },
+      error_trend: { points: [] },
+    })
+    mocks.getThroughputTrend.mockResolvedValue({ points: [] })
+    mocks.getLatencyHistogram.mockResolvedValue(null)
+    mocks.getErrorDistribution.mockResolvedValue(null)
+  })
+
+  it.each([
+    ['all platforms', undefined, ''],
+    ['OpenAI', 'openai', 'openai'],
+    ['DeepSeek', 'deepseek', 'deepseek'],
+  ])('renders one card for %s and forwards the platform filter', async (_label, platform, expected) => {
+    if (platform) mocks.route.query = { platform }
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+    await flushPromises()
+
+    const cards = wrapper.findAll('[data-testid="token-stats-card"]')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].attributes('data-platform')).toBe(expected)
+    wrapper.unmount()
+  })
+
+  it('does not render the card when the existing dashboard setting is disabled', async () => {
+    mocks.displayTokenStats = false
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="token-stats-card"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/views/admin/ops/components/OpsTokenStatsCard.vue
+++ b/frontend/src/views/admin/ops/components/OpsTokenStatsCard.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
+defineOptions({ name: 'OpsTokenStatsCard' })
+
 import { computed, ref, watch } from 'vue'
 import { useMediaQuery } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import Select from '@/components/common/Select.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
-import { opsAPI, type OpsOpenAITokenStatsResponse, type OpsOpenAITokenStatsTimeRange } from '@/api/admin/ops'
+import {
+  opsAPI,
+  type OpsTokenStatsParams,
+  type OpsTokenStatsResponse,
+  type OpsTokenStatsTimeRange
+} from '@/api/admin/ops'
 import { formatNumber } from '@/utils/format'
+import { platformLabel } from '@/utils/platformColors'
 
 interface Props {
   platformFilter?: string
@@ -27,9 +35,9 @@ const isDesktopViewport = useMediaQuery('(min-width: 768px)')
 
 const loading = ref(false)
 const errorMessage = ref('')
-const response = ref<OpsOpenAITokenStatsResponse | null>(null)
+const response = ref<OpsTokenStatsResponse | null>(null)
 
-const timeRange = ref<OpsOpenAITokenStatsTimeRange>('30d')
+const timeRange = ref<OpsTokenStatsTimeRange>('30d')
 const viewMode = ref<ViewMode>('topn')
 const topN = ref<number>(20)
 const page = ref<number>(1)
@@ -52,8 +60,8 @@ const timeRangeOptions = computed(() => [
 ])
 
 const viewModeOptions = computed(() => [
-  { value: 'topn', label: t('admin.ops.openaiTokenStats.viewModeTopN') },
-  { value: 'pagination', label: t('admin.ops.openaiTokenStats.viewModePagination') }
+  { value: 'topn', label: t('admin.ops.tokenStats.viewModeTopN') },
+  { value: 'pagination', label: t('admin.ops.tokenStats.viewModePagination') }
 ])
 
 const topNOptions = computed(() => [
@@ -80,12 +88,13 @@ function formatInt(v?: number | null): string {
   return formatNumber(Math.round(v))
 }
 
-function buildParams() {
-  const params: Record<string, any> = {
-    time_range: timeRange.value,
-    platform: props.platformFilter || undefined,
-    group_id: typeof props.groupIdFilter === 'number' && props.groupIdFilter > 0 ? props.groupIdFilter : undefined
+function buildParams(): OpsTokenStatsParams {
+  const params: OpsTokenStatsParams = {
+    time_range: timeRange.value
   }
+
+  if (props.platformFilter) params.platform = props.platformFilter
+  if (typeof props.groupIdFilter === 'number' && props.groupIdFilter > 0) params.group_id = props.groupIdFilter
 
   if (viewMode.value === 'topn') {
     params.top_n = topN.value
@@ -100,16 +109,16 @@ async function loadData() {
   loading.value = true
   errorMessage.value = ''
   try {
-    response.value = await opsAPI.getOpenAITokenStats(buildParams())
+    response.value = await opsAPI.getTokenStats(buildParams())
     // 防御：若 total 变化导致当前页超出最大页，则回退到末页并重新拉取一次。
     if (viewMode.value === 'pagination' && page.value > totalPages.value) {
       page.value = totalPages.value
-      response.value = await opsAPI.getOpenAITokenStats(buildParams())
+      response.value = await opsAPI.getTokenStats(buildParams())
     }
   } catch (err: any) {
-    console.error('[OpsOpenAITokenStatsCard] Failed to load data', err)
+    console.error('[OpsTokenStatsCard] Failed to load data', err)
     response.value = null
-    errorMessage.value = err?.message || t('admin.ops.openaiTokenStats.failedToLoad')
+    errorMessage.value = err?.message || t('admin.ops.tokenStats.failedToLoad')
   } finally {
     loading.value = false
   }
@@ -158,10 +167,10 @@ function onNextPage() {
 </script>
 
 <template>
-  <section class="card p-4 md:p-5">
+  <section class="card p-4 md:p-5" data-testid="ops-token-stats-card">
     <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
       <h3 class="text-sm font-bold text-gray-900 dark:text-white">
-        {{ t('admin.ops.openaiTokenStats.title') }}
+        {{ t('admin.ops.tokenStats.title') }}
       </h3>
       <div class="flex flex-wrap items-center gap-2">
         <div class="w-36">
@@ -182,17 +191,17 @@ function onNextPage() {
             :disabled="loading || page <= 1"
             @click="onPrevPage"
           >
-            {{ t('admin.ops.openaiTokenStats.prevPage') }}
+            {{ t('admin.ops.tokenStats.prevPage') }}
           </button>
           <button
             class="btn btn-secondary btn-sm"
             :disabled="loading || page >= totalPages"
             @click="onNextPage"
           >
-            {{ t('admin.ops.openaiTokenStats.nextPage') }}
+            {{ t('admin.ops.tokenStats.nextPage') }}
           </button>
           <span class="text-xs text-gray-500 dark:text-gray-400">
-            {{ t('admin.ops.openaiTokenStats.pageInfo', { page, total: totalPages }) }}
+            {{ t('admin.ops.tokenStats.pageInfo', { page, total: totalPages }) }}
           </span>
         </template>
       </div>
@@ -209,38 +218,42 @@ function onNextPage() {
     <EmptyState
       v-else-if="items.length === 0"
       :title="t('common.noData')"
-      :description="t('admin.ops.openaiTokenStats.empty')"
+      :description="t('admin.ops.tokenStats.empty')"
     />
 
     <div v-else class="space-y-3">
       <div class="overflow-hidden rounded-xl border border-gray-200 dark:border-dark-700">
         <div class="max-h-[420px] overflow-auto">
           <div v-if="!isDesktopViewport" class="divide-y divide-gray-100 dark:divide-dark-800">
-            <div v-for="row in items" :key="row.model" class="space-y-2 p-3">
+            <div v-for="row in items" :key="`${row.platform}:${row.model}`" class="space-y-2 p-3">
               <div class="break-all text-xs font-medium text-gray-900 dark:text-gray-100">{{ row.model }}</div>
               <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.requestCount') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.platform') }}</span>
+                  <span class="text-gray-700 dark:text-gray-200">{{ platformLabel(row.platform) }}</span>
+                </div>
+                <div class="flex items-baseline justify-between gap-2">
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.requestCount') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatInt(row.request_count) }}</span>
                 </div>
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.avgTokensPerSec') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.avgTokensPerSec') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatRate(row.avg_tokens_per_sec) }}</span>
                 </div>
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.avgFirstTokenMs') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.avgFirstTokenMs') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatRate(row.avg_first_token_ms) }}</span>
                 </div>
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.totalOutputTokens') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.totalOutputTokens') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatInt(row.total_output_tokens) }}</span>
                 </div>
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.avgDurationMs') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.avgDurationMs') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatInt(row.avg_duration_ms) }}</span>
                 </div>
                 <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.openaiTokenStats.table.requestsWithFirstToken') }}</span>
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('admin.ops.tokenStats.table.requestsWithFirstToken') }}</span>
                   <span class="text-gray-700 dark:text-gray-200">{{ formatInt(row.requests_with_first_token) }}</span>
                 </div>
               </div>
@@ -249,21 +262,23 @@ function onNextPage() {
           <table v-else class="min-w-full text-left text-xs md:text-sm">
             <thead class="sticky top-0 z-10 bg-white dark:bg-dark-800">
               <tr class="border-b border-gray-200 text-gray-500 dark:border-dark-700 dark:text-gray-400">
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.model') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.requestCount') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.avgTokensPerSec') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.avgFirstTokenMs') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.totalOutputTokens') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.avgDurationMs') }}</th>
-                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.openaiTokenStats.table.requestsWithFirstToken') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.platform') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.model') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.requestCount') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.avgTokensPerSec') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.avgFirstTokenMs') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.totalOutputTokens') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.avgDurationMs') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.tokenStats.table.requestsWithFirstToken') }}</th>
               </tr>
             </thead>
             <tbody>
               <tr
                 v-for="row in items"
-                :key="row.model"
+                :key="`${row.platform}:${row.model}`"
                 class="border-b border-gray-100 text-gray-700 last:border-b-0 dark:border-dark-800 dark:text-gray-200"
               >
+                <td class="px-2 py-2 font-medium">{{ platformLabel(row.platform) }}</td>
                 <td class="px-2 py-2 font-medium">{{ row.model }}</td>
                 <td class="px-2 py-2">{{ formatInt(row.request_count) }}</td>
                 <td class="px-2 py-2">{{ formatRate(row.avg_tokens_per_sec) }}</td>
@@ -277,7 +292,7 @@ function onNextPage() {
         </div>
       </div>
       <div v-if="viewMode === 'topn'" class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-        {{ t('admin.ops.openaiTokenStats.totalModels', { total }) }}
+        {{ t('admin.ops.tokenStats.totalRows', { total }) }}
       </div>
     </div>
   </section>

--- a/frontend/src/views/admin/ops/components/__tests__/OpsTokenStatsCard.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsTokenStatsCard.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
-import OpsOpenAITokenStatsCard from '../OpsOpenAITokenStatsCard.vue'
+import OpsTokenStatsCard from '../OpsTokenStatsCard.vue'
 
-const mockGetOpenAITokenStats = vi.fn()
+const mockGetTokenStats = vi.fn()
 
 vi.mock('@/api/admin/ops', () => ({
   opsAPI: {
-    getOpenAITokenStats: (...args: any[]) => mockGetOpenAITokenStats(...args),
+    getTokenStats: (...args: any[]) => mockGetTokenStats(...args),
   },
 }))
 
@@ -17,7 +17,7 @@ vi.mock('vue-i18n', async (importOriginal) => {
     ...actual,
     useI18n: () => ({
       t: (key: string, params?: Record<string, any>) => {
-        if (key === 'admin.ops.openaiTokenStats.pageInfo' && params) {
+        if (key === 'admin.ops.tokenStats.pageInfo' && params) {
           return `第 ${params.page}/${params.total} 页`
         }
         return key
@@ -55,6 +55,7 @@ const sampleResponse = {
   group_id: 7,
   items: [
     {
+      platform: 'openai',
       model: 'gpt-4o-mini',
       request_count: 12,
       avg_tokens_per_sec: 22.5,
@@ -70,15 +71,15 @@ const sampleResponse = {
   top_n: null,
 }
 
-describe('OpsOpenAITokenStatsCard', () => {
+describe('OpsTokenStatsCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('默认加载并透传 platform/group 过滤，支持时间窗口切换', async () => {
-    mockGetOpenAITokenStats.mockResolvedValue(sampleResponse)
+    mockGetTokenStats.mockResolvedValue(sampleResponse)
 
-    const wrapper = mount(OpsOpenAITokenStatsCard, {
+    const wrapper = mount(OpsTokenStatsCard, {
       props: {
         platformFilter: 'openai',
         groupIdFilter: 7,
@@ -93,7 +94,7 @@ describe('OpsOpenAITokenStatsCard', () => {
     })
 
     await flushPromises()
-    expect(mockGetOpenAITokenStats).toHaveBeenCalledWith(
+    expect(mockGetTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({
         time_range: '30d',
         platform: 'openai',
@@ -106,17 +107,58 @@ describe('OpsOpenAITokenStatsCard', () => {
     await selects[0].vm.$emit('update:modelValue', '1h')
     await flushPromises()
 
-    expect(mockGetOpenAITokenStats).toHaveBeenCalledWith(
+    expect(mockGetTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({
         time_range: '1h',
         platform: 'openai',
         group_id: 7,
       })
     )
+
+    await wrapper.setProps({ platformFilter: 'deepseek' })
+    await flushPromises()
+
+    expect(mockGetTokenStats).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        platform: 'deepseek',
+        group_id: 7,
+      })
+    )
+  })
+
+  it('全平台模式不发送 platform，并展示每行所属平台', async () => {
+    mockGetTokenStats.mockResolvedValue({
+      ...sampleResponse,
+      platform: undefined,
+      items: [
+        sampleResponse.items[0],
+        {
+          ...sampleResponse.items[0],
+          platform: 'deepseek',
+          model: 'deepseek-v4-pro',
+        },
+      ],
+    })
+
+    const wrapper = mount(OpsTokenStatsCard, {
+      props: { refreshToken: 0 },
+      global: {
+        stubs: {
+          Select: SelectStub,
+          EmptyState: EmptyStateStub,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(mockGetTokenStats.mock.calls[0][0]).not.toHaveProperty('platform')
+    expect(wrapper.text()).toContain('admin.ops.tokenStats.table.platform')
+    expect(wrapper.text()).toContain('OpenAI')
+    expect(wrapper.text()).toContain('DeepSeek')
   })
 
   it('支持分页与 TopN 模式切换并按参数请求', async () => {
-    mockGetOpenAITokenStats.mockImplementation(async (params: Record<string, any>) => ({
+    mockGetTokenStats.mockImplementation(async (params: Record<string, any>) => ({
       ...sampleResponse,
       time_range: params.time_range ?? '30d',
       page: params.page ?? 1,
@@ -125,7 +167,7 @@ describe('OpsOpenAITokenStatsCard', () => {
       total: 40,
     }))
 
-    const wrapper = mount(OpsOpenAITokenStatsCard, {
+    const wrapper = mount(OpsTokenStatsCard, {
       props: {
         refreshToken: 0,
       },
@@ -142,7 +184,7 @@ describe('OpsOpenAITokenStatsCard', () => {
     await selects[1].vm.$emit('update:modelValue', 'pagination')
     await flushPromises()
 
-    expect(mockGetOpenAITokenStats).toHaveBeenCalledWith(
+    expect(mockGetTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({
         page: 1,
         page_size: 20,
@@ -154,7 +196,7 @@ describe('OpsOpenAITokenStatsCard', () => {
     await buttons[1].trigger('click')
     await flushPromises()
 
-    expect(mockGetOpenAITokenStats).toHaveBeenCalledWith(
+    expect(mockGetTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({
         page: 2,
         page_size: 20,
@@ -168,7 +210,7 @@ describe('OpsOpenAITokenStatsCard', () => {
     await selects[2].vm.$emit('update:modelValue', 50)
     await flushPromises()
 
-    expect(mockGetOpenAITokenStats).toHaveBeenCalledWith(
+    expect(mockGetTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({
         top_n: 50,
       })
@@ -176,13 +218,13 @@ describe('OpsOpenAITokenStatsCard', () => {
   })
 
   it('接口返回空数据时显示空态', async () => {
-    mockGetOpenAITokenStats.mockResolvedValue({
+    mockGetTokenStats.mockResolvedValue({
       ...sampleResponse,
       items: [],
       total: 0,
     })
 
-    const wrapper = mount(OpsOpenAITokenStatsCard, {
+    const wrapper = mount(OpsTokenStatsCard, {
       props: { refreshToken: 0 },
       global: {
         stubs: {
@@ -197,9 +239,9 @@ describe('OpsOpenAITokenStatsCard', () => {
   })
 
   it('数据表使用固定高度滚动容器，避免纵向无限增长', async () => {
-    mockGetOpenAITokenStats.mockResolvedValue(sampleResponse)
+    mockGetTokenStats.mockResolvedValue(sampleResponse)
 
-    const wrapper = mount(OpsOpenAITokenStatsCard, {
+    const wrapper = mount(OpsTokenStatsCard, {
       props: { refreshToken: 0 },
       global: {
         stubs: {
@@ -214,9 +256,9 @@ describe('OpsOpenAITokenStatsCard', () => {
   })
 
   it('接口异常时显示错误提示', async () => {
-    mockGetOpenAITokenStats.mockRejectedValue(new Error('加载失败'))
+    mockGetTokenStats.mockRejectedValue(new Error('加载失败'))
 
-    const wrapper = mount(OpsOpenAITokenStatsCard, {
+    const wrapper = mount(OpsTokenStatsCard, {
       props: { refreshToken: 0 },
       global: {
         stubs: {


### PR DESCRIPTION
## 变更内容

- 将运营面板的 OpenAI Token 统计泛化为全平台 Token 统计
  - 按实际平台和请求模型聚合统计数据
  - 支持平台、分组、时间范围、Top N 和分页筛选
  - 前端增加平台列，并适配全平台及移动端展示
- 将统计接口从 `/dashboard/openai-token-stats` 调整为 `/dashboard/token-stats`
- 收紧 OpenAI Fast 策略作用域，仅对最终路由到 OpenAI 的账号生效，避免向 Grok、Kimi、智谱和 DeepSeek 等上游注入 `service_tier`
- 完善 `force_priority` 语义：即使请求未携带 `service_tier`，也会强制写入 `priority`
- 统一 HTTP、WebSocket、Chat Completions 和 Messages fallback 等入口的 Fast 策略行为
- 为 Fast 策略配置增加本地缓存、并发请求合并和异常回退，减少网关热路径的数据库查询
- 保留 `display_openai_token_stats` 配置字段，兼容现有设置数据

## 兼容性说明

原 `/api/v1/admin/ops/dashboard/openai-token-stats` 接口已替换为 `/api/v1/admin/ops/dashboard/token-stats`，外部调用方需要同步更新接口路径。

## 测试覆盖

- 补充 Fast 策略在不同入口、不同上游平台及 WebSocket 场景下的测试
- 补充 Token 统计路由、参数校验、数据库聚合及平台筛选测试
- 补充前端 API、运营面板和 Token 统计组件测试