### PR TITLE
fix(securityaudit): log prompt_guard.config_loaded only on change

### DIFF
--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -136,12 +136,26 @@ func (m *ConfigManager) Reload(ctx context.Context) error {
 	previous := m.snapshot.Load()
 	m.snapshot.Store(&activeConfigSnapshot{storage: cloneStorageConfig(storage), active: cloneActiveConfig(active), loadedAt: now})
 	m.configUntrusted.Store(false)
-	m.clearLoadError()
+	recovered := m.clearLoadError()
 	m.logInvalidTokenEndpoints(previous, active)
-	LogInfo(EventConfigLoaded, map[string]any{
-		"config_version": storage.ConfigVersion, "status": "loaded",
-	})
+	// refreshLoop calls Reload every 5s, so logging every successful load turns
+	// config_loaded into a heartbeat that buries real config changes.
+	if recovered || shouldLogConfigLoaded(previous, storage, active) {
+		LogInfo(EventConfigLoaded, map[string]any{
+			"config_version": storage.ConfigVersion, "status": "loaded",
+		})
+	}
 	return nil
+}
+
+// shouldLogConfigLoaded reports whether a successful reload carries news: the
+// first snapshot, a new config version (every admin save bumps it under the
+// advisory lock in UpdateConfig) or a flip of the global risk control gate,
+// which lives in its own setting and so leaves the version untouched.
+func shouldLogConfigLoaded(previous *activeConfigSnapshot, storage storageConfig, active ActiveConfig) bool {
+	return previous == nil ||
+		previous.storage.ConfigVersion != storage.ConfigVersion ||
+		previous.active.RiskControlEnabled != active.RiskControlEnabled
 }
 
 // logInvalidTokenEndpoints warns once per change (not on every 5s refresh)
@@ -490,11 +504,15 @@ func (m *ConfigManager) recordLoadError(_ error) {
 	m.stateMu.Unlock()
 }
 
-func (m *ConfigManager) clearLoadError() {
+// clearLoadError drops the recorded load failure and reports whether one was
+// pending, so callers can tell a recovery apart from an unchanged reload.
+func (m *ConfigManager) clearLoadError() bool {
 	m.stateMu.Lock()
+	recovered := m.lastLoadError != ""
 	m.lastLoadError = ""
 	m.lastErrorAt = nil
 	m.stateMu.Unlock()
+	return recovered
 }
 
 func cloneStorageConfig(cfg storageConfig) storageConfig {

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -1,9 +1,11 @@
 package securityaudit
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -453,4 +455,52 @@ func TestUpdateConfigStrictBoundsAndKnownValues(t *testing.T) {
 			require.Equal(t, tt.reason, infraerrors.Reason(err))
 		})
 	}
+}
+
+// Regression coverage for issue #5732: refreshLoop reloads every 5s, so
+// config_loaded must stay a change signal instead of ~17k identical lines a
+// day, while still reporting the first load, real config changes and a
+// recovery from a failed reload.
+func TestConfigLoadedIsLoggedOnlyWhenSomethingChanged(t *testing.T) {
+	storage := DefaultStorageConfig()
+	storage.ConfigVersion = 4
+	raw, err := json.Marshal(storage)
+	require.NoError(t, err)
+	repository := &switchableSettingRepository{staticSettingRepository: staticSettingRepository{values: map[string]string{
+		SettingKeyPromptAuditConfig: string(raw),
+		SettingKeyRiskControl:       "false",
+	}}}
+	manager := NewConfigManager(nil, repository, nil, prefixEncryptor{}, testTotpKeyConfig())
+
+	var output bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	loadedCount := func() int { return strings.Count(output.String(), EventConfigLoaded) }
+
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 1, loadedCount(), "the first successful load must be logged")
+
+	require.NoError(t, manager.Reload(context.Background()))
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 1, loadedCount(), "TTL refreshes of an unchanged config must stay silent")
+
+	repository.values[SettingKeyRiskControl] = "true"
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 2, loadedCount(), "flipping the global risk control gate must be logged")
+
+	storage.ConfigVersion = 5
+	raw, err = json.Marshal(storage)
+	require.NoError(t, err)
+	repository.values[SettingKeyPromptAuditConfig] = string(raw)
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 3, loadedCount(), "a new config version must be logged")
+
+	repository.loadErr = errors.New("settings unavailable")
+	require.Error(t, manager.Reload(context.Background()))
+	require.Equal(t, 3, loadedCount(), "a failed reload must not claim a load")
+
+	repository.loadErr = nil
+	require.NoError(t, manager.Reload(context.Background()))
+	require.Equal(t, 4, loadedCount(), "recovering from a failed reload must be visible")
 }


### PR DESCRIPTION
## Problem

`ConfigManager.refreshLoop` reloads the Prompt Guard config every 5 seconds (`backend/internal/securityaudit/prompt_config_store.go:436`), and `Reload` logged `prompt_guard.config_loaded` on every successful load, whether or not anything had changed (`prompt_config_store.go:141` before this change).

One instance therefore emits up to ~17,280 identical `config_loaded` lines per day, which is what #5732 reports (~12k lines counted in a single day of logs). The noise inflates log storage and hides the lines that matter — real config changes, degraded reloads and token warnings.

The same file already draws this distinction one function below: `logInvalidTokenEndpoints` is documented as "warns once per change (not on every 5s refresh)" (`prompt_config_store.go:159`). `config_loaded` was the outlier.

## Change

**`backend/internal/securityaudit/prompt_config_store.go`**

- `Reload` now emits `config_loaded` only when the reload carries news, via a new `shouldLogConfigLoaded(previous, storage, active)`:
  - first successful snapshot (`previous == nil`);
  - `ConfigVersion` changed — every admin save bumps it by one under the advisory lock in `UpdateConfig` (`prompt_config_store.go:280`), so the version is a reliable change signal for the audit config itself;
  - `RiskControlEnabled` changed — the global gate is a separate setting (`SettingKeyRiskControl`) fed into `ActiveFromStorage` and does not touch `ConfigVersion`, so it needs its own clause.
- `clearLoadError` now reports whether a load error was pending, and `Reload` logs `config_loaded` on that transition too. Without this clause, a service that recovers from a stretch of `config_reload_degraded` would go silent instead of confirming the recovery, since the version is usually unchanged. Redis invalidation reloads (`subscribeLoop`) are unaffected: they arrive with a new version and still log.

**`backend/internal/securityaudit/prompt_config_test.go`**

- `TestConfigLoadedIsLoggedOnlyWhenSomethingChanged` captures `slog` output the way `prompt_logging_test.go:17` does and walks one manager through: first load, two unchanged reloads, a risk-control flip, a version bump, a failed reload, and a recovery — asserting the running `config_loaded` count at each step.

## Verification

```
cd backend
go test -tags=unit ./...          # ok, 53 packages
go test -tags=integration ./...   # ok, 47 packages
golangci-lint run ./...           # 0 issues (v2.9.0, as pinned in backend-ci.yml)
gofmt -l internal/securityaudit/  # clean
```

The new test fails on unpatched `main` — reverting only `prompt_config_store.go` gives:

```
--- FAIL: TestConfigLoadedIsLoggedOnlyWhenSomethingChanged
    Error: Not equal: expected: 1  actual: 3
    Messages: TTL refreshes of an unchanged config must stay silent
```

## What the test would catch

A regression that turns `config_loaded` back into a 5-second heartbeat, and equally a regression in the other direction: dropping the risk-control clause, the version clause, or the recovery clause each flips one of the four assertions.

Closes #5732
