### PR TITLE
fix(openai): 生图端点豁免文本额度自动暂停

### DIFF
--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -2084,6 +2084,10 @@ func (s *OpenAIGatewayService) SelectAccountWithSchedulerForImages(
 	excludedIDs map[int64]struct{},
 	requiredCapability OpenAIImagesCapability,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+	// 本入口只服务 /v1/images/*。handler 已在请求 ctx 上打过该标记，这里再补一次是
+	// 为不经 handler 装配 ctx 的内部调用兜底：标记同时决定生图请求豁免文本额度
+	// 自动暂停（shouldAutoPauseOpenAIAccountByQuota）与图片维度的限流口径。
+	ctx = WithOpenAIImagesEndpoint(ctx)
 	selection, decision, err := s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", requiredCapability, false, PlatformOpenAI, false, false)
 	if err == nil && selection != nil && selection.Account != nil {
 		return selection, decision, nil

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -452,6 +452,25 @@ func shouldAutoPauseOpenAIAccountByQuota(ctx context.Context, account *Account) 
 	if account == nil || !account.IsOpenAI() {
 		return false, openAIQuotaAutoPauseDecision{}
 	}
+	// /v1/images/* 专用生图端点豁免文本额度自动暂停（issue #1886）。
+	//
+	// OAuth 账号在上游持有两套互不相干的配额：Codex 文本用量走 5h/7d 滚动窗口，
+	// gpt-image 系列生图走自己的限额（命中后上游返回的 429 带 "for limit gpt-image"
+	// / "input-images per min"）。文本窗口打满不代表生图不可用，但自动暂停是账号
+	// 维度的——只要文本窗口到阈值，账号就整体退出候选池，仍有生图额度的账号也再
+	// 拿不到 /v1/images/* 请求。
+	//
+	// 豁免刻意只认最窄口径 OpenAIImagesEndpointFromContext（仅 /v1/images/* 入站）：
+	// Responses 端点内嵌生图工具的请求同样消耗文本额度，必须继续受暂停约束，
+	// 所以这里不能改用 OpenAIImageGenerationIntentFromContext。
+	//
+	// 生图额度自身耗尽时不会因此空转：HandleOpenAIImageRateLimit 会写入
+	// openai:image_generation 维度冷却，选中后的 DB 复核
+	// （isOpenAICompatibleAccountEligibleForRequest → IsSchedulableForModelWithContext）
+	// 会拦下该账号。方向上也与既有语义对称——图片被限流时同样不封停整个账号。
+	if OpenAIImagesEndpointFromContext(ctx) {
+		return false, openAIQuotaAutoPauseDecision{}
+	}
 	// Per-account explicit-disable flags must take precedence over the global default.
 	// Without these, leaving the account threshold blank means "use global default",
 	// so an admin has no way to exempt a single account from auto-pause once a global

--- a/backend/internal/service/openai_images_quota_auto_pause_test.go
+++ b/backend/internal/service/openai_images_quota_auto_pause_test.go
@@ -1,0 +1,96 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Codex 文本用量（5h/7d 窗口）与 gpt-image 生图额度在上游是两套独立配额，
+// 文本窗口触发自动暂停不应连带让账号无法服务 /v1/images/*（issue #1886）。
+
+func TestShouldAutoPauseOpenAIAccountByQuota_ImagesEndpointExempt(t *testing.T) {
+	account := &Account{
+		ID:       188601,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent":   100.0,
+			"auto_pause_5h_threshold": 0.95,
+		},
+	}
+
+	paused, decision := shouldAutoPauseOpenAIAccountByQuota(context.Background(), account)
+	require.True(t, paused, "文本请求仍按 5h 窗口自动暂停")
+	require.Equal(t, "5h", decision.window)
+
+	paused, _ = shouldAutoPauseOpenAIAccountByQuota(WithOpenAIImagesEndpoint(context.Background()), account)
+	require.False(t, paused, "/v1/images/* 消耗独立生图配额，不受文本窗口暂停影响")
+
+	// Responses 端点内嵌生图工具的请求同样吃文本额度，只带生图意图不构成豁免。
+	paused, _ = shouldAutoPauseOpenAIAccountByQuota(WithOpenAIImageGenerationIntent(context.Background()), account)
+	require.True(t, paused, "仅生图意图（非 /v1/images/* 入站）不豁免")
+}
+
+func TestShouldAutoPauseOpenAIAccountByQuota_ImagesEndpointExemptFor7dWindow(t *testing.T) {
+	account := &Account{
+		ID:       188602,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_7d_used_percent":   99.0,
+			"auto_pause_7d_threshold": 0.9,
+		},
+	}
+
+	paused, decision := shouldAutoPauseOpenAIAccountByQuota(context.Background(), account)
+	require.True(t, paused)
+	require.Equal(t, "7d", decision.window)
+
+	paused, _ = shouldAutoPauseOpenAIAccountByQuota(WithOpenAIImagesEndpoint(context.Background()), account)
+	require.False(t, paused)
+}
+
+func TestSelectAccountWithSchedulerForImages_TextQuotaExhaustedAccountStaysSelectable(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	exhausted := Account{
+		ID:          188603,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"codex_7d_used_percent":   99.0,
+			"auto_pause_7d_threshold": 0.95,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: []Account{exhausted}},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	_, _, err := svc.SelectAccountWithScheduler(
+		context.Background(), nil, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false,
+	)
+	require.Error(t, err, "文本调度仍应因 7d 窗口打满而无可用账号")
+
+	selection, _, err := svc.SelectAccountWithSchedulerForImages(
+		context.Background(), nil, "", "gpt-image-2", nil, OpenAIImagesCapabilityBasic,
+	)
+	require.NoError(t, err, "生图调度必须仍能选中该账号")
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(188603), selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}


### PR DESCRIPTION
Codex 文本用量（5h/7d 滚动窗口）与 gpt-image 系列的生图额度在上游是两套
互相独立的配额，但 quota auto-pause 是账号维度的：只要文本窗口达到阈值，
账号就整体退出候选池，仍有生图额度的账号也再拿不到 /v1/images/* 请求。

shouldAutoPauseOpenAIAccountByQuota 增加最窄口径豁免：仅 /v1/images/* 入站 （OpenAIImagesEndpointFromContext）跳过文本窗口暂停。Responses 端点内嵌生图 工具的请求同样消耗文本额度，因此不能改用 OpenAIImageGenerationIntentFromContext， 这类请求继续受暂停约束。SelectAccountWithSchedulerForImages 补打该标记，为不经 handler 装配 ctx 的内部调用兜底。

生图额度自身耗尽时不会空转重试：上游 429 会由 HandleOpenAIImageRateLimit 写入 openai:image_generation 维度冷却，选中后的 DB 复核（IsSchedulableForModelWithContext） 会拦下该账号。方向上与既有的「图片被限流不封停整个账号」保持对称。

Closes #1886


Claude-Session: https://claude.ai/code/session_013c3A11YapeeD2ZtBD1VV2B