### PR TITLE
feat(openai): DSML leak guard - detect and heal deepseek-v4 tool calls leaked as plain text

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -999,6 +999,15 @@ type GatewayConfig struct {
 	// OpenAIPassthroughAllowTimeoutHeaders: OpenAI 透传模式是否放行客户端超时头
 	// 关闭（默认）可避免 x-stainless-timeout 等头导致上游提前断流。
 	OpenAIPassthroughAllowTimeoutHeaders bool `mapstructure:"openai_passthrough_allow_timeout_headers"`
+	// DSMLGuardEnabled: deepseek-v4 DSML 泄漏防护总开关。拦截「工具调用漏成正文」的坏流并原地重试，
+	// 同时从请求历史的 assistant 消息中剥离已泄漏的 DSML 碎片（治级联）。
+	DSMLGuardEnabled bool `mapstructure:"dsml_guard_enabled"`
+	// DSMLGuardModels: 防护生效的上游模型前缀列表（对 upstreamModel 做前缀匹配）。
+	DSMLGuardModels []string `mapstructure:"dsml_guard_models"`
+	// DSMLGuardMaxRetries: 判定泄漏后对同账号的最大原地重试次数。
+	DSMLGuardMaxRetries int `mapstructure:"dsml_guard_max_retries"`
+	// DSMLGuardObserve: true 时只检测记录、不扣流不重试不清洗（灰度用）。
+	DSMLGuardObserve bool `mapstructure:"dsml_guard_observe"`
 	// OpenAICompactModel: /responses/compact 上游使用的模型。
 	// compact 端点支持模型滞后于普通 /responses 时，可用该配置降级规避上游错误。
 	OpenAICompactModel string `mapstructure:"openai_compact_model"`
@@ -2370,6 +2379,10 @@ func setDefaults() {
 	viper.SetDefault("gateway.disable_codex_originator_normalization", false)
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)
 	viper.SetDefault("gateway.openai_passthrough_allow_timeout_headers", false)
+	viper.SetDefault("gateway.dsml_guard_enabled", true)
+	viper.SetDefault("gateway.dsml_guard_models", []string{"deepseek-v4"})
+	viper.SetDefault("gateway.dsml_guard_max_retries", 1)
+	viper.SetDefault("gateway.dsml_guard_observe", false)
 	viper.SetDefault("gateway.openai_compact_model", "gpt-5.4")
 	viper.SetDefault("gateway.live.max_session_duration_seconds", 3600)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1070,6 +1070,8 @@ func (state *opsCaptureWriterState) shouldCapture() bool {
 }
 
 // OpsErrorLoggerMiddleware records error responses (status >= 400) into ops_error_logs.
+// Successful responses (<400) are also persisted when upstream error/retry events were
+// appended during the request, so retry-covered upstream instability stays observable.
 //
 // Notes:
 // - It buffers response bodies only for status >= 400 or terminal SSE frames.

--- a/backend/internal/service/openai_dsml_leak_guard.go
+++ b/backend/internal/service/openai_dsml_leak_guard.go
@@ -1,0 +1,641 @@
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// DSML 泄漏防护：deepseek-v4 间歇性把 DSML 工具调用漏成 `delta.content` 正文
+// （开标签被上游 serving 吃掉，参数体+闭合标签当正文流出，finish_reason:"stop"，
+// 全程无 tool_calls delta）。客户端视为回合正常结束，表现为「跑到一半自己停了」。
+//
+// 本文件提供：
+//
+//   - openAIDSMLLeakGuard：流式响应侧的观察者+扣流状态机（仿 openai_silent_refusal.go，
+//     纯状态机不碰 IO；扣流/放行由调用方按返回值执行）。与 silent-refusal 的
+//     pendingLines 门并存、不合并：refusal 门管「零字节 failover 资格」，本门管
+//     「文本通道扣留与原地重试」。
+//   - applyDSMLHistoryScrub：请求侧历史清洗（治级联——历史里带泄漏文本时模型会模仿，
+//     不清洗则重试大概率复漏）。仅动 assistant 角色的字符串 content，user/tool 一律不碰。
+//
+// 失败路径全部「放行降级」：误判或重试失败的最坏代价是延迟，绝不向客户端造错、
+// 绝不丢数据。
+const (
+	// dsmlLeakMarker 是泄漏文本的检测信号：全角竖线（U+FF5C）包裹的 DSML 标记。
+	// 正常模型输出不含此序列；用户「讨论」DSML 的文本走 user 角色，不在响应文本
+	// 通道的判定范围内。
+	dsmlLeakMarker = "｜DSML｜"
+
+	// dsmlGuardSniffReleaseBytes：累计正文超过该字节数且无标记、无可疑前缀时，
+	// 判为正常答案，冲洗放行并转直通（后续只扫不扣）。
+	dsmlGuardSniffReleaseBytes = 128
+
+	// 扣留上限：超限原样冲洗转直通（兜底，防止极长输出被无限扣留）。
+	dsmlGuardHoldMaxBytes    = 1 << 20 // 1 MiB
+	dsmlGuardHoldMaxDuration = 5 * time.Minute
+
+	// content-hold 生效期间向客户端写的 SSE 注释保活行（规范允许、解析器必须忽略）。
+	// reasoning 结束后正文被扣住，零字节间隔可能触发客户端/中间层空闲超时，注释行
+	// 在不产生语义输出的前提下维持连接。
+	dsmlGuardKeepaliveComment  = ": dsml-guard-hold"
+	dsmlGuardKeepaliveInterval = 15 * time.Second
+
+	// ops_error_logs 事件类别（appendOpsUpstreamError 的 Kind）。
+	dsmlGuardOpsKind = "dsml_leak"
+
+	// 前缀判定与标记跨 chunk 拼接所需的缓冲长度。
+	dsmlGuardPrefixProbeBytes = 64
+)
+
+// dsmlGuardHoldPrefixes：正文以这些前缀开头时视为疑似泄漏，持续扣到终态
+// （泄漏形态为 content 以 `<thinking>` 或残留的 `<｜` 开标签片段起头）。
+var dsmlGuardHoldPrefixes = []string{"<thinking>", "<｜"}
+
+var (
+	// 完整块：<｜DSML｜xxx> … </｜DSML｜xxx>（兼容单/双全角竖线两种拼写）。
+	dsmlLeakBlockRe = regexp.MustCompile(`(?s)<｜{1,2}DSML｜{1,2}[^>]*>.*?</｜{1,2}DSML｜{1,2}[^>]*>`)
+	// 孤儿闭合标签（chat 直转形态里开标签常被上游吃掉，只剩闭合簇）。
+	dsmlLeakCloseTagRe = regexp.MustCompile(`</｜{1,2}DSML｜{1,2}[^>]*>`)
+	// 任意残留的 DSML 开/闭标签。
+	dsmlLeakTagRe = regexp.MustCompile(`</?｜{1,2}DSML｜{1,2}[^>]*>`)
+)
+
+type dsmlGuardState int
+
+const (
+	// 正文尚未出现：一切照常直播。
+	dsmlGuardWatching dsmlGuardState = iota
+	// 正文通道扣留中：所有后续行进入 heldLines（含空行分隔符），保持顺序。
+	dsmlGuardHolding
+	// 已放行转直通：只扫不扣（尾部再现标记只计 ops，不可回收）。
+	dsmlGuardPassthrough
+	// 终态判定为泄漏：持续吞掉本 attempt 的剩余行（usage、[DONE]），等调用方重试或冲洗。
+	dsmlGuardLeakLatched
+)
+
+// openAIDSMLLeakGuard 是单个上游 attempt 流的 DSML 泄漏检测/扣流状态机。
+// 非并发安全（除 Holding()，供保活 goroutine 读取）；重试换流后用 ResetForRetry 复位。
+type openAIDSMLLeakGuard struct {
+	observeOnly bool
+	now         func() time.Time
+
+	state         dsmlGuardState
+	holding       atomic.Bool
+	heldLines     []string
+	heldBytes     int
+	holdStartedAt time.Time
+
+	contentLen    int
+	contentPrefix string // 左侧去空白后的正文前缀（前 dsmlGuardPrefixProbeBytes 字节）
+	markerTail    string // 跨 chunk 标记拼接探针（保留末尾若干字节）
+
+	markerSeen     bool
+	sawToolCall    bool
+	terminalSeen   bool
+	lateMarkerSeen bool
+	capReleased    bool
+}
+
+func newOpenAIDSMLLeakGuard(observeOnly bool) *openAIDSMLLeakGuard {
+	return &openAIDSMLLeakGuard{
+		observeOnly: observeOnly,
+		now:         time.Now,
+	}
+}
+
+// dsmlChunkView 是单条 SSE 行中与判定相关的字段快照。
+// 同时支持 chat completions chunk（delta.content / delta.tool_calls / finish_reason）
+// 与 Responses 事件（response.output_text.delta / function_call 事件 / 终态事件）。
+type dsmlChunkView struct {
+	contentText string
+	hasToolCall bool
+	terminal    bool // finish_reason 非空、[DONE] 或 Responses 终态事件
+}
+
+func parseDSMLChunkView(line string) dsmlChunkView {
+	var v dsmlChunkView
+	payload, ok := extractOpenAISSEDataLine(line)
+	if !ok {
+		return v
+	}
+	p := strings.TrimSpace(payload)
+	if p == "" {
+		return v
+	}
+	if p == "[DONE]" {
+		v.terminal = true
+		return v
+	}
+	if !gjson.Valid(p) {
+		return v
+	}
+	root := gjson.Parse(p)
+	if eventType := strings.TrimSpace(root.Get("type").String()); eventType != "" && strings.HasPrefix(eventType, "response.") {
+		switch eventType {
+		case "response.output_text.delta":
+			v.contentText = root.Get("delta").String()
+		case "response.output_item.added", "response.output_item.done":
+			if strings.TrimSpace(root.Get("item.type").String()) == "function_call" {
+				v.hasToolCall = true
+			}
+		case "response.function_call_arguments.delta", "response.function_call_arguments.done":
+			v.hasToolCall = true
+		case "response.completed", "response.done", "response.incomplete", "response.failed":
+			v.terminal = true
+		}
+		return v
+	}
+	choices := root.Get("choices")
+	if !choices.Exists() || !choices.IsArray() {
+		return v
+	}
+	for _, choice := range choices.Array() {
+		if finish := choice.Get("finish_reason"); finish.Exists() && strings.TrimSpace(finish.String()) != "" {
+			v.terminal = true
+		}
+		delta := choice.Get("delta")
+		if !delta.Exists() {
+			continue
+		}
+		if content := delta.Get("content"); content.Type == gjson.String && content.String() != "" {
+			v.contentText += content.String()
+		}
+		if delta.Get("tool_calls").Exists() || delta.Get("function_call").Exists() {
+			v.hasToolCall = true
+		}
+	}
+	return v
+}
+
+// HandleLine 消费一条上游 SSE 行，返回「现在就该写给客户端」的行（按序，可能包含
+// 之前被扣的积压）。返回空切片表示该行被扣留。nil guard 恒为直通。
+func (g *openAIDSMLLeakGuard) HandleLine(line string) []string {
+	if g == nil {
+		return []string{line}
+	}
+	v := parseDSMLChunkView(line)
+
+	if g.observeOnly {
+		g.observeVirtual(v)
+		return []string{line}
+	}
+
+	switch g.state {
+	case dsmlGuardPassthrough:
+		if v.contentText != "" && strings.Contains(v.contentText, dsmlLeakMarker) {
+			g.lateMarkerSeen = true
+		}
+		if v.hasToolCall {
+			g.sawToolCall = true
+		}
+		return []string{line}
+
+	case dsmlGuardLeakLatched:
+		// 泄漏已判定：吞掉本 attempt 的剩余行（usage-only chunk、[DONE]），
+		// 否则重试后客户端会收到两份 usage（求和型客户端双计）。
+		g.hold(line)
+		return nil
+
+	case dsmlGuardWatching:
+		if v.hasToolCall {
+			g.sawToolCall = true
+		}
+		if v.terminal {
+			g.terminalSeen = true
+		}
+		if v.contentText == "" {
+			// reasoning / role / usage-only 等非正文行照常直播。
+			return []string{line}
+		}
+		// 首个非空正文 chunk：进入 content-hold。
+		g.trackContent(v.contentText)
+		g.state = dsmlGuardHolding
+		g.holding.Store(true)
+		g.holdStartedAt = g.now()
+		g.hold(line)
+		if v.terminal {
+			return g.decideAtTerminal()
+		}
+		return g.maybeRelease()
+
+	case dsmlGuardHolding:
+		if v.contentText != "" {
+			g.trackContent(v.contentText)
+		}
+		g.hold(line)
+		if v.hasToolCall {
+			// 工具轮：前导文本无害。含标记的行剔除标记片段后冲洗放行（shape-2 清理）。
+			g.sawToolCall = true
+			g.state = dsmlGuardPassthrough
+			g.holding.Store(false)
+			return g.releaseHeld(g.markerSeen)
+		}
+		if v.terminal {
+			g.terminalSeen = true
+			return g.decideAtTerminal()
+		}
+		return g.maybeRelease()
+	}
+	return []string{line}
+}
+
+// observeVirtual 在 observe 模式下推进虚拟状态机：只做判定所需的记账，字节零改动。
+func (g *openAIDSMLLeakGuard) observeVirtual(v dsmlChunkView) {
+	if v.contentText != "" {
+		g.trackContent(v.contentText)
+	}
+	if v.hasToolCall {
+		g.sawToolCall = true
+	}
+	if v.terminal {
+		g.terminalSeen = true
+	}
+}
+
+func (g *openAIDSMLLeakGuard) trackContent(text string) {
+	g.contentLen += len(text)
+	if len(g.contentPrefix) < dsmlGuardPrefixProbeBytes {
+		candidate := g.contentPrefix + text
+		if g.contentPrefix == "" {
+			candidate = strings.TrimLeft(candidate, " \t\r\n")
+		}
+		if len(candidate) > dsmlGuardPrefixProbeBytes {
+			candidate = candidate[:dsmlGuardPrefixProbeBytes]
+		}
+		g.contentPrefix = candidate
+	}
+	if !g.markerSeen {
+		probe := g.markerTail + text
+		if strings.Contains(probe, dsmlLeakMarker) {
+			g.markerSeen = true
+			g.markerTail = ""
+			return
+		}
+		if len(probe) > dsmlGuardPrefixProbeBytes {
+			probe = probe[len(probe)-dsmlGuardPrefixProbeBytes:]
+		}
+		g.markerTail = probe
+	}
+}
+
+func (g *openAIDSMLLeakGuard) hold(line string) {
+	g.heldLines = append(g.heldLines, line)
+	g.heldBytes += len(line)
+}
+
+// decideAtTerminal 在终态帧（finish/[DONE]，已入 heldLines、尚未写出）处做终局判定。
+func (g *openAIDSMLLeakGuard) decideAtTerminal() []string {
+	if g.markerSeen && !g.sawToolCall {
+		g.state = dsmlGuardLeakLatched
+		return nil
+	}
+	g.state = dsmlGuardPassthrough
+	g.holding.Store(false)
+	return g.releaseHeld(g.markerSeen)
+}
+
+// maybeRelease 检查扣留中的提前放行条件（sniff 窗口 / 扣留上限）。
+func (g *openAIDSMLLeakGuard) maybeRelease() []string {
+	if !g.markerSeen && g.contentLen >= dsmlGuardSniffReleaseBytes && !dsmlGuardPrefixSuspicious(g.contentPrefix) {
+		// 正常答案：冲洗后转直通，后续只扫不扣。
+		g.state = dsmlGuardPassthrough
+		g.holding.Store(false)
+		return g.releaseHeld(false)
+	}
+	if g.heldBytes > dsmlGuardHoldMaxBytes || g.now().Sub(g.holdStartedAt) > dsmlGuardHoldMaxDuration {
+		// 超限兜底：原样冲洗转直通（降级 = 今天的行为，绝不报错）。
+		g.capReleased = true
+		g.state = dsmlGuardPassthrough
+		g.holding.Store(false)
+		return g.releaseHeld(false)
+	}
+	return nil
+}
+
+// releaseHeld 交出全部被扣行。scrub=true 时做 shape-2 清理
+// （只剔标记片段，不动其余内容）。
+func (g *openAIDSMLLeakGuard) releaseHeld(scrub bool) []string {
+	held := g.heldLines
+	g.heldLines = nil
+	g.heldBytes = 0
+	if !scrub {
+		return held
+	}
+	return scrubDSMLFromHeldSSELines(held)
+}
+
+// scrubDSMLFromHeldSSELines 对被扣行做 shape-2 清理（工具轮前导文本含标记）。
+// 标记可能跨 chunk 断裂，单行 Contains 检不出：把全部纯正文行的 delta.content
+// 按序拼接后整体清洗，结果并入第一条正文行，其余纯正文行（及其空行分隔符）
+// 删除——客户端本就按序拼接 content，chunk 粒度无语义。带 tool_calls 或终态的
+// 行不参与合并（不能删），原样保序、就地单行清理。任何重写失败都退回逐行清理
+// （放行降级）。
+func scrubDSMLFromHeldSSELines(held []string) []string {
+	mergeable := make([]bool, len(held))
+	firstContent := -1
+	var total strings.Builder
+	for i, line := range held {
+		v := parseDSMLChunkView(line)
+		if v.contentText == "" || v.hasToolCall || v.terminal {
+			continue
+		}
+		mergeable[i] = true
+		if firstContent < 0 {
+			firstContent = i
+		}
+		total.WriteString(v.contentText)
+	}
+	if firstContent < 0 {
+		return scrubDSMLHeldLinesInPlace(held)
+	}
+	clean, changed := scrubDSMLLeakFragments(total.String())
+	if !changed {
+		return scrubDSMLHeldLinesInPlace(held)
+	}
+	out := make([]string, 0, len(held))
+	skipBlank := false
+	for i, line := range held {
+		if mergeable[i] {
+			if i == firstContent {
+				rewritten, ok := dsmlRewriteSSELineContent(line, clean)
+				if !ok {
+					return scrubDSMLHeldLinesInPlace(held)
+				}
+				out = append(out, rewritten)
+			} else {
+				skipBlank = true
+			}
+			continue
+		}
+		if skipBlank && line == "" {
+			skipBlank = false
+			continue
+		}
+		skipBlank = false
+		out = append(out, scrubDSMLFromSSELine(line))
+	}
+	return out
+}
+
+func scrubDSMLHeldLinesInPlace(held []string) []string {
+	out := make([]string, 0, len(held))
+	for _, line := range held {
+		out = append(out, scrubDSMLFromSSELine(line))
+	}
+	return out
+}
+
+// dsmlRewriteSSELineContent 把一条正文 SSE 行的 choices.0.delta.content 重写为 text。
+func dsmlRewriteSSELineContent(line, text string) (string, bool) {
+	payload, ok := extractOpenAISSEDataLine(line)
+	if !ok {
+		return "", false
+	}
+	updated, err := sjson.Set(strings.TrimSpace(payload), "choices.0.delta.content", text)
+	if err != nil {
+		return "", false
+	}
+	return "data: " + updated, true
+}
+
+// TakeHeldLines 交出残留的被扣行（上游中途断流的 fail-open 冲洗、或重试耗尽的原样放行）。
+func (g *openAIDSMLLeakGuard) TakeHeldLines() []string {
+	if g == nil {
+		return nil
+	}
+	g.state = dsmlGuardPassthrough
+	g.holding.Store(false)
+	return g.releaseHeld(false)
+}
+
+// ResetForRetry 丢弃本 attempt 的全部被扣行并复位状态机，返回丢弃量（供 ops 记录）。
+func (g *openAIDSMLLeakGuard) ResetForRetry() (discardedLines int, discardedBytes int) {
+	discardedLines = len(g.heldLines)
+	discardedBytes = g.heldBytes
+	g.heldLines = nil
+	g.heldBytes = 0
+	g.state = dsmlGuardWatching
+	g.holding.Store(false)
+	g.contentLen = 0
+	g.contentPrefix = ""
+	g.markerTail = ""
+	g.markerSeen = false
+	g.sawToolCall = false
+	g.terminalSeen = false
+	g.capReleased = false
+	return discardedLines, discardedBytes
+}
+
+// LeakVerdict 报告终局判定：被扣正文含标记且全程无结构化工具调用。
+func (g *openAIDSMLLeakGuard) LeakVerdict() bool {
+	if g == nil {
+		return false
+	}
+	if g.observeOnly {
+		return g.terminalSeen && g.markerSeen && !g.sawToolCall
+	}
+	return g.state == dsmlGuardLeakLatched
+}
+
+// Holding 供保活 goroutine 并发读取：当前是否处于扣流（含泄漏已判定、等待重试）状态。
+func (g *openAIDSMLLeakGuard) Holding() bool {
+	return g != nil && g.holding.Load()
+}
+
+// LateMarkerSeen 报告直通后才出现标记（sniff 放行的尾部风险，不可回收，只计 ops）。
+func (g *openAIDSMLLeakGuard) LateMarkerSeen() bool {
+	return g != nil && g.lateMarkerSeen
+}
+
+// CapReleased 报告扣留因超限被原样放行。
+func (g *openAIDSMLLeakGuard) CapReleased() bool {
+	return g != nil && g.capReleased
+}
+
+func dsmlGuardPrefixSuspicious(prefix string) bool {
+	// 空前缀 = 目前只见过空白字符。按不可疑处理，否则纯空白开头的正常答案会被
+	// 「部分前缀匹配」规则一路扣到上限。
+	if prefix == "" {
+		return false
+	}
+	for _, p := range dsmlGuardHoldPrefixes {
+		if strings.HasPrefix(prefix, p) {
+			return true
+		}
+		// 前缀尚不足以判定（如首 chunk 只有 "<thi"）时按可疑处理，继续扣留。
+		if len(prefix) < len(p) && strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubDSMLFromSSELine 对单条 SSE 行做 shape-2 清理：剔除 delta.content 中的
+// DSML 标记片段，其余字段原样。非 data 行或解析失败时原样返回（放行降级）。
+func scrubDSMLFromSSELine(line string) string {
+	if !strings.Contains(line, dsmlLeakMarker) {
+		return line
+	}
+	payload, ok := extractOpenAISSEDataLine(line)
+	if !ok {
+		return line
+	}
+	p := strings.TrimSpace(payload)
+	if p == "" || p == "[DONE]" || !gjson.Valid(p) {
+		return line
+	}
+	choices := gjson.Get(p, "choices")
+	if !choices.Exists() || !choices.IsArray() {
+		return line
+	}
+	out := p
+	for i, choice := range choices.Array() {
+		content := choice.Get("delta.content")
+		if content.Type != gjson.String || !strings.Contains(content.String(), dsmlLeakMarker) {
+			continue
+		}
+		clean, _ := scrubDSMLLeakFragments(content.String())
+		updated, err := sjson.Set(out, fmt.Sprintf("choices.%d.delta.content", i), clean)
+		if err != nil {
+			return line
+		}
+		out = updated
+	}
+	return "data: " + out
+}
+
+// scrubDSMLLeakFragments 从一段文本中剥离泄漏的 DSML 碎片：
+//
+//  1. 完整块 <｜DSML｜x>…</｜DSML｜x>（Responses 侧泄漏块常完整保留）；
+//  2. chat 直转主形态：开标签被上游吃掉，剩 `<thinking>…参数体…</｜DSML｜x>` ——
+//     从 <thinking> 起剥到最后一个闭合标签为止（参数体一并剥除）;
+//  3. 残留的孤儿开/闭标签。
+//
+// 返回清理后的文本与是否发生改动。剥后为空是合法结果（调用方保留空串，不删消息）。
+func scrubDSMLLeakFragments(s string) (string, bool) {
+	if !strings.Contains(s, dsmlLeakMarker) {
+		return s, false
+	}
+	out := dsmlLeakBlockRe.ReplaceAllString(s, "")
+	if strings.Contains(out, dsmlLeakMarker) {
+		if end := dsmlLastCloseTagEnd(out); end > 0 {
+			// 取最后一个闭合标签之前「最近」的 <thinking> 起剥：早段合法的
+			// <thinking> 思考块与正文不受牵连（评审加固）。
+			if head := strings.LastIndex(out[:end], "<thinking>"); head >= 0 {
+				out = out[:head] + out[end:]
+			}
+		}
+	}
+	out = dsmlLeakTagRe.ReplaceAllString(out, "")
+	return out, out != s
+}
+
+func dsmlLastCloseTagEnd(s string) int {
+	locs := dsmlLeakCloseTagRe.FindAllStringIndex(s, -1)
+	if len(locs) == 0 {
+		return -1
+	}
+	return locs[len(locs)-1][1]
+}
+
+// --- 服务级门控与请求侧清洗 ---
+
+// dsmlGuardModelMatches 报告 upstreamModel 是否命中配置的前缀列表。
+func (s *OpenAIGatewayService) dsmlGuardModelMatches(upstreamModel string) bool {
+	if s == nil || s.cfg == nil || !s.cfg.Gateway.DSMLGuardEnabled {
+		return false
+	}
+	for _, prefix := range s.cfg.Gateway.DSMLGuardModels {
+		prefix = strings.TrimSpace(prefix)
+		if prefix != "" && strings.HasPrefix(upstreamModel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// dsmlGuardActiveForBody 报告响应侧检测器是否激活：配置开启 + 模型命中 + 请求带 tools。
+func (s *OpenAIGatewayService) dsmlGuardActiveForBody(upstreamModel string, body []byte) bool {
+	if !s.dsmlGuardModelMatches(upstreamModel) {
+		return false
+	}
+	tools := gjson.GetBytes(body, "tools")
+	return tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+}
+
+// applyDSMLHistoryScrub 从请求历史的 assistant 消息里剥离已泄漏的 DSML 碎片（治级联）。
+// 仅动 assistant 角色的字符串 content；user/tool 角色一律不碰（用户可能正在讨论这个 bug）。
+// 剥后为空的消息保留为空串（不删消息、不动结构）。observe 模式只记录不改写。
+func (s *OpenAIGatewayService) applyDSMLHistoryScrub(c *gin.Context, account *Account, upstreamModel string, body []byte) []byte {
+	if !s.dsmlGuardModelMatches(upstreamModel) {
+		return body
+	}
+	if !bytes.Contains(body, []byte(dsmlLeakMarker)) {
+		return body
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body
+	}
+	observe := s.cfg.Gateway.DSMLGuardObserve
+	out := body
+	scrubbedCount := 0
+	for i, msg := range messages.Array() {
+		if msg.Get("role").String() != "assistant" {
+			continue
+		}
+		content := msg.Get("content")
+		if content.Type != gjson.String || !strings.Contains(content.String(), dsmlLeakMarker) {
+			continue
+		}
+		clean, changed := scrubDSMLLeakFragments(content.String())
+		if !changed {
+			continue
+		}
+		scrubbedCount++
+		if observe {
+			continue
+		}
+		updated, err := sjson.SetBytes(out, fmt.Sprintf("messages.%d.content", i), clean)
+		if err != nil {
+			continue
+		}
+		out = updated
+	}
+	if scrubbedCount > 0 {
+		message := fmt.Sprintf("dsml history scrub: stripped leaked fragments from %d assistant message(s)", scrubbedCount)
+		if observe {
+			message += " (observe mode, request unchanged)"
+		}
+		appendDSMLGuardOpsEvent(c, account, "", message, "")
+	}
+	if observe {
+		return body
+	}
+	return out
+}
+
+// appendDSMLGuardOpsEvent 落一条 Kind=dsml_leak 的 ops 事件。成功响应（<400）里的
+// 事件也会被 OpsErrorLoggerMiddleware 持久化，恢复动作因此可观测、零新表。
+func appendDSMLGuardOpsEvent(c *gin.Context, account *Account, upstreamRequestID, message, detail string) {
+	ev := OpsUpstreamErrorEvent{
+		Kind:              dsmlGuardOpsKind,
+		Message:           message,
+		Detail:            detail,
+		UpstreamRequestID: upstreamRequestID,
+	}
+	if account != nil {
+		ev.Platform = account.Platform
+		ev.AccountID = account.ID
+		ev.AccountName = account.Name
+	}
+	appendOpsUpstreamError(c, ev)
+}

--- a/backend/internal/service/openai_dsml_leak_guard_test.go
+++ b/backend/internal/service/openai_dsml_leak_guard_test.go
@@ -1,0 +1,730 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// 所有 fixture 均为按已核验形态合成的样本（生产捕获含用户内容，禁止入库）。
+
+func dsmlGuardTestConfig() *config.Config {
+	cfg := rawChatCompletionsTestConfig()
+	cfg.Gateway.DSMLGuardEnabled = true
+	cfg.Gateway.DSMLGuardModels = []string{"deepseek-v4"}
+	cfg.Gateway.DSMLGuardMaxRetries = 1
+	return cfg
+}
+
+func dsmlLeakOpsEvents(c *gin.Context) []*OpsUpstreamErrorEvent {
+	v, ok := c.Get(OpsUpstreamErrorsKey)
+	if !ok {
+		return nil
+	}
+	events, _ := v.([]*OpsUpstreamErrorEvent)
+	var out []*OpsUpstreamErrorEvent
+	for _, ev := range events {
+		if ev != nil && ev.Kind == dsmlGuardOpsKind {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func dsmlStreamRequestBody() []byte {
+	return []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t"}}],"stream":true}`)
+}
+
+// runDSMLStreamFixture 起一条流式 raw CC 请求并返回客户端字节与上游记录。
+func runDSMLStreamFixture(t *testing.T, cfg *config.Config, reqBody []byte, upstreamResponses ...*http.Response) (*httptest.ResponseRecorder, *httpUpstreamRecorder, *gin.Context, *OpenAIForwardResult, error) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody)))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{}
+	if len(upstreamResponses) == 1 {
+		upstream.resp = upstreamResponses[0]
+	} else {
+		upstream.responses = upstreamResponses
+	}
+
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, rawChatCompletionsTestAccount(), reqBody, "")
+	return rec, upstream, c, result, err
+}
+
+func dsmlSSEResponse(requestID string, lines ...string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{requestID}},
+		Body:       io.NopCloser(strings.NewReader(strings.Join(lines, "\n") + "\n")),
+	}
+}
+
+// dsmlLeakAttemptLines 复刻已核验的全漏形态：reasoning 正常直播 → content 以
+// <thinking> 起头、参数体+闭合标签当正文流出 → finish_reason:"stop"，全程无 tool_calls。
+func dsmlLeakAttemptLines(id string, promptTokens, completionTokens int) []string {
+	return []string{
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"reasoning_content":"let me think"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"<thinking>use weather tool"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"city=SEA</｜DSML｜tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":` + itoa(promptTokens) + `,"completion_tokens":` + itoa(completionTokens) + `,"total_tokens":` + itoa(promptTokens+completionTokens) + `}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+}
+
+func dsmlCleanAttemptLines(id string, promptTokens, completionTokens int) []string {
+	return []string{
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"reasoning_content":"second pass"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"the weather in SEA is cloudy"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"id":"` + id + `","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":` + itoa(promptTokens) + `,"completion_tokens":` + itoa(completionTokens) + `,"total_tokens":` + itoa(promptTokens+completionTokens) + `}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+}
+
+func itoa(v int) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// ① 全漏 → 同账号重试拿到干净流，客户端字节序列正确。
+func TestDSMLGuard_LeakRetriesOnSameAccountAndHealsStream(t *testing.T) {
+	rec, upstream, c, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_leak_1", dsmlLeakAttemptLines("a1", 11, 7)...),
+		dsmlSSEResponse("rid_clean_2", dsmlCleanAttemptLines("a2", 13, 9)...),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	body := rec.Body.String()
+	// 坏 attempt 的正文一个字节都不该到客户端。
+	require.NotContains(t, body, "｜DSML｜")
+	require.NotContains(t, body, "<thinking>")
+	// attempt-1 的 reasoning 已直播（扣的只是正文通道）。
+	require.Contains(t, body, `"reasoning_content":"let me think"`)
+	// attempt-2 完整续写进同一条 SSE。
+	require.Contains(t, body, `"reasoning_content":"second pass"`)
+	require.Contains(t, body, "the weather in SEA is cloudy")
+	// 客户端只收到最后一次 attempt 的 usage 与一个 [DONE]。
+	require.Equal(t, 1, strings.Count(body, `"prompt_tokens"`))
+	require.Contains(t, body, `"prompt_tokens":13`)
+	require.Equal(t, 1, strings.Count(body, "data: [DONE]"))
+
+	// 计费口径：最后一次 attempt。
+	require.Equal(t, 13, result.Usage.InputTokens)
+	require.Equal(t, 9, result.Usage.OutputTokens)
+
+	// 同账号同请求体重发。
+	require.Len(t, upstream.requests, 2)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, string(upstream.bodies[0]), string(upstream.bodies[1]))
+
+	events := dsmlLeakOpsEvents(c)
+	require.NotEmpty(t, events)
+	foundRetry := false
+	for _, ev := range events {
+		if strings.Contains(ev.Message, "retried on same account") {
+			foundRetry = true
+		}
+	}
+	require.True(t, foundRetry, "expected a dsml_leak retry ops event, got: %+v", events)
+}
+
+// ①b 重试后 response-model 观察按 attempt 重置：坏 attempt 声明的模型串不得
+// 让 conflict 锁存（否则 response_model 计费静默降级 baseline），最终观察到的
+// 模型应来自干净 attempt。
+func TestDSMLGuard_RetryResetsUpstreamResponseModelObservation(t *testing.T) {
+	leakLines := dsmlLeakAttemptLines("a1", 11, 7)
+	for i, line := range leakLines {
+		leakLines[i] = strings.ReplaceAll(line, `"model":"deepseek-v4-flash"`, `"model":"deepseek-v4-flash-exp"`)
+	}
+	_, _, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_leak_1", leakLines...),
+		dsmlSSEResponse("rid_clean_2", dsmlCleanAttemptLines("a2", 13, 9)...),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Equal(t, "deepseek-v4-flash", result.UpstreamResponseModel,
+		"observed model must come from the clean attempt, not the discarded one")
+	require.False(t, result.UpstreamResponseModelConflict,
+		"discarded attempt's model declaration must not latch a billing conflict")
+}
+
+// ② 混合（标记与真 tool_calls 并存）→ 剔标记冲洗，不重试。
+func TestDSMLGuard_MixedToolCallScrubsMarkerWithoutRetry(t *testing.T) {
+	lines := []string{
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"calling <｜DSML｜tool_calls>x=1</｜DSML｜tool_calls> now"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_mixed", lines...))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 1, "mixed tool round must not retry")
+
+	body := rec.Body.String()
+	require.Contains(t, body, `"tool_calls"`)
+	require.Contains(t, body, `"finish_reason":"tool_calls"`)
+	require.NotContains(t, body, "｜DSML｜")
+	require.Contains(t, body, "calling  now")
+}
+
+// ③ 干净长答案 → 128 字节后直通，字节与无防护完全一致（关键回归）。
+func TestDSMLGuard_CleanLongAnswerBytesUnchanged(t *testing.T) {
+	long := strings.Repeat("all good here ", 12) // ≥128 字节、无标记、无可疑前缀
+	lines := []string{
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"` + long + `"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"tail"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+
+	guardedRec, guardedUpstream, guardedCtx, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_clean", lines...))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, guardedUpstream.requests, 1)
+	require.Empty(t, dsmlLeakOpsEvents(guardedCtx))
+
+	plainRec, _, _, _, err := runDSMLStreamFixture(t, rawChatCompletionsTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_clean", lines...))
+	require.NoError(t, err)
+	require.Equal(t, plainRec.Body.String(), guardedRec.Body.String(), "guard must be byte-invisible on clean streams")
+}
+
+// ④ 两次全漏 → 耗尽，最后一次 attempt 原样放行，无错误帧。
+func TestDSMLGuard_RetryExhaustedReleasesHeldOutputUnchanged(t *testing.T) {
+	rec, upstream, c, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_leak_1", dsmlLeakAttemptLines("a1", 11, 7)...),
+		dsmlSSEResponse("rid_leak_2", dsmlLeakAttemptLines("a2", 13, 9)...),
+	)
+	require.NoError(t, err, "exhausted retry must degrade, never error")
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 2)
+
+	body := rec.Body.String()
+	// 最后一次 attempt 的被扣输出原样放行（降级 = 今天的行为）。
+	require.Equal(t, 1, strings.Count(body, "<thinking>use weather tool"))
+	require.Contains(t, body, "</｜DSML｜tool_calls>")
+	require.NotContains(t, body, `"error"`)
+	require.Equal(t, 1, strings.Count(body, "data: [DONE]"))
+	require.Equal(t, 13, result.Usage.InputTokens)
+	require.Equal(t, 9, result.Usage.OutputTokens)
+
+	events := dsmlLeakOpsEvents(c)
+	foundExhausted := false
+	for _, ev := range events {
+		if strings.Contains(ev.Message, "persisted after") {
+			foundExhausted = true
+		}
+	}
+	require.True(t, foundExhausted, "expected an exhausted ops event, got: %+v", events)
+}
+
+// ⑤ observe 模式 → 只记录，字节零改动。
+func TestDSMLGuard_ObserveModeDetectsWithoutChangingBytes(t *testing.T) {
+	observeCfg := dsmlGuardTestConfig()
+	observeCfg.Gateway.DSMLGuardObserve = true
+
+	observedRec, observedUpstream, observedCtx, result, err := runDSMLStreamFixture(t, observeCfg, dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_observe", dsmlLeakAttemptLines("a1", 11, 7)...))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, observedUpstream.requests, 1, "observe mode must not retry")
+
+	plainRec, _, _, _, err := runDSMLStreamFixture(t, rawChatCompletionsTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_observe", dsmlLeakAttemptLines("a1", 11, 7)...))
+	require.NoError(t, err)
+	require.Equal(t, plainRec.Body.String(), observedRec.Body.String(), "observe mode must be byte-invisible")
+
+	events := dsmlLeakOpsEvents(observedCtx)
+	require.NotEmpty(t, events)
+	foundObserve := false
+	for _, ev := range events {
+		if strings.Contains(ev.Message, "observe") {
+			foundObserve = true
+		}
+	}
+	require.True(t, foundObserve, "expected an observe-mode ops event, got: %+v", events)
+}
+
+// ⑥ 请求清洗：脏历史进 → 干净体出；user/tool 角色原样；observe 模式不改写。
+func TestDSMLGuard_HistoryScrubStripsAssistantLeaks(t *testing.T) {
+	reqBody := []byte(`{"model":"deepseek-v4-flash","stream":false,"messages":[{"role":"user","content":"why does ｜DSML｜ appear in my chat?"},{"role":"assistant","content":"<thinking>orphan params q=1</｜DSML｜tool_calls>"},{"role":"assistant","content":"before <｜DSML｜tool_calls>x=2</｜DSML｜tool_calls> after"},{"role":"tool","tool_call_id":"c1","content":"tool text ｜DSML｜ mention"}]}`)
+	upstreamJSON := `{"id":"s1","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	jsonResp := func() *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamJSON)),
+		}
+	}
+
+	_, upstream, c, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), reqBody, jsonResp())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	sent := upstream.lastBody
+	messages := gjson.GetBytes(sent, "messages").Array()
+	require.Len(t, messages, 4, "scrub must not add or drop messages")
+	require.Equal(t, "why does ｜DSML｜ appear in my chat?", messages[0].Get("content").String(), "user content must stay untouched")
+	require.Equal(t, "", messages[1].Get("content").String(), "fully-leaked assistant message keeps an empty string")
+	require.Equal(t, "before  after", messages[2].Get("content").String())
+	require.Equal(t, "tool text ｜DSML｜ mention", messages[3].Get("content").String(), "tool content must stay untouched")
+
+	events := dsmlLeakOpsEvents(c)
+	foundScrub := false
+	for _, ev := range events {
+		if strings.Contains(ev.Message, "dsml history scrub") {
+			foundScrub = true
+		}
+	}
+	require.True(t, foundScrub, "expected a history-scrub ops event, got: %+v", events)
+
+	// observe 模式：请求体零改动。
+	observeCfg := dsmlGuardTestConfig()
+	observeCfg.Gateway.DSMLGuardObserve = true
+	_, observeUpstream, observeCtx, _, err := runDSMLStreamFixture(t, observeCfg, reqBody, jsonResp())
+	require.NoError(t, err)
+	require.Equal(t, string(reqBody), string(observeUpstream.lastBody), "observe mode must not rewrite the request")
+	require.NotEmpty(t, dsmlLeakOpsEvents(observeCtx), "observe mode still records the would-scrub event")
+}
+
+// ⑦ 非门控模型 / 无 tools / 非流式 → 检测器不激活，字节零改动。
+func TestDSMLGuard_NotActivated(t *testing.T) {
+	t.Run("other model", func(t *testing.T) {
+		reqBody := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t"}}],"stream":true}`)
+		lines := dsmlLeakAttemptLines("n1", 3, 2)
+		rec, _, c, _, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), reqBody, dsmlSSEResponse("rid_na1", lines...))
+		require.NoError(t, err)
+		require.Contains(t, rec.Body.String(), "</｜DSML｜tool_calls>", "non-gated model streams through unchanged")
+		require.Empty(t, dsmlLeakOpsEvents(c))
+	})
+
+	t.Run("no tools", func(t *testing.T) {
+		reqBody := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+		lines := dsmlLeakAttemptLines("n2", 3, 2)
+		rec, _, c, _, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), reqBody, dsmlSSEResponse("rid_na2", lines...))
+		require.NoError(t, err)
+		require.Contains(t, rec.Body.String(), "</｜DSML｜tool_calls>", "tool-less request streams through unchanged")
+		require.Empty(t, dsmlLeakOpsEvents(c))
+	})
+
+	t.Run("non-streaming", func(t *testing.T) {
+		reqBody := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t"}}],"stream":false}`)
+		upstreamJSON := `{"id":"n3","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"<thinking>leak</｜DSML｜tool_calls>"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+		rec, _, c, _, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), reqBody, &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamJSON)),
+		})
+		require.NoError(t, err)
+		require.Contains(t, rec.Body.String(), "</｜DSML｜tool_calls>", "non-streaming responses are out of detector scope")
+		require.Empty(t, dsmlLeakOpsEvents(c))
+	})
+}
+
+// ⑧ 扣流中途上游断流 → 已扣内容冲洗放行（fail-open），无重试，无错误帧。
+func TestDSMLGuard_MidHoldUpstreamAbortFlushesHeldLines(t *testing.T) {
+	prefix := strings.Join([]string{
+		`data: {"id":"x1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"x1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"<thinking>partial"},"finish_reason":null}]}`,
+		``,
+	}, "\n") + "\n"
+	abortingBody := io.NopCloser(io.MultiReader(
+		strings.NewReader(prefix),
+		passthroughErrReadCloser{err: errors.New("upstream aborted mid-hold")},
+	))
+
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(), &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_abort"}},
+		Body:       abortingBody,
+	})
+	require.NoError(t, err, "mid-hold abort must fail open, not error")
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 1, "no terminal frame means no leak verdict, so no retry")
+
+	body := rec.Body.String()
+	require.Contains(t, body, "<thinking>partial", "held lines must be flushed as-is on abort")
+	require.NotContains(t, body, `"error"`)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestScrubDSMLLeakFragments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		in          string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "complete block removed",
+			in:          "before <｜DSML｜tool_calls>x=1</｜DSML｜tool_calls> after",
+			want:        "before  after",
+			wantChanged: true,
+		},
+		{
+			name:        "thinking head with orphan close tail stripped to empty",
+			in:          "<thinking>params body q=1</｜DSML｜tool_calls>",
+			want:        "",
+			wantChanged: true,
+		},
+		{
+			name:        "thinking head keeps trailing text after last close tag",
+			in:          "<thinking>p</｜DSML｜tool_calls> trailing",
+			want:        " trailing",
+			wantChanged: true,
+		},
+		{
+			name:        "orphan close tag cluster removed",
+			in:          "text </｜DSML｜tool_calls></｜DSML｜end> tail",
+			want:        "text  tail",
+			wantChanged: true,
+		},
+		{
+			name:        "double fullwidth bar spelling matched",
+			in:          "a <｜｜DSML｜｜tool_calls>x</｜｜DSML｜｜tool_calls> b",
+			want:        "a  b",
+			wantChanged: true,
+		},
+		{
+			name:        "no marker untouched",
+			in:          "hello <thinking> world",
+			want:        "hello <thinking> world",
+			wantChanged: false,
+		},
+		{
+			name:        "legit prose before late leak preserved",
+			in:          "<thinking>plan</thinking>real answer <thinking>q=1</｜DSML｜tool_calls>",
+			want:        "<thinking>plan</thinking>real answer ",
+			wantChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, changed := scrubDSMLLeakFragments(tt.in)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantChanged, changed)
+		})
+	}
+}
+
+func dsmlTestContentLine(text string) string {
+	encoded, _ := json.Marshal(text)
+	return `data: {"id":"t","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":` + string(encoded) + `},"finish_reason":null}]}`
+}
+
+const dsmlTestFinishLine = `data: {"id":"t","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+
+func TestDSMLLeakGuard_HandleLineStateMachine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sniff releases long clean content", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(false)
+		line := dsmlTestContentLine(strings.Repeat("a", 200))
+		out := g.HandleLine(line)
+		require.Equal(t, []string{line}, out, "clean ≥128B content releases immediately")
+		require.False(t, g.Holding())
+		require.False(t, g.LeakVerdict())
+	})
+
+	t.Run("thinking prefix holds past sniff window until clean terminal", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(false)
+		line := dsmlTestContentLine("<thinking>" + strings.Repeat("b", 200))
+		require.Empty(t, g.HandleLine(line), "suspicious prefix keeps holding past 128 bytes")
+		require.True(t, g.Holding())
+		out := g.HandleLine(dsmlTestFinishLine)
+		require.Equal(t, []string{line, dsmlTestFinishLine}, out, "no marker by terminal → clean flush")
+		require.False(t, g.LeakVerdict())
+	})
+
+	t.Run("marker split across chunks still detected", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(false)
+		require.Empty(t, g.HandleLine(dsmlTestContentLine("abc ｜DS")))
+		require.Empty(t, g.HandleLine(dsmlTestContentLine("ML｜ def")))
+		require.Empty(t, g.HandleLine(dsmlTestFinishLine), "leak verdict swallows the terminal frame")
+		require.True(t, g.LeakVerdict())
+	})
+
+	t.Run("late marker after release is observed but not recoverable", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(false)
+		clean := dsmlTestContentLine(strings.Repeat("c", 200))
+		require.Equal(t, []string{clean}, g.HandleLine(clean))
+		late := dsmlTestContentLine("tail ｜DSML｜ garbage")
+		require.Equal(t, []string{late}, g.HandleLine(late), "passthrough keeps streaming")
+		require.True(t, g.LateMarkerSeen())
+		require.False(t, g.LeakVerdict())
+	})
+
+	t.Run("nil guard passes lines through", func(t *testing.T) {
+		t.Parallel()
+		var g *openAIDSMLLeakGuard
+		require.Equal(t, []string{"data: x"}, g.HandleLine("data: x"))
+		require.False(t, g.LeakVerdict())
+		require.False(t, g.Holding())
+	})
+
+	t.Run("prefix suspicion covers partial prefixes", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, dsmlGuardPrefixSuspicious("<thi"), "partial prefix stays suspicious")
+		require.True(t, dsmlGuardPrefixSuspicious("<thinking>x"))
+		require.True(t, dsmlGuardPrefixSuspicious("<｜"))
+		require.False(t, dsmlGuardPrefixSuspicious("normal text"))
+		require.False(t, dsmlGuardPrefixSuspicious(""), "whitespace-only content must not be held forever")
+	})
+
+	t.Run("whitespace-leading content releases after sniff window", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(false)
+		require.Empty(t, g.HandleLine(dsmlTestContentLine(strings.Repeat(" ", 64))), "first chunk enters hold")
+		released := g.HandleLine(dsmlTestContentLine(strings.Repeat(" ", 64)))
+		require.Len(t, released, 2, "128 whitespace bytes with empty prefix must sniff-release")
+		require.False(t, g.Holding())
+	})
+}
+
+// TestDSMLGuard_ResponsesLaneObserveVerdict 锁定 observe 模式的 Responses 事件解析：
+// output_text.delta 里的标记 + 终态事件 → 判定泄漏；出现 function_call 事件则豁免。
+func TestDSMLGuard_ResponsesLaneObserveVerdict(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text leak with terminal event is a leak verdict", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(true)
+		lines := []string{
+			`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+			`data: {"type":"response.output_text.delta","delta":"<thinking>echo args</｜DSML｜tool_calls>"}`,
+			`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`,
+		}
+		for _, line := range lines {
+			require.Equal(t, []string{line}, g.HandleLine(line), "observe mode never withholds bytes")
+		}
+		require.True(t, g.LeakVerdict())
+	})
+
+	t.Run("structured function_call exempts the verdict", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(true)
+		lines := []string{
+			`data: {"type":"response.output_text.delta","delta":"prefix ｜DSML｜ noise"}`,
+			`data: {"type":"response.output_item.added","item":{"type":"function_call","name":"lookup"}}`,
+			`data: {"type":"response.completed","response":{"id":"resp_2"}}`,
+		}
+		for _, line := range lines {
+			require.Equal(t, []string{line}, g.HandleLine(line))
+		}
+		require.False(t, g.LeakVerdict())
+	})
+
+	t.Run("no terminal event means no verdict", func(t *testing.T) {
+		t.Parallel()
+		g := newOpenAIDSMLLeakGuard(true)
+		line := `data: {"type":"response.output_text.delta","delta":"<thinking>x</｜DSML｜tool_calls>"}`
+		require.Equal(t, []string{line}, g.HandleLine(line))
+		require.False(t, g.LeakVerdict())
+	})
+}
+
+// 工具轮前导泄漏、标记被 chunk 边界拆开：单行 Contains 检不出完整标记，
+// 必须整体拼接清洗后再放行（评审回归：跨 chunk 断裂标记曾原样漏给客户端）。
+func TestDSMLGuard_SplitMarkerToolRoundScrubbedAcrossChunks(t *testing.T) {
+	lines := []string{
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		dsmlTestContentLine("<thinking>use weather "),
+		``,
+		dsmlTestContentLine("city=SEA</｜DS"),
+		``,
+		dsmlTestContentLine("ML｜tool_calls>"),
+		``,
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"weather","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_split", lines...))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 1, "tool round must not retry")
+
+	body := rec.Body.String()
+	require.NotContains(t, body, "DSML", "no fragment of the split marker may reach the client")
+	require.NotContains(t, body, "use weather", "leaked pre-tool text must be scrubbed")
+	require.Contains(t, body, `"tool_calls"`)
+	require.Contains(t, body, `"finish_reason":"tool_calls"`)
+	require.Equal(t, 1, strings.Count(body, "data: [DONE]"))
+}
+
+// 重试流在 usage chunk 之前断掉：回退计上一 attempt 的 usage，不能计零
+// （上游两次生成都已产生费用）。
+func TestDSMLGuard_RetryTruncatedBeforeUsageFallsBackToPriorAttemptUsage(t *testing.T) {
+	truncatedRetry := []string{
+		`data: {"id":"a2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"partial answer before drop"},"finish_reason":null}]}`,
+		``,
+		// 连接在 finish/usage/[DONE] 之前断掉。
+	}
+	_, _, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_leak_1", dsmlLeakAttemptLines("a1", 11, 7)...),
+		dsmlSSEResponse("rid_trunc_2", truncatedRetry...),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 11, result.Usage.InputTokens, "must fall back to attempt-1 usage, not zero")
+	require.Equal(t, 7, result.Usage.OutputTokens)
+}
+
+// 评审修复回归：shape-2 的标记跨 chunk 断裂（前半 <thinking>… 不含标记、后半才含
+// 闭合标签）时，冲洗放行必须对拼接后的正文整体清洗，不能漏放前半的泄漏文本。
+func TestDSMLGuard_MixedToolCallScrubsSplitMarkerAcrossChunks(t *testing.T) {
+	lines := []string{
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"<thinking>call weather"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"</｜DSML｜tool_call>"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"m1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_split", lines...))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 1, "tool round must not retry")
+
+	body := rec.Body.String()
+	require.NotContains(t, body, "｜DSML｜")
+	require.NotContains(t, body, "call weather", "split leak halves must not reach the client")
+	require.Contains(t, body, `"tool_calls"`)
+	require.Contains(t, body, `"finish_reason":"tool_calls"`)
+	require.Contains(t, body, "data: [DONE]")
+}
+
+// 评审修复回归：重试后必须换新 silent-refusal detector——坏 attempt 锁存的
+// sawContent 不能吞掉 attempt-2 真 silent refusal 的零字节 failover 资格。
+func TestDSMLGuard_RetrySilentRefusalStillFailsOver(t *testing.T) {
+	reqBody := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"` +
+		strings.Repeat("x", openAISilentRefusalMinRequestBodyBytes) +
+		`"}],"tools":[{"type":"function","function":{"name":"t"}}],"stream":true}`)
+	// 无 reasoning 的全漏形态：客户端零字节（role 行被 refusal 门扣、正文被 guard 扣），
+	// 零字节 failover 资格才可能保留到 attempt-2。
+	noReasoningLeakLines := []string{
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"<thinking>x</｜DSML｜tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"s1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	silentRefusalLines := []string{
+		`data: {"id":"s2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+		``,
+		`data: {"id":"s2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), reqBody,
+		dsmlSSEResponse("rid_leak", noReasoningLeakLines...),
+		dsmlSSEResponse("rid_silent", silentRefusalLines...),
+	)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.True(t, IsOpenAISilentRefusalErrorBody(failoverErr.ResponseBody))
+	require.Len(t, upstream.requests, 2)
+	require.Empty(t, rec.Body.String(), "zero bytes may reach the client before a silent-refusal failover")
+}
+
+// 评审修复回归：attempt-2 在 usage chunk 之前断流时回退计 attempt-1 的 usage，
+// 不允许上游双计费而网关计零；被扣的 attempt-2 正文照旧 fail-open 冲洗。
+func TestDSMLGuard_TruncatedRetryFallsBackToPreviousAttemptUsage(t *testing.T) {
+	truncatedLines := []string{
+		`data: {"id":"t2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"t2","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"partial answer"},"finish_reason":null}]}`,
+		``,
+	}
+	rec, upstream, _, result, err := runDSMLStreamFixture(t, dsmlGuardTestConfig(), dsmlStreamRequestBody(),
+		dsmlSSEResponse("rid_leak", dsmlLeakAttemptLines("t1", 7, 3)...),
+		dsmlSSEResponse("rid_truncated", truncatedLines...),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 2)
+	require.Equal(t, 7, result.Usage.InputTokens, "fall back to attempt-1 usage")
+	require.Equal(t, 3, result.Usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), `"content":"partial answer"`, "held lines flush fail-open on truncation")
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -130,6 +130,13 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	// ShouldUseResponsesAPI 分流：该类账号经 probe 落标
 	// openai_responses_supported=false，会先命中下方的 CC 直转分支。
 	if account.IsAnthropicProtocol() {
+		// DSML 泄漏防护·请求侧：deepseek 是显式的 anthropic 协议平台，历史里的
+		// 已泄漏 DSML 碎片同样会诱导复漏。清洗在 CC body（转换链之前）即可完成；
+		// 模型解析与 raw 直转 lane 同式。
+		// TODO(dsml-guard): anthropic lane response-side detection
+		scrubModel := normalizeOpenAIModelForUpstream(account,
+			resolveOpenAIForwardModel(account, gjson.GetBytes(body, "model").String(), defaultMappedModel))
+		body = s.applyDSMLHistoryScrub(c, account, scrubModel, body)
 		return s.forwardChatCompletionsViaNativeAnthropic(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
@@ -91,6 +92,10 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	if normalizedBody, normalized := NormalizeGLMOpenAIReasoningEffort(upstreamBody, upstreamModel); normalized {
 		upstreamBody = normalizedBody
 	}
+
+	// 3b. DSML 泄漏防护·请求侧：从 assistant 历史里剥离已泄漏的 DSML 碎片（治级联）。
+	// 不清洗则污染历史会诱导模型复漏，响应侧的原地重试也会大概率失效。
+	upstreamBody = s.applyDSMLHistoryScrub(c, account, upstreamModel, upstreamBody)
 
 	// 4. Apply OpenAI fast policy on the CC body
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, upstreamBody)
@@ -230,7 +235,21 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	var result *OpenAIForwardResult
 	var forwardErr error
 	if clientStream {
-		result, forwardErr = s.streamRawChatCompletions(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime, len(body))
+		// DSML 泄漏防护·响应侧：门控命中时挂检测器；enforce 模式下再挂同账号
+		// 同请求体的原地重发闭包（重试不走 handler 的 failover 循环——那条路只在
+		// 零字节写出时可用，而这里 reasoning 已直播）。
+		var dsmlGuard *openAIDSMLLeakGuard
+		var dsmlResend func() (*http.Response, error)
+		if s.dsmlGuardActiveForBody(upstreamModel, upstreamBody) {
+			dsmlGuard = newOpenAIDSMLLeakGuard(s.cfg.Gateway.DSMLGuardObserve)
+			if !s.cfg.Gateway.DSMLGuardObserve {
+				resendBody := upstreamBody
+				dsmlResend = func() (*http.Response, error) {
+					return s.sendCCUpstreamRequest(ctx, c, account, targetURL, resendBody, clientStream, token, customUA, grokCacheIdentity)
+				}
+			}
+		}
+		result, forwardErr = s.streamRawChatCompletions(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime, len(body), dsmlGuard, dsmlResend)
 	} else {
 		result, forwardErr = s.bufferRawChatCompletions(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
@@ -259,6 +278,12 @@ func (s *OpenAIGatewayService) rawChatCompletionsURL(account *Account) (string, 
 // usage 字段仅在客户端请求 stream_options.include_usage=true 时出现于上游响应中。
 // 网关会对上游强制打开 include_usage 以保证计费完整，并原样向下游透传 usage，
 // 让级联代理或下游计费系统也能拿到完整用量。
+//
+// dsmlGuard 非 nil 时启用 DSML 泄漏防护（见 openai_dsml_leak_guard.go）：
+// reasoning 照常直播，正文通道进入 128 字节 sniff 扣留；终局判定为泄漏且
+// dsmlResend 可用时，丢弃被扣坏流、对同账号重发同一请求体，下一个 attempt 的
+// 事件续写进同一条客户端 SSE。重试耗尽或重发失败一律原样冲洗被扣输出——
+// 误判的最坏代价是延迟，绝不向客户端造错、绝不丢数据。
 func (s *OpenAIGatewayService) streamRawChatCompletions(
 	c *gin.Context,
 	resp *http.Response,
@@ -270,6 +295,8 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 	serviceTier *string,
 	startTime time.Time,
 	requestBodyLen int,
+	dsmlGuard *openAIDSMLLeakGuard,
+	dsmlResend func() (*http.Response, error),
 ) (*OpenAIForwardResult, error) {
 	observer := upstreamResponseModelObserverFromContext(c)
 	if observer == nil {
@@ -277,7 +304,6 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 	}
 	requestID := resp.Header.Get("x-request-id")
 	writeStreamHeaders := s.newStreamHeaderWriter(c, resp.Header)
-	scanner := s.newUpstreamSSEScanner(resp.Body)
 
 	var usage OpenAIUsage
 	var firstTokenMs *int
@@ -286,7 +312,11 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 	pendingLines := make([]string, 0, 8)
 	refusalDetector := newOpenAIChatSilentRefusalDetector(requestBodyLen)
 
-	writeLine := func(line string) {
+	// writeMu 串行化扫描循环与 DSML 保活 goroutine 对 c.Writer 及输出状态的访问。
+	// 无 guard 时没有第二个写者，锁无竞争。
+	var writeMu sync.Mutex
+
+	writeLineLocked := func(line string) {
 		if clientDisconnected {
 			return
 		}
@@ -315,69 +345,231 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 				zap.Error(werr),
 				zap.String("request_id", requestID),
 			)
+			return
+		}
+		c.Writer.Flush()
+	}
+	writeLine := func(line string) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		writeLineLocked(line)
+	}
+
+	// content-hold 生效期间的 SSE 注释保活：reasoning 已直播、正文被扣住时，
+	// 防止零字节间隔触发客户端/中间层空闲超时。零字节不变量在 relay 内重试
+	// 方案下无须保持（保活仅在已开流、即 clientOutputStarted 后写出）。
+	if dsmlGuard != nil && !dsmlGuard.observeOnly {
+		keepaliveStop := make(chan struct{})
+		var keepaliveDone sync.WaitGroup
+		keepaliveDone.Add(1)
+		// 必须 join：不等 goroutine 退出就返回的话，一次已越过 select 的 tick 可能
+		// 在外层中间件回收 pooled writer 之后才拿到 writeMu 并写 c.Writer。
+		defer func() {
+			close(keepaliveStop)
+			keepaliveDone.Wait()
+		}()
+		go func() {
+			defer keepaliveDone.Done()
+			ticker := time.NewTicker(dsmlGuardKeepaliveInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-keepaliveStop:
+					return
+				case <-ticker.C:
+					if !dsmlGuard.Holding() {
+						continue
+					}
+					writeMu.Lock()
+					if clientOutputStarted && !clientDisconnected {
+						if _, werr := c.Writer.WriteString(dsmlGuardKeepaliveComment + "\n\n"); werr != nil {
+							clientDisconnected = true
+						} else {
+							c.Writer.Flush()
+						}
+					}
+					writeMu.Unlock()
+				}
+			}
+		}()
+	}
+
+	originalResp := resp
+	defer func() {
+		if resp != originalResp {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	maxAttempts := 1
+	if dsmlGuard != nil && !dsmlGuard.observeOnly && dsmlResend != nil && s.cfg != nil && s.cfg.Gateway.DSMLGuardMaxRetries > 0 {
+		maxAttempts = 1 + s.cfg.Gateway.DSMLGuardMaxRetries
+	}
+	attempt := 1
+	var attemptUsages []string
+	var retryFallbackUsage OpenAIUsage
+	var scanErr error
+	flushHeld := func() {
+		for _, held := range dsmlGuard.TakeHeldLines() {
+			writeLine(held)
 		}
 	}
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		refusalDetector.ObserveSSELine(line)
-		if payload, ok := extractOpenAISSEDataLine(line); ok {
-			trimmedPayload := strings.TrimSpace(payload)
-			if trimmedPayload != "[DONE]" {
-				observer.ObserveOpenAI([]byte(payload), strings.TrimSpace(gjson.Get(payload, "type").String()))
-				usageOnlyChunk := isOpenAIChatUsageOnlyStreamChunk(payload)
-				if u := extractCCStreamUsage(payload); u != nil {
-					usage = *u
-				}
-				if firstTokenMs == nil && !usageOnlyChunk {
-					elapsed := int(time.Since(startTime).Milliseconds())
-					firstTokenMs = &elapsed
+	for {
+		scanner := s.newUpstreamSSEScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			refusalDetector.ObserveSSELine(line)
+			if payload, ok := extractOpenAISSEDataLine(line); ok {
+				trimmedPayload := strings.TrimSpace(payload)
+				if trimmedPayload != "[DONE]" {
+					observer.ObserveOpenAI([]byte(payload), strings.TrimSpace(gjson.Get(payload, "type").String()))
+					usageOnlyChunk := isOpenAIChatUsageOnlyStreamChunk(payload)
+					if u := extractCCStreamUsage(payload); u != nil {
+						usage = *u
+					}
+					if firstTokenMs == nil && !usageOnlyChunk {
+						elapsed := int(time.Since(startTime).Milliseconds())
+						firstTokenMs = &elapsed
+					}
 				}
 			}
-		}
-		line = applyOllamaCloudRawChatCompletionsSSELine(account, line)
-		line = stripEmptyChatToolCallIdentityFromSSELine(line)
+			line = applyOllamaCloudRawChatCompletionsSSELine(account, line)
+			line = stripEmptyChatToolCallIdentityFromSSELine(line)
 
-		writeLine(line)
-		if line == "" {
-			if !clientDisconnected && clientOutputStarted {
-				c.Writer.Flush()
+			if dsmlGuard == nil {
+				writeLine(line)
+				continue
 			}
-			continue
+			for _, out := range dsmlGuard.HandleLine(line) {
+				writeLine(out)
+			}
 		}
-		if !clientDisconnected && clientOutputStarted {
-			c.Writer.Flush()
+		scanErr = scanner.Err()
+
+		if dsmlGuard == nil || dsmlGuard.observeOnly || !dsmlGuard.LeakVerdict() {
+			break
+		}
+
+		// 泄漏判定成立（enforce 模式）：坏流的正文一个字节都没写给客户端。
+		attemptUsages = append(attemptUsages, fmt.Sprintf("attempt %d usage: input=%d output=%d", attempt, usage.InputTokens, usage.OutputTokens))
+		if attempt >= maxAttempts {
+			// 耗尽即放行：最后一次 attempt 的被扣输出原样冲洗（降级 = 今天的行为）。
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				fmt.Sprintf("dsml leak persisted after %d attempt(s); released held output unchanged", attempt),
+				strings.Join(attemptUsages, "; "))
+			flushHeld()
+			break
+		}
+
+		_ = resp.Body.Close()
+		newResp, retryErr := dsmlResend()
+		if retryErr != nil {
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				"dsml leak detected but retry request failed; released held output unchanged",
+				retryErr.Error())
+			flushHeld()
+			break
+		}
+		if newResp.StatusCode >= 400 {
+			_, upstreamMsg := s.readOpenAIUpstreamError(newResp)
+			_ = newResp.Body.Close()
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				fmt.Sprintf("dsml leak retry got HTTP %d; released held output unchanged", newResp.StatusCode),
+				upstreamMsg)
+			flushHeld()
+			break
+		}
+
+		// 重试可行：丢弃坏 attempt 的全部被扣行（含终态帧、usage、[DONE]），
+		// 同一条客户端 SSE 续写下一个 attempt。
+		discardedLines, discardedBytes := dsmlGuard.ResetForRetry()
+		appendDSMLGuardOpsEvent(c, account, requestID,
+			fmt.Sprintf("dsml tool-call leak detected in text channel; discarded %d held line(s) (%d bytes) and retried on same account (attempt %d/%d)", discardedLines, discardedBytes, attempt+1, maxAttempts),
+			strings.Join(attemptUsages, "; "))
+		writeMu.Lock()
+		if !clientOutputStarted {
+			// 客户端尚未收到任何字节：坏 attempt 的前导行（role/reasoning）也一并
+			// 丢弃，客户端将只看到干净 attempt，TTFT 也随之复位。
+			pendingLines = pendingLines[:0]
+			firstTokenMs = nil
+		}
+		writeMu.Unlock()
+		// 换新 refusal detector：其旗标单调锁存，坏 attempt 的 sawContent 会让
+		// 下一个 attempt 的真 silent refusal 失去零字节 failover 资格。
+		refusalDetector = newOpenAIChatSilentRefusalDetector(requestBodyLen)
+		// 换新 response-model observer：Observe() 在模型串不一致时单调锁存
+		// conflict=true，坏 attempt 的观察会让 response_model 计费静默降级为
+		// baseline。begin 会同时刷新 gin context 里的引用，计费读取的即新观察。
+		observer = beginUpstreamResponseModelObservation(c)
+		resp = newResp
+		if rid := strings.TrimSpace(newResp.Header.Get("x-request-id")); rid != "" {
+			requestID = rid
+		}
+		// 计费口径：只记最后一次 attempt 的 usage（各 attempt 的 usage 已入 ops
+		// 事件）；上一 attempt 的 usage 留作断流兜底，见循环后的回退。
+		retryFallbackUsage = usage
+		usage = OpenAIUsage{}
+		attempt++
+	}
+
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 &&
+		(retryFallbackUsage.InputTokens != 0 || retryFallbackUsage.OutputTokens != 0) {
+		// 最后一次 attempt 在 usage chunk 之前断流：回退计上一 attempt 的 usage，
+		// 避免上游已双计费而网关计零。
+		usage = retryFallbackUsage
+	}
+
+	if dsmlGuard != nil {
+		// 上游中途断流等场景的 fail-open：残留被扣行原样冲洗，绝不丢数据。
+		flushHeld()
+		if dsmlGuard.observeOnly && dsmlGuard.LeakVerdict() {
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				"dsml leak detected (observe mode; stream passed through unchanged)", "")
+		}
+		if dsmlGuard.LateMarkerSeen() {
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				"dsml marker appeared after sniff release; stream not recoverable", "")
+		}
+		if dsmlGuard.CapReleased() {
+			appendDSMLGuardOpsEvent(c, account, requestID,
+				"dsml guard hold cap exceeded; released held output unchanged", "")
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+	if scanErr != nil {
+		if !errors.Is(scanErr, context.Canceled) && !errors.Is(scanErr, context.DeadlineExceeded) {
 			logger.L().Warn("openai chat_completions raw: stream read error",
-				zap.Error(err),
+				zap.Error(scanErr),
 				zap.String("request_id", requestID),
 			)
 		}
-	} else if !clientDisconnected && !clientOutputStarted {
-		if refusalDetector.IsSilentRefusal() {
-			return nil, newOpenAISilentRefusalFailoverError(c, account, requestID)
-		}
-		if len(pendingLines) > 0 {
-			writeStreamHeaders()
-			for _, pending := range pendingLines {
-				if _, werr := c.Writer.WriteString(pending + "\n"); werr != nil {
-					clientDisconnected = true
-					logger.L().Debug("openai chat_completions raw: client disconnected during final flush",
-						zap.Error(werr),
-						zap.String("request_id", requestID),
-					)
-					break
+	} else {
+		writeMu.Lock()
+		if !clientDisconnected && !clientOutputStarted {
+			if refusalDetector.IsSilentRefusal() {
+				writeMu.Unlock()
+				return nil, newOpenAISilentRefusalFailoverError(c, account, requestID)
+			}
+			if len(pendingLines) > 0 {
+				writeStreamHeaders()
+				for _, pending := range pendingLines {
+					if _, werr := c.Writer.WriteString(pending + "\n"); werr != nil {
+						clientDisconnected = true
+						logger.L().Debug("openai chat_completions raw: client disconnected during final flush",
+							zap.Error(werr),
+							zap.String("request_id", requestID),
+						)
+						break
+					}
+				}
+				if !clientDisconnected {
+					c.Writer.Flush()
+					clientOutputStarted = true
 				}
 			}
-			if !clientDisconnected {
-				c.Writer.Flush()
-				clientOutputStarted = true
-			}
 		}
+		writeMu.Unlock()
 	}
 
 	return &OpenAIForwardResult{

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -147,6 +147,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	// CN 供应商 anthropic 协议账号：/v1/responses 入站是交叉协议组合
 	// （Responses 客户端 × Anthropic 上游），转成 Anthropic 请求走原生端点。
 	// 不能落到下面的 raw-CC 分支——其 URL 构造会把 anthropic base 当 CC base 用。
+	// TODO(dsml-guard): anthropic lane response-side detection；本 lane 的
+	// Responses 形态历史清洗（input[] 而非 messages[]）一并推迟到该改造。
 	if account.IsAnthropicProtocol() {
 		return s.forwardResponsesViaNativeAnthropic(ctx, c, account, body, reqModel)
 	}
@@ -1109,7 +1111,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		searchCount := 0
 		var imageOutputSizes []string
 		if reqStream {
-			streamResult, err := s.handleStreamingResponseWithReasoning(ctx, resp, c, account, startTime, originalModel, upstreamModel, reasoningEffortValue)
+			// DSML 泄漏防护：native Responses lane 目前只接观察（本 lane 此前无任何
+			// 检测器）。恒用 observe 语义——扣流/重试尚未在此 relay 落地。
+			var dsmlGuard *openAIDSMLLeakGuard
+			if s.dsmlGuardActiveForBody(upstreamModel, body) {
+				dsmlGuard = newOpenAIDSMLLeakGuard(true)
+			}
+			streamResult, err := s.handleStreamingResponseWithReasoning(ctx, resp, c, account, startTime, originalModel, upstreamModel, reasoningEffortValue, dsmlGuard)
 			if err != nil {
 				if signal, ok := asOpenAICompactFallbackSignal(err); ok {
 					if retryBody, fallbackModel, retry := s.prepareOpenAICompactFallbackRetry(

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -45,10 +45,12 @@ type openaiNonStreamingResult struct {
 }
 
 func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string) (*openaiStreamingResult, error) {
-	return s.handleStreamingResponseWithReasoning(ctx, resp, c, account, startTime, originalModel, mappedModel, "")
+	return s.handleStreamingResponseWithReasoning(ctx, resp, c, account, startTime, originalModel, mappedModel, "", nil)
 }
 
-func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel, reasoningEffort string) (*openaiStreamingResult, error) {
+// dsmlGuard 仅以 observe 语义接入本 relay：检测并记 ops，不扣流不重试（本函数的
+// 逐事件缓冲写出与 attempt 级状态量多，扣流/重试改造独立为后续工作）。
+func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel, reasoningEffort string, dsmlGuard *openAIDSMLLeakGuard) (*openaiStreamingResult, error) {
 	observer := upstreamResponseModelObserverFromContext(c)
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
@@ -383,6 +385,10 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				failureDelivered = true
 			}
 		}
+		if dsmlGuard.LeakVerdict() {
+			appendDSMLGuardOpsEvent(c, account, upstreamRequestID,
+				"dsml leak detected on responses lane (observe; recovery not wired on this lane yet)", "")
+		}
 		if sawTerminalEvent && !sawFailedEvent {
 			s.clearOpenAIProxyStreamDisconnect(account)
 		}
@@ -470,6 +476,10 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 	processSSELine := func(line string, queueDrained bool) {
 		if streamEarlyErr != nil {
 			return
+		}
+		if dsmlGuard != nil {
+			// observe 语义：只记账（正文累积/工具调用/终态），不改写任何字节。
+			_ = dsmlGuard.HandleLine(line)
 		}
 		if eventType, ok := extractOpenAISSEEventLine(line); ok {
 			pendingSSEEventType = eventType

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -376,7 +376,7 @@ type OpsUpstreamErrorEvent struct {
 	// Best-effort upstream response capture (sanitized+trimmed).
 	UpstreamResponseBody string `json:"upstream_response_body,omitempty"`
 
-	// Kind: http_error | request_error | retry_exhausted | failover
+	// Kind: http_error | request_error | retry_exhausted | failover | dsml_leak
 	Kind string `json:"kind,omitempty"`
 	// Stage/Scope/Reason distinguish credential acquisition from inference
 	// without overloading upstream_status_code with a synthetic HTTP status.

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -258,6 +258,21 @@ gateway:
   #
   # 注意：开启后会影响所有客户端的行为（不仅限于 VS Code / Codex CLI），请谨慎开启。
   force_codex_cli: false
+  # DSML leak guard: heal deepseek-v4 tool calls leaked as plain text (in-place retry on the
+  # same account) and scrub leaked DSML fragments from assistant history (cures the cascade).
+  # DSML 泄漏防护：拦截 deepseek-v4 把工具调用漏成正文的坏流并对同账号原地重试，
+  # 同时从请求历史的 assistant 消息中剥离已泄漏的 DSML 碎片（治级联）。
+  dsml_guard_enabled: true
+  # Model prefixes the guard applies to (prefix match against the upstream model id).
+  # 防护生效的上游模型前缀列表（对上游模型 ID 做前缀匹配）。
+  dsml_guard_models: ["deepseek-v4"]
+  # Max in-place retries on the same account after a confirmed leak. Exhausted = release
+  # the held output unchanged (never an error to the client).
+  # 判定泄漏后同账号最大原地重试次数；耗尽则原样放行被扣输出（绝不向客户端报错）。
+  dsml_guard_max_retries: 1
+  # Observe mode: detect and log only - no holding, no retry, no history scrub (grey release).
+  # 灰度观察模式：只检测记录，不扣流、不重试、不清洗历史。
+  dsml_guard_observe: false
   # Stop rewriting load-shed Codex originators to the official CLI identity.
   # 关闭「把落在上游降载桶的 Codex originator 改写为官方 CLI 身份（codex_cli_rs）」。
   #


### PR DESCRIPTION
**Problem.** deepseek-v4 intermittently emits DSML tool-call blocks as plain `delta.content` text instead of structured `tool_calls` deltas: the opening tag is eaten serving-side, the parameter body and closing tags (`…</｜DSML｜tool_calls>`, usually with a `<thinking>` head) stream out as assistant text, the turn ends `finish_reason:"stop"`, and no `tool_calls` delta ever arrives. Clients see the agent "stop mid-task". Once a leaked turn enters history the model imitates it, so the failure cascades. Same phenomenon reported across the ecosystem: opencode#24566, cherry-studio#14714, vllm#41240.

**Mechanism.** Response side, raw chat-completions lane (enforce): a content-hold state machine lets reasoning stream live while holding the text channel through a 128-byte sniff window; a suspicious prefix (`<thinking>`, `<｜`) or the DSML marker holds to the terminal frame. Leak verdict (marker seen, no structured tool call) discards the held frames — including finish/usage/[DONE] — re-POSTs the identical body to the same account, and continues the same client SSE with the retry. Retry exhaustion, resend failure, hold caps (1 MiB / 5 min), or mid-stream abort all release the held output unchanged: held output is preserved. Upstream truncation still returns a typed stream-read error with retained usage, rather than reporting an incomplete response as success. SSE comment keepalives protect long holds; each retry re-scopes terminal tracking, the silent-refusal detector and response-model observation; billing uses the final attempt's usage with fallback to the prior attempt on truncation. Tool rounds with leaked leading text are scrubbed (marker reassembled across chunk boundaries) and released without retry. Native Responses lane: observe-only detection with an ops event at stream finalization. Request side: leaked DSML fragments are scrubbed from assistant-role history strings (user/tool untouched) on the chat-completions lanes including the anthropic-protocol lane — this cures the cascade. Every action lands a `Kind=dsml_leak` ops upstream-error event, persisted even on 200 responses.

**Config.**
```yaml
gateway:
  dsml_guard_enabled: true
  dsml_guard_models: ["deepseek-v4"]  # prefix match on the upstream model id
  dsml_guard_max_retries: 1           # exhausted = release held output unchanged
  dsml_guard_observe: false           # detect + log only, zero byte changes
```
The detector activates only for gated models on streaming requests carrying a non-empty `tools` array.

**Tests.** 28 unit cases with synthesized fixtures (no production captures): heal-by-retry client byte sequence, byte-invisibility on clean streams and in observe mode, retry-exhaustion release, split-marker detection and scrub across chunk boundaries, silent-refusal failover across retries, response-model observation reset, usage fallback on truncated retries, history-scrub role isolation, activation gating, mid-hold abort fail-open, Responses-lane observe verdicts, and a scrub pure-function table.

**Soak evidence.** A production deployment of this patch ran observe-then-enforce on live deepseek-v4 traffic. In a ~3-hour observe window covering 308+ requests, 4/4 response-side leaks were detected with zero false positives — 4/4 correlation against an independent rescan of raw traffic captures — and 76 requests carried leaked fragments in assistant history. In the following ~14-hour enforce window, 3 leaks were detected and retried: 2 healed by the same-account retry (client received a clean stream), 1 exhausted retries and was released unchanged (fail-open). Zero panics, zero client-visible errors, and leaked-marker-in-request counts dropped to zero once the history scrub went live.


**Current validation.** Merged upstream main at 32682a4f8. Targeted unit tests for DSML, raw streaming and silent refusal passed. Truncation regressions assert typed errors, retained partial output and prior-attempt usage fallback; a discarded attempt's terminal cannot mask a truncated retry.
