### PR TITLE
fix: guard malformed Anthropic tool-call passthrough

### DIFF
--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -507,13 +507,8 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			if !ok {
 				guardedLines, guardErr := protocolGuard.Flush()
 				if !clientDisconnected && len(guardedLines) > 0 {
-					disconnected, completedEvent := writeAnthropicGuardedLines(w, c, flusher, guardedLines)
+					disconnected, _ := writeAnthropicGuardedLines(w, c, flusher, guardedLines)
 					clientDisconnected = disconnected
-					if completedEvent {
-						lastDataAt = time.Now()
-						resetKeepaliveTimer()
-						inPartialEvent = false
-					}
 				}
 				if guardErr != nil {
 					return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: clientDisconnected}, guardErr

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -418,6 +418,7 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 	var firstTokenMs *int
 	clientDisconnected := false
 	sawTerminalEvent := false
+	protocolGuard := newAnthropicPassthroughSSEGuard()
 
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
@@ -504,6 +505,19 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 		select {
 		case ev, ok := <-events:
 			if !ok {
+				guardedLines, guardErr := protocolGuard.Flush()
+				if !clientDisconnected && len(guardedLines) > 0 {
+					disconnected, completedEvent := writeAnthropicGuardedLines(w, c, flusher, guardedLines)
+					clientDisconnected = disconnected
+					if completedEvent {
+						lastDataAt = time.Now()
+						resetKeepaliveTimer()
+						inPartialEvent = false
+					}
+				}
+				if guardErr != nil {
+					return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: clientDisconnected}, guardErr
+				}
 				if !clientDisconnected {
 					// 兜底补刷，确保最后一个未以空行结尾的事件也能及时送达客户端。
 					flusher.Flush()
@@ -555,23 +569,23 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 				}
 			}
 
-			if !clientDisconnected {
-				restored := string(reverseToolNamesIfPresent(c, []byte(line)))
-				if _, err := io.WriteString(w, restored); err != nil {
-					clientDisconnected = true
+			guardedLines, guardErr := protocolGuard.PushLine(line)
+			if line != "" {
+				inPartialEvent = true
+			}
+			if !clientDisconnected && len(guardedLines) > 0 {
+				disconnected, completedEvent := writeAnthropicGuardedLines(w, c, flusher, guardedLines)
+				clientDisconnected = disconnected
+				if clientDisconnected {
 					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
-				} else if _, err := io.WriteString(w, "\n"); err != nil {
-					clientDisconnected = true
-					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
-				} else if line == "" {
-					// 按 SSE 事件边界刷出，减少每行 flush 带来的 syscall 开销。
-					flusher.Flush()
+				} else if completedEvent {
 					lastDataAt = time.Now()
 					resetKeepaliveTimer()
 					inPartialEvent = false
-				} else {
-					inPartialEvent = true
 				}
+			}
+			if guardErr != nil {
+				return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: clientDisconnected}, guardErr
 			}
 
 		case <-intervalCh:
@@ -807,6 +821,11 @@ func (s *GatewayService) handleNonStreamingResponseAnthropicAPIKeyPassthrough(
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return nil, invalidNonStreamingJSONFailoverError(ctx, s.rateLimitService, resp, account, body, err)
 		}
+		normalizedBody, protocolErr := normalizeAnthropicPassthroughResponseBody(body)
+		if protocolErr != nil {
+			return nil, anthropicProtocolFailoverError(resp, account, protocolErr)
+		}
+		body = normalizedBody
 	}
 
 	usage := parseClaudeUsageFromResponseBody(body)

--- a/backend/internal/service/gateway_anthropic_passthrough_protocol_test.go
+++ b/backend/internal/service/gateway_anthropic_passthrough_protocol_test.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,47 +17,40 @@ import (
 )
 
 func anthropicPassthroughProtocolFixture(toolName string, stopReason string, includeStructuredTool bool) string {
-	var builder strings.Builder
-	builder.WriteString("event: message_start\n")
-	builder.WriteString(`data: {"type":"message_start","message":{"id":"msg_fixture","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}`)
-	builder.WriteString("\n\n")
-	builder.WriteString("event: content_block_start\n")
-	builder.WriteString(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
-	builder.WriteString("\n\n")
-	builder.WriteString("event: content_block_delta\n")
-	builder.WriteString(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Running.\n<inv"}}`)
-	builder.WriteString("\n\n")
-	builder.WriteString("event: content_block_delta\n")
-	builder.WriteString(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"}}`)
-	builder.WriteString("\n\n")
-	builder.WriteString("event: content_block_stop\n")
-	builder.WriteString(`data: {"type":"content_block_stop","index":0}`)
-	builder.WriteString("\n\n")
+	structuredToolEvents := ""
 	if includeStructuredTool {
-		builder.WriteString("event: content_block_start\n")
-		builder.WriteString(`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"`)
-		builder.WriteString(toolName)
-		builder.WriteString(`","input":{}}}`)
-		builder.WriteString("\n\n")
-		builder.WriteString("event: content_block_delta\n")
-		builder.WriteString(`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}`)
-		builder.WriteString("\n\n")
-		builder.WriteString("event: content_block_stop\n")
-		builder.WriteString(`data: {"type":"content_block_stop","index":1}`)
-		builder.WriteString("\n\n")
+		structuredToolEvents = fmt.Sprintf(
+			"event: content_block_start\n"+
+				`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"%s","input":{}}}`+"\n\n"+
+				"event: content_block_delta\n"+
+				`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}`+"\n\n"+
+				"event: content_block_stop\n"+
+				`data: {"type":"content_block_stop","index":1}`+"\n\n",
+			toolName,
+		)
 	}
-	builder.WriteString("event: message_delta\n")
-	builder.WriteString(`data: {"type":"message_delta","delta":{"stop_reason":"`)
-	builder.WriteString(stopReason)
-	builder.WriteString(`","stop_sequence":null},"usage":{"output_tokens":3}}`)
-	builder.WriteString("\n\n")
-	builder.WriteString("event: message_stop\n")
-	builder.WriteString(`data: {"type":"message_stop"}`)
-	builder.WriteString("\n\n")
-	return builder.String()
+	return fmt.Sprintf(
+		"event: message_start\n"+
+			`data: {"type":"message_start","message":{"id":"msg_fixture","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}`+"\n\n"+
+			"event: content_block_start\n"+
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n"+
+			"event: content_block_delta\n"+
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Running.\n<inv"}}`+"\n\n"+
+			"event: content_block_delta\n"+
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"}}`+"\n\n"+
+			"event: content_block_stop\n"+
+			`data: {"type":"content_block_stop","index":0}`+"\n\n"+
+			"%s"+
+			"event: message_delta\n"+
+			`data: {"type":"message_delta","delta":{"stop_reason":"%s","stop_sequence":null},"usage":{"output_tokens":3}}`+"\n\n"+
+			"event: message_stop\n"+
+			`data: {"type":"message_stop"}`+"\n\n",
+		structuredToolEvents,
+		stopReason,
+	)
 }
 
-func runAnthropicPassthroughProtocolFixture(t *testing.T, fixture string) (*streamingResult, error, string) {
+func runAnthropicPassthroughProtocolFixture(t *testing.T, fixture string) (*streamingResult, string, error) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -79,7 +72,7 @@ func runAnthropicPassthroughProtocolFixture(t *testing.T, fixture string) (*stre
 		time.Now(),
 		"test-model",
 	)
-	return result, err, rec.Body.String()
+	return result, rec.Body.String(), err
 }
 
 func anthropicPassthroughTextDeltas(body string) string {
@@ -90,14 +83,14 @@ func anthropicPassthroughTextDeltas(body string) string {
 			continue
 		}
 		if gjson.Get(data, "delta.type").String() == "text_delta" {
-			text.WriteString(gjson.Get(data, "delta.text").String())
+			_, _ = text.WriteString(gjson.Get(data, "delta.text").String())
 		}
 	}
 	return text.String()
 }
 
 func TestAnthropicPassthroughProtocolGuard_StripsDuplicatedRawToolCall(t *testing.T) {
-	result, err, body := runAnthropicPassthroughProtocolFixture(
+	result, body, err := runAnthropicPassthroughProtocolFixture(
 		t,
 		anthropicPassthroughProtocolFixture("Bash", "tool_use", true),
 	)
@@ -109,45 +102,114 @@ func TestAnthropicPassthroughProtocolGuard_StripsDuplicatedRawToolCall(t *testin
 	require.Contains(t, body, `"name":"Bash"`)
 }
 
-func TestAnthropicPassthroughProtocolGuard_RejectsRawOnlyEndTurn(t *testing.T) {
-	result, err, body := runAnthropicPassthroughProtocolFixture(
+func TestAnthropicPassthroughProtocolGuard_PreservesRawOnlyEndTurn(t *testing.T) {
+	result, body, err := runAnthropicPassthroughProtocolFixture(
 		t,
 		anthropicPassthroughProtocolFixture("", "end_turn", false),
 	)
 
+	require.NoError(t, err)
 	require.NotNil(t, result)
-	var protocolErr *anthropicToolCallProtocolError
-	require.True(t, errors.As(err, &protocolErr))
-	require.NotContains(t, body, "<invoke")
-	require.Contains(t, body, "event: error")
-	require.Contains(t, body, `"type":"protocol_error"`)
+	require.Equal(t, "Running.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>", anthropicPassthroughTextDeltas(body))
+	require.NotContains(t, body, "event: error")
 }
 
-func TestAnthropicPassthroughProtocolGuard_RejectsMismatchedToolNames(t *testing.T) {
-	result, err, body := runAnthropicPassthroughProtocolFixture(
+func TestAnthropicPassthroughProtocolGuard_PreservesMismatchedToolNames(t *testing.T) {
+	result, body, err := runAnthropicPassthroughProtocolFixture(
 		t,
 		anthropicPassthroughProtocolFixture("Read", "tool_use", true),
 	)
 
+	require.NoError(t, err)
 	require.NotNil(t, result)
-	var protocolErr *anthropicToolCallProtocolError
-	require.True(t, errors.As(err, &protocolErr))
-	require.NotContains(t, body, "<invoke")
-	require.Contains(t, body, "event: error")
+	require.Equal(t, "Running.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>", anthropicPassthroughTextDeltas(body))
+	require.Contains(t, body, `"name":"Read"`)
+	require.NotContains(t, body, "event: error")
 }
 
-func TestAnthropicPassthroughProtocolGuard_RejectsIncompleteRawToolCall(t *testing.T) {
+func TestAnthropicPassthroughProtocolGuard_PreservesIncompleteRawToolCall(t *testing.T) {
 	fixture := strings.Replace(
 		anthropicPassthroughProtocolFixture("", "end_turn", false),
 		"</invoke>",
 		"",
 		1,
 	)
-	result, err, body := runAnthropicPassthroughProtocolFixture(t, fixture)
+	result, body, err := runAnthropicPassthroughProtocolFixture(t, fixture)
 
+	require.NoError(t, err)
 	require.NotNil(t, result)
-	var protocolErr *anthropicToolCallProtocolError
-	require.True(t, errors.As(err, &protocolErr))
-	require.NotContains(t, body, "<invoke")
-	require.Contains(t, body, "event: error")
+	require.Equal(t, "Running.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter>", anthropicPassthroughTextDeltas(body))
+	require.NotContains(t, body, "event: error")
+}
+
+func TestAnthropicPassthroughProtocolGuard_PreservesOverlongIncompleteRawToolCall(t *testing.T) {
+	overlongCandidate := `<invoke name="Bash">` + strings.Repeat("x", maxAnthropicToolCallCandidateBytes+1)
+	fixture := strings.Replace(
+		anthropicPassthroughProtocolFixture("", "end_turn", false),
+		`oke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>`,
+		`oke name=\"Bash\">`+strings.Repeat("x", maxAnthropicToolCallCandidateBytes+1),
+		1,
+	)
+	result, body, err := runAnthropicPassthroughProtocolFixture(t, fixture)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Running.\n"+overlongCandidate, anthropicPassthroughTextDeltas(body))
+	require.NotContains(t, body, "event: error")
+}
+
+func TestAnthropicPassthroughProtocolGuard_FallsBackWhenDeferredEventsExceedLimit(t *testing.T) {
+	fixture := strings.Replace(
+		anthropicPassthroughProtocolFixture("Bash", "tool_use", true),
+		`"partial_json":"{}"`,
+		`"partial_json":"`+strings.Repeat("x", maxAnthropicToolCallDeferredEventBytes+1)+`"`,
+		1,
+	)
+	result, body, err := runAnthropicPassthroughProtocolFixture(t, fixture)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Running.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>", anthropicPassthroughTextDeltas(body))
+	require.Contains(t, body, strings.Repeat("x", 1024))
+	require.NotContains(t, body, "event: error")
+}
+
+func TestAnthropicPassthroughProtocolGuard_PreservesCandidateWithTrailingText(t *testing.T) {
+	fixture := strings.Replace(
+		anthropicPassthroughProtocolFixture("Bash", "tool_use", true),
+		`</invoke>"}}`,
+		`</invoke>\nLiteral XML example."}}`,
+		1,
+	)
+	result, body, err := runAnthropicPassthroughProtocolFixture(t, fixture)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Running.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>\nLiteral XML example.", anthropicPassthroughTextDeltas(body))
+	require.Contains(t, body, `"name":"Bash"`)
+	require.NotContains(t, body, "event: error")
+}
+
+func TestNormalizeAnthropicPassthroughResponseBody_PreservesUnverifiedLiteralMarkup(t *testing.T) {
+	tests := []string{
+		`{"content":[{"type":"text","text":"<invoke name=\"Bash\">example</invoke>\nLiteral XML example."},{"type":"tool_use","name":"Bash"}],"stop_reason":"tool_use"}`,
+		`{"content":[{"type":"text","text":"<invoke name=\"Bash\">example</invoke><note>Literal XML example.</note>"},{"type":"tool_use","name":"Bash"}],"stop_reason":"tool_use"}`,
+	}
+
+	for _, body := range tests {
+		normalized, err := normalizeAnthropicPassthroughResponseBody([]byte(body))
+
+		require.NoError(t, err)
+		require.JSONEq(t, body, string(normalized))
+	}
+}
+
+func TestNormalizeAnthropicPassthroughResponseBody_UsesConsistentXMLGrammar(t *testing.T) {
+	body := `{"content":[{"type":"text","text":"<invoke  name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"},{"type":"tool_use","name":"Bash"}],"stop_reason":"tool_use"}`
+
+	normalized, err := normalizeAnthropicPassthroughResponseBody([]byte(body))
+
+	require.NoError(t, err)
+	require.Len(t, gjson.GetBytes(normalized, "content").Array(), 1)
+	require.Equal(t, "tool_use", gjson.GetBytes(normalized, "content.0.type").String())
 }

--- a/backend/internal/service/gateway_anthropic_passthrough_protocol_test.go
+++ b/backend/internal/service/gateway_anthropic_passthrough_protocol_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func anthropicPassthroughProtocolFixture(toolName string, stopReason string, includeStructuredTool bool) string {
+	var builder strings.Builder
+	builder.WriteString("event: message_start\n")
+	builder.WriteString(`data: {"type":"message_start","message":{"id":"msg_fixture","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}`)
+	builder.WriteString("\n\n")
+	builder.WriteString("event: content_block_start\n")
+	builder.WriteString(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+	builder.WriteString("\n\n")
+	builder.WriteString("event: content_block_delta\n")
+	builder.WriteString(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Running.\n<inv"}}`)
+	builder.WriteString("\n\n")
+	builder.WriteString("event: content_block_delta\n")
+	builder.WriteString(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"}}`)
+	builder.WriteString("\n\n")
+	builder.WriteString("event: content_block_stop\n")
+	builder.WriteString(`data: {"type":"content_block_stop","index":0}`)
+	builder.WriteString("\n\n")
+	if includeStructuredTool {
+		builder.WriteString("event: content_block_start\n")
+		builder.WriteString(`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"`)
+		builder.WriteString(toolName)
+		builder.WriteString(`","input":{}}}`)
+		builder.WriteString("\n\n")
+		builder.WriteString("event: content_block_delta\n")
+		builder.WriteString(`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}`)
+		builder.WriteString("\n\n")
+		builder.WriteString("event: content_block_stop\n")
+		builder.WriteString(`data: {"type":"content_block_stop","index":1}`)
+		builder.WriteString("\n\n")
+	}
+	builder.WriteString("event: message_delta\n")
+	builder.WriteString(`data: {"type":"message_delta","delta":{"stop_reason":"`)
+	builder.WriteString(stopReason)
+	builder.WriteString(`","stop_sequence":null},"usage":{"output_tokens":3}}`)
+	builder.WriteString("\n\n")
+	builder.WriteString("event: message_stop\n")
+	builder.WriteString(`data: {"type":"message_stop"}`)
+	builder.WriteString("\n\n")
+	return builder.String()
+}
+
+func runAnthropicPassthroughProtocolFixture(t *testing.T, fixture string) (*streamingResult, error, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(fixture)),
+	}
+	svc := &GatewayService{
+		cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}},
+	}
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(
+		context.Background(),
+		resp,
+		c,
+		&Account{ID: 2},
+		time.Now(),
+		"test-model",
+	)
+	return result, err, rec.Body.String()
+}
+
+func anthropicPassthroughTextDeltas(body string) string {
+	var text strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := extractAnthropicSSEDataLine(line)
+		if !ok || !gjson.Valid(data) || gjson.Get(data, "type").String() != "content_block_delta" {
+			continue
+		}
+		if gjson.Get(data, "delta.type").String() == "text_delta" {
+			text.WriteString(gjson.Get(data, "delta.text").String())
+		}
+	}
+	return text.String()
+}
+
+func TestAnthropicPassthroughProtocolGuard_StripsDuplicatedRawToolCall(t *testing.T) {
+	result, err, body := runAnthropicPassthroughProtocolFixture(
+		t,
+		anthropicPassthroughProtocolFixture("Bash", "tool_use", true),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Running.\n", anthropicPassthroughTextDeltas(body))
+	require.Contains(t, body, `"type":"tool_use"`)
+	require.Contains(t, body, `"name":"Bash"`)
+}
+
+func TestAnthropicPassthroughProtocolGuard_RejectsRawOnlyEndTurn(t *testing.T) {
+	result, err, body := runAnthropicPassthroughProtocolFixture(
+		t,
+		anthropicPassthroughProtocolFixture("", "end_turn", false),
+	)
+
+	require.NotNil(t, result)
+	var protocolErr *anthropicToolCallProtocolError
+	require.True(t, errors.As(err, &protocolErr))
+	require.NotContains(t, body, "<invoke")
+	require.Contains(t, body, "event: error")
+	require.Contains(t, body, `"type":"protocol_error"`)
+}
+
+func TestAnthropicPassthroughProtocolGuard_RejectsMismatchedToolNames(t *testing.T) {
+	result, err, body := runAnthropicPassthroughProtocolFixture(
+		t,
+		anthropicPassthroughProtocolFixture("Read", "tool_use", true),
+	)
+
+	require.NotNil(t, result)
+	var protocolErr *anthropicToolCallProtocolError
+	require.True(t, errors.As(err, &protocolErr))
+	require.NotContains(t, body, "<invoke")
+	require.Contains(t, body, "event: error")
+}
+
+func TestAnthropicPassthroughProtocolGuard_RejectsIncompleteRawToolCall(t *testing.T) {
+	fixture := strings.Replace(
+		anthropicPassthroughProtocolFixture("", "end_turn", false),
+		"</invoke>",
+		"",
+		1,
+	)
+	result, err, body := runAnthropicPassthroughProtocolFixture(t, fixture)
+
+	require.NotNil(t, result)
+	var protocolErr *anthropicToolCallProtocolError
+	require.True(t, errors.As(err, &protocolErr))
+	require.NotContains(t, body, "<invoke")
+	require.Contains(t, body, "event: error")
+}

--- a/backend/internal/service/gateway_anthropic_protocol_guard.go
+++ b/backend/internal/service/gateway_anthropic_protocol_guard.go
@@ -1,0 +1,388 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const rawAnthropicToolCallMarker = `<invoke name="`
+
+var rawAnthropicToolCallNamePattern = regexp.MustCompile(`<invoke\s+name="([^"]+)">`)
+
+type anthropicToolCallProtocolError struct {
+	reason string
+}
+
+func (e *anthropicToolCallProtocolError) Error() string {
+	return "upstream returned malformed tool-call protocol: " + e.reason
+}
+
+func rawAnthropicToolCallNames(text string) ([]string, bool) {
+	matches := rawAnthropicToolCallNamePattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 || strings.Count(text, "</invoke>") < len(matches) {
+		return nil, false
+	}
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 || strings.TrimSpace(match[1]) == "" {
+			return nil, false
+		}
+		names = append(names, strings.TrimSpace(match[1]))
+	}
+	return names, true
+}
+
+func splitRawAnthropicToolCallText(text string) (visible string, names []string, found, complete bool) {
+	markerIndex := strings.Index(text, rawAnthropicToolCallMarker)
+	if markerIndex < 0 {
+		return text, nil, false, true
+	}
+	rawNames, isComplete := rawAnthropicToolCallNames(text[markerIndex:])
+	if !isComplete {
+		return text[:markerIndex], nil, true, false
+	}
+	return text[:markerIndex], rawNames, true, true
+}
+
+func sameToolNameMultiset(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	for index := range leftCopy {
+		if leftCopy[index] != rightCopy[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateAnthropicToolCallProtocol(stopReason string, rawToolNames, structuredToolNames []string) error {
+	if len(rawToolNames) > 0 {
+		if len(structuredToolNames) == 0 {
+			return &anthropicToolCallProtocolError{reason: "raw tool-call markup had no structured tool_use block"}
+		}
+		if !sameToolNameMultiset(rawToolNames, structuredToolNames) {
+			return &anthropicToolCallProtocolError{reason: "raw and structured tool names disagree"}
+		}
+	}
+	if stopReason == "tool_use" && len(structuredToolNames) == 0 {
+		return &anthropicToolCallProtocolError{reason: "stop_reason=tool_use had no structured tool_use block"}
+	}
+	return nil
+}
+
+func normalizeAnthropicPassthroughResponseBody(body []byte) ([]byte, error) {
+	var envelope struct {
+		Content    []json.RawMessage `json:"content"`
+		StopReason string            `json:"stop_reason"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+
+	normalizedContent := make([]json.RawMessage, 0, len(envelope.Content))
+	rawToolNames := make([]string, 0)
+	structuredToolNames := make([]string, 0)
+	for _, rawBlock := range envelope.Content {
+		var block struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(rawBlock, &block); err != nil {
+			return nil, err
+		}
+		switch block.Type {
+		case "text":
+			visible, names, found, complete := splitRawAnthropicToolCallText(block.Text)
+			if found {
+				if !complete {
+					return nil, &anthropicToolCallProtocolError{reason: "raw tool-call markup was incomplete"}
+				}
+				rawToolNames = append(rawToolNames, names...)
+				if visible == "" {
+					continue
+				}
+				normalizedBlock, err := sjson.SetBytes(rawBlock, "text", visible)
+				if err != nil {
+					return nil, err
+				}
+				normalizedContent = append(normalizedContent, normalizedBlock)
+				continue
+			}
+		case "tool_use":
+			if strings.TrimSpace(block.Name) != "" {
+				structuredToolNames = append(structuredToolNames, strings.TrimSpace(block.Name))
+			}
+		}
+		normalizedContent = append(normalizedContent, rawBlock)
+	}
+
+	if err := validateAnthropicToolCallProtocol(envelope.StopReason, rawToolNames, structuredToolNames); err != nil {
+		return nil, err
+	}
+	if len(rawToolNames) == 0 {
+		return body, nil
+	}
+	contentJSON, err := json.Marshal(normalizedContent)
+	if err != nil {
+		return nil, err
+	}
+	return sjson.SetRawBytes(body, "content", contentJSON)
+}
+
+func anthropicProtocolFailoverError(resp *http.Response, account *Account, protocolErr error) error {
+	retryableOnSameAccount := false
+	if account != nil {
+		retryableOnSameAccount = account.IsPoolMode() && account.IsPoolModeRetryableStatus(http.StatusBadGateway)
+	}
+	responseBody, _ := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    "protocol_error",
+			"message": "Upstream returned malformed tool-call content",
+		},
+	})
+	return &UpstreamFailoverError{
+		StatusCode:             http.StatusBadGateway,
+		ResponseBody:           responseBody,
+		ResponseHeaders:        resp.Header,
+		RetryableOnSameAccount: retryableOnSameAccount,
+	}
+}
+
+type anthropicPassthroughTextBlockState struct {
+	pending      string
+	rawCandidate strings.Builder
+	readingRaw   bool
+}
+
+type anthropicPassthroughSSEGuard struct {
+	eventLines          []string
+	textBlocks          map[int]*anthropicPassthroughTextBlockState
+	rawToolNames        []string
+	structuredToolNames []string
+}
+
+func newAnthropicPassthroughSSEGuard() *anthropicPassthroughSSEGuard {
+	return &anthropicPassthroughSSEGuard{
+		textBlocks: make(map[int]*anthropicPassthroughTextBlockState),
+	}
+}
+
+func (g *anthropicPassthroughSSEGuard) PushLine(line string) ([]string, error) {
+	if line != "" {
+		g.eventLines = append(g.eventLines, line)
+		if g.canEagerEmitEvent(line) {
+			lines := append([]string(nil), g.eventLines...)
+			g.eventLines = nil
+			return lines, nil
+		}
+		return nil, nil
+	}
+	if len(g.eventLines) == 0 {
+		return []string{""}, nil
+	}
+	lines, err := g.transformEvent(g.eventLines)
+	g.eventLines = nil
+	return append(lines, ""), err
+}
+
+func (g *anthropicPassthroughSSEGuard) canEagerEmitEvent(line string) bool {
+	data, ok := extractAnthropicSSEDataLine(line)
+	if !ok || !gjson.Valid(data) {
+		return false
+	}
+	switch gjson.Get(data, "type").String() {
+	case "message_start", "ping":
+		return true
+	default:
+		return false
+	}
+}
+
+func (g *anthropicPassthroughSSEGuard) Flush() ([]string, error) {
+	if len(g.eventLines) == 0 {
+		return nil, nil
+	}
+	lines, err := g.transformEvent(g.eventLines)
+	g.eventLines = nil
+	return lines, err
+}
+
+func (g *anthropicPassthroughSSEGuard) transformEvent(lines []string) ([]string, error) {
+	dataLineIndex := -1
+	data := ""
+	for index, line := range lines {
+		if extracted, ok := extractAnthropicSSEDataLine(line); ok {
+			dataLineIndex = index
+			data = extracted
+			break
+		}
+	}
+	if dataLineIndex < 0 || data == "" || data == "[DONE]" || !gjson.Valid(data) {
+		return append([]string(nil), lines...), nil
+	}
+
+	eventType := gjson.Get(data, "type").String()
+	switch eventType {
+	case "content_block_start":
+		index := int(gjson.Get(data, "index").Int())
+		blockType := gjson.Get(data, "content_block.type").String()
+		if blockType == "text" {
+			state := &anthropicPassthroughTextBlockState{}
+			g.textBlocks[index] = state
+			initialText := gjson.Get(data, "content_block.text").String()
+			if initialText != "" {
+				visible := g.consumeTextDelta(state, initialText)
+				updated, err := sjson.Set(data, "content_block.text", visible)
+				if err != nil {
+					return nil, err
+				}
+				updatedLines := append([]string(nil), lines...)
+				updatedLines[dataLineIndex] = "data: " + updated
+				return updatedLines, nil
+			}
+		}
+		if blockType == "tool_use" {
+			name := strings.TrimSpace(gjson.Get(data, "content_block.name").String())
+			if name != "" {
+				g.structuredToolNames = append(g.structuredToolNames, name)
+			}
+		}
+	case "content_block_delta":
+		if gjson.Get(data, "delta.type").String() != "text_delta" {
+			return append([]string(nil), lines...), nil
+		}
+		index := int(gjson.Get(data, "index").Int())
+		state := g.textBlocks[index]
+		if state == nil {
+			state = &anthropicPassthroughTextBlockState{}
+			g.textBlocks[index] = state
+		}
+		visible := g.consumeTextDelta(state, gjson.Get(data, "delta.text").String())
+		updated, err := sjson.Set(data, "delta.text", visible)
+		if err != nil {
+			return nil, err
+		}
+		updatedLines := append([]string(nil), lines...)
+		updatedLines[dataLineIndex] = "data: " + updated
+		return updatedLines, nil
+	case "content_block_stop":
+		index := int(gjson.Get(data, "index").Int())
+		state := g.textBlocks[index]
+		if state == nil {
+			return append([]string(nil), lines...), nil
+		}
+		delete(g.textBlocks, index)
+		flushText := state.pending
+		if state.readingRaw {
+			candidate := state.rawCandidate.String()
+			if names, complete := rawAnthropicToolCallNames(candidate); complete {
+				g.rawToolNames = append(g.rawToolNames, names...)
+				flushText = ""
+			} else {
+				return anthropicProtocolSSEErrorLines(), &anthropicToolCallProtocolError{reason: "raw tool-call markup was incomplete"}
+			}
+		}
+		if flushText == "" {
+			return append([]string(nil), lines...), nil
+		}
+		return append(g.syntheticTextDelta(index, flushText), append([]string(nil), lines...)...), nil
+	case "message_delta":
+		stopReason := gjson.Get(data, "delta.stop_reason").String()
+		if err := validateAnthropicToolCallProtocol(stopReason, g.rawToolNames, g.structuredToolNames); err != nil {
+			return anthropicProtocolSSEErrorLines(), err
+		}
+	case "message_stop":
+		if err := validateAnthropicToolCallProtocol("", g.rawToolNames, g.structuredToolNames); err != nil {
+			return anthropicProtocolSSEErrorLines(), err
+		}
+	}
+	return append([]string(nil), lines...), nil
+}
+
+func (g *anthropicPassthroughSSEGuard) consumeTextDelta(state *anthropicPassthroughTextBlockState, text string) string {
+	if state.readingRaw {
+		state.rawCandidate.WriteString(text)
+		return ""
+	}
+	combined := state.pending + text
+	markerIndex := strings.Index(combined, rawAnthropicToolCallMarker)
+	if markerIndex >= 0 {
+		state.pending = ""
+		state.readingRaw = true
+		state.rawCandidate.WriteString(combined[markerIndex:])
+		return combined[:markerIndex]
+	}
+	pendingLength := longestRawToolCallMarkerPrefixSuffix(combined)
+	if pendingLength == 0 {
+		state.pending = ""
+		return combined
+	}
+	state.pending = combined[len(combined)-pendingLength:]
+	return combined[:len(combined)-pendingLength]
+}
+
+func longestRawToolCallMarkerPrefixSuffix(text string) int {
+	maxLength := len(rawAnthropicToolCallMarker) - 1
+	if len(text) < maxLength {
+		maxLength = len(text)
+	}
+	for length := maxLength; length > 0; length-- {
+		if strings.HasSuffix(text, rawAnthropicToolCallMarker[:length]) {
+			return length
+		}
+	}
+	return 0
+}
+
+func (g *anthropicPassthroughSSEGuard) syntheticTextDelta(index int, text string) []string {
+	payload, _ := json.Marshal(map[string]any{
+		"type":  "content_block_delta",
+		"index": index,
+		"delta": map[string]string{
+			"type": "text_delta",
+			"text": text,
+		},
+	})
+	return []string{"event: content_block_delta", "data: " + string(payload), ""}
+}
+
+func anthropicProtocolSSEErrorLines() []string {
+	payload, _ := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    "protocol_error",
+			"message": "Upstream returned malformed tool-call content",
+		},
+	})
+	return []string{"event: error", "data: " + string(payload)}
+}
+
+func writeAnthropicGuardedLines(w http.ResponseWriter, c interface {
+	Get(string) (any, bool)
+}, flusher http.Flusher, lines []string) (clientDisconnected bool, completedEvent bool) {
+	for _, line := range lines {
+		restored := string(reverseToolNamesIfPresent(c, []byte(line)))
+		if _, err := fmt.Fprintln(w, restored); err != nil {
+			return true, completedEvent
+		}
+		if line == "" {
+			flusher.Flush()
+			completedEvent = true
+		}
+	}
+	return false, completedEvent
+}

--- a/backend/internal/service/gateway_anthropic_protocol_guard.go
+++ b/backend/internal/service/gateway_anthropic_protocol_guard.go
@@ -2,9 +2,10 @@ package service
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -12,9 +13,11 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-const rawAnthropicToolCallMarker = `<invoke name="`
-
-var rawAnthropicToolCallNamePattern = regexp.MustCompile(`<invoke\s+name="([^"]+)">`)
+const (
+	rawAnthropicToolCallMarker             = `<invoke`
+	maxAnthropicToolCallCandidateBytes     = 64 * 1024
+	maxAnthropicToolCallDeferredEventBytes = 128 * 1024
+)
 
 type anthropicToolCallProtocolError struct {
 	reason string
@@ -25,30 +28,75 @@ func (e *anthropicToolCallProtocolError) Error() string {
 }
 
 func rawAnthropicToolCallNames(text string) ([]string, bool) {
-	matches := rawAnthropicToolCallNamePattern.FindAllStringSubmatch(text, -1)
-	if len(matches) == 0 || strings.Count(text, "</invoke>") < len(matches) {
+	if len(text) == 0 || len(text) > maxAnthropicToolCallCandidateBytes {
 		return nil, false
 	}
-	names := make([]string, 0, len(matches))
-	for _, match := range matches {
-		if len(match) < 2 || strings.TrimSpace(match[1]) == "" {
+	decoder := xml.NewDecoder(strings.NewReader("<raw-tool-calls>" + text + "</raw-tool-calls>"))
+	names := make([]string, 0, 1)
+	depth := 0
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return names, len(names) > 0
+		}
+		if err != nil {
 			return nil, false
 		}
-		names = append(names, strings.TrimSpace(match[1]))
+		switch value := token.(type) {
+		case xml.StartElement:
+			depth++
+			if depth == 1 {
+				if value.Name.Local != "raw-tool-calls" {
+					return nil, false
+				}
+				continue
+			}
+			if depth != 2 {
+				continue
+			}
+			if value.Name.Local != "invoke" {
+				return nil, false
+			}
+			name := ""
+			for _, attribute := range value.Attr {
+				if attribute.Name.Local == "name" {
+					name = strings.TrimSpace(attribute.Value)
+					break
+				}
+			}
+			if name == "" {
+				return nil, false
+			}
+			names = append(names, name)
+		case xml.EndElement:
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case xml.CharData:
+			if depth == 1 && strings.TrimSpace(string(value)) != "" {
+				return nil, false
+			}
+		case xml.Comment:
+			if depth == 1 {
+				return nil, false
+			}
+		case xml.Directive, xml.ProcInst:
+			return nil, false
+		}
 	}
-	return names, true
 }
 
-func splitRawAnthropicToolCallText(text string) (visible string, names []string, found, complete bool) {
+func splitRawAnthropicToolCallText(text string) (visible string, names []string, found bool) {
 	markerIndex := strings.Index(text, rawAnthropicToolCallMarker)
 	if markerIndex < 0 {
-		return text, nil, false, true
+		return text, nil, false
 	}
 	rawNames, isComplete := rawAnthropicToolCallNames(text[markerIndex:])
 	if !isComplete {
-		return text[:markerIndex], nil, true, false
+		return text, nil, false
 	}
-	return text[:markerIndex], rawNames, true, true
+	return text[:markerIndex], rawNames, true
 }
 
 func sameToolNameMultiset(left, right []string) bool {
@@ -67,15 +115,7 @@ func sameToolNameMultiset(left, right []string) bool {
 	return true
 }
 
-func validateAnthropicToolCallProtocol(stopReason string, rawToolNames, structuredToolNames []string) error {
-	if len(rawToolNames) > 0 {
-		if len(structuredToolNames) == 0 {
-			return &anthropicToolCallProtocolError{reason: "raw tool-call markup had no structured tool_use block"}
-		}
-		if !sameToolNameMultiset(rawToolNames, structuredToolNames) {
-			return &anthropicToolCallProtocolError{reason: "raw and structured tool names disagree"}
-		}
-	}
+func validateAnthropicToolCallProtocol(stopReason string, structuredToolNames []string) error {
 	if stopReason == "tool_use" && len(structuredToolNames) == 0 {
 		return &anthropicToolCallProtocolError{reason: "stop_reason=tool_use had no structured tool_use block"}
 	}
@@ -91,10 +131,14 @@ func normalizeAnthropicPassthroughResponseBody(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	normalizedContent := make([]json.RawMessage, 0, len(envelope.Content))
+	type rawCandidate struct {
+		blockIndex int
+		visible    string
+	}
+	candidates := make([]rawCandidate, 0, 1)
 	rawToolNames := make([]string, 0)
 	structuredToolNames := make([]string, 0)
-	for _, rawBlock := range envelope.Content {
+	for blockIndex, rawBlock := range envelope.Content {
 		var block struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
@@ -105,35 +149,43 @@ func normalizeAnthropicPassthroughResponseBody(body []byte) ([]byte, error) {
 		}
 		switch block.Type {
 		case "text":
-			visible, names, found, complete := splitRawAnthropicToolCallText(block.Text)
+			visible, names, found := splitRawAnthropicToolCallText(block.Text)
 			if found {
-				if !complete {
-					return nil, &anthropicToolCallProtocolError{reason: "raw tool-call markup was incomplete"}
-				}
 				rawToolNames = append(rawToolNames, names...)
-				if visible == "" {
-					continue
-				}
-				normalizedBlock, err := sjson.SetBytes(rawBlock, "text", visible)
-				if err != nil {
-					return nil, err
-				}
-				normalizedContent = append(normalizedContent, normalizedBlock)
-				continue
+				candidates = append(candidates, rawCandidate{blockIndex: blockIndex, visible: visible})
 			}
 		case "tool_use":
 			if strings.TrimSpace(block.Name) != "" {
 				structuredToolNames = append(structuredToolNames, strings.TrimSpace(block.Name))
 			}
 		}
-		normalizedContent = append(normalizedContent, rawBlock)
 	}
 
-	if err := validateAnthropicToolCallProtocol(envelope.StopReason, rawToolNames, structuredToolNames); err != nil {
+	if err := validateAnthropicToolCallProtocol(envelope.StopReason, structuredToolNames); err != nil {
 		return nil, err
 	}
-	if len(rawToolNames) == 0 {
+	if len(candidates) == 0 || envelope.StopReason != "tool_use" || !sameToolNameMultiset(rawToolNames, structuredToolNames) {
 		return body, nil
+	}
+	candidateByBlock := make(map[int]rawCandidate, len(candidates))
+	for _, candidate := range candidates {
+		candidateByBlock[candidate.blockIndex] = candidate
+	}
+	normalizedContent := make([]json.RawMessage, 0, len(envelope.Content))
+	for blockIndex, rawBlock := range envelope.Content {
+		candidate, ok := candidateByBlock[blockIndex]
+		if !ok {
+			normalizedContent = append(normalizedContent, rawBlock)
+			continue
+		}
+		if candidate.visible == "" {
+			continue
+		}
+		normalizedBlock, err := sjson.SetBytes(rawBlock, "text", candidate.visible)
+		if err != nil {
+			return nil, err
+		}
+		normalizedContent = append(normalizedContent, normalizedBlock)
 	}
 	contentJSON, err := json.Marshal(normalizedContent)
 	if err != nil {
@@ -163,16 +215,22 @@ func anthropicProtocolFailoverError(resp *http.Response, account *Account, proto
 }
 
 type anthropicPassthroughTextBlockState struct {
-	pending      string
-	rawCandidate strings.Builder
-	readingRaw   bool
+	pending           string
+	rawCandidate      strings.Builder
+	readingRaw        bool
+	detectionDisabled bool
 }
 
 type anthropicPassthroughSSEGuard struct {
 	eventLines          []string
 	textBlocks          map[int]*anthropicPassthroughTextBlockState
-	rawToolNames        []string
 	structuredToolNames []string
+	deferredLines       []string
+	deferredBytes       int
+	deferredCandidate   string
+	deferredBlockIndex  int
+	deferring           bool
+	passthrough         bool
 }
 
 func newAnthropicPassthroughSSEGuard() *anthropicPassthroughSSEGuard {
@@ -182,9 +240,12 @@ func newAnthropicPassthroughSSEGuard() *anthropicPassthroughSSEGuard {
 }
 
 func (g *anthropicPassthroughSSEGuard) PushLine(line string) ([]string, error) {
+	if g.passthrough {
+		return []string{line}, nil
+	}
 	if line != "" {
 		g.eventLines = append(g.eventLines, line)
-		if g.canEagerEmitEvent(line) {
+		if !g.deferring && g.canEagerEmitEvent(line) {
 			lines := append([]string(nil), g.eventLines...)
 			g.eventLines = nil
 			return lines, nil
@@ -196,6 +257,19 @@ func (g *anthropicPassthroughSSEGuard) PushLine(line string) ([]string, error) {
 	}
 	lines, err := g.transformEvent(g.eventLines)
 	g.eventLines = nil
+	if err != nil {
+		return append(lines, ""), err
+	}
+	if g.deferring {
+		deferredEventLines := append(lines, "")
+		if !g.deferLines(deferredEventLines) {
+			resolved := g.resolveDeferred(false)
+			resolved = append(resolved, deferredEventLines...)
+			g.passthrough = true
+			return resolved, nil
+		}
+		return nil, nil
+	}
 	return append(lines, ""), err
 }
 
@@ -213,12 +287,80 @@ func (g *anthropicPassthroughSSEGuard) canEagerEmitEvent(line string) bool {
 }
 
 func (g *anthropicPassthroughSSEGuard) Flush() ([]string, error) {
-	if len(g.eventLines) == 0 {
-		return nil, nil
+	if g.passthrough {
+		lines := append([]string(nil), g.eventLines...)
+		g.eventLines = nil
+		return lines, nil
 	}
-	lines, err := g.transformEvent(g.eventLines)
-	g.eventLines = nil
-	return lines, err
+	output := make([]string, 0)
+	if len(g.eventLines) > 0 {
+		lines, err := g.transformEvent(g.eventLines)
+		g.eventLines = nil
+		if err != nil {
+			return lines, err
+		}
+		if g.deferring {
+			if !g.deferLines(lines) {
+				output = append(output, g.resolveDeferred(false)...)
+				output = append(output, lines...)
+			}
+		} else {
+			output = append(output, lines...)
+		}
+	}
+	if g.deferring {
+		output = append(output, g.resolveDeferred(false)...)
+	}
+	for index, state := range g.textBlocks {
+		text := state.pending
+		if state.readingRaw {
+			text += state.rawCandidate.String()
+		}
+		if text != "" {
+			output = append(output, g.syntheticTextDelta(index, text)...)
+		}
+	}
+	return output, nil
+}
+
+func (g *anthropicPassthroughSSEGuard) deferLines(lines []string) bool {
+	additionalBytes := 0
+	for _, line := range lines {
+		additionalBytes += len(line) + 1
+	}
+	if additionalBytes > maxAnthropicToolCallDeferredEventBytes-g.deferredBytes {
+		return false
+	}
+	g.deferredLines = append(g.deferredLines, lines...)
+	g.deferredBytes += additionalBytes
+	return true
+}
+
+func (g *anthropicPassthroughSSEGuard) beginDeferredCandidate(index int, candidate string) {
+	g.deferring = true
+	g.deferredBlockIndex = index
+	g.deferredCandidate = candidate
+	g.deferredBytes = len(candidate)
+}
+
+func (g *anthropicPassthroughSSEGuard) resolveDeferred(stripCandidate bool) []string {
+	lines := make([]string, 0, len(g.deferredLines)+3)
+	if !stripCandidate && g.deferredCandidate != "" {
+		lines = append(lines, g.syntheticTextDelta(g.deferredBlockIndex, g.deferredCandidate)...)
+	}
+	lines = append(lines, g.deferredLines...)
+	g.deferredLines = nil
+	g.deferredBytes = 0
+	g.deferredCandidate = ""
+	g.deferredBlockIndex = 0
+	g.deferring = false
+	return lines
+}
+
+func (g *anthropicPassthroughSSEGuard) resolveDeferredForStopReason(stopReason string) []string {
+	rawToolNames, complete := rawAnthropicToolCallNames(g.deferredCandidate)
+	stripCandidate := complete && stopReason == "tool_use" && sameToolNameMultiset(rawToolNames, g.structuredToolNames)
+	return g.resolveDeferred(stripCandidate)
 }
 
 func (g *anthropicPassthroughSSEGuard) transformEvent(lines []string) ([]string, error) {
@@ -288,13 +430,8 @@ func (g *anthropicPassthroughSSEGuard) transformEvent(lines []string) ([]string,
 		delete(g.textBlocks, index)
 		flushText := state.pending
 		if state.readingRaw {
-			candidate := state.rawCandidate.String()
-			if names, complete := rawAnthropicToolCallNames(candidate); complete {
-				g.rawToolNames = append(g.rawToolNames, names...)
-				flushText = ""
-			} else {
-				return anthropicProtocolSSEErrorLines(), &anthropicToolCallProtocolError{reason: "raw tool-call markup was incomplete"}
-			}
+			g.beginDeferredCandidate(index, state.rawCandidate.String())
+			return append([]string(nil), lines...), nil
 		}
 		if flushText == "" {
 			return append([]string(nil), lines...), nil
@@ -302,28 +439,49 @@ func (g *anthropicPassthroughSSEGuard) transformEvent(lines []string) ([]string,
 		return append(g.syntheticTextDelta(index, flushText), append([]string(nil), lines...)...), nil
 	case "message_delta":
 		stopReason := gjson.Get(data, "delta.stop_reason").String()
-		if err := validateAnthropicToolCallProtocol(stopReason, g.rawToolNames, g.structuredToolNames); err != nil {
+		if err := validateAnthropicToolCallProtocol(stopReason, g.structuredToolNames); err != nil {
+			g.resolveDeferred(true)
 			return anthropicProtocolSSEErrorLines(), err
 		}
+		if g.deferring {
+			resolved := g.resolveDeferredForStopReason(stopReason)
+			return append(resolved, lines...), nil
+		}
 	case "message_stop":
-		if err := validateAnthropicToolCallProtocol("", g.rawToolNames, g.structuredToolNames); err != nil {
-			return anthropicProtocolSSEErrorLines(), err
+		if g.deferring {
+			resolved := g.resolveDeferred(false)
+			return append(resolved, lines...), nil
 		}
 	}
 	return append([]string(nil), lines...), nil
 }
 
 func (g *anthropicPassthroughSSEGuard) consumeTextDelta(state *anthropicPassthroughTextBlockState, text string) string {
+	if state.detectionDisabled {
+		return text
+	}
 	if state.readingRaw {
-		state.rawCandidate.WriteString(text)
+		if state.rawCandidate.Len()+len(text) > maxAnthropicToolCallCandidateBytes {
+			restored := state.rawCandidate.String() + text
+			state.rawCandidate.Reset()
+			state.readingRaw = false
+			state.detectionDisabled = true
+			return restored
+		}
+		_, _ = state.rawCandidate.WriteString(text)
 		return ""
 	}
 	combined := state.pending + text
 	markerIndex := strings.Index(combined, rawAnthropicToolCallMarker)
 	if markerIndex >= 0 {
+		candidate := combined[markerIndex:]
 		state.pending = ""
+		if len(candidate) > maxAnthropicToolCallCandidateBytes {
+			state.detectionDisabled = true
+			return combined
+		}
 		state.readingRaw = true
-		state.rawCandidate.WriteString(combined[markerIndex:])
+		_, _ = state.rawCandidate.WriteString(candidate)
 		return combined[:markerIndex]
 	}
 	pendingLength := longestRawToolCallMarkerPrefixSuffix(combined)

--- a/backend/internal/service/gateway_non_streaming_response_test.go
+++ b/backend/internal/service/gateway_non_streaming_response_test.go
@@ -177,7 +177,7 @@ func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_StripsDuplicatedRa
 	require.Equal(t, "Bash", gjson.Get(rec.Body.String(), "content.1.name").String())
 }
 
-func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsRawOnlyToolCall(t *testing.T) {
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_PreservesRawOnlyToolCall(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -199,14 +199,12 @@ func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsRawOnlyTool
 
 	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
 
-	require.Nil(t, usage)
-	var failoverErr *UpstreamFailoverError
-	require.True(t, errors.As(err, &failoverErr))
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
-	require.False(t, c.Writer.Written(), "malformed tool-call content must fail before committing the response")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, `<invoke name="Bash"><parameter name="command">printf test</parameter></invoke>`, gjson.Get(rec.Body.String(), "content.0.text").String())
 }
 
-func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsIncompleteRawToolCall(t *testing.T) {
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_PreservesIncompleteRawToolCall(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -228,14 +226,12 @@ func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsIncompleteR
 
 	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
 
-	require.Nil(t, usage)
-	var failoverErr *UpstreamFailoverError
-	require.True(t, errors.As(err, &failoverErr))
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
-	require.False(t, c.Writer.Written(), "incomplete raw tool-call content must fail before committing the response")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, `<invoke name="Bash"><parameter name="command">printf test</parameter>`, gjson.Get(rec.Body.String(), "content.0.text").String())
 }
 
-func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsMismatchedRawToolCall(t *testing.T) {
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_PreservesMismatchedRawToolCall(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -260,11 +256,37 @@ func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsMismatchedR
 
 	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
 
-	require.Nil(t, usage)
-	var failoverErr *UpstreamFailoverError
-	require.True(t, errors.As(err, &failoverErr))
-	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
-	require.False(t, c.Writer.Written(), "mismatched tool-call content must fail before committing the response")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, `<invoke name="Bash"><parameter name="command">printf test</parameter></invoke>`, gjson.Get(rec.Body.String(), "content.0.text").String())
+	require.Equal(t, "Read", gjson.Get(rec.Body.String(), "content.1.name").String())
+}
+
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_PreservesInvokeCodeExample(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{
+		"id":"msg_invoke_example",
+		"type":"message",
+		"content":[{"type":"text","text":"Example:\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>\nThis is literal XML."}],
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":5,"output_tokens":3}
+	}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+	svc := &GatewayService{cfg: &config.Config{}}
+
+	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
+
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.JSONEq(t, string(body), rec.Body.String())
 }
 
 func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_ForceCacheBillingResponse(t *testing.T) {

--- a/backend/internal/service/gateway_non_streaming_response_test.go
+++ b/backend/internal/service/gateway_non_streaming_response_test.go
@@ -144,6 +144,129 @@ func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_ValidJSONUnchanged
 	require.JSONEq(t, string(body), rec.Body.String())
 }
 
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_StripsDuplicatedRawToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{
+		"id":"msg_raw_duplicate",
+		"type":"message",
+		"content":[
+			{"type":"text","text":"Running the check.\n<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"},
+			{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"printf test"}}
+		],
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":5,"output_tokens":3}
+	}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+	svc := &GatewayService{cfg: &config.Config{}}
+
+	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
+
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.NotContains(t, rec.Body.String(), "<invoke")
+	require.Equal(t, "Running the check.\n", gjson.Get(rec.Body.String(), "content.0.text").String())
+	require.Equal(t, "tool_use", gjson.Get(rec.Body.String(), "content.1.type").String())
+	require.Equal(t, "Bash", gjson.Get(rec.Body.String(), "content.1.name").String())
+}
+
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsRawOnlyToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{
+		"id":"msg_raw_only",
+		"type":"message",
+		"content":[{"type":"text","text":"<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"}],
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":5,"output_tokens":3}
+	}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+	svc := &GatewayService{cfg: &config.Config{}}
+
+	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
+
+	require.Nil(t, usage)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(), "malformed tool-call content must fail before committing the response")
+}
+
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsIncompleteRawToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{
+		"id":"msg_raw_incomplete",
+		"type":"message",
+		"content":[{"type":"text","text":"<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter>"}],
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":5,"output_tokens":3}
+	}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+	svc := &GatewayService{cfg: &config.Config{}}
+
+	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
+
+	require.Nil(t, usage)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(), "incomplete raw tool-call content must fail before committing the response")
+}
+
+func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_RejectsMismatchedRawToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{
+		"id":"msg_raw_mismatch",
+		"type":"message",
+		"content":[
+			{"type":"text","text":"<invoke name=\"Bash\"><parameter name=\"command\">printf test</parameter></invoke>"},
+			{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"README.md"}}
+		],
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":5,"output_tokens":3}
+	}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+	svc := &GatewayService{cfg: &config.Config{}}
+
+	usage, err := svc.handleNonStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 2})
+
+	require.Nil(t, usage)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(), "mismatched tool-call content must fail before committing the response")
+}
+
 func TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_ForceCacheBillingResponse(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Strip duplicated raw `<invoke>` suffixes only when the candidate is well-formed XML, `stop_reason` is `tool_use`, and raw tool names exactly match the structured `tool_use` blocks.
- Preserve raw-only, incomplete, mismatched, trailing-text, and otherwise unverified markup as ordinary response text instead of truncating content or returning 502.
- Bound streaming state to a 64 KiB candidate buffer and 128 KiB deferred-event buffer; overflow restores the original text and switches to passthrough.
- Use one XML grammar for streaming and non-streaming paths, including markers split across SSE chunks.

## Tests

- `GOTOOLCHAIN=auto go test ./internal/service -run 'TestAnthropicPassthroughProtocolGuard|TestNormalizeAnthropicPassthroughResponseBody|TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_(Preserves|Strips)' -count=1`\n- `GOTOOLCHAIN=auto go test -race ./internal/service -run 'TestAnthropicPassthroughProtocolGuard|TestNormalizeAnthropicPassthroughResponseBody|TestHandleNonStreamingResponseAnthropicAPIKeyPassthrough_(Preserves|Strips)' -count=1`\n- `GOTOOLCHAIN=auto go test ./internal/service -count=1`\n- `GOTOOLCHAIN=auto go vet ./internal/service`\n- `GOTOOLCHAIN=auto go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=30m`\n- `GOTOOLCHAIN=auto make test-unit`\n- `GOTOOLCHAIN=auto make test-integration`