### PR TITLE
fix: allow messages dispatch for composite groups

### DIFF
--- a/backend/internal/handler/openai_gateway_cn_dispatch_test.go
+++ b/backend/internal/handler/openai_gateway_cn_dispatch_test.go
@@ -1,11 +1,10 @@
 package handler
 
 // CN 分组 /v1/messages 调度闸门回归（修复:正常途径创建的 CN 分组曾恒 403）：
-// sanitizeGroupMessagesDispatchFields 对非 openai 平台强制 AllowMessagesDispatch
+// sanitizeGroupMessagesDispatchFields 对非 openai/composite 平台强制 AllowMessagesDispatch
 // =false，故 CN 分组必须与 grok 一样在闸门处豁免，否则原生 Anthropic 直通
-//（Claude Code 主用例）永远不可达。composite 分组同理：sanitize 对 composite
-// 恒置 false，解析到 grok/CN 目标时必须按目标平台豁免，解析到 openai 目标
-// 仍受开关控制。
+//（Claude Code 主用例）永远不可达。composite 分组解析到 grok/CN 目标时按
+// 目标平台豁免，解析到 openai 目标仍受其可配置开关控制。
 
 import (
 	"net/http/httptest"
@@ -35,23 +34,25 @@ func TestAllowOpenAICompatibleMessagesDispatch_CNProvidersExempt(t *testing.T) {
 func TestAllowOpenAICompatibleMessagesDispatch_CompositeResolvedTargets(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	newCompositeCtx := func(model string) (*gin.Context, *service.APIKey) {
+	newCompositeCtx := func(model string, allow bool) (*gin.Context, *service.APIKey) {
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = httptest.NewRequest("POST", "/v1/messages", nil)
-		apiKey := &service.APIKey{Group: &service.Group{Platform: service.PlatformComposite, AllowMessagesDispatch: false}}
+		apiKey := &service.APIKey{Group: &service.Group{Platform: service.PlatformComposite, AllowMessagesDispatch: allow}}
 		ensureCompositeTargetPlatform(c, apiKey, model)
 		return c, apiKey
 	}
 
 	// 解析到 grok/CN 目标：与对应独立分组同语义豁免。
 	for _, model := range []string{"grok-4.3", "kimi-k2-thinking", "glm-5.2", "deepseek-v3.2"} {
-		c, apiKey := newCompositeCtx(model)
+		c, apiKey := newCompositeCtx(model, false)
 		require.True(t, allowOpenAICompatibleMessagesDispatch(c, apiKey), "model=%s", model)
 	}
 
-	// 解析到 openai 目标：仍受开关控制（composite 被 sanitize 恒置 false ⇒ 拒绝）。
-	c, apiKey := newCompositeCtx("gpt-5.5")
+	// 解析到 openai 目标：受 composite 分组自身开关控制。
+	c, apiKey := newCompositeCtx("gpt-5.5", false)
 	require.False(t, allowOpenAICompatibleMessagesDispatch(c, apiKey))
+	c, apiKey = newCompositeCtx("gpt-5.5", true)
+	require.True(t, allowOpenAICompatibleMessagesDispatch(c, apiKey))
 
 	// 未解析出目标平台：保持拒绝，不放宽。
 	cNone, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -223,14 +223,13 @@ func allowOpenAICompatibleMessagesDispatch(c *gin.Context, apiKey *service.APIKe
 	}
 	// 国产供应商分组与 grok 同语义:/v1/messages 就是其主要服务形态(anthropic
 	// 协议账号原生直通 Claude Code),无需 allow_messages_dispatch 开关授权——
-	// 该开关对非 openai 平台恒被 sanitizeGroupMessagesDispatchFields 置 false,
+	// 该开关对非 openai/composite 平台恒被 sanitizeGroupMessagesDispatchFields 置 false,
 	// 若不豁免,CN 分组将永远 403。
 	if service.IsCNProvider(apiKey.Group.Platform) {
 		return true
 	}
-	// composite 分组解析到 grok/CN 目标时与对应独立分组同语义豁免：sanitize
-	// 对 composite 同样恒置 false,不豁免则这些目标的 /v1/messages 永远 403；
-	// 解析到 openai 目标仍受开关控制,维持现状。
+	// composite 分组解析到 grok/CN 目标时与对应独立分组同语义豁免；
+	// 解析到 openai 目标则受 composite 分组自身的可配置开关控制。
 	if apiKey.Group.Platform == service.PlatformComposite && c != nil && c.Request != nil {
 		if platform, ok := service.ResolvedTargetPlatformFromContext(c.Request.Context()); ok &&
 			(platform == service.PlatformGrok || service.IsCNProvider(platform)) {

--- a/backend/internal/service/openai_messages_dispatch.go
+++ b/backend/internal/service/openai_messages_dispatch.go
@@ -116,7 +116,9 @@ func sanitizeGroupMessagesDispatchFields(g *Group) {
 	if g == nil || g.Platform == PlatformOpenAI {
 		return
 	}
-	g.AllowMessagesDispatch = false
+	if g.Platform != PlatformComposite {
+		g.AllowMessagesDispatch = false
+	}
 	g.DefaultMappedModel = ""
 	g.MessagesDispatchModelConfig = OpenAIMessagesDispatchModelConfig{}
 }

--- a/backend/internal/service/openai_messages_dispatch_test.go
+++ b/backend/internal/service/openai_messages_dispatch_test.go
@@ -69,3 +69,25 @@ func TestSanitizeGroupMessagesDispatchFields_ClearsNonOpenAIPlatform(t *testing.
 	require.Empty(t, group.DefaultMappedModel)
 	require.Equal(t, OpenAIMessagesDispatchModelConfig{}, group.MessagesDispatchModelConfig)
 }
+
+func TestSanitizeGroupMessagesDispatchFields_PreservesCompositeDispatchToggle(t *testing.T) {
+	t.Parallel()
+
+	group := &Group{
+		Platform:              PlatformComposite,
+		AllowMessagesDispatch: true,
+		DefaultMappedModel:    "gpt-5.6-sol",
+		MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+			SonnetMappedModel: "gpt-5.3-codex",
+			ExactModelMappings: map[string]string{
+				"claude-fable-5": "gpt-5.6-sol",
+			},
+		},
+	}
+
+	sanitizeGroupMessagesDispatchFields(group)
+
+	require.True(t, group.AllowMessagesDispatch)
+	require.Empty(t, group.DefaultMappedModel)
+	require.Equal(t, OpenAIMessagesDispatchModelConfig{}, group.MessagesDispatchModelConfig)
+}

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1614,9 +1614,9 @@
           </p>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- OpenAI Messages 调度配置（OpenAI 与 Composite 平台） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="supportsMessagesDispatchPlatform(createForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -1655,7 +1655,13 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
-          <div v-if="createForm.allow_messages_dispatch" class="mt-3">
+          <div
+            v-if="
+              createForm.platform === 'openai' &&
+              createForm.allow_messages_dispatch
+            "
+            class="mt-3"
+          >
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
             >
@@ -3336,9 +3342,9 @@
           </p>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- OpenAI Messages 调度配置（OpenAI 与 Composite 平台） -->
         <div
-          v-if="editForm.platform === 'openai'"
+          v-if="supportsMessagesDispatchPlatform(editForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -3377,7 +3383,12 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
-          <div v-if="editForm.allow_messages_dispatch" class="mt-3">
+          <div
+            v-if="
+              editForm.platform === 'openai' && editForm.allow_messages_dispatch
+            "
+            class="mt-3"
+          >
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
             >
@@ -4462,6 +4473,7 @@ import {
   messagesDispatchConfigToFormState,
   messagesDispatchFormStateToConfig,
   resetMessagesDispatchFormState,
+  supportsMessagesDispatchPlatform,
   type MessagesDispatchMappingRow,
 } from "./groupsMessagesDispatch";
 import {
@@ -6646,7 +6658,7 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       createForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!supportsMessagesDispatchPlatform(newVal)) {
       resetMessagesDispatchFormState(createForm);
     }
     if (!supportsLivePlatform(newVal)) {
@@ -6696,7 +6708,7 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!supportsMessagesDispatchPlatform(newVal)) {
       resetMessagesDispatchFormState(editForm);
     }
     if (!supportsLivePlatform(newVal)) {
@@ -6748,7 +6760,7 @@ watch(
     if (!['anthropic', 'antigravity'].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null
     }
-    if (newVal !== 'openai') {
+    if (!supportsMessagesDispatchPlatform(newVal)) {
       editForm.allow_messages_dispatch = false
       editForm.default_mapped_model = ''
     }

--- a/frontend/src/views/admin/__tests__/groupsMessagesDispatch.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsMessagesDispatch.spec.ts
@@ -5,9 +5,16 @@ import {
   messagesDispatchConfigToFormState,
   messagesDispatchFormStateToConfig,
   resetMessagesDispatchFormState,
+  supportsMessagesDispatchPlatform,
 } from "../groupsMessagesDispatch";
 
 describe("groupsMessagesDispatch", () => {
+  it("supports OpenAI and composite groups", () => {
+    expect(supportsMessagesDispatchPlatform("openai")).toBe(true);
+    expect(supportsMessagesDispatchPlatform("composite")).toBe(true);
+    expect(supportsMessagesDispatchPlatform("anthropic")).toBe(false);
+  });
+
   it("returns the expected default form state", () => {
     expect(createDefaultMessagesDispatchFormState()).toEqual({
       allow_messages_dispatch: false,

--- a/frontend/src/views/admin/groupsMessagesDispatch.ts
+++ b/frontend/src/views/admin/groupsMessagesDispatch.ts
@@ -13,6 +13,10 @@ export interface MessagesDispatchFormState {
   exact_model_mappings: MessagesDispatchMappingRow[];
 }
 
+export function supportsMessagesDispatchPlatform(platform: string): boolean {
+  return platform === "openai" || platform === "composite";
+}
+
 export function createDefaultMessagesDispatchFormState(): MessagesDispatchFormState {
   return {
     allow_messages_dispatch: false,


### PR DESCRIPTION
## 问题
Composite 分组解析到 OpenAI 目标后，`/v1/messages` 与 `/v1/messages/count_tokens` 仍要求 `allow_messages_dispatch`，但该字段会被后端清洗且管理端不展示，导致开关无法启用。

## 根因
分组清洗逻辑仅允许 OpenAI 平台保留该开关；Composite 分组因此始终为 false。现有网关闸门却会读取 Composite 分组自身的该字段。

## 改动
- 允许 Composite 分组保留 `allow_messages_dispatch`
- 在 Composite 分组创建和编辑界面展示现有调度开关
- Composite 分组不展示 OpenAI 专用模型映射配置
- 保持自定义模型的平台解析为 fail-closed，不引入宽泛回退
- 补充后端清洗/闸门与前端平台支持回归测试

## 验证
已验证：
- Go 1.26.6 unit tests 全量通过
- Go 1.26.6 integration tests 全量通过
- `golangci-lint v2.9.0`：0 issues
- 后端目标包测试与 `go vet` 通过
- 前端 ESLint、typecheck 通过
- 前端关键测试 14 files / 169 tests 通过
- 新增前端测试 5 tests 通过
- 前端生产构建通过（仅现有 chunk size 警告）
- `govulncheck ./...`：当前代码调用路径 0 vulnerabilities
- 前端生产依赖审计例外校验通过
- `git diff --check` 通过

Fixes #5886