### PR TITLE
fix(frontend): prevent token refresh lock loop

### DIFF
--- a/frontend/src/api/__tests__/tokenRefresh.spec.ts
+++ b/frontend/src/api/__tests__/tokenRefresh.spec.ts
@@ -91,6 +91,23 @@ describe('refreshAuthTokens', () => {
     })
   })
 
+  it('does not mistake boundary timer jitter for a completed peer refresh', async () => {
+    vi.useFakeTimers()
+    seedSession({ token_expires_at: String(Date.now() + 120_001) })
+    mockedPost.mockResolvedValueOnce(refreshedResponse())
+    const request = vi.fn(async (_name: string, callback: () => Promise<unknown>) => callback())
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: { request }
+    })
+    const { refreshAuthTokens } = await import('@/api/tokenRefresh')
+
+    await expect(refreshAuthTokens()).resolves.toMatchObject({ access_token: 'new-access' })
+
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+  })
+
   it('recovers when a peer publishes the rotated token just after this request fails', async () => {
     seedSession()
     mockedPost.mockRejectedValueOnce(new Error('refresh token already used'))

--- a/frontend/src/api/tokenRefresh.ts
+++ b/frontend/src/api/tokenRefresh.ts
@@ -8,7 +8,6 @@ const REFRESH_TOKEN_KEY = 'refresh_token'
 const TOKEN_EXPIRES_AT_KEY = 'token_expires_at'
 const TOKEN_REFRESH_LOCK_NAME = 'sub2api-auth-token-refresh'
 const TOKEN_REFRESH_TIMEOUT_MS = 30_000
-const TOKEN_REFRESH_BUFFER_MS = 120_000
 const PEER_REFRESH_WAIT_MS = 1_000
 const PEER_REFRESH_GRACE_MS = 1_000
 const PEER_REFRESH_POLL_MS = 25
@@ -104,17 +103,6 @@ function readPeerRefreshResult(
     storedPair.access_token === snapshot.accessToken
   ) {
     return storedPair
-  }
-
-  if (!failedAccessToken) {
-    const expiresAt = Number(localStorage.getItem(TOKEN_EXPIRES_AT_KEY))
-    if (
-      expiresAt === snapshot.expiresAt &&
-      storedPair.access_token === snapshot.accessToken &&
-      expiresAt > Date.now() + TOKEN_REFRESH_BUFFER_MS
-    ) {
-      return storedPair
-    }
   }
 
   return null


### PR DESCRIPTION
## 问题
通过 HTTPS 反向代理登录后，主动刷新在到达两分钟提前刷新边界时可能持续重新排程，页面 CPU 长时间占满。

## 根因
Web Lock 回调把锁前后完全未变化、但仍略高于两分钟阈值的本地 token 快照误判为其他标签页已经完成刷新。调用方据此按仅剩约两分钟的 expires_in 再次安排立即刷新，形成无网络请求的锁、定时器与 localStorage 热循环。

## 改动
- 仅在 refresh token 实际轮换，或 401 请求携带的 access token 已落后时采纳其他标签页结果
- 不再把未变化的近到期 token 快照当作刷新成功
- 补充 Web Lock 边界抖动回归测试

## 验证
已验证：
- 前端 CI 对齐检查：ESLint、typecheck、13 files / 165 tests 通过
- token refresh 定向测试：7 tests 通过
- 前端生产构建通过（仅现有 chunk size 警告）
- Go unit tests 与 integration tests 全量通过
- golangci-lint v2.9：0 issues
- govulncheck：当前代码调用路径 0 vulnerabilities
- 前端生产依赖审计例外校验通过
- git diff --check 通过

Fixes #5899