### PR TITLE
fix(openai): normalize strict Responses fields in WebSocket forwarding

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -919,6 +919,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		responseID := ""
 		usage := OpenAIUsage{}
 		imageCounter := newOpenAIImageOutputCounter()
+		strictWireNormalizer := newOpenAIWSStrictWireNormalizer()
 		var firstTokenMs *int
 		reqStream := openAIWSPayloadBoolFromRaw(payload, "stream", true)
 		turnPreviousResponseID := openAIWSPayloadStringFromRaw(payload, "previous_response_id")
@@ -957,6 +958,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				)
 			}
 			if normalized, changed := normalizeCompletedImageGenerationStatus(upstreamMessage); changed {
+				upstreamMessage = normalized
+			}
+			if normalized, changed := strictWireNormalizer.normalize(upstreamMessage); changed {
 				upstreamMessage = normalized
 			}
 

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -960,7 +960,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if normalized, changed := normalizeCompletedImageGenerationStatus(upstreamMessage); changed {
 				upstreamMessage = normalized
 			}
-			if normalized, changed := strictWireNormalizer.normalize(upstreamMessage); changed {
+			if normalized, changed, err := strictWireNormalizer.normalize(upstreamMessage); err != nil {
+				logOpenAIWSModeInfo("strict_wire_normalize_failed path=ingress err=%v", err)
+			} else if changed {
 				upstreamMessage = normalized
 			}
 

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -522,7 +522,9 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		if normalized, changed := normalizeCompletedImageGenerationStatus(message); changed {
 			message = normalized
 		}
-		if normalized, changed := strictWireNormalizer.normalize(message); changed {
+		if normalized, changed, err := strictWireNormalizer.normalize(message); err != nil {
+			logOpenAIWSModeInfo("strict_wire_normalize_failed path=ws_v2 err=%v", err)
+		} else if changed {
 			message = normalized
 		}
 

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -350,6 +350,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 
 	usage := &OpenAIUsage{}
 	imageCounter := newOpenAIImageOutputCounter()
+	strictWireNormalizer := newOpenAIWSStrictWireNormalizer()
 	var firstTokenMs *int
 	responseID := ""
 	var finalResponse []byte
@@ -519,6 +520,9 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 			return nil, fmt.Errorf("openai ws read event: %w", readErr)
 		}
 		if normalized, changed := normalizeCompletedImageGenerationStatus(message); changed {
+			message = normalized
+		}
+		if normalized, changed := strictWireNormalizer.normalize(message); changed {
 			message = normalized
 		}
 

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -609,7 +609,9 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 		if normalized, changed := normalizeCompletedImageGenerationStatus(upstreamMessage); changed {
 			upstreamMessage = normalized
 		}
-		if normalized, changed := strictWireNormalizer.normalize(upstreamMessage); changed {
+		if normalized, changed, err := strictWireNormalizer.normalize(upstreamMessage); err != nil {
+			logOpenAIWSModeInfo("strict_wire_normalize_failed path=http_bridge err=%v", err)
+		} else if changed {
 			upstreamMessage = normalized
 		}
 		eventType, eventResponseID, _ := parseOpenAIWSEventEnvelope(upstreamMessage)

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -474,6 +474,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 	responseID := ""
 	usage := OpenAIUsage{}
 	imageCounter := newOpenAIImageOutputCounter()
+	strictWireNormalizer := newOpenAIWSStrictWireNormalizer()
 	var firstTokenMs *int
 	reqStream := openAIWSPayloadBoolFromRaw(body, "stream", true)
 	eventCount := 0
@@ -606,6 +607,9 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 
 		upstreamMessage := []byte(openAICompatPayloadWithEventType(trimmedData, pendingSSEEventType))
 		if normalized, changed := normalizeCompletedImageGenerationStatus(upstreamMessage); changed {
+			upstreamMessage = normalized
+		}
+		if normalized, changed := strictWireNormalizer.normalize(upstreamMessage); changed {
 			upstreamMessage = normalized
 		}
 		eventType, eventResponseID, _ := parseOpenAIWSEventEnvelope(upstreamMessage)

--- a/backend/internal/service/openai_ws_strict_wire.go
+++ b/backend/internal/service/openai_ws_strict_wire.go
@@ -1,0 +1,350 @@
+package service
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// openAIWSStrictWireNormalizer keeps output-item fields stable across the
+// lifecycle events emitted by Responses-compatible upstreams. Some upstreams
+// send a complete output_item.done item but a reduced response.completed item.
+// Strict clients deserialize both forms and require the fields to agree.
+type openAIWSStrictWireNormalizer struct {
+	itemIDs   map[int]string
+	snapshots map[int]json.RawMessage
+}
+
+func newOpenAIWSStrictWireNormalizer() *openAIWSStrictWireNormalizer {
+	return &openAIWSStrictWireNormalizer{
+		itemIDs:   make(map[int]string),
+		snapshots: make(map[int]json.RawMessage),
+	}
+}
+
+// normalize repairs only known Responses output item shapes. Existing values
+// and unknown fields remain untouched, so this is safe for vendor extensions.
+func (n *openAIWSStrictWireNormalizer) normalize(data []byte) ([]byte, bool) {
+	if n == nil || len(data) == 0 || !gjson.ValidBytes(data) {
+		return data, false
+	}
+
+	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
+	switch eventType {
+	case "response.output_item.added", "response.output_item.done":
+		status := "in_progress"
+		if eventType == "response.output_item.done" {
+			status = "completed"
+		}
+		index := int(gjson.GetBytes(data, "output_index").Int())
+		updated, changed := n.normalizeItem(data, "item", status, index, eventType)
+		if item := gjson.GetBytes(updated, "item"); item.IsObject() {
+			n.rememberSnapshot(index, item.Raw)
+		}
+		return updated, changed
+
+	case "response.content_part.added", "response.content_part.done":
+		return normalizeOpenAIWSOutputTextPart(data, "part")
+
+	case "response.created", "response.in_progress", "response.completed", "response.done",
+		"response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+		responseStatus := strings.TrimSpace(gjson.GetBytes(data, "response.status").String())
+		status := openAIWSStrictItemStatusForResponseStatus(responseStatus)
+		if responseStatus == "" && (eventType == "response.completed" || eventType == "response.done") {
+			status = "completed"
+		}
+		return n.normalizeOutputList(data, "response.output", status, eventType)
+	default:
+		if gjson.GetBytes(data, "object").String() == "response" || gjson.GetBytes(data, "output").IsArray() {
+			responseStatus := strings.TrimSpace(gjson.GetBytes(data, "status").String())
+			status := openAIWSStrictItemStatusForResponseStatus(responseStatus)
+			if responseStatus == "" {
+				status = "completed"
+			}
+			return n.normalizeOutputList(data, "output", status, "response")
+		}
+		return data, false
+	}
+}
+
+func (n *openAIWSStrictWireNormalizer) normalizeOutputList(data []byte, path, status, eventType string) ([]byte, bool) {
+	output := gjson.GetBytes(data, path)
+	if !output.IsArray() {
+		return data, false
+	}
+	updated := data
+	changed := false
+	for index := range output.Array() {
+		itemPath := path + "." + strconv.Itoa(index)
+		next, itemChanged := n.normalizeItem(updated, itemPath, status, index, eventType)
+		if itemChanged {
+			updated = next
+			changed = true
+		}
+	}
+	return updated, changed
+}
+
+func (n *openAIWSStrictWireNormalizer) normalizeItem(
+	data []byte,
+	path string,
+	defaultStatus string,
+	outputIndex int,
+	eventType string,
+) ([]byte, bool) {
+	item := gjson.GetBytes(data, path)
+	if !item.IsObject() {
+		return data, false
+	}
+
+	updated := data
+	changed := false
+	itemType := strings.TrimSpace(item.Get("type").String())
+	if snapshot := n.snapshots[outputIndex]; len(snapshot) > 0 {
+		var snapshotObject map[string]json.RawMessage
+		if json.Unmarshal(snapshot, &snapshotObject) == nil {
+			updated, changed = mergeOpenAIWSItemSnapshot(updated, path, snapshotObject)
+			item = gjson.GetBytes(updated, path)
+		}
+	}
+
+	prefix, strict := openAIWSStrictItemIDPrefix(itemType)
+	if !strict {
+		return updated, changed
+	}
+
+	itemID := strings.TrimSpace(item.Get("id").String())
+	if itemID == "" {
+		itemID = n.itemIDs[outputIndex]
+		if itemID == "" {
+			itemID = generateOpenAIWSStrictItemID(prefix)
+		}
+		next, err := sjson.SetBytes(updated, path+".id", itemID)
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	} else {
+		n.itemIDs[outputIndex] = itemID
+	}
+
+	item = gjson.GetBytes(updated, path)
+	if (item.Get("status").Type == gjson.Null || !item.Get("status").Exists()) && defaultStatus != "" {
+		next, err := sjson.SetBytes(updated, path+".status", defaultStatus)
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+
+	if itemType == "message" {
+		contentPath := path + ".content"
+		content := gjson.GetBytes(updated, contentPath)
+		if !content.IsArray() {
+			next, err := sjson.SetRawBytes(updated, contentPath, []byte("[]"))
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		} else {
+			for index, part := range content.Array() {
+				partType := strings.TrimSpace(part.Get("type").String())
+				if partType == "" || partType == "text" || partType == "output_text" {
+					partPath := contentPath + "." + strconv.Itoa(index)
+					next, partChanged := normalizeOpenAIWSOutputTextPart(updated, partPath)
+					if partChanged {
+						updated = next
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	if eventType == "response.output_item.added" || eventType == "response.output_item.done" {
+		if item := gjson.GetBytes(updated, path); item.IsObject() {
+			n.rememberSnapshot(outputIndex, item.Raw)
+		}
+	}
+	return updated, changed
+}
+
+func mergeOpenAIWSItemSnapshot(
+	data []byte,
+	path string,
+	snapshot map[string]json.RawMessage,
+) ([]byte, bool) {
+	updated := data
+	changed := false
+	for _, field := range []string{
+		"id", "phase", "role", "call_id", "name", "arguments", "namespace", "input",
+		"encrypted_content", "summary",
+	} {
+		raw, ok := snapshot[field]
+		if !ok || len(raw) == 0 {
+			continue
+		}
+		current := gjson.GetBytes(updated, path+"."+field)
+		if current.Exists() && current.Type != gjson.Null {
+			continue
+		}
+		next, err := sjson.SetRawBytes(updated, path+"."+field, raw)
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	// The status reported by output_item.added/done outranks anything derived
+	// from the response-level status: an item that already reached a terminal
+	// state keeps it even when the response as a whole later fails.
+	if raw, ok := snapshot["status"]; ok && len(raw) > 0 {
+		current := gjson.GetBytes(updated, path+".status")
+		if !current.Exists() || current.Type == gjson.Null {
+			next, err := sjson.SetRawBytes(updated, path+".status", raw)
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		}
+	}
+
+	contentRaw, ok := snapshot["content"]
+	if !ok || len(contentRaw) == 0 {
+		return updated, changed
+	}
+	currentContent := gjson.GetBytes(updated, path+".content")
+	if !currentContent.IsArray() {
+		next, err := sjson.SetRawBytes(updated, path+".content", contentRaw)
+		if err == nil {
+			return next, true
+		}
+		return updated, changed
+	}
+	var snapshotParts []json.RawMessage
+	if json.Unmarshal(contentRaw, &snapshotParts) != nil {
+		return updated, changed
+	}
+	for index, partRaw := range snapshotParts {
+		if index >= len(currentContent.Array()) {
+			break
+		}
+		var snapshotPart map[string]json.RawMessage
+		if json.Unmarshal(partRaw, &snapshotPart) != nil {
+			continue
+		}
+		partPath := path + ".content." + strconv.Itoa(index)
+		for _, field := range []string{"type", "text", "annotations", "logprobs"} {
+			raw, exists := snapshotPart[field]
+			if !exists || len(raw) == 0 {
+				continue
+			}
+			current := gjson.GetBytes(updated, partPath+"."+field)
+			if current.Exists() && current.Type != gjson.Null {
+				continue
+			}
+			next, err := sjson.SetRawBytes(updated, partPath+"."+field, raw)
+			if err == nil {
+				updated = next
+				changed = true
+			}
+		}
+	}
+	return updated, changed
+}
+
+func normalizeOpenAIWSOutputTextPart(data []byte, path string) ([]byte, bool) {
+	part := gjson.GetBytes(data, path)
+	if !part.IsObject() {
+		return data, false
+	}
+	partType := strings.TrimSpace(part.Get("type").String())
+	if partType != "" && partType != "text" && partType != "output_text" {
+		return data, false
+	}
+	updated := data
+	changed := false
+	if partType == "" || partType == "text" {
+		next, err := sjson.SetBytes(updated, path+".type", "output_text")
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	part = gjson.GetBytes(updated, path)
+	if part.Get("text").Type != gjson.String {
+		next, err := sjson.SetBytes(updated, path+".text", "")
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	if !part.Get("annotations").IsArray() {
+		next, err := sjson.SetRawBytes(updated, path+".annotations", []byte("[]"))
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	if !part.Get("logprobs").IsArray() {
+		next, err := sjson.SetRawBytes(updated, path+".logprobs", []byte("[]"))
+		if err == nil {
+			updated = next
+			changed = true
+		}
+	}
+	return updated, changed
+}
+
+func (n *openAIWSStrictWireNormalizer) rememberSnapshot(index int, raw string) {
+	if n == nil || raw == "" {
+		return
+	}
+	n.snapshots[index] = json.RawMessage(append([]byte(nil), raw...))
+}
+
+// openAIWSStrictItemStatusForResponseStatus maps a response-level status onto
+// a status the Responses protocol allows on an output item. Response terminal
+// states such as failed or cancelled have no item-level counterpart, so items
+// that never reported one of their own are reported as incomplete. An empty
+// result means "say nothing", which leaves the item status to the lifecycle
+// snapshot instead of inventing a value strict clients would reject.
+func openAIWSStrictItemStatusForResponseStatus(responseStatus string) string {
+	switch strings.TrimSpace(responseStatus) {
+	case "completed":
+		return "completed"
+	case "in_progress", "queued":
+		return "in_progress"
+	case "incomplete", "failed", "cancelled", "canceled":
+		return "incomplete"
+	default:
+		return ""
+	}
+}
+
+func openAIWSStrictItemIDPrefix(itemType string) (string, bool) {
+	switch strings.TrimSpace(itemType) {
+	case "message":
+		return "msg", true
+	case "reasoning":
+		return "rs", true
+	case "function_call":
+		return "fc", true
+	case "custom_tool_call":
+		return "ctc", true
+	case "tool_search_call":
+		return "tsc", true
+	default:
+		return "", false
+	}
+}
+
+func generateOpenAIWSStrictItemID(prefix string) string {
+	buf := make([]byte, 12)
+	_, _ = rand.Read(buf)
+	return prefix + "_" + hex.EncodeToString(buf)
+}

--- a/backend/internal/service/openai_ws_strict_wire.go
+++ b/backend/internal/service/openai_ws_strict_wire.go
@@ -17,12 +17,14 @@ import (
 // Strict clients deserialize both forms and require the fields to agree.
 type openAIWSStrictWireNormalizer struct {
 	itemIDs   map[int]string
+	itemTypes map[int]string
 	snapshots map[int]json.RawMessage
 }
 
 func newOpenAIWSStrictWireNormalizer() *openAIWSStrictWireNormalizer {
 	return &openAIWSStrictWireNormalizer{
 		itemIDs:   make(map[int]string),
+		itemTypes: make(map[int]string),
 		snapshots: make(map[int]json.RawMessage),
 	}
 }
@@ -105,7 +107,13 @@ func (n *openAIWSStrictWireNormalizer) normalizeItem(
 	updated := data
 	changed := false
 	itemType := strings.TrimSpace(item.Get("type").String())
-	if snapshot := n.snapshots[outputIndex]; len(snapshot) > 0 {
+	// A terminal rebuild may drop or reorder items, so the same array position
+	// can hold a different item than it did during the lifecycle events. Only
+	// inherit remembered state when the type still agrees, otherwise fields
+	// from one item type leak onto another (a reasoning summary landing on a
+	// message, for example).
+	inheritsRememberedState := n.rememberedTypeMatches(outputIndex, itemType)
+	if snapshot := n.snapshots[outputIndex]; inheritsRememberedState && len(snapshot) > 0 {
 		var snapshotObject map[string]json.RawMessage
 		if json.Unmarshal(snapshot, &snapshotObject) == nil {
 			updated, changed = mergeOpenAIWSItemSnapshot(updated, path, snapshotObject)
@@ -120,7 +128,9 @@ func (n *openAIWSStrictWireNormalizer) normalizeItem(
 
 	itemID := strings.TrimSpace(item.Get("id").String())
 	if itemID == "" {
-		itemID = n.itemIDs[outputIndex]
+		if inheritsRememberedState {
+			itemID = n.itemIDs[outputIndex]
+		}
 		if itemID == "" {
 			itemID = generateOpenAIWSStrictItemID(prefix)
 		}
@@ -131,6 +141,7 @@ func (n *openAIWSStrictWireNormalizer) normalizeItem(
 		}
 	} else {
 		n.itemIDs[outputIndex] = itemID
+		n.itemTypes[outputIndex] = itemType
 	}
 
 	item = gjson.GetBytes(updated, path)
@@ -305,6 +316,20 @@ func (n *openAIWSStrictWireNormalizer) rememberSnapshot(index int, raw string) {
 		return
 	}
 	n.snapshots[index] = json.RawMessage(append([]byte(nil), raw...))
+	if itemType := strings.TrimSpace(gjson.Get(raw, "type").String()); itemType != "" {
+		n.itemTypes[index] = itemType
+	}
+}
+
+// rememberedTypeMatches reports whether the state remembered for outputIndex
+// describes an item of the same type. An unknown or disagreeing type means the
+// remembered state belongs to a different item and must not be applied.
+func (n *openAIWSStrictWireNormalizer) rememberedTypeMatches(outputIndex int, itemType string) bool {
+	if n == nil || itemType == "" {
+		return false
+	}
+	remembered := strings.TrimSpace(n.itemTypes[outputIndex])
+	return remembered != "" && remembered == itemType
 }
 
 // openAIWSStrictItemStatusForResponseStatus maps a response-level status onto

--- a/backend/internal/service/openai_ws_strict_wire.go
+++ b/backend/internal/service/openai_ws_strict_wire.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -11,29 +12,54 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+// openAIWSStrictItemMemory is the lifecycle form of a single output item, kept
+// so a reduced terminal item can be repaired from it.
+type openAIWSStrictItemMemory struct {
+	itemType string
+	callID   string
+	snapshot json.RawMessage
+}
+
 // openAIWSStrictWireNormalizer keeps output-item fields stable across the
 // lifecycle events emitted by Responses-compatible upstreams. Some upstreams
 // send a complete output_item.done item but a reduced response.completed item.
 // Strict clients deserialize both forms and require the fields to agree.
+//
+// Memory is keyed by item id rather than by array position: a terminal rebuild
+// may drop, reorder, or collapse items, so the index of an item in
+// response.output proves nothing about which lifecycle item it came from.
+//
+// The normalizer describes exactly one turn. Callers that reuse a connection
+// across turns must call reset before the next turn is accepted.
 type openAIWSStrictWireNormalizer struct {
-	itemIDs   map[int]string
-	itemTypes map[int]string
-	snapshots map[int]json.RawMessage
+	items    map[string]*openAIWSStrictItemMemory
+	indexIDs map[int]string
 }
 
 func newOpenAIWSStrictWireNormalizer() *openAIWSStrictWireNormalizer {
-	return &openAIWSStrictWireNormalizer{
-		itemIDs:   make(map[int]string),
-		itemTypes: make(map[int]string),
-		snapshots: make(map[int]json.RawMessage),
+	n := &openAIWSStrictWireNormalizer{}
+	n.reset()
+	return n
+}
+
+// reset drops every item remembered for the current turn. A connection that
+// serves several turns must call this between them, otherwise the next turn
+// inherits ids and content from the previous one.
+func (n *openAIWSStrictWireNormalizer) reset() {
+	if n == nil {
+		return
 	}
+	n.items = make(map[string]*openAIWSStrictItemMemory)
+	n.indexIDs = make(map[int]string)
 }
 
 // normalize repairs only known Responses output item shapes. Existing values
 // and unknown fields remain untouched, so this is safe for vendor extensions.
-func (n *openAIWSStrictWireNormalizer) normalize(data []byte) ([]byte, bool) {
+// It returns an error only when a repair could not be completed safely; the
+// returned payload is then the untouched input.
+func (n *openAIWSStrictWireNormalizer) normalize(data []byte) ([]byte, bool, error) {
 	if n == nil || len(data) == 0 || !gjson.ValidBytes(data) {
-		return data, false
+		return data, false, nil
 	}
 
 	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
@@ -44,14 +70,13 @@ func (n *openAIWSStrictWireNormalizer) normalize(data []byte) ([]byte, bool) {
 			status = "completed"
 		}
 		index := int(gjson.GetBytes(data, "output_index").Int())
-		updated, changed := n.normalizeItem(data, "item", status, index, eventType)
-		if item := gjson.GetBytes(updated, "item"); item.IsObject() {
-			n.rememberSnapshot(index, item.Raw)
-		}
-		return updated, changed
+		// Live lifecycle events address items by position, so the index is a
+		// reliable identity here, and a single item is never ambiguous.
+		return n.normalizeItem(data, "item", status, index, eventType, true, nil, nil)
 
 	case "response.content_part.added", "response.content_part.done":
-		return normalizeOpenAIWSOutputTextPart(data, "part")
+		updated, changed := normalizeOpenAIWSOutputTextPart(data, "part")
+		return updated, changed, nil
 
 	case "response.created", "response.in_progress", "response.completed", "response.done",
 		"response.failed", "response.incomplete", "response.cancelled", "response.canceled":
@@ -70,26 +95,69 @@ func (n *openAIWSStrictWireNormalizer) normalize(data []byte) ([]byte, bool) {
 			}
 			return n.normalizeOutputList(data, "output", status, "response")
 		}
-		return data, false
+		return data, false, nil
 	}
 }
 
-func (n *openAIWSStrictWireNormalizer) normalizeOutputList(data []byte, path, status, eventType string) ([]byte, bool) {
+func (n *openAIWSStrictWireNormalizer) normalizeOutputList(
+	data []byte,
+	path string,
+	status string,
+	eventType string,
+) ([]byte, bool, error) {
 	output := gjson.GetBytes(data, path)
 	if !output.IsArray() {
-		return data, false
+		return data, false, nil
 	}
+	// Walk the list once before repairing anything, so the outcome does not
+	// depend on the order the items happen to appear in.
+	//
+	// reserved holds every memory an item names outright, by id or by call_id.
+	// Those memories belong to that item, and the type fallback below must not
+	// hand one to an anonymous item as well; doing so would mint a duplicate id
+	// whenever the anonymous item was listed first.
+	//
+	// fallbackCandidates counts the items that carry neither, which can only be
+	// matched by type. If a type names more than one such item none of them can
+	// be proven to be the remembered one, so none may inherit.
+	reserved := make(map[string]bool)
+	fallbackCandidates := make(map[string]int)
+	for _, item := range output.Array() {
+		if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+			if _, ok := n.items[id]; ok {
+				reserved[id] = true
+			}
+			continue
+		}
+		if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+			for id, memory := range n.items {
+				if memory.callID == callID {
+					reserved[id] = true
+				}
+			}
+			continue
+		}
+		if itemType := strings.TrimSpace(item.Get("type").String()); itemType != "" {
+			fallbackCandidates[itemType]++
+		}
+	}
+
 	updated := data
 	changed := false
 	for index := range output.Array() {
 		itemPath := path + "." + strconv.Itoa(index)
-		next, itemChanged := n.normalizeItem(updated, itemPath, status, index, eventType)
+		// A rebuilt output list may have dropped or reordered items, so the
+		// position must not be used to identify them.
+		next, itemChanged, err := n.normalizeItem(updated, itemPath, status, index, eventType, false, reserved, fallbackCandidates)
+		if err != nil {
+			return data, false, err
+		}
 		if itemChanged {
 			updated = next
 			changed = true
 		}
 	}
-	return updated, changed
+	return updated, changed, nil
 }
 
 func (n *openAIWSStrictWireNormalizer) normalizeItem(
@@ -98,50 +166,53 @@ func (n *openAIWSStrictWireNormalizer) normalizeItem(
 	defaultStatus string,
 	outputIndex int,
 	eventType string,
-) ([]byte, bool) {
+	indexTrusted bool,
+	reserved map[string]bool,
+	fallbackCandidates map[string]int,
+) ([]byte, bool, error) {
 	item := gjson.GetBytes(data, path)
 	if !item.IsObject() {
-		return data, false
+		return data, false, nil
 	}
 
 	updated := data
 	changed := false
 	itemType := strings.TrimSpace(item.Get("type").String())
-	// A terminal rebuild may drop or reorder items, so the same array position
-	// can hold a different item than it did during the lifecycle events. Only
-	// inherit remembered state when the type still agrees, otherwise fields
-	// from one item type leak onto another (a reasoning summary landing on a
-	// message, for example).
-	inheritsRememberedState := n.rememberedTypeMatches(outputIndex, itemType)
-	if snapshot := n.snapshots[outputIndex]; inheritsRememberedState && len(snapshot) > 0 {
-		var snapshotObject map[string]json.RawMessage
-		if json.Unmarshal(snapshot, &snapshotObject) == nil {
-			updated, changed = mergeOpenAIWSItemSnapshot(updated, path, snapshotObject)
-			item = gjson.GetBytes(updated, path)
+
+	// Only inherit remembered state when this item can be proven to be the same
+	// item that produced the snapshot. When identity cannot be established the
+	// current fields are kept as they are and a fresh id is generated below.
+	// output_item.added/done state which phase of the lifecycle the item is in,
+	// so their own status wins. Only a rebuilt terminal item, whose status was
+	// dropped, may take the status back from the snapshot.
+	lifecycleEvent := eventType == "response.output_item.added" || eventType == "response.output_item.done"
+	if memoryID := n.resolveMemoryID(item, itemType, outputIndex, indexTrusted, reserved, fallbackCandidates); memoryID != "" {
+		if memory := n.items[memoryID]; memory != nil && len(memory.snapshot) > 0 {
+			var snapshotObject map[string]json.RawMessage
+			if json.Unmarshal(memory.snapshot, &snapshotObject) == nil {
+				updated, changed = mergeOpenAIWSItemSnapshot(updated, path, snapshotObject, !lifecycleEvent)
+				item = gjson.GetBytes(updated, path)
+			}
 		}
 	}
 
 	prefix, strict := openAIWSStrictItemIDPrefix(itemType)
 	if !strict {
-		return updated, changed
+		return updated, changed, nil
 	}
 
 	itemID := strings.TrimSpace(item.Get("id").String())
 	if itemID == "" {
-		if inheritsRememberedState {
-			itemID = n.itemIDs[outputIndex]
+		generated, err := generateOpenAIWSStrictItemID(prefix)
+		if err != nil {
+			return data, false, err
 		}
-		if itemID == "" {
-			itemID = generateOpenAIWSStrictItemID(prefix)
-		}
-		next, err := sjson.SetBytes(updated, path+".id", itemID)
-		if err == nil {
+		itemID = generated
+		next, setErr := sjson.SetBytes(updated, path+".id", itemID)
+		if setErr == nil {
 			updated = next
 			changed = true
 		}
-	} else {
-		n.itemIDs[outputIndex] = itemID
-		n.itemTypes[outputIndex] = itemType
 	}
 
 	item = gjson.GetBytes(updated, path)
@@ -179,16 +250,111 @@ func (n *openAIWSStrictWireNormalizer) normalizeItem(
 
 	if eventType == "response.output_item.added" || eventType == "response.output_item.done" {
 		if item := gjson.GetBytes(updated, path); item.IsObject() {
-			n.rememberSnapshot(outputIndex, item.Raw)
+			n.remember(outputIndex, itemID, itemType, item)
 		}
 	}
-	return updated, changed
+	return updated, changed, nil
+}
+
+// resolveMemoryID returns the id of the remembered item this item provably is,
+// or an empty string when identity cannot be established. Inheriting on a weak
+// match would copy one item's id, tool arguments, or reasoning payload onto a
+// different item, so every branch here fails closed.
+func (n *openAIWSStrictWireNormalizer) resolveMemoryID(
+	item gjson.Result,
+	itemType string,
+	outputIndex int,
+	indexTrusted bool,
+	reserved map[string]bool,
+	fallbackCandidates map[string]int,
+) string {
+	if n == nil || itemType == "" {
+		return ""
+	}
+
+	// The item's own id is the strongest identity available. When it names an
+	// item we never saw, nothing remembered describes it.
+	if id := strings.TrimSpace(item.Get("id").String()); id != "" {
+		if memory := n.items[id]; memory != nil && memory.itemType == itemType {
+			return id
+		}
+		return ""
+	}
+
+	// Tool calls carry call_id, which survives a terminal rebuild even when the
+	// item id does not.
+	if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+		for id, memory := range n.items {
+			if memory.callID == callID && memory.itemType == itemType {
+				return id
+			}
+		}
+		// A live lifecycle event may report call_id for the first time on done,
+		// after added already minted an id without one. Falling through to the
+		// trusted index keeps that item's id stable; a rebuilt terminal item has
+		// no such fallback and stops here.
+		if !indexTrusted {
+			return ""
+		}
+	}
+
+	// Live lifecycle events are addressed by output_index, so the position is
+	// authoritative there.
+	if indexTrusted {
+		if id := n.indexIDs[outputIndex]; id != "" {
+			if memory := n.items[id]; memory != nil && memory.itemType == itemType {
+				return id
+			}
+		}
+		return ""
+	}
+
+	// In a rebuilt list the position proves nothing. Inheriting by type alone is
+	// only safe when it can name exactly one item on both sides: one remembered
+	// item of this type, and one terminal item that needs it. Anything else
+	// leaves two items competing for the same memory.
+	if fallbackCandidates[itemType] != 1 {
+		return ""
+	}
+	matchID := ""
+	for id, memory := range n.items {
+		if memory.itemType != itemType {
+			continue
+		}
+		if matchID != "" {
+			return ""
+		}
+		matchID = id
+	}
+	if matchID == "" || reserved[matchID] {
+		return ""
+	}
+	return matchID
+}
+
+// remember records the lifecycle form of an item. An item observed again at the
+// same output_index supersedes the previous recording rather than adding a
+// second entry, so the per-type uniqueness check stays accurate.
+func (n *openAIWSStrictWireNormalizer) remember(outputIndex int, itemID string, itemType string, item gjson.Result) {
+	if n == nil || itemID == "" || item.Raw == "" {
+		return
+	}
+	if previousID := n.indexIDs[outputIndex]; previousID != "" && previousID != itemID {
+		delete(n.items, previousID)
+	}
+	n.indexIDs[outputIndex] = itemID
+	n.items[itemID] = &openAIWSStrictItemMemory{
+		itemType: itemType,
+		callID:   strings.TrimSpace(item.Get("call_id").String()),
+		snapshot: json.RawMessage(append([]byte(nil), item.Raw...)),
+	}
 }
 
 func mergeOpenAIWSItemSnapshot(
 	data []byte,
 	path string,
 	snapshot map[string]json.RawMessage,
+	restoreStatus bool,
 ) ([]byte, bool) {
 	updated := data
 	changed := false
@@ -210,16 +376,23 @@ func mergeOpenAIWSItemSnapshot(
 			changed = true
 		}
 	}
-	// The status reported by output_item.added/done outranks anything derived
-	// from the response-level status: an item that already reached a terminal
-	// state keeps it even when the response as a whole later fails.
-	if raw, ok := snapshot["status"]; ok && len(raw) > 0 {
-		current := gjson.GetBytes(updated, path+".status")
-		if !current.Exists() || current.Type == gjson.Null {
-			next, err := sjson.SetRawBytes(updated, path+".status", raw)
-			if err == nil {
-				updated = next
-				changed = true
+	// For a rebuilt terminal item a status the item itself already settled on
+	// outranks anything derived from the response-level status, so an item that
+	// already completed is not downgraded when the response later fails. Only a
+	// settled status counts: the in_progress minted for output_item.added is
+	// provisional, and an item that never reached done must follow the response
+	// into completed or incomplete instead of staying in flight. A lifecycle
+	// event states its own phase and never takes a status back from the
+	// snapshot at all.
+	if restoreStatus {
+		if raw, ok := snapshot["status"]; ok && len(raw) > 0 && openAIWSStrictSnapshotStatusIsTerminal(raw) {
+			current := gjson.GetBytes(updated, path+".status")
+			if !current.Exists() || current.Type == gjson.Null {
+				next, err := sjson.SetRawBytes(updated, path+".status", raw)
+				if err == nil {
+					updated = next
+					changed = true
+				}
 			}
 		}
 	}
@@ -311,27 +484,6 @@ func normalizeOpenAIWSOutputTextPart(data []byte, path string) ([]byte, bool) {
 	return updated, changed
 }
 
-func (n *openAIWSStrictWireNormalizer) rememberSnapshot(index int, raw string) {
-	if n == nil || raw == "" {
-		return
-	}
-	n.snapshots[index] = json.RawMessage(append([]byte(nil), raw...))
-	if itemType := strings.TrimSpace(gjson.Get(raw, "type").String()); itemType != "" {
-		n.itemTypes[index] = itemType
-	}
-}
-
-// rememberedTypeMatches reports whether the state remembered for outputIndex
-// describes an item of the same type. An unknown or disagreeing type means the
-// remembered state belongs to a different item and must not be applied.
-func (n *openAIWSStrictWireNormalizer) rememberedTypeMatches(outputIndex int, itemType string) bool {
-	if n == nil || itemType == "" {
-		return false
-	}
-	remembered := strings.TrimSpace(n.itemTypes[outputIndex])
-	return remembered != "" && remembered == itemType
-}
-
 // openAIWSStrictItemStatusForResponseStatus maps a response-level status onto
 // a status the Responses protocol allows on an output item. Response terminal
 // states such as failed or cancelled have no item-level counterpart, so items
@@ -348,6 +500,22 @@ func openAIWSStrictItemStatusForResponseStatus(responseStatus string) string {
 		return "incomplete"
 	default:
 		return ""
+	}
+}
+
+// openAIWSStrictSnapshotStatusIsTerminal reports whether a remembered status is
+// one the item settled on, as opposed to the provisional in_progress that
+// output_item.added mints before the item has finished.
+func openAIWSStrictSnapshotStatusIsTerminal(raw json.RawMessage) bool {
+	var status string
+	if json.Unmarshal(raw, &status) != nil {
+		return false
+	}
+	switch strings.TrimSpace(status) {
+	case "completed", "incomplete":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -368,8 +536,18 @@ func openAIWSStrictItemIDPrefix(itemType string) (string, bool) {
 	}
 }
 
-func generateOpenAIWSStrictItemID(prefix string) string {
+// generateOpenAIWSStrictItemID mints an item id. A failing entropy source must
+// not silently yield an all-zero, repeatable id, so the error is returned and
+// the caller leaves the payload untouched rather than emitting a colliding id.
+//
+// On the current toolchain this error is unreachable: crypto/rand.Read is
+// documented never to return an error and crashes the process instead. The
+// error is still surfaced rather than discarded, so the guarantee lives in one
+// place if that contract or the package's Reader ever changes.
+func generateOpenAIWSStrictItemID(prefix string) (string, error) {
 	buf := make([]byte, 12)
-	_, _ = rand.Read(buf)
-	return prefix + "_" + hex.EncodeToString(buf)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate strict responses item id: %w", err)
+	}
+	return prefix + "_" + hex.EncodeToString(buf), nil
 }

--- a/backend/internal/service/openai_ws_strict_wire_test.go
+++ b/backend/internal/service/openai_ws_strict_wire_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIWSStrictWireNormalizerKeepsMessageLifecycleConsistent(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	added, changed := normalizer.normalize([]byte(`{
+		"type":"response.output_item.added",
+		"output_index":0,
+		"item":{"type":"message","role":"assistant","phase":"final_answer","content":[]}
+	}`))
+	require.True(t, changed)
+	messageID := gjson.GetBytes(added, "item.id").String()
+	require.True(t, strings.HasPrefix(messageID, "msg_"))
+	require.Equal(t, "in_progress", gjson.GetBytes(added, "item.status").String())
+
+	done, changed := normalizer.normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":0,
+		"item":{"type":"message","status":"completed","phase":"final_answer","role":"assistant","content":[{"type":"output_text","text":"MATRIX_TEXT_OK","annotations":[],"logprobs":[]}]}
+	}`))
+	require.True(t, changed)
+	require.Equal(t, messageID, gjson.GetBytes(done, "item.id").String())
+
+	completed, changed := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"MATRIX_TEXT_OK"}],"vendor_extension":{"keep":true}}]}
+	}`))
+	require.True(t, changed)
+	require.Equal(t, messageID, gjson.GetBytes(completed, "response.output.0.id").String())
+	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String())
+	require.Equal(t, "final_answer", gjson.GetBytes(completed, "response.output.0.phase").String())
+	require.Equal(t, "MATRIX_TEXT_OK", gjson.GetBytes(completed, "response.output.0.content.0.text").String())
+	require.True(t, gjson.GetBytes(completed, "response.output.0.content.0.annotations").IsArray())
+	require.True(t, gjson.GetBytes(completed, "response.output.0.content.0.logprobs").IsArray())
+	require.True(t, gjson.GetBytes(completed, "response.output.0.vendor_extension.keep").Bool())
+}
+
+func TestOpenAIWSStrictWireNormalizerRepairsFunctionCallTerminalItem(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	done, changed := normalizer.normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":0,
+		"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"lookup_order_status","arguments":"{}"}
+	}`))
+	require.False(t, changed, "a complete item needs no repair")
+	require.Equal(t, "fc_1", gjson.GetBytes(done, "item.id").String())
+
+	completed, changed := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"lookup_order_status","arguments":"{}"}]}
+	}`))
+	require.True(t, changed)
+	require.Equal(t, "fc_1", gjson.GetBytes(completed, "response.output.0.id").String())
+	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String())
+	require.Equal(t, "lookup_order_status", gjson.GetBytes(completed, "response.output.0.name").String())
+}
+
+func TestOpenAIWSStrictWireNormalizerDoesNotTouchUnrelatedEvents(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+	raw := []byte(`{"type":"response.output_text.delta","output_index":0,"delta":"hello"}`)
+	got, changed := normalizer.normalize(raw)
+	require.False(t, changed)
+	require.Equal(t, string(raw), string(got))
+}
+
+func TestOpenAIWSStrictWireNormalizerMapsTerminalResponseStatusToItemStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		eventType      string
+		responseStatus string
+		wantStatus     string
+	}{
+		{name: "failed", eventType: "response.failed", responseStatus: "failed", wantStatus: "incomplete"},
+		{name: "cancelled", eventType: "response.cancelled", responseStatus: "cancelled", wantStatus: "incomplete"},
+		{name: "incomplete", eventType: "response.incomplete", responseStatus: "incomplete", wantStatus: "incomplete"},
+		{name: "completed", eventType: "response.completed", responseStatus: "completed", wantStatus: "completed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			normalizer := newOpenAIWSStrictWireNormalizer()
+			event := []byte(`{
+				"type":"` + tc.eventType + `",
+				"response":{"status":"` + tc.responseStatus + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial"}]}]}
+			}`)
+			normalized, changed := normalizer.normalize(event)
+			require.True(t, changed)
+			require.Equal(t, tc.wantStatus, gjson.GetBytes(normalized, "response.output.0.status").String())
+		})
+	}
+}
+
+func TestOpenAIWSStrictWireNormalizerKeepsFinishedItemStatusOnFailedResponse(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	_, changed := normalizer.normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":0,
+		"item":{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"done","annotations":[],"logprobs":[]}]}
+	}`))
+	require.False(t, changed, "a complete item needs no repair")
+
+	failed, changed := normalizer.normalize([]byte(`{
+		"type":"response.failed",
+		"response":{"status":"failed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}
+	}`))
+	require.True(t, changed)
+	require.Equal(t, "msg_1", gjson.GetBytes(failed, "response.output.0.id").String())
+	require.Equal(t, "completed", gjson.GetBytes(failed, "response.output.0.status").String(),
+		"an item that already reported completed must not be downgraded by the response status")
+}
+
+func TestOpenAIWSStrictWireNormalizerLeavesUnknownResponseStatusAlone(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	normalized, _ := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"some_vendor_state","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}
+	}`))
+	require.False(t, gjson.GetBytes(normalized, "response.output.0.status").Exists(),
+		"an unmappable response status must not be copied onto the item")
+}

--- a/backend/internal/service/openai_ws_strict_wire_test.go
+++ b/backend/internal/service/openai_ws_strict_wire_test.go
@@ -11,28 +11,31 @@ import (
 func TestOpenAIWSStrictWireNormalizerKeepsMessageLifecycleConsistent(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 
-	added, changed := normalizer.normalize([]byte(`{
+	added, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.output_item.added",
 		"output_index":0,
 		"item":{"type":"message","role":"assistant","phase":"final_answer","content":[]}
 	}`))
+	require.NoError(t, err)
 	require.True(t, changed)
 	messageID := gjson.GetBytes(added, "item.id").String()
 	require.True(t, strings.HasPrefix(messageID, "msg_"))
 	require.Equal(t, "in_progress", gjson.GetBytes(added, "item.status").String())
 
-	done, changed := normalizer.normalize([]byte(`{
+	done, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.output_item.done",
 		"output_index":0,
 		"item":{"type":"message","status":"completed","phase":"final_answer","role":"assistant","content":[{"type":"output_text","text":"MATRIX_TEXT_OK","annotations":[],"logprobs":[]}]}
 	}`))
+	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, messageID, gjson.GetBytes(done, "item.id").String())
 
-	completed, changed := normalizer.normalize([]byte(`{
+	completed, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.completed",
 		"response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"MATRIX_TEXT_OK"}],"vendor_extension":{"keep":true}}]}
 	}`))
+	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, messageID, gjson.GetBytes(completed, "response.output.0.id").String())
 	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String())
@@ -46,18 +49,20 @@ func TestOpenAIWSStrictWireNormalizerKeepsMessageLifecycleConsistent(t *testing.
 func TestOpenAIWSStrictWireNormalizerRepairsFunctionCallTerminalItem(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 
-	done, changed := normalizer.normalize([]byte(`{
+	done, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.output_item.done",
 		"output_index":0,
 		"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"lookup_order_status","arguments":"{}"}
 	}`))
+	require.NoError(t, err)
 	require.False(t, changed, "a complete item needs no repair")
 	require.Equal(t, "fc_1", gjson.GetBytes(done, "item.id").String())
 
-	completed, changed := normalizer.normalize([]byte(`{
+	completed, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.completed",
 		"response":{"status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"lookup_order_status","arguments":"{}"}]}
 	}`))
+	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, "fc_1", gjson.GetBytes(completed, "response.output.0.id").String())
 	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String())
@@ -67,7 +72,8 @@ func TestOpenAIWSStrictWireNormalizerRepairsFunctionCallTerminalItem(t *testing.
 func TestOpenAIWSStrictWireNormalizerDoesNotTouchUnrelatedEvents(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 	raw := []byte(`{"type":"response.output_text.delta","output_index":0,"delta":"hello"}`)
-	got, changed := normalizer.normalize(raw)
+	got, changed, err := normalizer.normalize(raw)
+	require.NoError(t, err)
 	require.False(t, changed)
 	require.Equal(t, string(raw), string(got))
 }
@@ -90,7 +96,8 @@ func TestOpenAIWSStrictWireNormalizerMapsTerminalResponseStatusToItemStatus(t *t
 				"type":"` + tc.eventType + `",
 				"response":{"status":"` + tc.responseStatus + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial"}]}]}
 			}`)
-			normalized, changed := normalizer.normalize(event)
+			normalized, changed, err := normalizer.normalize(event)
+			require.NoError(t, err)
 			require.True(t, changed)
 			require.Equal(t, tc.wantStatus, gjson.GetBytes(normalized, "response.output.0.status").String())
 		})
@@ -100,17 +107,19 @@ func TestOpenAIWSStrictWireNormalizerMapsTerminalResponseStatusToItemStatus(t *t
 func TestOpenAIWSStrictWireNormalizerKeepsFinishedItemStatusOnFailedResponse(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 
-	_, changed := normalizer.normalize([]byte(`{
+	_, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.output_item.done",
 		"output_index":0,
 		"item":{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"done","annotations":[],"logprobs":[]}]}
 	}`))
+	require.NoError(t, err)
 	require.False(t, changed, "a complete item needs no repair")
 
-	failed, changed := normalizer.normalize([]byte(`{
+	failed, changed, err := normalizer.normalize([]byte(`{
 		"type":"response.failed",
 		"response":{"status":"failed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}
 	}`))
+	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, "msg_1", gjson.GetBytes(failed, "response.output.0.id").String())
 	require.Equal(t, "completed", gjson.GetBytes(failed, "response.output.0.status").String(),
@@ -120,38 +129,41 @@ func TestOpenAIWSStrictWireNormalizerKeepsFinishedItemStatusOnFailedResponse(t *
 func TestOpenAIWSStrictWireNormalizerLeavesUnknownResponseStatusAlone(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 
-	normalized, _ := normalizer.normalize([]byte(`{
+	normalized, _, err := normalizer.normalize([]byte(`{
 		"type":"response.completed",
 		"response":{"status":"some_vendor_state","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}
 	}`))
+	require.NoError(t, err)
 	require.False(t, gjson.GetBytes(normalized, "response.output.0.status").Exists(),
 		"an unmappable response status must not be copied onto the item")
 }
 
-// A terminal rebuild can collapse several lifecycle items into a single output
-// entry, leaving array position 0 holding a different item than the one the
-// lifecycle events reported there. Remembered state must not leak across that
-// mismatch.
+// A terminal rebuild can drop items, so the array position of an item in
+// response.output need not be the output_index of the lifecycle events reported
+// there. Remembered state must not leak across that mismatch.
 func TestOpenAIWSStrictWireNormalizerDoesNotLeakStateAcrossItemTypes(t *testing.T) {
 	normalizer := newOpenAIWSStrictWireNormalizer()
 
-	_, _ = normalizer.normalize([]byte(`{
+	_, _, err := normalizer.normalize([]byte(`{
 		"type":"response.output_item.done",
 		"output_index":0,
 		"item":{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"thinking"}],"encrypted_content":"secret"}
 	}`))
-	_, _ = normalizer.normalize([]byte(`{
+	require.NoError(t, err)
+	_, _, err = normalizer.normalize([]byte(`{
 		"type":"response.output_item.done",
 		"output_index":1,
 		"item":{"id":"msg_1","type":"message","status":"completed","phase":"final_answer","role":"assistant","content":[{"type":"output_text","text":"hi","annotations":[],"logprobs":[]}]}
 	}`))
+	require.NoError(t, err)
 
 	// The terminal event kept only one message, now sitting at index 0 where
 	// the reasoning item used to be.
-	completed, _ := normalizer.normalize([]byte(`{
+	completed, _, err := normalizer.normalize([]byte(`{
 		"type":"response.completed",
 		"response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}
 	}`))
+	require.NoError(t, err)
 
 	terminal := gjson.GetBytes(completed, "response.output.0")
 	require.Equal(t, "message", terminal.Get("type").String())
@@ -162,5 +174,323 @@ func TestOpenAIWSStrictWireNormalizerDoesNotLeakStateAcrossItemTypes(t *testing.
 		"the reasoning item's summary must not leak onto a message")
 	require.False(t, terminal.Get("encrypted_content").Exists(),
 		"the reasoning item's encrypted_content must not leak onto a message")
-	require.Equal(t, "completed", terminal.Get("status").String())
+}
+
+// Two items of the same type may both appear in one turn. If the terminal
+// rebuild drops or reorders one of them the array position no longer identifies
+// which lifecycle item it came from, so nothing may be inherited on position
+// alone.
+func TestOpenAIWSStrictWireNormalizerDoesNotConfuseTwoFunctionCalls(t *testing.T) {
+	newTurn := func(t *testing.T) *openAIWSStrictWireNormalizer {
+		t.Helper()
+		normalizer := newOpenAIWSStrictWireNormalizer()
+		for _, event := range []string{
+			`{"type":"response.output_item.done","output_index":0,
+			  "item":{"id":"fc_first","type":"function_call","status":"completed","call_id":"call_first","name":"lookup_a","arguments":"{\"a\":1}"}}`,
+			`{"type":"response.output_item.done","output_index":1,
+			  "item":{"id":"fc_second","type":"function_call","status":"completed","call_id":"call_second","name":"lookup_b","arguments":"{\"b\":2}"}}`,
+		} {
+			_, _, err := normalizer.normalize([]byte(event))
+			require.NoError(t, err)
+		}
+		return normalizer
+	}
+
+	t.Run("call_id identifies the surviving item", func(t *testing.T) {
+		normalizer := newTurn(t)
+		// fc_first was dropped, so fc_second now sits at terminal index 0.
+		completed, _, err := normalizer.normalize([]byte(`{
+			"type":"response.completed",
+			"response":{"status":"completed","output":[{"type":"function_call","call_id":"call_second","name":"lookup_b","arguments":"{\"b\":2}"}]}
+		}`))
+		require.NoError(t, err)
+
+		terminal := gjson.GetBytes(completed, "response.output.0")
+		require.Equal(t, "fc_second", terminal.Get("id").String(),
+			"call_id must identify the item, not its position")
+		require.Equal(t, "lookup_b", terminal.Get("name").String())
+		require.Equal(t, `{"b":2}`, terminal.Get("arguments").String(),
+			"the other call's arguments must not be copied in")
+	})
+
+	t.Run("an unidentifiable item inherits nothing", func(t *testing.T) {
+		normalizer := newTurn(t)
+		// Neither id nor call_id survived, and two function_calls are
+		// remembered, so this item cannot be proven to be either of them.
+		completed, _, err := normalizer.normalize([]byte(`{
+			"type":"response.completed",
+			"response":{"status":"completed","output":[{"type":"function_call"}]}
+		}`))
+		require.NoError(t, err)
+
+		terminal := gjson.GetBytes(completed, "response.output.0")
+		require.True(t, strings.HasPrefix(terminal.Get("id").String(), "fc_"))
+		require.NotEqual(t, "fc_first", terminal.Get("id").String())
+		require.NotEqual(t, "fc_second", terminal.Get("id").String())
+		require.False(t, terminal.Get("call_id").Exists(),
+			"an unidentifiable item must not adopt another call's call_id")
+		require.False(t, terminal.Get("arguments").Exists(),
+			"an unidentifiable item must not adopt another call's arguments")
+		require.False(t, terminal.Get("name").Exists())
+	})
+}
+
+// Reasoning items carry encrypted_content and summary, which must never be
+// attributed to a different reasoning item.
+func TestOpenAIWSStrictWireNormalizerDoesNotConfuseTwoReasoningItems(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+	for _, event := range []string{
+		`{"type":"response.output_item.done","output_index":0,
+		  "item":{"id":"rs_first","type":"reasoning","summary":[{"type":"summary_text","text":"first"}],"encrypted_content":"secret_first"}}`,
+		`{"type":"response.output_item.done","output_index":1,
+		  "item":{"id":"rs_second","type":"reasoning","summary":[{"type":"summary_text","text":"second"}],"encrypted_content":"secret_second"}}`,
+	} {
+		_, _, err := normalizer.normalize([]byte(event))
+		require.NoError(t, err)
+	}
+
+	// The terminal list reordered the two reasoning items; position 0 now holds
+	// the item that was reported at index 1.
+	completed, _, err := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"id":"rs_second","type":"reasoning"},{"type":"reasoning"}]}
+	}`))
+	require.NoError(t, err)
+
+	first := gjson.GetBytes(completed, "response.output.0")
+	require.Equal(t, "rs_second", first.Get("id").String())
+	require.Equal(t, "secret_second", first.Get("encrypted_content").String(),
+		"an id-identified item must inherit its own encrypted_content")
+	require.Equal(t, "second", first.Get("summary.0.text").String())
+
+	second := gjson.GetBytes(completed, "response.output.1")
+	require.True(t, strings.HasPrefix(second.Get("id").String(), "rs_"))
+	require.NotEqual(t, "rs_first", second.Get("id").String())
+	require.NotEqual(t, "rs_second", second.Get("id").String())
+	require.False(t, second.Get("encrypted_content").Exists(),
+		"an unidentifiable reasoning item must not adopt another item's encrypted_content")
+	require.False(t, second.Get("summary").Exists(),
+		"an unidentifiable reasoning item must not adopt another item's summary")
+}
+
+// A passthrough WebSocket connection serves several turns. State remembered for
+// one turn must not be visible to the next, even when the upstream reuses the
+// same output_index and item type.
+func TestOpenAIWSStrictWireNormalizerDoesNotInheritAcrossTurns(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	runTurn := func(t *testing.T, text string) string {
+		t.Helper()
+		added, _, err := normalizer.normalize([]byte(`{
+			"type":"response.output_item.added",
+			"output_index":0,
+			"item":{"type":"message","role":"assistant","phase":"final_answer","content":[]}
+		}`))
+		require.NoError(t, err)
+		messageID := gjson.GetBytes(added, "item.id").String()
+		require.True(t, strings.HasPrefix(messageID, "msg_"))
+
+		_, _, err = normalizer.normalize([]byte(`{
+			"type":"response.output_item.done",
+			"output_index":0,
+			"item":{"type":"message","status":"completed","phase":"final_answer","role":"assistant","content":[{"type":"output_text","text":"` + text + `","annotations":[],"logprobs":[]}]}
+		}`))
+		require.NoError(t, err)
+
+		completed, _, err := normalizer.normalize([]byte(`{
+			"type":"response.completed",
+			"response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"` + text + `"}]}]}
+		}`))
+		require.NoError(t, err)
+		require.Equal(t, messageID, gjson.GetBytes(completed, "response.output.0.id").String())
+		require.Equal(t, text, gjson.GetBytes(completed, "response.output.0.content.0.text").String())
+		return messageID
+	}
+
+	firstID := runTurn(t, "TURN_ONE")
+
+	// The relay resets the normalizer once a turn's terminal frame has been
+	// written to the client.
+	normalizer.reset()
+
+	secondID := runTurn(t, "TURN_TWO")
+
+	require.NotEqual(t, firstID, secondID,
+		"turn 2 must mint its own item id instead of reusing turn 1's")
+}
+
+// Without the per-turn reset the second turn would silently adopt the first
+// turn's item id at the same output_index.
+func TestOpenAIWSStrictWireNormalizerResetClearsRememberedItems(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	added, _, err := normalizer.normalize([]byte(`{
+		"type":"response.output_item.added",
+		"output_index":0,
+		"item":{"type":"message","role":"assistant","content":[]}
+	}`))
+	require.NoError(t, err)
+	firstID := gjson.GetBytes(added, "item.id").String()
+	require.NotEmpty(t, normalizer.items)
+	require.NotEmpty(t, normalizer.indexIDs)
+
+	normalizer.reset()
+	require.Empty(t, normalizer.items)
+	require.Empty(t, normalizer.indexIDs)
+
+	completed, _, err := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}
+	}`))
+	require.NoError(t, err)
+	require.NotEqual(t, firstID, gjson.GetBytes(completed, "response.output.0.id").String(),
+		"a reset normalizer must not hand out the previous turn's id")
+}
+
+func TestGenerateOpenAIWSStrictItemIDIsUnique(t *testing.T) {
+	seen := make(map[string]struct{}, 128)
+	for i := 0; i < 128; i++ {
+		id, err := generateOpenAIWSStrictItemID("msg")
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(id, "msg_"))
+		require.NotContains(t, seen, id)
+		seen[id] = struct{}{}
+	}
+}
+
+// An output_item.added that mints in_progress must not pin the item there: the
+// done event and the rebuilt terminal item state their own phase.
+func TestOpenAIWSStrictWireNormalizerLifecycleStatusOutranksSnapshot(t *testing.T) {
+	n := newOpenAIWSStrictWireNormalizer()
+	_, _, err := n.normalize([]byte(`{"type":"response.output_item.added","output_index":0,
+		"item":{"type":"message","role":"assistant","content":[]}}`))
+	require.NoError(t, err)
+	done, _, err := n.normalize([]byte(`{"type":"response.output_item.done","output_index":0,
+		"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}`))
+	require.NoError(t, err)
+	require.Equal(t, "completed", gjson.GetBytes(done, "item.status").String(), "done must be completed")
+
+	completed, _, err := n.normalize([]byte(`{"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}}`))
+	require.NoError(t, err)
+	require.Equal(t, "completed", gjson.GetBytes(completed, "response.output.0.status").String(), "terminal must be completed")
+}
+
+// One remembered item may only be claimed by one terminal item. Two same-type
+// items that both lack an id and a call_id are indistinguishable, so neither
+// may take the memory and both must mint their own id.
+func TestOpenAIWSStrictWireNormalizerDoesNotHandOneMemoryToTwoItems(t *testing.T) {
+	n := newOpenAIWSStrictWireNormalizer()
+	_, _, err := n.normalize([]byte(`{"type":"response.output_item.done","output_index":0,
+		"item":{"id":"fc_only","type":"function_call","status":"completed","call_id":"call_only","name":"lookup","arguments":"{\"a\":1}"}}`))
+	require.NoError(t, err)
+
+	completed, _, err := n.normalize([]byte(`{"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"function_call"},{"type":"function_call"}]}}`))
+	require.NoError(t, err)
+	id0 := gjson.GetBytes(completed, "response.output.0.id").String()
+	id1 := gjson.GetBytes(completed, "response.output.1.id").String()
+	require.NotEqual(t, id0, id1, "two terminal items must not share one id")
+}
+
+// An upstream may only reveal call_id on done, after added already minted an id
+// without one. The trusted output_index must still keep that id stable.
+func TestOpenAIWSStrictWireNormalizerKeepsIDWhenCallIDArrivesLate(t *testing.T) {
+	n := newOpenAIWSStrictWireNormalizer()
+	added, _, err := n.normalize([]byte(`{"type":"response.output_item.added","output_index":0,
+		"item":{"type":"function_call","name":"lookup"}}`))
+	require.NoError(t, err)
+	addedID := gjson.GetBytes(added, "item.id").String()
+
+	done, _, err := n.normalize([]byte(`{"type":"response.output_item.done","output_index":0,
+		"item":{"type":"function_call","status":"completed","call_id":"call_1","name":"lookup","arguments":"{}"}}`))
+	require.NoError(t, err)
+	require.Equal(t, addedID, gjson.GetBytes(done, "item.id").String(), "added/done at one index must share an id")
+}
+
+// A response can settle while an item is still in flight, with no
+// output_item.done ever reported for it. The provisional in_progress minted by
+// output_item.added must not pin the item there: it has to follow the response
+// into a settled status.
+func TestOpenAIWSStrictWireNormalizerAdvancesItemsThatNeverReachedDone(t *testing.T) {
+	for _, tc := range []struct {
+		eventType      string
+		responseStatus string
+		wantStatus     string
+	}{
+		{eventType: "response.completed", responseStatus: "completed", wantStatus: "completed"},
+		{eventType: "response.failed", responseStatus: "failed", wantStatus: "incomplete"},
+		{eventType: "response.incomplete", responseStatus: "incomplete", wantStatus: "incomplete"},
+		{eventType: "response.cancelled", responseStatus: "cancelled", wantStatus: "incomplete"},
+	} {
+		t.Run(tc.responseStatus, func(t *testing.T) {
+			normalizer := newOpenAIWSStrictWireNormalizer()
+			_, _, err := normalizer.normalize([]byte(`{
+				"type":"response.output_item.added",
+				"output_index":0,
+				"item":{"type":"message","role":"assistant","content":[]}
+			}`))
+			require.NoError(t, err)
+
+			// No output_item.done for this item; the response settles first.
+			terminal, _, err := normalizer.normalize([]byte(`{
+				"type":"` + tc.eventType + `",
+				"response":{"status":"` + tc.responseStatus + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial"}]}]}
+			}`))
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStatus, gjson.GetBytes(terminal, "response.output.0.status").String(),
+				"a provisional in_progress must not survive the response settling")
+		})
+	}
+}
+
+// A memory named outright by one item belongs to that item. An anonymous item
+// of the same type must not take it just because it was listed first, which
+// would hand both items the same id.
+func TestOpenAIWSStrictWireNormalizerReservesExplicitlyNamedMemories(t *testing.T) {
+	run := func(t *testing.T, output string) (gjson.Result, gjson.Result) {
+		t.Helper()
+		normalizer := newOpenAIWSStrictWireNormalizer()
+		_, _, err := normalizer.normalize([]byte(`{
+			"type":"response.output_item.done",
+			"output_index":0,
+			"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"lookup","arguments":"{\"a\":1}"}
+		}`))
+		require.NoError(t, err)
+
+		completed, _, err := normalizer.normalize([]byte(`{
+			"type":"response.completed",
+			"response":{"status":"completed","output":` + output + `}
+		}`))
+		require.NoError(t, err)
+		return gjson.GetBytes(completed, "response.output.0"), gjson.GetBytes(completed, "response.output.1")
+	}
+
+	assertDistinct := func(t *testing.T, anonymous, named gjson.Result) {
+		t.Helper()
+		require.Equal(t, "fc_1", named.Get("id").String())
+		require.NotEqual(t, "fc_1", anonymous.Get("id").String(),
+			"the anonymous item must not claim a memory an explicit id names")
+		require.True(t, strings.HasPrefix(anonymous.Get("id").String(), "fc_"))
+		require.False(t, anonymous.Get("call_id").Exists())
+		require.False(t, anonymous.Get("arguments").Exists())
+		require.False(t, anonymous.Get("name").Exists())
+	}
+
+	t.Run("anonymous item listed first", func(t *testing.T) {
+		anonymous, named := run(t, `[{"type":"function_call"},{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"a\":1}"}]`)
+		assertDistinct(t, anonymous, named)
+	})
+
+	t.Run("anonymous item listed last", func(t *testing.T) {
+		named, anonymous := run(t, `[{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"a\":1}"},{"type":"function_call"}]`)
+		assertDistinct(t, anonymous, named)
+	})
+
+	t.Run("memory named by call_id alone is still reserved", func(t *testing.T) {
+		anonymous, named := run(t, `[{"type":"function_call"},{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"a\":1}"}]`)
+		require.Equal(t, "fc_1", named.Get("id").String())
+		require.NotEqual(t, "fc_1", anonymous.Get("id").String())
+		require.False(t, anonymous.Get("call_id").Exists())
+	})
 }

--- a/backend/internal/service/openai_ws_strict_wire_test.go
+++ b/backend/internal/service/openai_ws_strict_wire_test.go
@@ -127,3 +127,40 @@ func TestOpenAIWSStrictWireNormalizerLeavesUnknownResponseStatusAlone(t *testing
 	require.False(t, gjson.GetBytes(normalized, "response.output.0.status").Exists(),
 		"an unmappable response status must not be copied onto the item")
 }
+
+// A terminal rebuild can collapse several lifecycle items into a single output
+// entry, leaving array position 0 holding a different item than the one the
+// lifecycle events reported there. Remembered state must not leak across that
+// mismatch.
+func TestOpenAIWSStrictWireNormalizerDoesNotLeakStateAcrossItemTypes(t *testing.T) {
+	normalizer := newOpenAIWSStrictWireNormalizer()
+
+	_, _ = normalizer.normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":0,
+		"item":{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"thinking"}],"encrypted_content":"secret"}
+	}`))
+	_, _ = normalizer.normalize([]byte(`{
+		"type":"response.output_item.done",
+		"output_index":1,
+		"item":{"id":"msg_1","type":"message","status":"completed","phase":"final_answer","role":"assistant","content":[{"type":"output_text","text":"hi","annotations":[],"logprobs":[]}]}
+	}`))
+
+	// The terminal event kept only one message, now sitting at index 0 where
+	// the reasoning item used to be.
+	completed, _ := normalizer.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}
+	}`))
+
+	terminal := gjson.GetBytes(completed, "response.output.0")
+	require.Equal(t, "message", terminal.Get("type").String())
+	require.NotEqual(t, "rs_1", terminal.Get("id").String(),
+		"a message must not inherit the reasoning item's id")
+	require.True(t, strings.HasPrefix(terminal.Get("id").String(), "msg_"))
+	require.False(t, terminal.Get("summary").Exists(),
+		"the reasoning item's summary must not leak onto a message")
+	require.False(t, terminal.Get("encrypted_content").Exists(),
+		"the reasoning item's encrypted_content must not leak onto a message")
+	require.Equal(t, "completed", terminal.Get("status").String())
+}

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -29,9 +29,13 @@ type openAIWSClientFrameConn struct {
 	// model identifier they supplied for the current turn.
 	restoreResponseModel func([]byte) []byte
 	restoreToolNames     func([]byte) []byte
-	// strictWire carries per-turn output-item state. WriteFrame is the only
-	// method that touches it, and the passthrough relay drives WriteFrame from
-	// the single runUpstreamToClient goroutine, so it needs no locking.
+	// strictWire carries output-item state for the turn currently being
+	// relayed. It is touched only by WriteFrame and by markTurnCompleted, both
+	// of which the passthrough relay drives from the single
+	// runUpstreamToClient goroutine (WriteFrame via writeClient,
+	// markTurnCompleted via the AfterClientWrite hook), so it needs no locking.
+	// markTurnStarted deliberately does not touch it: that runs on the
+	// client-to-upstream goroutine and would race with the writer.
 	strictWire *openAIWSStrictWireNormalizer
 }
 
@@ -621,6 +625,12 @@ func (c *openAIWSClientFrameConn) markTurnCompleted() {
 	if c == nil {
 		return
 	}
+	// A passthrough connection serves many turns. The terminal frame for this
+	// turn has now reached the client, and the next response.create has not
+	// been accepted yet, so this is the point where the remembered output
+	// items must be dropped. Without it turn N+1 would inherit turn N's item
+	// ids and content whenever the upstream reuses an output_index.
+	c.strictWire.reset()
 	c.waitingForNextTurn.Store(true)
 	select {
 	case c.interTurnStarted <- struct{}{}:
@@ -639,7 +649,9 @@ func (c *openAIWSClientFrameConn) WriteFrame(ctx context.Context, msgType coderw
 		if normalized, changed := normalizeCompletedImageGenerationStatus(payload); changed {
 			payload = normalized
 		}
-		if normalized, changed := c.strictWire.normalize(payload); changed {
+		if normalized, changed, err := c.strictWire.normalize(payload); err != nil {
+			logOpenAIWSModeInfo("strict_wire_normalize_failed path=passthrough err=%v", err)
+		} else if changed {
 			payload = normalized
 		}
 		if c.restoreResponseModel != nil {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -29,6 +29,10 @@ type openAIWSClientFrameConn struct {
 	// model identifier they supplied for the current turn.
 	restoreResponseModel func([]byte) []byte
 	restoreToolNames     func([]byte) []byte
+	// strictWire carries per-turn output-item state. WriteFrame is the only
+	// method that touches it, and the passthrough relay drives WriteFrame from
+	// the single runUpstreamToClient goroutine, so it needs no locking.
+	strictWire *openAIWSStrictWireNormalizer
 }
 
 // openAIWSPolicyEnforcingFrameConn wraps a client-side FrameConn and runs
@@ -635,6 +639,9 @@ func (c *openAIWSClientFrameConn) WriteFrame(ctx context.Context, msgType coderw
 		if normalized, changed := normalizeCompletedImageGenerationStatus(payload); changed {
 			payload = normalized
 		}
+		if normalized, changed := c.strictWire.normalize(payload); changed {
+			payload = normalized
+		}
 		if c.restoreResponseModel != nil {
 			payload = c.restoreResponseModel(payload)
 		}
@@ -940,6 +947,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		controlCtx:           ctx,
 		interTurnIdleTimeout: s.openAIWSIngressInterTurnIdleTimeout(),
 		interTurnStarted:     make(chan struct{}, 1),
+		strictWire:           newOpenAIWSStrictWireNormalizer(),
 		restoreResponseModel: func(payload []byte) []byte {
 			eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
 			if !openAIWSEventMayContainModel(eventType) {

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -589,3 +589,49 @@ func TestPassthroughLifecycle_SecondTurnTimeoutIsNotFailoverSafe(t *testing.T) {
 		t.Fatal("second turn first semantic output was left unbounded")
 	}
 }
+
+// A passthrough connection reuses one normalizer for every turn, so the relay
+// must clear it once a turn's terminal frame has reached the client. Otherwise
+// turn N+1 inherits turn N's item ids whenever the upstream reuses an
+// output_index and item type.
+func TestOpenAIWSPassthroughMarkTurnCompletedResetsStrictWire(t *testing.T) {
+	clientFrameConn := &openAIWSClientFrameConn{
+		interTurnStarted: make(chan struct{}, 1),
+		strictWire:       newOpenAIWSStrictWireNormalizer(),
+	}
+
+	added, _, err := clientFrameConn.strictWire.normalize([]byte(`{
+		"type":"response.output_item.added",
+		"output_index":0,
+		"item":{"type":"message","role":"assistant","phase":"final_answer","content":[]}
+	}`))
+	require.NoError(t, err)
+	turnOneID := gjson.GetBytes(added, "item.id").String()
+	require.True(t, strings.HasPrefix(turnOneID, "msg_"))
+	require.NotEmpty(t, clientFrameConn.strictWire.items)
+
+	clientFrameConn.markTurnCompleted()
+	require.Empty(t, clientFrameConn.strictWire.items,
+		"the terminal frame has been written, so this turn's items must be forgotten")
+	require.Empty(t, clientFrameConn.strictWire.indexIDs)
+
+	// Turn 2 reuses output_index 0 with the same item type and again omits the
+	// id, which is exactly the upstream shape this normalizer repairs.
+	completed, _, err := clientFrameConn.strictWire.normalize([]byte(`{
+		"type":"response.completed",
+		"response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"turn two"}]}]}
+	}`))
+	require.NoError(t, err)
+	terminal := gjson.GetBytes(completed, "response.output.0")
+	require.NotEqual(t, turnOneID, terminal.Get("id").String(),
+		"turn 2 must mint its own item id instead of reusing turn 1's")
+	require.False(t, terminal.Get("phase").Exists(),
+		"turn 1's phase must not carry into turn 2")
+}
+
+// markTurnCompleted must stay safe on a connection that never received a
+// normalizer, which is how several lifecycle tests construct it.
+func TestOpenAIWSPassthroughMarkTurnCompletedHandlesNilStrictWire(t *testing.T) {
+	clientFrameConn := &openAIWSClientFrameConn{interTurnStarted: make(chan struct{}, 1)}
+	require.NotPanics(t, clientFrameConn.markTurnCompleted)
+}


### PR DESCRIPTION
Fixes WebSocket Responses streaming events that omit strict fields from response.completed output items.\n\nThis restores stable item IDs and statuses, carries lifecycle fields from response.output_item.done into response.completed, and ensures message content parts include annotations and logprobs arrays.\n\nThis complements #5270 by covering the WebSocket forwarder, ingress, and HTTP bridge paths. Related to #5140.