### PR TITLE
fix: cover Responses moderation input extraction

### DIFF
--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -324,6 +324,12 @@ type ContentModerationCheckInput struct {
 type ContentModerationInput struct {
 	Text   string
 	Images []string
+
+	classification string
+	inputShape     string
+	tailItemKind   string
+	itemCount      int
+	failClosed     bool
 }
 
 func (in *ContentModerationInput) Normalize() {
@@ -336,6 +342,17 @@ func (in *ContentModerationInput) Normalize() {
 
 func (in ContentModerationInput) IsEmpty() bool {
 	return strings.TrimSpace(in.Text) == "" && len(in.Images) == 0
+}
+
+func (in ContentModerationInput) Classification() string {
+	if in.classification != "" {
+		return in.classification
+	}
+	return classifyExtractedModerationInput(in)
+}
+
+func (in ContentModerationInput) MustFailClosed() bool {
+	return in.failClosed
 }
 
 func (in ContentModerationInput) ModerationInput() any {
@@ -910,23 +927,59 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 		return allow, nil
 	}
 	content := ExtractContentModerationInput(input.Protocol, input.Body)
-	if content.IsEmpty() {
-		slog.Info("content_moderation.skip_empty_input",
+	if content.MustFailClosed() {
+		slog.Warn("content_moderation.fail_closed_unreviewable_input",
+			"request_id", input.RequestID,
 			"user_id", input.UserID,
 			"api_key_id", input.APIKeyID,
 			"group_id", contentModerationLogGroupID(input.GroupID),
 			"endpoint", input.Endpoint,
 			"protocol", input.Protocol,
+			"classification", content.Classification(),
+			"input_shape", content.inputShape,
+			"tail_item_kind", content.tailItemKind,
+			"input_item_count", content.itemCount,
+			"body_bytes", len(input.Body),
+			"mode", cfg.Mode)
+		if cfg.Mode == ContentModerationModePreBlock {
+			s.recordPreBlockSyncMetric(0, ContentModerationActionError)
+			return &ContentModerationDecision{
+				Allowed:    false,
+				Blocked:    true,
+				Message:    cfg.BlockMessage,
+				StatusCode: cfg.BlockStatus,
+				Action:     ContentModerationActionError,
+			}, nil
+		}
+		return allow, nil
+	}
+	if content.IsEmpty() {
+		slog.Info("content_moderation.skip_empty_input",
+			"request_id", input.RequestID,
+			"user_id", input.UserID,
+			"api_key_id", input.APIKeyID,
+			"group_id", contentModerationLogGroupID(input.GroupID),
+			"endpoint", input.Endpoint,
+			"protocol", input.Protocol,
+			"classification", content.Classification(),
+			"input_shape", content.inputShape,
+			"tail_item_kind", content.tailItemKind,
+			"input_item_count", content.itemCount,
 			"body_bytes", len(input.Body))
 		return allow, nil
 	}
 	content.Normalize()
 	slog.Info("content_moderation.input_extracted",
+		"request_id", input.RequestID,
 		"user_id", input.UserID,
 		"api_key_id", input.APIKeyID,
 		"group_id", contentModerationLogGroupID(input.GroupID),
 		"endpoint", input.Endpoint,
 		"protocol", input.Protocol,
+		"classification", content.Classification(),
+		"input_shape", content.inputShape,
+		"tail_item_kind", content.tailItemKind,
+		"input_item_count", content.itemCount,
 		"text_runes", len([]rune(content.Text)),
 		"image_count", len(content.Images))
 	hashText := content.Hash()

--- a/backend/internal/service/content_moderation_input.go
+++ b/backend/internal/service/content_moderation_input.go
@@ -9,23 +9,56 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const (
+	contentModerationInputClassText                = "user_text"
+	contentModerationInputClassImage               = "user_image"
+	contentModerationInputClassTextImage           = "user_text_image"
+	contentModerationInputClassToolContinuation    = "tool_continuation"
+	contentModerationInputClassNonUserContinuation = "non_user_continuation"
+	contentModerationInputClassEmpty               = "empty"
+	contentModerationInputClassInvalidJSON         = "invalid_json"
+	contentModerationInputClassUnsupported         = "unsupported_nonempty"
+
+	contentModerationInputShapeMissing = "missing"
+	contentModerationInputShapeString  = "string"
+	contentModerationInputShapeObject  = "object"
+	contentModerationInputShapeArray   = "array"
+	contentModerationInputShapeOther   = "other"
+
+	responsesItemKindNone       = "none"
+	responsesItemKindUser       = "user"
+	responsesItemKindAssistant  = "assistant"
+	responsesItemKindToolCall   = "tool_call"
+	responsesItemKindToolOutput = "tool_output"
+	responsesItemKindReasoning  = "reasoning"
+	responsesItemKindOther      = "other"
+)
+
 func ExtractContentModerationText(protocol string, body []byte) string {
 	return ExtractContentModerationInput(protocol, body).Text
 }
 
 func ExtractContentModerationInput(protocol string, body []byte) ContentModerationInput {
-	if len(body) == 0 || !gjson.ValidBytes(body) {
-		return ContentModerationInput{}
+	if len(body) == 0 {
+		return newContentModerationInput(nil, nil, contentModerationInputClassEmpty, contentModerationInputShapeMissing, responsesItemKindNone, 0, false)
+	}
+	if !gjson.ValidBytes(body) {
+		return newContentModerationInput(nil, nil, contentModerationInputClassInvalidJSON, contentModerationInputShapeOther, responsesItemKindOther, 0, protocol == ContentModerationProtocolOpenAIResponses)
 	}
 	var parts []string
 	var images []string
+	classification := ""
+	inputShape := contentModerationInputShapeMissing
+	tailItemKind := responsesItemKindNone
+	itemCount := 0
+	failClosed := false
 	switch protocol {
 	case ContentModerationProtocolAnthropicMessages:
 		collectLastAnthropicUserMessage(gjson.GetBytes(body, "messages"), &parts, &images)
 	case ContentModerationProtocolOpenAIChat:
 		collectLastRoleMessage(gjson.GetBytes(body, "messages"), "user", &parts, &images)
 	case ContentModerationProtocolOpenAIResponses:
-		collectLastResponsesInput(gjson.GetBytes(body, "input"), &parts, &images)
+		return extractResponsesContentModerationInput(gjson.GetBytes(body, "input"))
 	case ContentModerationProtocolGemini:
 		collectLastGeminiContent(gjson.GetBytes(body, "contents"), &parts, &images)
 	case ContentModerationProtocolOpenAIImages:
@@ -36,12 +69,39 @@ func ExtractContentModerationInput(protocol string, body []byte) ContentModerati
 		collectLastRoleMessage(gjson.GetBytes(body, "messages"), "user", &parts, &images)
 		collectLastGeminiContent(gjson.GetBytes(body, "contents"), &parts, &images)
 	}
+	return newContentModerationInput(parts, images, classification, inputShape, tailItemKind, itemCount, failClosed)
+}
+
+func newContentModerationInput(parts []string, images []string, classification string, inputShape string, tailItemKind string, itemCount int, failClosed bool) ContentModerationInput {
 	out := ContentModerationInput{
-		Text:   normalizeContentModerationText(strings.Join(parts, "\n")),
-		Images: normalizeModerationImages(images),
+		Text:           normalizeContentModerationText(strings.Join(parts, "\n")),
+		Images:         normalizeModerationImages(images),
+		classification: classification,
+		inputShape:     inputShape,
+		tailItemKind:   tailItemKind,
+		itemCount:      itemCount,
+		failClosed:     failClosed,
 	}
 	out.Normalize()
+	if out.classification == "" {
+		out.classification = classifyExtractedModerationInput(out)
+	}
 	return out
+}
+
+func classifyExtractedModerationInput(input ContentModerationInput) string {
+	hasText := strings.TrimSpace(input.Text) != ""
+	hasImages := len(input.Images) > 0
+	switch {
+	case hasText && hasImages:
+		return contentModerationInputClassTextImage
+	case hasText:
+		return contentModerationInputClassText
+	case hasImages:
+		return contentModerationInputClassImage
+	default:
+		return contentModerationInputClassEmpty
+	}
 }
 
 func collectLastRoleMessage(messages gjson.Result, role string, parts *[]string, images *[]string) {
@@ -121,54 +181,144 @@ func isAnthropicSystemReminderText(text string) bool {
 	return strings.HasPrefix(strings.TrimSpace(text), "<system-reminder>")
 }
 
-func collectLastResponsesInput(input gjson.Result, parts *[]string, images *[]string) {
+func extractResponsesContentModerationInput(input gjson.Result) ContentModerationInput {
 	switch {
 	case !input.Exists():
-		return
+		return newContentModerationInput(nil, nil, contentModerationInputClassEmpty, contentModerationInputShapeMissing, responsesItemKindNone, 0, false)
 	case input.Type == gjson.String:
-		addModerationText(parts, input.String())
+		var parts []string
+		addModerationText(&parts, input.String())
+		return newContentModerationInput(parts, nil, "", contentModerationInputShapeString, responsesItemKindUser, 1, false)
 	case input.IsArray():
 		array := input.Array()
 		if len(array) == 0 {
-			return
+			return newContentModerationInput(nil, nil, contentModerationInputClassEmpty, contentModerationInputShapeArray, responsesItemKindNone, 0, false)
 		}
-		last := array[len(array)-1]
-		if !isResponsesUserTextItem(last) {
-			return
+		tailKind := classifyResponsesItem(array[len(array)-1])
+		switch tailKind {
+		case responsesItemKindToolCall, responsesItemKindToolOutput:
+			return newContentModerationInput(nil, nil, contentModerationInputClassToolContinuation, contentModerationInputShapeArray, tailKind, len(array), false)
+		case responsesItemKindAssistant, responsesItemKindReasoning:
+			return newContentModerationInput(nil, nil, contentModerationInputClassNonUserContinuation, contentModerationInputShapeArray, tailKind, len(array), false)
+		case responsesItemKindOther:
+			return newContentModerationInput(nil, nil, contentModerationInputClassUnsupported, contentModerationInputShapeArray, tailKind, len(array), true)
 		}
-		collectContentValue(last.Get("content"), parts, images)
-		if last.Get("type").String() == "input_text" || last.Get("text").Exists() {
-			collectContentValue(last, parts, images)
+		var parts []string
+		var images []string
+		failClosed := false
+		start := len(array) - 1
+		for start > 0 && classifyResponsesItem(array[start-1]) == responsesItemKindUser {
+			start--
 		}
-	case input.IsObject():
-		if isResponsesUserTextItem(input) {
-			collectContentValue(input.Get("content"), parts, images)
-			if input.Get("type").String() == "input_text" || input.Get("text").Exists() {
-				collectContentValue(input, parts, images)
+		for idx := start; idx < len(array); idx++ {
+			item := array[idx]
+			beforeText := len(parts)
+			beforeImages := len(images)
+			collectResponsesUserItem(item, &parts, &images)
+			if len(parts) == beforeText && len(images) == beforeImages && responsesUserItemHasNonEmptyContent(item) {
+				failClosed = true
 			}
 		}
+		classification := ""
+		if failClosed && normalizeContentModerationText(strings.Join(parts, "\n")) == "" && len(images) == 0 {
+			classification = contentModerationInputClassUnsupported
+		}
+		return newContentModerationInput(parts, images, classification, contentModerationInputShapeArray, tailKind, len(array), failClosed)
+	case input.IsObject():
+		kind := classifyResponsesItem(input)
+		if kind != responsesItemKindUser {
+			classification := contentModerationInputClassUnsupported
+			failClosed := true
+			if kind == responsesItemKindToolCall || kind == responsesItemKindToolOutput {
+				classification = contentModerationInputClassToolContinuation
+				failClosed = false
+			} else if kind == responsesItemKindAssistant || kind == responsesItemKindReasoning {
+				classification = contentModerationInputClassNonUserContinuation
+				failClosed = false
+			}
+			return newContentModerationInput(nil, nil, classification, contentModerationInputShapeObject, kind, 1, failClosed)
+		}
+		var parts []string
+		var images []string
+		collectResponsesUserItem(input, &parts, &images)
+		failClosed := len(parts) == 0 && len(images) == 0 && responsesUserItemHasNonEmptyContent(input)
+		classification := ""
+		if failClosed {
+			classification = contentModerationInputClassUnsupported
+		}
+		return newContentModerationInput(parts, images, classification, contentModerationInputShapeObject, kind, 1, failClosed)
+	default:
+		return newContentModerationInput(nil, nil, contentModerationInputClassUnsupported, contentModerationInputShapeOther, responsesItemKindOther, 1, true)
 	}
 }
 
-func isResponsesUserTextItem(item gjson.Result) bool {
+func collectLastResponsesInput(input gjson.Result, parts *[]string, images *[]string) {
+	extracted := extractResponsesContentModerationInput(input)
+	if extracted.IsEmpty() {
+		return
+	}
+	if extracted.Text != "" {
+		*parts = append(*parts, extracted.Text)
+	}
+	*images = append(*images, extracted.Images...)
+}
+
+func classifyResponsesItem(item gjson.Result) string {
 	role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
-	if role == "user" {
-		return responseItemHasModerationText(item)
+	switch role {
+	case "user":
+		return responsesItemKindUser
+	case "assistant", "developer", "system":
+		return responsesItemKindAssistant
+	case "tool", "function":
+		return responsesItemKindToolOutput
 	}
 	if role != "" {
-		return false
+		return responsesItemKindOther
 	}
-	return responseItemHasModerationText(item)
+	typ := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
+	switch typ {
+	case "input_text", "input_image", "text", "image", "image_url":
+		return responsesItemKindUser
+	case "function_call_output", "computer_call_output", "local_shell_call_output", "mcp_call_output", "custom_tool_call_output":
+		return responsesItemKindToolOutput
+	case "function_call", "computer_call", "local_shell_call", "web_search_call", "file_search_call", "mcp_call", "custom_tool_call":
+		return responsesItemKindToolCall
+	case "reasoning":
+		return responsesItemKindReasoning
+	case "message":
+		return responsesItemKindOther
+	case "":
+		if item.Get("content").Exists() || item.Get("text").Exists() || item.Get("image_url").Exists() {
+			return responsesItemKindUser
+		}
+	}
+	return responsesItemKindOther
 }
 
-func responseItemHasModerationText(item gjson.Result) bool {
-	var parts []string
-	var images []string
-	collectContentValue(item.Get("content"), &parts, &images)
-	if item.Get("type").String() == "input_text" || item.Get("text").Exists() {
-		collectContentValue(item, &parts, &images)
+func collectResponsesUserItem(item gjson.Result, parts *[]string, images *[]string) {
+	collectContentValue(item.Get("content"), parts, images)
+	typ := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
+	if typ == "input_text" || typ == "input_image" || typ == "text" || typ == "image" || typ == "image_url" || item.Get("text").Exists() || item.Get("image_url").Exists() {
+		collectContentValue(item, parts, images)
 	}
-	return normalizeContentModerationText(strings.Join(parts, "\n")) != "" || len(images) > 0
+}
+
+func responsesUserItemHasNonEmptyContent(item gjson.Result) bool {
+	for _, path := range []string{"content", "text", "image_url", "url", "file_id"} {
+		value := item.Get(path)
+		if !value.Exists() || value.Type == gjson.Null {
+			continue
+		}
+		if value.Type == gjson.String && strings.TrimSpace(value.String()) == "" {
+			continue
+		}
+		if value.IsArray() && len(value.Array()) == 0 {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func collectLastGeminiContent(contents gjson.Result, parts *[]string, images *[]string) {

--- a/backend/internal/service/content_moderation_input_test.go
+++ b/backend/internal/service/content_moderation_input_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,4 +178,174 @@ func TestExtractContentModerationInput_ResponsesLastIsAssistantSkipped(t *testin
 
 	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
+}
+
+func TestExtractContentModerationInput_ResponsesCollectsCurrentUserSuffix(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"policy"}]},
+			{"type":"message","role":"user","content":[
+				{"type":"input_text","text":"first segment"},
+				{"type":"input_text","text":"second segment"}
+			]},
+			{"type":"input_text","text":"final segment"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "first segment second segment final segment", input.Text)
+	require.Empty(t, input.Images)
+	require.Equal(t, contentModerationInputClassText, input.Classification())
+	require.False(t, input.MustFailClosed())
+}
+
+func TestExtractContentModerationInput_ResponsesCollectsTextAndImages(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[
+				{"type":"input_text","text":"check both"},
+				{"type":"input_image","image_url":"https://example.com/one.png"}
+			]},
+			{"type":"input_image","image_url":"data:image/png;base64,dHdv"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "check both", input.Text)
+	require.Equal(t, []string{"https://example.com/one.png", "data:image/png;base64,dHdv"}, input.Images)
+	require.Equal(t, contentModerationInputClassTextImage, input.Classification())
+}
+
+func TestExtractContentModerationInput_ResponsesCollectsImageOnly(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[
+				{"type":"input_image","image_url":"https://example.com/only.png"}
+			]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text)
+	require.Equal(t, []string{"https://example.com/only.png"}, input.Images)
+	require.Equal(t, contentModerationInputClassImage, input.Classification())
+	require.False(t, input.MustFailClosed())
+}
+
+func TestExtractContentModerationInput_ResponsesClassifiesToolContinuation(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run tests"}]},
+			{"type":"function_call","call_id":"call_1","name":"run_tests","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_1","output":"all passed"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.True(t, input.IsEmpty())
+	require.Equal(t, contentModerationInputClassToolContinuation, input.Classification())
+	require.Equal(t, responsesItemKindToolOutput, input.tailItemKind)
+	require.False(t, input.MustFailClosed())
+}
+
+func TestExtractContentModerationInput_ResponsesLongHistoryEndingInToolOutputSkipsHistoricalUser(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"historical prompt"}]},
+			{"type":"reasoning","encrypted_content":"opaque"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]},
+			{"type":"function_call","call_id":"call_9","name":"shell","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_9","output":"very long tool output"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.True(t, input.IsEmpty())
+	require.NotContains(t, input.Text, "historical prompt")
+	require.Equal(t, contentModerationInputClassToolContinuation, input.Classification())
+	require.False(t, input.MustFailClosed())
+}
+
+func TestExtractContentModerationInput_ResponsesTrulyEmptyInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing input", body: `{}`},
+		{name: "empty array", body: `{"input":[]}`},
+		{name: "empty user content", body: `{"input":[{"type":"message","role":"user","content":[]}]}`},
+		{name: "blank string", body: `{"input":"   "}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, []byte(tt.body))
+
+			require.True(t, input.IsEmpty())
+			require.Equal(t, contentModerationInputClassEmpty, input.Classification())
+			require.False(t, input.MustFailClosed())
+		})
+	}
+}
+
+func TestExtractContentModerationInput_ResponsesUnreviewableNonEmptyFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{"input":`},
+		{name: "unsupported user file", body: `{"input":[{"type":"message","role":"user","content":[{"type":"input_file","file_id":"file_1"}]}]}`},
+		{name: "unknown tail item", body: `{"input":[{"type":"unknown","payload":{"value":1}}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, []byte(tt.body))
+
+			require.True(t, input.IsEmpty())
+			require.True(t, input.MustFailClosed())
+			require.Contains(t, []string{contentModerationInputClassInvalidJSON, contentModerationInputClassUnsupported}, input.Classification())
+		})
+	}
+}
+
+func TestContentModerationCheck_ResponsesUnreviewableNonEmptyFailsClosedWithoutAuditCall(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	cfg.Enabled = true
+	cfg.Mode = ContentModerationModePreBlock
+	cfg.APIKeys = []string{"sk-test"}
+	rawCfg, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{
+			SettingKeyRiskControlEnabled:      "true",
+			SettingKeyContentModerationConfig: string(rawCfg),
+		}},
+		&contentModerationTestRepo{},
+		&contentModerationTestHashCache{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	decision, err := svc.Check(context.Background(), ContentModerationCheckInput{
+		RequestID: "req-fail-closed",
+		Endpoint:  "/responses",
+		Protocol:  ContentModerationProtocolOpenAIResponses,
+		Body:      []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_file","file_id":"file_1"}]}]}`),
+	})
+
+	require.NoError(t, err)
+	require.False(t, decision.Allowed)
+	require.True(t, decision.Blocked)
+	require.Equal(t, ContentModerationActionError, decision.Action)
+	require.Equal(t, cfg.BlockStatus, decision.StatusCode)
 }

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -990,7 +990,7 @@ func TestBuildModerationTestInputRejectsMultipleImages(t *testing.T) {
 	require.Contains(t, err.Error(), "最多上传 1 张测试图片")
 }
 
-func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesLastUserMessage(t *testing.T) {
+func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesCurrentUserSuffix(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5.5",
 		"instructions":"instructions.....",
@@ -1004,10 +1004,9 @@ func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesLastUserMe
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, "last user prompt", input.Text)
+	require.Equal(t, "first user prompt last user prompt", input.Text)
 	require.Empty(t, input.Images)
 	require.NotContains(t, input.Text, "developer permissions")
-	require.NotContains(t, input.Text, "first user prompt")
 }
 
 func TestContentModerationCheck_OpenAIResponsesRecordsNonHitForCodexPayload(t *testing.T) {
@@ -1070,8 +1069,8 @@ func TestContentModerationCheck_OpenAIResponsesRecordsNonHitForCodexPayload(t *t
 	require.False(t, logs[0].Flagged)
 	require.Equal(t, ContentModerationActionAllow, logs[0].Action)
 	require.Equal(t, "/responses", logs[0].Endpoint)
-	require.Equal(t, "last user prompt", logs[0].InputExcerpt)
-	require.Equal(t, "last user prompt", moderationRequest.Input)
+	require.Equal(t, "first user prompt last user prompt", logs[0].InputExcerpt)
+	require.Equal(t, "first user prompt last user prompt", moderationRequest.Input)
 }
 
 func TestContentModerationCheck_PreBlockBlocksCodexResponsesLatestUserInput(t *testing.T) {


### PR DESCRIPTION
This ports the Responses moderation input extraction fix onto the latest upstream main. It covers multi-part text, text plus image, image-only input, tool/assistant continuation boundaries, and fail-closed behavior for non-empty but unextractable input. It adds low-cardinality structured logs without prompt contents. Tests: targeted moderation tests pass; full unit suite has only pre-existing Aliyun Captcha HTTP 502 failures.