### PR TITLE
feat(admin): add Codex account analytics

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -197,7 +197,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	antigravityQuotaFetcher := service.NewAntigravityQuotaFetcher(proxyRepository)
 	grokQuotaFetcher := service.NewGrokQuotaFetcher()
 	grokQuotaService := service.ProvideGrokQuotaService(accountRepository, proxyRepository, grokTokenProvider, httpUpstream, configConfig, usageLogRepository, settingService)
-	openAIQuotaService := service.ProvideOpenAIQuotaService(accountRepository, proxyRepository, openAITokenProvider, privacyClientFactory, openAIGatewayService)
+	openAIQuotaService := service.ProvideOpenAIQuotaService(accountRepository, proxyRepository, openAITokenProvider, privacyClientFactory, openAIGatewayService, usageLogRepository, repository.NewCodexAnalyticsRedisCache(redisClient))
 	usageCache := service.NewUsageCache()
 	accountUsageService := service.ProvideAccountUsageService(accountRepository, usageLogRepository, claudeUsageFetcher, geminiQuotaService, antigravityQuotaFetcher, grokQuotaFetcher, grokQuotaService, openAIQuotaService, usageCache, identityCache, tlsFingerprintProfileService, openAIGatewayService)
 	accountTestService := service.ProvideAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, grokTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, openAIGatewayService, settingService)

--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -26,6 +26,7 @@ type OpenAIOAuthHandler struct {
 
 type openAIQuotaService interface {
 	QueryUsage(ctx context.Context, accountID int64) (*service.OpenAIQuotaUsage, error)
+	QueryCodexAnalytics(ctx context.Context, accountID int64, query service.OpenAICodexAnalyticsQuery) (*service.OpenAICodexAnalytics, error)
 	CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *service.OpenAIRateLimitResetCredits) error
 	ResetCredit(ctx context.Context, accountID int64) (*service.OpenAIQuotaResetResult, error)
 }
@@ -494,6 +495,67 @@ func (h *OpenAIOAuthHandler) QueryQuota(c *gin.Context) {
 		return
 	}
 	response.Success(c, usage)
+}
+
+// QueryCodexAnalytics returns official ChatGPT activity alongside Sub2API-managed traffic.
+// GET /api/v1/admin/accounts/:id/codex-analytics
+func (h *OpenAIOAuthHandler) QueryCodexAnalytics(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || accountID <= 0 {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	query := service.OpenAICodexAnalyticsQuery{Period: service.OpenAICodexAnalyticsCurrent7Days}
+	period := strings.TrimSpace(c.Query("period"))
+	if period != "" {
+		query.Period = service.OpenAICodexAnalyticsPeriodMode(period)
+	}
+	switch query.Period {
+	case service.OpenAICodexAnalyticsCurrent7Days:
+		if strings.TrimSpace(c.Query("days")) != "" {
+			response.BadRequest(c, "days is only valid for recent period")
+			return
+		}
+	case service.OpenAICodexAnalyticsRecent:
+		days, parseErr := strconv.Atoi(strings.TrimSpace(c.Query("days")))
+		if parseErr != nil || days < 1 || days > 30 {
+			response.BadRequest(c, "days must be between 1 and 30")
+			return
+		}
+		query.Days = days
+	default:
+		response.BadRequest(c, "period must be current_7d or recent")
+		return
+	}
+	if h.quotaService == nil {
+		response.BadRequest(c, "openai quota service is not enabled")
+		return
+	}
+
+	account, err := h.adminService.GetAccount(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if account == nil {
+		response.NotFound(c, "Account not found")
+		return
+	}
+	if account.Platform != service.PlatformOpenAI {
+		response.BadRequest(c, "Account platform must be openai")
+		return
+	}
+	if account.Type != service.AccountTypeOAuth {
+		response.BadRequest(c, "Account type must be oauth")
+		return
+	}
+
+	analytics, err := h.quotaService.QueryCodexAnalytics(c.Request.Context(), accountID, query)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, analytics)
 }
 
 // RefreshQuota queries the rate-limit / quota usage AND persists the reset-credit

--- a/backend/internal/handler/admin/openai_oauth_handler_codex_analytics_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_codex_analytics_test.go
@@ -1,0 +1,109 @@
+//go:build unit
+
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func performCodexAnalyticsRequest(handler *OpenAIOAuthHandler, query string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/api/v1/admin/accounts/:id/codex-analytics", handler.QueryCodexAnalytics)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/42/codex-analytics"+query, nil)
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestQueryCodexAnalyticsValidatesAccountBeforeServiceInvocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *service.Account
+	}{
+		{
+			name: "platform",
+			account: &service.Account{
+				ID:       42,
+				Platform: service.PlatformAnthropic,
+				Type:     service.AccountTypeOAuth,
+			},
+		},
+		{
+			name: "type",
+			account: &service.Account{
+				ID:       42,
+				Platform: service.PlatformOpenAI,
+				Type:     service.AccountTypeSetupToken,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			quota := &openAIQuotaWorkflowStub{}
+			handler := &OpenAIOAuthHandler{
+				adminService: &openAIResetAdminServiceStub{account: test.account},
+				quotaService: quota,
+			}
+
+			response := performCodexAnalyticsRequest(handler, "?period=recent&days=7")
+
+			require.Equal(t, http.StatusBadRequest, response.Code)
+			require.Zero(t, quota.analyticsCalls)
+		})
+	}
+}
+
+func TestQueryCodexAnalyticsDefaultsToCurrentSevenDayCycle(t *testing.T) {
+	account := &service.Account{ID: 42, Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth}
+	quota := &openAIQuotaWorkflowStub{analyticsResult: &service.OpenAICodexAnalytics{AccountID: 42, PeriodDays: 7}}
+	handler := &OpenAIOAuthHandler{adminService: &openAIResetAdminServiceStub{account: account}, quotaService: quota}
+
+	response := performCodexAnalyticsRequest(handler, "")
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, 1, quota.analyticsCalls)
+	require.Equal(t, int64(42), quota.analyticsID)
+	require.Equal(t, service.OpenAICodexAnalyticsQuery{Period: service.OpenAICodexAnalyticsCurrent7Days}, quota.analyticsQuery)
+}
+
+func TestQueryCodexAnalyticsParsesRecentDays(t *testing.T) {
+	account := &service.Account{ID: 42, Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth}
+	quota := &openAIQuotaWorkflowStub{analyticsResult: &service.OpenAICodexAnalytics{AccountID: 42, PeriodDays: 14}}
+	handler := &OpenAIOAuthHandler{adminService: &openAIResetAdminServiceStub{account: account}, quotaService: quota}
+
+	response := performCodexAnalyticsRequest(handler, "?period=recent&days=14")
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, service.OpenAICodexAnalyticsQuery{Period: service.OpenAICodexAnalyticsRecent, Days: 14}, quota.analyticsQuery)
+}
+
+func TestQueryCodexAnalyticsValidatesPeriodQuery(t *testing.T) {
+	account := &service.Account{ID: 42, Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth}
+	queries := []string{
+		"?period=recent",
+		"?period=recent&days=0",
+		"?period=recent&days=31",
+		"?period=recent&days=invalid",
+		"?period=current_7d&days=7",
+		"?period=invalid&days=7",
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			quota := &openAIQuotaWorkflowStub{}
+			handler := &OpenAIOAuthHandler{adminService: &openAIResetAdminServiceStub{account: account}, quotaService: quota}
+
+			response := performCodexAnalyticsRequest(handler, query)
+
+			require.Equal(t, http.StatusBadRequest, response.Code)
+			require.Zero(t, quota.analyticsCalls)
+		})
+	}
+}

--- a/backend/internal/handler/admin/openai_oauth_handler_reset_quota_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_reset_quota_test.go
@@ -17,15 +17,20 @@ import (
 )
 
 type openAIQuotaWorkflowStub struct {
-	resetResult *service.OpenAIQuotaResetResult
-	resetErr    error
-	queryResult *service.OpenAIQuotaUsage
-	queryErr    error
-	cacheErr    error
+	resetResult     *service.OpenAIQuotaResetResult
+	resetErr        error
+	queryResult     *service.OpenAIQuotaUsage
+	queryErr        error
+	cacheErr        error
+	analyticsResult *service.OpenAICodexAnalytics
+	analyticsErr    error
 
-	resetCalls int
-	queryCalls int
-	cacheCalls int
+	resetCalls     int
+	queryCalls     int
+	cacheCalls     int
+	analyticsCalls int
+	analyticsID    int64
+	analyticsQuery service.OpenAICodexAnalyticsQuery
 
 	queryCtxErr error
 	cacheCtxErr error
@@ -40,6 +45,13 @@ func (s *openAIQuotaWorkflowStub) QueryUsage(ctx context.Context, _ int64) (*ser
 	s.queryCalls++
 	s.queryCtxErr = ctx.Err()
 	return s.queryResult, s.queryErr
+}
+
+func (s *openAIQuotaWorkflowStub) QueryCodexAnalytics(_ context.Context, accountID int64, query service.OpenAICodexAnalyticsQuery) (*service.OpenAICodexAnalytics, error) {
+	s.analyticsCalls++
+	s.analyticsID = accountID
+	s.analyticsQuery = query
+	return s.analyticsResult, s.analyticsErr
 }
 
 func (s *openAIQuotaWorkflowStub) CacheResetCreditsSnapshot(ctx context.Context, _ int64, _ *service.OpenAIRateLimitResetCredits) error {

--- a/backend/internal/repository/openai_codex_analytics_cache.go
+++ b/backend/internal/repository/openai_codex_analytics_cache.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/redis/go-redis/v9"
+)
+
+// CodexAnalyticsRedisCache adapts Redis to the Codex analytics service cache seam.
+type CodexAnalyticsRedisCache struct {
+	client *redis.Client
+}
+
+func NewCodexAnalyticsRedisCache(client *redis.Client) service.CodexAnalyticsCache {
+	return &CodexAnalyticsRedisCache{client: client}
+}
+
+func (c *CodexAnalyticsRedisCache) Get(ctx context.Context, key string) ([]byte, time.Duration, error) {
+	value, err := c.client.Get(ctx, key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, 0, service.ErrCodexAnalyticsCacheMiss
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	ttl, err := c.client.PTTL(ctx, key).Result()
+	if err != nil {
+		return nil, 0, err
+	}
+	return value, ttl, nil
+}
+
+func (c *CodexAnalyticsRedisCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.client.Set(ctx, key, value, ttl).Err()
+}
+
+func (c *CodexAnalyticsRedisCache) Delete(ctx context.Context, key string) error {
+	return c.client.Del(ctx, key).Err()
+}

--- a/backend/internal/repository/openai_codex_analytics_cache_test.go
+++ b/backend/internal/repository/openai_codex_analytics_cache_test.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexAnalyticsRedisCacheMissTranslation(t *testing.T) {
+	mini := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mini.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	cache := NewCodexAnalyticsRedisCache(client)
+
+	value, ttl, err := cache.Get(context.Background(), "missing")
+
+	require.Nil(t, value)
+	require.Zero(t, ttl)
+	require.ErrorIs(t, err, service.ErrCodexAnalyticsCacheMiss)
+}
+
+func TestCodexAnalyticsRedisCacheReadWriteTTLAndDelete(t *testing.T) {
+	mini := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mini.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	cache := NewCodexAnalyticsRedisCache(client)
+	ctx := context.Background()
+	const key = "codex_analytics:v2:100:recent:7"
+	value := []byte(`{"account_id":100}`)
+	wantTTL := 4 * time.Minute
+
+	require.NoError(t, cache.Set(ctx, key, value, wantTTL))
+	got, ttl, err := cache.Get(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+	require.Equal(t, wantTTL, ttl)
+
+	mini.FastForward(time.Minute)
+	_, ttl, err = cache.Get(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, 3*time.Minute, ttl)
+
+	require.NoError(t, cache.Delete(ctx, key))
+	_, _, err = cache.Get(ctx, key)
+	require.True(t, errors.Is(err, service.ErrCodexAnalyticsCacheMiss))
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -107,6 +107,7 @@ var ProviderSet = wire.NewSet(
 
 	// Cache implementations
 	NewGatewayCache,
+	NewCodexAnalyticsRedisCache,
 	NewBillingCache,
 	NewAPIKeyCache,
 	NewTempUnschedCache,

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -1,4 +1,3 @@
-// Package routes provides HTTP route registration and handlers.
 package routes
 
 import (
@@ -380,6 +379,7 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.POST("/:id/set-privacy", h.Admin.Account.SetPrivacy)
 		accounts.POST("/:id/refresh-tier", h.Admin.Account.RefreshTier)
 		accounts.GET("/:id/stats", h.Admin.Account.GetStats)
+		accounts.GET("/:id/codex-analytics", h.Admin.OpenAIOAuth.QueryCodexAnalytics)
 		accounts.POST("/:id/clear-error", h.Admin.Account.ClearError)
 		accounts.POST("/:id/revert-proxy-fallback", h.Admin.Account.RevertProxyFallback)
 		accounts.GET("/:id/usage", h.Admin.Account.GetUsage)

--- a/backend/internal/service/account_usage_service_spark_shadow_test.go
+++ b/backend/internal/service/account_usage_service_spark_shadow_test.go
@@ -117,7 +117,7 @@ func TestGetOpenAIUsage_SparkShadow_WritesExtraAndReturnsNonEmptyWindows(t *test
 	}))
 	defer srv.Close()
 
-	quotaService := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	quotaService := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
 	svc := &AccountUsageService{
 		accountRepo:        repo,
 		openAIQuotaService: quotaService,

--- a/backend/internal/service/openai_codex_analytics.go
+++ b/backend/internal/service/openai_codex_analytics.go
@@ -1,0 +1,568 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
+)
+
+const (
+	chatGPTCodexProfileURL                                             = "https://chatgpt.com/backend-api/wham/profiles/me"
+	openAICodexAnalyticsTTL                                            = 4 * time.Minute
+	openAICodexAnalyticsFetchTimeout                                   = 2*openaiQuotaUpstreamTimeout + 10*time.Second
+	openAICodexAnalyticsMax                                            = 30
+	openAICodexAnalyticsSevenDaySeconds                                = int64(7 * 24 * time.Hour / time.Second)
+	OpenAICodexAnalyticsCurrent7Days    OpenAICodexAnalyticsPeriodMode = "current_7d"
+	OpenAICodexAnalyticsRecent          OpenAICodexAnalyticsPeriodMode = "recent"
+)
+
+type codexAnalyticsUsageRepository interface {
+	GetAccountStatsAggregated(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.UsageStats, error)
+	GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) ([]usagestats.TrendDataPoint, error)
+	GetModelStatsWithFilters(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8) ([]usagestats.ModelStat, error)
+}
+type OpenAICodexAnalyticsPeriodMode string
+
+type OpenAICodexAnalyticsQuery struct {
+	Period OpenAICodexAnalyticsPeriodMode
+	Days   int
+}
+
+type OpenAICodexAnalytics struct {
+	AccountID   int64                          `json:"account_id"`
+	PeriodDays  int                            `json:"period_days"`
+	PeriodMode  OpenAICodexAnalyticsPeriodMode `json:"period_mode"`
+	PeriodStart int64                          `json:"period_start"`
+	PeriodEnd   int64                          `json:"period_end"`
+	FetchedAt   int64                          `json:"fetched_at"`
+	DataScope   OpenAICodexAnalyticsDataScope  `json:"data_scope"`
+	Cache       OpenAICodexAnalyticsCache      `json:"cache"`
+	RateLimits  OpenAICodexAnalyticsRateLimits `json:"rate_limits"`
+	Profile     OpenAICodexAnalyticsProfile    `json:"profile"`
+	Summary     OpenAICodexAnalyticsSummary    `json:"summary"`
+	TimeSeries  []OpenAICodexAnalyticsDay      `json:"time_series"`
+	Models      []OpenAICodexAnalyticsModel    `json:"models"`
+	Warnings    []OpenAICodexAnalyticsWarning  `json:"warnings,omitempty"`
+}
+
+type OpenAICodexAnalyticsDataScope struct {
+	OfficialAccountActivity string `json:"official_account_activity"`
+	ManagedTraffic          string `json:"managed_traffic"`
+	RateLimits              string `json:"rate_limits"`
+}
+
+type OpenAICodexAnalyticsCache struct {
+	Hit        bool  `json:"hit"`
+	TTLSeconds int64 `json:"ttl_seconds"`
+	ExpiresAt  int64 `json:"expires_at"`
+}
+
+type OpenAICodexAnalyticsRateLimits struct {
+	FiveHour *OpenAICodexAnalyticsRateLimitWindow `json:"five_hour,omitempty"`
+	SevenDay *OpenAICodexAnalyticsRateLimitWindow `json:"seven_day,omitempty"`
+}
+
+type OpenAICodexAnalyticsRateLimitWindow struct {
+	UsedPercent        float64 `json:"used_percent"`
+	LimitWindowSeconds int64   `json:"limit_window_seconds"`
+	ResetAfterSeconds  int64   `json:"reset_after_seconds"`
+	ResetAt            int64   `json:"reset_at"`
+	Allowed            bool    `json:"allowed"`
+	LimitReached       bool    `json:"limit_reached"`
+}
+
+type OpenAICodexDailyUsageBucket struct {
+	StartDate string `json:"start_date"`
+	Tokens    int64  `json:"tokens"`
+}
+
+type OpenAICodexAnalyticsProfile struct {
+	LifetimeTokens            *int64                        `json:"lifetime_tokens,omitempty"`
+	PeakDailyTokens           *int64                        `json:"peak_daily_tokens,omitempty"`
+	LongestRunningTurnSeconds *int64                        `json:"longest_running_turn_seconds,omitempty"`
+	CurrentStreakDays         *int64                        `json:"current_streak_days,omitempty"`
+	LongestStreakDays         *int64                        `json:"longest_streak_days,omitempty"`
+	DailyUsageBuckets         []OpenAICodexDailyUsageBucket `json:"daily_usage_buckets"`
+}
+
+type OpenAICodexAnalyticsSummary struct {
+	OfficialTotalTokens     *int64  `json:"official_total_tokens,omitempty"`
+	ManagedTotalTokens      int64   `json:"managed_total_tokens"`
+	InputTokens             int64   `json:"input_tokens"`
+	OutputTokens            int64   `json:"output_tokens"`
+	CacheTokens             int64   `json:"cache_tokens"`
+	CacheReadTokens         int64   `json:"cache_read_tokens"`
+	CacheHitRate            float64 `json:"cache_hit_rate"`
+	EstimatedCost           float64 `json:"estimated_cost"`
+	Requests                int64   `json:"requests"`
+	CurrentLimitUsedPercent float64 `json:"current_limit_used_percent"`
+}
+
+type OpenAICodexAnalyticsDay struct {
+	Date                string  `json:"date"`
+	OfficialTotalTokens *int64  `json:"official_total_tokens,omitempty"`
+	InputTokens         int64   `json:"input_tokens"`
+	OutputTokens        int64   `json:"output_tokens"`
+	CacheTokens         int64   `json:"cache_tokens"`
+	TotalTokens         int64   `json:"total_tokens"`
+	Requests            int64   `json:"requests"`
+	EstimatedCost       float64 `json:"estimated_cost"`
+}
+
+type OpenAICodexAnalyticsModel struct {
+	Model         string  `json:"model"`
+	InputTokens   int64   `json:"input_tokens"`
+	OutputTokens  int64   `json:"output_tokens"`
+	CacheTokens   int64   `json:"cache_tokens"`
+	TotalTokens   int64   `json:"total_tokens"`
+	Requests      int64   `json:"requests"`
+	EstimatedCost float64 `json:"estimated_cost"`
+}
+
+type OpenAICodexAnalyticsWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type codexTokenUsageProfileResponse struct {
+	Stats codexTokenUsageProfileStats `json:"stats"`
+}
+
+type codexTokenUsageProfileStats struct {
+	LifetimeTokens        *int64                        `json:"lifetime_tokens"`
+	PeakDailyTokens       *int64                        `json:"peak_daily_tokens"`
+	LongestRunningTurnSec *int64                        `json:"longest_running_turn_sec"`
+	CurrentStreakDays     *int64                        `json:"current_streak_days"`
+	LongestStreakDays     *int64                        `json:"longest_streak_days"`
+	DailyUsageBuckets     []OpenAICodexDailyUsageBucket `json:"daily_usage_buckets"`
+}
+
+func (s *OpenAIQuotaService) QueryCodexAnalytics(ctx context.Context, accountID int64, query OpenAICodexAnalyticsQuery) (*OpenAICodexAnalytics, error) {
+	query, err := normalizeCodexAnalyticsQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.analyticsUsageRepo == nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_ANALYTICS_NOT_CONFIGURED", "codex analytics service is not configured")
+	}
+
+	key := openAICodexAnalyticsCacheKey(accountID, query)
+	cached, cacheWarning := s.readCodexAnalyticsCache(ctx, key, query)
+	if cached != nil {
+		return cached, nil
+	}
+
+	resultCh := s.analyticsFlight.DoChan(key, func() (any, error) {
+		sharedCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openAICodexAnalyticsFetchTimeout)
+		defer cancel()
+
+		if cached, _ := s.readCodexAnalyticsCache(sharedCtx, key, query); cached != nil {
+			return cached, nil
+		}
+		return s.fetchCodexAnalytics(sharedCtx, accountID, query, key, cacheWarning)
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case shared := <-resultCh:
+		if shared.Err != nil {
+			return nil, shared.Err
+		}
+		result, ok := shared.Val.(*OpenAICodexAnalytics)
+		if !ok || result == nil {
+			return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_ANALYTICS_EMPTY_RESULT", "codex analytics query returned an empty result")
+		}
+		return result, nil
+	}
+}
+
+func normalizeCodexAnalyticsQuery(query OpenAICodexAnalyticsQuery) (OpenAICodexAnalyticsQuery, error) {
+	if query.Period == "" {
+		query.Period = OpenAICodexAnalyticsCurrent7Days
+	}
+	switch query.Period {
+	case OpenAICodexAnalyticsCurrent7Days:
+		query.Days = 7
+	case OpenAICodexAnalyticsRecent:
+		if query.Days < 1 || query.Days > openAICodexAnalyticsMax {
+			return OpenAICodexAnalyticsQuery{}, infraerrors.New(http.StatusBadRequest, "OPENAI_CODEX_ANALYTICS_INVALID_DAYS", "days must be between 1 and 30")
+		}
+	default:
+		return OpenAICodexAnalyticsQuery{}, infraerrors.New(http.StatusBadRequest, "OPENAI_CODEX_ANALYTICS_INVALID_PERIOD", "period must be current_7d or recent")
+	}
+	return query, nil
+}
+
+func (s *OpenAIQuotaService) fetchCodexAnalytics(ctx context.Context, accountID int64, query OpenAICodexAnalyticsQuery, cacheKey string, cacheWarning *OpenAICodexAnalyticsWarning) (*OpenAICodexAnalytics, error) {
+	now := time.Now().UTC().Truncate(time.Second)
+	warnings := make([]OpenAICodexAnalyticsWarning, 0, 5)
+	if cacheWarning != nil {
+		warnings = append(warnings, *cacheWarning)
+	}
+
+	quota, err := s.QueryUsage(ctx, accountID)
+	if err != nil {
+		status, _ := infraerrors.ToHTTP(err)
+		if status == http.StatusUnauthorized || status == http.StatusTooManyRequests {
+			return nil, err
+		}
+		warnings = append(warnings, OpenAICodexAnalyticsWarning{Code: "rate_limits_unavailable", Message: "Current ChatGPT rate limits are temporarily unavailable."})
+		quota = nil
+	}
+	rateLimits := normalizeCodexAnalyticsRateLimits(quota)
+	start, end, periodWarning := resolveCodexAnalyticsPeriod(query, rateLimits, now)
+	if periodWarning != nil {
+		warnings = append(warnings, *periodWarning)
+	}
+
+	profile, err := s.queryCodexTokenUsageProfile(ctx, accountID)
+	profileAvailable := err == nil
+	if err != nil {
+		status, _ := infraerrors.ToHTTP(err)
+		if status == http.StatusUnauthorized || status == http.StatusTooManyRequests {
+			return nil, err
+		}
+		warnings = append(warnings, OpenAICodexAnalyticsWarning{Code: "official_profile_unavailable", Message: "Official account activity is temporarily unavailable."})
+		profile = &OpenAICodexAnalyticsProfile{DailyUsageBuckets: []OpenAICodexDailyUsageBucket{}}
+	}
+	if profileAvailable && codexAnalyticsHasPartialDayBoundary(start, end) {
+		warnings = append(warnings, OpenAICodexAnalyticsWarning{Code: "official_daily_buckets_approximate_period", Message: "Official account activity is available only in daily buckets and may approximate partial-day period boundaries."})
+	}
+
+	stats, err := s.analyticsUsageRepo.GetAccountStatsAggregated(ctx, accountID, start, end)
+	if err != nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_ANALYTICS_LOCAL_QUERY_FAILED", "failed to query managed traffic summary").WithCause(err)
+	}
+	trend, err := s.analyticsUsageRepo.GetUsageTrendWithFilters(ctx, start, end, "day", 0, 0, accountID, 0, "", nil, nil, nil)
+	if err != nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_ANALYTICS_LOCAL_QUERY_FAILED", "failed to query managed traffic timeline").WithCause(err)
+	}
+	modelStats, err := s.analyticsUsageRepo.GetModelStatsWithFilters(ctx, start, end, 0, 0, accountID, 0, nil, nil, nil)
+	if err != nil {
+		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_ANALYTICS_LOCAL_QUERY_FAILED", "failed to query managed traffic models").WithCause(err)
+	}
+
+	filterCodexProfileBuckets(profile, start, end)
+	officialPeriodTotal := sumCodexOfficialPeriodTokens(profile, profileAvailable)
+	result := &OpenAICodexAnalytics{
+		AccountID:   accountID,
+		PeriodDays:  query.Days,
+		PeriodMode:  query.Period,
+		PeriodStart: start.Unix(),
+		PeriodEnd:   end.Unix(),
+		FetchedAt:   now.Unix(),
+		DataScope: OpenAICodexAnalyticsDataScope{
+			OfficialAccountActivity: "chatgpt_profile",
+			ManagedTraffic:          "sub2api_usage_logs",
+			RateLimits:              "chatgpt_wham_usage",
+		},
+		Cache:      OpenAICodexAnalyticsCache{},
+		RateLimits: rateLimits,
+		Profile:    *profile,
+		Summary:    buildCodexAnalyticsSummary(stats, officialPeriodTotal, rateLimits),
+		TimeSeries: buildCodexAnalyticsTimeSeries(start, end, trend, profile.DailyUsageBuckets),
+		Models:     buildCodexAnalyticsModels(modelStats),
+		Warnings:   warnings,
+	}
+
+	if warning := s.writeCodexAnalyticsCache(ctx, cacheKey, result); warning != nil {
+		result.Warnings = append(result.Warnings, *warning)
+	}
+	return result, nil
+}
+
+func resolveCodexAnalyticsPeriod(query OpenAICodexAnalyticsQuery, limits OpenAICodexAnalyticsRateLimits, now time.Time) (time.Time, time.Time, *OpenAICodexAnalyticsWarning) {
+	if query.Period == OpenAICodexAnalyticsRecent {
+		return now.Add(-time.Duration(query.Days) * 24 * time.Hour), now, nil
+	}
+	if window := limits.SevenDay; window != nil && window.LimitWindowSeconds == openAICodexAnalyticsSevenDaySeconds && window.ResetAt > 0 {
+		resetAt := time.Unix(window.ResetAt, 0).UTC()
+		start := resetAt.Add(-time.Duration(openAICodexAnalyticsSevenDaySeconds) * time.Second)
+		if resetAt.After(now) && start.Before(now) {
+			return start, now, nil
+		}
+	}
+	return now.Add(-time.Duration(openAICodexAnalyticsSevenDaySeconds) * time.Second), now, &OpenAICodexAnalyticsWarning{
+		Code:    "current_7d_window_unavailable",
+		Message: "The official seven-day window was unavailable or invalid; recent seven-day analytics were returned.",
+	}
+}
+
+func codexAnalyticsHasPartialDayBoundary(start, end time.Time) bool {
+	return !start.Equal(start.Truncate(24*time.Hour)) || !end.Equal(end.Truncate(24*time.Hour))
+}
+
+func (s *OpenAIQuotaService) queryCodexTokenUsageProfile(ctx context.Context, accountID int64) (*OpenAICodexAnalyticsProfile, error) {
+	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.privacyClientFactory(proxyURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_PROFILE_CLIENT_ERROR", "failed to build upstream client: %v", err)
+	}
+	callCtx, cancel := context.WithTimeout(ctx, openaiQuotaUpstreamTimeout)
+	defer cancel()
+	agentIdentity := s.isAgentIdentityAccount(ctx, accountID)
+
+	var payload codexTokenUsageProfileResponse
+	for recovered := false; ; {
+		headers, expectedTaskID, headerErr := s.buildCodexQuotaHeaders(callCtx, accountID, accessToken, chatGPTAccountID, fedRAMP)
+		if headerErr != nil {
+			return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_PROFILE_AUTH_FAILED", "failed to build upstream authentication: %v", headerErr)
+		}
+		resp, requestErr := client.R().SetContext(callCtx).SetHeaders(headers).SetSuccessResult(&payload).Get(chatGPTCodexProfileURL)
+		if requestErr != nil {
+			return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_PROFILE_REQUEST_FAILED", "upstream request failed: %v", requestErr)
+		}
+		if resp.IsSuccessState() {
+			break
+		}
+		if agentIdentity && !recovered && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, resp.Bytes()) {
+			recovered = true
+			if recoverErr := s.recoverAgentIdentityTask(ctx, accountID, expectedTaskID); recoverErr != nil {
+				return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_PROFILE_AUTH_FAILED", "agent identity task recovery failed: %v", recoverErr)
+			}
+			continue
+		}
+		status := resp.StatusCode
+		body := truncate(logredact.RedactText(s.redactQuotaErrorBody(callCtx, accountID, resp.String())), 240)
+		slog.Warn("openai_codex_profile_query_failed", "account_id", accountID, "status", status, "body", body)
+		switch status {
+		case http.StatusUnauthorized:
+			return nil, infraerrors.Newf(http.StatusUnauthorized, "OPENAI_CODEX_PROFILE_UNAUTHORIZED", "official profile authentication failed: %s", body)
+		case http.StatusTooManyRequests:
+			return nil, infraerrors.Newf(http.StatusTooManyRequests, "OPENAI_CODEX_PROFILE_RATE_LIMITED", "official profile rate limited: %s", body)
+		default:
+			return nil, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_CODEX_PROFILE_UPSTREAM_ERROR", "official profile returned %d: %s", status, body)
+		}
+	}
+
+	return &OpenAICodexAnalyticsProfile{
+		LifetimeTokens:            payload.Stats.LifetimeTokens,
+		PeakDailyTokens:           payload.Stats.PeakDailyTokens,
+		LongestRunningTurnSeconds: payload.Stats.LongestRunningTurnSec,
+		CurrentStreakDays:         payload.Stats.CurrentStreakDays,
+		LongestStreakDays:         payload.Stats.LongestStreakDays,
+		DailyUsageBuckets:         append(make([]OpenAICodexDailyUsageBucket, 0, len(payload.Stats.DailyUsageBuckets)), payload.Stats.DailyUsageBuckets...),
+	}, nil
+}
+
+func (s *OpenAIQuotaService) readCodexAnalyticsCache(ctx context.Context, key string, query OpenAICodexAnalyticsQuery) (*OpenAICodexAnalytics, *OpenAICodexAnalyticsWarning) {
+	if s == nil || s.analyticsCache == nil {
+		return nil, nil
+	}
+	raw, ttl, err := s.analyticsCache.Get(ctx, key)
+	if errors.Is(err, ErrCodexAnalyticsCacheMiss) {
+		return nil, nil
+	}
+	if err != nil {
+		slog.Warn("openai_codex_analytics_cache_read_failed", "error", err)
+		return nil, &OpenAICodexAnalyticsWarning{Code: "cache_read_failed", Message: "Analytics cache was unavailable; fresh data was fetched."}
+	}
+	var cached OpenAICodexAnalytics
+	if err := json.Unmarshal(raw, &cached); err != nil {
+		slog.Warn("openai_codex_analytics_cache_decode_failed", "error", err)
+		_ = s.analyticsCache.Delete(ctx, key)
+		return nil, &OpenAICodexAnalyticsWarning{Code: "cache_read_failed", Message: "Analytics cache was invalid; fresh data was fetched."}
+	}
+	if query.Period == OpenAICodexAnalyticsCurrent7Days && cached.RateLimits.SevenDay != nil && cached.RateLimits.SevenDay.ResetAt > 0 && cached.RateLimits.SevenDay.ResetAt <= time.Now().Unix() {
+		_ = s.analyticsCache.Delete(ctx, key)
+		return nil, nil
+	}
+	if ttl <= 0 {
+		return nil, nil
+	}
+	cached.Cache = OpenAICodexAnalyticsCache{
+		Hit:        true,
+		TTLSeconds: int64(ttl / time.Second),
+		ExpiresAt:  time.Now().Add(ttl).Unix(),
+	}
+	return &cached, nil
+}
+
+func (s *OpenAIQuotaService) writeCodexAnalyticsCache(ctx context.Context, key string, result *OpenAICodexAnalytics) *OpenAICodexAnalyticsWarning {
+	if s == nil || s.analyticsCache == nil || result == nil {
+		return nil
+	}
+	ttl := openAICodexAnalyticsTTL
+	if result.PeriodMode == OpenAICodexAnalyticsCurrent7Days && result.RateLimits.SevenDay != nil && result.RateLimits.SevenDay.ResetAt > 0 {
+		untilReset := time.Until(time.Unix(result.RateLimits.SevenDay.ResetAt, 0))
+		if untilReset <= 0 {
+			result.Cache = OpenAICodexAnalyticsCache{}
+			return nil
+		}
+		if untilReset < ttl {
+			ttl = untilReset
+		}
+	}
+	result.Cache = OpenAICodexAnalyticsCache{TTLSeconds: int64(ttl / time.Second), ExpiresAt: time.Now().Add(ttl).Unix()}
+	raw, err := json.Marshal(result)
+	if err == nil {
+		err = s.analyticsCache.Set(ctx, key, raw, ttl)
+	}
+	if err == nil {
+		return nil
+	}
+	result.Cache = OpenAICodexAnalyticsCache{}
+	slog.Warn("openai_codex_analytics_cache_write_failed", "error", err)
+	return &OpenAICodexAnalyticsWarning{Code: "cache_write_failed", Message: "Fresh analytics were returned without caching."}
+}
+
+func openAICodexAnalyticsCacheKey(accountID int64, query OpenAICodexAnalyticsQuery) string {
+	if query.Period == OpenAICodexAnalyticsRecent {
+		return fmt.Sprintf("codex_analytics:v2:%d:recent:%d", accountID, query.Days)
+	}
+	return fmt.Sprintf("codex_analytics:v2:%d:current_7d", accountID)
+}
+
+func normalizeCodexAnalyticsRateLimits(usage *OpenAIQuotaUsage) OpenAICodexAnalyticsRateLimits {
+	if usage == nil || usage.RateLimit == nil {
+		return OpenAICodexAnalyticsRateLimits{}
+	}
+	rateLimit := usage.RateLimit
+	windows := make([]*OpenAIRateLimitWindow, 0, 2)
+	if rateLimit.PrimaryWindow != nil {
+		windows = append(windows, rateLimit.PrimaryWindow)
+	}
+	if rateLimit.SecondaryWindow != nil {
+		windows = append(windows, rateLimit.SecondaryWindow)
+	}
+	sort.SliceStable(windows, func(i, j int) bool { return windows[i].LimitWindowSeconds < windows[j].LimitWindowSeconds })
+	toAnalyticsWindow := func(window *OpenAIRateLimitWindow) *OpenAICodexAnalyticsRateLimitWindow {
+		return &OpenAICodexAnalyticsRateLimitWindow{
+			UsedPercent:        window.UsedPercent,
+			LimitWindowSeconds: window.LimitWindowSeconds,
+			ResetAfterSeconds:  window.ResetAfterSeconds,
+			ResetAt:            window.ResetAt,
+			Allowed:            rateLimit.Allowed,
+			LimitReached:       rateLimit.LimitReached,
+		}
+	}
+	result := OpenAICodexAnalyticsRateLimits{}
+	for _, window := range windows {
+		switch {
+		case window.LimitWindowSeconds == openAICodexAnalyticsSevenDaySeconds:
+			result.SevenDay = toAnalyticsWindow(window)
+		case result.FiveHour == nil && window.LimitWindowSeconds <= int64(6*time.Hour/time.Second):
+			result.FiveHour = toAnalyticsWindow(window)
+		}
+	}
+	return result
+}
+
+func buildCodexAnalyticsSummary(stats *usagestats.UsageStats, officialPeriodTotal *int64, limits OpenAICodexAnalyticsRateLimits) OpenAICodexAnalyticsSummary {
+	result := OpenAICodexAnalyticsSummary{OfficialTotalTokens: officialPeriodTotal}
+	if stats != nil {
+		result.ManagedTotalTokens = stats.TotalTokens
+		result.InputTokens = stats.TotalInputTokens
+		result.OutputTokens = stats.TotalOutputTokens
+		result.CacheTokens = stats.TotalCacheTokens
+		result.CacheReadTokens = stats.TotalCacheReadTokens
+		result.EstimatedCost = stats.TotalCost
+		result.Requests = stats.TotalRequests
+		denominator := stats.TotalInputTokens + stats.TotalCacheReadTokens
+		if denominator > 0 {
+			result.CacheHitRate = float64(stats.TotalCacheReadTokens) / float64(denominator) * 100
+		}
+	}
+	for _, window := range []*OpenAICodexAnalyticsRateLimitWindow{limits.FiveHour, limits.SevenDay} {
+		if window != nil && window.UsedPercent > result.CurrentLimitUsedPercent {
+			result.CurrentLimitUsedPercent = window.UsedPercent
+		}
+	}
+	return result
+}
+
+func filterCodexProfileBuckets(profile *OpenAICodexAnalyticsProfile, start, end time.Time) {
+	if profile == nil {
+		return
+	}
+	filtered := make([]OpenAICodexDailyUsageBucket, 0, len(profile.DailyUsageBuckets))
+	for _, bucket := range profile.DailyUsageBuckets {
+		date := codexBucketDate(bucket.StartDate)
+		parsed, err := time.Parse("2006-01-02", date)
+		if err == nil && parsed.AddDate(0, 0, 1).After(start) && parsed.Before(end) {
+			bucket.StartDate = date
+			filtered = append(filtered, bucket)
+		}
+	}
+	profile.DailyUsageBuckets = filtered
+}
+
+func sumCodexOfficialPeriodTokens(profile *OpenAICodexAnalyticsProfile, available bool) *int64 {
+	if !available || profile == nil {
+		return nil
+	}
+	total := int64(0)
+	for _, bucket := range profile.DailyUsageBuckets {
+		total += bucket.Tokens
+	}
+	return &total
+}
+
+func buildCodexAnalyticsTimeSeries(start, end time.Time, trend []usagestats.TrendDataPoint, official []OpenAICodexDailyUsageBucket) []OpenAICodexAnalyticsDay {
+	managedByDate := make(map[string]usagestats.TrendDataPoint, len(trend))
+	for _, point := range trend {
+		managedByDate[point.Date] = point
+	}
+	officialByDate := make(map[string]int64, len(official))
+	for _, bucket := range official {
+		officialByDate[codexBucketDate(bucket.StartDate)] = bucket.Tokens
+	}
+	firstDay := start.UTC().Truncate(24 * time.Hour)
+	series := make([]OpenAICodexAnalyticsDay, 0, int(end.Sub(firstDay)/(24*time.Hour))+1)
+	for day := firstDay; day.Before(end); day = day.AddDate(0, 0, 1) {
+		date := day.Format("2006-01-02")
+		point := managedByDate[date]
+		row := OpenAICodexAnalyticsDay{
+			Date:          date,
+			InputTokens:   point.InputTokens,
+			OutputTokens:  point.OutputTokens,
+			CacheTokens:   point.CacheCreationTokens + point.CacheReadTokens,
+			TotalTokens:   point.TotalTokens,
+			Requests:      point.Requests,
+			EstimatedCost: point.Cost,
+		}
+		if tokens, ok := officialByDate[date]; ok {
+			row.OfficialTotalTokens = &tokens
+		}
+		series = append(series, row)
+	}
+	return series
+}
+
+func buildCodexAnalyticsModels(stats []usagestats.ModelStat) []OpenAICodexAnalyticsModel {
+	models := make([]OpenAICodexAnalyticsModel, 0, len(stats))
+	for _, model := range stats {
+		models = append(models, OpenAICodexAnalyticsModel{
+			Model:         model.Model,
+			InputTokens:   model.InputTokens,
+			OutputTokens:  model.OutputTokens,
+			CacheTokens:   model.CacheCreationTokens + model.CacheReadTokens,
+			TotalTokens:   model.TotalTokens,
+			Requests:      model.Requests,
+			EstimatedCost: model.Cost,
+		})
+	}
+	return models
+}
+
+func codexBucketDate(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= len("2006-01-02") {
+		return value[:len("2006-01-02")]
+	}
+	return value
+}

--- a/backend/internal/service/openai_codex_analytics_test.go
+++ b/backend/internal/service/openai_codex_analytics_test.go
@@ -1,0 +1,576 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	"github.com/stretchr/testify/require"
+)
+
+type codexAnalyticsUsageRepoStub struct {
+	stats      *usagestats.UsageStats
+	trend      []usagestats.TrendDataPoint
+	models     []usagestats.ModelStat
+	statsCalls int
+	trendCalls int
+	modelCalls int
+	statsStart time.Time
+	statsEnd   time.Time
+	trendStart time.Time
+	trendEnd   time.Time
+	modelStart time.Time
+	modelEnd   time.Time
+}
+
+func (s *codexAnalyticsUsageRepoStub) GetAccountStatsAggregated(_ context.Context, _ int64, start, end time.Time) (*usagestats.UsageStats, error) {
+	s.statsCalls++
+	s.statsStart = start
+	s.statsEnd = end
+	return s.stats, nil
+}
+
+func (s *codexAnalyticsUsageRepoStub) GetUsageTrendWithFilters(_ context.Context, start, end time.Time, _ string, _, _, _, _ int64, _ string, _ *int16, _ *bool, _ *int8) ([]usagestats.TrendDataPoint, error) {
+	s.trendCalls++
+	s.trendStart = start
+	s.trendEnd = end
+	return s.trend, nil
+}
+
+func (s *codexAnalyticsUsageRepoStub) GetModelStatsWithFilters(_ context.Context, start, end time.Time, _, _, _, _ int64, _ *int16, _ *bool, _ *int8) ([]usagestats.ModelStat, error) {
+	s.modelCalls++
+	s.modelStart = start
+	s.modelEnd = end
+	return s.models, nil
+}
+
+type codexAnalyticsDoneSignalingContext struct {
+	context.Context
+	once   sync.Once
+	signal chan struct{}
+}
+
+func (c *codexAnalyticsDoneSignalingContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.signal) })
+	return c.Context.Done()
+}
+
+type codexAnalyticsCacheFakeEntry struct {
+	value     []byte
+	expiresAt time.Time
+}
+
+type codexAnalyticsCacheFake struct {
+	mu        sync.Mutex
+	now       time.Time
+	entries   map[string]codexAnalyticsCacheFakeEntry
+	getErr    error
+	setErr    error
+	deleteErr error
+}
+
+func newCodexAnalyticsCacheFake() *codexAnalyticsCacheFake {
+	return &codexAnalyticsCacheFake{
+		now:     time.Unix(0, 0),
+		entries: make(map[string]codexAnalyticsCacheFakeEntry),
+	}
+}
+
+func (f *codexAnalyticsCacheFake) Get(_ context.Context, key string) ([]byte, time.Duration, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, 0, f.getErr
+	}
+	entry, ok := f.entries[key]
+	if !ok || !entry.expiresAt.After(f.now) {
+		delete(f.entries, key)
+		return nil, 0, ErrCodexAnalyticsCacheMiss
+	}
+	return append([]byte(nil), entry.value...), entry.expiresAt.Sub(f.now), nil
+}
+
+func (f *codexAnalyticsCacheFake) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.entries[key] = codexAnalyticsCacheFakeEntry{
+		value:     append([]byte(nil), value...),
+		expiresAt: f.now.Add(ttl),
+	}
+	return nil
+}
+
+func (f *codexAnalyticsCacheFake) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.entries, key)
+	return nil
+}
+
+func (f *codexAnalyticsCacheFake) seed(key string, value []byte, ttl time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries[key] = codexAnalyticsCacheFakeEntry{
+		value:     append([]byte(nil), value...),
+		expiresAt: f.now.Add(ttl),
+	}
+}
+
+func (f *codexAnalyticsCacheFake) advance(elapsed time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(elapsed)
+}
+
+func (f *codexAnalyticsCacheFake) failGet(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getErr = err
+}
+
+func (f *codexAnalyticsCacheFake) failSet(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setErr = err
+}
+
+func newCodexAnalyticsTestService(t *testing.T, upstream *httptest.Server, usageRepo codexAnalyticsUsageRepository, analyticsCache CodexAnalyticsCache) *OpenAIQuotaService {
+	t.Helper()
+	account := &Account{
+		ID:       100,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "chatgpt-account-100",
+		},
+	}
+	accountRepo := &stubQuotaAccountRepo{accounts: map[int64]*Account{account.ID: account}}
+	tokenCache := &stubQuotaTokenCache{tokens: map[string]string{OpenAITokenCacheKey(account): "test-access-token"}}
+	tokenProvider := NewOpenAITokenProvider(accountRepo, tokenCache, nil)
+	return NewOpenAIQuotaService(accountRepo, nil, tokenProvider, newQuotaRedirectingFactory(upstream), usageRepo, analyticsCache)
+}
+
+func newCodexAnalyticsPeriodUpstream(t *testing.T, sevenDay *OpenAIRateLimitWindow, calls map[string]int) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			calls[r.URL.Path]++
+		}
+		w.Header().Set("content-type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/wham/profiles/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{"stats": map[string]any{"daily_usage_buckets": []any{}}})
+		case "/backend-api/wham/usage":
+			_ = json.NewEncoder(w).Encode(OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{Allowed: true, PrimaryWindow: sevenDay}})
+		case "/backend-api/wham/rate-limit-reset-credits":
+			_, _ = w.Write([]byte(`{"available_count":0,"credits":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func requireCodexAnalyticsWarning(t *testing.T, warnings []OpenAICodexAnalyticsWarning, code string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return
+		}
+	}
+	require.Failf(t, "missing analytics warning", "code %q was not present in %#v", code, warnings)
+}
+
+func TestQueryCodexAnalyticsCachesMissThenHit(t *testing.T) {
+	today := time.Now().UTC().Format("2006-01-02")
+	calls := map[string]int{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.URL.Path]++
+		w.Header().Set("content-type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/wham/profiles/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{"stats": map[string]any{
+				"lifetime_tokens":          1000,
+				"peak_daily_tokens":        400,
+				"longest_running_turn_sec": 12,
+				"current_streak_days":      3,
+				"longest_streak_days":      8,
+				"daily_usage_buckets":      []map[string]any{{"start_date": today, "tokens": 300}},
+			}})
+		case "/backend-api/wham/usage":
+			_ = json.NewEncoder(w).Encode(OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+				Allowed:         false,
+				LimitReached:    true,
+				PrimaryWindow:   &OpenAIRateLimitWindow{UsedPercent: 65, LimitWindowSeconds: 604800},
+				SecondaryWindow: &OpenAIRateLimitWindow{UsedPercent: 25, LimitWindowSeconds: 18000},
+			}})
+		case "/backend-api/wham/rate-limit-reset-credits":
+			_, _ = w.Write([]byte(`{"available_count":0,"credits":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	cache := newCodexAnalyticsCacheFake()
+	usageRepo := &codexAnalyticsUsageRepoStub{
+		stats: &usagestats.UsageStats{
+			TotalRequests: 2, TotalInputTokens: 100, TotalOutputTokens: 50,
+			TotalCacheTokens: 20, TotalCacheReadTokens: 15, TotalTokens: 170, TotalCost: 0.42,
+		},
+		trend: []usagestats.TrendDataPoint{{
+			Date: today, Requests: 2, InputTokens: 100, OutputTokens: 50,
+			CacheCreationTokens: 5, CacheReadTokens: 15, TotalTokens: 170, Cost: 0.42,
+		}},
+		models: []usagestats.ModelStat{{
+			Model: "gpt-5-codex", Requests: 2, InputTokens: 100, OutputTokens: 50,
+			CacheCreationTokens: 5, CacheReadTokens: 15, TotalTokens: 170, Cost: 0.42,
+		}},
+	}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, cache)
+
+	first, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+	require.NoError(t, err)
+	require.False(t, first.Cache.Hit)
+	require.Equal(t, int64(240), first.Cache.TTLSeconds)
+	require.Equal(t, int64(300), *first.Summary.OfficialTotalTokens)
+	require.Equal(t, int64(1000), *first.Profile.LifetimeTokens)
+	require.Equal(t, int64(170), first.Summary.ManagedTotalTokens)
+	require.Equal(t, float64(65), first.Summary.CurrentLimitUsedPercent)
+	require.NotNil(t, first.RateLimits.FiveHour)
+	require.Equal(t, int64(18000), first.RateLimits.FiveHour.LimitWindowSeconds)
+	require.False(t, first.RateLimits.FiveHour.Allowed)
+	require.True(t, first.RateLimits.FiveHour.LimitReached)
+	require.NotNil(t, first.RateLimits.SevenDay)
+	require.True(t, first.RateLimits.SevenDay.LimitReached)
+
+	cache.advance(time.Minute)
+	second, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+	require.NoError(t, err)
+	require.True(t, second.Cache.Hit)
+	require.Equal(t, int64(180), second.Cache.TTLSeconds)
+	require.Equal(t, 1, usageRepo.statsCalls)
+	require.Equal(t, 1, usageRepo.trendCalls)
+	require.Equal(t, 1, usageRepo.modelCalls)
+	require.Equal(t, 1, calls["/backend-api/wham/profiles/me"])
+	require.Equal(t, 1, calls["/backend-api/wham/usage"])
+}
+
+func TestQueryCodexAnalyticsLeaderCancellationDoesNotCancelFollower(t *testing.T) {
+	usageStarted := make(chan struct{})
+	releaseUsage := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseUsage) }) }
+	defer release()
+
+	var usageCalls atomic.Int32
+	var profileCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/wham/usage":
+			if usageCalls.Add(1) == 1 {
+				close(usageStarted)
+			}
+			select {
+			case <-releaseUsage:
+				_ = json.NewEncoder(w).Encode(OpenAIQuotaUsage{})
+			case <-r.Context().Done():
+			}
+		case "/backend-api/wham/rate-limit-reset-credits":
+			_, _ = w.Write([]byte(`{"available_count":0,"credits":[]}`))
+		case "/backend-api/wham/profiles/me":
+			profileCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"stats": map[string]any{"daily_usage_buckets": []any{}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	service := newCodexAnalyticsTestService(t, upstream, &codexAnalyticsUsageRepoStub{}, nil)
+	query := OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days}
+	type queryResult struct {
+		analytics *OpenAICodexAnalytics
+		err       error
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+	leaderDone := make(chan queryResult, 1)
+	go func() {
+		analytics, err := service.QueryCodexAnalytics(leaderCtx, 100, query)
+		leaderDone <- queryResult{analytics: analytics, err: err}
+	}()
+
+	select {
+	case <-usageStarted:
+	case <-time.After(time.Second):
+		t.Fatal("leader did not start the shared analytics fetch")
+	}
+
+	followerWaiting := make(chan struct{})
+	followerCtx := &codexAnalyticsDoneSignalingContext{Context: context.Background(), signal: followerWaiting}
+	followerDone := make(chan queryResult, 1)
+	go func() {
+		analytics, err := service.QueryCodexAnalytics(followerCtx, 100, query)
+		followerDone <- queryResult{analytics: analytics, err: err}
+	}()
+
+	select {
+	case <-followerWaiting:
+	case <-time.After(time.Second):
+		t.Fatal("follower did not join the shared analytics fetch")
+	}
+	cancelLeader()
+
+	var leader queryResult
+	select {
+	case leader = <-leaderDone:
+	case <-time.After(time.Second):
+		t.Fatal("canceled leader did not return promptly")
+	}
+	require.Nil(t, leader.analytics)
+	require.ErrorIs(t, leader.err, context.Canceled)
+	release()
+
+	select {
+	case follower := <-followerDone:
+		require.NoError(t, follower.err)
+		require.NotNil(t, follower.analytics)
+	case <-time.After(time.Second):
+		t.Fatal("follower did not receive the shared analytics result")
+	}
+	require.Equal(t, int32(1), usageCalls.Load())
+	require.Equal(t, int32(1), profileCalls.Load())
+}
+
+func TestCodexOfficialPeriodTotalFiltersAndSumsBuckets(t *testing.T) {
+	start := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 7)
+	profile := &OpenAICodexAnalyticsProfile{
+		LifetimeTokens: func() *int64 { value := int64(9999); return &value }(),
+		DailyUsageBuckets: []OpenAICodexDailyUsageBucket{
+			{StartDate: "2026-08-09", Tokens: 50},
+			{StartDate: "2026-08-10", Tokens: 100},
+			{StartDate: "2026-08-16T12:00:00Z", Tokens: 200},
+			{StartDate: "2026-08-17", Tokens: 400},
+			{StartDate: "invalid", Tokens: 800},
+		},
+	}
+
+	filterCodexProfileBuckets(profile, start, end)
+	total := sumCodexOfficialPeriodTokens(profile, true)
+
+	require.Equal(t, []OpenAICodexDailyUsageBucket{
+		{StartDate: "2026-08-10", Tokens: 100},
+		{StartDate: "2026-08-16", Tokens: 200},
+	}, profile.DailyUsageBuckets)
+	require.NotNil(t, total)
+	require.Equal(t, int64(300), *total)
+	require.Nil(t, sumCodexOfficialPeriodTokens(profile, false))
+	emptyTotal := sumCodexOfficialPeriodTokens(&OpenAICodexAnalyticsProfile{}, true)
+	require.NotNil(t, emptyTotal)
+	require.Zero(t, *emptyTotal)
+}
+
+func TestQueryCodexAnalyticsUsesExactOfficialCurrentWindow(t *testing.T) {
+	resetAt := time.Now().UTC().Truncate(time.Second).Add(36 * time.Hour)
+	windowSeconds := int64((7 * 24 * time.Hour) / time.Second)
+	upstream := newCodexAnalyticsPeriodUpstream(t, &OpenAIRateLimitWindow{
+		LimitWindowSeconds: windowSeconds,
+		ResetAt:            resetAt.Unix(),
+	}, nil)
+	usageRepo := &codexAnalyticsUsageRepoStub{}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, nil)
+
+	result, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+
+	require.NoError(t, err)
+	wantStart := resetAt.Add(-7 * 24 * time.Hour)
+	require.Equal(t, OpenAICodexAnalyticsCurrent7Days, result.PeriodMode)
+	require.Equal(t, wantStart.Unix(), result.PeriodStart)
+	require.Equal(t, result.FetchedAt, result.PeriodEnd)
+	require.Equal(t, wantStart, usageRepo.statsStart)
+	require.Equal(t, time.Unix(result.PeriodEnd, 0).UTC(), usageRepo.statsEnd)
+	require.Equal(t, usageRepo.statsStart, usageRepo.trendStart)
+	require.Equal(t, usageRepo.statsEnd, usageRepo.trendEnd)
+	require.Equal(t, usageRepo.statsStart, usageRepo.modelStart)
+	require.Equal(t, usageRepo.statsEnd, usageRepo.modelEnd)
+	requireCodexAnalyticsWarning(t, result.Warnings, "official_daily_buckets_approximate_period")
+}
+
+func TestQueryCodexAnalyticsFallsBackToExactRecentSevenDays(t *testing.T) {
+	upstream := newCodexAnalyticsPeriodUpstream(t, &OpenAIRateLimitWindow{
+		LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+		ResetAt:            time.Now().Add(-time.Minute).Unix(),
+	}, nil)
+	usageRepo := &codexAnalyticsUsageRepoStub{}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, nil)
+
+	result, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+
+	require.NoError(t, err)
+	require.Equal(t, OpenAICodexAnalyticsCurrent7Days, result.PeriodMode)
+	require.Equal(t, int64((7*24*time.Hour)/time.Second), result.PeriodEnd-result.PeriodStart)
+	require.Equal(t, time.Unix(result.PeriodStart, 0).UTC(), usageRepo.statsStart)
+	require.Equal(t, time.Unix(result.PeriodEnd, 0).UTC(), usageRepo.statsEnd)
+	requireCodexAnalyticsWarning(t, result.Warnings, "current_7d_window_unavailable")
+}
+func TestQueryCodexAnalyticsRejectsNonSevenDayOfficialWindow(t *testing.T) {
+	upstream := newCodexAnalyticsPeriodUpstream(t, &OpenAIRateLimitWindow{
+		LimitWindowSeconds: int64((24 * time.Hour) / time.Second),
+		ResetAt:            time.Now().Add(12 * time.Hour).Unix(),
+	}, nil)
+	usageRepo := &codexAnalyticsUsageRepoStub{}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, nil)
+
+	result, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+
+	require.NoError(t, err)
+	require.Nil(t, result.RateLimits.SevenDay)
+	require.Equal(t, openAICodexAnalyticsSevenDaySeconds, result.PeriodEnd-result.PeriodStart)
+	require.Equal(t, time.Unix(result.PeriodStart, 0).UTC(), usageRepo.statsStart)
+	require.Equal(t, time.Unix(result.PeriodEnd, 0).UTC(), usageRepo.statsEnd)
+	requireCodexAnalyticsWarning(t, result.Warnings, "current_7d_window_unavailable")
+}
+
+func TestQueryCodexAnalyticsSeparatesCurrentAndRecentCaches(t *testing.T) {
+	calls := map[string]int{}
+	upstream := newCodexAnalyticsPeriodUpstream(t, &OpenAIRateLimitWindow{LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second)}, calls)
+	cache := newCodexAnalyticsCacheFake()
+	usageRepo := &codexAnalyticsUsageRepoStub{}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, cache)
+
+	current, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+	require.NoError(t, err)
+	recent, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsRecent, Days: 7})
+	require.NoError(t, err)
+	cachedCurrent, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+	require.NoError(t, err)
+
+	require.False(t, current.Cache.Hit)
+	require.False(t, recent.Cache.Hit)
+	require.True(t, cachedCurrent.Cache.Hit)
+	require.Equal(t, OpenAICodexAnalyticsRecent, recent.PeriodMode)
+	require.Equal(t, 2, usageRepo.statsCalls)
+	require.Equal(t, 2, calls["/backend-api/wham/usage"])
+}
+
+func TestQueryCodexAnalyticsInvalidatesCurrentCacheAfterReset(t *testing.T) {
+	resetAt := time.Now().UTC().Truncate(time.Second).Add(24 * time.Hour)
+	upstream := newCodexAnalyticsPeriodUpstream(t, &OpenAIRateLimitWindow{
+		LimitWindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+		ResetAt:            resetAt.Unix(),
+	}, nil)
+	cache := newCodexAnalyticsCacheFake()
+	usageRepo := &codexAnalyticsUsageRepoStub{}
+	service := newCodexAnalyticsTestService(t, upstream, usageRepo, cache)
+	query := OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days}
+	stale := OpenAICodexAnalytics{
+		AccountID:  100,
+		PeriodMode: OpenAICodexAnalyticsCurrent7Days,
+		RateLimits: OpenAICodexAnalyticsRateLimits{SevenDay: &OpenAICodexAnalyticsRateLimitWindow{ResetAt: time.Now().Add(-time.Second).Unix()}},
+	}
+	raw, err := json.Marshal(stale)
+	require.NoError(t, err)
+	cache.seed(openAICodexAnalyticsCacheKey(100, query), raw, openAICodexAnalyticsTTL)
+
+	result, err := service.QueryCodexAnalytics(context.Background(), 100, query)
+
+	require.NoError(t, err)
+	require.False(t, result.Cache.Hit)
+	require.Equal(t, resetAt.Unix(), result.RateLimits.SevenDay.ResetAt)
+	require.Equal(t, 1, usageRepo.statsCalls)
+}
+
+func TestCodexAnalyticsCacheWarnings(t *testing.T) {
+	query := OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days}
+	key := openAICodexAnalyticsCacheKey(100, query)
+
+	t.Run("read failure", func(t *testing.T) {
+		cache := newCodexAnalyticsCacheFake()
+		cache.failGet(errors.New("cache unavailable"))
+		service := &OpenAIQuotaService{analyticsCache: cache}
+
+		cached, warning := service.readCodexAnalyticsCache(context.Background(), key, query)
+
+		require.Nil(t, cached)
+		require.NotNil(t, warning)
+		require.Equal(t, "cache_read_failed", warning.Code)
+	})
+
+	t.Run("invalid cached value", func(t *testing.T) {
+		cache := newCodexAnalyticsCacheFake()
+		cache.seed(key, []byte("invalid json"), openAICodexAnalyticsTTL)
+		service := &OpenAIQuotaService{analyticsCache: cache}
+
+		cached, warning := service.readCodexAnalyticsCache(context.Background(), key, query)
+
+		require.Nil(t, cached)
+		require.NotNil(t, warning)
+		require.Equal(t, "cache_read_failed", warning.Code)
+		_, _, err := cache.Get(context.Background(), key)
+		require.ErrorIs(t, err, ErrCodexAnalyticsCacheMiss)
+	})
+
+	t.Run("write failure", func(t *testing.T) {
+		cache := newCodexAnalyticsCacheFake()
+		cache.failSet(errors.New("cache unavailable"))
+		service := &OpenAIQuotaService{analyticsCache: cache}
+		result := &OpenAICodexAnalytics{PeriodMode: OpenAICodexAnalyticsRecent}
+
+		warning := service.writeCodexAnalyticsCache(context.Background(), key, result)
+
+		require.NotNil(t, warning)
+		require.Equal(t, "cache_write_failed", warning.Code)
+		require.Equal(t, OpenAICodexAnalyticsCache{}, result.Cache)
+	})
+}
+
+func TestQueryCodexAnalyticsPreservesProfile401And429(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("content-type", "application/json")
+				switch r.URL.Path {
+				case "/backend-api/wham/usage":
+					_ = json.NewEncoder(w).Encode(OpenAIQuotaUsage{})
+				case "/backend-api/wham/rate-limit-reset-credits":
+					_, _ = w.Write([]byte(`{"available_count":0,"credits":[]}`))
+				case "/backend-api/wham/profiles/me":
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(`{"access_token":"secret-upstream-token"}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer upstream.Close()
+
+			service := newCodexAnalyticsTestService(t, upstream, &codexAnalyticsUsageRepoStub{}, nil)
+			result, err := service.QueryCodexAnalytics(context.Background(), 100, OpenAICodexAnalyticsQuery{Period: OpenAICodexAnalyticsCurrent7Days})
+
+			require.Nil(t, result)
+			require.Error(t, err)
+			gotStatus, _ := infraerrors.ToHTTP(err)
+			require.Equal(t, status, gotStatus)
+			require.NotContains(t, err.Error(), "secret-upstream-token")
+		})
+	}
+}

--- a/backend/internal/service/openai_quota_reset_credits_test.go
+++ b/backend/internal/service/openai_quota_reset_credits_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -171,7 +172,7 @@ func TestQueryUsageResetCreditCountPrecedence(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+			svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
 			usage, err := svc.QueryUsage(context.Background(), 100)
 			require.NoError(t, err)
 			require.NotNil(t, usage)
@@ -183,6 +184,53 @@ func TestQueryUsageResetCreditCountPrecedence(t *testing.T) {
 			require.NotNil(t, usage.RateLimitResetCredits)
 			require.Equal(t, tt.wantCount, usage.RateLimitResetCredits.AvailableCount)
 			require.Len(t, usage.RateLimitResetCredits.Credits, tt.wantCredits)
+		})
+	}
+}
+
+func TestQueryUsageRedactsSensitiveUpstreamErrorBody(t *testing.T) {
+	const (
+		accessToken  = "upstream-access-secret"
+		refreshToken = "upstream-refresh-secret"
+		password     = "upstream-password-secret"
+		responseBody = `{"access_token":"upstream-access-secret","refresh_token":"upstream-refresh-secret","password":"upstream-password-secret","detail":"authentication failed"}`
+	)
+
+	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			account := &Account{
+				ID:       100,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+				Credentials: map[string]any{
+					"chatgpt_account_id": "org-parent123",
+				},
+			}
+			repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{100: account}}
+			tokenCache := &stubQuotaTokenCache{tokens: map[string]string{
+				OpenAITokenCacheKey(account): "fake-token",
+			}}
+			tokenProvider := NewOpenAITokenProvider(repo, tokenCache, nil)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("content-type", "application/json")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(responseBody))
+			}))
+			defer srv.Close()
+
+			svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
+			_, err := svc.QueryUsage(context.Background(), 100)
+			require.Error(t, err)
+			require.Equal(t, status, infraerrors.Code(err))
+			require.Equal(t, "OPENAI_QUOTA_UPSTREAM_ERROR", infraerrors.Reason(err))
+
+			errorText := infraerrors.Message(err)
+			require.Contains(t, errorText, "***")
+			for _, secret := range []string{accessToken, refreshToken, password} {
+				require.NotContains(t, errorText, secret)
+			}
 		})
 	}
 }

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,8 +13,20 @@ import (
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
 	"github.com/imroc/req/v3"
+	"golang.org/x/sync/singleflight"
 )
+
+// ErrCodexAnalyticsCacheMiss identifies an absent Codex analytics cache entry.
+var ErrCodexAnalyticsCacheMiss = errors.New("codex analytics cache miss")
+
+// CodexAnalyticsCache stores serialized analytics responses behind the service boundary.
+type CodexAnalyticsCache interface {
+	Get(ctx context.Context, key string) ([]byte, time.Duration, error)
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+}
 
 // ErrSparkShadowResetNotSupported is returned when ResetCredit is called on a
 // spark shadow account. Shadow accounts do not hold credentials of their own;
@@ -120,6 +133,9 @@ type OpenAIQuotaService struct {
 	privacyClientFactory PrivacyClientFactory
 	agentIdentityTaskMu  sync.Mutex
 	agentIdentityWS      agentIdentityWSConnectionInvalidator
+	analyticsUsageRepo   codexAnalyticsUsageRepository
+	analyticsCache       CodexAnalyticsCache
+	analyticsFlight      singleflight.Group
 }
 
 // NewOpenAIQuotaService constructs a quota service. token provider is required —
@@ -130,12 +146,16 @@ func NewOpenAIQuotaService(
 	proxyRepo ProxyRepository,
 	tokenProvider *OpenAITokenProvider,
 	privacyClientFactory PrivacyClientFactory,
+	analyticsUsageRepo codexAnalyticsUsageRepository,
+	analyticsCache CodexAnalyticsCache,
 ) *OpenAIQuotaService {
 	return &OpenAIQuotaService{
 		accountRepo:          accountRepo,
 		proxyRepo:            proxyRepo,
 		tokenProvider:        tokenProvider,
 		privacyClientFactory: privacyClientFactory,
+		analyticsUsageRepo:   analyticsUsageRepo,
+		analyticsCache:       analyticsCache,
 	}
 }
 
@@ -180,7 +200,7 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 				continue
 			}
 			status := resp.StatusCode
-			body := truncate(s.redactQuotaErrorBody(ctx, accountID, resp.String()), 240)
+			body := truncate(logredact.RedactText(s.redactQuotaErrorBody(ctx, accountID, resp.String())), 240)
 			slog.Warn("openai_quota_query_failed", "account_id", accountID, "status", status, "body", body)
 			return nil, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_QUOTA_UPSTREAM_ERROR", "upstream returned %d: %s", status, body)
 		}

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -233,7 +233,7 @@ func TestResetCreditAgentIdentityUsesAssertionAndRecoversInvalidTaskOnce(t *test
 	t.Cleanup(func() { openAIAgentIdentityAuthAPIBaseURL = oldBase })
 
 	invalidator := &agentIdentityWSInvalidationRecorder{}
-	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv), nil, nil)
 	svc.agentIdentityWS = invalidator
 
 	result, err := svc.ResetCredit(context.Background(), account.ID)
@@ -295,7 +295,7 @@ func TestResetCreditAgentIdentityReusesConcurrentlyRecoveredTask(t *testing.T) {
 	openAIAgentIdentityAuthAPIBaseURL = srv.URL
 	t.Cleanup(func() { openAIAgentIdentityAuthAPIBaseURL = oldBase })
 
-	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv), nil, nil)
 	result, err := svc.ResetCredit(context.Background(), account.ID)
 	require.NoError(t, err)
 	require.Equal(t, "ok", result.Code)
@@ -348,7 +348,7 @@ func TestPrepareUpstreamCallShadowResolve(t *testing.T) {
 	// privacyClientFactory 可以是任意合法工厂；prepareUpstreamCall 在返回前不调用它
 	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, func(_ string) (*req.Client, error) {
 		return req.C(), nil
-	})
+	}, nil, nil)
 
 	_, chatGPTAccountID, _, _, err := svc.prepareUpstreamCall(ctx, 200)
 	require.NoError(t, err, "shadow resolve should succeed; got error: %v", err)
@@ -386,7 +386,7 @@ func TestQueryUsageAgentIdentityUsesAssertionWithoutOAuthToken(t *testing.T) {
 		_, _ = w.Write([]byte(`{"plan_type":"pro","rate_limit":{"allowed":true}}`))
 	}))
 	defer srv.Close()
-	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv), nil, nil)
 	usage, err := svc.QueryUsage(context.Background(), account.ID)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
@@ -440,7 +440,7 @@ func TestQueryUsageAgentIdentityRecoversInvalidTaskOnce(t *testing.T) {
 	t.Cleanup(func() { openAIAgentIdentityAuthAPIBaseURL = oldBase })
 
 	invalidator := &agentIdentityWSInvalidationRecorder{}
-	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv), nil, nil)
 	svc.agentIdentityWS = invalidator
 	usage, err := svc.QueryUsage(context.Background(), account.ID)
 	require.NoError(t, err)
@@ -536,7 +536,7 @@ func TestQueryUsageIncludesResetCreditExpirations_EndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
 	usage, err := svc.QueryUsage(ctx, 100)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
@@ -597,7 +597,7 @@ func TestQueryUsageResetCreditDetails401NonFatal(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
 	usage, err := svc.QueryUsage(ctx, 100)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
@@ -719,7 +719,7 @@ func TestQueryUsageShadowResolve_EndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv), nil, nil)
 	usage, err := svc.QueryUsage(ctx, 200)
 	require.NoError(t, err)
 	require.NotNil(t, usage)

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -174,17 +174,17 @@ func ProvideOpenAITokenProvider(
 	return p
 }
 
-// ProvideOpenAIQuotaService wires the OpenAI quota query/reset service.
-// It depends on the OpenAI token provider for refreshed access tokens and the
-// privacy client factory for the impersonated upstream HTTP client.
+// ProvideOpenAIQuotaService wires quota/reset and Codex analytics dependencies.
 func ProvideOpenAIQuotaService(
 	accountRepo AccountRepository,
 	proxyRepo ProxyRepository,
 	tokenProvider *OpenAITokenProvider,
 	privacyClientFactory PrivacyClientFactory,
 	openAIGatewayService *OpenAIGatewayService,
+	usageLogRepo UsageLogRepository,
+	analyticsCache CodexAnalyticsCache,
 ) *OpenAIQuotaService {
-	service := NewOpenAIQuotaService(accountRepo, proxyRepo, tokenProvider, privacyClientFactory)
+	service := NewOpenAIQuotaService(accountRepo, proxyRepo, tokenProvider, privacyClientFactory, usageLogRepo, analyticsCache)
 	service.agentIdentityWS = openAIGatewayService
 	return service
 }

--- a/frontend/src/api/__tests__/admin.accounts.codexAnalyticsAuth.spec.ts
+++ b/frontend/src/api/__tests__/admin.accounts.codexAnalyticsAuth.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { InternalAxiosRequestConfig } from 'axios'
+import { apiClient } from '@/api/client'
+import { getCodexAnalytics } from '@/api/admin/accounts'
+
+const { refreshAuthTokens } = vi.hoisted(() => ({
+  refreshAuthTokens: vi.fn()
+}))
+
+vi.mock('@/api/tokenRefresh', () => ({ refreshAuthTokens }))
+
+describe('admin account Codex analytics authentication handling', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    refreshAuthTokens.mockReset()
+    window.history.replaceState({}, '', '/admin/accounts/42')
+  })
+
+  it('returns an upstream 401 without refreshing or clearing the admin session', async () => {
+    localStorage.setItem('auth_token', 'admin-access')
+    localStorage.setItem('refresh_token', 'admin-refresh')
+    localStorage.setItem('auth_user', JSON.stringify({ id: 42 }))
+    localStorage.setItem('token_expires_at', '4102444800000')
+
+    const adapter = vi.fn((config: InternalAxiosRequestConfig) => Promise.reject({
+      response: {
+        status: 401,
+        data: {
+          code: 'UPSTREAM_UNAUTHORIZED',
+          reason: 'OPENAI_QUOTA_UPSTREAM_ERROR',
+          message: 'OpenAI account authorization failed'
+        },
+        headers: {},
+        config,
+        statusText: 'Unauthorized'
+      },
+      config,
+      code: 'ERR_BAD_REQUEST',
+      message: 'Request failed with status code 401'
+    }))
+    apiClient.defaults.adapter = adapter
+
+    await expect(getCodexAnalytics(42)).rejects.toMatchObject({
+      status: 401,
+      code: 'UPSTREAM_UNAUTHORIZED',
+      reason: 'OPENAI_QUOTA_UPSTREAM_ERROR'
+    })
+
+    expect(adapter).toHaveBeenCalledTimes(1)
+    expect(adapter.mock.calls[0][0]).toMatchObject({
+      skipAuthRefreshReasons: [
+        'OPENAI_QUOTA_UPSTREAM_ERROR',
+        'OPENAI_CODEX_PROFILE_UNAUTHORIZED'
+      ]
+    })
+    expect(refreshAuthTokens).not.toHaveBeenCalled()
+    expect(localStorage.getItem('auth_token')).toBe('admin-access')
+    expect(localStorage.getItem('refresh_token')).toBe('admin-refresh')
+    expect(localStorage.getItem('auth_user')).toBe(JSON.stringify({ id: 42 }))
+    expect(localStorage.getItem('token_expires_at')).toBe('4102444800000')
+    expect(window.location.pathname).toBe('/admin/accounts/42')
+  })
+
+  it('refreshes and retries when the same endpoint returns a panel-auth 401', async () => {
+    localStorage.setItem('auth_token', 'expired-admin-access')
+    localStorage.setItem('refresh_token', 'admin-refresh')
+    localStorage.setItem('auth_user', JSON.stringify({ id: 42 }))
+    localStorage.setItem('token_expires_at', '0')
+    refreshAuthTokens.mockImplementationOnce(async () => {
+      localStorage.setItem('auth_token', 'renewed-admin-access')
+      localStorage.setItem('refresh_token', 'renewed-admin-refresh')
+      localStorage.setItem('token_expires_at', String(Date.now() + 3_600_000))
+      return {
+        access_token: 'renewed-admin-access',
+        refresh_token: 'renewed-admin-refresh',
+        expires_in: 3600,
+        token_type: 'Bearer'
+      }
+    })
+
+    const adapter = vi.fn()
+    adapter.mockImplementationOnce((config: InternalAxiosRequestConfig) => Promise.reject({
+      response: {
+        status: 401,
+        data: {
+          code: 'TOKEN_EXPIRED',
+          reason: 'TOKEN_EXPIRED',
+          message: 'Token expired'
+        },
+        headers: {},
+        config,
+        statusText: 'Unauthorized'
+      },
+      config,
+      code: 'ERR_BAD_REQUEST',
+      message: 'Request failed with status code 401'
+    }))
+    adapter.mockResolvedValueOnce({
+      status: 200,
+      data: { code: 0, data: { ok: true } },
+      headers: {},
+      config: {},
+      statusText: 'OK'
+    })
+    apiClient.defaults.adapter = adapter
+
+    await expect(getCodexAnalytics(42)).resolves.toEqual({ ok: true })
+
+    expect(refreshAuthTokens).toHaveBeenCalledTimes(1)
+    expect(refreshAuthTokens).toHaveBeenCalledWith({ failedAccessToken: 'expired-admin-access' })
+    expect(adapter).toHaveBeenCalledTimes(2)
+    expect(adapter.mock.calls[1][0].headers.get('Authorization')).toBe('Bearer renewed-admin-access')
+  })
+})

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -1,8 +1,3 @@
-/**
- * Admin Accounts API endpoints
- * Handles AI platform account management for administrators
- */
-
 import { apiClient } from '../client'
 import type {
   Account,
@@ -289,6 +284,119 @@ export async function getStats(id: number, days: number = 30): Promise<AccountUs
   const { data } = await apiClient.get<AccountUsageStatsResponse>(`/admin/accounts/${id}/stats`, {
     params: { days }
   })
+  return data
+}
+
+export interface CodexAnalyticsRateLimitWindow {
+  used_percent?: number | null
+  reset_at?: number | string | null
+  reset_after_seconds?: number | null
+  limit_window_seconds?: number | null
+  limit_reached?: boolean | null
+  allowed?: boolean | null
+}
+
+export interface CodexAnalyticsDailyUsageBucket {
+  start_date?: string | null
+  date?: string | null
+  tokens?: number | null
+  total_tokens?: number | null
+  [key: string]: unknown
+}
+export type CodexAnalyticsPeriodMode = 'current_7d' | 'recent'
+
+export type CodexAnalyticsPeriodQuery =
+  | { period: 'current_7d' }
+  | { period: 'recent'; days: number }
+
+export const DEFAULT_CODEX_ANALYTICS_PERIOD_QUERY: CodexAnalyticsPeriodQuery = {
+  period: 'current_7d'
+}
+
+export interface CodexAnalyticsResponse {
+  account_id: number
+  period_days: number
+  fetched_at: number | string
+  period_mode: CodexAnalyticsPeriodMode
+  period_start: number
+  period_end: number
+  data_scope: {
+    official_account_activity?: string | null
+    managed_traffic?: string | null
+    rate_limits?: string | null
+  }
+  cache: {
+    hit: boolean
+    ttl_seconds: number
+    expires_at: number | string
+  }
+  rate_limits: {
+    five_hour?: CodexAnalyticsRateLimitWindow | null
+    seven_day?: CodexAnalyticsRateLimitWindow | null
+  }
+  profile: {
+    lifetime_tokens?: number | null
+    peak_daily_tokens?: number | null
+    longest_running_turn_seconds?: number | null
+    current_streak_days?: number | null
+    longest_streak_days?: number | null
+    daily_usage_buckets: CodexAnalyticsDailyUsageBucket[]
+  }
+  summary: {
+    official_total_tokens?: number | null
+    managed_total_tokens: number
+    input_tokens: number
+    output_tokens: number
+    cache_tokens: number
+    cache_read_tokens: number
+    cache_hit_rate: number
+    estimated_cost: number
+    requests: number
+    current_limit_used_percent: number
+  }
+  time_series: Array<{
+    date: string
+    official_total_tokens?: number | null
+    input_tokens: number
+    output_tokens: number
+    cache_tokens: number
+    total_tokens: number
+    requests: number
+    estimated_cost: number
+  }>
+  models: Array<{
+    model: string
+    input_tokens: number
+    output_tokens: number
+    cache_tokens: number
+    total_tokens: number
+    requests: number
+    estimated_cost: number
+  }>
+  warnings?: Array<{ code: string; message: string }>
+}
+
+/** Fetch the combined official-account and Sub2API-managed Codex analytics view. */
+export async function getCodexAnalytics(
+  id: number,
+  periodQuery: CodexAnalyticsPeriodQuery = DEFAULT_CODEX_ANALYTICS_PERIOD_QUERY,
+  options?: { signal?: AbortSignal }
+): Promise<CodexAnalyticsResponse> {
+  const params = periodQuery.period === 'recent'
+    ? { period: periodQuery.period, days: Math.min(30, Math.max(1, Math.trunc(periodQuery.days))) }
+    : { period: periodQuery.period }
+  const config = {
+    params,
+    signal: options?.signal,
+    skipAuthRefreshReasons: [
+      'OPENAI_QUOTA_UPSTREAM_ERROR',
+      'OPENAI_CODEX_PROFILE_UNAUTHORIZED'
+    ]
+  }
+  const { data } = await apiClient.get<CodexAnalyticsResponse>(
+    `/admin/accounts/${id}/codex-analytics`,
+    config
+  )
   return data
 }
 
@@ -999,6 +1107,7 @@ export const accountsAPI = {
   refreshCredentials,
   applyOAuthCredentials,
   getStats,
+  getCodexAnalytics,
   clearError,
   getUsage,
   getBatchUsage,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,10 @@ import { getAPIBaseURL } from './url'
 export { buildApiUrl, buildGatewayUrl } from './url'
 
 // ==================== Axios Instance Configuration ====================
+type InternalApiRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean
+  skipAuthRefreshReasons?: readonly string[]
+}
 
 export const apiClient: AxiosInstance = axios.create({
   baseURL: getAPIBaseURL(),
@@ -107,7 +111,7 @@ apiClient.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean }
+    const originalRequest = error.config as InternalApiRequestConfig
 
     // Handle common errors
     if (error.response) {
@@ -162,7 +166,9 @@ apiClient.interceptors.response.use(
 
       // 401: Try to refresh the token if we have a refresh token
       // This handles TOKEN_EXPIRED, INVALID_TOKEN, TOKEN_REVOKED, etc.
-      if (status === 401 && !originalRequest._retry) {
+      const skipAuthRefresh =
+        typeof apiData.reason === 'string' && originalRequest.skipAuthRefreshReasons?.includes(apiData.reason)
+      if (status === 401 && !skipAuthRefresh && !originalRequest._retry) {
         const refreshToken = localStorage.getItem('refresh_token')
         const isAuthEndpoint =
           url.includes('/auth/login') || url.includes('/auth/register') || url.includes('/auth/refresh')

--- a/frontend/src/components/admin/AccountCodexAnalyticsModal.vue
+++ b/frontend/src/components/admin/AccountCodexAnalyticsModal.vue
@@ -1,0 +1,767 @@
+<template>
+  <BaseDialog
+    :show="show"
+    :title="t('admin.accounts.codexAnalytics.title')"
+    width="extra-wide"
+    @close="handleClose"
+  >
+    <div :lang="locale" class="min-h-[22rem] tabular-nums">
+      <div v-if="loading" class="flex min-h-[22rem] flex-col items-center justify-center gap-3" role="status">
+        <LoadingSpinner />
+        <p class="text-sm text-gray-500 dark:text-dark-400">
+          {{ t('admin.accounts.codexAnalytics.loading') }}
+        </p>
+      </div>
+
+      <section
+        v-else-if="errorKind"
+        class="flex min-h-[22rem] flex-col items-center justify-center px-4 text-center"
+        role="alert"
+      >
+        <div
+          :class="[
+            'mb-4 flex h-11 w-11 items-center justify-center rounded-xl',
+            errorKind === 'unauthorized'
+              ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+              : errorKind === 'rate-limited'
+                ? 'bg-orange-100 text-orange-700 dark:bg-orange-500/15 dark:text-orange-300'
+                : 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
+          ]"
+        >
+          <Icon :name="errorKind === 'unauthorized' ? 'link' : 'exclamationTriangle'" size="lg" />
+        </div>
+        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+          {{ t(`admin.accounts.codexAnalytics.errors.${errorKind}.title`) }}
+        </h3>
+        <p class="mt-2 max-w-lg text-sm leading-6 text-gray-600 dark:text-dark-300">
+          {{ t(`admin.accounts.codexAnalytics.errors.${errorKind}.description`) }}
+        </p>
+        <p v-if="errorMessage" class="mt-2 max-w-lg break-words text-xs text-gray-500 dark:text-dark-400">
+          {{ errorMessage }}
+        </p>
+        <button type="button" class="btn btn-secondary mt-5 min-h-10 active:scale-95" @click="fetchAnalytics">
+          <Icon name="refresh" size="sm" />
+          {{ t('admin.accounts.codexAnalytics.retry') }}
+        </button>
+      </section>
+
+      <template v-else-if="analytics">
+        <header class="mb-4 flex flex-col gap-3 border-b border-gray-200 pb-4 dark:border-dark-700 sm:flex-row sm:items-start sm:justify-between">
+          <div class="min-w-0">
+            <div class="flex min-w-0 items-center gap-2">
+              <span class="h-2 w-2 flex-none rounded-full bg-emerald-500"></span>
+              <h3 class="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {{ account?.name }}
+              </h3>
+            </div>
+            <p class="mt-1 text-xs leading-5 text-gray-500 dark:text-dark-400">
+              {{ t('admin.accounts.codexAnalytics.scopeDescription') }}
+            </p>
+          </div>
+          <div class="grid w-full min-w-0 gap-2 sm:w-auto sm:max-w-sm sm:justify-items-end">
+            <label for="codex-analytics-period" class="sr-only">
+              {{ t('admin.accounts.codexAnalytics.periodSelector.label') }}
+            </label>
+            <Select
+              id="codex-analytics-period"
+              v-model="selectedPeriod"
+              :options="periodOptions"
+              :aria-label="t('admin.accounts.codexAnalytics.periodSelector.label')"
+              class="w-full sm:w-56"
+              @change="handlePeriodChange"
+            />
+            <div class="flex min-w-0 max-w-full flex-wrap items-center gap-x-2 gap-y-1 text-[11px] leading-5 text-gray-500 dark:text-dark-400 sm:justify-end">
+              <span class="max-w-full break-words rounded-md bg-gray-100 px-2 py-1 dark:bg-dark-800">
+                {{ t('admin.accounts.codexAnalytics.periodRange', { start: formatPeriodDate(analytics.period_start), end: formatPeriodDate(analytics.period_end) }) }}
+              </span>
+              <span class="max-w-full break-words rounded-md bg-gray-100 px-2 py-1 dark:bg-dark-800">
+                {{ analytics.cache.hit ? t('admin.accounts.codexAnalytics.cacheExpires', { time: formatDateTime(analytics.cache.expires_at) }) : t('admin.accounts.codexAnalytics.fresh') }}
+              </span>
+              <span class="max-w-full break-words">{{ formatDateTime(analytics.fetched_at) }}</span>
+            </div>
+          </div>
+        </header>
+
+        <div v-if="warnings.length" class="mb-4 space-y-2" role="status">
+          <div
+            v-for="warning in warnings"
+            :key="`${warning.code}:${warning.message}`"
+            class="flex gap-2 rounded-lg bg-amber-50 px-3 py-2.5 text-xs leading-5 text-amber-900 ring-1 ring-inset ring-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:ring-amber-500/20"
+          >
+            <Icon name="exclamationTriangle" size="sm" class="mt-0.5 flex-none" />
+            <div>
+              <span class="font-semibold">{{ isLocalFallback ? t('admin.accounts.codexAnalytics.localFallback') : t('admin.accounts.codexAnalytics.warning') }}</span>
+              <span class="ml-1">{{ warningMessage(warning) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <section v-if="isEmpty" class="flex min-h-[18rem] flex-col items-center justify-center px-4 text-center">
+          <Icon name="chartBar" size="xl" class="text-gray-300 dark:text-dark-600" />
+          <h3 class="mt-3 text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {{ t('admin.accounts.codexAnalytics.empty.title') }}
+          </h3>
+          <p class="mt-1 max-w-md text-sm leading-6 text-gray-500 dark:text-dark-400">
+            {{ t('admin.accounts.codexAnalytics.empty.description') }}
+          </p>
+          <button type="button" class="btn btn-secondary mt-4 min-h-10 active:scale-95" @click="fetchAnalytics">
+            <Icon name="refresh" size="sm" />
+            {{ t('admin.accounts.codexAnalytics.retry') }}
+          </button>
+        </section>
+
+        <div v-else class="space-y-4">
+          <section aria-labelledby="codex-kpis-title">
+            <div class="mb-2 flex items-end justify-between gap-3">
+              <div>
+                <h3 id="codex-kpis-title" class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {{ t('admin.accounts.codexAnalytics.overview') }}
+                </h3>
+                <p class="mt-0.5 text-xs text-gray-500 dark:text-dark-400">
+                  {{ t('admin.accounts.codexAnalytics.officialVsManaged') }}
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-2 overflow-hidden rounded-xl ring-1 ring-gray-200 dark:ring-dark-700 lg:grid-cols-4">
+              <div v-for="kpi in primaryKpis" :key="kpi.label" class="min-w-0 bg-white p-3 odd:bg-gray-50/70 dark:bg-dark-900 dark:odd:bg-dark-800/50 sm:p-3.5">
+                <p class="min-h-10 break-words text-[11px] font-medium leading-4 text-gray-500 dark:text-dark-400 lg:min-h-0" :title="kpi.label">{{ kpi.label }}</p>
+                <p class="mt-1 whitespace-nowrap text-base font-semibold leading-6 tracking-tight text-gray-900 dark:text-gray-100 sm:text-xl" :title="kpi.fullValue">{{ kpi.value }}</p>
+                <p class="mt-1 min-h-8 break-words text-[11px] leading-4 text-gray-400 dark:text-dark-500 lg:min-h-0">{{ kpi.source }}</p>
+              </div>
+            </div>
+            <dl class="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 rounded-lg bg-gray-50 px-3 py-2.5 text-xs dark:bg-dark-800/60 sm:grid-cols-3 lg:grid-cols-7">
+              <div v-for="metric in detailMetrics" :key="metric.label" class="min-h-14 min-w-0 lg:min-h-0">
+                <dt class="break-words leading-4 text-gray-500 dark:text-dark-400">{{ metric.label }}</dt>
+                <dd class="mt-1 whitespace-nowrap text-left font-semibold leading-4 text-gray-800 dark:text-gray-200">{{ metric.value }}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section aria-labelledby="codex-limits-title">
+            <h3 id="codex-limits-title" class="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {{ t('admin.accounts.codexAnalytics.rateLimits') }}
+            </h3>
+            <div class="grid gap-2 sm:grid-cols-2">
+              <div v-for="window in rateLimitWindows" :key="window.key" class="rounded-xl bg-gray-50 p-3.5 ring-1 ring-inset ring-gray-200 dark:bg-dark-800/60 dark:ring-dark-700">
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-xs font-semibold text-gray-700 dark:text-gray-200">{{ window.label }}</span>
+                  <span :class="window.statusClass" class="rounded-full px-2 py-0.5 text-[11px] font-semibold">{{ window.status }}</span>
+                </div>
+                <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-dark-700">
+                  <div :class="window.barClass" class="h-full rounded-full" :style="{ width: `${window.percent}%` }"></div>
+                </div>
+                <div class="mt-2 flex items-center justify-between gap-3 text-xs">
+                  <span class="font-semibold text-gray-900 dark:text-gray-100">{{ formatPercent(window.percent) }}</span>
+                  <span class="text-right text-gray-500 dark:text-dark-400">
+                    {{ window.resetText }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section v-if="profileMetrics.length" aria-labelledby="codex-profile-title">
+            <h3 id="codex-profile-title" class="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {{ t('admin.accounts.codexAnalytics.profile.title') }}
+            </h3>
+            <dl class="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-gray-200 ring-1 ring-gray-200 dark:bg-dark-700 dark:ring-dark-700 sm:grid-cols-3 lg:grid-cols-5">
+              <div v-for="metric in profileMetrics" :key="metric.label" class="bg-white px-3 py-3 dark:bg-dark-900">
+                <dt class="text-[11px] leading-4 text-gray-500 dark:text-dark-400">{{ metric.label }}</dt>
+                <dd class="mt-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ metric.value }}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <div class="grid gap-4 lg:grid-cols-[minmax(0,1.7fr)_minmax(16rem,0.8fr)]">
+            <section class="min-w-0 rounded-xl bg-white p-3.5 ring-1 ring-gray-200 dark:bg-dark-900 dark:ring-dark-700" aria-labelledby="codex-trend-title">
+              <div class="mb-3">
+                <h3 id="codex-trend-title" class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {{ t('admin.accounts.codexAnalytics.trend.title') }}
+                </h3>
+                <p class="mt-0.5 text-[11px] text-gray-500 dark:text-dark-400">
+                  {{ t('admin.accounts.codexAnalytics.trend.description') }}
+                </p>
+              </div>
+              <div class="h-64 sm:h-72">
+                <Bar v-if="trendChartData" :data="trendChartData" :options="barOptions" />
+                <div v-else class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-dark-400">
+                  {{ t('admin.accounts.codexAnalytics.noManagedTraffic') }}
+                </div>
+              </div>
+            </section>
+
+            <section class="min-w-0 rounded-xl bg-white p-3.5 ring-1 ring-gray-200 dark:bg-dark-900 dark:ring-dark-700" aria-labelledby="codex-models-title">
+              <div class="mb-3">
+                <h3 id="codex-models-title" class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {{ t('admin.accounts.codexAnalytics.models.title') }}
+                </h3>
+                <p class="mt-0.5 text-[11px] text-gray-500 dark:text-dark-400">
+                  {{ t('admin.accounts.codexAnalytics.models.description') }}
+                </p>
+              </div>
+              <div v-if="modelChartData" class="h-52">
+                <Doughnut :data="modelChartData" :options="doughnutOptions" />
+              </div>
+              <div v-else class="flex h-52 items-center justify-center text-sm text-gray-500 dark:text-dark-400">
+                {{ t('admin.accounts.codexAnalytics.noManagedTraffic') }}
+              </div>
+              <ol v-if="modelRows.length" class="mt-2 divide-y divide-gray-100 text-xs dark:divide-dark-700">
+                <li v-for="model in modelRows" :key="model.label" class="flex items-center justify-between gap-3 py-2">
+                  <span class="min-w-0 truncate text-gray-600 dark:text-dark-300" :title="model.label">{{ model.label }}</span>
+                  <span class="flex-none font-semibold text-gray-900 dark:text-gray-100">{{ formatTokens(model.value) }}</span>
+                </li>
+              </ol>
+            </section>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end">
+        <button type="button" class="btn btn-secondary min-h-10 active:scale-95" @click="handleClose">
+          {{ t('common.close') }}
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip
+} from 'chart.js'
+import { Bar, Doughnut } from 'vue-chartjs'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import Select from '@/components/common/Select.vue'
+import Icon from '@/components/icons/Icon.vue'
+import { adminAPI } from '@/api/admin'
+import {
+  DEFAULT_CODEX_ANALYTICS_PERIOD_QUERY,
+  type CodexAnalyticsPeriodQuery,
+  type CodexAnalyticsRateLimitWindow,
+  type CodexAnalyticsResponse
+} from '@/api/admin/accounts'
+import type { Account } from '@/types'
+import { extractApiErrorMessage } from '@/utils/apiError'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Tooltip, Legend)
+
+const props = defineProps<{
+  show: boolean
+  account: Account | null
+}>()
+
+const emit = defineEmits<{
+  (event: 'close'): void
+}>()
+
+const { t, locale } = useI18n()
+type AnalyticsPeriodSelection = 'current_7d' | 'recent_7' | 'recent_14' | 'recent_30'
+
+const PERIOD_QUERIES: Record<AnalyticsPeriodSelection, CodexAnalyticsPeriodQuery> = {
+  current_7d: DEFAULT_CODEX_ANALYTICS_PERIOD_QUERY,
+  recent_7: { period: 'recent', days: 7 },
+  recent_14: { period: 'recent', days: 14 },
+  recent_30: { period: 'recent', days: 30 }
+}
+
+const selectedPeriod = ref<AnalyticsPeriodSelection>('current_7d')
+const periodOptions = computed(() => [
+  { value: 'current_7d', label: t('admin.accounts.codexAnalytics.periodSelector.currentCycle') },
+  { value: 'recent_7', label: t('admin.accounts.codexAnalytics.periodSelector.recent7') },
+  { value: 'recent_14', label: t('admin.accounts.codexAnalytics.periodSelector.recent14') },
+  { value: 'recent_30', label: t('admin.accounts.codexAnalytics.periodSelector.recent30') }
+])
+const analytics = ref<CodexAnalyticsResponse | null>(null)
+const loading = ref(false)
+const errorKind = ref<'unauthorized' | 'rate-limited' | 'generic' | null>(null)
+const errorMessage = ref('')
+const now = ref(Date.now())
+const isDark = ref(false)
+let countdownTimer: ReturnType<typeof setInterval> | null = null
+let themeObserver: MutationObserver | null = null
+let requestController: AbortController | null = null
+let requestVersion = 0
+
+const warnings = computed(() => analytics.value?.warnings ?? [])
+const warningTranslationKeys: Readonly<Record<string, string>> = {
+  current_7d_window_unavailable: 'admin.accounts.codexAnalytics.warnings.current_7d_window_unavailable',
+  official_daily_buckets_approximate_period: 'admin.accounts.codexAnalytics.warnings.official_daily_buckets_approximate_period',
+  rate_limits_unavailable: 'admin.accounts.codexAnalytics.warnings.rate_limits_unavailable',
+  official_profile_unavailable: 'admin.accounts.codexAnalytics.warnings.official_profile_unavailable',
+  cache_read_failed: 'admin.accounts.codexAnalytics.warnings.cache_read_failed',
+  cache_write_failed: 'admin.accounts.codexAnalytics.warnings.cache_write_failed'
+}
+const isLocalFallback = computed(() => warnings.value.length > 0 && analytics.value?.summary.official_total_tokens == null)
+const isEmpty = computed(() => {
+  const value = analytics.value
+  if (!value) return true
+
+  const summary = value.summary
+  const hasSummaryActivity = hasNonzeroValue(
+    summary.official_total_tokens,
+    summary.managed_total_tokens,
+    summary.input_tokens,
+    summary.output_tokens,
+    summary.cache_tokens,
+    summary.cache_read_tokens,
+    summary.cache_hit_rate,
+    summary.estimated_cost,
+    summary.requests
+  )
+  const hasModelActivity = value.models.some((model) => hasNonzeroValue(
+    model.input_tokens,
+    model.output_tokens,
+    model.cache_tokens,
+    model.total_tokens,
+    model.requests,
+    model.estimated_cost
+  ))
+  const hasTimeSeriesActivity = value.time_series.some((row) => hasNonzeroValue(
+    row.official_total_tokens,
+    row.input_tokens,
+    row.output_tokens,
+    row.cache_tokens,
+    row.total_tokens,
+    row.requests,
+    row.estimated_cost
+  ))
+
+  return !hasSummaryActivity && !hasModelActivity && !hasTimeSeriesActivity
+})
+
+function hasNonzeroValue(...values: Array<number | null | undefined>): boolean {
+  return values.some((value) => value != null && Number.isFinite(value) && value !== 0)
+}
+
+function warningMessage(warning: { code: string; message: string }): string {
+  const translationKey = warningTranslationKeys[warning.code]
+  return translationKey ? t(translationKey) : warning.message
+}
+
+const primaryKpis = computed(() => {
+  const value = analytics.value
+  if (!value) return []
+  const summary = value.summary
+  const resetCountdown = formatPreferredResetCountdown(value)
+  return [
+    {
+      label: t('admin.accounts.codexAnalytics.kpis.officialTokens'),
+      value: formatOptionalTokens(summary.official_total_tokens),
+      fullValue: formatOptionalNumber(summary.official_total_tokens),
+      source: t('admin.accounts.codexAnalytics.sources.openai')
+    },
+    {
+      label: t('admin.accounts.codexAnalytics.kpis.cacheHitRate'),
+      value: formatPercent(summary.cache_hit_rate),
+      fullValue: formatPercent(summary.cache_hit_rate),
+      source: t('admin.accounts.codexAnalytics.sources.sub2api')
+    },
+    {
+      label: t('admin.accounts.codexAnalytics.kpis.estimatedCost'),
+      value: formatCurrency(summary.estimated_cost),
+      fullValue: formatCurrency(summary.estimated_cost),
+      source: t('admin.accounts.codexAnalytics.sources.sub2api')
+    },
+    {
+      label: t('admin.accounts.codexAnalytics.kpis.resetCountdown'),
+      value: resetCountdown,
+      fullValue: resetCountdown,
+      source: t('admin.accounts.codexAnalytics.sources.openai')
+    }
+  ]
+})
+
+const detailMetrics = computed(() => {
+  const summary = analytics.value?.summary
+  if (!summary) return []
+  return [
+    { label: t('admin.accounts.codexAnalytics.kpis.managedTokens'), value: formatTokens(summary.managed_total_tokens) },
+    { label: t('admin.accounts.codexAnalytics.kpis.requests'), value: formatNumber(summary.requests) },
+    { label: t('admin.accounts.codexAnalytics.kpis.currentLimit'), value: formatPercent(summary.current_limit_used_percent) },
+    { label: t('admin.accounts.codexAnalytics.kpis.input'), value: formatTokens(summary.input_tokens) },
+    { label: t('admin.accounts.codexAnalytics.kpis.output'), value: formatTokens(summary.output_tokens) },
+    { label: t('admin.accounts.codexAnalytics.kpis.cache'), value: formatTokens(summary.cache_tokens) },
+    { label: t('admin.accounts.codexAnalytics.kpis.cacheRead'), value: formatTokens(summary.cache_read_tokens) }
+  ]
+})
+
+const profileMetrics = computed(() => {
+  const profile = analytics.value?.profile
+  if (!profile) return []
+  const rows = [
+    [t('admin.accounts.codexAnalytics.profile.lifetimeTokens'), formatOptionalTokens(profile.lifetime_tokens), profile.lifetime_tokens],
+    [t('admin.accounts.codexAnalytics.profile.peakDailyTokens'), formatOptionalTokens(profile.peak_daily_tokens), profile.peak_daily_tokens],
+    [t('admin.accounts.codexAnalytics.profile.longestTurn'), formatOptionalDuration(profile.longest_running_turn_seconds), profile.longest_running_turn_seconds],
+    [t('admin.accounts.codexAnalytics.profile.currentStreak'), formatOptionalDays(profile.current_streak_days), profile.current_streak_days],
+    [t('admin.accounts.codexAnalytics.profile.longestStreak'), formatOptionalDays(profile.longest_streak_days), profile.longest_streak_days]
+  ] as const
+  return rows
+    .filter((row) => row[2] != null)
+    .map((row) => ({ label: row[0], value: row[1] }))
+})
+
+const rateLimitWindows = computed(() => {
+  const limits = analytics.value?.rate_limits
+  return [
+    buildRateWindow('five-hour', t('admin.accounts.codexAnalytics.windows.fiveHour'), limits?.five_hour),
+    buildRateWindow('seven-day', t('admin.accounts.codexAnalytics.windows.sevenDay'), limits?.seven_day)
+  ]
+})
+
+const chartPalette = computed(() => ({
+  text: isDark.value ? '#d1d5db' : '#4b5563',
+  grid: isDark.value ? 'rgba(107, 114, 128, 0.22)' : 'rgba(107, 114, 128, 0.16)',
+  input: '#3b82f6',
+  output: '#10b981',
+  cache: '#f59e0b',
+  official: '#f97316',
+  models: ['#2563eb', '#10b981', '#f59e0b', '#94a3b8']
+}))
+
+const trendChartData = computed(() => {
+  const rows = analytics.value?.time_series ?? []
+  if (!rows.length) return null
+  return {
+    labels: rows.map((row) => row.date),
+    datasets: [
+      {
+        label: t('admin.accounts.codexAnalytics.trend.input'),
+        data: rows.map((row) => row.input_tokens),
+        backgroundColor: chartPalette.value.input,
+        stack: 'managed'
+      },
+      {
+        label: t('admin.accounts.codexAnalytics.trend.output'),
+        data: rows.map((row) => row.output_tokens),
+        backgroundColor: chartPalette.value.output,
+        stack: 'managed'
+      },
+      {
+        label: t('admin.accounts.codexAnalytics.trend.cache'),
+        data: rows.map((row) => row.cache_tokens),
+        backgroundColor: chartPalette.value.cache,
+        stack: 'managed'
+      },
+      {
+        label: t('admin.accounts.codexAnalytics.trend.official'),
+        data: rows.map((row) => row.official_total_tokens ?? null),
+        backgroundColor: 'transparent',
+        borderColor: chartPalette.value.official,
+        borderWidth: 2,
+        borderRadius: 3,
+        borderSkipped: false,
+        stack: 'official'
+      }
+    ]
+  }
+})
+
+const barOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: 'index' as const, intersect: false },
+  plugins: {
+    legend: {
+      position: 'bottom' as const,
+      labels: { color: chartPalette.value.text, usePointStyle: true, pointStyle: 'circle', padding: 14, font: { size: 10 } }
+    }
+  },
+  scales: {
+    x: {
+      stacked: true,
+      grid: { display: false },
+      ticks: { color: chartPalette.value.text, maxRotation: 0, autoSkip: true, font: { size: 10 } }
+    },
+    y: {
+      stacked: true,
+      beginAtZero: true,
+      grid: { color: chartPalette.value.grid },
+      ticks: { color: chartPalette.value.text, callback: (value: string | number) => formatTokens(Number(value)), font: { size: 10 } }
+    },
+  }
+}))
+
+const modelRows = computed(() => {
+  const sorted = [...(analytics.value?.models ?? [])]
+    .filter((model) => model.total_tokens > 0)
+    .sort((left, right) => right.total_tokens - left.total_tokens)
+  const top = sorted.slice(0, 3).map((model) => ({ label: model.model, value: model.total_tokens }))
+  const remainder = sorted.slice(3).reduce((total, model) => total + model.total_tokens, 0)
+  if (remainder > 0) top.push({ label: t('admin.accounts.codexAnalytics.models.other'), value: remainder })
+  return top
+})
+
+const modelChartData = computed(() => {
+  if (!modelRows.value.length) return null
+  return {
+    labels: modelRows.value.map((model) => model.label),
+    datasets: [{
+      data: modelRows.value.map((model) => model.value),
+      backgroundColor: chartPalette.value.models.slice(0, modelRows.value.length),
+      borderWidth: 0,
+      hoverOffset: 3
+    }]
+  }
+})
+
+const doughnutOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  cutout: '68%',
+  plugins: {
+    legend: {
+      display: false
+    }
+  }
+}))
+
+watch(
+  () => [props.show, props.account?.id] as const,
+  ([visible]) => {
+    if (visible && props.account) {
+      void fetchAnalytics()
+      return
+    }
+    cleanupRequest()
+    stopCountdown()
+    analytics.value = null
+    errorKind.value = null
+    errorMessage.value = ''
+    selectedPeriod.value = 'current_7d'
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  syncTheme()
+  themeObserver = new MutationObserver(syncTheme)
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+})
+
+onUnmounted(() => {
+  cleanupRequest()
+  stopCountdown()
+  themeObserver?.disconnect()
+  themeObserver = null
+})
+
+async function fetchAnalytics(): Promise<void> {
+  if (!props.account || !props.show) return
+  cleanupRequest()
+  const version = ++requestVersion
+  requestController = new AbortController()
+  loading.value = true
+  errorKind.value = null
+  errorMessage.value = ''
+  try {
+    const response = await adminAPI.accounts.getCodexAnalytics(
+      props.account.id,
+      PERIOD_QUERIES[selectedPeriod.value],
+      { signal: requestController.signal }
+    )
+    if (version !== requestVersion) return
+    analytics.value = response
+    startCountdown()
+  } catch (error) {
+    if (version !== requestVersion || requestController?.signal.aborted) return
+    const status = extractStatus(error)
+    errorKind.value = status === 401 ? 'unauthorized' : status === 429 ? 'rate-limited' : 'generic'
+    errorMessage.value = extractApiErrorMessage(error, '')
+    analytics.value = null
+    stopCountdown()
+  } finally {
+    if (version === requestVersion) {
+      loading.value = false
+      requestController = null
+    }
+  }
+}
+
+function handlePeriodChange(): void {
+  void fetchAnalytics()
+}
+
+function extractStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null
+  const value = error as { status?: unknown; code?: unknown; response?: { status?: unknown } }
+  const raw = value.status ?? value.response?.status ?? value.code
+  const status = Number(raw)
+  return Number.isFinite(status) ? status : null
+}
+
+function cleanupRequest(): void {
+  requestVersion += 1
+  requestController?.abort()
+  requestController = null
+  loading.value = false
+}
+
+function startCountdown(): void {
+  stopCountdown()
+  now.value = Date.now()
+  countdownTimer = setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+}
+
+function stopCountdown(): void {
+  if (countdownTimer) clearInterval(countdownTimer)
+  countdownTimer = null
+}
+
+function syncTheme(): void {
+  isDark.value = document.documentElement.classList.contains('dark')
+}
+
+function handleClose(): void {
+  cleanupRequest()
+  stopCountdown()
+  analytics.value = null
+  errorKind.value = null
+  errorMessage.value = ''
+  selectedPeriod.value = 'current_7d'
+  emit('close')
+}
+
+function buildRateWindow(key: string, label: string, window?: CodexAnalyticsRateLimitWindow | null) {
+  const percent = clampPercent(window?.used_percent)
+  const seconds = secondsUntilReset(window)
+  const unavailable = window == null
+  const limited = window?.limit_reached === true || window?.allowed === false || percent >= 100
+  const warning = !limited && percent >= 80
+  return {
+    key,
+    label,
+    percent,
+    status: unavailable
+      ? t('admin.accounts.codexAnalytics.windows.unavailable')
+      : limited
+        ? t('admin.accounts.codexAnalytics.windows.limited')
+        : warning
+          ? t('admin.accounts.codexAnalytics.windows.nearLimit')
+          : t('admin.accounts.codexAnalytics.windows.available'),
+    statusClass: unavailable
+      ? 'bg-gray-200 text-gray-600 dark:bg-dark-700 dark:text-dark-300'
+      : limited
+        ? 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
+        : warning
+          ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+          : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300',
+    barClass: limited ? 'bg-red-500' : warning ? 'bg-amber-500' : unavailable ? 'bg-gray-300 dark:bg-dark-600' : 'bg-emerald-500',
+    resetText: unavailable
+      ? t('admin.accounts.codexAnalytics.windows.noReset')
+      : seconds == null
+        ? t('admin.accounts.codexAnalytics.windows.resetUnknown')
+        : seconds <= 0
+          ? t('admin.accounts.codexAnalytics.windows.resetting')
+          : t('admin.accounts.codexAnalytics.windows.resetsIn', { time: formatCountdown(seconds) })
+  }
+}
+
+function secondsUntilReset(window?: CodexAnalyticsRateLimitWindow | null): number | null {
+  if (!window) return null
+  if (window.reset_at != null) {
+    const timestamp = parseTimestamp(window.reset_at)
+    if (timestamp != null) return Math.max(0, Math.ceil((timestamp - now.value) / 1000))
+  }
+  if (window.reset_after_seconds != null && analytics.value) {
+    const fetchedAt = parseTimestamp(analytics.value.fetched_at)
+    if (fetchedAt != null) {
+      return Math.max(0, Math.ceil((fetchedAt + window.reset_after_seconds * 1000 - now.value) / 1000))
+    }
+  }
+  return null
+}
+
+function formatPreferredResetCountdown(value: CodexAnalyticsResponse): string {
+  const sevenDaySeconds = secondsUntilReset(value.rate_limits.seven_day)
+  const seconds = sevenDaySeconds ?? secondsUntilReset(value.rate_limits.five_hour)
+  if (seconds == null) return t('admin.accounts.codexAnalytics.unavailable')
+  if (seconds <= 0) return t('admin.accounts.codexAnalytics.windows.resetting')
+  return formatCountdown(seconds)
+}
+
+function clampPercent(value: unknown): number {
+  const percent = Number(value)
+  return Number.isFinite(percent) ? Math.min(100, Math.max(0, percent)) : 0
+}
+
+function formatCountdown(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds))
+  const days = Math.floor(seconds / 86_400)
+  const hours = Math.floor((seconds % 86_400) / 3_600)
+  const minutes = Math.floor((seconds % 3_600) / 60)
+  const rest = seconds % 60
+  if (days > 0) return `${days}d ${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat(locale.value).format(Number.isFinite(value) ? value : 0)
+}
+
+function formatOptionalNumber(value?: number | null): string {
+  return value == null ? t('admin.accounts.codexAnalytics.unavailable') : formatNumber(value)
+}
+
+function formatTokens(value: number): string {
+  const safe = Number.isFinite(value) ? value : 0
+  return new Intl.NumberFormat(locale.value, { notation: 'compact', maximumFractionDigits: 1 }).format(safe)
+}
+
+function formatOptionalTokens(value?: number | null): string {
+  return value == null ? t('admin.accounts.codexAnalytics.unavailable') : formatTokens(value)
+}
+
+function formatPercent(value: number): string {
+  const safe = Number.isFinite(value) ? value : 0
+  return `${safe.toFixed(1)}%`
+}
+
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat(locale.value, { style: 'currency', currency: 'USD', maximumFractionDigits: 4 }).format(Number.isFinite(value) ? value : 0)
+}
+
+function formatOptionalDuration(value?: number | null): string {
+  if (value == null) return t('admin.accounts.codexAnalytics.unavailable')
+  if (value < 60) return t('admin.accounts.codexAnalytics.profile.seconds', { count: Math.round(value) })
+  return t('admin.accounts.codexAnalytics.profile.minutes', { count: (value / 60).toFixed(1) })
+}
+
+function formatOptionalDays(value?: number | null): string {
+  return value == null
+    ? t('admin.accounts.codexAnalytics.unavailable')
+    : t('admin.accounts.codexAnalytics.profile.days', { count: formatNumber(value) })
+}
+
+function parseTimestamp(value: number | string): number | null {
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) return numeric < 10_000_000_000 ? numeric * 1000 : numeric
+  const parsed = Date.parse(String(value))
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function formatPeriodDate(value: number): string {
+  const timestamp = parseTimestamp(value)
+  if (timestamp == null) return t('admin.accounts.codexAnalytics.unavailable')
+  return new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' }).format(timestamp)
+}
+
+function formatDateTime(value: number | string): string {
+  const timestamp = parseTimestamp(value)
+  if (timestamp == null) return t('admin.accounts.codexAnalytics.unavailable')
+  return new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium', timeStyle: 'short' }).format(timestamp)
+}
+</script>

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -1429,6 +1429,111 @@ export default {
       audioReceived: 'Received test audio #{count}',
       videoPreview: 'Generated video:',
       videoReceived: 'Received test video #{count}',
+      codexAnalytics: {
+        action: 'Analytics',
+        openAction: 'Open Codex analytics',
+        openActionFor: 'Open Codex analytics for {name}',
+        title: 'Codex Analytics',
+        loading: 'Loading official account activity and managed traffic...',
+        retry: 'Retry',
+        periodRange: '{start} to {end}',
+        periodSelector: {
+          label: 'Analytics period',
+          currentCycle: 'Current 7d cycle',
+          recent7: 'Recent 7 days',
+          recent14: 'Recent 14 days',
+          recent30: 'Recent 30 days'
+        },
+        cacheExpires: 'Cached until {time}',
+        fresh: 'Fresh response',
+        unavailable: 'Unavailable',
+        scopeDescription: 'OpenAI account activity and Sub2API-managed traffic use separate source labels throughout this view.',
+        localFallback: 'Local fallback:',
+        warning: 'Warning:',
+        warnings: {
+          current_7d_window_unavailable: 'The official seven-day window was unavailable or invalid. Recent seven-day analytics are shown instead.',
+          official_daily_buckets_approximate_period: 'Official account activity is available only in daily buckets and may approximate partial-day period boundaries.',
+          rate_limits_unavailable: 'Current ChatGPT rate limits are temporarily unavailable.',
+          official_profile_unavailable: 'Official account activity is temporarily unavailable.',
+          cache_read_failed: 'The analytics cache was unavailable, so fresh data was fetched.',
+          cache_write_failed: 'Fresh analytics were returned without caching.'
+        },
+        overview: 'Activity overview',
+        officialVsManaged: 'Official totals reflect the OpenAI account. Token splits, requests, models, and cost reflect traffic managed by Sub2API.',
+        rateLimits: 'Official rate-limit windows',
+        noManagedTraffic: 'No Sub2API-managed traffic in this period',
+        sources: {
+          openai: 'OpenAI account activity',
+          sub2api: 'Sub2API-managed traffic'
+        },
+        kpis: {
+          officialTokens: 'Official total tokens',
+          managedTokens: 'Managed total tokens',
+          requests: 'Requests',
+          currentLimit: 'Current limit used',
+          input: 'Input tokens',
+          output: 'Output tokens',
+          cache: 'Cache tokens',
+          cacheRead: 'Cache-read tokens',
+          cacheHitRate: 'Cache hit rate',
+          estimatedCost: 'Estimated cost',
+          resetCountdown: 'Remaining reset countdown'
+        },
+        windows: {
+          fiveHour: '5-hour window',
+          sevenDay: '7-day window',
+          available: 'Available',
+          nearLimit: 'Near limit',
+          limited: 'Limit reached',
+          unavailable: 'Unavailable',
+          resetsIn: 'Resets in {time}',
+          resetting: 'Resetting now',
+          resetUnknown: 'Reset time unavailable',
+          noReset: 'Window data unavailable'
+        },
+        profile: {
+          title: 'Official account profile',
+          lifetimeTokens: 'Lifetime tokens',
+          peakDailyTokens: 'Peak daily tokens',
+          longestTurn: 'Longest running turn',
+          currentStreak: 'Current streak',
+          longestStreak: 'Longest streak',
+          seconds: '{count}s',
+          minutes: '{count} min',
+          days: '{count} days'
+        },
+        trend: {
+          title: 'Daily token activity',
+          description: 'Stacked bars show Sub2API-managed traffic. The orange indicator shows OpenAI official account activity when available.',
+          input: 'Managed input',
+          output: 'Managed output',
+          cache: 'Managed cache',
+          official: 'Official total'
+        },
+        models: {
+          title: 'Managed traffic by model',
+          description: 'Top three models from Sub2API usage logs, grouped with the remaining traffic.',
+          other: 'Other'
+        },
+        empty: {
+          title: 'No activity for this period',
+          description: 'OpenAI reported no official account total, and Sub2API recorded no managed traffic during the selected period.'
+        },
+        errors: {
+          unauthorized: {
+            title: 'OpenAI authorization expired',
+            description: 'Reauthorize this OAuth account from the account actions, then retry analytics.'
+          },
+          'rate-limited': {
+            title: 'OpenAI analytics is rate limited',
+            description: 'Wait for the upstream retry window, then load analytics again.'
+          },
+          generic: {
+            title: 'Analytics could not be loaded',
+            description: 'Retry the request. Existing account scheduling and usage polling remain available.'
+          }
+        }
+      },
       // Stats Modal
       viewStats: 'View Stats',
       usageStatistics: 'Usage Statistics',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -1479,6 +1479,111 @@ export default {
       audioReceived: '已收到第 {count} 段测试音频',
       videoPreview: '生成视频：',
       videoReceived: '已收到第 {count} 段测试视频',
+      codexAnalytics: {
+        action: '分析',
+        openAction: '打开 Codex 分析',
+        openActionFor: '打开 {name} 的 Codex 分析',
+        title: 'Codex 分析',
+        loading: '正在加载官方账号活动与托管流量...',
+        retry: '重试',
+        periodRange: '{start} 至 {end}',
+        periodSelector: {
+          label: '分析周期',
+          currentCycle: '当前 7 天周期',
+          recent7: '最近 7 天',
+          recent14: '最近 14 天',
+          recent30: '最近 30 天'
+        },
+        cacheExpires: '缓存至 {time}',
+        fresh: '实时响应',
+        unavailable: '暂无数据',
+        scopeDescription: '本视图全程分别标注 OpenAI 账号活动与 Sub2API 托管流量的数据来源。',
+        localFallback: '本地数据回退：',
+        warning: '警告：',
+        warnings: {
+          current_7d_window_unavailable: '官方 7 天窗口暂不可用或无效，已改为展示最近 7 天的分析数据。',
+          official_daily_buckets_approximate_period: '官方账号活动仅按日汇总，周期包含非整日边界时数据可能为近似值。',
+          rate_limits_unavailable: '当前 ChatGPT 限额暂不可用。',
+          official_profile_unavailable: '官方账号活动暂不可用。',
+          cache_read_failed: '分析缓存暂不可用，已获取实时数据。',
+          cache_write_failed: '已返回实时分析数据，但本次未写入缓存。'
+        },
+        overview: '活动概览',
+        officialVsManaged: '官方总量反映 OpenAI 账号活动；Token 拆分、请求、模型与成本反映 Sub2API 托管流量。',
+        rateLimits: '官方限额窗口',
+        noManagedTraffic: '此周期内没有 Sub2API 托管流量',
+        sources: {
+          openai: 'OpenAI 账号活动',
+          sub2api: 'Sub2API 托管流量'
+        },
+        kpis: {
+          officialTokens: '官方总 Token',
+          managedTokens: '托管总 Token',
+          requests: '请求数',
+          currentLimit: '当前限额用量',
+          input: '输入 Token',
+          output: '输出 Token',
+          cache: '缓存 Token',
+          cacheRead: '缓存读取 Token',
+          cacheHitRate: '缓存命中率',
+          estimatedCost: '预估成本',
+          resetCountdown: '剩余重置倒计时'
+        },
+        windows: {
+          fiveHour: '5 小时窗口',
+          sevenDay: '7 天窗口',
+          available: '可用',
+          nearLimit: '接近限额',
+          limited: '已达限额',
+          unavailable: '暂无数据',
+          resetsIn: '{time} 后重置',
+          resetting: '正在重置',
+          resetUnknown: '暂无重置时间',
+          noReset: '暂无窗口数据'
+        },
+        profile: {
+          title: '官方账号档案',
+          lifetimeTokens: '生命周期 Token',
+          peakDailyTokens: '单日峰值 Token',
+          longestTurn: '最长运行轮次',
+          currentStreak: '当前连续天数',
+          longestStreak: '最长连续天数',
+          seconds: '{count} 秒',
+          minutes: '{count} 分钟',
+          days: '{count} 天'
+        },
+        trend: {
+          title: '每日 Token 活动',
+          description: '堆叠柱展示 Sub2API 托管流量；橙色指标在有数据时展示 OpenAI 官方账号活动。',
+          input: '托管输入',
+          output: '托管输出',
+          cache: '托管缓存',
+          official: '官方总量'
+        },
+        models: {
+          title: '托管流量模型构成',
+          description: '展示 Sub2API 用量日志中的前三个模型，其余流量合并展示。',
+          other: '其他'
+        },
+        empty: {
+          title: '此周期暂无活动',
+          description: 'OpenAI 未返回官方账号总量，Sub2API 在所选周期内也没有托管流量记录。'
+        },
+        errors: {
+          unauthorized: {
+            title: 'OpenAI 授权已过期',
+            description: '请从账号操作中重新授权此 OAuth 账号，然后重试分析。'
+          },
+          'rate-limited': {
+            title: 'OpenAI 分析请求已限流',
+            description: '请等待上游重试窗口结束，然后重新加载分析。'
+          },
+          generic: {
+            title: '分析数据加载失败',
+            description: '请重试请求。现有账号调度与用量轮询会继续正常运行。'
+          }
+        }
+      },
       // Stats Modal
       viewStats: '查看统计',
       usageStatistics: '使用统计',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -431,6 +431,17 @@
           </template>
           <template #cell-actions="{ row }">
             <div class="flex items-center gap-1">
+              <button
+                v-if="row.platform === 'openai' && row.type === 'oauth'"
+                type="button"
+                class="flex min-h-10 min-w-10 flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-1 text-gray-500 transition-[color,background-color,transform] duration-150 active:scale-95 hover:bg-primary-50 hover:text-primary-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40 dark:hover:bg-primary-500/10 dark:hover:text-primary-400"
+                :title="t('admin.accounts.codexAnalytics.openAction')"
+                :aria-label="t('admin.accounts.codexAnalytics.openActionFor', { name: row.name })"
+                @click="handleCodexAnalytics(row)"
+              >
+                <Icon name="chartBar" size="sm" />
+                <span class="text-xs">{{ t('admin.accounts.codexAnalytics.action') }}</span>
+              </button>
               <button @click="handleEdit(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400">
                 <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
                 <span class="text-xs">{{ t('common.edit') }}</span>
@@ -455,6 +466,7 @@
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
     <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
+    <AccountCodexAnalyticsModal :show="showCodexAnalytics" :account="codexAnalyticsAcc" @close="closeCodexAnalyticsModal" />
     <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
     <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @duplicate="handleDuplicateAccount" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @create-spark-shadow="handleCreateSparkShadow" />
     <SyncFromCrsModal :show="showSync" @close="showSync = false" @synced="reload" />
@@ -512,6 +524,7 @@ import ImportDataModal from '@/components/admin/account/ImportDataModal.vue'
 import ReAuthAccountModal from '@/components/admin/account/ReAuthAccountModal.vue'
 import AccountTestModal from '@/components/admin/account/AccountTestModal.vue'
 import AccountStatsModal from '@/components/admin/account/AccountStatsModal.vue'
+import AccountCodexAnalyticsModal from '@/components/admin/AccountCodexAnalyticsModal.vue'
 import ScheduledTestsPanel from '@/components/admin/account/ScheduledTestsPanel.vue'
 import type { SelectOption } from '@/components/common/Select.vue'
 import AccountStatusIndicator from '@/components/account/AccountStatusIndicator.vue'
@@ -595,6 +608,7 @@ const showCreateShadowDialog = ref(false)
 const showReAuth = ref(false)
 const showTest = ref(false)
 const showStats = ref(false)
+const showCodexAnalytics = ref(false)
 const showErrorPassthrough = ref(false)
 const showTLSFingerprintProfiles = ref(false)
 const edAcc = ref<Account | null>(null)
@@ -604,6 +618,7 @@ const creatingShadowAcc = ref<Account | null>(null)
 const reAuthAcc = ref<Account | null>(null)
 const testingAcc = ref<Account | null>(null)
 const statsAcc = ref<Account | null>(null)
+const codexAnalyticsAcc = ref<Account | null>(null)
 const showSchedulePanel = ref(false)
 const scheduleAcc = ref<Account | null>(null)
 const scheduleModelOptions = ref<SelectOption[]>([])
@@ -1274,6 +1289,7 @@ const isAnyModalOpen = computed(() => {
     showReAuth.value ||
     showTest.value ||
     showStats.value ||
+    showCodexAnalytics.value ||
     showSchedulePanel.value ||
     showErrorPassthrough.value ||
     showTLSFingerprintProfiles.value
@@ -1308,6 +1324,7 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
 const syncAccountRefs = (nextAccount: Account) => {
   if (edAcc.value?.id === nextAccount.id) edAcc.value = nextAccount
   if (reAuthAcc.value?.id === nextAccount.id) reAuthAcc.value = nextAccount
+  if (codexAnalyticsAcc.value?.id === nextAccount.id) codexAnalyticsAcc.value = nextAccount
   if (tempUnschedAcc.value?.id === nextAccount.id) tempUnschedAcc.value = nextAccount
   if (deletingAcc.value?.id === nextAccount.id) deletingAcc.value = nextAccount
   if (menu.acc?.id === nextAccount.id) menu.acc = nextAccount
@@ -2241,9 +2258,11 @@ const handleExportData = async () => {
 const accountExportStepUp = useStepUp()
 const closeTestModal = () => { showTest.value = false; testingAcc.value = null }
 const closeStatsModal = () => { showStats.value = false; statsAcc.value = null }
+const closeCodexAnalyticsModal = () => { showCodexAnalytics.value = false; codexAnalyticsAcc.value = null }
 const closeReAuthModal = () => { showReAuth.value = false; reAuthAcc.value = null }
 const handleTest = (a: Account) => { testingAcc.value = a; showTest.value = true }
 const handleViewStats = (a: Account) => { statsAcc.value = a; showStats.value = true }
+const handleCodexAnalytics = (a: Account) => { codexAnalyticsAcc.value = a; showCodexAnalytics.value = true }
 const handleSchedule = async (a: Account) => {
   scheduleAcc.value = a
   scheduleModelOptions.value = []


### PR DESCRIPTION
## Summary

- extend the existing View Stats dialog with a Codex official-data section for OpenAI OAuth accounts
- combine official ChatGPT 5h/7d limits and profile activity with Sub2API-managed token, request, model, cache, and cost aggregates
- default to the current official 7-day reset cycle, with recent 7/14/30-day selectors
- cache account/period analytics in Redis for up to four minutes, bounded by the active reset boundary
- responsive light/dark layout with localized error, warning, empty, and retry states

## Data scope

Official totals and rate-limit windows are labeled as OpenAI account activity. Input/output/cache tokens, requests, model distribution, and estimated cost are labeled as Sub2API-managed traffic.

## Verification

- `go test ./internal/service -run 'CodexAnalytics|QueryUsageRedactsSensitive'`
- `go test -tags=unit ./internal/handler/admin -run CodexAnalytics`
- `go build ./...`
- `pnpm exec vitest run src/api/__tests__/admin.accounts.codexAnalyticsAuth.spec.ts src/api/__tests__/client.spec.ts`
- `pnpm build`
- browser-verified current 7d and recent period switching at desktop and 375px widths