### PR TITLE
fix(openai): disable parallel tool calls for Responses Lite

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -56,6 +56,16 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if legacyIngressChanged {
 		body = legacyIngressBody
 	}
+	responsesLite := isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader))
+	if responsesLite {
+		liteBody, changed, liteErr := normalizeOpenAIResponsesLiteParallelToolCalls(body)
+		if liteErr != nil {
+			return nil, liteErr
+		}
+		if changed {
+			body = liteBody
+		}
+	}
 	// 在分流到 passthrough / Codex transform / 原生 ChatCompletions 之前统一修正
 	// 显式为 null 的工具 Schema type，否则 upstream 的 400 会被归一成可重试的 502，
 	// 同一份坏定义在账号池里反复重放。
@@ -73,7 +83,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			body = reasoningBody
 		}
 	}
-	if account.IsOpenAIOAuthLike() && isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
+	if account.IsOpenAIOAuthLike() && responsesLite {
 		liteBody, changed, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
 		if liteErr != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, liteErr.Error(), "")

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -377,6 +377,20 @@ func normalizeOpenAIParallelToolCallsWithoutTools(body []byte) ([]byte, bool, er
 	return normalized, true, nil
 }
 
+// Responses Lite rejects omitted or true parallel_tool_calls, even when tools are present.
+// Normalize it before account routing so API-key and OAuth paths follow the same contract.
+func normalizeOpenAIResponsesLiteParallelToolCalls(body []byte) ([]byte, bool, error) {
+	parallel := gjson.GetBytes(body, "parallel_tool_calls")
+	if parallel.Type == gjson.False {
+		return body, false, nil
+	}
+	normalized, err := sjson.SetBytes(body, "parallel_tool_calls", false)
+	if err != nil {
+		return body, false, fmt.Errorf("normalize Responses Lite parallel_tool_calls: %w", err)
+	}
+	return normalized, true, nil
+}
+
 func normalizeOpenAIAPIKeyStoreFalseReasoningReplay(body []byte, knownStoreFalse bool) ([]byte, bool, error) {
 	if !knownStoreFalse && gjson.GetBytes(body, "store").Type != gjson.False {
 		return body, false, nil

--- a/backend/internal/service/openai_responses_lite_tools_test.go
+++ b/backend/internal/service/openai_responses_lite_tools_test.go
@@ -232,6 +232,29 @@ func TestNormalizeOpenAIResponsesLiteToolsPayload_PreservesResponseCreateShape(t
 	require.Equal(t, "namespace", gjson.GetBytes(updated, "tool_choice.type").String())
 }
 
+func TestNormalizeOpenAIResponsesLiteParallelToolCalls(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantChanged bool
+	}{
+		{name: "missing", body: `{"model":"gpt-5.6-terra"}`, wantChanged: true},
+		{name: "true with tools", body: `{"tools":[{"type":"function","name":"lookup"}],"parallel_tool_calls":true}`, wantChanged: true},
+		{name: "already false", body: `{"parallel_tool_calls":false}`, wantChanged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, changed, err := normalizeOpenAIResponsesLiteParallelToolCalls([]byte(tt.body))
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantChanged, changed)
+			require.True(t, gjson.GetBytes(normalized, "parallel_tool_calls").Exists())
+			require.False(t, gjson.GetBytes(normalized, "parallel_tool_calls").Bool())
+		})
+	}
+}
+
 func TestApplyCodexOAuthTransform_PreservesLiteNamespaceToolChoice(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.6-terra",
@@ -306,6 +329,54 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, `input.#(type=="additional_tools").tools.0.name`).String())
 			require.Equal(t, "namespace", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
 			require.Equal(t, "collaboration", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
+		})
+	}
+}
+
+func TestOpenAIGatewayServiceForward_DisablesParallelToolCallsForResponsesLiteAPIKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, passthrough := range []bool{false, true} {
+		name := "managed"
+		if passthrough {
+			name = "passthrough"
+		}
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+			c.Request.Header.Set("User-Agent", "codex_cli_rs/0.144.1")
+			c.Request.Header.Set(responsesLiteHeader, "true")
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body: io.NopCloser(strings.NewReader(
+					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_lite\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n" +
+						"data: [DONE]\n\n",
+				)),
+			}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := &Account{
+				ID: 502, Name: "responses-lite-api-key", Platform: PlatformOpenAI, Type: AccountTypeAPIKey,
+				Concurrency: 1, Status: StatusActive, Schedulable: true, RateMultiplier: f64p(1),
+				Credentials: map[string]any{"api_key": "sk-test"},
+				Extra:       map[string]any{"openai_passthrough": passthrough},
+			}
+			body := []byte(`{
+				"model":"gpt-5.6-terra","stream":true,"instructions":"test",
+				"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+				"parallel_tool_calls":true,
+				"input":[{"type":"message","role":"user","content":"hello"}]
+			}`)
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, "true", upstream.lastReq.Header.Get(responsesLiteHeader))
+			require.True(t, gjson.GetBytes(upstream.lastBody, "tools").IsArray())
+			require.True(t, gjson.GetBytes(upstream.lastBody, "parallel_tool_calls").Exists())
+			require.False(t, gjson.GetBytes(upstream.lastBody, "parallel_tool_calls").Bool())
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- force Responses Lite requests to send `parallel_tool_calls: false` before account routing
- preserve tools while applying the Lite-only constraint to managed and passthrough API-key paths
- add regression coverage for missing/true values and both API-key forwarding modes

## Why
OpenAI rejects Responses Lite requests with `X-OpenAI-Internal-Codex-Responses-Lite` when `parallel_tool_calls` is omitted or true. The existing generic normalization intentionally retained `true` when tools were present, so Lite requests could fail with HTTP 400 after the recent Responses compatibility changes.

## Tests
- `go test -tags=unit ./internal/service -run 'TestNormalizeOpenAIResponsesLiteParallelToolCalls|TestOpenAIGatewayServiceForward_(DisablesParallelToolCallsForResponsesLiteAPIKey|NormalizesResponsesLiteToolsForOAuth)' -count=1`
- `git diff --check`

The full service package was also run. Its Lite/OpenAI coverage passed; an unrelated DNS-dependent channel monitor test fails because the test hostname resolves differently in the current environment.