### PR TITLE
refactor(cn-providers): drop platform enum CHECK constraints in favor of application-level validation

### DIFF
--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -2392,7 +2392,6 @@ func init() {
 		fns := [...]func(string) error{
 			validators[0].(func(string) error),
 			validators[1].(func(string) error),
-			validators[2].(func(string) error),
 		}
 		return func(platform string) error {
 			for _, fn := range fns {

--- a/backend/ent/schema/user_platform_quota.go
+++ b/backend/ent/schema/user_platform_quota.go
@@ -1,8 +1,6 @@
 package schema
 
 import (
-	"fmt"
-
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/entsql"
@@ -37,17 +35,10 @@ func (UserPlatformQuota) Fields() []ent.Field {
 		field.String("platform").
 			MaxLen(32).
 			NotEmpty().
-			Validate(func(s string) error {
-				// 注意：平台列表的单一权威源为 service.AllowedQuotaPlatforms；
-				// 此处为 ent 构建期约束，需与 service.AllowedQuotaPlatforms 保持同步。
-				switch s {
-				case "anthropic", "openai", "gemini", "antigravity", "grok",
-					"kimi", "zhipu", "deepseek":
-					return nil
-				default:
-					return fmt.Errorf("platform %q is not allowed", s)
-				}
-			}),
+			// 平台合法性由应用层保证（service.IsAllowedQuotaPlatform，权威源为
+			// CN 注册表派生的 service.AllowedQuotaPlatforms）；ent 层不再重复枚举，
+			// 避免新增供应商时 schema/约束/代码三处脱节（见 migration 229 头注释）。
+			Comment("平台标识（anthropic/openai/gemini/antigravity/grok/国产供应商等）"),
 
 		// 日 / 周 / 月 USD 上限：
 		//   nil / not set → 无限额（完全放行）

--- a/backend/ent/userplatformquota.go
+++ b/backend/ent/userplatformquota.go
@@ -26,7 +26,7 @@ type UserPlatformQuota struct {
 	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 	// UserID holds the value of the "user_id" field.
 	UserID int64 `json:"user_id,omitempty"`
-	// Platform holds the value of the "platform" field.
+	// 平台标识（anthropic/openai/gemini/antigravity/grok/国产供应商等）
 	Platform string `json:"platform,omitempty"`
 	// DailyLimitUsd holds the value of the "daily_limit_usd" field.
 	DailyLimitUsd *float64 `json:"daily_limit_usd,omitempty"`

--- a/backend/internal/handler/admin/channel_handler.go
+++ b/backend/internal/handler/admin/channel_handler.go
@@ -611,15 +611,23 @@ func (h *ChannelHandler) GetModelDefaultPricing(c *gin.Context) {
 
 // platformToLiteLLMProvider maps a channel platform name to the corresponding
 // LiteLLM provider string used as the key in the pricing catalog.
-var platformToLiteLLMProvider = map[string]string{
-	service.PlatformAnthropic:   "anthropic",
-	service.PlatformOpenAI:      "openai",
-	service.PlatformGemini:      "gemini",
-	service.PlatformAntigravity: "anthropic",
-	service.PlatformGrok:        "xai",
-	service.PlatformKimi:        "moonshot",
-	service.PlatformZhipu:       "zhipu",
-	service.PlatformDeepseek:    "deepseek",
+// CN 平台条目由注册表（CNProviderSpec.LiteLLMProvider）派生，新增供应商自动纳入。
+var platformToLiteLLMProvider = buildPlatformToLiteLLMProvider()
+
+func buildPlatformToLiteLLMProvider() map[string]string {
+	out := map[string]string{
+		service.PlatformAnthropic:   "anthropic",
+		service.PlatformOpenAI:      "openai",
+		service.PlatformGemini:      "gemini",
+		service.PlatformAntigravity: "anthropic",
+		service.PlatformGrok:        "xai",
+	}
+	for _, code := range service.CNProviderCodes() {
+		if spec, ok := service.GetCNProviderSpec(code); ok && spec.LiteLLMProvider != "" {
+			out[code] = spec.LiteLLMProvider
+		}
+	}
+	return out
 }
 
 // SyncPricingModels 返回 LiteLLM 定价目录中指定平台的最新模型列表

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1147,7 +1147,7 @@ func (h *GatewayHandler) compositeAvailableModels(ctx context.Context, groupID *
 	seen := make(map[string]struct{})
 	models := make([]string, 0)
 	schedulablePlatforms := h.gatewayService.GetSchedulablePlatforms(ctx, groupID)
-	for _, platform := range []string{service.PlatformAnthropic, service.PlatformGemini, service.PlatformOpenAI, service.PlatformAntigravity, service.PlatformGrok, service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek} {
+	for _, platform := range service.ConcretePlatforms() {
 		platformModels := h.gatewayService.GetAvailableModels(ctx, groupID, platform)
 		if len(platformModels) == 0 {
 			// CN 供应商没有静态默认模型列表（defaultModelIDsForPlatform 的
@@ -1374,7 +1374,7 @@ func defaultModelIDsForPlatform(platform string) []string {
 	case service.PlatformComposite:
 		ids := make([]string, 0)
 		seen := make(map[string]struct{})
-		for _, concretePlatform := range []string{service.PlatformAnthropic, service.PlatformGemini, service.PlatformOpenAI, service.PlatformAntigravity, service.PlatformGrok, service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek} {
+		for _, concretePlatform := range service.ConcretePlatforms() {
 			for _, id := range defaultModelIDsForPlatform(concretePlatform) {
 				if _, ok := seen[id]; ok {
 					continue

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -240,9 +240,8 @@ func allowOpenAICompatibleMessagesDispatch(c *gin.Context, apiKey *service.APIKe
 }
 
 func openAICompatibleTextTargetAllowed(c *gin.Context, apiKey *service.APIKey, model string) bool {
-	return compositeTargetPlatformAllowed(c, apiKey, model,
-		service.PlatformOpenAI, service.PlatformGrok,
-		service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek)
+	platforms := append([]string{service.PlatformOpenAI, service.PlatformGrok}, service.CNProviderCodes()...)
+	return compositeTargetPlatformAllowed(c, apiKey, model, platforms...)
 }
 
 // isResponsesWebSocketCompositePlatform 限定 composite 分组在 Responses WebSocket

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -46,20 +46,21 @@ func RegisterGatewayRoutes(
 	requireGroupGoogle := middleware.RequireGroupAssignment(settingService, middleware.GoogleErrorWriter)
 
 	isOpenAIResponsesCompatibleGatewayPlatform := func(c *gin.Context) bool {
-		switch getGroupPlatform(c) {
-		case service.PlatformOpenAI, service.PlatformGrok,
-			service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek:
-			// 国产 OpenAI 兼容供应商（kimi/zhipu/deepseek）与 openai/grok 一样经 OpenAI 网关转发。
+		platform := getGroupPlatform(c)
+		// 国产 OpenAI 兼容供应商（注册表派生）与 openai/grok 一样经 OpenAI 网关转发。
+		switch platform {
+		case service.PlatformOpenAI, service.PlatformGrok:
 			return true
 		default:
-			return false
+			return service.IsCNProvider(platform)
 		}
 	}
 	countTokensHandler := func(c *gin.Context) {
-		switch getGroupPlatform(c) {
-		case service.PlatformOpenAI, service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek:
+		platform := getGroupPlatform(c)
+		switch {
+		case platform == service.PlatformOpenAI || service.IsCNProvider(platform):
 			h.OpenAIGateway.CountTokens(c)
-		case service.PlatformGrok:
+		case platform == service.PlatformGrok:
 			h.OpenAIGateway.GrokCountTokens(c)
 		default:
 			h.Gateway.CountTokens(c)

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -291,11 +291,10 @@ func (a *Account) IsCNProvider() bool {
 }
 
 // IsOpenAICompatible 报告账号是否走 OpenAI 网关（OpenAI 协议族）。
-// openai/grok 原生走 OpenAI 网关；kimi/zhipu/deepseek 同为 OpenAI Chat Completions
+// openai/grok 原生走 OpenAI 网关；已注册的国产供应商同为 OpenAI Chat Completions
 // 兼容上游，也经 OpenAI 网关转发。
 func (a *Account) IsOpenAICompatible() bool {
-	return a != nil && (a.Platform == PlatformOpenAI || a.Platform == PlatformGrok ||
-		a.Platform == PlatformKimi || a.Platform == PlatformZhipu || a.Platform == PlatformDeepseek)
+	return a != nil && (a.Platform == PlatformOpenAI || a.Platform == PlatformGrok || a.IsCNProvider())
 }
 
 func (a *Account) GeminiOAuthType() string {
@@ -1348,23 +1347,11 @@ func (a *Account) GetOpenAIBaseURL() string {
 			return baseURL
 		}
 	}
-	// 平台默认 base_url：CN 供应商按 account_mode 选择 payg / coding 默认值。
-	switch a.Platform {
-	case PlatformKimi:
-		if a.GetAccountMode() == AccountModeCoding {
-			return DefaultKimiCodingBaseURL
-		}
-		return DefaultKimiPayGBaseURL
-	case PlatformZhipu:
-		if a.GetAccountMode() == AccountModeCoding {
-			return DefaultZhipuCodingBaseURL
-		}
-		return DefaultZhipuPayGBaseURL
-	case PlatformDeepseek:
-		return DefaultDeepseekBaseURL
-	default:
-		return "https://api.openai.com"
+	// 平台默认 base_url：CN 供应商按注册表端点矩阵选择（协议 × 模式）。
+	if spec, ok := GetCNProviderSpec(a.Platform); ok {
+		return spec.DefaultBaseURL(APIProtocolChatCompletions, a.GetAccountMode())
 	}
+	return "https://api.openai.com"
 }
 
 // GetAccountMode 返回国产供应商账号的接入模式（payg / coding）；非国产供应商或未设置时
@@ -1399,7 +1386,9 @@ func (a *Account) GetAPIProtocol() string {
 	case APIProtocolAnthropic:
 		return APIProtocolAnthropic
 	case APIProtocolResponses:
-		if a.Platform == PlatformDeepseek {
+		// responses 协议仅声明了原生 Responses 能力的平台支持
+		// （SupportsNativeResponses，如 deepseek 官方原生 /responses 端点）。
+		if cnSupportsNativeResponses(a.Platform) {
 			return APIProtocolResponses
 		}
 	case APIProtocolChatCompletions:
@@ -1436,36 +1425,11 @@ func (a *Account) GetCNProtocolBaseURL(protocol string) string {
 }
 
 func (a *Account) defaultCNProtocolBaseURL(protocol string) string {
-	switch protocol {
-	case APIProtocolAnthropic:
-		switch a.Platform {
-		case PlatformKimi:
-			if a.GetAccountMode() == AccountModeCoding {
-				return DefaultKimiCodingAnthropicBaseURL
-			}
-			return DefaultKimiPayGAnthropicBaseURL
-		case PlatformZhipu:
-			return DefaultZhipuAnthropicBaseURL
-		case PlatformDeepseek:
-			return DefaultDeepseekAnthropicBaseURL
-		}
-	case APIProtocolChatCompletions, APIProtocolResponses:
-		switch a.Platform {
-		case PlatformKimi:
-			if a.GetAccountMode() == AccountModeCoding {
-				return DefaultKimiCodingBaseURL
-			}
-			return DefaultKimiPayGBaseURL
-		case PlatformZhipu:
-			if a.GetAccountMode() == AccountModeCoding {
-				return DefaultZhipuCodingBaseURL
-			}
-			return DefaultZhipuPayGBaseURL
-		case PlatformDeepseek:
-			return DefaultDeepseekBaseURL
-		}
+	spec, ok := GetCNProviderSpec(a.Platform)
+	if !ok {
+		return ""
 	}
-	return ""
+	return spec.DefaultBaseURL(protocol, a.GetAccountMode())
 }
 
 // IsAnthropicProtocol 报告账号是否以原生 Anthropic 协议接入上游
@@ -1489,19 +1453,11 @@ func (a *Account) GetAnthropicProtocolBaseURL() string {
 			return baseURL
 		}
 	}
-	switch a.Platform {
-	case PlatformKimi:
-		if a.GetAccountMode() == AccountModeCoding {
-			return DefaultKimiCodingAnthropicBaseURL
-		}
-		return DefaultKimiPayGAnthropicBaseURL
-	case PlatformZhipu:
-		return DefaultZhipuAnthropicBaseURL
-	case PlatformDeepseek:
-		return DefaultDeepseekAnthropicBaseURL
-	default:
+	spec, ok := GetCNProviderSpec(a.Platform)
+	if !ok {
 		return ""
 	}
+	return spec.DefaultBaseURL(APIProtocolAnthropic, a.GetAccountMode())
 }
 
 // GetOpenAIFormatBaseURL 返回供 OpenAI 格式端点（/v1/models、/v1/chat/completions
@@ -1513,22 +1469,11 @@ func (a *Account) GetOpenAIFormatBaseURL() string {
 	if a == nil || !a.IsAnthropicProtocol() {
 		return a.GetOpenAIBaseURL()
 	}
-	switch a.Platform {
-	case PlatformKimi:
-		if a.GetAccountMode() == AccountModeCoding {
-			return DefaultKimiCodingBaseURL
-		}
-		return DefaultKimiPayGBaseURL
-	case PlatformZhipu:
-		if a.GetAccountMode() == AccountModeCoding {
-			return DefaultZhipuCodingBaseURL
-		}
-		return DefaultZhipuPayGBaseURL
-	case PlatformDeepseek:
-		return DefaultDeepseekBaseURL
-	default:
+	spec, ok := GetCNProviderSpec(a.Platform)
+	if !ok {
 		return a.GetOpenAIBaseURL()
 	}
+	return spec.DefaultBaseURL(APIProtocolChatCompletions, a.GetAccountMode())
 }
 
 // GetCNAPIKey 返回国产 OpenAI 兼容供应商账号的 api_key 凭据（kimi/zhipu/deepseek）。
@@ -1540,22 +1485,21 @@ func (a *Account) GetCNAPIKey() string {
 	return a.GetCredential("api_key")
 }
 
-// GetCodingPlanProvider 根据 base_url 识别 Coding Plan 供应商（kimi / zhipu），
+// GetCodingPlanProvider 根据 base_url 识别 Coding Plan 供应商，
 // 用于路由到对应的额度查询端点。非 coding 模式或无法识别时返回空串。
-// 判定规则与 cc-switch coding_plan.rs::detect_provider 保持一致。
+// 判定规则与 cc-switch coding_plan.rs::detect_provider 保持一致；
+// 识别逻辑由各平台注册的 MatchCodingPlanBaseURL 钩子承担。
 func (a *Account) GetCodingPlanProvider() string {
 	if a == nil || a.GetAccountMode() != AccountModeCoding {
 		return ""
 	}
 	baseURL := strings.ToLower(a.GetOpenAIBaseURL())
-	switch {
-	case strings.Contains(baseURL, "api.kimi.com/coding"):
-		return PlatformKimi
-	case strings.Contains(baseURL, "bigmodel.cn"), strings.Contains(baseURL, "api.z.ai"):
-		return PlatformZhipu
-	default:
-		return ""
+	for _, spec := range cnProviderSpecs() {
+		if spec.MatchCodingPlanBaseURL != nil && spec.MatchCodingPlanBaseURL(baseURL) {
+			return spec.Code
+		}
 	}
+	return ""
 }
 
 func (a *Account) GetOpenAIAccessToken() string {

--- a/backend/internal/service/account_header_override.go
+++ b/backend/internal/service/account_header_override.go
@@ -78,12 +78,13 @@ func (a *Account) IsHeaderOverrideEligible() bool {
 		return false
 	}
 	switch a.Platform {
-	case PlatformAnthropic, PlatformOpenAI, PlatformKimi, PlatformZhipu, PlatformDeepseek:
+	case PlatformAnthropic, PlatformOpenAI:
 		return a.Type == AccountTypeAPIKey
 	case PlatformGrok:
 		return a.Type == AccountTypeAPIKey || a.Type == AccountTypeOAuth
 	default:
-		return false
+		// 国产 OpenAI 兼容供应商（注册表派生）：API Key 型可覆写请求头。
+		return IsCNProvider(a.Platform) && a.Type == AccountTypeAPIKey
 	}
 }
 

--- a/backend/internal/service/account_scheduling_threshold_eval.go
+++ b/backend/internal/service/account_scheduling_threshold_eval.go
@@ -58,12 +58,14 @@ func EvaluateAccountSchedulingThreshold(account *Account, thresholds map[string]
 		winner = pickLatestResetSchedulingCandidate(anthropicThresholdCandidates(account), threshold, now)
 	case PlatformGrok:
 		winner = pickLatestResetSchedulingCandidate(grokThresholdCandidates(account), threshold, now)
-	case PlatformKimi:
-		winner = pickLatestResetSchedulingCandidate(cnProviderThresholdCandidates(account, PlatformKimi), threshold, now)
-	case PlatformZhipu:
-		winner = pickLatestResetSchedulingCandidate(cnProviderThresholdCandidates(account, PlatformZhipu), threshold, now)
 	default:
-		return decision
+		// CN 平台：仅有滚动窗口端点（QuotaProbe）的平台参与阈值评估，
+		// 与 AllowedSchedulingThresholdPlatforms 的派生口径一致。
+		spec, ok := GetCNProviderSpec(decision.Platform)
+		if !ok || spec.QuotaProbe == nil {
+			return decision
+		}
+		winner = pickLatestResetSchedulingCandidate(cnProviderThresholdCandidates(account, decision.Platform), threshold, now)
 	}
 
 	if winner == nil {

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -514,10 +514,11 @@ func (s *AccountService) TestCredentials(ctx context.Context, id int64) error {
 	case PlatformGrok:
 		// Grok OAuth credentials are validated via token exchange/refresh and request-path probes.
 		return nil
-	case PlatformKimi, PlatformZhipu, PlatformDeepseek:
-		// 国产 OpenAI 兼容供应商：凭证为 API Key，实际可用性经余额/额度探测与转发路径验证。
-		return nil
 	default:
+		if IsCNProvider(account.Platform) {
+			// 国产 OpenAI 兼容供应商：凭证为 API Key，实际可用性经余额/额度探测与转发路径验证。
+			return nil
+		}
 		return fmt.Errorf("unsupported platform: %s", account.Platform)
 	}
 }

--- a/backend/internal/service/admin_group.go
+++ b/backend/internal/service/admin_group.go
@@ -267,7 +267,7 @@ func defaultAllowImageGenerationForPlatform(platform string) bool {
 func compositeDefaultModelsListCandidateIDs() []string {
 	seen := make(map[string]struct{})
 	ids := make([]string, 0)
-	for _, platform := range []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+	for _, platform := range ConcretePlatforms() {
 		for _, id := range defaultModelsListCandidateIDs(platform) {
 			if _, ok := seen[id]; ok {
 				continue

--- a/backend/internal/service/channel_monitor_quota_fetcher.go
+++ b/backend/internal/service/channel_monitor_quota_fetcher.go
@@ -197,15 +197,13 @@ func (f *ChannelMonitorQuotaFetcher) fetchUncached(ctx context.Context, accountI
 	// 账号只在路由前加载这一次；已加载的 account 直接传给数据源
 	// （GetUsageForAccount / QueryUsageForAccount / QueryBalanceForAccount），
 	// 下游服务不再各自 GetByID（每次含 proxies/groups 联查）。
-	switch account.Platform {
-	case domain.PlatformKimi, domain.PlatformZhipu, domain.PlatformDeepseek:
+	if IsCNProvider(account.Platform) {
 		if account.IsCodingPlan() {
 			return f.fetchCNQuota(ctx, account, now)
 		}
 		return f.fetchCNBalance(ctx, account, now)
-	default:
-		return f.fetchUsage(ctx, account, now)
 	}
+	return f.fetchUsage(ctx, account, now)
 }
 
 // fetchUsage 海外平台：AccountUsageService.GetUsageForAccount → 快照。

--- a/backend/internal/service/channel_monitor_validate.go
+++ b/backend/internal/service/channel_monitor_validate.go
@@ -218,18 +218,23 @@ func normalizeMonitorPrimaryModel(provider, checkMode, model string) string {
 //   - openai：OAuth（API-Key 型无 usage 通道）
 //   - gemini/grok/antigravity：本地统计/值通道降级，不会永久 error，放行
 func monitorAccountQuotaCapability(account *Account) error {
-	switch account.Platform {
-	case PlatformKimi, PlatformZhipu, PlatformDeepseek:
+	if IsCNProvider(account.Platform) {
 		if account.IsCodingPlan() {
-			if p := account.GetCodingPlanProvider(); p != PlatformKimi && p != PlatformZhipu {
+			// coding 账号需能路由到注册了额度端点（QuotaProbe）的平台。
+			spec, ok := GetCNProviderSpec(account.GetCodingPlanProvider())
+			if !ok || spec.QuotaProbe == nil {
 				return ErrChannelMonitorAccountNotSupportable
 			}
 			return nil
 		}
-		if account.Platform == PlatformZhipu {
+		// payg：仅有公开余额端点（BalanceProbe）的平台可监控。
+		spec, _ := GetCNProviderSpec(account.Platform)
+		if spec == nil || spec.BalanceProbe == nil {
 			return ErrChannelMonitorAccountNotSupportable
 		}
 		return nil
+	}
+	switch account.Platform {
 	case PlatformAnthropic:
 		if account.Type == AccountTypeOAuth || account.Type == AccountTypeSetupToken {
 			return nil

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -357,7 +357,7 @@ func isPlatformPricingMatch(groupPlatform, pricingPlatform string) bool {
 // fallback used before a request target has been resolved.
 func matchingPlatforms(groupPlatform string) []string {
 	if groupPlatform == PlatformComposite {
-		return []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek}
+		return ConcretePlatforms()
 	}
 	return []string{groupPlatform}
 }

--- a/backend/internal/service/cn_provider_balance_check_service.go
+++ b/backend/internal/service/cn_provider_balance_check_service.go
@@ -119,9 +119,10 @@ func (s *CNProviderBalanceCheckService) runOnce() {
 				quotaTargets = append(quotaTargets, quotaTarget{id: account.ID, platform: account.Platform})
 				continue
 			}
-			// payg 余额探测仅 kimi/deepseek（智谱无公开余额端点，payg 账号
-			// 依赖响应式 402/429 处理）。
-			if platform != PlatformZhipu && account.Schedulable {
+			// payg 余额探测仅有余额端点（BalanceProbe）的平台（无公开余额端点的
+			// 平台，payg 账号依赖响应式 402/429 处理）。
+			spec, specOK := GetCNProviderSpec(platform)
+			if specOK && spec.BalanceProbe != nil && account.Schedulable {
 				paygTargets = append(paygTargets, account)
 			}
 		}
@@ -134,13 +135,15 @@ func (s *CNProviderBalanceCheckService) runOnce() {
 		}
 		collect(platform, accounts)
 	}
-	// 智谱无余额端点，仅进额度探测。
+	// 无余额端点但有额度端点的平台（如智谱）：仅进额度探测。
 	if s.quotaService != nil {
-		accounts, err := s.accountRepo.ListByPlatform(context.Background(), PlatformZhipu)
-		if err != nil {
-			log.Printf("[CNBalance] list %s accounts failed: %v", PlatformZhipu, err)
-		} else {
-			collect(PlatformZhipu, accounts)
+		for _, platform := range cnQuotaOnlyPlatforms() {
+			accounts, err := s.accountRepo.ListByPlatform(context.Background(), platform)
+			if err != nil {
+				log.Printf("[CNBalance] list %s accounts failed: %v", platform, err)
+				continue
+			}
+			collect(platform, accounts)
 		}
 	}
 
@@ -245,8 +248,28 @@ func (s *CNProviderBalanceCheckService) checkOne(ctx context.Context, account *A
 	return cnBalanceNoChange
 }
 
+// platforms 返回进入主循环的平台：有公开余额端点（BalanceProbe）的平台
+// 同时承担 payg 余额探测与 coding 额度探测。
 func (s *CNProviderBalanceCheckService) platforms() []string {
-	return []string{PlatformKimi, PlatformDeepseek}
+	var out []string
+	for _, spec := range cnProviderSpecs() {
+		if spec.BalanceProbe != nil {
+			out = append(out, spec.Code)
+		}
+	}
+	return out
+}
+
+// cnQuotaOnlyPlatforms 返回无余额端点但有额度端点的平台（如智谱），
+// 仅进额度探测补充循环。
+func cnQuotaOnlyPlatforms() []string {
+	var out []string
+	for _, spec := range cnProviderSpecs() {
+		if spec.BalanceProbe == nil && spec.QuotaProbe != nil {
+			out = append(out, spec.Code)
+		}
+	}
+	return out
 }
 
 // allCNBalancesBelowThreshold 判断全部币种余额是否均低于阈值。

--- a/backend/internal/service/cn_provider_balance_service.go
+++ b/backend/internal/service/cn_provider_balance_service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
-	"github.com/tidwall/gjson"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -124,7 +123,8 @@ func (s *CNProviderBalanceService) QueryBalanceForAccount(ctx context.Context, a
 
 func (s *CNProviderBalanceService) queryBalanceForAccount(ctx context.Context, account *Account) (*CNProviderBalanceResult, error) {
 	provider := account.Platform
-	if provider != PlatformKimi && provider != PlatformDeepseek {
+	spec, ok := GetCNProviderSpec(provider)
+	if !ok || spec.BalanceProbe == nil {
 		return nil, infraerrors.New(http.StatusBadRequest, "CN_BALANCE_NO_ENDPOINT", "account provider has no balance endpoint")
 	}
 
@@ -133,7 +133,7 @@ func (s *CNProviderBalanceService) queryBalanceForAccount(ctx context.Context, a
 		return nil, infraerrors.New(http.StatusBadRequest, "CN_BALANCE_NO_APIKEY", "account api_key is empty")
 	}
 
-	targetURL := cnBalanceURL(account)
+	targetURL := spec.BalanceProbe.BalanceURL(account)
 	// 探测发起前过出站 URL 安全策略（与网关转发/Grok 探测同一套校验）：
 	// DeepSeek 端点由账号 base_url 衍生，不得把 API key 发往策略外主机。
 	validatedURL, err := cnValidateProbeURL(s.cfg, targetURL)
@@ -176,42 +176,10 @@ func (s *CNProviderBalanceService) queryBalanceForAccount(ctx context.Context, a
 		return result, nil
 	}
 
-	var entries []CNProviderBalanceEntry
-	available := true
-	switch provider {
-	case PlatformKimi:
-		// Moonshot：code==0 成功；data.available_balance（number），单币种 CNY。
-		balance, _ := cnParseF64(gjson.GetBytes(bodyBytes, "data.available_balance").Value())
-		entries = append(entries, CNProviderBalanceEntry{Currency: "CNY", Balance: balance})
-	case PlatformDeepseek:
-		// is_available 缺省视为 true（健康）；显式存在时取其值。
-		if v := gjson.GetBytes(bodyBytes, "is_available"); v.Exists() {
-			available = v.Bool()
-		}
-		// balance_infos 逐条解析：双币种账号同时返回 CNY + USD（数组顺序即
-		// 主次序，首条为主币种）。
-		balanceInfos := gjson.GetBytes(bodyBytes, "balance_infos")
-		if !balanceInfos.Exists() || !balanceInfos.IsArray() {
-			result.Error = "Invalid balance response: missing balance_infos"
-			return result, nil
-		}
-		balanceInfos.ForEach(func(_, info gjson.Result) bool {
-			currency := strings.ToUpper(strings.TrimSpace(info.Get("currency").String()))
-			totalBalance := info.Get("total_balance")
-			balance, ok := cnParseF64(totalBalance.Value())
-			if !totalBalance.Exists() || !ok {
-				return true
-			}
-			if currency == "" {
-				currency = "CNY"
-			}
-			entries = append(entries, CNProviderBalanceEntry{Currency: currency, Balance: balance})
-			return true
-		})
-		if len(entries) == 0 {
-			result.Error = "Invalid balance response: no valid balance entries"
-			return result, nil
-		}
+	entries, available, parseErrMsg := spec.BalanceProbe.ParseBalance(bodyBytes)
+	if parseErrMsg != "" {
+		result.Error = parseErrMsg
+		return result, nil
 	}
 	result.Balances = entries
 	result.Balance = entries[0].Balance
@@ -287,19 +255,5 @@ func (s *CNProviderBalanceService) resolveProxyURL(ctx context.Context, account 
 	return ""
 }
 
-// cnBalanceURL 解析账号的余额端点。
-//
-//   - Kimi：固定 https://api.moonshot.cn/v1/users/me/balance（与 base_url 无关，Moonshot 仅此一处）
-//   - DeepSeek：基于 base_url 拼接 /user/balance（支持自定义域名）
-func cnBalanceURL(account *Account) string {
-	switch account.Platform {
-	case PlatformKimi:
-		return "https://api.moonshot.cn/v1/users/me/balance"
-	case PlatformDeepseek:
-		// Anthropic 协议账号的凭证 base_url 指向 /anthropic 端点，余额探测需回退
-		// 到 OpenAI 格式 base（协议感知）再拼接 /user/balance。
-		return strings.TrimRight(account.GetOpenAIFormatBaseURL(), "/") + "/user/balance"
-	default:
-		return ""
-	}
-}
+// cnBalanceURL 已迁移至各平台的 CNBalanceProbe.BalanceURL 钩子
+// （cn_provider_kimi.go / cn_provider_deepseek.go）。

--- a/backend/internal/service/cn_provider_balance_service.go
+++ b/backend/internal/service/cn_provider_balance_service.go
@@ -255,5 +255,5 @@ func (s *CNProviderBalanceService) resolveProxyURL(ctx context.Context, account 
 	return ""
 }
 
-// cnBalanceURL 已迁移至各平台的 CNBalanceProbe.BalanceURL 钩子
+// 余额端点构造逻辑在各平台的 CNBalanceProbe.BalanceURL 钩子
 // （cn_provider_kimi.go / cn_provider_deepseek.go）。

--- a/backend/internal/service/cn_provider_builtin.go
+++ b/backend/internal/service/cn_provider_builtin.go
@@ -1,0 +1,13 @@
+package service
+
+// 内建国产供应商注册入口。
+//
+// 注册顺序即 CNProviderCodes() / ConcretePlatforms() 等派生列表中的平台顺序，
+// 与历史硬编码列表（kimi/zhipu/deepseek）保持一致——Go 同包多文件的 init()
+// 按文件名字典序执行，无法表达该顺序，故集中在单个 init() 中显式注册。
+// 各平台的 spec 与探测钩子实现见 cn_provider_{kimi,zhipu,deepseek}.go。
+func init() {
+	RegisterCNProvider(kimiProviderSpec)
+	RegisterCNProvider(zhipuProviderSpec)
+	RegisterCNProvider(deepseekProviderSpec)
+}

--- a/backend/internal/service/cn_provider_deepseek.go
+++ b/backend/internal/service/cn_provider_deepseek.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// DeepSeek 内建注册。
+//
+//   - 余额：{base}/user/balance（由账号 base_url 衍生，支持自定义域名），
+//     balance_infos[] 多币种 + is_available 健康标记。
+//   - 无 Coding Plan 滚动窗口端点（QuotaProbe 为 nil）；余额型平台走余额检测
+//     而非调度阈值。
+//   - 唯一提供原生 OpenAI Responses 端点的 CN 供应商（/responses，无 /v1
+//     前缀、无状态，适配 Codex）。
+var deepseekProviderSpec = CNProviderSpec{
+	Code:        PlatformDeepseek,
+	DisplayName: "DeepSeek",
+	DefaultBaseURLs: map[CNEndpointKey]string{
+		{APIProtocolChatCompletions, ""}: DefaultDeepseekBaseURL,
+		{APIProtocolResponses, ""}:       DefaultDeepseekBaseURL,
+		{APIProtocolAnthropic, ""}:       DefaultDeepseekAnthropicBaseURL,
+	},
+	BalanceProbe:            deepseekBalanceProbe{},
+	QuotaProbe:              nil, // 无 Coding Plan 窗口端点
+	SupportsNativeResponses: true,
+	MatchCodingPlanBaseURL:  nil, // deepseek coding 无法路由额度端点
+	LiteLLMProvider:         "deepseek",
+	ModelDetectPrefixes:     []string{"deepseek-"},
+	ModelDetectAliases:      []string{"deepseek"},
+}
+
+// deepseekBalanceProbe 实现 DeepSeek 余额探测。
+type deepseekBalanceProbe struct{}
+
+func (deepseekBalanceProbe) BalanceURL(account *Account) string {
+	// Anthropic 协议账号的凭证 base_url 指向 /anthropic 端点，余额探测需回退
+	// 到 OpenAI 格式 base（协议感知）再拼接 /user/balance。
+	return strings.TrimRight(account.GetOpenAIFormatBaseURL(), "/") + "/user/balance"
+}
+
+func (deepseekBalanceProbe) ParseBalance(body []byte) ([]CNProviderBalanceEntry, bool, string) {
+	// is_available 缺省视为 true（健康）；显式存在时取其值。
+	available := true
+	if v := gjson.GetBytes(body, "is_available"); v.Exists() {
+		available = v.Bool()
+	}
+	// balance_infos 逐条解析：双币种账号同时返回 CNY + USD（数组顺序即
+	// 主次序，首条为主币种）。
+	balanceInfos := gjson.GetBytes(body, "balance_infos")
+	if !balanceInfos.Exists() || !balanceInfos.IsArray() {
+		return nil, available, "Invalid balance response: missing balance_infos"
+	}
+	var entries []CNProviderBalanceEntry
+	balanceInfos.ForEach(func(_, info gjson.Result) bool {
+		currency := strings.ToUpper(strings.TrimSpace(info.Get("currency").String()))
+		totalBalance := info.Get("total_balance")
+		balance, ok := cnParseF64(totalBalance.Value())
+		if !totalBalance.Exists() || !ok {
+			return true
+		}
+		if currency == "" {
+			currency = "CNY"
+		}
+		entries = append(entries, CNProviderBalanceEntry{Currency: currency, Balance: balance})
+		return true
+	})
+	if len(entries) == 0 {
+		return nil, available, "Invalid balance response: no valid balance entries"
+	}
+	return entries, available, ""
+}

--- a/backend/internal/service/cn_provider_kimi.go
+++ b/backend/internal/service/cn_provider_kimi.go
@@ -52,12 +52,17 @@ type kimiQuotaProbe struct{}
 
 // QuotaURL 根据 base_url 解析 Kimi For Coding 额度端点。
 // cc-switch query_kimi 固定探测 https://api.kimi.com/coding/v1/usages
+// kimiQuotaURL 返回 Kimi For Coding 的固定额度端点
 // （实测 /coding/usages 无 /v1 → 404）。coding/v1（CC 协议默认）与
 // coding（Anthropic 协议默认）两种 base 统一剥掉尾部后拼回 /v1/usages，
 // 协议切换不影响额度探测端点。
-func (kimiQuotaProbe) QuotaURL(account *Account) string {
-	base := strings.TrimSuffix(strings.TrimRight(account.GetOpenAIBaseURL(), "/"), "/v1")
+func kimiQuotaURL(baseURL string) string {
+	base := strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1")
 	return base + "/v1/usages"
+}
+
+func (kimiQuotaProbe) QuotaURL(account *Account) string {
+	return kimiQuotaURL(account.GetOpenAIBaseURL())
 }
 
 func (kimiQuotaProbe) QuotaAuthHeader(apiKey string) string {

--- a/backend/internal/service/cn_provider_kimi.go
+++ b/backend/internal/service/cn_provider_kimi.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// Kimi（月之暗面 / Moonshot）内建注册。
+//
+//   - 余额：固定 https://api.moonshot.cn/v1/users/me/balance（与 base_url 无关，
+//     Moonshot 仅此一处），data.available_balance 单币种 CNY。
+//   - Coding Plan 额度：{base}/v1/usages（5h 滚动窗口 + weekly 周窗口）。
+var kimiProviderSpec = CNProviderSpec{
+	Code:        PlatformKimi,
+	DisplayName: "Kimi (月之暗面)",
+	DefaultBaseURLs: map[CNEndpointKey]string{
+		{APIProtocolChatCompletions, AccountModePayG}:   DefaultKimiPayGBaseURL,
+		{APIProtocolChatCompletions, AccountModeCoding}: DefaultKimiCodingBaseURL,
+		{APIProtocolResponses, AccountModePayG}:         DefaultKimiPayGBaseURL,
+		{APIProtocolResponses, AccountModeCoding}:       DefaultKimiCodingBaseURL,
+		{APIProtocolAnthropic, AccountModePayG}:         DefaultKimiPayGAnthropicBaseURL,
+		{APIProtocolAnthropic, AccountModeCoding}:       DefaultKimiCodingAnthropicBaseURL,
+	},
+	BalanceProbe:            kimiBalanceProbe{},
+	QuotaProbe:              kimiQuotaProbe{},
+	SupportsNativeResponses: false,
+	MatchCodingPlanBaseURL: func(lowerBaseURL string) bool {
+		return strings.Contains(lowerBaseURL, "api.kimi.com/coding")
+	},
+	LiteLLMProvider:     "moonshot",
+	ModelDetectPrefixes: []string{"kimi-", "moonshot-"},
+	ModelDetectAliases:  []string{"kimi", "moonshot"},
+}
+
+// kimiBalanceProbe 实现 Moonshot 余额探测。
+type kimiBalanceProbe struct{}
+
+func (kimiBalanceProbe) BalanceURL(_ *Account) string {
+	return "https://api.moonshot.cn/v1/users/me/balance"
+}
+
+func (kimiBalanceProbe) ParseBalance(body []byte) ([]CNProviderBalanceEntry, bool, string) {
+	// Moonshot：code==0 成功；data.available_balance（number），单币种 CNY。
+	balance, _ := cnParseF64(gjson.GetBytes(body, "data.available_balance").Value())
+	return []CNProviderBalanceEntry{{Currency: "CNY", Balance: balance}}, true, ""
+}
+
+// kimiQuotaProbe 实现 Kimi For Coding 额度探测。
+type kimiQuotaProbe struct{}
+
+// QuotaURL 根据 base_url 解析 Kimi For Coding 额度端点。
+// cc-switch query_kimi 固定探测 https://api.kimi.com/coding/v1/usages
+// （实测 /coding/usages 无 /v1 → 404）。coding/v1（CC 协议默认）与
+// coding（Anthropic 协议默认）两种 base 统一剥掉尾部后拼回 /v1/usages，
+// 协议切换不影响额度探测端点。
+func (kimiQuotaProbe) QuotaURL(account *Account) string {
+	base := strings.TrimSuffix(strings.TrimRight(account.GetOpenAIBaseURL(), "/"), "/v1")
+	return base + "/v1/usages"
+}
+
+func (kimiQuotaProbe) QuotaAuthHeader(apiKey string) string {
+	return "Bearer " + apiKey
+}
+
+func (kimiQuotaProbe) SetQuotaHeaders(_ *http.Request) {}
+
+// ParseQuota 解析 Kimi For Coding 的 /usages 响应。
+//
+//   - limits[].detail.{limit,remaining,resetTime} → 5h 窗口（取首个 detail）
+//   - usage.{limit,remaining,resetTime} → 周窗口
+//
+// utilization = (limit-remaining)/limit*100。
+func (kimiQuotaProbe) ParseQuota(body []byte) ([]CNQuotaTier, string, string) {
+	return parseKimiUsageTiers(body), "", ""
+}
+
+func parseKimiUsageTiers(body []byte) []CNQuotaTier {
+	var tiers []CNQuotaTier
+
+	if limits := gjson.GetBytes(body, "limits"); limits.IsArray() {
+		limits.ForEach(func(_, item gjson.Result) bool {
+			detail := item.Get("detail")
+			if !detail.Exists() {
+				return true
+			}
+			limit, _ := cnParseF64(detail.Get("limit").Value())
+			remaining, _ := cnParseF64(detail.Get("remaining").Value())
+			used := limit - remaining
+			if used < 0 {
+				used = 0
+			}
+			var util float64
+			if limit > 0 {
+				util = used / limit * 100
+			}
+			tiers = append(tiers, CNQuotaTier{
+				Window:      "5h",
+				UsedPercent: util,
+				ResetAt:     cnNormalizeResetTime(detail.Get("resetTime").Value()),
+			})
+			return false // 取首个 detail 作为 5h 窗口
+		})
+	}
+
+	if usage := gjson.GetBytes(body, "usage"); usage.Exists() {
+		limit, _ := cnParseF64(usage.Get("limit").Value())
+		remaining, _ := cnParseF64(usage.Get("remaining").Value())
+		used := limit - remaining
+		if used < 0 {
+			used = 0
+		}
+		var util float64
+		if limit > 0 {
+			util = used / limit * 100
+		}
+		tiers = append(tiers, CNQuotaTier{
+			Window:      "weekly",
+			UsedPercent: util,
+			ResetAt:     cnNormalizeResetTime(usage.Get("resetTime").Value()),
+		})
+	}
+
+	return tiers
+}

--- a/backend/internal/service/cn_provider_quota_service.go
+++ b/backend/internal/service/cn_provider_quota_service.go
@@ -7,14 +7,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
-	"github.com/tidwall/gjson"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -129,8 +127,9 @@ func (s *CNProviderQuotaService) QueryUsageForAccount(ctx context.Context, accou
 
 func (s *CNProviderQuotaService) queryUsageForAccount(ctx context.Context, account *Account) (*CNProviderQuotaProbeResult, error) {
 	provider := account.GetCodingPlanProvider()
-	if provider != PlatformKimi && provider != PlatformZhipu {
-		return nil, infraerrors.New(http.StatusBadRequest, "CN_QUOTA_NOT_CODING_PLAN", "account is not a kimi/zhipu coding plan account")
+	spec, ok := GetCNProviderSpec(provider)
+	if !ok || spec.QuotaProbe == nil {
+		return nil, infraerrors.New(http.StatusBadRequest, "CN_QUOTA_NOT_CODING_PLAN", "account is not a coding plan account with quota endpoint")
 	}
 
 	apiKey := strings.TrimSpace(account.GetCNAPIKey())
@@ -138,19 +137,8 @@ func (s *CNProviderQuotaService) queryUsageForAccount(ctx context.Context, accou
 		return nil, infraerrors.New(http.StatusBadRequest, "CN_QUOTA_NO_APIKEY", "account api_key is empty")
 	}
 
-	baseURL := account.GetOpenAIBaseURL()
-	var (
-		targetURL  string
-		authHeader string
-	)
-	switch provider {
-	case PlatformKimi:
-		targetURL = kimiQuotaURL(baseURL)
-		authHeader = "Bearer " + apiKey
-	case PlatformZhipu:
-		targetURL = zhipuQuotaURL(baseURL)
-		authHeader = apiKey // 智谱额度端点鉴权不加 Bearer 前缀
-	}
+	targetURL := spec.QuotaProbe.QuotaURL(account)
+	authHeader := spec.QuotaProbe.QuotaAuthHeader(apiKey)
 
 	// 探测发起前过出站 URL 安全策略（与网关转发/Grok 探测同一套校验）：
 	// 端点多由账号 base_url 衍生，不得把 API key 发往策略外主机。
@@ -169,10 +157,7 @@ func (s *CNProviderQuotaService) queryUsageForAccount(ctx context.Context, accou
 	}
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Accept", "application/json")
-	if provider == PlatformZhipu {
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept-Language", "en-US,en")
-	}
+	spec.QuotaProbe.SetQuotaHeaders(req)
 	// 探测与真实转发保持同一套账号级请求头覆写，避免探测通过但转发失败。
 	account.ApplyHeaderOverrides(req.Header)
 
@@ -201,27 +186,14 @@ func (s *CNProviderQuotaService) queryUsageForAccount(ctx context.Context, accou
 		return result, nil
 	}
 
-	// 智谱业务级错误（HTTP 2xx 但 success=false）。
-	if provider == PlatformZhipu {
-		if success := gjson.GetBytes(bodyBytes, "success"); success.Exists() && !success.Bool() {
-			msg := strings.TrimSpace(gjson.GetBytes(bodyBytes, "msg").String())
-			if msg == "" {
-				msg = "unknown zhipu quota error"
-			}
-			result.Error = "API error: " + msg
-			return result, nil
-		}
-	}
-
-	var tiers []CNQuotaTier
-	switch provider {
-	case PlatformKimi:
-		tiers = parseKimiUsageTiers(bodyBytes)
-	case PlatformZhipu:
-		tiers = parseZhipuTokenTiers(gjson.GetBytes(bodyBytes, "data"))
-		result.PlanLevel = strings.TrimSpace(gjson.GetBytes(bodyBytes, "data.level").String())
+	// 平台钩子负责业务级错误判定（HTTP 2xx 但 success=false 之类）与窗口解析。
+	tiers, planLevel, bizErrMsg := spec.QuotaProbe.ParseQuota(bodyBytes)
+	if bizErrMsg != "" {
+		result.Error = bizErrMsg
+		return result, nil
 	}
 	result.Tiers = tiers
+	result.PlanLevel = planLevel
 	result.Success = true
 	result.CredentialValid = true
 
@@ -274,224 +246,6 @@ func (s *CNProviderQuotaService) resolveProxyURL(ctx context.Context, account *A
 		}
 	}
 	return ""
-}
-
-// zhipuQuotaURL 根据 base_url 解析智谱额度端点（与数据面推理域名同主机）。
-func zhipuQuotaURL(baseURL string) string {
-	return zhipuQuotaHost(baseURL) + "/api/monitor/usage/quota/limit"
-}
-
-// kimiQuotaURL 根据 base_url 解析 Kimi For Coding 额度端点。
-// cc-switch query_kimi 固定探测 https://api.kimi.com/coding/v1/usages
-// （实测 /coding/usages 无 /v1 → 404）。coding/v1（CC 协议默认）与
-// coding（Anthropic 协议默认）两种 base 统一剥掉尾部后拼回 /v1/usages，
-// 协议切换不影响额度探测端点。
-func kimiQuotaURL(baseURL string) string {
-	base := strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1")
-	return base + "/v1/usages"
-}
-
-func zhipuQuotaHost(baseURL string) string {
-	switch u := strings.ToLower(baseURL); {
-	case strings.Contains(u, "bigmodel.cn"):
-		return "https://open.bigmodel.cn"
-	case strings.Contains(u, "z.ai"):
-		return "https://api.z.ai"
-	default:
-		// 国产优先：未知域名回落国内站（与前端 zhipu 预设一致）。
-		return "https://open.bigmodel.cn"
-	}
-}
-
-// parseKimiUsageTiers 解析 Kimi For Coding 的 /usages 响应。
-//
-//   - limits[].detail.{limit,remaining,resetTime} → 5h 窗口（取首个 detail）
-//   - usage.{limit,remaining,resetTime} → 周窗口
-//
-// utilization = (limit-remaining)/limit*100。
-func parseKimiUsageTiers(body []byte) []CNQuotaTier {
-	var tiers []CNQuotaTier
-
-	if limits := gjson.GetBytes(body, "limits"); limits.IsArray() {
-		limits.ForEach(func(_, item gjson.Result) bool {
-			detail := item.Get("detail")
-			if !detail.Exists() {
-				return true
-			}
-			limit, _ := cnParseF64(detail.Get("limit").Value())
-			remaining, _ := cnParseF64(detail.Get("remaining").Value())
-			used := limit - remaining
-			if used < 0 {
-				used = 0
-			}
-			var util float64
-			if limit > 0 {
-				util = used / limit * 100
-			}
-			tiers = append(tiers, CNQuotaTier{
-				Window:      "5h",
-				UsedPercent: util,
-				ResetAt:     cnNormalizeResetTime(detail.Get("resetTime").Value()),
-			})
-			return false // 取首个 detail 作为 5h 窗口
-		})
-	}
-
-	if usage := gjson.GetBytes(body, "usage"); usage.Exists() {
-		limit, _ := cnParseF64(usage.Get("limit").Value())
-		remaining, _ := cnParseF64(usage.Get("remaining").Value())
-		used := limit - remaining
-		if used < 0 {
-			used = 0
-		}
-		var util float64
-		if limit > 0 {
-			util = used / limit * 100
-		}
-		tiers = append(tiers, CNQuotaTier{
-			Window:      "weekly",
-			UsedPercent: util,
-			ResetAt:     cnNormalizeResetTime(usage.Get("resetTime").Value()),
-		})
-	}
-
-	return tiers
-}
-
-// cnZhipuWindow 标识智谱 TOKENS_LIMIT 条目所属窗口。
-type cnZhipuWindow int
-
-const (
-	cnZhipuWindowUnknown cnZhipuWindow = iota
-	cnZhipuWindow5h
-	cnZhipuWindowWeekly
-)
-
-// classifyZhipuWindowUnit 按 unit 字段判定窗口类型（3=5h，6=weekly）。
-// unit 缺失或未识别时返回 Unknown，由调用方走 reset 时间启发式兜底。
-func classifyZhipuWindowUnit(unit int64) cnZhipuWindow {
-	switch unit {
-	case 3:
-		return cnZhipuWindow5h
-	case 6:
-		return cnZhipuWindowWeekly
-	default:
-		return cnZhipuWindowUnknown
-	}
-}
-
-// parseZhipuTokenTiers 解析智谱额度响应 data.limits 为 5h + weekly 两档。
-//
-// 分类优先级（对齐 cc-switch parse_zhipu_token_tiers，issue #3036）：
-//  1. 显式 unit 字段（3=5h / 6=weekly）——不能用 reset 排序代替，周期末尾
-//     周窗口会比 5h 更早重置，时间排序必然标反。
-//  2. unit 缺失/未识别：无 nextResetTime 的条目优先归 5h（0% 状态下 5h 桶可能
-//     没有 reset），其余按 reset 升序依次填入仍空缺的槽位。
-//
-// CREDIT_LIMIT（信用额度）与 TOKENS_LIMIT（token 窗口）度量不同：两者同时返回时
-// 只让 TOKENS_LIMIT 参与 5h/weekly 槽位竞争，避免信用额度百分比污染阈值停调
-// 快照；仅当无任何 TOKENS_LIMIT 条目时才降级用 CREDIT_LIMIT 展示。
-// 老套餐只回 1 条 TOKENS_LIMIT，自然降级为仅 5h；新套餐回 2 条。
-func parseZhipuTokenTiers(data gjson.Result) []CNQuotaTier {
-	type entry struct {
-		resetMs    int64
-		hasReset   bool
-		percentage float64
-		resetISO   string
-	}
-	var (
-		fiveHour     entry
-		fiveHourSet  bool
-		weekly       entry
-		weeklySet    bool
-		unclassified []entry
-	)
-
-	classify := func(item gjson.Result, e entry) {
-		switch classifyZhipuWindowUnit(item.Get("unit").Int()) {
-		case cnZhipuWindow5h:
-			if !fiveHourSet {
-				fiveHour, fiveHourSet = e, true
-			} else {
-				unclassified = append(unclassified, e)
-			}
-		case cnZhipuWindowWeekly:
-			if !weeklySet {
-				weekly, weeklySet = e, true
-			} else {
-				unclassified = append(unclassified, e)
-			}
-		default:
-			unclassified = append(unclassified, e)
-		}
-	}
-	var creditFallback []entry
-	hasTokensLimit := false
-
-	data.Get("limits").ForEach(func(_, item gjson.Result) bool {
-		limitType := strings.ToUpper(strings.TrimSpace(item.Get("type").String()))
-		if limitType != "TOKENS_LIMIT" && limitType != "CREDIT_LIMIT" {
-			return true
-		}
-		percentage := 0.0
-		if p, ok := cnParseF64(item.Get("percentage").Value()); ok {
-			percentage = p
-		}
-		var (
-			resetMs  int64
-			hasReset bool
-			resetISO string
-		)
-		if nr := item.Get("nextResetTime"); nr.Exists() {
-			switch nr.Type {
-			case gjson.Number:
-				resetMs = nr.Int()
-				hasReset = resetMs > 0
-				resetISO = cnMillisToRFC3339(resetMs)
-			case gjson.String:
-				resetISO = cnNormalizeResetTime(nr.String())
-				hasReset = resetISO != ""
-			}
-		}
-		e := entry{resetMs: resetMs, hasReset: hasReset, percentage: percentage, resetISO: resetISO}
-		if limitType == "TOKENS_LIMIT" {
-			hasTokensLimit = true
-			classify(item, e)
-		} else {
-			creditFallback = append(creditFallback, e)
-		}
-		return true
-	})
-
-	// 无任何 TOKENS_LIMIT 条目（部分套餐只报信用额度）：降级用 CREDIT_LIMIT 展示。
-	if !hasTokensLimit {
-		unclassified = append(unclassified, creditFallback...)
-	}
-
-	// 无 reset 的条目排前，再按 reset 升序，依次填入仍空缺的槽位。
-	sort.SliceStable(unclassified, func(i, j int) bool {
-		if unclassified[i].hasReset != unclassified[j].hasReset {
-			return !unclassified[i].hasReset
-		}
-		return unclassified[i].resetMs < unclassified[j].resetMs
-	})
-	for _, e := range unclassified {
-		switch {
-		case !fiveHourSet:
-			fiveHour, fiveHourSet = e, true
-		case !weeklySet:
-			weekly, weeklySet = e, true
-		}
-	}
-
-	var tiers []CNQuotaTier
-	if fiveHourSet {
-		tiers = append(tiers, CNQuotaTier{Window: "5h", UsedPercent: fiveHour.percentage, ResetAt: fiveHour.resetISO})
-	}
-	if weeklySet {
-		tiers = append(tiers, CNQuotaTier{Window: "weekly", UsedPercent: weekly.percentage, ResetAt: weekly.resetISO})
-	}
-	return tiers
 }
 
 // cnQuotaExtraUpdates 根据 tier 列表构造 provider 维度的 Extra 快照更新。

--- a/backend/internal/service/cn_provider_registry.go
+++ b/backend/internal/service/cn_provider_registry.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// 国产 OpenAI 兼容供应商（CN provider）注册表。
+//
+// 背景：CN 供应商体系最初以内建 switch 散落实现（平台集合判定、默认端点矩阵、
+// 余额/额度探测解析、调度阈值平台列表……），新增一家供应商需要改动十余处且
+// 容易漏改（migration 157 的 platform CHECK 约束曾导致新用户注册拿不到配额行，
+// 见 migration 224 的修复）。本注册表把「平台元数据 + 端点矩阵 + 探测行为钩子」
+// 收敛为单一权威来源：
+//
+//   - 平台集合判定（IsCNProvider）、配额/调度阈值平台列表、快照平台列表等
+//     全部由注册表派生，注册新平台即自动生效；
+//   - 余额/额度探测的平台差异（端点构造、鉴权方式、响应解析）通过可选钩子
+//     注入；钩子为 nil 表示该平台无对应探测端点，退化为纯响应式限流
+//     （与 zhipu 无公开余额端点的现状同型）；
+//   - 内建供应商（kimi/zhipu/deepseek）在 cn_provider_{kimi,zhipu,deepseek}.go
+//     中各以一个 RegisterCNProvider 调用完成注册；新增供应商只需新增一个
+//     同类文件，无需改动任何现有代码路径。
+//
+// 注册时机约束：RegisterCNProvider 仅允许在包级 var 初始化或 init() 中调用
+// （非并发安全）；运行期注册表只读。
+
+// CNEndpointKey 是默认端点矩阵的键：Protocol 取 APIProtocol*，Mode 取
+// AccountMode*（空串表示模式无关的通用端点）。查找顺序为精确 (protocol, mode)
+// 命中后回退 (protocol, "")。
+type CNEndpointKey struct {
+	Protocol string
+	Mode     string
+}
+
+// CNBalanceProbe 是余额探测钩子，覆盖平台特定的端点构造与 2xx 响应解析。
+// 请求执行、代理解析、出站 URL 安全校验、Extra 快照落库由通用层
+// （cn_provider_balance_service.go）完成。
+type CNBalanceProbe interface {
+	// BalanceURL 返回余额探测端点（可由账号 base_url 衍生）。
+	BalanceURL(account *Account) string
+	// ParseBalance 解析 2xx 响应体：entries 首条为主币种；available 为上游
+	// 健康标记（无此概念的平台恒返回 true）；errMsg 非空表示响应结构非法
+	// （结果不置 Success，不落快照）。
+	ParseBalance(body []byte) (entries []CNProviderBalanceEntry, available bool, errMsg string)
+}
+
+// CNQuotaProbe 是 Coding Plan 滚动窗口额度探测钩子。
+type CNQuotaProbe interface {
+	// QuotaURL 返回额度探测端点（可由账号 base_url 衍生）。
+	QuotaURL(account *Account) string
+	// QuotaAuthHeader 返回 Authorization 头值（kimi 为 "Bearer "+key；
+	// zhipu 为 key 本体，不加 Bearer 前缀）。
+	QuotaAuthHeader(apiKey string) string
+	// SetQuotaHeaders 写入平台特定的追加请求头（无则空实现）。
+	SetQuotaHeaders(req *http.Request)
+	// ParseQuota 解析 2xx 响应体为用量窗口列表；planLevel 为套餐档位（可空）；
+	// errMsg 非空表示业务级错误（HTTP 2xx 但 success=false 之类）。
+	ParseQuota(body []byte) (tiers []CNQuotaTier, planLevel string, errMsg string)
+}
+
+// CNProviderSpec 描述一家国产 OpenAI 兼容供应商的注册定义。
+type CNProviderSpec struct {
+	// Code 是平台标识（account.platform 值），如 "kimi"。注册后不可变。
+	Code string
+	// DisplayName 是展示名，如 "Kimi (月之暗面)"。
+	DisplayName string
+
+	// DefaultBaseURLs 是默认端点矩阵：账号未显式配置 credentials.base_url /
+	// api_base_urls 时按 (协议, 模式) 取官方默认端点。
+	DefaultBaseURLs map[CNEndpointKey]string
+
+	// BalanceProbe 余额探测钩子；nil 表示该平台无公开余额端点（纯响应式 402/429）。
+	BalanceProbe CNBalanceProbe
+	// QuotaProbe Coding Plan 额度探测钩子；nil 表示该平台无滚动窗口端点。
+	QuotaProbe CNQuotaProbe
+
+	// SupportsNativeResponses 报告该平台是否提供原生 OpenAI Responses 端点
+	// （deepseek：/responses，无 /v1 前缀、无状态）。为 false 的平台在
+	// adaptive 协议下对 Responses 形状请求回退 Chat Completions 转换链。
+	SupportsNativeResponses bool
+
+	// MatchCodingPlanBaseURL 按账号 base_url（已转小写）识别 coding plan 归属，
+	// 供 GetCodingPlanProvider 反推；nil 表示该平台无 coding plan 形态。
+	MatchCodingPlanBaseURL func(lowerBaseURL string) bool
+
+	// ModelDetectPrefixes 是「模型名 → 平台」识别的前缀列表（如 kimi-、moonshot-），
+	// ModelDetectAliases 是 "provider/model" 形式的 provider 段别名（如 kimi、moonshot）。
+	// 供 composite 路由的 DetectModelPlatform 使用；不同平台的前缀不得重叠。
+	ModelDetectPrefixes []string
+	ModelDetectAliases  []string
+
+	// LiteLLMProvider 是 LiteLLM 定价目录中该平台对应的 vendor 键
+	// （如 kimi → "moonshot"）；空串表示定价目录中无独立 vendor 条目。
+	LiteLLMProvider string
+}
+
+// DefaultBaseURL 按 (协议, 模式) 查默认端点：coding 模式先查精确键，
+// 再回退 payg 键，最后回退模式无关键（空 Mode）。与历史 switch 语义一致：
+// 未设置 account_mode 的账号按 payg 端点处理。
+func (s *CNProviderSpec) DefaultBaseURL(protocol, mode string) string {
+	if s == nil {
+		return ""
+	}
+	if mode == AccountModeCoding {
+		if u := s.DefaultBaseURLs[CNEndpointKey{protocol, AccountModeCoding}]; u != "" {
+			return u
+		}
+	}
+	if u := s.DefaultBaseURLs[CNEndpointKey{protocol, AccountModePayG}]; u != "" {
+		return u
+	}
+	return s.DefaultBaseURLs[CNEndpointKey{protocol, ""}]
+}
+
+// cnProviderRegistry 是注册表本体：codes 保持注册序（保证 DetectModelPlatform
+// 等遍历语义确定），byCode 为索引。
+var cnProviderRegistry = struct {
+	codes  []string
+	byCode map[string]*CNProviderSpec
+}{
+	byCode: make(map[string]*CNProviderSpec),
+}
+
+// RegisterCNProvider 注册一家国产供应商。重复注册同 code 或定义非法会 panic
+// （编程错误应在启动期暴露）。仅允许在包级 var 初始化 / init() 中调用。
+func RegisterCNProvider(spec CNProviderSpec) {
+	if spec.Code == "" {
+		panic("cn_provider: register with empty code")
+	}
+	if _, dup := cnProviderRegistry.byCode[spec.Code]; dup {
+		panic(fmt.Sprintf("cn_provider: duplicate registration for %q", spec.Code))
+	}
+	cloned := spec
+	cnProviderRegistry.codes = append(cnProviderRegistry.codes, spec.Code)
+	cnProviderRegistry.byCode[spec.Code] = &cloned
+	rebuildCNProviderDerivedLists()
+}
+
+// GetCNProviderSpec 返回指定平台 code 的注册定义。
+func GetCNProviderSpec(code string) (*CNProviderSpec, bool) {
+	spec, ok := cnProviderRegistry.byCode[code]
+	return spec, ok
+}
+
+// CNProviderCodes 返回全部已注册平台 code（注册序）。
+func CNProviderCodes() []string {
+	out := make([]string, len(cnProviderRegistry.codes))
+	copy(out, cnProviderRegistry.codes)
+	return out
+}
+
+// cnProviderSpecs 返回全部已注册定义（注册序），供遍历匹配（模型识别、
+// coding plan 反推等）。
+func cnProviderSpecs() []*CNProviderSpec {
+	out := make([]*CNProviderSpec, 0, len(cnProviderRegistry.codes))
+	for _, code := range cnProviderRegistry.codes {
+		out = append(out, cnProviderRegistry.byCode[code])
+	}
+	return out
+}
+
+// 非 CN 的具体上游平台（注册表派生列表的固定前缀）。
+var concreteNonCNPlatforms = []string{
+	PlatformAnthropic,
+	PlatformGemini,
+	PlatformOpenAI,
+	PlatformAntigravity,
+	PlatformGrok,
+}
+
+// ConcretePlatforms 返回全部具体上游平台（非 CN 平台 + 已注册 CN 平台，
+// 顺序与历史硬编码列表一致）。调度快照、平台筛选等「全平台枚举」统一由此派生。
+func ConcretePlatforms() []string {
+	out := make([]string, 0, len(concreteNonCNPlatforms)+len(cnProviderRegistry.codes))
+	out = append(out, concreteNonCNPlatforms...)
+	out = append(out, cnProviderRegistry.codes...)
+	return out
+}
+
+// rebuildCNProviderDerivedLists 在注册变化后重算派生平台列表。
+// AllowedQuotaPlatforms / AllowedSchedulingThresholdPlatforms 保持公开 var
+// 形态（调用点零改动），仅在 init 期随注册重建，运行期只读。
+func rebuildCNProviderDerivedLists() {
+	AllowedQuotaPlatforms = deriveAllowedQuotaPlatforms()
+	AllowedSchedulingThresholdPlatforms = deriveAllowedSchedulingThresholdPlatforms()
+}
+
+func deriveAllowedQuotaPlatforms() []string {
+	// 历史顺序：anthropic/openai/gemini/antigravity/grok + CN 平台（注册序）。
+	out := []string{
+		PlatformAnthropic,
+		PlatformOpenAI,
+		PlatformGemini,
+		PlatformAntigravity,
+		PlatformGrok,
+	}
+	return append(out, cnProviderRegistry.codes...)
+}
+
+func deriveAllowedSchedulingThresholdPlatforms() []string {
+	// openai/anthropic/grok 有原生用量窗口；有 QuotaProbe 的 CN 平台（Coding Plan
+	// 滚动窗口）纳入阈值评估；余额型平台（无 QuotaProbe）走余额检测而非阈值。
+	out := []string{PlatformOpenAI, PlatformAnthropic, PlatformGrok}
+	for _, spec := range cnProviderSpecs() {
+		if spec.QuotaProbe != nil {
+			out = append(out, spec.Code)
+		}
+	}
+	return out
+}
+
+// SortedCNProviderCodes 返回按字典序排序的已注册平台 code（仅测试与调试用途）。
+func SortedCNProviderCodes() []string {
+	out := CNProviderCodes()
+	sort.Strings(out)
+	return out
+}
+
+// cnSupportsNativeResponses 报告平台是否声明了原生 OpenAI Responses 端点能力
+// （当前仅 deepseek）。供路由决策使用；端点路径/body 归一化等平台实现细节
+// 不在此能力位覆盖范围内。
+func cnSupportsNativeResponses(platform string) bool {
+	spec, ok := GetCNProviderSpec(platform)
+	return ok && spec.SupportsNativeResponses
+}

--- a/backend/internal/service/cn_provider_registry_test.go
+++ b/backend/internal/service/cn_provider_registry_test.go
@@ -1,0 +1,169 @@
+package service
+
+// CN 供应商注册表的派生语义回归测试：
+// 平台集合判定、配额/调度阈值列表、端点矩阵查找、能力位、模型识别
+// 均由注册表派生，须与历史硬编码行为完全一致。
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCNProviderRegistry_BuiltinProvidersRegistered(t *testing.T) {
+	require.ElementsMatch(t, []string{PlatformKimi, PlatformZhipu, PlatformDeepseek}, CNProviderCodes())
+
+	for _, code := range []string{PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		spec, ok := GetCNProviderSpec(code)
+		require.True(t, ok, "builtin provider %q must be registered", code)
+		require.Equal(t, code, spec.Code)
+		require.NotEmpty(t, spec.DisplayName)
+	}
+}
+
+func TestIsCNProvider_DerivedFromRegistry(t *testing.T) {
+	for _, p := range []string{PlatformKimi, PlatformZhipu, PlatformDeepseek} {
+		require.True(t, IsCNProvider(p), p)
+	}
+	for _, p := range []string{PlatformOpenAI, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformGrok, PlatformComposite, "kiro", ""} {
+		require.False(t, IsCNProvider(p), p)
+	}
+}
+
+func TestAllowedQuotaPlatforms_DerivedOrder(t *testing.T) {
+	// 历史顺序：anthropic/openai/gemini/antigravity/grok + CN 平台（注册序）。
+	require.Equal(t, []string{
+		PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformGrok,
+		PlatformKimi, PlatformZhipu, PlatformDeepseek,
+	}, AllowedQuotaPlatforms)
+}
+
+func TestAllowedSchedulingThresholdPlatforms_OnlyQuotaProbeProviders(t *testing.T) {
+	// openai/anthropic/grok 原生窗口 + 有 QuotaProbe 的 CN 平台（kimi/zhipu）；
+	// deepseek 为余额型（无 QuotaProbe），不纳入阈值评估。
+	require.Equal(t, []string{
+		PlatformOpenAI, PlatformAnthropic, PlatformGrok, PlatformKimi, PlatformZhipu,
+	}, AllowedSchedulingThresholdPlatforms)
+}
+
+func TestConcretePlatforms_DerivedOrder(t *testing.T) {
+	require.Equal(t, []string{
+		PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok,
+		PlatformKimi, PlatformZhipu, PlatformDeepseek,
+	}, ConcretePlatforms())
+}
+
+func TestCNProviderSpec_DefaultBaseURL_FallbackChain(t *testing.T) {
+	kimi, _ := GetCNProviderSpec(PlatformKimi)
+	// 精确模式键命中。
+	require.Equal(t, DefaultKimiCodingBaseURL, kimi.DefaultBaseURL(APIProtocolChatCompletions, AccountModeCoding))
+	require.Equal(t, DefaultKimiPayGBaseURL, kimi.DefaultBaseURL(APIProtocolChatCompletions, AccountModePayG))
+	require.Equal(t, DefaultKimiCodingAnthropicBaseURL, kimi.DefaultBaseURL(APIProtocolAnthropic, AccountModeCoding))
+	// 未设置 mode（空串）回退 payg 键。
+	require.Equal(t, DefaultKimiPayGBaseURL, kimi.DefaultBaseURL(APIProtocolChatCompletions, ""))
+
+	zhipu, _ := GetCNProviderSpec(PlatformZhipu)
+	// anthropic 端点模式无关：coding/payg 均回退到空 Mode 键。
+	require.Equal(t, DefaultZhipuAnthropicBaseURL, zhipu.DefaultBaseURL(APIProtocolAnthropic, AccountModeCoding))
+	require.Equal(t, DefaultZhipuAnthropicBaseURL, zhipu.DefaultBaseURL(APIProtocolAnthropic, AccountModePayG))
+	require.Equal(t, DefaultZhipuCodingBaseURL, zhipu.DefaultBaseURL(APIProtocolChatCompletions, AccountModeCoding))
+
+	deepseek, _ := GetCNProviderSpec(PlatformDeepseek)
+	require.Equal(t, DefaultDeepseekBaseURL, deepseek.DefaultBaseURL(APIProtocolChatCompletions, AccountModePayG))
+	require.Equal(t, DefaultDeepseekAnthropicBaseURL, deepseek.DefaultBaseURL(APIProtocolAnthropic, ""))
+
+	// 未注册平台 / 未知协议返回空串。
+	var nilSpec *CNProviderSpec
+	require.Equal(t, "", nilSpec.DefaultBaseURL(APIProtocolChatCompletions, AccountModePayG))
+	require.Equal(t, "", kimi.DefaultBaseURL("unknown_protocol", AccountModePayG))
+}
+
+func TestCNProviderSpec_ProbeCapabilities(t *testing.T) {
+	kimi, _ := GetCNProviderSpec(PlatformKimi)
+	require.NotNil(t, kimi.BalanceProbe)
+	require.NotNil(t, kimi.QuotaProbe)
+	require.False(t, kimi.SupportsNativeResponses)
+
+	zhipu, _ := GetCNProviderSpec(PlatformZhipu)
+	require.Nil(t, zhipu.BalanceProbe) // 无公开余额端点
+	require.NotNil(t, zhipu.QuotaProbe)
+
+	deepseek, _ := GetCNProviderSpec(PlatformDeepseek)
+	require.NotNil(t, deepseek.BalanceProbe)
+	require.Nil(t, deepseek.QuotaProbe) // 无 Coding Plan 窗口端点
+	require.True(t, deepseek.SupportsNativeResponses)
+
+	require.True(t, cnSupportsNativeResponses(PlatformDeepseek))
+	require.False(t, cnSupportsNativeResponses(PlatformKimi))
+	require.False(t, cnSupportsNativeResponses(PlatformOpenAI)) // 非 CN 平台
+}
+
+func TestAccountDefaultBaseURL_ViaRegistry(t *testing.T) {
+	// GetOpenAIBaseURL / GetAnthropicProtocolBaseURL 的默认端点与历史 switch 等价。
+	codingKimi := &Account{Platform: PlatformKimi, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"account_mode": AccountModeCoding, "api_protocol": APIProtocolAnthropic,
+	}}
+	require.Equal(t, DefaultKimiCodingAnthropicBaseURL, codingKimi.GetAnthropicProtocolBaseURL())
+
+	paygZhipu := &Account{Platform: PlatformZhipu, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"account_mode": AccountModePayG, "api_protocol": APIProtocolAnthropic,
+	}}
+	require.Equal(t, DefaultZhipuAnthropicBaseURL, paygZhipu.GetAnthropicProtocolBaseURL())
+
+	// 凭证 base_url 优先于平台默认。
+	custom := &Account{Platform: PlatformKimi, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"base_url": "https://proxy.example.com/anthropic", "api_protocol": APIProtocolAnthropic,
+	}}
+	require.Equal(t, "https://proxy.example.com/anthropic", custom.GetAnthropicProtocolBaseURL())
+}
+
+func TestGetCodingPlanProvider_ViaRegistry(t *testing.T) {
+	mk := func(baseURL string) *Account {
+		return &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+			"account_mode": AccountModeCoding, "base_url": baseURL,
+		}}
+	}
+	require.Equal(t, PlatformKimi, mk("https://api.kimi.com/coding/v1").GetCodingPlanProvider())
+	require.Equal(t, PlatformZhipu, mk("https://open.bigmodel.cn/api/coding/paas/v4").GetCodingPlanProvider())
+	require.Equal(t, PlatformZhipu, mk("https://api.z.ai/api/coding/paas/v4").GetCodingPlanProvider())
+	require.Equal(t, "", mk("https://api.deepseek.com").GetCodingPlanProvider())
+
+	// 非 coding 模式不反推。
+	payg := &Account{Platform: PlatformKimi, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"account_mode": AccountModePayG, "base_url": "https://api.kimi.com/coding/v1",
+	}}
+	require.Equal(t, "", payg.GetCodingPlanProvider())
+}
+
+func TestDetectModelPlatform_ViaRegistry(t *testing.T) {
+	cases := map[string]string{
+		"kimi-k2":                  PlatformKimi,
+		"moonshot-v1-8k":           PlatformKimi,
+		"kimi/kimi-k2":             PlatformKimi,
+		"moonshot/moonshot-v1-8k":  PlatformKimi,
+		"glm-4.6":                  PlatformZhipu,
+		"zhipu/glm-4.6":            PlatformZhipu,
+		"bigmodel/glm-4.6":         PlatformZhipu,
+		"deepseek-chat":            PlatformDeepseek,
+		"deepseek/deepseek-chat":   PlatformDeepseek,
+		"claude-sonnet-4":          PlatformAnthropic,
+		"gpt-5":                    PlatformOpenAI,
+		"grok-4":                   PlatformGrok,
+		"gemini-2.5-pro":           PlatformGemini,
+		"totally-unknown-model-42": "",
+	}
+	for model, want := range cases {
+		got, ok := DetectModelPlatform(model)
+		require.Equal(t, want, got, "model %q", model)
+		require.Equal(t, want != "", ok, "model %q matched flag", model)
+	}
+}
+
+func TestRegisterCNProvider_DuplicatePanics(t *testing.T) {
+	require.Panics(t, func() {
+		RegisterCNProvider(CNProviderSpec{Code: PlatformKimi})
+	})
+	require.Panics(t, func() {
+		RegisterCNProvider(CNProviderSpec{Code: ""})
+	})
+}

--- a/backend/internal/service/cn_provider_zhipu.go
+++ b/backend/internal/service/cn_provider_zhipu.go
@@ -39,7 +39,12 @@ var zhipuProviderSpec = CNProviderSpec{
 type zhipuQuotaProbe struct{}
 
 func (zhipuQuotaProbe) QuotaURL(account *Account) string {
-	return zhipuQuotaHost(account.GetOpenAIBaseURL()) + "/api/monitor/usage/quota/limit"
+	return zhipuQuotaURL(account.GetOpenAIBaseURL())
+}
+
+// zhipuQuotaURL 拼接智谱额度端点（按域名路由主机）。
+func zhipuQuotaURL(baseURL string) string {
+	return zhipuQuotaHost(baseURL) + "/api/monitor/usage/quota/limit"
 }
 
 // QuotaAuthHeader 智谱额度端点鉴权不加 Bearer 前缀。

--- a/backend/internal/service/cn_provider_zhipu.go
+++ b/backend/internal/service/cn_provider_zhipu.go
@@ -1,0 +1,216 @@
+package service
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// 智谱 GLM（bigmodel）内建注册。
+//
+//   - 余额：无公开余额端点（OpenAPI 规格验证），BalanceProbe 为 nil，
+//     仅靠响应式 429/402（见 ratelimit_cn_providers.go）。
+//   - Coding Plan 额度：{host}/api/monitor/usage/quota/limit（5h + weekly 窗口），
+//     鉴权不加 Bearer 前缀，业务级错误以 success=false 表达。
+var zhipuProviderSpec = CNProviderSpec{
+	Code:        PlatformZhipu,
+	DisplayName: "Zhipu GLM (智谱)",
+	DefaultBaseURLs: map[CNEndpointKey]string{
+		{APIProtocolChatCompletions, AccountModePayG}:   DefaultZhipuPayGBaseURL,
+		{APIProtocolChatCompletions, AccountModeCoding}: DefaultZhipuCodingBaseURL,
+		{APIProtocolResponses, AccountModePayG}:         DefaultZhipuPayGBaseURL,
+		{APIProtocolResponses, AccountModeCoding}:       DefaultZhipuCodingBaseURL,
+		{APIProtocolAnthropic, ""}:                      DefaultZhipuAnthropicBaseURL,
+	},
+	BalanceProbe:            nil, // 无公开余额端点
+	QuotaProbe:              zhipuQuotaProbe{},
+	SupportsNativeResponses: false,
+	MatchCodingPlanBaseURL: func(lowerBaseURL string) bool {
+		return strings.Contains(lowerBaseURL, "bigmodel.cn") || strings.Contains(lowerBaseURL, "api.z.ai")
+	},
+	LiteLLMProvider:     "zhipu",
+	ModelDetectPrefixes: []string{"glm-"},
+	ModelDetectAliases:  []string{"zhipu", "glm", "bigmodel"},
+}
+
+// zhipuQuotaProbe 实现智谱 Coding Plan 额度探测。
+type zhipuQuotaProbe struct{}
+
+func (zhipuQuotaProbe) QuotaURL(account *Account) string {
+	return zhipuQuotaHost(account.GetOpenAIBaseURL()) + "/api/monitor/usage/quota/limit"
+}
+
+// QuotaAuthHeader 智谱额度端点鉴权不加 Bearer 前缀。
+func (zhipuQuotaProbe) QuotaAuthHeader(apiKey string) string {
+	return apiKey
+}
+
+func (zhipuQuotaProbe) SetQuotaHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Language", "en-US,en")
+}
+
+// ParseQuota 解析智谱额度响应：先做业务级错误判定（HTTP 2xx 但
+// success=false），再解析 data.limits 为 5h + weekly 两档。
+func (zhipuQuotaProbe) ParseQuota(body []byte) ([]CNQuotaTier, string, string) {
+	if success := gjson.GetBytes(body, "success"); success.Exists() && !success.Bool() {
+		msg := strings.TrimSpace(gjson.GetBytes(body, "msg").String())
+		if msg == "" {
+			msg = "unknown zhipu quota error"
+		}
+		return nil, "", "API error: " + msg
+	}
+	data := gjson.GetBytes(body, "data")
+	planLevel := strings.TrimSpace(gjson.GetBytes(body, "data.level").String())
+	return parseZhipuTokenTiers(data), planLevel, ""
+}
+
+func zhipuQuotaHost(baseURL string) string {
+	switch u := strings.ToLower(baseURL); {
+	case strings.Contains(u, "bigmodel.cn"):
+		return "https://open.bigmodel.cn"
+	case strings.Contains(u, "z.ai"):
+		return "https://api.z.ai"
+	default:
+		// 国产优先：未知域名回落国内站（与前端 zhipu 预设一致）。
+		return "https://open.bigmodel.cn"
+	}
+}
+
+// cnZhipuWindow 标识智谱 TOKENS_LIMIT 条目所属窗口。
+type cnZhipuWindow int
+
+const (
+	cnZhipuWindowUnknown cnZhipuWindow = iota
+	cnZhipuWindow5h
+	cnZhipuWindowWeekly
+)
+
+// classifyZhipuWindowUnit 按 unit 字段判定窗口类型（3=5h，6=weekly）。
+// unit 缺失或未识别时返回 Unknown，由调用方走 reset 时间启发式兜底。
+func classifyZhipuWindowUnit(unit int64) cnZhipuWindow {
+	switch unit {
+	case 3:
+		return cnZhipuWindow5h
+	case 6:
+		return cnZhipuWindowWeekly
+	default:
+		return cnZhipuWindowUnknown
+	}
+}
+
+// parseZhipuTokenTiers 解析智谱额度响应 data.limits 为 5h + weekly 两档。
+//
+// 分类优先级（对齐 cc-switch parse_zhipu_token_tiers，issue #3036）：
+//  1. 显式 unit 字段（3=5h / 6=weekly）——不能用 reset 排序代替，周期末尾
+//     周窗口会比 5h 更早重置，时间排序必然标反。
+//  2. unit 缺失/未识别：无 nextResetTime 的条目优先归 5h（0% 状态下 5h 桶可能
+//     没有 reset），其余按 reset 升序依次填入仍空缺的槽位。
+//
+// CREDIT_LIMIT（信用额度）与 TOKENS_LIMIT（token 窗口）度量不同：两者同时返回时
+// 只让 TOKENS_LIMIT 参与 5h/weekly 槽位竞争，避免信用额度百分比污染阈值停调
+// 快照；仅当无任何 TOKENS_LIMIT 条目时才降级用 CREDIT_LIMIT 展示。
+// 老套餐只回 1 条 TOKENS_LIMIT，自然降级为仅 5h；新套餐回 2 条。
+func parseZhipuTokenTiers(data gjson.Result) []CNQuotaTier {
+	type entry struct {
+		resetMs    int64
+		hasReset   bool
+		percentage float64
+		resetISO   string
+	}
+	var (
+		fiveHour     entry
+		fiveHourSet  bool
+		weekly       entry
+		weeklySet    bool
+		unclassified []entry
+	)
+
+	classify := func(item gjson.Result, e entry) {
+		switch classifyZhipuWindowUnit(item.Get("unit").Int()) {
+		case cnZhipuWindow5h:
+			if !fiveHourSet {
+				fiveHour, fiveHourSet = e, true
+			} else {
+				unclassified = append(unclassified, e)
+			}
+		case cnZhipuWindowWeekly:
+			if !weeklySet {
+				weekly, weeklySet = e, true
+			} else {
+				unclassified = append(unclassified, e)
+			}
+		default:
+			unclassified = append(unclassified, e)
+		}
+	}
+	var creditFallback []entry
+	hasTokensLimit := false
+
+	data.Get("limits").ForEach(func(_, item gjson.Result) bool {
+		limitType := strings.ToUpper(strings.TrimSpace(item.Get("type").String()))
+		if limitType != "TOKENS_LIMIT" && limitType != "CREDIT_LIMIT" {
+			return true
+		}
+		percentage := 0.0
+		if p, ok := cnParseF64(item.Get("percentage").Value()); ok {
+			percentage = p
+		}
+		var (
+			resetMs  int64
+			hasReset bool
+			resetISO string
+		)
+		if nr := item.Get("nextResetTime"); nr.Exists() {
+			switch nr.Type {
+			case gjson.Number:
+				resetMs = nr.Int()
+				hasReset = resetMs > 0
+				resetISO = cnMillisToRFC3339(resetMs)
+			case gjson.String:
+				resetISO = cnNormalizeResetTime(nr.String())
+				hasReset = resetISO != ""
+			}
+		}
+		e := entry{resetMs: resetMs, hasReset: hasReset, percentage: percentage, resetISO: resetISO}
+		if limitType == "TOKENS_LIMIT" {
+			hasTokensLimit = true
+			classify(item, e)
+		} else {
+			creditFallback = append(creditFallback, e)
+		}
+		return true
+	})
+
+	// 无任何 TOKENS_LIMIT 条目（部分套餐只报信用额度）：降级用 CREDIT_LIMIT 展示。
+	if !hasTokensLimit {
+		unclassified = append(unclassified, creditFallback...)
+	}
+
+	// 无 reset 的条目排前，再按 reset 升序，依次填入仍空缺的槽位。
+	sort.SliceStable(unclassified, func(i, j int) bool {
+		if unclassified[i].hasReset != unclassified[j].hasReset {
+			return !unclassified[i].hasReset
+		}
+		return unclassified[i].resetMs < unclassified[j].resetMs
+	})
+	for _, e := range unclassified {
+		switch {
+		case !fiveHourSet:
+			fiveHour, fiveHourSet = e, true
+		case !weeklySet:
+			weekly, weeklySet = e, true
+		}
+	}
+
+	var tiers []CNQuotaTier
+	if fiveHourSet {
+		tiers = append(tiers, CNQuotaTier{Window: "5h", UsedPercent: fiveHour.percentage, ResetAt: fiveHour.resetISO})
+	}
+	if weeklySet {
+		tiers = append(tiers, CNQuotaTier{Window: "weekly", UsedPercent: weekly.percentage, ResetAt: weekly.resetISO})
+	}
+	return tiers
+}

--- a/backend/internal/service/cn_providers_test.go
+++ b/backend/internal/service/cn_providers_test.go
@@ -230,16 +230,23 @@ func TestKimiQuotaURL(t *testing.T) {
 }
 
 // TestCNBalanceURL Kimi 固定端点；DeepSeek 基于 base_url 拼接。
+// 端点构造由各平台注册的 CNBalanceProbe.BalanceURL 钩子承担。
 func TestCNBalanceURL(t *testing.T) {
 	t.Parallel()
+	kimiSpec, ok := GetCNProviderSpec(PlatformKimi)
+	require.True(t, ok)
+	require.NotNil(t, kimiSpec.BalanceProbe)
 	kimi := &Account{Platform: PlatformKimi}
-	require.Equal(t, "https://api.moonshot.cn/v1/users/me/balance", cnBalanceURL(kimi))
+	require.Equal(t, "https://api.moonshot.cn/v1/users/me/balance", kimiSpec.BalanceProbe.BalanceURL(kimi))
 
+	deepseekSpec, ok := GetCNProviderSpec(PlatformDeepseek)
+	require.True(t, ok)
+	require.NotNil(t, deepseekSpec.BalanceProbe)
 	deepseek := &Account{
 		Platform:    PlatformDeepseek,
 		Credentials: map[string]any{"base_url": "https://api.deepseek.com"},
 	}
-	require.Equal(t, "https://api.deepseek.com/user/balance", cnBalanceURL(deepseek))
+	require.Equal(t, "https://api.deepseek.com/user/balance", deepseekSpec.BalanceProbe.BalanceURL(deepseek))
 }
 
 // TestCNProviderThresholdCandidates 从 Extra 快照读取 5h / weekly 候选。

--- a/backend/internal/service/composite_platform.go
+++ b/backend/internal/service/composite_platform.go
@@ -106,12 +106,14 @@ func DetectModelPlatform(model string) (string, bool) {
 			return PlatformGemini, true
 		case "xai", "x-ai", "grok":
 			return PlatformGrok, true
-		case "kimi", "moonshot":
-			return PlatformKimi, true
-		case "zhipu", "glm", "bigmodel":
-			return PlatformZhipu, true
-		case "deepseek":
-			return PlatformDeepseek, true
+		}
+		// CN 平台别名由注册表定义（如 kimi/moonshot、zhipu/glm/bigmodel）。
+		for _, spec := range cnProviderSpecs() {
+			for _, alias := range spec.ModelDetectAliases {
+				if provider == alias {
+					return spec.Code, true
+				}
+			}
 		}
 		if rest != "" {
 			normalized = strings.TrimPrefix(rest, "models/")
@@ -139,16 +141,16 @@ func DetectModelPlatform(model string) (string, bool) {
 		return PlatformGemini, true
 	case normalized == "grok" || strings.HasPrefix(normalized, "grok-"):
 		return PlatformGrok, true
-	case strings.HasPrefix(normalized, "kimi-"),
-		strings.HasPrefix(normalized, "moonshot-"):
-		return PlatformKimi, true
-	case strings.HasPrefix(normalized, "glm-"):
-		return PlatformZhipu, true
-	case strings.HasPrefix(normalized, "deepseek-"):
-		return PlatformDeepseek, true
-	default:
-		return "", false
 	}
+	// CN 平台模型前缀由注册表定义（如 kimi-/moonshot-、glm-、deepseek-）。
+	for _, spec := range cnProviderSpecs() {
+		for _, prefix := range spec.ModelDetectPrefixes {
+			if strings.HasPrefix(normalized, prefix) {
+				return spec.Code, true
+			}
+		}
+	}
+	return "", false
 }
 
 func hasOpenAISeriesPrefix(model string) bool {
@@ -192,10 +194,9 @@ func (s *GatewayService) resolveCompositeRouteDecision(ctx context.Context, grou
 
 func isConcreteRequestPlatform(platform string) bool {
 	switch platform {
-	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformGrok,
-		PlatformKimi, PlatformZhipu, PlatformDeepseek:
+	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformGrok:
 		return true
 	default:
-		return false
+		return IsCNProvider(platform)
 	}
 }

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -86,40 +86,25 @@ const (
 	DefaultDeepseekAnthropicBaseURL   = "https://api.deepseek.com/anthropic"
 )
 
-// IsCNProvider 报告 platform 是否为国产 OpenAI 兼容供应商（kimi/zhipu/deepseek）。
+// IsCNProvider 报告 platform 是否为国产 OpenAI 兼容供应商。
+// 平台集合由注册表（cn_provider_registry.go）派生：内建 kimi/zhipu/deepseek，
+// 新增供应商经 RegisterCNProvider 注册后自动纳入。
 func IsCNProvider(platform string) bool {
-	switch platform {
-	case PlatformKimi, PlatformZhipu, PlatformDeepseek:
-		return true
-	default:
-		return false
-	}
+	_, ok := GetCNProviderSpec(platform)
+	return ok
 }
 
-// AllowedQuotaPlatforms 是允许设置 user × platform quota 的平台列表（单一权威来源）。
+// AllowedQuotaPlatforms 是允许设置 user × platform quota 的平台列表。
+// 由 CN 注册表派生重建（RegisterCNProvider 时刷新，运行期只读）；
 // ent/schema/user_platform_quota.go 的 Validate 函数独立维护（构建期约束），
 // 若新增平台需同步修改该 schema。
-var AllowedQuotaPlatforms = []string{
-	PlatformAnthropic,
-	PlatformOpenAI,
-	PlatformGemini,
-	PlatformAntigravity,
-	PlatformGrok,
-	PlatformKimi,
-	PlatformZhipu,
-	PlatformDeepseek,
-}
+var AllowedQuotaPlatforms []string
 
 // AllowedSchedulingThresholdPlatforms 是允许设置账号自动停调阈值的平台列表。
-// openai/anthropic/grok 有原生用量窗口；kimi/zhipu 的 Coding Plan 同样暴露 5h/weekly
-// 滚动窗口，纳入阈值评估。deepseek 为余额型，走余额检测而非阈值。
-var AllowedSchedulingThresholdPlatforms = []string{
-	PlatformOpenAI,
-	PlatformAnthropic,
-	PlatformGrok,
-	PlatformKimi,
-	PlatformZhipu,
-}
+// openai/anthropic/grok 有原生用量窗口；有 QuotaProbe 的 CN 平台（Coding Plan
+// 滚动窗口）纳入阈值评估；余额型平台（无 QuotaProbe）走余额检测而非阈值。
+// 由 CN 注册表派生重建（RegisterCNProvider 时刷新，运行期只读）。
+var AllowedSchedulingThresholdPlatforms []string
 
 // IsAllowedQuotaPlatform 报告 s 是否为合法的 quota platform 标识。
 func IsAllowedQuotaPlatform(s string) bool {

--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -123,12 +123,13 @@ func (s *AccountTestService) ProbeOpenAIAPIKeyResponsesSupport(ctx context.Conte
 		return
 	}
 	if account.IsCNProvider() {
-		// 国产 OpenAI 兼容上游（kimi/zhipu/deepseek）普遍仅支持 /v1/chat/completions，
-		// 不存在 /v1/responses 端点。直接落标 false 走 Chat Completions 直转，跳过网络探测。
-		// 例外：deepseek 的固定 responses 和 adaptive 账号使用官方原生 /responses
-		// 端点，落标 force_responses；其余协议显式重置为 auto，避免切换后残留强制模式。
+		// 国产 OpenAI 兼容上游普遍仅支持 /v1/chat/completions，不存在
+		// /v1/responses 端点。直接落标 false 走 Chat Completions 直转，跳过网络探测。
+		// 例外：声明了原生 Responses 能力（SupportsNativeResponses，如 deepseek）的
+		// 平台在显式 responses / adaptive 协议下使用官方原生端点，落标 force_responses；
+		// 其余协议显式重置为 auto，避免切换后残留强制模式。
 		if account.GetAPIProtocol() == APIProtocolResponses ||
-			(account.Platform == PlatformDeepseek && account.IsAdaptiveAPIProtocol()) {
+			(cnSupportsNativeResponses(account.Platform) && account.IsAdaptiveAPIProtocol()) {
 			_ = s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{
 				openai_compat.ExtraKeyResponsesMode:      string(openai_compat.ResponsesSupportModeForceResponses),
 				openai_compat.ExtraKeyResponsesSupported: true,

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -95,13 +95,14 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	isResponsesShape := !gjson.GetBytes(body, "messages").Exists() && gjson.GetBytes(body, "input").Exists()
 
 	// 自适应账号的标准 Chat Completions 入站使用供应商原生 CC 端点。
-	// Responses 形状下，DeepSeek 继续走下方原生 Responses 链；Kimi/GLM
-	// 没有 Responses 端点，先转换成 Chat Completions 再直转。
+	// Responses 形状下，声明了原生 Responses 能力的平台（SupportsNativeResponses，
+	// 如 DeepSeek）继续走下方原生 Responses 链；其余 CN 平台没有 Responses 端点，
+	// 先转换成 Chat Completions 再直转。
 	if account.IsAdaptiveAPIProtocol() {
 		if !isResponsesShape {
 			return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 		}
-		if account.Platform != PlatformDeepseek {
+		if !cnSupportsNativeResponses(account.Platform) {
 			var responsesReq apicompat.ResponsesRequest
 			if err := json.Unmarshal(body, &responsesReq); err != nil {
 				return nil, fmt.Errorf("parse responses-shaped chat completions request: %w", err)

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -120,9 +120,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	nativeDeepSeekResponses := account.Platform == PlatformDeepseek &&
+	nativeCNResponses := cnSupportsNativeResponses(account.Platform) &&
 		(account.GetAPIProtocol() == APIProtocolResponses || account.IsAdaptiveAPIProtocol())
-	if nativeDeepSeekResponses && account.Type == AccountTypeAPIKey && !compactPath &&
+	if nativeCNResponses && account.Type == AccountTypeAPIKey && !compactPath &&
 		needsOpenAIResponsesClientToolAdaptation(body) {
 		adaptedBody, mapping, adaptErr := adaptOpenAIResponsesClientTools(body)
 		if adaptErr != nil {
@@ -335,7 +335,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	instructions := gjson.GetBytes(body, "instructions")
 	instructionsEmpty := !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == ""
-	if instructionsEmpty && !compatMessagesBridge && !nativeDeepSeekResponses {
+	if instructionsEmpty && !compatMessagesBridge && !nativeCNResponses {
 		markPatchSet("instructions", defaultCodexSynthInstructions(reqModel))
 	}
 
@@ -514,11 +514,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if !isCodexCLI {
 		maxOutputTokens := gjson.GetBytes(body, "max_output_tokens")
 		if maxOutputTokens.Exists() {
-			switch account.Platform {
-			case PlatformOpenAI, PlatformDeepseek:
+			switch {
+			case account.Platform == PlatformOpenAI || cnSupportsNativeResponses(account.Platform):
 				// Preserve Responses-native output limits unless the selected upstream
 				// explicitly rejects the field in the bounded HTTP retry loop below.
-			case PlatformAnthropic:
+			case account.Platform == PlatformAnthropic:
 				decoded, decodeErr := ensureReqBody()
 				if decodeErr != nil {
 					return nil, decodeErr
@@ -528,7 +528,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 					decoded["max_tokens"] = maxOutputTokens.Value()
 				}
 				markDecodedModified()
-			case PlatformGemini:
+			case account.Platform == PlatformGemini:
 				markPatchDelete("max_output_tokens")
 			default:
 				markPatchDelete("max_output_tokens")
@@ -1209,13 +1209,14 @@ func shouldForwardOpenAIResponsesViaRawChatCompletions(account *Account) bool {
 		return false
 	}
 	if account.IsCNProvider() {
-		// CN 的显式协议配置优先于异步探针 Extra；adaptive 仅 DeepSeek 有原生
-		// Responses，Kimi/GLM 回退 Chat Completions。
+		// CN 的显式协议配置优先于异步探针 Extra；adaptive 下仅声明了原生
+		// Responses 能力的平台（SupportsNativeResponses，如 deepseek）走原生
+		// 端点，其余回退 Chat Completions。
 		switch account.GetAPIProtocol() {
 		case APIProtocolChatCompletions:
 			return true
 		case APIProtocolAdaptive:
-			return account.Platform != PlatformDeepseek
+			return !cnSupportsNativeResponses(account.Platform)
 		default:
 			return false
 		}
@@ -1239,7 +1240,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	case AccountTypeAPIKey:
 		// API Key accounts use Platform API or custom base URL
 		baseURL := account.GetOpenAIBaseURL()
-		if account.Platform == PlatformDeepseek && account.IsAdaptiveAPIProtocol() {
+		if cnSupportsNativeResponses(account.Platform) && account.IsAdaptiveAPIProtocol() {
 			baseURL = account.GetCNProtocolBaseURL(APIProtocolResponses)
 		}
 		if baseURL == "" {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -290,12 +290,10 @@ func (s *OpenAIGatewayService) SelectAccountForTokenCount(
 // （upstream 曾将本函数改为未导出 normalizeOpenAICompatiblePlatform，本分支的
 // handler 调度入口仍需导出，保持导出名。）
 func NormalizeOpenAICompatiblePlatform(platform string) string {
-	switch platform {
-	case PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek:
+	if platform == PlatformGrok || IsCNProvider(platform) {
 		return platform
-	default:
-		return PlatformOpenAI
 	}
+	return PlatformOpenAI
 }
 
 // noAvailableOpenAISelectionError builds the standard "no account available" error

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -608,10 +608,12 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 			continue
 		}
 		accountGroupIDs := s.normalizeGroupIDs(account.GroupIDs)
-		switch account.Platform {
-		case PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek:
+		switch {
+		case account.Platform == PlatformAnthropic || account.Platform == PlatformGemini ||
+			account.Platform == PlatformOpenAI || account.Platform == PlatformGrok ||
+			IsCNProvider(account.Platform):
 			addPlatformGroups(account.Platform, accountGroupIDs)
-		case PlatformAntigravity:
+		case account.Platform == PlatformAntigravity:
 			// 批量更新可能刚关闭 mixed_scheduling，仍需清理两个兼容平台的旧快照。
 			addPlatformGroups(PlatformAntigravity, accountGroupIDs)
 			addPlatformGroups(PlatformAnthropic, accountGroupIDs)
@@ -824,8 +826,8 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 	return s.rebuildBuckets(ctx, buckets, reason)
 }
 
-func schedulerSnapshotPlatforms() [8]string {
-	return [8]string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok, PlatformKimi, PlatformZhipu, PlatformDeepseek}
+func schedulerSnapshotPlatforms() []string {
+	return ConcretePlatforms()
 }
 
 // 生命周期辅助函数有意排除 group0；full rebuild 构造 group0 canonical 集时必须显式调用 canonical helper。

--- a/backend/internal/service/upstream_billing_probe.go
+++ b/backend/internal/service/upstream_billing_probe.go
@@ -983,11 +983,10 @@ func IsUpstreamBillingProbeIdentity(platform, accountType string) bool {
 		return false
 	}
 	switch platform {
-	case PlatformOpenAI, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformGrok,
-		PlatformKimi, PlatformZhipu, PlatformDeepseek:
+	case PlatformOpenAI, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformGrok:
 		return true
 	default:
-		return false
+		return IsCNProvider(platform)
 	}
 }
 

--- a/backend/migrations/229_drop_platform_enum_check_constraints.sql
+++ b/backend/migrations/229_drop_platform_enum_check_constraints.sql
@@ -1,0 +1,20 @@
+-- 移除平台枚举 CHECK 约束，平台合法性收敛到应用层校验。
+--
+-- 背景：user_platform_quotas.platform 与 composite_model_routes.target_platform
+-- 的 CHECK 约束把平台列表固化在数据库层，每次新增供应商都必须伴随一次约束迁移，
+-- 且代码列表与约束一旦脱节就是注册路径事故——157 号迁移的 CHECK 曾导致新用户
+-- 注册拿不到配额行（grok），224 号迁移为 kimi/zhipu/deepseek 又重演了一次同型修复。
+--
+-- 平台集合的权威来源已是 CN 注册表派生的应用层校验：
+--   - user_platform_quotas：service.IsAllowedQuotaPlatform
+--     （setting_update.go / admin user_handler.go 全部写入入口均已覆盖）；
+--   - composite_model_routes：isConcreteRequestPlatform
+--     （admin_group.go 路由写入入口覆盖）。
+-- 数据库层不再重复枚举，新增供应商不再需要约束迁移。
+--
+-- DROP ... IF EXISTS 保证可重入；移除约束对存量行无影响。
+ALTER TABLE user_platform_quotas
+    DROP CONSTRAINT IF EXISTS user_platform_quotas_platform_check;
+
+ALTER TABLE composite_model_routes
+    DROP CONSTRAINT IF EXISTS composite_model_routes_target_platform_check;

--- a/backend/migrations/drop_platform_enum_check_constraints_migration_test.go
+++ b/backend/migrations/drop_platform_enum_check_constraints_migration_test.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDropPlatformEnumCheckConstraintsMigration 校验 229 号迁移移除
+// user_platform_quotas.platform 与 composite_model_routes.target_platform
+// 的枚举 CHECK 约束——平台合法性收敛到应用层（CN 注册表派生的
+// service.IsAllowedQuotaPlatform / isConcreteRequestPlatform），
+// 新增供应商不再需要约束迁移（157/224 两次同型事故的根因）。
+func TestDropPlatformEnumCheckConstraintsMigration(t *testing.T) {
+	content, err := FS.ReadFile("229_drop_platform_enum_check_constraints.sql")
+	require.NoError(t, err)
+
+	sql := strings.Join(strings.Fields(string(content)), " ")
+	require.Contains(t, sql, "DROP CONSTRAINT IF EXISTS user_platform_quotas_platform_check")
+	require.Contains(t, sql, "DROP CONSTRAINT IF EXISTS composite_model_routes_target_platform_check")
+	// 不得再引入新的平台枚举约束。
+	require.NotContains(t, sql, "ADD CONSTRAINT")
+}


### PR DESCRIPTION
## Summary

> ⚠️ Stacked on #6128 (CN provider registry). Please review/merge that first; this branch will be rebased onto `main` afterwards.

Removes the platform enum CHECK constraints from `user_platform_quotas.platform` and `composite_model_routes.target_platform` (migration 229), so onboarding a new CN supplier no longer requires a constraint migration.

## Motivation

These constraints froze the platform list in the database layer and have already caused the same class of incident twice:

- migration 157's CHECK predated grok → new-user registration's bulk quota insert aborted entirely → **new users got zero quota rows** (= no limits);
- migration 224 had to repeat the identical fix when kimi/zhipu/deepseek landed.

With #6128, the authoritative platform set lives in the CN provider registry, and **every write path already validates at the application layer**:

- `user_platform_quotas`: `service.IsAllowedQuotaPlatform` in `setting_update.go` and both admin user handler entry points;
- `composite_model_routes`: `isConcreteRequestPlatform` in the group admin route writer.

The DB-level enums only duplicated that list, so they are dropped. The ent field validator is relaxed to non-empty + max-length with a comment pointing at the application-layer source of truth.

## Test plan

- [x] `go build ./...` / `go generate ./ent` / `golangci-lint run` — clean
- [x] `go test ./migrations/... ./internal/...` — all pass
- [x] New migration test asserts both constraints are dropped and no new enum constraint is introduced
- [x] Existing 224 migration test untouched (historical migration content unchanged)
