### PR TITLE
feat: 运维监控错误详情支持返回列表并保留筛选状态

### DIFF
--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -307,6 +307,7 @@ export default {
         title: 'Error Detail',
         titleWithId: 'Error #{id}',
         noErrorSelected: 'No error selected.',
+        backToList: 'Back to List',
         resolution: 'Resolved:',
         failedToUpdateResolvedStatus: 'Failed to update resolved status',
         classificationKeys: {

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -307,6 +307,7 @@ export default {
         title: '错误详情',
         titleWithId: '错误 #{id}',
         noErrorSelected: '未选择错误。',
+        backToList: '返回列表',
         resolution: '已解决：',
         failedToUpdateResolvedStatus: '更新解决状态失败',
         classificationKeys: {

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -119,11 +119,12 @@
           :platform="platform"
           :group-id="groupId"
           :error-type="errorDetailsType"
+          :resume-state="resumeListState"
           @update:show="showErrorDetails = $event"
           @openErrorDetail="openError"
         />
 
-        <OpsErrorDetailModal v-model:show="showErrorModal" :error-id="selectedErrorId" :error-type="errorDetailsType" />
+        <OpsErrorDetailModal v-model:show="showErrorModal" :error-id="selectedErrorId" :error-type="errorDetailsType" :back-to-list="detailReturnTarget !== null" @back="handleBackToList" />
 
         <OpsRequestDetailsModal
           v-model="showRequestDetails"
@@ -131,6 +132,7 @@
           :preset="requestDetailsPreset"
           :platform="platform"
           :group-id="groupId"
+          :resume-state="resumeListState"
           @openErrorDetail="openError"
         />
       </template>
@@ -377,6 +379,13 @@ const requestDetailsPreset = ref<OpsRequestDetailsPreset>({
   sort: 'created_at_desc'
 })
 
+// 记录单条错误详情来自哪个列表，便于"返回列表"时重新打开对应弹窗并保留状态。
+type DetailReturnTarget = 'errorList' | 'requestList' | null
+const detailReturnTarget = ref<DetailReturnTarget>(null)
+
+// 从详情返回时，列表弹窗应保留上一次的筛选/分页状态而非重置。
+const resumeListState = ref(false)
+
 const showSettingsDialog = ref(false)
 const showAlertRulesCard = ref(false)
 
@@ -508,10 +517,32 @@ function onQueryModeChange(v: string | number | boolean | null) {
 
 function openError(id: number) {
   selectedErrorId.value = id
+  // 记录来源列表，便于详情页"返回列表"。
+  detailReturnTarget.value = showRequestDetails.value ? 'requestList' : showErrorDetails.value ? 'errorList' : null
   // Ensure only one modal visible at a time.
   showErrorDetails.value = false
   showRequestDetails.value = false
   showErrorModal.value = true
+}
+
+// 从单条错误详情返回其来源列表，重新打开关联弹窗（保留筛选/分页状态）。
+function handleBackToList() {
+  const target = detailReturnTarget.value
+  resumeListState.value = true
+  if (target === 'requestList') {
+    showErrorModal.value = false
+    showErrorDetails.value = false
+    showRequestDetails.value = true
+  } else if (target === 'errorList') {
+    showErrorModal.value = false
+    showRequestDetails.value = false
+    showErrorDetails.value = true
+  }
+  detailReturnTarget.value = null
+  // 子组件 watch 在本次 show 变化中消费 resumeState 后复位，保证下次手动打开仍会重置筛选。
+  window.setTimeout(() => {
+    resumeListState.value = false
+  }, 0)
 }
 
 function buildApiParams() {

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailModal.vue
@@ -211,6 +211,16 @@
         </div>
       </div>
     </div>
+    <template v-if="backToList" #footer>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        data-testid="error-detail-back-to-list"
+        @click="goBack"
+      >
+        {{ t('admin.ops.errorDetail.backToList') }}
+      </button>
+    </template>
   </BaseDialog>
 </template>
 
@@ -228,10 +238,12 @@ interface Props {
   show: boolean
   errorId: number | null
   errorType?: 'request' | 'upstream'
+  backToList?: boolean
 }
 
 interface Emits {
   (e: 'update:show', value: boolean): void
+  (e: 'back'): void
 }
 
 const props = defineProps<Props>()
@@ -361,6 +373,11 @@ async function fetchCorrelatedUpstreamErrors(requestErrorId: number) {
 
 function close() {
   emit('update:show', false)
+}
+
+function goBack() {
+  emit('update:show', false)
+  emit('back')
 }
 
 function prettyJSON(raw?: string): string {

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -15,6 +15,7 @@ interface Props {
   platform?: string
   groupId?: number | null
   errorType: 'request' | 'upstream'
+  resumeState?: boolean
 }
 
 const props = defineProps<Props>()
@@ -167,6 +168,7 @@ watch(
   () => props.show,
   (open) => {
     if (!open) return
+    if (props.resumeState) return
     page.value = 1
     pageSize.value = 10
     resetFilters()

--- a/frontend/src/views/admin/ops/components/OpsRequestDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsRequestDetailsModal.vue
@@ -23,6 +23,7 @@ interface Props {
   preset: OpsRequestDetailsPreset
   platform?: string
   groupId?: number | null
+  resumeState?: boolean
 }
 
 const props = defineProps<Props>()
@@ -98,6 +99,7 @@ watch(
   () => props.modelValue,
   (open) => {
     if (open) {
+      if (props.resumeState) return
       page.value = 1
       pageSize.value = 10
       fetchData()
@@ -142,7 +144,6 @@ async function handleCopyRequestId(requestId: string) {
 
 function openErrorDetail(errorId: number | null | undefined) {
   if (!errorId) return
-  close()
   emit('openErrorDetail', errorId)
 }
 


### PR DESCRIPTION
## 背景

运维监控中，用户从 SLA/请求错误/上游错误等卡片进入明细列表（错误列表 / 请求明细列表），查看某一条日志详情后，**无法返回到明细列表页面并保留筛选/分页状态**，只能通过右上角关闭详情回到运维监控总览，需重新打开明细页面并重新筛选，严重影响查看错误详情的效率。

## 改动

1. **单条错误详情弹窗**（`OpsErrorDetailModal.vue`）
   - 新增 `backToList` prop 与 `back` 事件
   - 底部 footer 新增「返回列表」按钮（仅在从列表进入时显示，默认不显示）
   - 新增 `goBack()`：关闭详情并触发 `back`

2. **运维监控仪表盘**（`OpsDashboard.vue`）
   - 新增 `detailReturnTarget` 记录单条详情来自哪个列表（`requestList` / `errorList`）
   - 新增 `resumeListState` 标记，返回时让列表保留状态
   - `openError()` 进入详情前记录来源列表；新增 `handleBackToList()` 收到 `back` 后关闭详情、重新打开对应列表弹窗
   - 给两个列表弹窗传 `:resume-state`

3. **两个列表弹窗**（`OpsErrorDetailsModal.vue` / `OpsRequestDetailsModal.vue`）
   - 新增 `resumeState` prop；为 true 时跳过「重新打开时的筛选/分页重置」，从而保留用户之前的筛选与分页状态

4. **i18n**
   - en / zh 各新增 `admin.ops.errorDetail.backToList`（`Back to List` / `返回列表`）

## 交互效果

- 从卡片 → 明细列表 → 查看某条错误详情后，点底部「返回列表」可直接回到之前的明细列表，**筛选和分页保持原样**，可继续查看下一条
- 点右上角 X 关闭仍回到运维监控总览，两种退出路径并存

## 验证

- `vue-tsc` 类型检查通过
- `eslint` 通过
- ops 相关测试 29 个通过（含 `OpsErrorDetailModal.spec`）
- i18n 测试 46 个通过（含 `opsLocaleKeys`）