### PR TITLE
fix(openai): harden flaky alloc guard in tool schema sanitize test

### DIFF
--- a/backend/internal/service/openai_responses_tool_schema_test.go
+++ b/backend/internal/service/openai_responses_tool_schema_test.go
@@ -587,7 +587,9 @@ func TestSanitizeOpenAIResponsesToolParameterTypes_RewriteCountIndependentOfHits
 	})
 
 	// 命中切片扩容是对数级，留出充裕余量；线性写法在这里会是 2000 量级。
-	require.Less(t, largeAllocs, smallAllocs+40,
+	// 干净环境实测 large 约 17 allocs，200 是 10 倍余量，同时容忍 CI 慢 pod 上
+	// 包内后台 goroutine（日志/ticker）对进程级 Mallocs 的噪声污染。
+	require.Less(t, largeAllocs, 200.0,
 		"分配次数随命中数线性增长，说明退回了逐路径全量重写 (small=%v large=%v)", smallAllocs, largeAllocs)
 
 	// 同时确认大 body 的结果确实全部修好了。


### PR DESCRIPTION
## 概述

修复 `TestSanitizeOpenAIResponsesToolParameterTypes_RewriteCountIndependentOfHits` 在 CI 上的 flaky 失败：把相对阈值断言改为绝对上限，消除进程级分配测量被包内后台 goroutine 污染导致的误报，同时保留对线性分配回归的捕获能力。

## 问题

该测试用 `testing.AllocsPerRun` 守卫"命中数放大 500 倍时分配次数不得线性增长"，断言 `largeAllocs < smallAllocs + 40`。在 CI 上偶发失败（实测 `largeAllocs=83` vs 阈值 `47`，干净环境实测 `small=7 / large=17`）。

## 根因（已实测验证）

`testing.AllocsPerRun` 测量的是**进程级** `MemStats.Mallocs` 增量，不是被测函数自身的分配：

- `internal/service` 包有 606 处 `t.Parallel()`，且大量测试启动后台服务（logrus 日志、ticker、重试循环），这些 goroutine 全程持续分配（CI 失败时刻每秒 8–11 条后台日志）。
- `AllocsPerRun` 内部强制 `GOMAXPROCS(1)`：大 body（2000 命中）在慢 CI pod 上处理超过 ~10ms 异步抢占量子时被抢占，后台 goroutine 趁机分配污染计数（83 vs 干净 17）；小 body 微秒级完成从不被抢占（small=7 干净）。
- 本地模拟验证：`GOMAXPROCS=1` + 20000 命中 body + 日志型后台 goroutine → largeAllocs 膨胀到 1,880,772。

证据：本地 20 次连跑、全量包测试、shuffle 均未复现；CI 历史 30 个 integration pipeline 仅 1 次失败；测试与实现文件在失败前后 byte-identical（非代码回归）。

## 修复

`backend/internal/service/openai_responses_tool_schema_test.go:590`：

- 相对阈值 `require.Less(t, largeAllocs, smallAllocs+40, ...)` → 绝对上限 `require.Less(t, largeAllocs, 200.0, ...)`
- 保留 `smallAllocs` 测量与原有注释，新增注释说明：干净环境 large 约 17 allocs、200 为 10 倍余量、容忍 CI 慢 pod 上包内后台 goroutine 对进程级 Mallocs 的噪声污染
- 注意使用 `200.0`（float64）：`AllocsPerRun` 返回 float64，`require.Less` 要求两参数同类型

## 验证

- `go test ./internal/service/ -run TestSanitizeOpenAIResponsesToolParameterTypes_RewriteCountIndependentOfHits -count=5` → 5/5 通过（实测 small=7 large=17）
- `go test ./internal/service/ -run TestSanitizeOpenAIResponsesToolParameterTypes -count=1` → ok
- `gofmt -l` 无输出；`git diff --check` 干净

## 备注

- 仅改测试断言一处，无生产代码改动。
- 若上游更倾向子进程隔离或清理后台服务等根治方案，可另行讨论；本 PR 以最小改动消除 CI 误报。
