### PR TITLE
feat(gateway): apply max_sessions session cap to API Key accounts

### DIFF
--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -1407,12 +1407,15 @@ func (s *GatewayService) IncrementAccountRPM(ctx context.Context, accountID int6
 }
 
 // checkAndRegisterSession 检查并注册会话，用于会话数量限制
-// 仅适用于 Anthropic OAuth/SetupToken 账号
+// 适用范围：Anthropic OAuth/SetupToken 账号，以及显式配置了 max_sessions 的
+// API Key 账号（多人共享同一上游 Key 的池化场景同样需要会话上限，否则单账号
+// 会堆积过多活跃会话，粘性绑定失效后引发整组会话迁移）。
+// 默认不生效：未配置 max_sessions（GetMaxSessions 返回 0）时直接放行，
+// 对存量账号行为零影响。
 // sessionID: 会话标识符（使用粘性会话的 hash）
 // 返回 true 表示允许（在限制内或会话已存在），false 表示拒绝（超出限制且是新会话）
 func (s *GatewayService) checkAndRegisterSession(ctx context.Context, account *Account, sessionID string) bool {
-	// 只检查 Anthropic OAuth/SetupToken 账号
-	if !account.IsAnthropicOAuthOrSetupToken() {
+	if !account.IsAnthropicOAuthOrSetupToken() && account.Type != AccountTypeAPIKey {
 		return true
 	}
 

--- a/backend/internal/service/session_limit_apikey_test.go
+++ b/backend/internal/service/session_limit_apikey_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sessionLimitCheckStub 只实现 checkAndRegisterSession 所需的 RegisterSession，
+// 其余接口方法由内嵌的 SessionLimitCache 接口占位（与 gateway_hotpath_optimization_test.go 同模式）。
+type sessionLimitCheckStub struct {
+	SessionLimitCache
+
+	mu     sync.Mutex
+	active map[int64]map[string]bool
+	err    error
+}
+
+func (s *sessionLimitCheckStub) RegisterSession(_ context.Context, accountID int64, sessionUUID string, maxSessions int, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return false, s.err
+	}
+	if s.active == nil {
+		s.active = make(map[int64]map[string]bool)
+	}
+	if s.active[accountID] == nil {
+		s.active[accountID] = make(map[string]bool)
+	}
+	if s.active[accountID][sessionUUID] {
+		return true, nil
+	}
+	if len(s.active[accountID]) >= maxSessions {
+		return false, nil
+	}
+	s.active[accountID][sessionUUID] = true
+	return true, nil
+}
+
+func TestCheckAndRegisterSessionForAPIKeyAccounts(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("api key account with max_sessions enforces the cap", func(t *testing.T) {
+		svc := &GatewayService{sessionLimitCache: &sessionLimitCheckStub{}}
+		account := &Account{
+			ID:       101,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+			Extra:    map[string]any{"max_sessions": 2},
+		}
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-a"))
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-a")) // 已有会话保持允许
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-b"))
+		require.False(t, svc.checkAndRegisterSession(ctx, account, "session-c")) // 第 3 个新会话被拒绝
+	})
+
+	t.Run("api key account without max_sessions stays unlimited", func(t *testing.T) {
+		svc := &GatewayService{sessionLimitCache: &sessionLimitCheckStub{}}
+		account := &Account{ID: 102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		for i := 0; i < 10; i++ {
+			require.True(t, svc.checkAndRegisterSession(ctx, account, "session-"+string(rune('a'+i))))
+		}
+	})
+
+	t.Run("anthropic oauth accounts keep the existing limit", func(t *testing.T) {
+		svc := &GatewayService{sessionLimitCache: &sessionLimitCheckStub{}}
+		account := &Account{
+			ID:       103,
+			Platform: PlatformAnthropic,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"max_sessions": 1},
+		}
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-a"))
+		require.False(t, svc.checkAndRegisterSession(ctx, account, "session-b"))
+	})
+
+	t.Run("other account types are unaffected", func(t *testing.T) {
+		svc := &GatewayService{sessionLimitCache: &sessionLimitCheckStub{}}
+		account := &Account{
+			ID:       104,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeUpstream,
+			Extra:    map[string]any{"max_sessions": 1},
+		}
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-a"))
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-b"))
+	})
+
+	t.Run("cache error fails open for api key accounts", func(t *testing.T) {
+		svc := &GatewayService{sessionLimitCache: &sessionLimitCheckStub{err: context.Canceled}}
+		account := &Account{
+			ID:       105,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+			Extra:    map[string]any{"max_sessions": 1},
+		}
+		require.True(t, svc.checkAndRegisterSession(ctx, account, "session-a"))
+	})
+}


### PR DESCRIPTION
## Summary

Allow per-account session caps (\xtra.max_sessions\) to apply to **API Key accounts**, not just Anthropic OAuth/SetupToken accounts.

## Motivation

API Key accounts are commonly pooled across many users (e.g. a shared upstream key bound to one group). \checkAndRegisterSession\ currently returns \	rue\ immediately for every non-Anthropic-OAuth account, so \max_sessions\ is silently ignored. In practice:

- one hot account accumulates far more active sticky sessions than others, and
- when it trips a 429/error, its sticky bindings are cleared **all at once**, forcing the whole session group to re-bind to other accounts (thrashing, cache-miss storms, and visibly unstable routing for users).

With the cap enforced, the n+1-th new session simply skips the saturated account during selection and binds to a less-loaded one — which matches the existing load-aware selection semantics.

## Behavior

- **Opt-in and default-off**: accounts without \xtra.max_sessions\ are unaffected (\GetMaxSessions()\ returns 0 and the check short-circuits before touching the cache).
- Anthropic OAuth/SetupToken behavior is unchanged (regression-tested).
- Other account types (upstream/bedrock/service_account) remain unaffected.
- Cache errors keep failing open, as before.

## Tests

\session_limit_apikey_test.go\ covers:

1. apikey account with \max_sessions\ enforces the cap (existing sessions keep passing, new sessions beyond the cap are rejected);
2. apikey account without \max_sessions\ stays unlimited;
3. Anthropic OAuth regression;
4. non-apikey/non-OAuth types unaffected;
5. fail-open on cache error.

---

## 摘要（中文）

让 \xtra.max_sessions\ 会话数上限对 **API Key 账号**生效（此前仅 Anthropic OAuth/SetupToken 生效）。共享上游 Key 的池化场景下，单账号会话堆积会导致限流时整组粘性绑定被清空、会话群整体迁移（抖动）。改为强制上限后，第 n+1 个新会话会在选号阶段直接跳过已满账号、绑定到负载更低的账号，与现有负载感知选号语义一致。默认关闭（未配置 max_sessions 的账号零影响），并有完整单测覆盖。