### PR TITLE
fix(openai): clear the rejected input status for the whole item type

### DIFF
--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -271,18 +271,56 @@ func openAIResponsesRejectedInputIndex(pattern *regexp.Regexp, param string) (in
 	return 0, false
 }
 
+// removeOpenAIResponsesRejectedStatusAtIndex drops the status field the
+// upstream rejected, and the status of every other input item sharing the
+// rejected item's type.
+//
+// The upstream names one offending index per response, but a replayed
+// conversation routinely carries dozens of items of the same type, each with a
+// status its schema does not accept. Clearing one index per round trip would
+// need one retry per item and exhaust the bounded retry budget long before the
+// request could succeed. Items of other types keep their status: the rejection
+// only proves that this type has no status field.
 func removeOpenAIResponsesRejectedStatusAtIndex(body []byte, index int) ([]byte, string, bool, error) {
 	itemPath := fmt.Sprintf("input.%d", index)
-	if !gjson.GetBytes(body, itemPath).IsObject() {
+	rejected := gjson.GetBytes(body, itemPath)
+	if !rejected.IsObject() {
 		return nil, "", false, nil
 	}
-	statusPath := itemPath + ".status"
-	if !gjson.GetBytes(body, statusPath).Exists() {
+	if !gjson.GetBytes(body, itemPath+".status").Exists() {
 		return nil, "", false, nil
 	}
-	retryBody, err := sjson.DeleteBytes(body, statusPath)
-	if err != nil {
-		return nil, "", false, fmt.Errorf("delete rejected status at input[%d]: %w", index, err)
+
+	retryBody := body
+	cleared := 0
+	rejectedType := strings.TrimSpace(rejected.Get("type").String())
+	if input := gjson.GetBytes(body, "input"); rejectedType != "" && input.IsArray() {
+		// Deleting a field never shifts array indexes, so positions read from
+		// the original body stay valid against the rewritten one.
+		for itemIndex, item := range input.Array() {
+			if !item.IsObject() || strings.TrimSpace(item.Get("type").String()) != rejectedType {
+				continue
+			}
+			statusPath := fmt.Sprintf("input.%d.status", itemIndex)
+			if !gjson.GetBytes(retryBody, statusPath).Exists() {
+				continue
+			}
+			next, err := sjson.DeleteBytes(retryBody, statusPath)
+			if err != nil {
+				return nil, "", false, fmt.Errorf("delete rejected status at input[%d]: %w", itemIndex, err)
+			}
+			retryBody = next
+			cleared++
+		}
+	}
+	if cleared == 0 {
+		// The rejected item carries no type to match on; fall back to clearing
+		// just the index the upstream named.
+		next, err := sjson.DeleteBytes(retryBody, itemPath+".status")
+		if err != nil {
+			return nil, "", false, fmt.Errorf("delete rejected status at input[%d]: %w", index, err)
+		}
+		retryBody = next
 	}
 	return retryBody, "indexed status parameter rejection", true, nil
 }

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -680,4 +681,43 @@ func newOpenAIRejectedFieldTestResponse(status int, body string) *http.Response 
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+// A replayed conversation carries many items of the same type, each with a
+// status the upstream schema rejects. One rejection must clear all of them:
+// clearing one index per round trip exhausts the bounded retry budget.
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyClearsStatusForWholeType(t *testing.T) {
+	input := make([]string, 0, 12)
+	for i := 0; i < 10; i++ {
+		input = append(input, `{"type":"tool_search_output","status":"completed","call_id":"call_`+strconv.Itoa(i)+`","tools":[]}`)
+	}
+	input = append(input, `{"type":"message","role":"user","status":"completed","content":"hi"}`)
+	body := []byte(`{"input":[` + strings.Join(input, ",") + `]}`)
+
+	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[7].status'.","param":"input[7].status"}}`)
+	retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NotEmpty(t, reason)
+
+	for i := 0; i < 10; i++ {
+		require.False(t, gjson.GetBytes(retryBody, "input."+strconv.Itoa(i)+".status").Exists(),
+			"every tool_search_output must lose its status in a single retry, index %d did not", i)
+		require.Equal(t, "call_"+strconv.Itoa(i), gjson.GetBytes(retryBody, "input."+strconv.Itoa(i)+".call_id").String(),
+			"unrelated fields must survive")
+	}
+	require.Equal(t, "completed", gjson.GetBytes(retryBody, "input.10.status").String(),
+		"a different item type keeps its status: the rejection only proves this type has none")
+}
+
+// The rejected item may carry no type to match on.
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyClearsUntypedStatusAtIndexOnly(t *testing.T) {
+	body := []byte(`{"input":[{"status":"keep_a"},{"status":"remove"}]}`)
+	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[1].status'.","param":"input[1].status"}}`)
+
+	retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "keep_a", gjson.GetBytes(retryBody, "input.0.status").String())
+	require.False(t, gjson.GetBytes(retryBody, "input.1.status").Exists())
 }


### PR DESCRIPTION
携带较多同类型 input item 的 Responses 请求，会在上游拒绝 `input[N].status` 后耗尽重试预算，最终把 400 透传给客户端。

## 问题表现

客户端回放一段较长的对话，其中含多个 `tool_search_output` item。按 [Tool search 文档](https://developers.openai.com/api/docs/guides/tools-tool-search)，`status` 是 `tool_search_output` 的合法可选字段（`in_progress | completed | incomplete`），但部分上游 schema 不接受该字段，返回：

```
400 Unknown parameter: 'input[60].status'
```

网关已有处理逻辑，但每次只清除上游点名的那**一个**索引：

```go
func removeOpenAIResponsesRejectedStatusAtIndex(body []byte, index int) (...) {
	statusPath := fmt.Sprintf("input.%d", index) + ".status"
	retryBody, err := sjson.DeleteBytes(body, statusPath)
	...
}
```

上游一次只报一个索引，因此每清一个就要往返一次。而重试预算是：

```go
const maxOpenAIResponsesRejectedFieldRetries = 6
```

带 `status` 的同类型 item 一旦超过 6 个，预算耗尽，400 直达客户端。上例中的索引已经到 60。

## 改动

`removeOpenAIResponsesRejectedStatusAtIndex` 在同一次处理中清除**所有与被拒 item 类型相同**的 input item 的 `status`。

其他类型的 item 保留各自的 `status` —— 上游的拒绝只能证明"被拒 item 的这个类型没有 status 字段"，不能推广到其他类型。既有用例 `TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRemovesExactIndexedStatus` 正是覆盖这一点（`input[0]` 为 `message`、`input[1]` 为 `reasoning`，拒绝 index 1 时 index 0 必须保留），改动后仍然通过。

被拒 item 没有 `type` 可供匹配时，退回原有行为，只清除上游点名的索引。

删除字段不会改变数组索引，因此从原始 body 读到的位置对改写后的 body 仍然有效。

## 测试

新增两个用例：

- 10 个 `tool_search_output` + 1 个 `message`，拒绝 `input[7].status`：一次重试后 10 个 `tool_search_output` 的 `status` 全部清除、`call_id` 等无关字段保留，而 `message` 的 `status` 不受影响
- 被拒 item 无 `type` 时只清除该索引

移除本次改动后，第一个用例失败。

```
go test ./internal/service/... ./internal/pkg/apicompat/... -count=1
go vet ./internal/service/...
```

均通过。

## 备注

本 PR 不改变"仅在上游确实拒收时才清除"的既有策略，只是把发现成本从每 item 一次往返降为每类型一次往返，因此不会影响接受该字段的上游。
