### PR TITLE
fix(openai): keep parallel_tool_calls for Responses Lite additional_tools

### DIFF
--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -366,8 +366,7 @@ func normalizeOpenAIParallelToolCallsWithoutTools(body []byte) ([]byte, bool, er
 	if !parallel.Exists() {
 		return body, false, nil
 	}
-	tools := gjson.GetBytes(body, "tools")
-	if tools.IsArray() && len(tools.Array()) > 0 {
+	if openAIRequestBodyHasTools(body) {
 		return body, false, nil
 	}
 	normalized, err := sjson.DeleteBytes(body, "parallel_tool_calls")
@@ -375,6 +374,31 @@ func normalizeOpenAIParallelToolCallsWithoutTools(body []byte) ([]byte, bool, er
 		return body, false, fmt.Errorf("normalize parallel_tool_calls without tools: %w", err)
 	}
 	return normalized, true, nil
+}
+
+// openAIRequestBodyHasTools is the []byte counterpart of openAIResponsesLiteHasTools:
+// besides the top-level "tools" array it also recognizes the Responses Lite carrier.
+// normalizeOpenAIResponsesLiteTools moves namespace tools into an input item of type
+// "additional_tools" and drops the top-level "tools" key; the request still carries
+// tools at that point. Looking only at the top level therefore misreads such a body as
+// "no tools" and deletes the parallel_tool_calls:false that
+// ensureOpenAIResponsesLiteParallelToolCalls had just pinned, and OpenAI falls back to
+// its default of true and rejects the request with
+// 400 unsupported_value: "X-OpenAI-Internal-Codex-Responses-Lite requires
+// `parallel_tool_calls` to be false."
+func openAIRequestBodyHasTools(body []byte) bool {
+	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() && len(tools.Array()) > 0 {
+		return true
+	}
+	for _, item := range gjson.GetBytes(body, "input").Array() {
+		if strings.TrimSpace(item.Get("type").String()) != "additional_tools" {
+			continue
+		}
+		if tools := item.Get("tools"); tools.IsArray() && len(tools.Array()) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeOpenAIAPIKeyStoreFalseReasoningReplay(body []byte, knownStoreFalse bool) ([]byte, bool, error) {

--- a/backend/internal/service/openai_gateway_request_body_reasoning_test.go
+++ b/backend/internal/service/openai_gateway_request_body_reasoning_test.go
@@ -270,3 +270,23 @@ func TestNormalizeOpenAIParallelToolCallsWithoutTools(t *testing.T) {
 	require.True(t, changed)
 	require.False(t, gjson.GetBytes(normalized, "parallel_tool_calls").Exists())
 }
+
+// A Responses Lite body that has already been through normalizeOpenAIResponsesLiteTools
+// carries its tools in an input item of type "additional_tools" and no longer has a
+// top-level "tools" key. It still has tools, so the parallel_tool_calls:false that
+// ensureOpenAIResponsesLiteParallelToolCalls pinned must survive this normalization —
+// otherwise OpenAI applies its default of true and rejects the request.
+func TestNormalizeOpenAIParallelToolCallsWithoutTools_KeepsResponsesLiteAdditionalTools(t *testing.T) {
+	liteBody := []byte(`{"input":[{"type":"message","role":"user","content":"hi"},{"type":"additional_tools","tools":[{"type":"function","name":"spawn_agent"}]}],"parallel_tool_calls":false}`)
+	normalized, changed, err := normalizeOpenAIParallelToolCallsWithoutTools(liteBody)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, gjson.False, gjson.GetBytes(normalized, "parallel_tool_calls").Type)
+
+	// An empty additional_tools item carries no tools, so the field is still dropped.
+	emptyLiteBody := []byte(`{"input":[{"type":"additional_tools","tools":[]}],"parallel_tool_calls":true}`)
+	normalized, changed, err = normalizeOpenAIParallelToolCallsWithoutTools(emptyLiteBody)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, gjson.GetBytes(normalized, "parallel_tool_calls").Exists())
+}


### PR DESCRIPTION
## What

`normalizeOpenAIParallelToolCallsWithoutTools` only recognizes the top-level `tools` array, so a Responses Lite request that carries its tools in an `additional_tools` input item is misread as having no tools, and its `parallel_tool_calls: false` is deleted before the request leaves the gateway.

## Why it breaks

The two functions disagree on what "has tools" means:

- `normalizeOpenAIResponsesLiteTools` moves namespace tools into an input item of type `additional_tools` and **deletes the top-level `tools` key**, then calls `ensureOpenAIResponsesLiteParallelToolCalls`, which pins `parallel_tool_calls: false`.
- `openAIResponsesLiteHasTools` correctly counts `input[].additional_tools` as tools.
- `normalizeOpenAIParallelToolCallsWithoutTools` runs afterwards and only checks the top level — sees "no tools" — and deletes the `false` that was just pinned.

OpenAI then applies its default of `true` and rejects the request:

```
400 unsupported_value: "X-OpenAI-Internal-Codex-Responses-Lite requires
`parallel_tool_calls` to be false."
```

This is reproducible in production against a Lite-headed upstream whenever the client sends namespace tools.

## Why not just pin it to false

The field can't be unconditionally set to `false`. With no tools at all, OpenAI rejects the request with:

```
'parallel_tool_calls' is only allowed when 'tools' are specified
```

So both constraints have to hold at once: present-and-`false` when tools exist, absent when they don't. The existing deletion behaviour is correct — it just needs the right definition of "has tools".

## The change

Adds `openAIRequestBodyHasTools`, the `[]byte` counterpart of the existing `openAIResponsesLiteHasTools`, and uses it in `normalizeOpenAIParallelToolCallsWithoutTools`. This makes both sides of the repo agree on a single tool-detection standard rather than introducing a new one.

No import changes are needed (`strings`, `gjson`, `sjson` are already imported), and no other call site changes behaviour: for bodies without an `additional_tools` input item, `openAIRequestBodyHasTools` is equivalent to the previous top-level check.

## Tests

Extends the existing `TestNormalizeOpenAIParallelToolCallsWithoutTools` in the same file with `TestNormalizeOpenAIParallelToolCallsWithoutTools_KeepsResponsesLiteAdditionalTools`, covering:

- a Lite body with `additional_tools` → `parallel_tool_calls: false` is preserved;
- an empty `additional_tools` array → the field is still deleted (no tools really means no tools).

Verified as a negative control: with the fix reverted and the test kept, the new test **fails** on the assertion that `parallel_tool_calls` survives; with the fix applied it passes. `go vet` is clean and `gofmt` reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
