### PR TITLE
fix(composite): route Kimi Code K3 model IDs

### DIFF
--- a/backend/internal/handler/composite_platform_test.go
+++ b/backend/internal/handler/composite_platform_test.go
@@ -31,6 +31,7 @@ func TestOpenAICompatibleTextTargetAllowsCompositeProviders(t *testing.T) {
 	}{
 		{model: "grok-4.3", platform: service.PlatformGrok},
 		{model: "kimi-k2-thinking", platform: service.PlatformKimi},
+		{model: "k3", platform: service.PlatformKimi},
 		{model: "glm-5.2", platform: service.PlatformZhipu},
 		{model: "deepseek-v3.2", platform: service.PlatformDeepseek},
 	}

--- a/backend/internal/service/composite_platform.go
+++ b/backend/internal/service/composite_platform.go
@@ -139,7 +139,9 @@ func DetectModelPlatform(model string) (string, bool) {
 		return PlatformGemini, true
 	case normalized == "grok" || strings.HasPrefix(normalized, "grok-"):
 		return PlatformGrok, true
-	case strings.HasPrefix(normalized, "kimi-"),
+	case normalized == "k3",
+		normalized == "k3-256k",
+		strings.HasPrefix(normalized, "kimi-"),
 		strings.HasPrefix(normalized, "moonshot-"):
 		return PlatformKimi, true
 	case strings.HasPrefix(normalized, "glm-"):

--- a/backend/internal/service/composite_platform_test.go
+++ b/backend/internal/service/composite_platform_test.go
@@ -26,9 +26,13 @@ func TestDetectModelPlatform(t *testing.T) {
 		{name: "grok", model: "grok-4", platform: PlatformGrok, ok: true},
 		{name: "xai prefix", model: "xai/grok-4", platform: PlatformGrok, ok: true},
 		{name: "kimi", model: "kimi-k2-thinking", platform: PlatformKimi, ok: true},
+		{name: "kimi code bare k3", model: "K3", platform: PlatformKimi, ok: true},
+		{name: "kimi code bare k3 256k", model: "k3-256k", platform: PlatformKimi, ok: true},
+		{name: "kimi code provider prefix", model: "kimi-code/k3", platform: PlatformKimi, ok: true},
 		{name: "moonshot prefix", model: "moonshot/moonshot-v1-32k", platform: PlatformKimi, ok: true},
 		{name: "zhipu", model: "glm-5.2", platform: PlatformZhipu, ok: true},
 		{name: "deepseek", model: "deepseek-v4-pro", platform: PlatformDeepseek, ok: true},
+		{name: "unknown k3 alias", model: "k3-preview", ok: false},
 		{name: "unknown", model: "llama-4-maverick", ok: false},
 	}
 

--- a/backend/internal/service/composite_route_resolver_test.go
+++ b/backend/internal/service/composite_route_resolver_test.go
@@ -191,6 +191,22 @@ func TestCompositeRouteResolverIgnoresDisabledRoutesAndFallsBackToDetector(t *te
 	require.Nil(t, decision.Route)
 }
 
+func TestCompositeRouteResolverDetectsKimiCodeBareModels(t *testing.T) {
+	resolver := NewCompositeRouteResolver(nil)
+
+	for _, model := range []string{"k3", "k3-256k", "kimi-code/k3"} {
+		t.Run(model, func(t *testing.T) {
+			decision, err := resolver.Resolve(context.Background(), 7, model, CompositeRouteEndpointMessages)
+
+			require.NoError(t, err)
+			require.True(t, decision.Matched)
+			require.Equal(t, CompositeRouteSourceDetector, decision.Source)
+			require.Equal(t, PlatformKimi, decision.TargetPlatform)
+			require.Equal(t, model, decision.UpstreamModel)
+		})
+	}
+}
+
 func TestCompositeRouteResolverExplicitRoutesCoverBucketTwoProviders(t *testing.T) {
 	resolver := NewCompositeRouteResolver(compositeRouteRepoStub{
 		routes: []CompositeModelRoute{


### PR DESCRIPTION
## Summary

- classify the official Kimi Code bare model IDs `k3` and `k3-256k` as Kimi in composite groups
- keep unknown `k3-*` aliases fail-closed to avoid routing unrelated custom model names
- cover detector, composite resolver, and OpenAI-compatible text endpoint guards

K3 support was added in #4906 before composite groups learned to route CN providers. As a result, direct Kimi groups could serve the bare IDs while composite groups rejected them before account scheduling because the target platform remained unresolved.

## Test plan

```text
go test ./internal/service ./internal/handler -run "TestDetectModelPlatform|TestCompositeRouteResolver|TestOpenAICompatibleTextTargetAllowsCompositeProviders" -count=1
```

Both packages pass on the latest `upstream/main`.