### PR TITLE
fix(openai): apply Responses Lite constraints wherever the header is sent

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -76,7 +76,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			body = reasoningBody
 		}
 	}
-	if account.IsOpenAIOAuthLike() && isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
+	// The Lite header sits in openaiPassthroughAllowedHeaders, so it reaches the
+	// upstream for every OpenAI account type, not just OAuth-like ones. Anything
+	// whose header is forwarded must also have the Lite constraints applied, or
+	// the upstream rejects the request with "requires parallel_tool_calls to be
+	// false" for a rule this gateway declared but never enforced.
+	if account.IsOpenAI() && (account.IsOpenAIApiKey() || account.IsOpenAIOAuthLike()) &&
+		isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
 		liteBody, changed, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
 		if liteErr != nil {
 			param := "tools"

--- a/backend/internal/service/openai_responses_lite_tools_test.go
+++ b/backend/internal/service/openai_responses_lite_tools_test.go
@@ -453,3 +453,60 @@ func TestOpenAIGatewayServiceForward_NormalizesResponsesLiteToolsForOAuth(t *tes
 		})
 	}
 }
+
+// The Lite header is forwarded upstream for every OpenAI account type, so the
+// Lite constraints must be applied for every account type that forwards it.
+// An API key account used to send the header without the constraint, and the
+// upstream answered "X-OpenAI-Internal-Codex-Responses-Lite requires
+// parallel_tool_calls to be false".
+func TestForwardAppliesResponsesLiteConstraintsToAPIKeyAccount(t *testing.T) {
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_lite","model":"gpt-5.4","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		},
+	}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+	c.Request.Header.Set(responsesLiteHeader, "true")
+
+	account := newOpenAIImageGenerationControlTestAccount()
+	require.Equal(t, AccountTypeAPIKey, account.Type, "the regression is specific to API key accounts")
+	require.False(t, account.IsOpenAIOAuthLike(), "the old gate skipped exactly this account shape")
+
+	body := []byte(`{"model":"gpt-5.4","input":"write code","stream":false,"parallel_tool_calls":true,` +
+		`"tools":[{"type":"function","name":"lookup","description":"d","parameters":{"type":"object","properties":{}}}]}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+
+	require.Equal(t, "true", upstream.lastReq.Header.Get(responsesLiteHeader),
+		"the header still reaches the upstream")
+	require.False(t, gjson.GetBytes(upstream.lastBody, "parallel_tool_calls").Bool(),
+		"declaring Lite upstream requires serialising tool calls")
+}
+
+// A request without tools carries no Lite tool constraint, so the gateway must
+// not invent parallel_tool_calls for it.
+func TestForwardLeavesParallelToolCallsAloneWithoutTools(t *testing.T) {
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_lite","model":"gpt-5.4","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		},
+	}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+	c.Request.Header.Set(responsesLiteHeader, "true")
+
+	_, err := svc.Forward(context.Background(), c,
+		newOpenAIImageGenerationControlTestAccount(),
+		[]byte(`{"model":"gpt-5.4","input":"write code","stream":false}`))
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "parallel_tool_calls").Exists())
+}

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -350,6 +350,19 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 		})
 	}
 
+	// The bridge announces Lite to the upstream below, so the payload must first
+	// satisfy what Lite requires. Declaring the mode without applying its
+	// constraints is what makes the upstream reject the request.
+	if account.Platform != PlatformGrok && isOpenAIResponsesLiteWebSocketPayload(payload) {
+		liteBody, liteChanged, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
+		if liteErr != nil {
+			return nil, fmt.Errorf("normalize responses Lite payload: %w", liteErr)
+		}
+		if liteChanged {
+			body = liteBody
+		}
+	}
+
 	buildUpstreamRequest := func(requestBody []byte) (*http.Request, error) {
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 		defer releaseUpstreamCtx()


### PR DESCRIPTION
Fixes #6147.

客户端设置 `X-OpenAI-Internal-Codex-Responses-Lite` 后，API Key 账号会收到上游 400：

```
X-OpenAI-Internal-Codex-Responses-Lite requires `parallel_tool_calls` to be false.
```

## 原因

该 header 位于 `openaiPassthroughAllowedHeaders`（`openai_gateway_service.go`），因此对**所有** OpenAI 账号类型都会原样转发到上游。

而施加 Lite 约束的入口 `openai_gateway_forward.go` 限定了 `account.IsOpenAIOAuthLike()`：

```go
if account.IsOpenAIOAuthLike() && isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
	liteBody, changed, liteErr := normalizeOpenAIResponsesLiteToolsPayload(body)
```

于是 API Key 账号向上游**声明了 Lite，却不执行 Lite 的约束**：`parallel_tool_calls` 保持缺省或 `true`，上游按 Lite 规则拒绝。

#7498d8fd 引入 `ensureOpenAIResponsesLiteParallelToolCalls` 时，该约束就落在这个已有的 OAuth 限定内，因此 API Key 路径从未被覆盖。

## 改动

把限定放宽到 header 实际会被转发的账号形态：

```go
if account.IsOpenAI() && (account.IsOpenAIApiKey() || account.IsOpenAIOAuthLike()) &&
	isOpenAIResponsesLiteHeader(c.GetHeader(responsesLiteHeader)) {
```

与同文件中 `sanitizeOpenAIResponsesInputItemIDs` 的限定形状一致。

不含 tools 的请求不受影响：`ensureOpenAIResponsesLiteParallelToolCalls` 在 `openAIResponsesLiteHasTools` 为假时直接返回，不会凭空添加 `parallel_tool_calls` 字段。

### 一并修正：WebSocket HTTP bridge

`openai_ws_http_bridge.go` 是同一问题的另一个方向 —— 它依据 `client_metadata` 标记**自行给上游请求设置 Lite header**：

```go
if account.Platform != PlatformGrok && isOpenAIResponsesLiteWebSocketPayload(payload) {
	upstreamReq.Header.Set(responsesLiteHeader, "true")
}
```

但该文件中不存在任何 Lite 归一化，`parallel_tool_calls` 出现 0 次。本 PR 在决定声明 Lite 的同一条件下对 payload 做归一化。

## 测试

`openai_responses_lite_tools_test.go` 新增两个端到端用例，经 `Forward` 观察真实出站请求：

- API Key 账号 + Lite header + 含 tools：断言 header 仍然到达上游，且出站 body 的 `parallel_tool_calls` 为 `false`
- 同样配置但不含 tools：断言出站 body 不出现 `parallel_tool_calls` 字段

将限定改回 `IsOpenAIOAuthLike()` 后，第一个用例失败（`parallel_tool_calls` 保持 `true`）。

```
go test ./internal/service/... ./internal/pkg/apicompat/... -count=1
go test ./internal/service/ -tags unit -count=1
go vet ./internal/service/...
```

均通过。

## 现网数据

一台生产实例的 journald 覆盖 2026-08-21 至 08-25，其间该错误共 558 次上游拒绝，全部为 `platform=openai type=apikey`，涉及 7 个账号；同期日志中不含任何 WebSocket bridge 标记，因此现网触发路径是上述 HTTP 转发路径，bridge 的缺口是代码审阅中发现并一并修正的。

该实例在 08-24 05:17 升级至 0.1.180、05:40 回退至 0.1.179，两个区间的客户端可见失败率为：

| 版本 | 失败请求 | `/v1/responses` 总请求 | 失败率 |
| --- | --- | --- | --- |
| 0.1.180（05:17–05:40） | 432 | 1,019 | 42.39% |
| 0.1.179（其余约 3.8 天） | 126 | 166,647 | 0.08% |

需要说明的是，**本 PR 修复的是「转发 header 却不施加约束」这一不对称本身**，该不对称在两个版本上同样存在，回退到 0.1.179 后该错误仍在以低频率发生。上述两个版本间失败率的巨大差异另有放大原因，我尚未定位：两版之间 `openaiPassthroughAllowedHeaders` 的内容、设置该 header 的代码位置、以及失败请求的 path 分布均无变化，而 7498d8fd 对 `openai_gateway_forward.go` 的改动仅涉及错误 `param` 的上报。因此不宜将该错误归因于 Lite 约束的引入。
