### PR TITLE
fix(openai): align OAuth session fields across headers and body

### DIFF
--- a/backend/internal/service/openai_agent_identity_compat_test.go
+++ b/backend/internal/service/openai_agent_identity_compat_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestAccountTestServiceOpenAICompactAgentIdentityUsesFreshAssertion(t *testing.T) {
@@ -133,11 +134,12 @@ func TestOpenAIAgentIdentityPassthroughKeepsSessionAndPromptCacheHeaders(t *test
 	require.Equal(t, "account-agent-passthrough", req.Header.Get("chatgpt-account-id"))
 	require.NotEqual(t, "client-session", req.Header.Get("session_id"))
 	require.NotEqual(t, "client-conversation", req.Header.Get("conversation_id"))
-	require.Equal(t, isolateOpenAIUpstreamSessionID(0, account, "client-session"), req.Header.Get("session_id"))
-	require.Equal(t, isolateOpenAIUpstreamSessionID(0, account, "client-conversation"), req.Header.Get("conversation_id"))
+	wantSession := isolateOpenAIUpstreamSessionID(0, account, "client-session")
+	require.Equal(t, wantSession, req.Header.Get("session_id"))
+	require.Equal(t, wantSession, req.Header.Get("conversation_id"))
 	requestBody, err := io.ReadAll(req.Body)
 	require.NoError(t, err)
-	require.Contains(t, string(requestBody), `"prompt_cache_key":"cache-agent"`)
+	require.Equal(t, wantSession, gjson.GetBytes(requestBody, "prompt_cache_key").String())
 
 	// Authentication mode must not affect session isolation or prompt-cache
 	// behavior. Compare the same request with the existing OAuth path instead

--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -20,7 +20,10 @@ import (
 // 由 Forward（非透传）或 forwardOpenAIPassthrough（透传）解析后写入，请求
 // 构造器读取用于出站头改写——请求体与出站头必须共享同一份 IDs，保证
 // turn_id 等随机字段一致。
-const codexFingerprintIDsContextKey = "codex_fingerprint_ids"
+const (
+	codexFingerprintIDsContextKey     = "codex_fingerprint_ids"
+	isolatedOpenAISessionIDContextKey = "isolated_openai_session_id"
+)
 
 // stageCodexFingerprintIDs 将本 attempt 解析出的收敛 ID 暂存到 gin context。
 // 必须无条件覆写（含 nil）：failover 从收敛账号切到 off 账号时，上一账号的
@@ -29,6 +32,25 @@ func stageCodexFingerprintIDs(c *gin.Context, ids *codexFingerprintIDs) {
 	if c != nil {
 		c.Set(codexFingerprintIDsContextKey, ids)
 	}
+}
+
+func stageIsolatedOpenAISessionID(c *gin.Context, isolated string) {
+	if c == nil {
+		return
+	}
+	c.Set(isolatedOpenAISessionIDContextKey, isolated)
+}
+
+func stagedIsolatedOpenAISessionID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, ok := c.Get(isolatedOpenAISessionIDContextKey)
+	if !ok {
+		return ""
+	}
+	isolated, _ := value.(string)
+	return strings.TrimSpace(isolated)
 }
 
 func stagedCodexFingerprintIDs(c *gin.Context, account *Account) *codexFingerprintIDs {
@@ -376,6 +398,9 @@ func applyCodexFingerprintHeaders(h http.Header, ids *codexFingerprintIDs) {
 	h.Set("session-id", ids.sessionID)
 	h.Set("session_id", ids.sessionID)
 	h.Set("thread-id", ids.threadID)
+	if strings.TrimSpace(h.Get("conversation_id")) != "" {
+		h.Set("conversation_id", ids.sessionID)
+	}
 
 	rewriteCodexTurnMetadataFields(h, map[string]any{
 		"installation_id":         ids.installationID,
@@ -598,4 +623,154 @@ func rewriteClientMetadataEmbeddedTurnMetadata(clientMetadata map[string]any, fi
 	if rebuilt, err := json.Marshal(metadata); err == nil {
 		clientMetadata["x-codex-turn-metadata"] = string(rebuilt)
 	}
+}
+
+var isolatedOpenAISessionHeaderNames = [...]string{
+	"session-id",
+	"thread-id",
+	"x-client-request-id",
+}
+
+func rewriteExistingHeaderValue(h http.Header, name, value string) {
+	if h == nil || value == "" || strings.TrimSpace(h.Get(name)) == "" {
+		return
+	}
+	h.Set(name, value)
+}
+
+func isolatedOpenAISessionWindowID(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	return sessionID + ":0"
+}
+
+func applyIsolatedOpenAISessionHeaders(h http.Header, isolated string) {
+	if h == nil || isolated == "" {
+		return
+	}
+	rewriteExistingHeaderValue(h, "session_id", isolated)
+	rewriteExistingHeaderValue(h, "conversation_id", isolated)
+	for _, name := range isolatedOpenAISessionHeaderNames {
+		rewriteExistingHeaderValue(h, name, isolated)
+	}
+	rewriteExistingHeaderValue(h, "x-codex-window-id", isolatedOpenAISessionWindowID(isolated))
+	if fields := isolatedOpenAISessionTurnMetadataFields(h.Get("x-codex-turn-metadata"), isolated); len(fields) > 0 {
+		rewriteCodexTurnMetadataFields(h, fields)
+	}
+}
+
+func isolatedOpenAISessionTurnMetadataFields(raw, isolated string) map[string]any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || isolated == "" {
+		return nil
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil || metadata == nil {
+		return nil
+	}
+	fields := map[string]any{}
+	if _, ok := metadata["session_id"]; ok {
+		fields["session_id"] = isolated
+	}
+	if _, ok := metadata["thread_id"]; ok {
+		fields["thread_id"] = isolated
+	}
+	if _, ok := metadata["window_id"]; ok {
+		fields["window_id"] = isolatedOpenAISessionWindowID(isolated)
+	}
+	return fields
+}
+
+func applyIsolatedOpenAISessionClientMetadata(existing map[string]any, isolated string) bool {
+	if existing == nil || isolated == "" {
+		return false
+	}
+	modified := false
+	if raw, ok := existing["session_id"].(string); ok && strings.TrimSpace(raw) != "" {
+		existing["session_id"] = isolated
+		modified = true
+	}
+	if raw, ok := existing["thread_id"].(string); ok && strings.TrimSpace(raw) != "" {
+		existing["thread_id"] = isolated
+		modified = true
+	}
+	if raw, ok := existing["x-codex-window-id"].(string); ok && strings.TrimSpace(raw) != "" {
+		existing["x-codex-window-id"] = isolatedOpenAISessionWindowID(isolated)
+		modified = true
+	}
+	embedded := isolatedOpenAISessionEmbeddedTurnFields(existing, isolated)
+	if len(embedded) > 0 {
+		rewriteClientMetadataEmbeddedTurnMetadata(existing, embedded)
+		modified = true
+	}
+	return modified
+}
+
+func isolatedOpenAISessionEmbeddedTurnFields(clientMetadata map[string]any, isolated string) map[string]any {
+	raw, ok := clientMetadata["x-codex-turn-metadata"].(string)
+	if !ok {
+		return nil
+	}
+	return isolatedOpenAISessionTurnMetadataFields(raw, isolated)
+}
+
+func applyIsolatedOpenAISessionBody(reqBody map[string]any, isolated string) bool {
+	if reqBody == nil || isolated == "" {
+		return false
+	}
+	modified := false
+	if raw, ok := reqBody["prompt_cache_key"].(string); ok && strings.TrimSpace(raw) != "" {
+		reqBody["prompt_cache_key"] = isolated
+		modified = true
+	}
+	existing, _ := reqBody["client_metadata"].(map[string]any)
+	if existing == nil {
+		return modified
+	}
+	if applyIsolatedOpenAISessionClientMetadata(existing, isolated) {
+		reqBody["client_metadata"] = existing
+		modified = true
+	}
+	return modified
+}
+
+func applyIsolatedOpenAISessionBodyRaw(body []byte, isolated string) ([]byte, bool, error) {
+	if len(body) == 0 || isolated == "" {
+		return body, false, nil
+	}
+	root := gjson.ParseBytes(body)
+	if !root.IsObject() {
+		return body, false, nil
+	}
+	next := body
+	modified := false
+	if pck := gjson.GetBytes(body, "prompt_cache_key"); pck.Exists() && pck.Type == gjson.String && strings.TrimSpace(pck.String()) != "" {
+		rewritten, err := sjson.SetBytes(next, "prompt_cache_key", isolated)
+		if err != nil {
+			return body, false, fmt.Errorf("splice isolated prompt_cache_key: %w", err)
+		}
+		next = rewritten
+		modified = true
+	}
+	cm := gjson.GetBytes(next, "client_metadata")
+	if !cm.IsObject() {
+		return next, modified, nil
+	}
+	existing := map[string]any{}
+	if err := json.Unmarshal([]byte(cm.Raw), &existing); err != nil {
+		return body, false, fmt.Errorf("decode client_metadata for session isolation: %w", err)
+	}
+	if !applyIsolatedOpenAISessionClientMetadata(existing, isolated) {
+		return next, modified, nil
+	}
+	raw, err := json.Marshal(existing)
+	if err != nil {
+		return body, false, fmt.Errorf("encode isolated client_metadata: %w", err)
+	}
+	spliced, err := sjson.SetRawBytes(next, "client_metadata", raw)
+	if err != nil {
+		return body, false, fmt.Errorf("splice isolated client_metadata: %w", err)
+	}
+	return spliced, true, nil
 }

--- a/backend/internal/service/openai_codex_fingerprint_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 const testCodexFingerprintSeed = "11111111-1111-4111-8111-111111111111"
@@ -224,6 +225,7 @@ func TestApplyCodexFingerprintHeaders_SessionMode(t *testing.T) {
 	h.Set("x-codex-window-id", "user-thread:0")
 	h.Set("x-codex-turn-metadata", turnMetadata)
 	h.Set("x-client-request-id", "user-thread")
+	h.Set("conversation_id", "hex-or-client-conversation")
 
 	ids := resolveCodexFingerprintIDsFromRequest(account, clientHeaders)
 	applyCodexFingerprintHeaders(h, ids)
@@ -239,6 +241,8 @@ func TestApplyCodexFingerprintHeaders_SessionMode(t *testing.T) {
 	assert.Equal(t, convergedSession, h.Get("session_id"), "下划线形式也应被改写")
 	assert.Equal(t, convergedThread, h.Get("thread-id"))
 	assert.Equal(t, convergedThread, h.Get("x-client-request-id"))
+	assert.Equal(t, convergedSession, h.Get("conversation_id"))
+	assert.NotEqual(t, convergedSession, convergedThread, "session 模式 thread 仍按客户端原始 session 派生")
 	assert.Equal(t, convergedThread+":0", h.Get("x-codex-window-id"))
 
 	var meta map[string]any
@@ -297,6 +301,7 @@ func TestApplyCodexFingerprintHeaders_FullMode(t *testing.T) {
 	idsA := resolveCodexFingerprintIDsFromRequest(account, clientA)
 	hA := http.Header{}
 	hA.Set("x-codex-turn-metadata", `{"installation_id":"x","session_id":"x","thread_id":"x","turn_id":"x","window_id":"x:0"}`)
+	hA.Set("conversation_id", "client-conversation")
 	applyCodexFingerprintHeaders(hA, idsA)
 
 	clientB := http.Header{}
@@ -308,7 +313,51 @@ func TestApplyCodexFingerprintHeaders_FullMode(t *testing.T) {
 
 	assert.Equal(t, hA.Get("thread-id"), hB.Get("thread-id"), "full 模式 thread_id 应相同")
 	assert.Equal(t, convergedSession, hA.Get("thread-id"), "full 模式 thread_id 应等于 session_id")
+	assert.Equal(t, convergedSession, hA.Get("conversation_id"), "full 模式已有 conversation_id 应改成 session UUID")
 	assert.Equal(t, hA.Get("x-codex-window-id"), hB.Get("x-codex-window-id"), "full 模式 window_id 应相同")
+}
+
+func TestApplyIsolatedOpenAISession_ExistingFieldsOnly(t *testing.T) {
+	isolated := isolateOpenAISessionID(7, "01a03238-04c3-7151-bfbe-5d249cb362dd")
+	require.NotEmpty(t, isolated)
+
+	h := http.Header{}
+	h.Set("session_id", "raw-session")
+	h.Set("conversation_id", "raw-conversation")
+	h.Set("x-codex-window-id", "raw-window:0")
+	h.Set("x-codex-turn-metadata", `{"session_id":"raw-session","thread_id":"raw-thread","window_id":"raw-window:0","sandbox":"seatbelt"}`)
+	applyIsolatedOpenAISessionHeaders(h, isolated)
+
+	assert.Equal(t, isolated, h.Get("session_id"))
+	assert.Equal(t, isolated, h.Get("conversation_id"))
+	assert.Equal(t, isolated+":0", h.Get("x-codex-window-id"))
+	assert.Empty(t, h.Get("session-id"), "off/device 不新注入 session-id")
+	assert.Empty(t, h.Get("thread-id"), "off/device 不新注入 thread-id")
+	assert.Empty(t, h.Get("x-client-request-id"), "off/device 不新注入 x-client-request-id")
+	assert.Equal(t, isolated, gjson.Get(h.Get("x-codex-turn-metadata"), "session_id").String())
+	assert.Equal(t, isolated, gjson.Get(h.Get("x-codex-turn-metadata"), "thread_id").String())
+	assert.Equal(t, isolated+":0", gjson.Get(h.Get("x-codex-turn-metadata"), "window_id").String())
+	assert.Equal(t, "seatbelt", gjson.Get(h.Get("x-codex-turn-metadata"), "sandbox").String())
+
+	reqBody := map[string]any{
+		"prompt_cache_key": "01a03238-04c3-7151-bfbe-5d249cb362dd",
+		"client_metadata": map[string]any{
+			"session_id":            "01a03238-04c3-7151-bfbe-5d249cb362dd",
+			"thread_id":             "01a03238-04c3-7151-bfbe-5d249cb362dd",
+			"x-codex-window-id":     "01a03238-04c3-7151-bfbe-5d249cb362dd:0",
+			"x-codex-turn-metadata": `{"session_id":"01a03238-04c3-7151-bfbe-5d249cb362dd","thread_id":"01a03238-04c3-7151-bfbe-5d249cb362dd","window_id":"01a03238-04c3-7151-bfbe-5d249cb362dd:0","sandbox":"seatbelt"}`,
+		},
+	}
+	require.True(t, applyIsolatedOpenAISessionBody(reqBody, isolated))
+	assert.Equal(t, isolated, reqBody["prompt_cache_key"])
+	metadata, ok := reqBody["client_metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, isolated, metadata["session_id"])
+	assert.Equal(t, isolated, metadata["thread_id"])
+	assert.Equal(t, isolated+":0", metadata["x-codex-window-id"])
+	turnMetadata, ok := metadata["x-codex-turn-metadata"].(string)
+	require.True(t, ok)
+	assert.Equal(t, isolated, gjson.Get(turnMetadata, "session_id").String())
 }
 
 // --- H1 修复验证：头和体的 turn_id 一致性 ---

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -318,7 +318,11 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 
 	if promptCacheKey != "" {
 		apiKeyID := getAPIKeyIDFromContext(c)
-		upstreamReq.Header.Set("session_id", generateSessionUUID(isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey)))
+		isolatedSessionID := generateSessionUUID(isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey))
+		upstreamReq.Header.Set("session_id", isolatedSessionID)
+		if strings.TrimSpace(upstreamReq.Header.Get("conversation_id")) != "" {
+			upstreamReq.Header.Set("conversation_id", isolatedSessionID)
+		}
 	}
 
 	// 7. Send request

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -494,6 +494,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		stageCodexFingerprintIDs(c, nil)
 		// 指纹收敛：一次性解析收敛 ID，请求体和出站头共享同一份 IDs（保证 turn_id 等随机字段一致）。
 		// fingerprintIDs 在此处解析，后续 buildUpstreamRequest 中使用同一份。
+		isolatedSessionBody := false
 		if !isCompactRequest {
 			var clientHeaders http.Header
 			if c != nil && c.Request != nil {
@@ -505,6 +506,18 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 					markDecodedModified()
 				}
 			}
+			if fpIDs == nil || fpIDs.mode == codexFingerprintDevice {
+				isolatedSeed := strings.TrimSpace(clientPromptCacheKey)
+				if isolatedSeed == "" {
+					isolatedSeed = extractClientSessionID(clientHeaders)
+				}
+				isolated := isolateOpenAIUpstreamSessionID(getAPIKeyIDFromContext(c), codexAccountIdentitySource(c, account), isolatedSeed)
+				stageIsolatedOpenAISessionID(c, isolated)
+				if applyIsolatedOpenAISessionBody(decoded, isolated) {
+					markDecodedModified()
+					isolatedSessionBody = true
+				}
+			}
 			// 将 fpIDs 存入 gin context，供 buildUpstreamRequest 中头改写使用。
 			// 无条件覆写（含 nil）：failover 从收敛账号切到 off 账号时，上一
 			// 账号的 IDs 不得残留（stageCodexFingerprintIDs 注释）。
@@ -514,14 +527,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamModel = codexResult.NormalizedModel
 		}
 		if strings.TrimSpace(clientPromptCacheKey) != "" {
-			// The body now carries an account-scoped value. Keep the original here
-			// so the header builder derives the same namespace exactly once.
+			// The body now carries an account-scoped or isolated value. Keep the
+			// original here so the header builder derives the same namespace exactly once.
 			promptCacheKey = clientPromptCacheKey
-		} else if currentPromptCacheKey, ok := decoded["prompt_cache_key"].(string); ok && currentPromptCacheKey != "" {
+		} else if currentPromptCacheKey, ok := decoded["prompt_cache_key"].(string); ok && currentPromptCacheKey != "" && !isolatedSessionBody {
 			// Fingerprint convergence may inject a default key when the client did
 			// not provide one; preserve that existing fallback.
 			promptCacheKey = currentPromptCacheKey
-		} else if codexResult.PromptCacheKey != "" {
+		} else if !isolatedSessionBody && codexResult.PromptCacheKey != "" {
 			promptCacheKey = codexResult.PromptCacheKey
 		}
 	}
@@ -1346,11 +1359,15 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			req.Header.Set("accept", "text/event-stream")
 		}
 		if promptCacheKey != "" {
-			isolated := isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey)
+			isolated := stagedIsolatedOpenAISessionID(c)
+			if isolated == "" {
+				isolated = isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey)
+			}
 			req.Header.Set("session_id", isolated)
 			if !compatMessagesBridge || clientConversationID != "" {
 				req.Header.Set("conversation_id", isolated)
 			}
+			applyIsolatedOpenAISessionHeaders(req.Header, isolated)
 		}
 	} else if isOpenAIResponsesCompactPath(c) {
 		// compact 上游是 unary JSON 协议：API-key 账号也显式声明 Accept，

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -180,6 +180,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		}
 		reqStream = gjson.GetBytes(body, "stream").Bool()
 
+		clientPromptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
 		accountScopedBody, accountScoped, scopeErr := applyCodexAccountIdentityClientMetadataRaw(body, codexAccountIdentitySource(c, account), getAPIKeyIDFromContext(c))
 		if scopeErr != nil {
 			return nil, scopeErr
@@ -201,6 +202,24 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 			fpIDs := resolveCodexFingerprintIDsFromRequest(account, clientHeaders)
 			if fpIDs != nil {
 				fpBody, fpChanged, fpErr := applyCodexFingerprintClientMetadataRaw(body, fpIDs)
+				if fpErr != nil {
+					return nil, fpErr
+				}
+				if fpChanged {
+					body = fpBody
+				}
+			}
+			if fpIDs == nil || fpIDs.mode == codexFingerprintDevice {
+				isolatedSeed := clientPromptCacheKey
+				if isolatedSeed == "" {
+					isolatedSeed = extractClientSessionID(clientHeaders)
+				}
+				if isolatedSeed == "" && clientHeaders != nil {
+					isolatedSeed = strings.TrimSpace(clientHeaders.Get("conversation_id"))
+				}
+				isolated := isolateOpenAIUpstreamSessionID(getAPIKeyIDFromContext(c), codexAccountIdentitySource(c, account), isolatedSeed)
+				stageIsolatedOpenAISessionID(c, isolated)
+				fpBody, fpChanged, fpErr := applyIsolatedOpenAISessionBodyRaw(body, isolated)
 				if fpErr != nil {
 					return nil, fpErr
 				}
@@ -671,17 +690,45 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			req.Header.Set("originator", resolveCodexOutboundIdentity("").originator)
 		}
 		// 用隔离后的 session 标识符覆盖客户端透传值，防止跨用户会话碰撞。
-		if clientSessionID == "" {
-			clientSessionID = promptCacheKey
+		identitySource := codexAccountIdentitySource(c, account)
+		isolated := stagedIsolatedOpenAISessionID(c)
+		if isolated == "" {
+			isolated = isolateOpenAIUpstreamSessionID(apiKeyID, identitySource, clientSessionID)
 		}
-		if clientConversationID == "" {
-			clientConversationID = promptCacheKey
+		if isolated == "" {
+			isolated = isolateOpenAIUpstreamSessionID(apiKeyID, identitySource, clientConversationID)
 		}
-		if clientSessionID != "" {
-			req.Header.Set("session_id", isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), clientSessionID))
+		// HTTP bridge 只走本构造器，body 已按账号 namespace 改写。不能再对
+		// prompt_cache_key 做 isolate，否则会把账号 UUID 压成 hex。
+		isolatedFromClientHeaders := isolated != "" && stagedIsolatedOpenAISessionID(c) == ""
+		if isolated == "" {
+			isolated = promptCacheKey
 		}
-		if clientConversationID != "" {
-			req.Header.Set("conversation_id", isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), clientConversationID))
+		if isolatedFromClientHeaders && account.GetCodexFingerprintMode() != codexFingerprintSession && account.GetCodexFingerprintMode() != codexFingerprintFull && !isOpenAIResponsesCompactPath(c) {
+			rewritten, changed, rewriteErr := applyIsolatedOpenAISessionBodyRaw(body, isolated)
+			if rewriteErr != nil {
+				return nil, rewriteErr
+			}
+			if changed {
+				body = rewritten
+				if req.Body != nil {
+					_ = req.Body.Close()
+				}
+				req.Body = io.NopCloser(bytes.NewReader(body))
+				req.ContentLength = int64(len(body))
+				req.GetBody = func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader(body)), nil
+				}
+			}
+		}
+		if isolated != "" {
+			if clientSessionID != "" || promptCacheKey != "" {
+				req.Header.Set("session_id", isolated)
+			}
+			if clientConversationID != "" || promptCacheKey != "" {
+				req.Header.Set("conversation_id", isolated)
+			}
+			applyIsolatedOpenAISessionHeaders(req.Header, isolated)
 		}
 	} else if isOpenAIResponsesCompactPath(c) {
 		// 透传白名单会放行客户端的 Accept: text/event-stream；compact 上游是

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -1957,6 +1957,8 @@ func TestOpenAIGatewayService_CodexFingerprintHTTPTransformedHeaderBodyParityAnd
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.144.1")
 	c.Request.Header.Set("originator", "codex_cli_rs")
 	c.Request.Header.Set("session-id", "header-session")
+	c.Request.Header.Set("session_id", "header-session")
+	c.Request.Header.Set("conversation_id", "header-conversation")
 	c.Request.Header.Set("x-codex-turn-metadata", `{"installation_id":"header-install","session_id":"header-session","thread_id":"header-thread","turn_id":"header-turn","window_id":"header-window","sandbox":"seatbelt"}`)
 
 	body := []byte(`{"model":"gpt-5.2","stream":false,"prompt_cache_key":"body-session","client_metadata":{"session_id":"body-session","x-codex-turn-metadata":"{\"installation_id\":\"body-install\",\"session_id\":\"body-session\",\"thread_id\":\"body-thread\",\"turn_id\":\"body-turn\",\"window_id\":\"body-window\",\"sandbox\":\"seatbelt\"}"},"input":[{"type":"message","role":"user","content":"hi"}]}`)
@@ -1991,6 +1993,7 @@ func TestOpenAIGatewayService_CodexFingerprintHTTPTransformedHeaderBodyParityAnd
 	require.Equal(t, wantInstall, upstream.lastReq.Header.Get("x-codex-installation-id"))
 	require.Equal(t, wantSession, upstream.lastReq.Header.Get("session-id"))
 	require.Equal(t, wantSession, upstream.lastReq.Header.Get("session_id"))
+	require.Equal(t, wantSession, upstream.lastReq.Header.Get("conversation_id"))
 	require.Equal(t, wantThread, upstream.lastReq.Header.Get("thread-id"))
 	require.Equal(t, wantThread, upstream.lastReq.Header.Get("x-client-request-id"))
 	require.Equal(t, wantThread+":0", upstream.lastReq.Header.Get("x-codex-window-id"))
@@ -2008,6 +2011,52 @@ func TestOpenAIGatewayService_CodexFingerprintHTTPTransformedHeaderBodyParityAnd
 	require.Equal(t, gjson.Get(bodyTurnMetadata, "turn_id").String(), gjson.Get(headerTurnMetadata, "turn_id").String())
 }
 
+func TestOpenAIGatewayService_OffModeIsolatesExistingSessionFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex-tui/0.149.1")
+	c.Request.Header.Set("originator", "codex-tui")
+	c.Request.Header.Set("session_id", "01a03238-04c3-7151-bfbe-5d249cb362dd")
+	c.Set("api_key", &APIKey{ID: 11})
+
+	rawSession := "01a03238-04c3-7151-bfbe-5d249cb362dd"
+	body := []byte(`{"model":"gpt-5.6-luna","stream":true,"store":false,"prompt_cache_key":"` + rawSession + `","client_metadata":{"session_id":"` + rawSession + `","thread_id":"` + rawSession + `","x-codex-window-id":"` + rawSession + `:0"},"input":[{"type":"message","role":"user","content":"hi"}]}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:           &config.Config{},
+		httpUpstream:  upstream,
+		toolCorrector: NewCodexToolCorrector(),
+	}
+	account := newTestOAuthAccount(4410, nil)
+	account.Name = "oauth-off"
+	account.Status = StatusActive
+	account.Schedulable = true
+	account.Concurrency = 1
+	account.Credentials = map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"}
+
+	_, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+
+	want := isolateOpenAIUpstreamSessionID(11, account, rawSession)
+	require.Equal(t, want, upstream.lastReq.Header.Get("session_id"))
+	require.Equal(t, want, upstream.lastReq.Header.Get("conversation_id"))
+	require.Empty(t, upstream.lastReq.Header.Get("session-id"))
+	require.Empty(t, upstream.lastReq.Header.Get("thread-id"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-client-request-id"))
+	require.Equal(t, want, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").String())
+	require.Equal(t, want, gjson.GetBytes(upstream.lastBody, "client_metadata.session_id").String())
+	require.Equal(t, want, gjson.GetBytes(upstream.lastBody, "client_metadata.thread_id").String())
+	require.Equal(t, want+":0", gjson.GetBytes(upstream.lastBody, "client_metadata.x-codex-window-id").String())
+}
+
 func TestOpenAIGatewayService_CodexFingerprintHTTPRawPassthroughHeaderBodyParityAndDefaultCacheKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -2017,6 +2066,8 @@ func TestOpenAIGatewayService_CodexFingerprintHTTPRawPassthroughHeaderBodyParity
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.144.1")
 	c.Request.Header.Set("originator", "codex_cli_rs")
 	c.Request.Header.Set("session-id", "header-session")
+	c.Request.Header.Set("session_id", "header-session")
+	c.Request.Header.Set("conversation_id", "header-conversation")
 	c.Request.Header.Set("x-codex-turn-metadata", `{"installation_id":"header-install","session_id":"header-session","thread_id":"header-thread","turn_id":"header-turn","window_id":"header-window","sandbox":"seatbelt"}`)
 
 	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"prompt_cache_key":"body-session","client_metadata":{"session_id":"body-session","x-codex-turn-metadata":"{\"installation_id\":\"body-install\",\"session_id\":\"body-session\",\"thread_id\":\"body-thread\",\"turn_id\":\"body-turn\",\"window_id\":\"body-window\",\"sandbox\":\"seatbelt\"}"},"input":[{"type":"message","role":"user","content":"hi"}]}`)
@@ -2053,6 +2104,7 @@ func TestOpenAIGatewayService_CodexFingerprintHTTPRawPassthroughHeaderBodyParity
 	require.Equal(t, wantInstall, upstream.lastReq.Header.Get("x-codex-installation-id"))
 	require.Equal(t, wantSession, upstream.lastReq.Header.Get("session-id"))
 	require.Equal(t, wantSession, upstream.lastReq.Header.Get("session_id"))
+	require.Equal(t, wantSession, upstream.lastReq.Header.Get("conversation_id"))
 	require.Equal(t, wantThread, upstream.lastReq.Header.Get("thread-id"))
 	require.Equal(t, wantThread, upstream.lastReq.Header.Get("x-client-request-id"))
 	require.Equal(t, wantThread+":0", upstream.lastReq.Header.Get("x-codex-window-id"))

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -120,11 +120,22 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 	// OAuth 账号：将 apiKeyID 混入 session 标识符，防止跨用户会话碰撞。
 	if account != nil && account.UsesOpenAICodexProtocol() {
 		apiKeyID := getAPIKeyIDFromContext(c)
-		if sessionResolution.SessionID != "" {
-			headers.Set("session_id", isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), sessionResolution.SessionID))
+		identitySource := codexAccountIdentitySource(c, account)
+		isolated := stagedIsolatedOpenAISessionID(c)
+		if isolated == "" {
+			isolated = isolateOpenAIUpstreamSessionID(apiKeyID, identitySource, sessionResolution.SessionID)
 		}
-		if sessionResolution.ConversationID != "" {
-			headers.Set("conversation_id", isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), sessionResolution.ConversationID))
+		if isolated == "" {
+			isolated = isolateOpenAIUpstreamSessionID(apiKeyID, identitySource, sessionResolution.ConversationID)
+		}
+		if isolated != "" {
+			if sessionResolution.SessionID != "" {
+				headers.Set("session_id", isolated)
+			}
+			if sessionResolution.ConversationID != "" {
+				headers.Set("conversation_id", isolated)
+			}
+			applyIsolatedOpenAISessionHeaders(headers, isolated)
 		}
 	} else {
 		if sessionResolution.SessionID != "" {

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -799,9 +799,10 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthStoreFalseByDefault(t *testing.T
 	require.Equal(t, openAIWSBetaV2Value, captureDialer.lastHeaders.Get("OpenAI-Beta"))
 	require.Equal(t, "remote_compaction_v2", captureDialer.lastHeaders.Get("x-codex-beta-features"))
 	// OAuth 账号的 session_id/conversation_id 应同时按 API key 和上游账号隔离，
-	// 测试中未设置 api_key 到 context，apiKeyID=0。
-	require.Equal(t, isolateOpenAIUpstreamSessionID(0, account, "sess-oauth-1"), captureDialer.lastHeaders.Get("session_id"))
-	require.Equal(t, isolateOpenAIUpstreamSessionID(0, account, "conv-oauth-1"), captureDialer.lastHeaders.Get("conversation_id"))
+	// 测试中未设置 api_key 到 context，apiKeyID=0。已有 conversation_id 与 session 对齐。
+	wantSession := isolateOpenAIUpstreamSessionID(0, account, "sess-oauth-1")
+	require.Equal(t, wantSession, captureDialer.lastHeaders.Get("session_id"))
+	require.Equal(t, wantSession, captureDialer.lastHeaders.Get("conversation_id"))
 }
 
 func TestOpenAIGatewayService_Forward_WSv2_OAuthOriginatorCompatibility(t *testing.T) {


### PR DESCRIPTION
> **感觉 codex 路径的很多 header 和 body 都和官方对不上了**
## 背景

对比真实 `codex-tui`（`0.149.1`）发往 `https://chatgpt.com/backend-api/codex/responses` 的请求，与当前网关 OAuth 出站请求，会话/线程/窗口身份并不一致。官方根 agent 下的身份是一套值打通的：

```
session-id == thread-id == x-client-request-id == prompt_cache_key
x-codex-window-id == thread-id:0
turn_id == root_turn_id
installation_id 独立固定
```

官方只发 `session-id`、`thread-id`、`x-client-request-id`、`x-codex-window-id`。官方从不发送 `conversation_id`，也不发送下划线形式的 `session_id`。根会话下 `session_id == thread_id`；只有子代理 / guardian / memory 才会拆开。

本次只修头和 body 分裂，以及 `session`/`full` 下 `conversation_id` 仍是 isolate hex 的问题。不是完整对齐官方 TUI。

## 问题

当前各指纹模式下，session 相关字段并不一致：

| 模式 | 头 `session_id` | body `client_metadata.session_id` | `prompt_cache_key` | 头 `conversation_id` |
|---|---|---|---|---|
| `off`（默认） | 16 位 hex | 通常仍是客户端 UUID | 通常仍是原始 UUID | 和头 `session_id` 一样是 hex |
| `device` | 仍是 hex | 仍是原始 UUID | 不改 | 仍是 hex |
| `session` / `full` | 改成账号派生 UUID | 改成同一份 UUID | 仅当它等于原 body session 时才改成同一份 | 不改，仍是 hex |

默认 `off` / `device` 因此会让上游同时看到两套会话身份：头是 isolate hex，body 仍是客户端 UUID。`session` / `full` 把头收成账号级 UUID 后，`conversation_id` 仍停在 hex，继续分裂。

## 改动

- 保持 `isolateOpenAISessionID()` 仍输出 16 位 hex，不改生成算法。
- `off` / `device`：把**已有** session 相关字段改成同一份隔离值，包括 header `session_id` / `conversation_id`、body `prompt_cache_key`、`client_metadata.session_id` / `thread_id`、已有 `window_id`。HTTP 不新注入官方 TUI 的 `session-id` / `thread-id` / `x-client-request-id`。
- `session` / `full`：若已有 `conversation_id`，改成 fingerprint 的 session UUID。`session` 模式仍保持 1 会话 + N 线程。
- 按 API Key 隔离仍然保留：不同下游不会因为这次对齐而共享 prompt cache。`session` / `full` 的账号级 cache 语义不变。

## 验证

- `gofmt`
- `go test ./internal/service -count=1 -run 'TestIsolateOpenAISessionID|TestApplyIsolatedOpenAISession_ExistingFieldsOnly|TestApplyCodexFingerprintHeaders_SessionMode$|TestApplyCodexFingerprintHeaders_FullMode|TestOpenAIGatewayService_OffModeIsolatesExistingSessionFields|TestOpenAIGatewayService_CodexFingerprintHTTPTransformedHeaderBodyParityAndDefaultCacheKey|TestOpenAIGatewayService_CodexFingerprintHTTPRawPassthroughHeaderBodyParityAndDefaultCacheKey|TestOpenAIGatewayService_CodexFingerprintCompactDoesNotRewriteBodyCacheKeyOrMetadata|TestOpenAIGatewayService_CodexFingerprintMessagesBridgeDoesNotInjectBodyPromptCacheKey|TestOpenAIAgentIdentityPassthroughKeepsSessionAndPromptCacheHeaders|TestOpenAIGatewayService_Forward_WSv2_OAuthStoreFalseByDefault|TestOpenAIGatewayService_Forward_WSv2_PromptCacheKey|TestOpenAICompat|ChatCompletions'`

## 仍然存在的问题

本次没有做完整官方 TUI 对齐，下面这些差异还在：

1. **仍会发送官方没有的头**
   - `conversation_id`
   - `session_id`（下划线）
   - 官方只发 `session-id` / `thread-id` / `x-client-request-id` / `x-codex-window-id`

2. **默认 HTTP 仍缺少官方连字符头**
   - `off` / `device` 不新注入 `session-id` / `thread-id` / `x-client-request-id`
   - 这些头不在 HTTP 白名单里，非透传默认仍会丢掉

3. **隔离值仍是 16 位 hex，不是 UUID**
   - `isolateOpenAISessionID()` 继续返回 `%016x`
   - 本次只让已有字段共用这份 hex，不改生成形态

4. **`session` 模式仍打破 `session == thread`**
   - `full`：`threadID = sessionID`
   - `session`：thread 仍按客户端原始 session 派生，`window_id = threadID:0`，与官方根会话 `window=session:0` 不一致

5. **`root_turn_id` 仍不参与收敛**
   - 官方根会话 `turn_id == root_turn_id`
   - 收敛只改 `turn_id`（UUIDv7），`root_turn_id` 仍可能是客户端原值

6. **`turn_started_at_unix_ms` 在收敛模式下仍替换为 `time.Now()`**

7. **其它未纳入本次的官方差异**
   - 自造 `version` 头。官方不发该头，版本走 `?client_version=`
   - 默认只补 `x-codex-beta-features: remote_compaction_v2`；官方可能还有 `prevent_idle_sleep`，这是客户端设置，当前只补 `remote_compaction_v2` 是预期行为

## 风险与兼容性

无 API 或配置格式变更。默认 `off` 下，已有 `prompt_cache_key` / `client_metadata` 会改成 isolate hex，同一 API Key 的后续请求仍确定性命中自己的 cache；不同 API Key 仍然隔离。`session` / `full` 仍是账号级 session/cache。