### PR TITLE
fix(monitor-v2): correct composite platform NULLIF syntax

### DIFF
--- a/backend/internal/repository/channel_monitor_v2_aggregation.go
+++ b/backend/internal/repository/channel_monitor_v2_aggregation.go
@@ -255,7 +255,7 @@ WITH dedup AS (
     -- group errors aggregate under platform 'composite', which is never an
     -- enabled config platform, and are filtered out of every monitor v2 query.
     lower(CASE
-      WHEN g.platform = 'composite' THEN COALESCE(NULLIF(TRIM(a.platform)), NULLIF(NULLIF(lower(TRIM(current_error.platform)), ''), 'composite'), 'unknown')
+      WHEN g.platform = 'composite' THEN COALESCE(NULLIF(TRIM(a.platform), ''), NULLIF(NULLIF(lower(TRIM(current_error.platform)), ''), 'composite'), 'unknown')
       ELSE COALESCE(NULLIF(TRIM(current_error.platform), ''), 'unknown')
     END) AS platform,
     COALESCE(current_error.group_id, 0) AS group_id,

--- a/backend/internal/repository/channel_monitor_v2_repo_test.go
+++ b/backend/internal/repository/channel_monitor_v2_repo_test.go
@@ -115,7 +115,9 @@ func TestChannelMonitorV2ErrorAggregationResolvesCompositePlatform(t *testing.T)
 	require.Contains(t, query, "g.platform = 'composite'")
 	require.Contains(t, query, "left join groups g on g.id = current_error.group_id")
 	require.Contains(t, query, "left join accounts a on a.id = current_error.account_id")
-	require.Contains(t, query, "a.platform")
+	// PostgreSQL NULLIF requires two arguments. Keep the empty-string argument
+	// explicit so this aggregation query remains syntactically valid.
+	require.Contains(t, query, "nullif(trim(a.platform), '')")
 }
 
 func TestChannelMonitorV2UsageSuccessExcludesCyberBillingRows(t *testing.T) {


### PR DESCRIPTION
## Summary

- pass the required empty-string argument to `NULLIF` when resolving a composite group's account platform
- strengthen the existing regression test to assert the syntactically valid expression

## Root cause

The composite-platform aggregation added a one-argument `NULLIF(TRIM(a.platform))`. PostgreSQL requires exactly two arguments, so the channel monitor V2 overlap aggregation failed with `syntax error at or near ")"` and its watermark stopped advancing.

## Validation

- `go test -mod=readonly ./internal/repository -run 'TestChannelMonitorV2' -count=1`
- prepared the complete aggregation statement successfully with PostgreSQL (`PREPARE` only; statement not executed)
- `git diff --check`
