### PR TITLE
fix(channel-monitor-v2): fix composite platform aggregation SQL

### DIFF
--- a/backend/internal/repository/channel_monitor_v2_aggregation.go
+++ b/backend/internal/repository/channel_monitor_v2_aggregation.go
@@ -255,7 +255,7 @@ WITH dedup AS (
     -- group errors aggregate under platform 'composite', which is never an
     -- enabled config platform, and are filtered out of every monitor v2 query.
     lower(CASE
-      WHEN g.platform = 'composite' THEN COALESCE(NULLIF(TRIM(a.platform)), NULLIF(NULLIF(lower(TRIM(current_error.platform)), ''), 'composite'), 'unknown')
+      WHEN g.platform = 'composite' THEN COALESCE(NULLIF(TRIM(a.platform), ''), NULLIF(NULLIF(lower(TRIM(current_error.platform)), ''), 'composite'), 'unknown')
       ELSE COALESCE(NULLIF(TRIM(current_error.platform), ''), 'unknown')
     END) AS platform,
     COALESCE(current_error.group_id, 0) AS group_id,

--- a/backend/internal/repository/channel_monitor_v2_repo_test.go
+++ b/backend/internal/repository/channel_monitor_v2_repo_test.go
@@ -116,6 +116,8 @@ func TestChannelMonitorV2ErrorAggregationResolvesCompositePlatform(t *testing.T)
 	require.Contains(t, query, "left join groups g on g.id = current_error.group_id")
 	require.Contains(t, query, "left join accounts a on a.id = current_error.account_id")
 	require.Contains(t, query, "a.platform")
+	require.Contains(t, query, "nullif(trim(a.platform), '')")
+	require.NotContains(t, query, "nullif(trim(a.platform))")
 }
 
 func TestChannelMonitorV2UsageSuccessExcludesCyberBillingRows(t *testing.T) {


### PR DESCRIPTION
## Bug

After upgrading to v0.1.182, Channel Monitor V2 aggregation fails every five minutes with:

```text
pq: syntax error at or near ")"
```

The Composite group platform resolution introduced an invalid PostgreSQL expression:

```sql
NULLIF(TRIM(a.platform))
```

`NULLIF` requires two arguments. Because usage aggregation, error aggregation, rollups, and watermark updates run in one transaction, this error rolls back the entire aggregation window and prevents Channel Monitor V2 from updating.

## Fix

Use a valid two-argument expression:

```sql
NULLIF(TRIM(a.platform), '')
```

A regression assertion was added to require the valid expression and reject the invalid single-argument form.

## Verification

```bash
go test ./internal/repository \
  -run 'TestChannelMonitorV2(ErrorAggregation|UsageSuccess|SQLTaxonomy)' \
  -count=1
```

Result:

```text
ok github.com/Wei-Shaw/sub2api/internal/repository
```