### PR TITLE
fix(accounts): reauthorize OpenAI with refresh token

### DIFF
--- a/frontend/src/components/admin/account/ReAuthAccountModal.vue
+++ b/frontend/src/components/admin/account/ReAuthAccountModal.vue
@@ -140,7 +140,7 @@
         :initial-input-method="grokInitialInputMethod"
         @generate-url="handleGenerateUrl"
         @cookie-auth="handleCookieAuth"
-        @validate-refresh-token="handleGrokValidateRefreshToken"
+        @validate-refresh-token="handleValidateRefreshToken"
         @import-sso="handleGrokImportSSO"
       />
 
@@ -624,6 +624,74 @@ const applyGrokReauthTokenInfo = async (tokenInfo: {
   appStore.showSuccess(t('admin.accounts.reAuthorizedSuccess'))
   emit('reauthorized', updatedAccount)
   handleClose()
+}
+
+/** Re-auth the existing account with one refresh token. */
+const handleValidateRefreshToken = async (refreshTokenInput: string) => {
+  if (!props.account) return
+  if (isGrok.value) {
+    await handleGrokValidateRefreshToken(refreshTokenInput)
+    return
+  }
+
+  const refreshToken = refreshTokenInput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)[0]
+  if (!refreshToken) return
+
+  if (isOpenAILike.value) {
+    openaiOAuth.loading.value = true
+    openaiOAuth.error.value = ''
+    try {
+      const tokenInfo = await openaiOAuth.validateRefreshToken(refreshToken, props.account.proxy_id)
+      if (!tokenInfo) return
+
+      const updatedAccount = await adminAPI.accounts.applyOAuthCredentials(props.account.id, {
+        type: 'oauth',
+        credentials: openaiOAuth.buildCredentials(tokenInfo),
+        extra: openaiOAuth.buildExtraInfo(tokenInfo)
+      })
+      appStore.showSuccess(t('admin.accounts.reAuthorizedSuccess'))
+      emit('reauthorized', updatedAccount)
+      handleClose()
+    } catch (error: any) {
+      openaiOAuth.error.value =
+        error.response?.data?.detail ||
+        error.response?.data?.message ||
+        error.message ||
+        t('admin.accounts.oauth.authFailed')
+      appStore.showError(openaiOAuth.error.value)
+    } finally {
+      openaiOAuth.loading.value = false
+    }
+    return
+  }
+
+  if (!isAntigravity.value) return
+  antigravityOAuth.loading.value = true
+  antigravityOAuth.error.value = ''
+  try {
+    const tokenInfo = await antigravityOAuth.validateRefreshToken(refreshToken, props.account.proxy_id)
+    if (!tokenInfo) return
+
+    const updatedAccount = await adminAPI.accounts.applyOAuthCredentials(props.account.id, {
+      type: 'oauth',
+      credentials: antigravityOAuth.buildCredentials(tokenInfo, refreshToken)
+    })
+    appStore.showSuccess(t('admin.accounts.reAuthorizedSuccess'))
+    emit('reauthorized', updatedAccount)
+    handleClose()
+  } catch (error: any) {
+    antigravityOAuth.error.value =
+      error.response?.data?.detail ||
+      error.response?.data?.message ||
+      error.message ||
+      t('admin.accounts.oauth.authFailed')
+    appStore.showError(antigravityOAuth.error.value)
+  } finally {
+    antigravityOAuth.loading.value = false
+  }
 }
 
 /** Re-auth with a single SSO cookie → Build OAuth (not batch create). */

--- a/frontend/src/components/admin/account/__tests__/ReAuthAccountModal.grok.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/ReAuthAccountModal.grok.spec.ts
@@ -17,7 +17,8 @@ describe('ReAuthAccountModal Grok re-auth paths', () => {
 
   it('wires SSO and RT reauth without batch account create', () => {
     expect(source).toContain('@import-sso="handleGrokImportSSO"')
-    expect(source).toContain('@validate-refresh-token="handleGrokValidateRefreshToken"')
+    expect(source).toContain('@validate-refresh-token="handleValidateRefreshToken"')
+    expect(source).toContain('await handleGrokValidateRefreshToken(refreshTokenInput)')
     expect(source).toContain('grokOAuth.validateSSOToken')
     expect(source).toContain('grokOAuth.buildCredentials')
     // Re-auth updates the existing account; must not call createFromSSO batch create


### PR DESCRIPTION
## Summary
- route refresh-token validation through the existing account reauthorization flow
- update the existing OpenAI or Antigravity account instead of creating a duplicate account
- preserve the existing Grok SSO and refresh-token paths

## Tests
- `pnpm exec vitest run src/components/admin/account/__tests__/ReAuthAccountModal.grok.spec.ts`
- `pnpm build`