### PR TITLE
feat(accounts): add linked Codex account copies

### DIFF
--- a/backend/ent/account.go
+++ b/backend/ent/account.go
@@ -77,9 +77,9 @@ type Account struct {
 	SessionWindowEnd *time.Time `json:"session_window_end,omitempty"`
 	// SessionWindowStatus holds the value of the "session_window_status" field.
 	SessionWindowStatus *string `json:"session_window_status,omitempty"`
-	// Parent account id for a linked spark shadow (NULL = normal).
+	// Credential-owning parent account id (NULL = normal).
 	ParentAccountID *int64 `json:"parent_account_id,omitempty"`
-	// 'global' (default) or 'spark' (shadow reads codex_bengalfox).
+	// 'global' for normal accounts, 'spark' for the independent Spark bucket, or 'linked' for a parent-shared global route.
 	QuotaDimension account.QuotaDimension `json:"quota_dimension,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AccountQuery when eager-loading is set.

--- a/backend/ent/account/account.go
+++ b/backend/ent/account/account.go
@@ -232,6 +232,7 @@ const DefaultQuotaDimension = QuotaDimensionGlobal
 const (
 	QuotaDimensionGlobal QuotaDimension = "global"
 	QuotaDimensionSpark  QuotaDimension = "spark"
+	QuotaDimensionLinked QuotaDimension = "linked"
 )
 
 func (qd QuotaDimension) String() string {
@@ -241,7 +242,7 @@ func (qd QuotaDimension) String() string {
 // QuotaDimensionValidator is a validator for the "quota_dimension" field enum values. It is called by the builders before save.
 func QuotaDimensionValidator(qd QuotaDimension) error {
 	switch qd {
-	case QuotaDimensionGlobal, QuotaDimensionSpark:
+	case QuotaDimensionGlobal, QuotaDimensionSpark, QuotaDimensionLinked:
 		return nil
 	default:
 		return fmt.Errorf("account: invalid enum value for quota_dimension field: %q", qd)

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -124,7 +124,7 @@ var (
 		{Name: "session_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "session_window_end", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "session_window_status", Type: field.TypeString, Nullable: true, Size: 20},
-		{Name: "quota_dimension", Type: field.TypeEnum, Enums: []string{"global", "spark"}, Default: "global"},
+		{Name: "quota_dimension", Type: field.TypeEnum, Enums: []string{"global", "spark", "linked"}, Default: "global"},
 		{Name: "proxy_id", Type: field.TypeInt64, Nullable: true},
 		{Name: "parent_account_id", Type: field.TypeInt64, Nullable: true},
 	}

--- a/backend/ent/schema/account.go
+++ b/backend/ent/schema/account.go
@@ -198,9 +198,9 @@ func (Account) Fields() []ent.Field {
 			MaxLen(20),
 
 		field.Int64("parent_account_id").Optional().Nillable().
-			Comment("Parent account id for a linked spark shadow (NULL = normal)."),
-		field.Enum("quota_dimension").Values("global", "spark").Default("global").
-			Comment("'global' (default) or 'spark' (shadow reads codex_bengalfox)."),
+			Comment("Credential-owning parent account id (NULL = normal)."),
+		field.Enum("quota_dimension").Values("global", "spark", "linked").Default("global").
+			Comment("'global' for normal accounts, 'spark' for the independent Spark bucket, or 'linked' for a parent-shared global route."),
 	}
 }
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -136,6 +136,8 @@ type UpdateAccountRequest struct {
 	Name                    string         `json:"name"`
 	Notes                   *string        `json:"notes"`
 	Type                    string         `json:"type" binding:"omitempty,oneof=oauth setup-token apikey upstream bedrock service_account"`
+	// ParentAccountID 仅对影子账号生效：复制出来的影子可改绑到另一个母账号。
+	ParentAccountID         *int64         `json:"parent_account_id"`
 	Credentials             map[string]any `json:"credentials"`
 	Extra                   map[string]any `json:"extra"`
 	ProxyID                 *int64         `json:"proxy_id"`
@@ -978,6 +980,7 @@ func (h *AccountHandler) Update(c *gin.Context) {
 		Name:                  req.Name,
 		Notes:                 req.Notes,
 		Type:                  req.Type,
+		ParentAccountID:       req.ParentAccountID,
 		Credentials:           req.Credentials,
 		Extra:                 req.Extra,
 		ProxyID:               req.ProxyID,

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -133,9 +133,9 @@ type CreateAccountRequest struct {
 // UpdateAccountRequest represents update account request
 // 使用指针类型来区分"未提供"和"设置为0"
 type UpdateAccountRequest struct {
-	Name                    string         `json:"name"`
-	Notes                   *string        `json:"notes"`
-	Type                    string         `json:"type" binding:"omitempty,oneof=oauth setup-token apikey upstream bedrock service_account"`
+	Name  string  `json:"name"`
+	Notes *string `json:"notes"`
+	Type  string  `json:"type" binding:"omitempty,oneof=oauth setup-token apikey upstream bedrock service_account"`
 	// ParentAccountID 仅对影子账号生效：复制出来的影子可改绑到另一个母账号。
 	ParentAccountID         *int64         `json:"parent_account_id"`
 	Credentials             map[string]any `json:"credentials"`

--- a/backend/internal/handler/admin/account_shadow_parent.go
+++ b/backend/internal/handler/admin/account_shadow_parent.go
@@ -17,12 +17,17 @@ var linkedAccountUsageExtraKeys = [...]string{
 	"codex_7d_reset_at",
 	"codex_7d_reset_after_seconds",
 	"codex_7d_window_minutes",
+	"session_window_utilization",
+	"passive_usage_7d_utilization",
+	"passive_usage_7d_reset",
+	"passive_usage_7d_oi_utilization",
+	"passive_usage_7d_oi_reset",
+	"passive_usage_sampled_at",
 }
 
-// inheritLinkedAccountUsageSnapshot makes the account-list row reflect the
-// credential-owning parent's shared Codex quota. AccountUsageCell watches these
-// fields and refreshes /usage when they change. Spark shadows keep their own
-// quota snapshot and must not inherit this state.
+// inheritLinkedAccountUsageSnapshot makes every normal linked account-list row
+// reflect the parent's core usage-window state, regardless of platform. Spark
+// shadows keep their own quota snapshot and must not inherit this state.
 func inheritLinkedAccountUsageSnapshot(account *dto.Account, parent *service.Account) {
 	if account == nil || parent == nil || account.QuotaDimension != service.QuotaDimensionLinked {
 		return
@@ -38,6 +43,9 @@ func inheritLinkedAccountUsageSnapshot(account *dto.Account, parent *service.Acc
 		}
 		account.Extra[key] = value
 	}
+	account.SessionWindowStart = parent.SessionWindowStart
+	account.SessionWindowEnd = parent.SessionWindowEnd
+	account.SessionWindowStatus = parent.SessionWindowStatus
 }
 
 // enrichShadowParentInfo 把母账号的展示信息回填到影子行的 parent_* 字段。

--- a/backend/internal/handler/admin/account_shadow_parent.go
+++ b/backend/internal/handler/admin/account_shadow_parent.go
@@ -3,8 +3,42 @@ package admin
 import (
 	"context"
 
+	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
+
+var linkedAccountUsageExtraKeys = [...]string{
+	"codex_usage_updated_at",
+	"codex_5h_used_percent",
+	"codex_5h_reset_at",
+	"codex_5h_reset_after_seconds",
+	"codex_5h_window_minutes",
+	"codex_7d_used_percent",
+	"codex_7d_reset_at",
+	"codex_7d_reset_after_seconds",
+	"codex_7d_window_minutes",
+}
+
+// inheritLinkedAccountUsageSnapshot makes the account-list row reflect the
+// credential-owning parent's shared Codex quota. AccountUsageCell watches these
+// fields and refreshes /usage when they change. Spark shadows keep their own
+// quota snapshot and must not inherit this state.
+func inheritLinkedAccountUsageSnapshot(account *dto.Account, parent *service.Account) {
+	if account == nil || parent == nil || account.QuotaDimension != service.QuotaDimensionLinked {
+		return
+	}
+	if account.Extra == nil {
+		account.Extra = make(map[string]any, len(linkedAccountUsageExtraKeys))
+	}
+	for _, key := range linkedAccountUsageExtraKeys {
+		value, exists := parent.Extra[key]
+		if !exists {
+			delete(account.Extra, key)
+			continue
+		}
+		account.Extra[key] = value
+	}
+}
 
 // enrichShadowParentInfo 把母账号的展示信息回填到影子行的 parent_* 字段。
 // 纯函数：仅依赖传入的母账号 map，便于单测；非影子或母账号缺失时优雅留空。
@@ -23,6 +57,7 @@ func enrichShadowParentInfo(items []AccountWithConcurrency, parents map[int64]*s
 		a.ParentSubscriptionExpiresAt = p.GetCredential("subscription_expires_at")
 		a.ParentChatGPTAccountID = p.GetCredential("chatgpt_account_id")
 		a.ParentPrivacyMode = p.GetExtraString("privacy_mode")
+		inheritLinkedAccountUsageSnapshot(a, p)
 	}
 }
 

--- a/backend/internal/handler/admin/account_shadow_parent_test.go
+++ b/backend/internal/handler/admin/account_shadow_parent_test.go
@@ -18,25 +18,58 @@ func TestEnrichShadowParentInfo(t *testing.T) {
 			"subscription_expires_at": "2026-12-31T00:00:00Z",
 			"chatgpt_account_id":      "acct_123",
 		},
-		Extra: map[string]any{"privacy_mode": "training_off"},
+		Extra: map[string]any{
+			"privacy_mode":                 "training_off",
+			"codex_usage_updated_at":       "2026-08-25T08:00:00Z",
+			"codex_5h_used_percent":        12.5,
+			"codex_5h_reset_at":            "2026-08-25T12:00:00Z",
+			"codex_5h_reset_after_seconds": 14400,
+			"codex_5h_window_minutes":      300,
+			"codex_7d_used_percent":        34.5,
+			"codex_7d_reset_at":            "2026-08-31T08:00:00Z",
+			"codex_7d_reset_after_seconds": 518400,
+			"codex_7d_window_minutes":      10080,
+		},
 	}
 	parents := map[int64]*service.Account{100: parent}
 
-	shadow := AccountWithConcurrency{Account: &dto.Account{ID: 200, ParentAccountID: &pid}}
+	linked := AccountWithConcurrency{Account: &dto.Account{
+		ID:              200,
+		ParentAccountID: &pid,
+		QuotaDimension:  service.QuotaDimensionLinked,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 99.0,
+			"unrelated":             "preserved",
+		},
+	}}
+	spark := AccountWithConcurrency{Account: &dto.Account{
+		ID:              202,
+		ParentAccountID: &pid,
+		QuotaDimension:  service.QuotaDimensionSpark,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 88.0,
+		},
+	}}
 	normal := AccountWithConcurrency{Account: &dto.Account{ID: 1}}
 	orphan := AccountWithConcurrency{Account: &dto.Account{ID: 201, ParentAccountID: ptrInt64(999)}}
-	items := []AccountWithConcurrency{shadow, normal, orphan}
+	items := []AccountWithConcurrency{linked, spark, normal, orphan}
 
 	enrichShadowParentInfo(items, parents)
 
-	require.Equal(t, "owner@example.com", items[0].ParentEmail, "影子回填母账号邮箱")
+	require.Equal(t, "owner@example.com", items[0].ParentEmail, "链接账号回填母账号邮箱")
 	require.Equal(t, "pro", items[0].ParentPlanType)
 	require.Equal(t, "training_off", items[0].ParentPrivacyMode)
 	require.Equal(t, "2026-12-31T00:00:00Z", items[0].ParentSubscriptionExpiresAt)
 	require.Equal(t, "acct_123", items[0].ParentChatGPTAccountID)
+	require.Equal(t, "2026-08-25T08:00:00Z", items[0].Extra["codex_usage_updated_at"])
+	require.Equal(t, 12.5, items[0].Extra["codex_5h_used_percent"])
+	require.Equal(t, 34.5, items[0].Extra["codex_7d_used_percent"])
+	require.Equal(t, "preserved", items[0].Extra["unrelated"])
 
-	require.Empty(t, items[1].ParentEmail, "非影子不回填")
-	require.Empty(t, items[2].ParentEmail, "母账号缺失时优雅留空")
+	require.Equal(t, 88.0, items[1].Extra["codex_5h_used_percent"], "Spark 影子保留独立额度")
+	require.Equal(t, "owner@example.com", items[1].ParentEmail, "Spark 影子仍回填母账号展示信息")
+	require.Empty(t, items[2].ParentEmail, "非影子不回填")
+	require.Empty(t, items[3].ParentEmail, "母账号缺失时优雅留空")
 }
 
 func ptrInt64(v int64) *int64 { return &v }

--- a/backend/internal/handler/admin/account_shadow_parent_test.go
+++ b/backend/internal/handler/admin/account_shadow_parent_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -10,8 +11,15 @@ import (
 
 func TestEnrichShadowParentInfo(t *testing.T) {
 	pid := int64(100)
+	parentWindowStart := time.Date(2026, 8, 25, 7, 0, 0, 0, time.UTC)
+	parentWindowEnd := parentWindowStart.Add(5 * time.Hour)
+	childWindowStart := parentWindowStart.Add(time.Hour)
+	childWindowEnd := childWindowStart.Add(5 * time.Hour)
 	parent := &service.Account{
-		ID: 100,
+		ID:                  100,
+		SessionWindowStart:  &parentWindowStart,
+		SessionWindowEnd:    &parentWindowEnd,
+		SessionWindowStatus: "allowed_warning",
 		Credentials: map[string]any{
 			"email":                   "owner@example.com",
 			"plan_type":               "pro",
@@ -29,23 +37,35 @@ func TestEnrichShadowParentInfo(t *testing.T) {
 			"codex_7d_reset_at":            "2026-08-31T08:00:00Z",
 			"codex_7d_reset_after_seconds": 518400,
 			"codex_7d_window_minutes":      10080,
+			"session_window_utilization":   0.23,
+			"passive_usage_7d_utilization": 0.45,
+			"passive_usage_7d_reset":       parentWindowEnd.Add(7 * 24 * time.Hour).Unix(),
+			"passive_usage_sampled_at":     "2026-08-25T08:01:00Z",
 		},
 	}
 	parents := map[int64]*service.Account{100: parent}
 
 	linked := AccountWithConcurrency{Account: &dto.Account{
-		ID:              200,
-		ParentAccountID: &pid,
-		QuotaDimension:  service.QuotaDimensionLinked,
+		ID:                  200,
+		ParentAccountID:     &pid,
+		QuotaDimension:      service.QuotaDimensionLinked,
+		SessionWindowStart:  &childWindowStart,
+		SessionWindowEnd:    &childWindowEnd,
+		SessionWindowStatus: "rejected",
 		Extra: map[string]any{
-			"codex_5h_used_percent": 99.0,
-			"unrelated":             "preserved",
+			"codex_5h_used_percent":        99.0,
+			"session_window_utilization":   0.91,
+			"passive_usage_7d_utilization": 0.92,
+			"unrelated":                    "preserved",
 		},
 	}}
 	spark := AccountWithConcurrency{Account: &dto.Account{
-		ID:              202,
-		ParentAccountID: &pid,
-		QuotaDimension:  service.QuotaDimensionSpark,
+		ID:                  202,
+		ParentAccountID:     &pid,
+		QuotaDimension:      service.QuotaDimensionSpark,
+		SessionWindowStart:  &childWindowStart,
+		SessionWindowEnd:    &childWindowEnd,
+		SessionWindowStatus: "rejected",
 		Extra: map[string]any{
 			"codex_5h_used_percent": 88.0,
 		},
@@ -64,9 +84,18 @@ func TestEnrichShadowParentInfo(t *testing.T) {
 	require.Equal(t, "2026-08-25T08:00:00Z", items[0].Extra["codex_usage_updated_at"])
 	require.Equal(t, 12.5, items[0].Extra["codex_5h_used_percent"])
 	require.Equal(t, 34.5, items[0].Extra["codex_7d_used_percent"])
+	require.Equal(t, 0.23, items[0].Extra["session_window_utilization"])
+	require.Equal(t, 0.45, items[0].Extra["passive_usage_7d_utilization"])
+	require.Equal(t, "2026-08-25T08:01:00Z", items[0].Extra["passive_usage_sampled_at"])
+	require.Equal(t, &parentWindowStart, items[0].SessionWindowStart)
+	require.Equal(t, &parentWindowEnd, items[0].SessionWindowEnd)
+	require.Equal(t, "allowed_warning", items[0].SessionWindowStatus)
 	require.Equal(t, "preserved", items[0].Extra["unrelated"])
 
 	require.Equal(t, 88.0, items[1].Extra["codex_5h_used_percent"], "Spark 影子保留独立额度")
+	require.Equal(t, &childWindowStart, items[1].SessionWindowStart)
+	require.Equal(t, &childWindowEnd, items[1].SessionWindowEnd)
+	require.Equal(t, "rejected", items[1].SessionWindowStatus)
 	require.Equal(t, "owner@example.com", items[1].ParentEmail, "Spark 影子仍回填母账号展示信息")
 	require.Empty(t, items[2].ParentEmail, "非影子不回填")
 	require.Empty(t, items[3].ParentEmail, "母账号缺失时优雅留空")

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1674,11 +1674,12 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 		writeError(http.StatusServiceUnavailable, "api_error", "No available accounts")
 		return nil, openAISlotAcquireFailed
 	}
+	slotAccountID, slotMaxConcurrency := h.gatewayService.OpenAIConcurrencyOwner(ctx, account)
 
 	fastReleaseFunc, fastAcquired, err := h.concurrencyHelper.TryAcquireAccountSlot(
 		ctx,
-		account.ID,
-		selection.WaitPlan.MaxConcurrency,
+		slotAccountID,
+		slotMaxConcurrency,
 	)
 	if err != nil {
 		reqLog.Warn("openai.account_slot_quick_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
@@ -1705,7 +1706,7 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 		return wrapReleaseOnDone(ctx, fastReleaseFunc), openAISlotAcquireOK
 	}
 
-	canWait, waitErr := h.concurrencyHelper.IncrementAccountWaitCount(ctx, account.ID, selection.WaitPlan.MaxWaiting)
+	canWait, waitErr := h.concurrencyHelper.IncrementAccountWaitCount(ctx, slotAccountID, selection.WaitPlan.MaxWaiting)
 	if waitErr != nil {
 		reqLog.Warn("openai.account_wait_counter_increment_failed", zap.Int64("account_id", account.ID), zap.Error(waitErr))
 	} else if !canWait {
@@ -1720,7 +1721,7 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 	accountWaitCounted := waitErr == nil && canWait
 	releaseWait := func() {
 		if accountWaitCounted {
-			h.concurrencyHelper.DecrementAccountWaitCount(ctx, account.ID)
+			h.concurrencyHelper.DecrementAccountWaitCount(ctx, slotAccountID)
 			accountWaitCounted = false
 		}
 	}
@@ -1728,8 +1729,8 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 
 	accountReleaseFunc, err := h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
 		c,
-		account.ID,
-		selection.WaitPlan.MaxConcurrency,
+		slotAccountID,
+		slotMaxConcurrency,
 		selection.WaitPlan.Timeout,
 		reqStream,
 		streamStarted,

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -3803,13 +3803,12 @@ func (r *accountRepository) RevertProxyFallback(ctx context.Context, accountID i
 	return nil
 }
 
-// ListShadowsByParent 返回指定父账号的影子账号；当前实现仅查 quota_dimension='spark'（唯一预设）。
-// 同时过滤 parent_account_id 和 quota_dimension='spark'，防止未来其它 linked 维度被误伤。
-// ⚠️ 新增影子维度时：须更新此函数（或新增维度专用列举），并检查所有调用点（级联删除/一母一影校验/type 守卫），否则会静默漏掉新维度。
+// ListShadowsByParent returns every linked child. Dimension-specific callers
+// filter the result in service code.
 // 软删除行由 SoftDeleteMixin 拦截器自动排除，无需手写 deleted_at IS NULL。
 func (r *accountRepository) ListShadowsByParent(ctx context.Context, parentID int64) ([]*service.Account, error) {
 	rows, err := r.client.Account.Query().
-		Where(dbaccount.ParentAccountIDEQ(parentID), dbaccount.QuotaDimensionEQ(dbaccount.QuotaDimensionSpark)).
+		Where(dbaccount.ParentAccountIDEQ(parentID)).
 		All(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -3171,11 +3171,21 @@ func parseExtraInt(value any) int {
 	return 0
 }
 
-// IsShadow 报告账号是否为影子账号（parent_account_id 非空；当前唯一预设是 spark 维度）。
+// IsShadow reports whether the account links to a credential-owning parent.
 func (a *Account) IsShadow() bool { return a != nil && a.ParentAccountID != nil }
 
 // IsCredentialShadow 语义别名，供「凭据消费者跳过影子」处使用（管理/后台 OAuth 路径）。
 func (a *Account) IsCredentialShadow() bool { return a.IsShadow() }
+
+// IsSparkShadow reports whether this linked account uses the independent Spark quota bucket.
+func (a *Account) IsSparkShadow() bool {
+	return a != nil && a.IsShadow() && a.QuotaDimensionOrDefault() == QuotaDimensionSpark
+}
+
+// IsLinkedAccount reports whether this is a normal Codex route linked to its parent's global quota.
+func (a *Account) IsLinkedAccount() bool {
+	return a != nil && a.IsShadow() && a.QuotaDimensionOrDefault() == QuotaDimensionLinked
+}
 
 // QuotaDimensionOrDefault 返回账号的用量维度，未设置时回退 "global"。
 func (a *Account) QuotaDimensionOrDefault() string {

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -59,7 +59,7 @@ type Account struct {
 	SessionWindowStatus string
 
 	ParentAccountID *int64 // non-nil → 影子账号（不持凭据，透传母账号凭据）
-	QuotaDimension  string // 用量维度："" / "global" / "spark"
+	QuotaDimension  string // 用量维度："" / "global" / "linked" / "spark"
 
 	Proxy         *Proxy
 	AccountGroups []AccountGroup
@@ -3182,7 +3182,7 @@ func (a *Account) IsSparkShadow() bool {
 	return a != nil && a.IsShadow() && a.QuotaDimensionOrDefault() == QuotaDimensionSpark
 }
 
-// IsLinkedAccount reports whether this is a normal Codex route linked to its parent's global quota.
+// IsLinkedAccount reports whether this account shares its parent's core usage state.
 func (a *Account) IsLinkedAccount() bool {
 	return a != nil && a.IsShadow() && a.QuotaDimensionOrDefault() == QuotaDimensionLinked
 }

--- a/backend/internal/service/account_credentials_persistence.go
+++ b/backend/internal/service/account_credentials_persistence.go
@@ -37,6 +37,14 @@ var sparkShadowAllowedCredentialKeys = map[string]struct{}{
 	"compact_model_mapping": {},
 }
 
+var linkedAccountAllowedCredentialKeys = map[string]struct{}{
+	"model_mapping":              {},
+	"compact_model_mapping":      {},
+	credKeyHeaderOverrideEnabled: {},
+	credKeyHeaderOverrides:       {},
+	"openai_capabilities":        {},
+}
+
 func isAllowedSparkShadowCredentialsUpdate(credentials map[string]any) bool {
 	if credentials == nil {
 		return true
@@ -55,6 +63,31 @@ func sanitizeSparkShadowCredentials(credentials map[string]any) map[string]any {
 	}
 	out := make(map[string]any, len(sparkShadowAllowedCredentialKeys))
 	for key := range sparkShadowAllowedCredentialKeys {
+		if value, ok := credentials[key]; ok && value != nil {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func isAllowedLinkedAccountCredentialsUpdate(credentials map[string]any) bool {
+	if credentials == nil {
+		return true
+	}
+	for key := range credentials {
+		if _, ok := linkedAccountAllowedCredentialKeys[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func sanitizeLinkedAccountCredentials(credentials map[string]any) map[string]any {
+	if len(credentials) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(linkedAccountAllowedCredentialKeys))
+	for key := range linkedAccountAllowedCredentialKeys {
 		if value, ok := credentials[key]; ok && value != nil {
 			out[key] = value
 		}

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -120,8 +120,8 @@ type AccountRepository interface {
 	// RevertProxyFallback 将账号的 proxy_id 切回 proxy_fallback_origin_id，并清空 origin 字段。
 	// 仅当 proxy_fallback_origin_id IS NOT NULL 时更新，否则视为账号不存在（返回 ErrAccountNotFound）。
 	RevertProxyFallback(ctx context.Context, accountID int64) error
-	// ListShadowsByParent 返回指定父账号的影子账号；当前实现仅查 quota_dimension='spark'（唯一预设）。
-	// ⚠️ 新增影子维度时：须更新此函数（或新增维度专用列举），并检查所有调用点（级联删除/一母一影校验/type 守卫），否则会静默漏掉新维度。
+	// ListShadowsByParent returns every linked child of the parent. Callers that
+	// need one dimension must filter with IsSparkShadow/IsLinkedAccount.
 	ListShadowsByParent(ctx context.Context, parentID int64) ([]*Account, error)
 }
 

--- a/backend/internal/service/account_spark_shadow_test.go
+++ b/backend/internal/service/account_spark_shadow_test.go
@@ -17,3 +17,20 @@ func TestAccountSparkShadowHelpers(t *testing.T) {
 	require.True(t, shadow.IsCredentialShadow())
 	require.Equal(t, QuotaDimensionSpark, shadow.QuotaDimensionOrDefault())
 }
+
+func TestCodexUsageSnapshotOwnerID(t *testing.T) {
+	parentID := int64(100)
+
+	require.Zero(t, codexUsageSnapshotOwnerID(nil))
+	require.Equal(t, int64(101), codexUsageSnapshotOwnerID(&Account{ID: 101}))
+	require.Equal(t, parentID, codexUsageSnapshotOwnerID(&Account{
+		ID:              102,
+		ParentAccountID: &parentID,
+		QuotaDimension:  QuotaDimensionLinked,
+	}))
+	require.Zero(t, codexUsageSnapshotOwnerID(&Account{
+		ID:              103,
+		ParentAccountID: &parentID,
+		QuotaDimension:  QuotaDimensionSpark,
+	}))
+}

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -345,10 +345,37 @@ func batchUsageErrorMessage(err error) string {
 	return err.Error()
 }
 
-func (s *AccountUsageService) getUsageForAccount(ctx context.Context, account *Account, forceProbe bool) (*UsageInfo, error) {
+// resolveUsageOwnerAccount returns the account whose quota and usage state own
+// the requested account's core usage data. Normal linked accounts always share
+// their parent's usage state, regardless of platform. Spark shadows keep their
+// own independent quota dimension and therefore resolve to themselves.
+func (s *AccountUsageService) resolveUsageOwnerAccount(ctx context.Context, account *Account) (*Account, error) {
 	if account == nil {
 		return nil, fmt.Errorf("account is required")
 	}
+	if !account.IsLinkedAccount() {
+		return account, nil
+	}
+
+	parent, err := s.accountRepo.GetByID(ctx, *account.ParentAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve linked account parent %d: %w", *account.ParentAccountID, err)
+	}
+	if parent == nil {
+		return nil, fmt.Errorf("linked account parent %d not found", *account.ParentAccountID)
+	}
+	if parent.IsShadow() {
+		return nil, fmt.Errorf("linked account parent %d is itself a shadow account", parent.ID)
+	}
+	return parent, nil
+}
+
+func (s *AccountUsageService) getUsageForAccount(ctx context.Context, account *Account, forceProbe bool) (*UsageInfo, error) {
+	usageAccount, err := s.resolveUsageOwnerAccount(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	account = usageAccount
 	accountID := account.ID
 
 	// Dedicated UI load-test accounts must remain fully interactive without ever
@@ -561,10 +588,13 @@ func (s *AccountUsageService) GetUsageBatch(ctx context.Context, accountIDs []in
 		g.Go(func() error {
 			var usage *UsageInfo
 			var usageErr error
-			if supportsAnthropicPassiveUsage(account) {
-				usage, usageErr = s.getPassiveUsageForAccount(gctx, account)
+			usageAccount, resolveErr := s.resolveUsageOwnerAccount(gctx, account)
+			if resolveErr != nil {
+				usageErr = resolveErr
+			} else if supportsAnthropicPassiveUsage(usageAccount) {
+				usage, usageErr = s.getPassiveUsageForAccount(gctx, usageAccount)
 			} else {
-				usage, usageErr = s.getUsageForAccount(gctx, account, force)
+				usage, usageErr = s.getUsageForAccount(gctx, usageAccount, force)
 			}
 
 			mu.Lock()
@@ -593,7 +623,11 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 		return nil, fmt.Errorf("get account failed: %w", err)
 	}
 
-	return s.getPassiveUsageForAccount(ctx, account)
+	usageAccount, err := s.resolveUsageOwnerAccount(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	return s.getPassiveUsageForAccount(ctx, usageAccount)
 }
 
 func (s *AccountUsageService) getPassiveUsageForAccount(ctx context.Context, account *Account) (*UsageInfo, error) {
@@ -716,22 +750,10 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	// Normal linked routes share the credential-owning parent's global Codex
-	// quota. Resolve that owner before reading cached windows, not only when a
-	// probe is needed: a linked row may still contain a complete legacy
-	// snapshot, which would otherwise make shouldRefreshOpenAICodexSnapshot
-	// return false and permanently mask the parent's 5h/7d windows.
-	snapshotAccount := account
-	if account.IsLinkedAccount() {
-		if parent, resolveErr := resolveCredentialAccount(ctx, s.accountRepo, account); resolveErr == nil && parent != nil {
-			snapshotAccount = parent
-		}
-	}
+	applyExtraToUsage(usage, account.Extra, now)
 
-	applyExtraToUsage(usage, snapshotAccount.Extra, now)
-
-	if (force || shouldRefreshOpenAICodexSnapshot(snapshotAccount, usage, now)) &&
-		s.shouldProbeOpenAICodexSnapshot(snapshotAccount.ID, now, force) {
+	if (force || shouldRefreshOpenAICodexSnapshot(account, usage, now)) &&
+		s.shouldProbeOpenAICodexSnapshot(account.ID, now, force) {
 		if account.IsSparkShadow() {
 			// Spark shadow accounts fetch usage from /wham/usage (bengalfox channel)
 			// via the shared OpenAIQuotaService, which resolves credentials from the
@@ -753,12 +775,12 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 				}
 			}
 		} else {
-			if updates, err := s.probeOpenAICodexSnapshot(ctx, snapshotAccount); err == nil && len(updates) > 0 {
-				mergeAccountExtra(snapshotAccount, updates)
+			if updates, err := s.probeOpenAICodexSnapshot(ctx, account); err == nil && len(updates) > 0 {
+				mergeAccountExtra(account, updates)
 				if usage.UpdatedAt == nil {
 					usage.UpdatedAt = &now
 				}
-				applyExtraToUsage(usage, snapshotAccount.Extra, now)
+				applyExtraToUsage(usage, account.Extra, now)
 			}
 		}
 	}

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -716,9 +716,22 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	applyExtraToUsage(usage, account.Extra, now)
+	// Normal linked routes share the credential-owning parent's global Codex
+	// quota. Resolve that owner before reading cached windows, not only when a
+	// probe is needed: a linked row may still contain a complete legacy
+	// snapshot, which would otherwise make shouldRefreshOpenAICodexSnapshot
+	// return false and permanently mask the parent's 5h/7d windows.
+	snapshotAccount := account
+	if account.IsLinkedAccount() {
+		if parent, resolveErr := resolveCredentialAccount(ctx, s.accountRepo, account); resolveErr == nil && parent != nil {
+			snapshotAccount = parent
+		}
+	}
 
-	if (force || shouldRefreshOpenAICodexSnapshot(account, usage, now)) && s.shouldProbeOpenAICodexSnapshot(account.ID, now, force) {
+	applyExtraToUsage(usage, snapshotAccount.Extra, now)
+
+	if (force || shouldRefreshOpenAICodexSnapshot(snapshotAccount, usage, now)) &&
+		s.shouldProbeOpenAICodexSnapshot(snapshotAccount.ID, now, force) {
 		if account.IsSparkShadow() {
 			// Spark shadow accounts fetch usage from /wham/usage (bengalfox channel)
 			// via the shared OpenAIQuotaService, which resolves credentials from the
@@ -740,19 +753,12 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 				}
 			}
 		} else {
-			probeAccount := account
-			if account.IsLinkedAccount() {
-				if parent, resolveErr := resolveCredentialAccount(ctx, s.accountRepo, account); resolveErr == nil && parent != nil {
-					probeAccount = parent
-					applyExtraToUsage(usage, parent.Extra, now)
-				}
-			}
-			if updates, err := s.probeOpenAICodexSnapshot(ctx, probeAccount); err == nil && len(updates) > 0 {
-				mergeAccountExtra(account, updates)
+			if updates, err := s.probeOpenAICodexSnapshot(ctx, snapshotAccount); err == nil && len(updates) > 0 {
+				mergeAccountExtra(snapshotAccount, updates)
 				if usage.UpdatedAt == nil {
 					usage.UpdatedAt = &now
 				}
-				applyExtraToUsage(usage, account.Extra, now)
+				applyExtraToUsage(usage, snapshotAccount.Extra, now)
 			}
 		}
 	}

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -719,7 +719,7 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 	applyExtraToUsage(usage, account.Extra, now)
 
 	if (force || shouldRefreshOpenAICodexSnapshot(account, usage, now)) && s.shouldProbeOpenAICodexSnapshot(account.ID, now, force) {
-		if account.IsShadow() {
+		if account.IsSparkShadow() {
 			// Spark shadow accounts fetch usage from /wham/usage (bengalfox channel)
 			// via the shared OpenAIQuotaService, which resolves credentials from the
 			// parent account.  The result is written to the shadow row's own codex_*
@@ -740,7 +740,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 				}
 			}
 		} else {
-			if updates, err := s.probeOpenAICodexSnapshot(ctx, account); err == nil && len(updates) > 0 {
+			probeAccount := account
+			if account.IsLinkedAccount() {
+				if parent, resolveErr := resolveCredentialAccount(ctx, s.accountRepo, account); resolveErr == nil && parent != nil {
+					probeAccount = parent
+					applyExtraToUsage(usage, parent.Extra, now)
+				}
+			}
+			if updates, err := s.probeOpenAICodexSnapshot(ctx, probeAccount); err == nil && len(updates) > 0 {
 				mergeAccountExtra(account, updates)
 				if usage.UpdatedAt == nil {
 					usage.UpdatedAt = &now

--- a/backend/internal/service/account_usage_service_batch_test.go
+++ b/backend/internal/service/account_usage_service_batch_test.go
@@ -189,3 +189,69 @@ func TestAccountUsageService_GetUsageBatch_BestEffortByAccount(t *testing.T) {
 		t.Fatalf("expected API key account error to be preserved, got %q", errorsByAccount[7003])
 	}
 }
+
+func TestAccountUsageService_GetUsageBatch_LinkedUsesParentCodexWindows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	parentID := int64(7101)
+	childID := int64(7102)
+	parentResetAt := now.Add(2 * time.Hour).Truncate(time.Second)
+	childResetAt := now.Add(4 * time.Hour).Truncate(time.Second)
+
+	repo := &stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:       parentID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra: map[string]any{
+					"codex_usage_updated_at": now.Format(time.RFC3339),
+					"codex_5h_used_percent":  12.0,
+					"codex_5h_reset_at":      parentResetAt.Format(time.RFC3339),
+					"codex_7d_used_percent":  34.0,
+					"codex_7d_reset_at":      parentResetAt.Add(24 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			{
+				ID:              childID,
+				Platform:        PlatformOpenAI,
+				Type:            AccountTypeOAuth,
+				ParentAccountID: &parentID,
+				QuotaDimension:  QuotaDimensionLinked,
+				Extra: map[string]any{
+					"codex_usage_updated_at": now.Format(time.RFC3339),
+					"codex_5h_used_percent":  91.0,
+					"codex_5h_reset_at":      childResetAt.Format(time.RFC3339),
+					"codex_7d_used_percent":  92.0,
+					"codex_7d_reset_at":      childResetAt.Add(24 * time.Hour).Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	svc := &AccountUsageService{
+		accountRepo:  repo,
+		usageLogRepo: &usageBatchLogRepoStub{},
+		cache:        NewUsageCache(),
+	}
+
+	usageByAccount, errorsByAccount, err := svc.GetUsageBatch(context.Background(), []int64{childID}, false)
+	if err != nil {
+		t.Fatalf("GetUsageBatch() error = %v", err)
+	}
+	if errorsByAccount[childID] != "" {
+		t.Fatalf("unexpected linked account usage error: %q", errorsByAccount[childID])
+	}
+
+	usage := usageByAccount[childID]
+	if usage == nil || usage.FiveHour == nil || usage.SevenDay == nil {
+		t.Fatalf("expected linked account Codex windows, got %#v", usage)
+	}
+	if usage.FiveHour.Utilization != 12.0 || usage.SevenDay.Utilization != 34.0 {
+		t.Fatalf(
+			"expected parent Codex windows 12/34, got %.1f/%.1f",
+			usage.FiveHour.Utilization,
+			usage.SevenDay.Utilization,
+		)
+	}
+}

--- a/backend/internal/service/account_usage_service_batch_test.go
+++ b/backend/internal/service/account_usage_service_batch_test.go
@@ -255,3 +255,77 @@ func TestAccountUsageService_GetUsageBatch_LinkedUsesParentCodexWindows(t *testi
 		)
 	}
 }
+
+func TestAccountUsageService_LinkedAnthropicUsesParentPassiveWindows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	parentID := int64(7201)
+	childID := int64(7202)
+	parentResetAt := now.Add(2 * time.Hour).Truncate(time.Second)
+	childResetAt := now.Add(4 * time.Hour).Truncate(time.Second)
+
+	repo := &stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:               parentID,
+				Platform:         PlatformAnthropic,
+				Type:             AccountTypeSetupToken,
+				SessionWindowEnd: &parentResetAt,
+				Extra: map[string]any{
+					"session_window_utilization":   0.23,
+					"passive_usage_7d_utilization": 0.45,
+					"passive_usage_7d_reset":       parentResetAt.Add(24 * time.Hour).Unix(),
+				},
+			},
+			{
+				ID:               childID,
+				Platform:         PlatformAnthropic,
+				Type:             AccountTypeSetupToken,
+				ParentAccountID:  &parentID,
+				QuotaDimension:   QuotaDimensionLinked,
+				SessionWindowEnd: &childResetAt,
+				Extra: map[string]any{
+					"session_window_utilization":   0.91,
+					"passive_usage_7d_utilization": 0.92,
+					"passive_usage_7d_reset":       childResetAt.Add(24 * time.Hour).Unix(),
+				},
+			},
+		},
+	}
+	svc := &AccountUsageService{
+		accountRepo:  repo,
+		usageLogRepo: &usageBatchLogRepoStub{},
+		cache:        NewUsageCache(),
+	}
+
+	usageByAccount, errorsByAccount, err := svc.GetUsageBatch(context.Background(), []int64{childID}, false)
+	if err != nil {
+		t.Fatalf("GetUsageBatch() error = %v", err)
+	}
+	if errorsByAccount[childID] != "" {
+		t.Fatalf("unexpected linked account usage error: %q", errorsByAccount[childID])
+	}
+	assertParentAnthropicUsage(t, usageByAccount[childID])
+
+	passiveUsage, err := svc.GetPassiveUsage(context.Background(), childID)
+	if err != nil {
+		t.Fatalf("GetPassiveUsage() error = %v", err)
+	}
+	assertParentAnthropicUsage(t, passiveUsage)
+}
+
+func assertParentAnthropicUsage(t *testing.T, usage *UsageInfo) {
+	t.Helper()
+
+	if usage == nil || usage.FiveHour == nil || usage.SevenDay == nil {
+		t.Fatalf("expected linked account Anthropic windows, got %#v", usage)
+	}
+	if usage.FiveHour.Utilization != 23.0 || usage.SevenDay.Utilization != 45.0 {
+		t.Fatalf(
+			"expected parent Anthropic windows 23/45, got %.1f/%.1f",
+			usage.FiveHour.Utilization,
+			usage.SevenDay.Utilization,
+		)
+	}
+}

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -617,6 +617,10 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 				"cannot change account type while it has linked accounts; delete them first")
 		}
 	}
+	// 影子账号允许在编辑时改绑到另一个母账号（复制出来的影子不一定要绑定复制的母账号）。
+	if err := s.changeShadowParent(ctx, account, input); err != nil {
+		return nil, err
+	}
 	wasOveragesEnabled := account.IsOveragesEnabled()
 
 	if input.Name != "" {
@@ -887,6 +891,62 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		return nil, err
 	}
 	return updated, nil
+}
+
+// changeShadowParent 处理影子账号在编辑时改绑母账号：仅影子账号且显式提供新
+// parent_account_id 时生效。新母账号必须存在、非影子、平台一致；spark 影子还
+// 要求母账号为 OpenAI OAuth 且目标母账号无其它 spark 影子（一母一影）。改绑后
+// 影子的代理恒继承新母账号（外审 B/P1），避免出现"有时继承、有时独立"的漂移。
+func (s *adminServiceImpl) changeShadowParent(ctx context.Context, account *Account, input *UpdateAccountInput) error {
+	if input == nil || input.ParentAccountID == nil || !account.IsCredentialShadow() {
+		return nil
+	}
+	newParentID := *input.ParentAccountID
+	if account.ParentAccountID != nil && *account.ParentAccountID == newParentID {
+		return nil
+	}
+	if account.ID == newParentID {
+		return infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_PARENT_SELF",
+			"shadow account cannot be linked to itself")
+	}
+	newParent, err := s.accountRepo.GetByID(ctx, newParentID)
+	if err != nil {
+		return infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_INVALID_PARENT",
+			"target parent account not found")
+	}
+	if newParent.IsCredentialShadow() {
+		return infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_PARENT_IS_SHADOW",
+			"target parent must be a real account, not another shadow")
+	}
+	if newParent.Platform != account.Platform {
+		return infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_PARENT_PLATFORM_MISMATCH",
+			"target parent platform must match the shadow account")
+	}
+	if newParent.Type != account.Type {
+		return infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_PARENT_TYPE_MISMATCH",
+			"target parent account type must match the shadow account")
+	}
+	if account.IsSparkShadow() {
+		if !newParent.IsOpenAIOAuth() {
+			return infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_INVALID_PARENT",
+				"spark shadow requires an OpenAI OAuth parent account")
+		}
+		shadows, serr := s.accountRepo.ListShadowsByParent(ctx, newParent.ID)
+		if serr != nil {
+			return serr
+		}
+		for _, existing := range shadows {
+			if existing != nil && existing.IsSparkShadow() && existing.ID != account.ID {
+				return infraerrors.New(http.StatusConflict, "SPARK_SHADOW_ALREADY_EXISTS",
+					"target parent already has a spark shadow account")
+			}
+		}
+	}
+	account.ParentAccountID = input.ParentAccountID
+	// 影子代理恒继承母账号：改绑后立即跟随新母账号的代理。
+	account.ProxyID = newParent.ProxyID
+	account.Proxy = nil
+	return nil
 }
 
 // UpdateAccountExtra 仅对 Extra JSONB 做 key 级合并，避免覆盖其它运行态键

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -98,6 +98,11 @@ var duplicateAccountDiscardedExtraKeys = map[string]struct{}{
 	"crs_account_id": {},
 	"crs_kind":       {},
 	"crs_synced_at":  {},
+	// Source account identity must not leak into the copy: a linked shadow
+	// displays the currently linked parent (parent_email), never the account
+	// it was duplicated from.
+	"email":         {},
+	"email_address": {},
 	// Local quota usage and derived window timestamps must start fresh.
 	"quota_used":            {},
 	"quota_daily_used":      {},
@@ -946,6 +951,11 @@ func (s *adminServiceImpl) changeShadowParent(ctx context.Context, account *Acco
 	// 影子代理恒继承母账号：改绑后立即跟随新母账号的代理。
 	account.ProxyID = newParent.ProxyID
 	account.Proxy = nil
+	// 复制来源的账号身份不再属于影子：改绑后清理残留身份键，展示统一走
+	// parent_* 回填（enrichShadowParentInfo），避免列表仍显示复制时的旧账号。
+	for _, key := range []string{"email", "email_address"} {
+		delete(account.Extra, key)
+	}
 	return nil
 }
 

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -168,6 +168,10 @@ func canDuplicateAccountType(accountType string) bool {
 	}
 }
 
+func canCreateLinkedDuplicate(source *Account) bool {
+	return source != nil && !source.IsShadow() && source.IsOpenAIOAuth()
+}
+
 func duplicateAccountGroups(source *Account) ([]AccountGroup, []int64) {
 	if len(source.AccountGroups) > 0 {
 		groups := make([]AccountGroup, 0, len(source.AccountGroups))
@@ -255,7 +259,8 @@ func (s *adminServiceImpl) DuplicateAccount(ctx context.Context, id int64, actor
 			"linked credential shadow accounts cannot be duplicated; duplicate the parent account instead",
 		)
 	}
-	if !canDuplicateAccountType(source.Type) {
+	linkedDuplicate := canCreateLinkedDuplicate(source)
+	if !linkedDuplicate && !canDuplicateAccountType(source.Type) {
 		return nil, infraerrors.BadRequest(
 			"ACCOUNT_DUPLICATE_CREDENTIAL_TYPE_UNSUPPORTED",
 			"accounts with rotating or unsupported credential types cannot be duplicated",
@@ -265,6 +270,9 @@ func (s *adminServiceImpl) DuplicateAccount(ctx context.Context, id int64, actor
 	credentials, err := cloneAccountJSONMap(source.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("clone account credentials: %w", err)
+	}
+	if linkedDuplicate {
+		credentials = sanitizeLinkedAccountCredentials(credentials)
 	}
 	extra, err := duplicateAccountExtra(source.Extra)
 	if err != nil {
@@ -320,6 +328,10 @@ func (s *adminServiceImpl) DuplicateAccount(ctx context.Context, id int64, actor
 	}
 	// A copied credential must be reviewed before it can share live traffic with its source.
 	duplicate.Schedulable = false
+	if linkedDuplicate {
+		duplicate.ParentAccountID = &source.ID
+		duplicate.QuotaDimension = QuotaDimensionLinked
+	}
 	if s.accountDuplicateRepo == nil {
 		return nil, errors.New("account duplicate repository is not configured")
 	}
@@ -578,15 +590,19 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	// 必须在此守住,否则仅在创建时的保证可被这些路径绕过。
 	if account.IsCredentialShadow() {
 		// 影子绝不持有凭据(凭据只在母账号)——外审 F5。
-		if !isAllowedSparkShadowCredentialsUpdate(input.Credentials) {
-			return nil, infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_NO_CREDENTIALS",
-				"spark shadow accounts do not hold auth credentials; only model mapping can be configured on the shadow account")
+		credentialsAllowed := isAllowedLinkedAccountCredentialsUpdate(input.Credentials)
+		if account.IsSparkShadow() {
+			credentialsAllowed = isAllowedSparkShadowCredentialsUpdate(input.Credentials)
+		}
+		if !credentialsAllowed {
+			return nil, infraerrors.Newf(http.StatusBadRequest, "LINKED_ACCOUNT_NO_CREDENTIALS",
+				"linked accounts do not hold auth credentials; only model mapping can be configured on the linked account")
 		}
 		// 影子 type 不可变——很多上游逻辑按 account.Type 分支(OAuth transform / ChatGPT
 		// header 注入 / WS OAuth 决策),改成 apikey 会让 spark 影子被选中后按错误协议转发(外审 G7)。
 		if input.Type != "" && input.Type != account.Type {
-			return nil, infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_IMMUTABLE_TYPE",
-				"spark shadow account type cannot be changed; it must remain an OpenAI OAuth shadow")
+			return nil, infraerrors.Newf(http.StatusBadRequest, "LINKED_ACCOUNT_IMMUTABLE_TYPE",
+				"linked account type cannot be changed; it must remain an OpenAI OAuth account")
 		}
 	} else if input.Type != "" && input.Type != account.Type && input.Type != AccountTypeOAuth {
 		// 母账号守卫(外审 D/P1):有 spark 影子的账号不能把 type 改出 OpenAI OAuth——影子读透母
@@ -597,8 +613,8 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 			return nil, serr
 		}
 		if len(shadows) > 0 {
-			return nil, infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_PARENT_IMMUTABLE_TYPE",
-				"cannot change account type while it has a spark shadow; delete the shadow first")
+			return nil, infraerrors.New(http.StatusBadRequest, "LINKED_ACCOUNT_PARENT_IMMUTABLE_TYPE",
+				"cannot change account type while it has linked accounts; delete them first")
 		}
 	}
 	wasOveragesEnabled := account.IsOveragesEnabled()
@@ -613,7 +629,11 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		account.Notes = normalizeAccountNotes(input.Notes)
 	}
 	if account.IsCredentialShadow() && input.Credentials != nil {
-		account.Credentials = sanitizeSparkShadowCredentials(input.Credentials)
+		if account.IsSparkShadow() {
+			account.Credentials = sanitizeSparkShadowCredentials(input.Credentials)
+		} else {
+			account.Credentials = sanitizeLinkedAccountCredentials(input.Credentials)
+		}
 	} else if len(input.Credentials) > 0 {
 		// 敏感子键采用"incoming 没提供就保留"的合并语义：前端响应已脱敏，
 		// 全对象 PUT 编辑时不会再带回 token，避免覆盖时清空已有凭证。
@@ -1219,14 +1239,14 @@ func (s *adminServiceImpl) resolveBulkUpdateTargetIDs(ctx context.Context, filte
 }
 
 func (s *adminServiceImpl) DeleteAccount(ctx context.Context, id int64) error {
-	// 级联删除 spark 影子账号（先删影子，再删母账号）
+	// Delete linked routes before their credential-owning parent.
 	shadows, err := s.accountRepo.ListShadowsByParent(ctx, id)
 	if err != nil {
-		return fmt.Errorf("list spark shadows for cascade delete: %w", err)
+		return fmt.Errorf("list linked accounts for cascade delete: %w", err)
 	}
 	for _, shadow := range shadows {
 		if err := s.accountRepo.Delete(ctx, shadow.ID); err != nil {
-			return fmt.Errorf("cascade delete spark shadow %d: %w", shadow.ID, err)
+			return fmt.Errorf("cascade delete linked account %d: %w", shadow.ID, err)
 		}
 	}
 	if err := s.accountRepo.Delete(ctx, id); err != nil {
@@ -1317,9 +1337,11 @@ func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opt
 	if err != nil {
 		return nil, fmt.Errorf("check existing spark shadows: %w", err)
 	}
-	if len(shadows) > 0 {
-		return nil, infraerrors.New(http.StatusConflict, "SPARK_SHADOW_ALREADY_EXISTS",
-			"parent account already has a spark shadow account")
+	for _, existing := range shadows {
+		if existing != nil && existing.IsSparkShadow() {
+			return nil, infraerrors.New(http.StatusConflict, "SPARK_SHADOW_ALREADY_EXISTS",
+				"parent account already has a spark shadow account")
+		}
 	}
 
 	// 3. 解析分组。未指定 GroupIDs 时:优先**继承母账号当前分组**(影子与母同路由域,母在自定义
@@ -1390,9 +1412,13 @@ func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opt
 	// 5. 持久化（Create 填充 shadow.ID）。并发竞态:预查(步骤2)放行后另一请求抢先建成,本次会撞
 	// 一母一影唯一索引。复查确认确为"已存在"竞态时返回结构化 409 而非裸 500——外审 A/P1。
 	if err := s.accountRepo.Create(ctx, shadow); err != nil {
-		if existing, qerr := s.accountRepo.ListShadowsByParent(ctx, parentID); qerr == nil && len(existing) > 0 {
-			return nil, infraerrors.New(http.StatusConflict, "SPARK_SHADOW_ALREADY_EXISTS",
-				"parent account already has a spark shadow account")
+		if existing, qerr := s.accountRepo.ListShadowsByParent(ctx, parentID); qerr == nil {
+			for _, candidate := range existing {
+				if candidate != nil && candidate.IsSparkShadow() {
+					return nil, infraerrors.New(http.StatusConflict, "SPARK_SHADOW_ALREADY_EXISTS",
+						"parent account already has a spark shadow account")
+				}
+			}
 		}
 		return nil, fmt.Errorf("create spark shadow: %w", err)
 	}

--- a/backend/internal/service/admin_account_change_parent_test.go
+++ b/backend/internal/service/admin_account_change_parent_test.go
@@ -230,3 +230,46 @@ func TestAdminUpdateAccountIgnoresParentForNonShadow(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, updated.ParentAccountID)
 }
+
+func TestAdminUpdateAccountChangeShadowParentDropsSourceIdentity(t *testing.T) {
+	shadowID := int64(100)
+	oldParentID := int64(10)
+	newParentID := int64(20)
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+		shadowID: {
+			ID:              shadowID,
+			Name:            "linked-shadow",
+			Platform:        PlatformOpenAI,
+			Type:            AccountTypeOAuth,
+			ParentAccountID: &oldParentID,
+			QuotaDimension:  QuotaDimensionLinked,
+			Status:          StatusActive,
+			Extra: map[string]any{
+				// 复制来源残留的身份键，改绑后必须清理。
+				"email":          "copied@example.com",
+				"email_address":  "copied@example.com",
+				"codex_cli_only": true,
+			},
+		},
+		oldParentID: {
+			ID:       oldParentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+		newParentID: {
+			ID:       newParentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	updated, err := svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &newParentID})
+	require.NoError(t, err)
+	require.Equal(t, newParentID, *updated.ParentAccountID)
+	require.NotContains(t, updated.Extra, "email")
+	require.NotContains(t, updated.Extra, "email_address")
+	require.Equal(t, true, updated.Extra["codex_cli_only"])
+}

--- a/backend/internal/service/admin_account_change_parent_test.go
+++ b/backend/internal/service/admin_account_change_parent_test.go
@@ -1,0 +1,232 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// changeParentRepo 复用上游计费探测的轻量 fake repo，并额外实现 spark 影子
+// 所需的一母一影查询，避免在核心测试里引入真实 DB。
+type changeParentRepo struct {
+	*upstreamBillingProbeAccountRepo
+	shadowsByParent map[int64][]*Account
+}
+
+func (r *changeParentRepo) ListShadowsByParent(_ context.Context, parentID int64) ([]*Account, error) {
+	return r.shadowsByParent[parentID], nil
+}
+
+func TestAdminUpdateAccountChangeShadowParentLinked(t *testing.T) {
+	shadowID := int64(100)
+	oldParentID := int64(10)
+	newParentID := int64(20)
+	oldProxy := int64(9)
+	newProxy := int64(29)
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+		shadowID: {
+			ID:              shadowID,
+			Name:            "linked-shadow",
+			Platform:        PlatformOpenAI,
+			Type:            AccountTypeOAuth,
+			ParentAccountID: &oldParentID,
+			QuotaDimension:  QuotaDimensionLinked,
+			ProxyID:         &oldProxy,
+			Status:          StatusActive,
+		},
+		oldParentID: {
+			ID:       oldParentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+		newParentID: {
+			ID:       newParentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+			ProxyID:  &newProxy,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	updated, err := svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{
+		ParentAccountID: &newParentID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentAccountID)
+	require.Equal(t, newParentID, *updated.ParentAccountID)
+	require.NotNil(t, updated.ProxyID)
+	require.Equal(t, newProxy, *updated.ProxyID)
+}
+
+func TestAdminUpdateAccountChangeShadowParentErrors(t *testing.T) {
+	shadowID := int64(100)
+	oldParentID := int64(10)
+	otherShadowID := int64(30)
+	missingID := int64(999)
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+		shadowID: {
+			ID:              shadowID,
+			Name:            "linked-shadow",
+			Platform:        PlatformOpenAI,
+			Type:            AccountTypeOAuth,
+			ParentAccountID: &oldParentID,
+			QuotaDimension:  QuotaDimensionLinked,
+			Status:          StatusActive,
+		},
+		oldParentID: {
+			ID:       oldParentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+		otherShadowID: {
+			ID:              otherShadowID,
+			Platform:        PlatformOpenAI,
+			Type:            AccountTypeOAuth,
+			ParentAccountID: &oldParentID,
+			QuotaDimension:  QuotaDimensionLinked,
+			Status:          StatusActive,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	// 自关联
+	selfID := shadowID
+	_, err := svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &selfID})
+	require.ErrorContains(t, err, "cannot be linked to itself")
+
+	// 目标不存在
+	_, err = svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &missingID})
+	require.ErrorContains(t, err, "target parent account not found")
+
+	// 目标是影子
+	_, err = svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &otherShadowID})
+	require.ErrorContains(t, err, "not another shadow")
+
+	// 平台不一致
+	otherPlatformID := int64(40)
+	repo.accounts[otherPlatformID] = &Account{
+		ID:       otherPlatformID,
+		Platform: PlatformDeepseek,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+	}
+	_, err = svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &otherPlatformID})
+	require.ErrorContains(t, err, "platform must match")
+}
+
+func TestAdminUpdateAccountChangeSparkShadowParentConflict(t *testing.T) {
+	shadowID := int64(100)
+	oldParentID := int64(10)
+	newParentID := int64(20)
+	existingSparkID := int64(200)
+	repo := &changeParentRepo{
+		upstreamBillingProbeAccountRepo: &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+			shadowID: {
+				ID:              shadowID,
+				Name:            "spark-shadow",
+				Platform:        PlatformOpenAI,
+				Type:            AccountTypeOAuth,
+				ParentAccountID: &oldParentID,
+				QuotaDimension:  QuotaDimensionSpark,
+				Status:          StatusActive,
+			},
+			oldParentID: {
+				ID:       oldParentID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+			},
+			newParentID: {
+				ID:       newParentID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+			},
+			existingSparkID: {
+				ID:              existingSparkID,
+				Platform:        PlatformOpenAI,
+				Type:            AccountTypeOAuth,
+				ParentAccountID: &newParentID,
+				QuotaDimension:  QuotaDimensionSpark,
+				Status:          StatusActive,
+			},
+		}},
+		shadowsByParent: map[int64][]*Account{
+			newParentID: {
+				{ID: existingSparkID, ParentAccountID: &newParentID, QuotaDimension: QuotaDimensionSpark},
+			},
+		},
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	_, err := svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &newParentID})
+	require.ErrorContains(t, err, "already has a spark shadow account")
+}
+
+func TestAdminUpdateAccountChangeSparkShadowParentOK(t *testing.T) {
+	shadowID := int64(100)
+	oldParentID := int64(10)
+	newParentID := int64(20)
+	newProxy := int64(29)
+	repo := &changeParentRepo{
+		upstreamBillingProbeAccountRepo: &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+			shadowID: {
+				ID:              shadowID,
+				Name:            "spark-shadow",
+				Platform:        PlatformOpenAI,
+				Type:            AccountTypeOAuth,
+				ParentAccountID: &oldParentID,
+				QuotaDimension:  QuotaDimensionSpark,
+				Status:          StatusActive,
+			},
+			oldParentID: {
+				ID:       oldParentID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+			},
+			newParentID: {
+				ID:       newParentID,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+				ProxyID:  &newProxy,
+			},
+		}},
+		shadowsByParent: map[int64][]*Account{},
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	updated, err := svc.UpdateAccount(context.Background(), shadowID, &UpdateAccountInput{ParentAccountID: &newParentID})
+	require.NoError(t, err)
+	require.Equal(t, newParentID, *updated.ParentAccountID)
+	require.Equal(t, newProxy, *updated.ProxyID)
+}
+
+func TestAdminUpdateAccountIgnoresParentForNonShadow(t *testing.T) {
+	accountID := int64(100)
+	parentID := int64(20)
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+		accountID: {
+			ID:       accountID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+		parentID: {
+			ID:       parentID,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	updated, err := svc.UpdateAccount(context.Background(), accountID, &UpdateAccountInput{ParentAccountID: &parentID})
+	require.NoError(t, err)
+	require.Nil(t, updated.ParentAccountID)
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -393,6 +393,7 @@ type UpdateAccountInput struct {
 	Name                  string
 	Notes                 *string
 	Type                  string // Account type: oauth, setup-token, apikey
+	ParentAccountID       *int64 // 影子账号可改绑的母账号；仅影子账号生效
 	Credentials           map[string]any
 	Extra                 map[string]any
 	ProxyID               *int64

--- a/backend/internal/service/admin_service_duplicate_account_test.go
+++ b/backend/internal/service/admin_service_duplicate_account_test.go
@@ -259,16 +259,25 @@ func TestDuplicateOpenAIOAuthCreatesLinkedRouteWithoutTokens(t *testing.T) {
 	require.Equal(t, source.GroupIDs, duplicate.GroupIDs)
 }
 
-func TestDuplicateAccountRejectsRotatingOrUnknownCredentialTypes(t *testing.T) {
-	for _, accountType := range []string{AccountTypeOAuth, AccountTypeSetupToken, "legacy-cookie"} {
-		t.Run(accountType, func(t *testing.T) {
+func TestDuplicateAccountRejectsUnsupportedCredentialTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    string
+		accountType string
+	}{
+		{name: "non_openai_oauth", platform: PlatformAnthropic, accountType: AccountTypeOAuth},
+		{name: "setup_token", platform: PlatformOpenAI, accountType: AccountTypeSetupToken},
+		{name: "unknown", platform: PlatformOpenAI, accountType: "legacy-cookie"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			repo := newDuplicateAccountRepoStub()
 			svc := &adminServiceImpl{accountRepo: repo, accountDuplicateRepo: repo}
 			source := &Account{
 				Name:        "rotating-credential-account",
-				Platform:    PlatformOpenAI,
-				Type:        accountType,
+				Platform:    tt.platform,
+				Type:        tt.accountType,
 				Credentials: map[string]any{"refresh_token": "shared-token"},
 			}
 			require.NoError(t, repo.Create(ctx, source))

--- a/backend/internal/service/admin_service_duplicate_account_test.go
+++ b/backend/internal/service/admin_service_duplicate_account_test.go
@@ -222,6 +222,43 @@ func TestDuplicateAccountRejectsCredentialShadow(t *testing.T) {
 	require.Len(t, repo.accounts, 1)
 }
 
+func TestDuplicateOpenAIOAuthCreatesLinkedRouteWithoutTokens(t *testing.T) {
+	ctx := context.Background()
+	repo := newDuplicateAccountRepoStub()
+	svc := &adminServiceImpl{accountRepo: repo, accountDuplicateRepo: repo}
+	source := &Account{
+		Name:        "codex-parent",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 4,
+		Credentials: map[string]any{
+			"access_token":          "access-secret",
+			"refresh_token":         "refresh-secret",
+			"chatgpt_account_id":    "workspace-1",
+			"model_mapping":         map[string]any{"gpt-5.6-sol": "gpt-5.6-sol"},
+			"compact_model_mapping": map[string]any{"gpt-5.6-sol": "gpt-5.6-sol"},
+		},
+		GroupIDs:      []int64{7},
+		AccountGroups: []AccountGroup{{GroupID: 7, Priority: 25}},
+	}
+	require.NoError(t, repo.Create(ctx, source))
+
+	duplicate, err := svc.DuplicateAccount(ctx, source.ID, "admin:1", "")
+
+	require.NoError(t, err)
+	require.NotNil(t, duplicate.ParentAccountID)
+	require.Equal(t, source.ID, *duplicate.ParentAccountID)
+	require.Equal(t, QuotaDimensionLinked, duplicate.QuotaDimension)
+	require.Equal(t, AccountTypeOAuth, duplicate.Type)
+	require.False(t, duplicate.Schedulable)
+	require.NotContains(t, duplicate.Credentials, "access_token")
+	require.NotContains(t, duplicate.Credentials, "refresh_token")
+	require.NotContains(t, duplicate.Credentials, "chatgpt_account_id")
+	require.Equal(t, source.Credentials["model_mapping"], duplicate.Credentials["model_mapping"])
+	require.Equal(t, source.Credentials["compact_model_mapping"], duplicate.Credentials["compact_model_mapping"])
+	require.Equal(t, source.GroupIDs, duplicate.GroupIDs)
+}
+
 func TestDuplicateAccountRejectsRotatingOrUnknownCredentialTypes(t *testing.T) {
 	for _, accountType := range []string{AccountTypeOAuth, AccountTypeSetupToken, "legacy-cookie"} {
 		t.Run(accountType, func(t *testing.T) {

--- a/backend/internal/service/admin_service_duplicate_account_test.go
+++ b/backend/internal/service/admin_service_duplicate_account_test.go
@@ -259,6 +259,36 @@ func TestDuplicateOpenAIOAuthCreatesLinkedRouteWithoutTokens(t *testing.T) {
 	require.Equal(t, source.GroupIDs, duplicate.GroupIDs)
 }
 
+func TestDuplicateOpenAIOAuthLinkedShadowDropsSourceIdentity(t *testing.T) {
+	ctx := context.Background()
+	repo := newDuplicateAccountRepoStub()
+	svc := &adminServiceImpl{accountRepo: repo, accountDuplicateRepo: repo}
+	source := &Account{
+		Name:     "codex-parent",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"email":          "copied@example.com",
+			"email_address":  "copied@example.com",
+			"codex_cli_only": true,
+		},
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.6-sol": "gpt-5.6-sol"},
+		},
+		GroupIDs: []int64{7},
+	}
+	require.NoError(t, repo.Create(ctx, source))
+
+	duplicate, err := svc.DuplicateAccount(ctx, source.ID, "admin:1", "")
+
+	require.NoError(t, err)
+	require.NotNil(t, duplicate.ParentAccountID)
+	// 复制来源的账号身份不得进入影子 Extra：列表展示走当前关联母账号的 parent_email。
+	require.NotContains(t, duplicate.Extra, "email")
+	require.NotContains(t, duplicate.Extra, "email_address")
+	require.Equal(t, true, duplicate.Extra["codex_cli_only"])
+}
+
 func TestDuplicateAccountRejectsUnsupportedCredentialTypes(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/backend/internal/service/admin_service_spark_shadow_test.go
+++ b/backend/internal/service/admin_service_spark_shadow_test.go
@@ -390,7 +390,12 @@ func TestPersistOpenAICodexSnapshot_SkipsShadow(t *testing.T) {
 	t.Run("shadow_skipped", func(t *testing.T) {
 		spy := &updateExtraSpyRepo{sparkShadowRepoStub: newSparkShadowRepoStub()}
 		s := &RateLimitService{accountRepo: spy}
-		shadow := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, ParentAccountID: &parentID}
+		shadow := &Account{
+			Platform:        PlatformOpenAI,
+			Type:            AccountTypeOAuth,
+			ParentAccountID: &parentID,
+			QuotaDimension:  QuotaDimensionSpark,
+		}
 		s.persistOpenAICodexSnapshot(context.Background(), shadow, headers)
 		require.False(t, spy.updateExtraCalled, "影子不应写 codex_* 头快照")
 	})

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -693,10 +693,12 @@ func SettingKeyAuthSourcePlatformQuotas(source string) string {
 	return fmt.Sprintf("auth_source_default_%s_platform_quotas", source)
 }
 
-// QuotaDimension constants for spark shadow accounts.
+// QuotaDimension constants for linked OpenAI OAuth accounts.
 const (
 	QuotaDimensionGlobal = "global"
 	QuotaDimensionSpark  = "spark"
+	// QuotaDimensionLinked shares the parent's global Codex quota and credentials.
+	QuotaDimensionLinked = "linked"
 )
 
 // AdminAPIKeyPrefix is the prefix for admin API keys (distinct from user "sk-" keys).

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -693,11 +693,11 @@ func SettingKeyAuthSourcePlatformQuotas(source string) string {
 	return fmt.Sprintf("auth_source_default_%s_platform_quotas", source)
 }
 
-// QuotaDimension constants for linked OpenAI OAuth accounts.
+// QuotaDimension constants for accounts that share credentials with a parent.
 const (
 	QuotaDimensionGlobal = "global"
 	QuotaDimensionSpark  = "spark"
-	// QuotaDimensionLinked shares the parent's global Codex quota and credentials.
+	// QuotaDimensionLinked shares the parent's core usage state and credentials.
 	QuotaDimensionLinked = "linked"
 )
 

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -161,7 +161,7 @@ func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context
 	}
 	// Spark 影子：不按 /responses 429 的 global x-codex-* 信号做内存运行时熔断(同 handle429,外审第8轮 P1)。
 	// 同时避免把 spark 的 429 计入全局 429 storm 计数(recordOpenAIOAuth429),否则会误伤母账号 failover 决策。
-	if account.IsShadow() {
+	if account.IsSparkShadow() {
 		return
 	}
 	s.recordOpenAIOAuth429()
@@ -186,7 +186,7 @@ func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context
 }
 
 func (s *OpenAIGatewayService) shouldRetryOpenAIOAuth429OnSameAccount(account *Account, statusCode int, shouldDisable bool) bool {
-	if shouldDisable || statusCode != http.StatusTooManyRequests || !isOpenAIOAuthAccount(account) || account.IsShadow() {
+	if shouldDisable || statusCode != http.StatusTooManyRequests || !isOpenAIOAuthAccount(account) || account.IsSparkShadow() {
 		return false
 	}
 	// markOpenAIOAuth429RateLimited parks the account once the window expires.
@@ -200,14 +200,14 @@ func (s *OpenAIGatewayService) shouldRetryOpenAIOAuth429OnSameAccount(account *A
 // ShouldRetryOpenAIOAuth429 lets RateLimitService defer persistent account
 // cooldown until the gateway's same-account retry window is exhausted.
 func (s *OpenAIGatewayService) ShouldRetryOpenAIOAuth429(account *Account, _ http.Header, _ []byte) bool {
-	if s == nil || !isOpenAIOAuthAccount(account) || account.IsShadow() || s.isOpenAIAccountRuntimeBlocked(account) {
+	if s == nil || !isOpenAIOAuthAccount(account) || account.IsSparkShadow() || s.isOpenAIAccountRuntimeBlocked(account) {
 		return false
 	}
 	return s.openAIOAuth429RetryWindowActive(account)
 }
 
 func (s *OpenAIGatewayService) openAIOAuth429RetryWindowActive(account *Account) bool {
-	if s == nil || !isOpenAIOAuthAccount(account) || account.IsShadow() {
+	if s == nil || !isOpenAIOAuthAccount(account) || account.IsSparkShadow() {
 		return false
 	}
 	now := time.Now()
@@ -221,7 +221,7 @@ func (s *OpenAIGatewayService) openAIOAuth429RetryWindowActive(account *Account)
 }
 
 func (s *OpenAIGatewayService) openAIOAuth429RetryDeadline(account *Account) time.Time {
-	if s == nil || !isOpenAIOAuthAccount(account) || account.IsShadow() {
+	if s == nil || !isOpenAIOAuthAccount(account) || account.IsSparkShadow() {
 		return time.Time{}
 	}
 	value, ok := s.openaiOAuth429RetryStartedAt.Load(account.ID)

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -392,12 +392,8 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 
 	// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
 	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if handleErr == nil && account.Type == AccountTypeOAuth && !account.IsShadow() {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-		}
-	} else if handleErr == nil && account.IsShadow() && account.ParentAccountID != nil {
-		notifyOpenAIAutoReset(*account.ParentAccountID)
+	if handleErr == nil && account.Type == AccountTypeOAuth {
+		s.updateCodexUsageSnapshotFromHeadersForAccount(ctx, account, resp.Header)
 	}
 
 	return result, handleErr

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -1181,12 +1181,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 		// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
 		// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-		if account.UsesOpenAICodexProtocol() && !account.IsShadow() {
-			if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-				s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-			}
-		} else if account.IsShadow() && account.ParentAccountID != nil {
-			notifyOpenAIAutoReset(*account.ParentAccountID)
+		if account.UsesOpenAICodexProtocol() {
+			s.updateCodexUsageSnapshotFromHeadersForAccount(ctx, account, resp.Header)
 		}
 
 		if usage == nil {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -509,12 +509,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 
 	// Extract and save Codex usage snapshot from response headers (for OAuth accounts).
 	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if handleErr == nil && account.Type == AccountTypeOAuth && !account.IsShadow() && account.Platform != PlatformGrok {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-		}
-	} else if handleErr == nil && account.IsShadow() && account.ParentAccountID != nil {
-		notifyOpenAIAutoReset(*account.ParentAccountID)
+	if handleErr == nil && account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
+		s.updateCodexUsageSnapshotFromHeadersForAccount(ctx, account, resp.Header)
 	}
 
 	return result, handleErr

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -505,13 +505,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	s.bindHTTPResponseAccount(ctx, c, account, responseID)
 
 	// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
-	if !account.IsShadow() {
-		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
-		}
-	} else if account.ParentAccountID != nil {
-		notifyOpenAIAutoReset(*account.ParentAccountID)
-	}
+	s.updateCodexUsageSnapshotFromHeadersForAccount(ctx, account, resp.Header)
 
 	if usage == nil {
 		usage = &OpenAIUsage{}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -1498,7 +1498,30 @@ func (s *OpenAIGatewayService) tryAcquireAccountSlot(ctx context.Context, accoun
 	if s.concurrencyService == nil {
 		return &AcquireResult{Acquired: true, ReleaseFunc: func() {}}, nil
 	}
+	if s.schedulerSnapshot != nil && s.accountRepo != nil {
+		if account, err := s.schedulerSnapshot.GetAccount(ctx, accountID); err == nil && account != nil && account.IsLinkedAccount() {
+			if parent, parentErr := s.schedulerSnapshot.GetAccount(ctx, *account.ParentAccountID); parentErr == nil && parent != nil {
+				accountID = parent.ID
+				maxConcurrency = parent.Concurrency
+			}
+		}
+	}
 	return s.concurrencyService.AcquireAccountSlot(ctx, accountID, maxConcurrency)
+}
+
+// OpenAIConcurrencyOwner returns the shared slot owner for a selected route.
+// Normal linked routes consume the parent's global concurrency; Spark keeps an
+// independent slot because it represents a separate quota dimension.
+func (s *OpenAIGatewayService) OpenAIConcurrencyOwner(ctx context.Context, account *Account) (int64, int) {
+	if account == nil {
+		return 0, 0
+	}
+	if account.IsLinkedAccount() && s.accountRepo != nil {
+		if parent, err := resolveCredentialAccount(ctx, s.accountRepo, account); err == nil && parent != nil {
+			return parent.ID, parent.Concurrency
+		}
+	}
+	return account.ID, account.Concurrency
 }
 
 func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -1050,9 +1050,35 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 	return updates
 }
 
+func codexUsageSnapshotOwnerID(account *Account) int64 {
+	if account == nil || account.IsSparkShadow() {
+		return 0
+	}
+	if account.IsLinkedAccount() && account.ParentAccountID != nil {
+		return *account.ParentAccountID
+	}
+	return account.ID
+}
+
+func (s *OpenAIGatewayService) updateCodexUsageSnapshotFromHeadersForAccount(ctx context.Context, account *Account, headers http.Header) {
+	if account == nil || headers == nil {
+		return
+	}
+	accountID := codexUsageSnapshotOwnerID(account)
+	if accountID <= 0 {
+		if account.IsSparkShadow() && account.ParentAccountID != nil {
+			notifyOpenAIAutoReset(*account.ParentAccountID)
+		}
+		return
+	}
+	if snapshot := ParseCodexRateLimitHeaders(headers); snapshot != nil {
+		s.updateCodexUsageSnapshot(ctx, accountID, snapshot)
+	}
+}
+
 // updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field
 // updateCodexUsageSnapshot 把 /responses 的 x-codex-* 全局头快照写入账号 codex_* Extra。
-// ⚠️ 调用方必须排除 spark 影子账号(account.IsShadow()):影子的 codex_* 仅由 QueryUsage
+// ⚠️ 调用方必须排除 spark 影子账号(account.IsSparkShadow()):影子的 codex_* 仅由 QueryUsage
 // (/wham/usage bengalfox 道)更新,不能被全局头口径污染(外审第7轮 P1)。本函数仅持 accountID,
 // 无法在此自检影子,故守卫前置到各调用点。
 func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot) {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -286,6 +286,14 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 // 返回是否应该停止该账号的调度
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) (shouldDisable bool) {
 	ctx = withTempUnschedulableModel(ctx, requestedModel)
+	if account != nil && account.IsLinkedAccount() {
+		// Normal linked routes share every global/auth state transition with the
+		// credential-owning parent. Spark is intentionally excluded because its
+		// quota window is independent.
+		if parent, err := resolveCredentialAccount(ctx, s.accountRepo, account); err == nil && parent != nil {
+			account = parent
+		}
+	}
 	// Team 联动熔断必须先于池模式/自定义错误码/临时不可调度的各类早退；
 	// 同请求内与 fastpath 调用点的重复触发由方法内去重吸收。
 	s.maybeHandleOpenAITeamLinkedError(ctx, account, statusCode, responseBody)
@@ -1095,7 +1103,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	// 套到影子会把 spark 误耦合到 global 窗口——即便 spark 仍有配额也会被冷却到 global reset,
 	// 单影子场景直接变成无可用账号(外审第8轮 P1)。整段跳过;影子的 codex_* 仅由 account_usage 的
 	// QueryUsage→persistOpenAICodexProbeSnapshot 维护,枯竭由调度守卫处理。
-	if account.IsShadow() {
+	if account.IsSparkShadow() {
 		if account.ParentAccountID != nil {
 			notifyOpenAIAutoReset(*account.ParentAccountID)
 		}
@@ -1615,7 +1623,7 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 	}
 	// spark 影子的 codex_* 仅由 QueryUsage(/wham/usage bengalfox 道)更新,不能被 /responses 的
 	// x-codex-* 全局头快照污染(外审第7轮 P1,与 updateCodexUsageSnapshot 同口径)。
-	if account.IsShadow() {
+	if account.IsSparkShadow() {
 		return
 	}
 	snapshot := ParseCodexRateLimitHeaders(headers)

--- a/backend/internal/service/shadow_routing.go
+++ b/backend/internal/service/shadow_routing.go
@@ -1,6 +1,6 @@
 package service
 
-// parentHealthyForShadow 报告 spark 影子账号的母账号凭据是否可用(影子据此可被调度)。
+// parentHealthyForShadow reports whether a linked account's parent can serve it.
 //
 // 非影子账号直接返回 true（不受此检查约束）。
 // lookup 将母账号 ID 解析为当前 Account（来自调度快照 map 或 repo）。
@@ -21,7 +21,17 @@ func parentHealthyForShadow(account *Account, lookup func(int64) *Account) bool 
 	if parent == nil {
 		return false
 	}
-	return parent.IsOpenAIOAuth() && parent.IsCredentialUsableForShadow()
+	if !parent.IsOpenAIOAuth() {
+		return false
+	}
+	if account.IsLinkedAccount() {
+		// A normal linked route shares the parent's global quota and operational
+		// state, while retaining its own route-level schedulable switch.
+		return parent.IsSchedulable() && parent.IsCredentialUsableForShadow()
+	}
+	// Spark has an independent quota bucket, so only shared credential and
+	// transport health cascade from the parent.
+	return parent.IsCredentialUsableForShadow()
 }
 
 // sparkModelVariants 返回所有归一到 spark 的模型 ID（当前仅 base：spark 无 effort 变体）。

--- a/backend/migrations/231_account_linked_routes.sql
+++ b/backend/migrations/231_account_linked_routes.sql
@@ -1,0 +1,7 @@
+-- Add the generic linked Codex route dimension. Linked routes own routing
+-- configuration but resolve OAuth credentials and global quota state through
+-- parent_account_id.
+ALTER TABLE accounts DROP CONSTRAINT IF EXISTS chk_accounts_quota_dimension;
+ALTER TABLE accounts ADD CONSTRAINT chk_accounts_quota_dimension
+  CHECK (quota_dimension IN ('global','spark','linked')) NOT VALID;
+ALTER TABLE accounts VALIDATE CONSTRAINT chk_accounts_quota_dimension;

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -29,11 +29,11 @@
       <!-- 影子账号(复制出来)：支持改绑到另一个母账号，不一定是复制的账号 -->
       <div v-if="isSparkShadow" class="space-y-2">
         <label class="input-label">{{ t('admin.accounts.shadowParent') }}</label>
-        <select v-model="parentAccountId" class="input" data-tour="edit-account-form-shadow-parent">
-          <option v-for="p in shadowParentCandidates" :key="p.id" :value="p.id">
-            {{ p.name }} (#{{ p.id }})
-          </option>
-        </select>
+        <Select
+          v-model="parentAccountId"
+          :options="shadowParentOptions"
+          data-tour="edit-account-form-shadow-parent"
+        />
         <p class="input-hint">{{ t('admin.accounts.shadowParentHint') }}</p>
       </div>
 
@@ -2954,6 +2954,20 @@ const shadowParentCandidates = computed<Account[]>(() => {
       a.platform === account.platform &&
       a.type === account.type
   )
+})
+
+// 与其它表单下拉统一走 common/Select，options 为 { value, label }。
+const shadowParentOptions = computed(() => {
+  const options = shadowParentCandidates.value.map((p) => ({
+    value: p.id,
+    label: `${p.name} (#${p.id})`
+  }))
+  const currentId = parentAccountId.value
+  if (currentId != null && !options.some((option) => option.value === currentId)) {
+    // 账号列表缺失当前母账号时兜底展示，避免控件显示为空。
+    options.unshift({ value: currentId, label: `#${currentId}` })
+  }
+  return options
 })
 
 const hideAccountLongContextBilling = computed(() => {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -26,6 +26,17 @@
         <p class="input-hint">{{ t('admin.accounts.notesHint') }}</p>
       </div>
 
+      <!-- 影子账号(复制出来)：支持改绑到另一个母账号，不一定是复制的账号 -->
+      <div v-if="isSparkShadow" class="space-y-2">
+        <label class="input-label">{{ t('admin.accounts.shadowParent') }}</label>
+        <select v-model="parentAccountId" class="input" data-tour="edit-account-form-shadow-parent">
+          <option v-for="p in shadowParentCandidates" :key="p.id" :value="p.id">
+            {{ p.name }} (#{{ p.id }})
+          </option>
+        </select>
+        <p class="input-hint">{{ t('admin.accounts.shadowParentHint') }}</p>
+      </div>
+
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
         <div v-if="!isCNApiKeyAccount || editApiProtocol !== 'adaptive'">
@@ -2912,6 +2923,8 @@ interface Props {
   account: Account | null
   proxies: Proxy[]
   groups: AdminGroup[]
+  // 候选母账号列表（仅影子账号改绑用）：过滤出同平台、同类型、非影子的真实账号。
+  accounts?: Account[]
 }
 
 const props = defineProps<Props>()
@@ -2927,6 +2940,21 @@ const authStore = useAuthStore()
 // Spark 影子账号(parent_account_id 非空):代理恒继承母账号,不可独立编辑(外审 B/P1),
 // 故隐藏代理选择器。
 const isSparkShadow = computed(() => props.account?.parent_account_id != null)
+
+// 影子账号改绑：当前选中的关联母账号（编辑时可变，不必是复制的原母账号）。
+const parentAccountId = ref<number | null>(null)
+
+const shadowParentCandidates = computed<Account[]>(() => {
+  const account = props.account
+  if (!account) return []
+  return (props.accounts ?? []).filter(
+    (a) =>
+      a.id !== account.id &&
+      a.parent_account_id == null &&
+      a.platform === account.platform &&
+      a.type === account.type
+  )
+})
 
 const hideAccountLongContextBilling = computed(() => {
   return allSelectedGroupsEnableLongContextPricing(form.group_ids, props.groups)
@@ -3664,6 +3692,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     : 'active'
   form.group_ids = newAccount.group_ids || []
   form.expires_at = newAccount.expires_at ?? null
+  parentAccountId.value = newAccount.parent_account_id ?? null
 
   // Load intercept warmup requests setting (applies to all account types)
   const credentials = newAccount.credentials as Record<string, unknown> | undefined
@@ -4596,6 +4625,10 @@ const handleSubmit = async () => {
 
   const updatePayload: Record<string, unknown> = { ...form }
   try {
+    // 影子账号可改绑到其它母账号（后端仅对影子账号生效并校验）。
+    if (isSparkShadow.value) {
+      updatePayload.parent_account_id = parentAccountId.value
+    }
     // 后端期望 proxy_id: 0 表示清除代理，而不是 null
     if (updatePayload.proxy_id === null) {
       updatePayload.proxy_id = 0

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -72,6 +72,7 @@ const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'duplicate', 're
 const { t } = useI18n()
 const canDuplicate = computed(() => {
   if (!props.account || props.account.parent_account_id != null) return false
+  if (props.account.platform === 'openai' && props.account.type === 'oauth') return true
   return ['apikey', 'upstream', 'bedrock', 'service_account'].includes(props.account.type)
 })
 const isRateLimited = computed(() => {

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
@@ -69,8 +69,18 @@ describe('AccountActionMenu — spark shadow 按钮可见性', () => {
     wrapper.unmount()
   })
 
-  it.each(['oauth', 'setup-token'] as const)('%s 账号隐藏「复制账号」按钮，避免共享可轮换令牌', (type) => {
-    const account = makeAccount({ platform: 'openai', type, parent_account_id: null })
+  it('OpenAI OAuth 母账号显示「复制账号」并创建链接账号', () => {
+    const account = makeAccount({ platform: 'openai', type: 'oauth', parent_account_id: null })
+    const wrapper = mount(AccountActionMenu, {
+      props: { show: true, account, position },
+      attachTo: document.body,
+    })
+    expect(getBodyText()).toContain('admin.accounts.duplicateAccount')
+    wrapper.unmount()
+  })
+
+  it('setup-token 账号仍隐藏「复制账号」按钮', () => {
+    const account = makeAccount({ platform: 'openai', type: 'setup-token', parent_account_id: null })
     const wrapper = mount(AccountActionMenu, {
       props: { show: true, account, position },
       attachTo: document.body,

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -82,6 +82,8 @@ export default {
       notes: 'Notes',
       notesPlaceholder: 'Enter notes',
       notesHint: 'Notes are optional',
+      shadowParent: 'Linked parent account',
+      shadowParentHint: 'A copied shadow account can be re-linked to another parent, not necessarily the account it was copied from.',
       allPlatforms: 'All Platforms',
       allTypes: 'All Types',
       allStatus: 'All Status',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -81,6 +81,8 @@ export default {
       notes: '备注',
       notesPlaceholder: '请输入备注',
       notesHint: '备注可选',
+      shadowParent: '关联母账号',
+      shadowParentHint: '影子账号(复制出来)可改绑到其它母账号，不一定是复制的账号。',
       // Filter options
       allPlatforms: '全部平台',
       allTypes: '全部类型',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1617,10 +1617,15 @@ function getAntigravityTierLabel(row: any): string | null {
   }
 }
 
-// 账号显示邮箱:优先账号自身(extra/credentials),影子账号回退母账号 parent_email。
+// 账号显示邮箱:普通账号优先账号自身(extra/credentials);
+// 影子账号只展示当前关联母账号 parent_email——复制来源残留的 extra/credentials
+// 身份不再作为展示来源,否则改绑后仍会显示复制时的旧账号。
 // 供名称单元格 v-if/标题/文本三处共用,避免同一回退链在模板里重复三次。
 function accountDisplayEmail(row: any): string {
-  return row.extra?.email_address || row.extra?.email || row.credentials?.email || row.parent_email || ''
+  if (row.parent_account_id != null) {
+    return row.parent_email || ''
+  }
+  return row.extra?.email_address || row.extra?.email || row.credentials?.email || ''
 }
 
 function accountHomepageUrl(row: Account): string {

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1617,13 +1617,13 @@ function getAntigravityTierLabel(row: any): string | null {
   }
 }
 
-// 账号显示邮箱:普通账号优先账号自身(extra/credentials);
-// 影子账号只展示当前关联母账号 parent_email——复制来源残留的 extra/credentials
-// 身份不再作为展示来源,否则改绑后仍会显示复制时的旧账号。
+// 账号显示邮箱:普通账号优先账号自身(extra/credentials)。
+// 影子账号不展示关联账号:底层数据仍返回 parent_* 字段,但界面按需求隐藏,
+// 避免把复制来源或改绑后的母账号身份暴露在列表行里。
 // 供名称单元格 v-if/标题/文本三处共用,避免同一回退链在模板里重复三次。
 function accountDisplayEmail(row: any): string {
   if (row.parent_account_id != null) {
-    return row.parent_email || ''
+    return ''
   }
   return row.extra?.email_address || row.extra?.email || row.credentials?.email || ''
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -451,7 +451,7 @@
       <template #pagination><Pagination v-if="pagination.total > 0" :page="pagination.page" :total="pagination.total" :page-size="pagination.page_size" @update:page="handlePageChange" @update:pageSize="handlePageSizeChange" /></template>
     </TablePageLayout>
     <CreateAccountModal :show="showCreate" :proxies="proxies" :groups="groups" @close="showCreate = false" @created="reload" />
-    <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
+    <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" :accounts="accounts" @close="showEdit = false" @updated="handleAccountUpdated" />
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
     <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />

--- a/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
@@ -275,7 +275,7 @@ describe('admin AccountsView — 账号行展示', () => {
     vi.unstubAllGlobals()
   })
 
-  it('影子行 email 单元格显示 parent_email，PlatformTypeBadge 接收 parent_plan_type/parent_privacy_mode', async () => {
+  it('影子行 email 单元格隐藏关联账号，PlatformTypeBadge 接收 parent_plan_type/parent_privacy_mode', async () => {
     const shadowAccount = {
       id: 100,
       name: '影子账号',
@@ -294,10 +294,10 @@ describe('admin AccountsView — 账号行展示', () => {
     const wrapper = mountViewWithRow()
     await flushPromises()
 
-    // 1. email 单元格通过 OR 兜底渲染 parent_email
-    expect(wrapper.text()).toContain('parent@example.com')
+    // 1. 影子行不展示关联账号邮箱（底层数据仍返回 parent_email，仅界面隐藏）
+    expect(wrapper.text()).not.toContain('parent@example.com')
 
-    // 2. PlatformTypeBadge 收到 parent_plan_type 和 parent_privacy_mode
+    // 2. PlatformTypeBadge 仍收到 parent_plan_type 和 parent_privacy_mode
     const badge = wrapper.findComponent(PlatformTypeBadge)
     expect(badge.exists()).toBe(true)
     expect(badge.props('planType')).toBe('plus')


### PR DESCRIPTION
## Summary
- allow duplicating an OpenAI OAuth account as a paused linked route without copying credentials
- resolve linked routes through the parent account for credentials and shared Codex quota state
- keep Spark shadow accounts on their independent quota dimension
- refresh linked-account usage from the parent snapshot when the account list is refreshed

## Tests
- `go test ./internal/service ./internal/handler/admin ./internal/repository`
- `pnpm exec vitest run src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts`