### PR TITLE
feat: add OpenAI Videos API gateway and billing

### DIFF
--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -678,7 +678,7 @@ func recordGrokMediaUsage(
 	videoTaskID := ""
 	if result != nil && result.VideoCount > 0 {
 		videoTaskID = strings.TrimSpace(firstNonEmptyString(requestID, result.ResponseID))
-		if stable := service.StableGrokVideoBillingRequestID(firstNonEmptyString(result.ResponseID, requestID)); stable != "" {
+		if stable := service.StableVideoTaskBillingRequestID(account.Platform, firstNonEmptyString(result.ResponseID, requestID)); stable != "" {
 			result.RequestID = stable
 		}
 		// Prefer task id hash for payload fingerprint stability across status/content.
@@ -704,7 +704,8 @@ func recordGrokMediaUsage(
 			ChannelUsageFields: channelUsageFields,
 		}); err != nil {
 			if videoTaskID != "" {
-				if releaseErr := h.gatewayService.ReleaseGrokVideoBilling(ctx, videoTaskID, subject.UserID, apiKey.ID); releaseErr != nil {
+				releaseErr := h.gatewayService.ReleaseVideoTaskBilling(ctx, account.Platform, videoTaskID, subject.UserID, apiKey.ID)
+				if releaseErr != nil {
 					reqLog.Warn("grok_media.video_billing_claim_release_failed",
 						zap.String("request_id", videoTaskID),
 						zap.Error(releaseErr),

--- a/backend/internal/handler/openai_video.go
+++ b/backend/internal/handler/openai_video.go
@@ -1,0 +1,174 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+// OpenAIVideo handles the asynchronous OpenAI Videos API. The task binding is
+// deliberately resolved before scheduling so status/content requests stay on
+// the account that created the upstream task.
+func (h *OpenAIGatewayHandler) OpenAIVideo(c *gin.Context) {
+	streamStarted := false
+	defer h.recoverResponsesPanic(c, &streamStarted)
+
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusUnauthorized, "authentication_error", "Invalid API key")
+		return
+	}
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
+		return
+	}
+
+	isCreate := c.Request.Method == http.MethodPost
+	isContent := strings.HasSuffix(strings.TrimSuffix(c.Request.URL.Path, "/"), "/content")
+	endpoint := service.OpenAIVideoStatus
+	requestID := strings.TrimSpace(c.Param("request_id"))
+	if isCreate {
+		endpoint = service.OpenAIVideoCreate
+	} else if isContent {
+		endpoint = service.OpenAIVideoContent
+	}
+	if !isCreate && requestID == "" {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "video_id is required")
+		return
+	}
+
+	reqLog := requestLogger(c, "handler.openai_gateway.openai_video",
+		zap.Int64("user_id", subject.UserID), zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID), zap.String("endpoint", string(endpoint)),
+		zap.String("video_id", requestID))
+	if !h.ensureResponsesDependencies(c, reqLog) {
+		return
+	}
+
+	var body []byte
+	var err error
+	if isCreate {
+		body, err = pkghttputil.ReadRequestBodyWithPrealloc(c.Request)
+		if err != nil || len(body) == 0 {
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Request body is required")
+			return
+		}
+	}
+
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if isCreate && model == "" {
+		model = "sora-2"
+	}
+	if isCreate && !service.GroupAllowsImageGeneration(apiKey.Group) {
+		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
+		return
+	}
+
+	ctx := service.WithOpenAIProfitControlSuppressed(c.Request.Context())
+	sessionHash := h.gatewayService.GenerateExplicitSessionHash(c, body)
+	if !isCreate {
+		bound, resolveErr := h.gatewayService.ResolveVideoTaskAccount(ctx, apiKey.GroupID, service.VideoTaskPlatformOpenAI, requestID, subject.UserID, apiKey.ID)
+		if resolveErr != nil || bound <= 0 {
+			h.errorResponse(c, http.StatusNotFound, "not_found_error", "Video request not found")
+			return
+		}
+		sessionHash = service.VideoTaskSessionHash(service.VideoTaskPlatformOpenAI, requestID, subject.UserID, apiKey.ID)
+	}
+
+	selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		ctx, apiKey.GroupID, "", sessionHash, model, nil,
+		service.OpenAIUpstreamTransportHTTPSSE, "", false, false, false, service.PlatformOpenAI,
+	)
+	if err != nil || selection == nil || selection.Account == nil {
+		if errors.Is(err, service.ErrNoAvailableAccounts) {
+			markOpsRoutingCapacityLimited(c)
+		}
+		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "No available OpenAI video accounts")
+		return
+	}
+	account := selection.Account
+	release, slotStatus := h.acquireResponsesAccountSlot(c, apiKey.GroupID, sessionHash, selection, false, &streamStarted, reqLog)
+	if slotStatus != openAISlotAcquireOK {
+		return
+	}
+	if release != nil {
+		defer release()
+	}
+	setOpsSelectedAccount(c, account.ID, account.Platform)
+
+	result, err := h.gatewayService.ForwardOpenAIVideo(ctx, c, account, endpoint, requestID, body, c.GetHeader("Content-Type"))
+	if err != nil {
+		var failoverErr *service.UpstreamFailoverError
+		if errors.As(err, &failoverErr) {
+			h.handleFailoverExhausted(c, failoverErr, false)
+			return
+		}
+		if !service.IsResponseCommitted(c) {
+			h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+		}
+		return
+	}
+
+	if isCreate && result != nil && strings.TrimSpace(result.ResponseID) != "" {
+		if err := h.gatewayService.BindVideoTaskAccount(ctx, apiKey.GroupID, service.VideoTaskPlatformOpenAI, result.ResponseID, subject.UserID, apiKey.ID, account.ID); err != nil {
+			reqLog.Warn("openai_video.bind_task_account_failed", zap.Error(err))
+		}
+		pending := service.GrokVideoPendingBilling{Model: model, BillingModel: firstNonEmptyString(result.BillingModel, model), UpstreamModel: result.UpstreamModel, VideoResolution: result.VideoResolution, VideoDurationSeconds: result.VideoDurationSeconds, OriginalModel: clientRequestedModel(c, model), CreatedAt: service.GrokVideoPendingCreatedAtNow()}
+		if err := h.gatewayService.StoreVideoTaskPendingBilling(ctx, service.VideoTaskPlatformOpenAI, result.ResponseID, subject.UserID, apiKey.ID, pending); err != nil {
+			reqLog.Warn("openai_video.store_pending_billing_failed", zap.Error(err))
+		}
+	}
+
+	if !isCreate && (endpoint == service.OpenAIVideoStatus || endpoint == service.OpenAIVideoContent) && result != nil {
+		// A successful content download is also proof that the asynchronous task
+		// completed; content responses are binary and carry no status JSON.
+		if endpoint == service.OpenAIVideoContent {
+			result.VideoCount = 1
+		}
+		if billResult := prepareOpenAIVideoCompletionBilling(ctx, h, reqLog, apiKey, subject.UserID, apiKey.ID, requestID, result); billResult != nil {
+			subscription, _ := middleware2.GetSubscriptionFromContext(c)
+			recordGrokMediaUsage(c, h, reqLog, apiKey, subject, subscription, account, billResult, billResult.Model, nil, requestID)
+		}
+	}
+}
+
+func prepareOpenAIVideoCompletionBilling(ctx context.Context, h *OpenAIGatewayHandler, reqLog *zap.Logger, apiKey *service.APIKey, userID, apiKeyID int64, requestID string, result *service.OpenAIForwardResult) *service.OpenAIForwardResult {
+	if result == nil || result.VideoCount <= 0 || strings.TrimSpace(requestID) == "" {
+		return nil
+	}
+	pending, err := h.gatewayService.LoadVideoTaskPendingBilling(ctx, service.VideoTaskPlatformOpenAI, requestID, userID, apiKeyID)
+	if err != nil || pending == nil {
+		reqLog.Warn("openai_video.pending_billing_missing", zap.Error(err))
+		return nil
+	}
+	claimed, err := h.gatewayService.ClaimVideoTaskBilling(ctx, service.VideoTaskPlatformOpenAI, requestID, userID, apiKeyID)
+	if err != nil || !claimed {
+		return nil
+	}
+	merged := *result
+	merged.Model = firstNonEmptyString(merged.Model, pending.BillingModel, pending.Model)
+	merged.BillingModel = firstNonEmptyString(merged.BillingModel, pending.BillingModel, pending.Model, merged.Model)
+	merged.UpstreamModel = firstNonEmptyString(merged.UpstreamModel, pending.UpstreamModel)
+	merged.VideoResolution = firstNonEmptyString(merged.VideoResolution, pending.VideoResolution)
+	if merged.VideoDurationSeconds <= 0 {
+		merged.VideoDurationSeconds = pending.VideoDurationSeconds
+	}
+	merged.VideoResolution = service.NormalizeVideoBillingResolutionOrDefault(merged.VideoResolution)
+	merged.VideoDurationSeconds = service.NormalizeVideoBillingDurationSecondsOrDefault(merged.VideoDurationSeconds)
+	merged.ResponseID = firstNonEmptyString(merged.ResponseID, requestID)
+	merged.RequestID = service.StableVideoTaskBillingRequestID(service.VideoTaskPlatformOpenAI, requestID)
+	if e2e := service.GrokVideoE2EDuration(pending.CreatedAt, time.Now()); e2e > 0 {
+		merged.Duration = e2e
+	}
+	return &merged
+}

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -98,7 +98,10 @@ func RegisterGatewayRoutes(
 		// Video status/content lookups below already allow Composite groups; keep
 		// task creation aligned so composite keys that route to Grok accounts can
 		// submit video generation jobs.
-		if platform := getGroupPlatform(c); platform == service.PlatformGrok || platform == service.PlatformComposite {
+		if platform := getGroupPlatform(c); platform == service.PlatformOpenAI {
+			h.OpenAIGateway.OpenAIVideo(c)
+			return
+		} else if platform == service.PlatformGrok || platform == service.PlatformComposite {
 			h.OpenAIGateway.GrokVideoGeneration(c)
 			return
 		}
@@ -114,7 +117,10 @@ func RegisterGatewayRoutes(
 		// Video status requests do not carry a model, so composite groups cannot
 		// be resolved by compositeTargetPlatformMiddleware. Route them through
 		// the Grok handler and let scheduler/account selection enforce capacity.
-		if getGroupPlatform(c) == service.PlatformGrok || getGroupPlatform(c) == service.PlatformComposite {
+		if getGroupPlatform(c) == service.PlatformOpenAI {
+			h.OpenAIGateway.OpenAIVideo(c)
+			return
+		} else if getGroupPlatform(c) == service.PlatformGrok || getGroupPlatform(c) == service.PlatformComposite {
 			h.OpenAIGateway.GrokVideoStatus(c)
 			return
 		}
@@ -130,7 +136,10 @@ func RegisterGatewayRoutes(
 		// Video content requests do not carry a model, so composite groups cannot
 		// be resolved by compositeTargetPlatformMiddleware. Route them through
 		// the Grok handler just like video status lookups.
-		if getGroupPlatform(c) == service.PlatformGrok || getGroupPlatform(c) == service.PlatformComposite {
+		if getGroupPlatform(c) == service.PlatformOpenAI {
+			h.OpenAIGateway.OpenAIVideo(c)
+			return
+		} else if getGroupPlatform(c) == service.PlatformGrok || getGroupPlatform(c) == service.PlatformComposite {
 			h.OpenAIGateway.GrokVideoContent(c)
 			return
 		}

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -302,7 +302,7 @@ func TestGatewayRoutesCompositeChatCompletionsWithGrokModelUsesOpenAIGateway(t *
 	}
 }
 
-func TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate(t *testing.T) {
+func TestGatewayRoutesOpenAIVideosReachOpenAIHandler(t *testing.T) {
 	router := newGatewayRoutesTestRouter(service.PlatformOpenAI)
 
 	for _, tc := range []struct {
@@ -314,10 +314,6 @@ func TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate(t *testing.T) {
 		{http.MethodPost, "/v1/videos", `{"model":"grok-imagine-video-1.5","prompt":"waves"}`},
 		{http.MethodPost, "/videos", `{"model":"grok-imagine-video-1.5","prompt":"waves"}`},
 		{http.MethodPost, "/videos/generations", `{"model":"grok-imagine-video-1.5","prompt":"waves"}`},
-		{http.MethodPost, "/v1/videos/edits", `{"model":"grok-imagine-video","prompt":"waves","video":{"url":"https://example.com/in.mp4"}}`},
-		{http.MethodPost, "/videos/edits", `{"model":"grok-imagine-video","prompt":"waves","video":{"url":"https://example.com/in.mp4"}}`},
-		{http.MethodPost, "/v1/videos/extensions", `{"model":"grok-imagine-video","prompt":"waves","video":{"url":"https://example.com/in.mp4"}}`},
-		{http.MethodPost, "/videos/extensions", `{"model":"grok-imagine-video","prompt":"waves","video":{"url":"https://example.com/in.mp4"}}`},
 		{http.MethodGet, "/v1/videos/request-123", ""},
 		{http.MethodGet, "/videos/request-123", ""},
 		{http.MethodGet, "/v1/videos/generations/request-123", ""},
@@ -340,8 +336,8 @@ func TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)
-		require.Equal(t, http.StatusNotFound, w.Code, "method=%s path=%s", tc.method, tc.path)
-		require.Contains(t, w.Body.String(), "Videos API is not supported for this platform")
+		require.NotEqual(t, http.StatusNotFound, w.Code, "method=%s path=%s", tc.method, tc.path)
+		require.NotContains(t, w.Body.String(), "Videos API is not supported for this platform")
 	}
 }
 

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -295,10 +295,10 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	// share one bill). Context-local client/local IDs would otherwise create a new row
 	// per poll if Redis claim is lost.
 	if result.VideoCount > 0 {
-		if stable := StableGrokVideoBillingRequestID(firstNonEmpty(
-			strings.TrimPrefix(strings.TrimSpace(result.RequestID), "grok-video:"),
+		if stable := StableVideoTaskBillingRequestID(account.Platform, firstNonEmpty(
+			strings.TrimPrefix(strings.TrimSpace(result.RequestID), account.Platform+"-video:"),
 			strings.TrimSpace(result.ResponseID),
-			strings.TrimPrefix(strings.TrimSpace(requestID), "grok-video:"),
+			strings.TrimPrefix(strings.TrimSpace(requestID), account.Platform+"-video:"),
 		)); stable != "" {
 			requestID = stable
 		}

--- a/backend/internal/service/openai_video.go
+++ b/backend/internal/service/openai_video.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+// OpenAIVideoEndpoint describes one OpenAI Videos API operation.
+type OpenAIVideoEndpoint string
+
+const (
+	OpenAIVideoCreate  OpenAIVideoEndpoint = "create"
+	OpenAIVideoStatus  OpenAIVideoEndpoint = "status"
+	OpenAIVideoContent OpenAIVideoEndpoint = "content"
+)
+
+// ForwardOpenAIVideo forwards a Videos API request through one already-selected
+// OpenAI account. Account selection and task ownership belong to the handler;
+// this method must never select a different account for a status request.
+func (s *OpenAIGatewayService) ForwardOpenAIVideo(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	endpoint OpenAIVideoEndpoint,
+	requestID string,
+	body []byte,
+	contentType string,
+) (*OpenAIForwardResult, error) {
+	if account == nil || account.Platform != PlatformOpenAI {
+		return nil, fmt.Errorf("openai account is required for videos")
+	}
+	token, _, err := s.getRequestCredential(ctx, c, account)
+	if err != nil {
+		return nil, err
+	}
+	path := "/v1/videos"
+	method := http.MethodPost
+	if endpoint == OpenAIVideoStatus || endpoint == OpenAIVideoContent {
+		path += "/" + requestID
+		method = http.MethodGet
+	}
+	if endpoint == OpenAIVideoContent {
+		path += "/content"
+	}
+	targetURL := buildOpenAIEndpointURL(account.GetOpenAIFormatBaseURL(), path)
+	var bodyReader io.Reader
+	if method == http.MethodPost {
+		bodyReader = strings.NewReader(string(body))
+	}
+	upstreamCtx, release := detachUpstreamContext(ctx)
+	defer release()
+	req, err := http.NewRequestWithContext(upstreamCtx, method, targetURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if method == http.MethodPost {
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		req.Header.Set("Content-Type", contentType)
+	}
+	if endpoint == OpenAIVideoContent {
+		req.Header.Set("Accept", "video/*,application/octet-stream;q=0.9,*/*;q=0.8")
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
+	account.ApplyHeaderOverrides(req.Header)
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	started := time.Now()
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(started).Milliseconds())
+	if err != nil {
+		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+	}
+	defer resp.Body.Close()
+	responseID := firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("openai-request-id"))
+	if endpoint == OpenAIVideoContent {
+		if resp.StatusCode >= 400 {
+			return s.forwardOpenAIVideoJSONError(c, resp, responseID)
+		}
+		if err := writeGrokMediaContentResponse(c, resp); err != nil {
+			return nil, err
+		}
+		return &OpenAIForwardResult{RequestID: responseID, ResponseHeaders: resp.Header.Clone(), Duration: time.Since(started)}, nil
+	}
+	respBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return s.forwardOpenAIVideoBodyError(c, resp, respBody, responseID)
+	}
+	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	contentType = strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	c.Data(resp.StatusCode, contentType, respBody)
+	return parseOpenAIVideoResult(respBody, responseID, time.Since(started)), nil
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIVideoJSONError(c *gin.Context, resp *http.Response, requestID string) (*OpenAIForwardResult, error) {
+	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return nil, err
+	}
+	return s.forwardOpenAIVideoBodyError(c, resp, body, requestID)
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIVideoBodyError(c *gin.Context, resp *http.Response, body []byte, requestID string) (*OpenAIForwardResult, error) {
+	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	c.Data(resp.StatusCode, contentType, body)
+	return nil, &UpstreamFailoverError{
+		StatusCode:      resp.StatusCode,
+		ResponseBody:    body,
+		ResponseHeaders: resp.Header.Clone(),
+	}
+}
+
+func parseOpenAIVideoResult(body []byte, requestID string, duration time.Duration) *OpenAIForwardResult {
+	result := &OpenAIForwardResult{
+		RequestID:    requestID,
+		ResponseID:   strings.TrimSpace(gjson.GetBytes(body, "id").String()),
+		Model:        strings.TrimSpace(gjson.GetBytes(body, "model").String()),
+		BillingModel: strings.TrimSpace(gjson.GetBytes(body, "model").String()),
+		Duration:     duration,
+	}
+	result.VideoResolution = openAIVideoBillingResolution(gjson.GetBytes(body, "size").String())
+	seconds := strings.TrimSpace(gjson.GetBytes(body, "seconds").String())
+	if parsed, err := strconv.Atoi(seconds); err == nil {
+		result.VideoDurationSeconds = parsed
+	}
+	status := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "status").String()))
+	if status == "completed" {
+		result.VideoCount = 1
+	}
+	return result
+}
+
+func openAIVideoBillingResolution(size string) string {
+	size = strings.ToLower(strings.TrimSpace(size))
+	if strings.Contains(size, "1024") || strings.Contains(size, "1792") {
+		return VideoBillingResolution1080P
+	}
+	if strings.Contains(size, "720") || strings.Contains(size, "1280") {
+		return VideoBillingResolution720P
+	}
+	return ""
+}

--- a/backend/internal/service/openai_video_test.go
+++ b/backend/internal/service/openai_video_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseOpenAIVideoResult(t *testing.T) {
+	result := parseOpenAIVideoResult([]byte(`{"id":"video_123","model":"sora-2-pro","status":"completed","seconds":"12","size":"1792x1024"}`), "req_1", time.Second)
+	if result.ResponseID != "video_123" || result.Model != "sora-2-pro" {
+		t.Fatalf("unexpected identity: %+v", result)
+	}
+	if result.VideoCount != 1 || result.VideoDurationSeconds != 12 || result.VideoResolution != VideoBillingResolution1080P {
+		t.Fatalf("unexpected billing fields: %+v", result)
+	}
+}
+
+func TestStableVideoTaskBillingRequestID(t *testing.T) {
+	if got := StableVideoTaskBillingRequestID(PlatformOpenAI, "video_123"); got != "openai-video:video_123" {
+		t.Fatalf("unexpected openai billing id: %q", got)
+	}
+	if got := StableVideoTaskBillingRequestID(PlatformGrok, "video_123"); got != "grok-video:video_123" {
+		t.Fatalf("unexpected grok billing id: %q", got)
+	}
+}

--- a/backend/internal/service/video_task.go
+++ b/backend/internal/service/video_task.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// VideoTaskPlatform identifies the upstream protocol that owns a video task.
+// Task IDs are only meaningful together with the platform and caller identity.
+const (
+	VideoTaskPlatformOpenAI = PlatformOpenAI
+	VideoTaskPlatformGrok   = PlatformGrok
+)
+
+// VideoTaskSessionHash derives the sticky-session key used by asynchronous
+// video status/content requests. The caller identity is part of the key so a
+// task ID cannot be used to discover another user's account binding.
+func VideoTaskSessionHash(platform, requestID string, userID, apiKeyID int64) string {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	requestID = strings.TrimSpace(requestID)
+	if platform == "" || requestID == "" || userID <= 0 || apiKeyID <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("video-task:%s:%s", platform,
+		DeriveSessionHashFromSeed(fmt.Sprintf("%d:%d:%s", userID, apiKeyID, requestID)))
+}
+
+// BindVideoTaskAccount records the account that successfully created a video
+// task. Subsequent status/content requests must use this binding instead of
+// selecting another account from the group.
+func (s *OpenAIGatewayService) BindVideoTaskAccount(
+	ctx context.Context,
+	groupID *int64,
+	platform, requestID string,
+	userID, apiKeyID, accountID int64,
+) error {
+	if s == nil || s.cache == nil {
+		return fmt.Errorf("video task binding cache is unavailable")
+	}
+	key := VideoTaskSessionHash(platform, requestID, userID, apiKeyID)
+	if key == "" || accountID <= 0 {
+		return fmt.Errorf("video task binding is invalid")
+	}
+	// Keep the account binding longer than the normal OpenAI sticky-session
+	// window. The upstream video job may remain queryable for many hours.
+	return s.cache.SetSessionAccountID(ctx, derefGroupID(groupID), key, accountID, 24*time.Hour)
+}
+
+// ResolveVideoTaskAccount returns the account bound at task creation time.
+func (s *OpenAIGatewayService) ResolveVideoTaskAccount(
+	ctx context.Context,
+	groupID *int64,
+	platform, requestID string,
+	userID, apiKeyID int64,
+) (int64, error) {
+	if s == nil || s.cache == nil {
+		return 0, fmt.Errorf("video task binding cache is unavailable")
+	}
+	key := VideoTaskSessionHash(platform, requestID, userID, apiKeyID)
+	if key == "" {
+		return 0, fmt.Errorf("video task binding is invalid")
+	}
+	return s.cache.GetSessionAccountID(ctx, derefGroupID(groupID), key)
+}
+
+func videoTaskStorageID(platform, requestID string) string {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	requestID = strings.TrimSpace(requestID)
+	// Preserve the existing Grok Redis key format while allowing new providers
+	// to share the same cache namespace safely.
+	if platform == VideoTaskPlatformGrok {
+		return requestID
+	}
+	return platform + ":" + requestID
+}
+
+// StableVideoTaskBillingRequestID is the durable usage/dedup key shared by
+// asynchronous video status polls and content downloads.
+func StableVideoTaskBillingRequestID(platform, requestID string) string {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	requestID = strings.TrimSpace(requestID)
+	if platform == "" || requestID == "" {
+		return ""
+	}
+	if strings.HasPrefix(requestID, platform+"-video:") {
+		return requestID
+	}
+	return platform + "-video:" + requestID
+}
+
+// The gateway cache predates the cross-provider task abstraction and exposes
+// these operations under the Grok-specific names. Keep the provider-neutral
+// service boundary here so callers do not encode that storage detail.
+func (s *OpenAIGatewayService) StoreVideoTaskPendingBilling(
+	ctx context.Context,
+	platform, requestID string,
+	userID, apiKeyID int64,
+	pending GrokVideoPendingBilling,
+) error {
+	return s.StoreGrokVideoPendingBilling(ctx, videoTaskStorageID(platform, requestID), userID, apiKeyID, pending)
+}
+
+func (s *OpenAIGatewayService) LoadVideoTaskPendingBilling(
+	ctx context.Context,
+	platform, requestID string,
+	userID, apiKeyID int64,
+) (*GrokVideoPendingBilling, error) {
+	return s.LoadGrokVideoPendingBilling(ctx, videoTaskStorageID(platform, requestID), userID, apiKeyID)
+}
+
+func (s *OpenAIGatewayService) ClaimVideoTaskBilling(
+	ctx context.Context,
+	platform, requestID string,
+	userID, apiKeyID int64,
+) (bool, error) {
+	return s.ClaimGrokVideoBilling(ctx, videoTaskStorageID(platform, requestID), userID, apiKeyID)
+}
+
+func (s *OpenAIGatewayService) ReleaseVideoTaskBilling(
+	ctx context.Context,
+	platform, requestID string,
+	userID, apiKeyID int64,
+) error {
+	return s.ReleaseGrokVideoBilling(ctx, videoTaskStorageID(platform, requestID), userID, apiKeyID)
+}

--- a/backend/internal/service/video_task_test.go
+++ b/backend/internal/service/video_task_test.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVideoTaskSessionHashScopesTaskBinding(t *testing.T) {
+	got := VideoTaskSessionHash(VideoTaskPlatformOpenAI, "video_123", 7, 9)
+	require.Equal(t, "video-task:openai:f643de2fa99d201b", got)
+	require.NotEqual(t, got, VideoTaskSessionHash(VideoTaskPlatformGrok, "video_123", 7, 9))
+	require.NotEqual(t, got, VideoTaskSessionHash(VideoTaskPlatformOpenAI, "video_123", 8, 9))
+	require.NotEqual(t, got, VideoTaskSessionHash(VideoTaskPlatformOpenAI, "video_123", 7, 10))
+}
+
+func TestVideoTaskSessionHashRejectsIncompleteIdentity(t *testing.T) {
+	require.Empty(t, VideoTaskSessionHash(VideoTaskPlatformOpenAI, "", 7, 9))
+	require.Empty(t, VideoTaskSessionHash(VideoTaskPlatformOpenAI, "video_123", 0, 9))
+	require.Empty(t, VideoTaskSessionHash(VideoTaskPlatformOpenAI, "video_123", 7, 0))
+}

--- a/frontend/src/views/admin/groupsImagePricing.ts
+++ b/frontend/src/views/admin/groupsImagePricing.ts
@@ -10,7 +10,7 @@ export const supportsImagePricingPlatform = (platform: string): boolean =>
   imagePricingPlatforms.has(platform);
 
 export const supportsVideoPricingPlatform = (platform: string): boolean =>
-  platform === "grok";
+  platform === "grok" || platform === "openai";
 
 export const imagePricingI18nKey = (_platform: string, key: string): string =>
   `admin.groups.imagePricing.${key}`;
@@ -40,8 +40,7 @@ const defaultImagePricePlaceholders: Record<
   },
 };
 
-// 视频价为每秒单价（USD/s）。480p/720p 取 grok-imagine-video（文生视频实际走该模型）的
-// 官方每秒价；1080p 仅 grok-imagine-video-1.5 图生视频支持，取 1.5 的每秒价。
+// 视频价为每秒单价（USD/s）。OpenAI 与 Grok 的默认值仅用于表单提示，实际计费以分组配置为准。
 const defaultVideoPricePlaceholders: Record<
   string,
   Record<VideoPricingTierKey, string>
@@ -50,6 +49,11 @@ const defaultVideoPricePlaceholders: Record<
     video_price_480p: "0.05",
     video_price_720p: "0.07",
     video_price_1080p: "0.25",
+  },
+  openai: {
+    video_price_480p: "0.10",
+    video_price_720p: "0.10",
+    video_price_1080p: "0.30",
   },
 };
 


### PR DESCRIPTION
## Summary
- add OpenAI Videos create, status, and content proxy routes
- persist video task ownership by platform, user, API key, and upstream video ID
- add deferred one-shot video billing for status polling and successful content downloads
- enable OpenAI video pricing fields and defaults in group administration

## Verification
- targeted Go service/handler/routes tests pass
- frontend ESLint and vue-tsc pass
- full service suite has pre-existing Windows/plugin file-lock and content-moderation timing failures