### PR TITLE
fix(auth): pass registration promo codes to OAuth signup

### DIFF
--- a/frontend/src/components/auth/EmailOAuthButtons.vue
+++ b/frontend/src/components/auth/EmailOAuthButtons.vue
@@ -40,6 +40,7 @@ const EMAIL_OAUTH_PENDING_PROVIDER_KEY = 'email_oauth_pending_provider'
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
+  promoCode?: string
   githubEnabled?: boolean
   googleEnabled?: boolean
   showDivider?: boolean
@@ -82,6 +83,10 @@ function startLogin(provider: EmailOAuthProvider): void {
   const params: Record<string, string> = { redirect: redirectTo }
   if (affiliateCode) {
     params.aff_code = affiliateCode
+  }
+  const promoCode = props.promoCode?.trim()
+  if (promoCode) {
+    params.promo_code = promoCode
   }
   emit('start', { provider, params })
 }

--- a/frontend/src/components/auth/LinuxDoOAuthSection.vue
+++ b/frontend/src/components/auth/LinuxDoOAuthSection.vue
@@ -48,6 +48,7 @@ import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/o
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
+  promoCode?: string
   showDivider?: boolean
 }>(), {
   showDivider: true
@@ -62,6 +63,11 @@ const { t } = useI18n()
 function startLogin(): void {
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   storeOAuthAffiliateCode(resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code))
-  emit('start', { provider: 'linuxdo', params: { redirect: redirectTo } })
+  const params: Record<string, string> = { redirect: redirectTo }
+  const promoCode = props.promoCode?.trim()
+  if (promoCode) {
+    params.promo_code = promoCode
+  }
+  emit('start', { provider: 'linuxdo', params })
 }
 </script>

--- a/frontend/src/components/auth/__tests__/EmailOAuthButtons.spec.ts
+++ b/frontend/src/components/auth/__tests__/EmailOAuthButtons.spec.ts
@@ -33,6 +33,7 @@ describe('EmailOAuthButtons', () => {
       props: {
         githubEnabled: true,
         googleEnabled: false,
+        promoCode: ' PROMO123 ',
       },
       global: {
         stubs: {
@@ -47,7 +48,7 @@ describe('EmailOAuthButtons', () => {
     expect(wrapper.emitted('start')).toEqual([[
       {
         provider: 'github',
-        params: { redirect: '/billing?plan=pro', aff_code: 'AFF123' }
+        params: { redirect: '/billing?plan=pro', aff_code: 'AFF123', promo_code: 'PROMO123' }
       }
     ]])
     expect(window.sessionStorage.getItem('oauth_aff_code')).toBe('AFF123')
@@ -60,6 +61,7 @@ describe('EmailOAuthButtons', () => {
       props: {
         githubEnabled: false,
         googleEnabled: true,
+        promoCode: 'PROMO456',
       },
       global: {
         stubs: {
@@ -73,7 +75,7 @@ describe('EmailOAuthButtons', () => {
 
     expect(wrapper.emitted('start')?.[0]?.[0]).toEqual({
       provider: 'google',
-      params: { redirect: '/billing?plan=pro', aff_code: 'AFF123' }
+      params: { redirect: '/billing?plan=pro', aff_code: 'AFF123', promo_code: 'PROMO456' }
     })
     expect(window.location.href).toBe(originalHref)
   })

--- a/frontend/src/components/auth/__tests__/OAuthLoginSections.spec.ts
+++ b/frontend/src/components/auth/__tests__/OAuthLoginSections.spec.ts
@@ -41,4 +41,23 @@ describe('OAuth login sections', () => {
     expect(window.sessionStorage.getItem('oauth_aff_code')).toBe('AFF456')
     expect(window.location.href).toBe(originalHref)
   })
+
+  it('includes a trimmed promo code in the LinuxDo OAuth request', async () => {
+    const wrapper = mount(LinuxDoOAuthSection, {
+      props: {
+        affCode: 'AFF456',
+        promoCode: ' PROMO789 '
+      }
+    })
+
+    await wrapper.get('button').trigger('click')
+
+    expect(wrapper.emitted('start')?.[0]?.[0]).toEqual({
+      provider: 'linuxdo',
+      params: {
+        redirect: '/billing?plan=pro',
+        promo_code: 'PROMO789'
+      }
+    })
+  })
 })

--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -284,6 +284,7 @@
         <EmailOAuthButtons
           :disabled="registrationActionDisabled"
           :aff-code="formData.aff_code"
+          :promo-code="formData.promo_code"
           :github-enabled="githubOAuthEnabled"
           :google-enabled="googleOAuthEnabled"
           :show-divider="false"
@@ -294,6 +295,7 @@
           v-if="linuxdoOAuthEnabled"
           :disabled="registrationActionDisabled"
           :aff-code="formData.aff_code"
+          :promo-code="formData.promo_code"
           :show-divider="false"
           @start="handleOAuthStart"
         />


### PR DESCRIPTION
## What changed

Pass the registration promo code through Google, GitHub, and LinuxDo OAuth signup starts. The code is trimmed before being added as the promo_code OAuth parameter.

## Why

The backend already captures promo_code during OAuth and applies it when a new OAuth account is created, but the registration page did not pass the value from the form into the OAuth start request.

## Scope

- Google OAuth
- GitHub OAuth
- LinuxDo OAuth
- Existing OAuth login behavior remains unchanged because promo codes are only sent from the registration page.
- Added regression coverage for Google, GitHub, and LinuxDo request payloads.

## Validation

- 8 targeted Vitest tests passed in the original development worktree.
- ue-tsc --noEmit passed.
- ESLint passed.
- git diff --check passed.

The PR branch was created from origin/main and contains only the five files related to this fix.