### PR TITLE
fix(zhipu): classify CREDIT_LIMIT tiers by unit to fix swapped 5h/weekly usage

### DIFF
--- a/backend/internal/service/cn_provider_quota_service.go
+++ b/backend/internal/service/cn_provider_quota_service.go
@@ -390,7 +390,9 @@ func classifyZhipuWindowUnit(unit int64) cnZhipuWindow {
 //
 // CREDIT_LIMIT（信用额度）与 TOKENS_LIMIT（token 窗口）度量不同：两者同时返回时
 // 只让 TOKENS_LIMIT 参与 5h/weekly 槽位竞争，避免信用额度百分比污染阈值停调
-// 快照；仅当无任何 TOKENS_LIMIT 条目时才降级用 CREDIT_LIMIT 展示。
+// 快照；仅当无任何 TOKENS_LIMIT 条目时才降级用 CREDIT_LIMIT 展示——降级条目
+// 同样先按 unit 分类，unit 缺失/未识别才落 reset 启发式（新版积分制套餐
+// GLM Token Plan 只回 CREDIT_LIMIT，条目带同样的 unit 枚举，cc-switch #6520）。
 // 老套餐只回 1 条 TOKENS_LIMIT，自然降级为仅 5h；新套餐回 2 条。
 func parseZhipuTokenTiers(data gjson.Result) []CNQuotaTier {
 	type entry struct {
@@ -425,7 +427,12 @@ func parseZhipuTokenTiers(data gjson.Result) []CNQuotaTier {
 			unclassified = append(unclassified, e)
 		}
 	}
-	var creditFallback []entry
+	// CREDIT 降级候选需保留原始 item，降级时复用同一套 unit 分类。
+	type creditCandidate struct {
+		item gjson.Result
+		e    entry
+	}
+	var creditFallback []creditCandidate
 	hasTokensLimit := false
 
 	data.Get("limits").ForEach(func(_, item gjson.Result) bool {
@@ -458,14 +465,19 @@ func parseZhipuTokenTiers(data gjson.Result) []CNQuotaTier {
 			hasTokensLimit = true
 			classify(item, e)
 		} else {
-			creditFallback = append(creditFallback, e)
+			creditFallback = append(creditFallback, creditCandidate{item: item, e: e})
 		}
 		return true
 	})
 
-	// 无任何 TOKENS_LIMIT 条目（部分套餐只报信用额度）：降级用 CREDIT_LIMIT 展示。
+	// 无任何 TOKENS_LIMIT 条目（新版积分制套餐只报信用额度）：降级用
+	// CREDIT_LIMIT 展示。降级条目同样先走 unit 分类（3=5h / 6=weekly），
+	// 仅 unit 缺失/未识别才落 reset 排序启发式——周期末尾周窗口会比 5h
+	// 更早重置，纯时间排序必然把两桶标反（cc-switch issue #3036 / #6520）。
 	if !hasTokensLimit {
-		unclassified = append(unclassified, creditFallback...)
+		for _, c := range creditFallback {
+			classify(c.item, c.e)
+		}
 	}
 
 	// 无 reset 的条目排前，再按 reset 升序，依次填入仍空缺的槽位。

--- a/backend/internal/service/cn_providers_test.go
+++ b/backend/internal/service/cn_providers_test.go
@@ -154,6 +154,64 @@ func TestParseZhipuTokenTiers_FallbackHeuristic(t *testing.T) {
 	require.InDelta(t, 50.0, tiers[1].UsedPercent, 1e-9)
 }
 
+// TestParseZhipuTokenTiers_CreditOnlyUnitClassification 新版积分制套餐（GLM Token
+// Plan，2026 改版）只回 CREDIT_LIMIT 条目：降级路径同样必须按 unit 分类
+// （3=5h / 6=weekly），不能落 reset 时间排序——周期末尾周窗口更早重置，
+// 纯时间排序必然把两桶标反（对齐 cc-switch，issue #3036 / #6520）。
+func TestParseZhipuTokenTiers_CreditOnlyUnitClassification(t *testing.T) {
+	t.Parallel()
+	// weekly 的 nextResetTime 早于 5h（模拟周期末尾），但 unit 必须胜出。
+	data := gjson.Parse(`{
+		"limits": [
+			{"type":"CREDIT_LIMIT","unit":6,"percentage":42,"nextResetTime":1700000000000},
+			{"type":"CREDIT_LIMIT","unit":3,"percentage":1,"nextResetTime":1700018000000}
+		]
+	}`)
+	tiers := parseZhipuTokenTiers(data)
+	require.Len(t, tiers, 2)
+	require.Equal(t, "5h", tiers[0].Window)
+	require.InDelta(t, 1.0, tiers[0].UsedPercent, 1e-9)
+	require.Equal(t, "weekly", tiers[1].Window)
+	require.InDelta(t, 42.0, tiers[1].UsedPercent, 1e-9)
+}
+
+// TestParseZhipuTokenTiers_CreditOnlyWithoutUnitKeepsHeuristic CREDIT 降级条目
+// 缺 unit 时仍走 reset 排序启发式（无 reset 优先归 5h）。
+func TestParseZhipuTokenTiers_CreditOnlyWithoutUnitKeepsHeuristic(t *testing.T) {
+	t.Parallel()
+	data := gjson.Parse(`{
+		"limits": [
+			{"type":"CREDIT_LIMIT","percentage":50,"nextResetTime":1700000000000},
+			{"type":"CREDIT_LIMIT","percentage":10}
+		]
+	}`)
+	tiers := parseZhipuTokenTiers(data)
+	require.Len(t, tiers, 2)
+	require.Equal(t, "5h", tiers[0].Window)
+	require.InDelta(t, 10.0, tiers[0].UsedPercent, 1e-9) // 无 reset 优先 5h
+	require.Equal(t, "weekly", tiers[1].Window)
+	require.InDelta(t, 50.0, tiers[1].UsedPercent, 1e-9)
+}
+
+// TestParseZhipuTokenTiers_TokensWinsOverCredit TOKENS 与 CREDIT 同时返回时，
+// 仅 TOKENS 参与槽位竞争，CREDIT 不污染展示（既有保护不回归）。
+func TestParseZhipuTokenTiers_TokensWinsOverCredit(t *testing.T) {
+	t.Parallel()
+	data := gjson.Parse(`{
+		"limits": [
+			{"type":"TOKENS_LIMIT","unit":3,"percentage":20,"nextResetTime":1700018000000},
+			{"type":"TOKENS_LIMIT","unit":6,"percentage":70,"nextResetTime":1700000000000},
+			{"type":"CREDIT_LIMIT","unit":3,"percentage":99,"nextResetTime":1700018000000}
+		]
+	}`)
+	tiers := parseZhipuTokenTiers(data)
+	require.Len(t, tiers, 2)
+	require.Equal(t, "5h", tiers[0].Window)
+	require.InDelta(t, 20.0, tiers[0].UsedPercent, 1e-9)
+	require.Equal(t, "weekly", tiers[1].Window)
+	require.InDelta(t, 70.0, tiers[1].UsedPercent, 1e-9)
+}
+
 // TestParseZhipuTokenTiers_IgnoresNonTokenEntries 非 TOKENS_LIMIT/CREDIT_LIMIT 条目跳过。
 func TestParseZhipuTokenTiers_IgnoresNonTokenEntries(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- 新版积分制套餐（GLM Token Plan，2026 改版）的额度接口只返回 `CREDIT_LIMIT` 条目（上游接口变动，见 farion1231/cc-switch#6520），条目仍带 `unit` 枚举（3=5h / 6=weekly）
- `parseZhipuTokenTiers` 只对 `TOKENS_LIMIT` 做 unit 分类，`CREDIT_LIMIT` 降级路径直接落入 `nextResetTime` 排序启发式；订阅周期末尾周窗口比重置更早时，排序必然把周桶填入 5h 槽位 → 账号管理页面周用量与 5 小时用量标反（farion1231/cc-switch#3036 同类问题）
- 修复：CREDIT 降级条目复用同一套 unit 分类；unit 缺失/未识别仍走 reset 启发式兜底；保留「TOKENS 与 CREDIT 同时返回时仅 TOKENS 参与槽位竞争」的既有保护

## Test plan

- [x] 新增 `TestParseZhipuTokenTiers_CreditOnlyUnitClassification`（修复前失败，精确复现标反）
- [x] 新增 `TestParseZhipuTokenTiers_CreditOnlyWithoutUnitKeepsHeuristic`（无 unit 时启发式行为不变）
- [x] 新增 `TestParseZhipuTokenTiers_TokensWinsOverCredit`（TOKENS 优先保护不回归）
- [x] `go test -tags unit ./internal/service/` 全量通过

Refs: farion1231/cc-switch#3036, farion1231/cc-switch#6520

🤖 Generated with [Claude Code](https://claude.com/claude-code)