### PR TITLE
fix(security): make raw forwarded IP trust opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ Additional security-related options are available in `config.yaml`:
 - `security.response_headers.enabled` to enable configurable response header filtering (disabled uses default allowlist)
 - `security.csp` to control Content-Security-Policy headers
 - `billing.circuit_breaker` to fail closed on billing errors
-- `security.trust_forwarded_ip_for_api_key_acl` enables legacy raw forwarded-header takeover (enabled by default for upgrade compatibility); disable it to enforce `server.trusted_proxies`, which should contain only the exact proxy CIDRs that connect directly to Sub2API
+- `security.trust_forwarded_ip_for_api_key_acl` enables legacy raw forwarded-header takeover (disabled for new installations; completed V2 choices are preserved, while the existing one-time legacy migration still applies); keep it disabled to enforce `server.trusted_proxies`, which should contain only the exact proxy CIDRs that connect directly to Sub2API
 - `security.forwarded_client_ip_headers` configures up to 16 third-party CDN client-IP header names; they are checked in order before the built-in headers only while legacy takeover is enabled
 - `turnstile.required` to require Turnstile in release mode
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -571,7 +571,7 @@ default:
 - `security.response_headers.enabled` 可启用可配置响应头过滤（关闭时使用默认白名单）
 - `security.csp` 配置 Content-Security-Policy
 - `billing.circuit_breaker` 计费异常时 fail-closed
-- `security.trust_forwarded_ip_for_api_key_acl` 控制旧版原始转发头接管（为升级兼容默认开启）；关闭后严格使用 `server.trusted_proxies`，其中只应填写直接连接 Sub2API 的精确代理 CIDR
+- `security.trust_forwarded_ip_for_api_key_acl` 控制旧版原始转发头接管（新安装默认关闭；已完成 V2 迁移的选择保持不变，未迁移的旧配置仍执行既有的一次性兼容迁移）；保持关闭会严格使用 `server.trusted_proxies`，其中只应填写直接连接 Sub2API 的精确代理 CIDR
 - `security.forwarded_client_ip_headers` 最多配置 16 个第三方 CDN 客户端 IP 请求头；仅在旧版接管开启时按顺序优先于内置请求头解析
 - `turnstile.required` 在 release 模式强制启用 Turnstile
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -558,7 +558,7 @@ default:
 - `security.response_headers.enabled` - 設定可能なレスポンスヘッダーフィルタリングを有効化（無効時はデフォルトの許可リストを使用）
 - `security.csp` - Content-Security-Policy ヘッダーの制御
 - `billing.circuit_breaker` - 課金エラー時にフェイルクローズ
-- `security.trust_forwarded_ip_for_api_key_acl` - 従来の生転送ヘッダーによる上書きを制御（アップグレード互換性のため既定で有効）。無効にすると `server.trusted_proxies` を厳格に使用し、Sub2API に直接接続するプロキシの正確な CIDR のみを指定
+- `security.trust_forwarded_ip_for_api_key_acl` - 従来の生転送ヘッダーによる上書きを制御（新規インストールでは既定で無効。V2 移行済みの選択は維持され、未移行の旧設定には既存の一度限りの互換移行が適用される）。無効のままにすると `server.trusted_proxies` を厳格に使用し、Sub2API に直接接続するプロキシの正確な CIDR のみを指定
 - `security.forwarded_client_ip_headers` - サードパーティ CDN のクライアント IP ヘッダーを最大 16 個指定。従来モードが有効な場合のみ、設定順で組み込みヘッダーより先に評価
 - `turnstile.required` - リリースモードでの Turnstile 必須化
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -2061,7 +2061,11 @@ func setDefaults() {
 	viper.SetDefault("security.csp.enabled", true)
 	viper.SetDefault("security.csp.policy", DefaultCSPPolicy)
 	viper.SetDefault("security.proxy_probe.insecure_skip_verify", false)
-	viper.SetDefault("security.trust_forwarded_ip_for_api_key_acl", true)
+	// Raw forwarding headers are attacker-controlled unless every ingress hop
+	// overwrites them. New installations therefore default to Gin's explicit
+	// server.trusted_proxies chain. Existing databases retain the established
+	// one-time compatibility migration in LoadForwardedClientIPSettings.
+	viper.SetDefault("security.trust_forwarded_ip_for_api_key_acl", false)
 
 	// Security - disable direct fallback on proxy error
 	viper.SetDefault("security.proxy_fallback.allow_direct_on_error", false)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -96,7 +96,7 @@ func TestLoadHTTPIngressSafetyDefaults(t *testing.T) {
 	require.Equal(t, 64*1024, cfg.Server.MaxHeaderBytes)
 	require.Empty(t, cfg.Server.TrustedProxies)
 	require.False(t, cfg.Server.TrustedProxiesConfigured)
-	require.True(t, cfg.TrustForwardedIPForAPIKeyACL())
+	require.False(t, cfg.TrustForwardedIPForAPIKeyACL())
 	require.Equal(t, int64(32*1024*1024), cfg.Gateway.TextMaxBodySize)
 	require.True(t, cfg.APIKeyAuth.InvalidAbuse.Enabled)
 	require.Equal(t, 120, cfg.APIKeyAuth.InvalidAbuse.Threshold)

--- a/backend/internal/service/setting_parse.go
+++ b/backend/internal/service/setting_parse.go
@@ -45,8 +45,10 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		return err
 	}
 	forwardedClientIPHeaders := []string{}
+	trustForwardedIP := false
 	if s != nil && s.cfg != nil {
 		forwardedClientIPHeaders = s.cfg.ForwardedClientIPSettings().Headers
+		trustForwardedIP = s.cfg.TrustForwardedIPForAPIKeyACL()
 	}
 	forwardedClientIPHeadersJSON, err := json.Marshal(forwardedClientIPHeaders)
 	if err != nil {
@@ -64,7 +66,7 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		SettingKeyLoginAgreementMode:                        defaultLoginAgreementMode,
 		SettingKeyLoginAgreementUpdatedAt:                   defaultLoginAgreementDate,
 		SettingKeyLoginAgreementDocuments:                   loginAgreementDocumentsJSON,
-		SettingKeyAPIKeyACLTrustForwardedIP:                 "true",
+		SettingKeyAPIKeyACLTrustForwardedIP:                 strconv.FormatBool(trustForwardedIP),
 		SettingKeyForwardedClientIPHeaders:                  string(forwardedClientIPHeadersJSON),
 		settingKeyForwardedClientIPModeV2:                   "true",
 		SettingKeySiteName:                                  "Sub2API",

--- a/backend/internal/service/setting_service_update_test.go
+++ b/backend/internal/service/setting_service_update_test.go
@@ -570,7 +570,18 @@ func TestSettingService_InitializeDefaultSettingsPersistsConfiguredForwardedClie
 	svc := NewSettingService(repo, cfg)
 
 	require.NoError(t, svc.InitializeDefaultSettings(context.Background()))
+	require.Equal(t, "true", repo.values[SettingKeyAPIKeyACLTrustForwardedIP])
+	require.Equal(t, "true", repo.values[settingKeyForwardedClientIPModeV2])
 	require.JSONEq(t, `["X-Cdn-Ip","True-Client-Ip"]`, repo.values[SettingKeyForwardedClientIPHeaders])
+}
+
+func TestSettingService_InitializeDefaultSettingsUsesSecureForwardedIPDefault(t *testing.T) {
+	repo := &forwardedIPMigrationRepoStub{values: map[string]string{}}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.NoError(t, svc.InitializeDefaultSettings(context.Background()))
+	require.Equal(t, "false", repo.values[SettingKeyAPIKeyACLTrustForwardedIP])
+	require.Equal(t, "true", repo.values[settingKeyForwardedClientIPModeV2])
 }
 
 func TestSettingService_UpdateSettings_APIKeyACLTrustForwardedIPRefreshesConfig(t *testing.T) {
@@ -713,6 +724,14 @@ func TestSettingService_LoadForwardedClientIPSettingsMigration(t *testing.T) {
 			},
 			wantEnabled: false,
 		},
+		{
+			name: "completed migration preserves later true choice",
+			values: map[string]string{
+				SettingKeyAPIKeyACLTrustForwardedIP: "true",
+				settingKeyForwardedClientIPModeV2:   "true",
+			},
+			wantEnabled: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -730,6 +749,67 @@ func TestSettingService_LoadForwardedClientIPSettingsMigration(t *testing.T) {
 				require.Equal(t, "true", repo.updates[settingKeyForwardedClientIPModeV2])
 			} else {
 				require.NotContains(t, repo.updates, settingKeyForwardedClientIPModeV2)
+			}
+		})
+	}
+}
+
+func TestSettingService_ExistingInstallRunsForwardedIPMigrationAfterDefaultInitialization(t *testing.T) {
+	tests := []struct {
+		name              string
+		values            map[string]string
+		trustedProxiesSet bool
+		wantEnabled       bool
+	}{
+		{
+			name: "legacy false without proxy config migrates to compatibility",
+			values: map[string]string{
+				SettingKeyRegistrationEnabled:       "true",
+				SettingKeyAPIKeyACLTrustForwardedIP: "false",
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "legacy false with explicit proxy config stays secure",
+			values: map[string]string{
+				SettingKeyRegistrationEnabled:       "true",
+				SettingKeyAPIKeyACLTrustForwardedIP: "false",
+			},
+			trustedProxiesSet: true,
+			wantEnabled:       false,
+		},
+		{
+			name: "completed migration preserves true",
+			values: map[string]string{
+				SettingKeyRegistrationEnabled:       "true",
+				SettingKeyAPIKeyACLTrustForwardedIP: "true",
+				settingKeyForwardedClientIPModeV2:   "true",
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "completed migration preserves false",
+			values: map[string]string{
+				SettingKeyRegistrationEnabled:       "true",
+				SettingKeyAPIKeyACLTrustForwardedIP: "false",
+				settingKeyForwardedClientIPModeV2:   "true",
+			},
+			wantEnabled: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := &forwardedIPMigrationRepoStub{values: test.values}
+			cfg := &config.Config{Server: config.ServerConfig{TrustedProxiesConfigured: test.trustedProxiesSet}}
+			svc := NewSettingService(repo, cfg)
+
+			require.NoError(t, svc.InitializeDefaultSettings(context.Background()))
+			require.Nil(t, repo.updates, "an initialized database must not be rewritten as a fresh install")
+			require.NoError(t, svc.LoadForwardedClientIPSettings(context.Background()))
+			require.Equal(t, test.wantEnabled, cfg.TrustForwardedIPForAPIKeyACL())
+			if test.values[settingKeyForwardedClientIPModeV2] != "true" {
+				require.Equal(t, "true", repo.values[settingKeyForwardedClientIPModeV2])
 			}
 		})
 	}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -39,7 +39,10 @@ api.sub2api.com {
 		lb_try_duration 5s
 		lb_try_interval 250ms
 
-		# 仅从实际 TCP 对端生成转发头，避免透传客户端伪造值。
+		# 仅从实际 TCP 对端生成内置转发头，避免透传客户端伪造值。
+		# 如果配置了 security.forwarded_client_ip_headers，也必须在此删除
+		# 或从可信 TCP 对端重写每个自定义头。
+		header_up -CF-Connecting-IP
 		header_up X-Real-IP {remote_host}
 		header_up X-Forwarded-For {remote_host}
 		header_up X-Forwarded-Proto {scheme}

--- a/deploy/EDGE_SECURITY.md
+++ b/deploy/EDGE_SECURITY.md
@@ -29,8 +29,11 @@ the application's responsibility.
 
 ## Trusted client IPs
 
-`security.trust_forwarded_ip_for_api_key_acl` is enabled by default for upgrade
-compatibility. While enabled, raw forwarding headers take over client-IP
+New installations default `security.trust_forwarded_ip_for_api_key_acl` to
+`false`, so Gin's explicit `server.trusted_proxies` chain is authoritative.
+Completed V2 migrations keep their persisted choice; pre-V2 settings still run
+the one-time compatibility migration described below.
+While the switch is enabled, raw forwarding headers take over client-IP
 resolution for logs and security-sensitive paths. Custom headers from
 `security.forwarded_client_ip_headers` are checked in configured order before
 the built-in `CF-Connecting-IP`, `X-Real-IP`, and `X-Forwarded-For` fallback.
@@ -49,10 +52,12 @@ headers are ignored completely when the switch is disabled. In that mode Gin's
 CIDR/IP addresses that connect directly to Sub2API. An explicit empty list
 trusts no forwarded client IPs.
 
-On the first upgrade to this mode, a legacy `false` value is changed to `true`
-only when `server.trusted_proxies` was not explicitly configured; explicit
-proxy policies remain in secure mode. New installations persist the configured
-custom header list during database initialization. Existing installations
+On the first upgrade to this mode, a pre-migration `false` value is changed to
+`true` only when `server.trusted_proxies` was not explicitly configured; this
+preserves the old installation's effective behavior. Explicit proxy policies
+remain in secure mode. New installations persist `false` together with the
+migration marker and the configured custom header list during database
+initialization. Existing installations
 backfill a missing database value from the YAML configuration. A hidden
 migration marker prevents later administrator changes from being overwritten.
 If settings cannot be read or the persisted custom-header list is malformed,
@@ -114,6 +119,9 @@ server {
         limit_req zone=sub2api_api burst=60 nodelay;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
+        # Also clear or overwrite every header configured in
+        # security.forwarded_client_ip_headers.
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -148,8 +156,9 @@ processing is restricted to explicit trusted proxy CIDRs.
 ## Caddy and CDN
 
 The bundled `deploy/Caddyfile` sets a 64 KiB header limit, a 10-second header
-timeout, a 256 MiB absolute body limit, and overwrites forwarded addresses from
-the TCP peer. It is therefore a direct-to-Caddy baseline. Do not use its
+timeout, a 256 MiB absolute body limit, removes incoming `CF-Connecting-IP`,
+and overwrites forwarded addresses from the TCP peer. It is therefore a
+direct-to-Caddy baseline. Do not use its
 `{remote_host}` forwarding lines unchanged behind a CDN: all clients would be
 attributed to a CDN egress address, collapsing rejection aggregation and the
 invalid-auth limiter onto unrelated users.


### PR DESCRIPTION
## Summary

- default raw forwarded-header trust to off for new installations while preserving explicit config and the existing one-time upgrade migration
- persist the secure default and V2 marker for fresh databases, with regression coverage for fresh, explicit, pre-V2, and completed-V2 states
- remove incoming `CF-Connecting-IP` in the bundled Caddy/Nginx baselines and clarify custom-header sanitization

This prevents client-supplied `CF-Connecting-IP` from bypassing API-key ACLs, per-IP auth throttles, and audit attribution on default deployments. Existing completed V2 choices are unchanged; the established pre-V2 compatibility migration remains intact.

Fixes #6112.

## Validation

- `cd backend && go test ./internal/config`
- `cd backend && go test -tags=unit ./internal/service -run 'TestSettingService_(InitializeDefaultSettingsPersistsConfiguredForwardedClientIPHeaders|InitializeDefaultSettingsUsesSecureForwardedIPDefault|LoadForwardedClientIPSettingsMigration|ExistingInstallRunsForwardedIPMigrationAfterDefaultInitialization)$' -count=1`
- `cd backend && go test -tags=unit ./internal/server/middleware -run 'APIKeyAuthIPRestriction' -count=1`
- `git diff --check`

`caddy validate` was not run because the binary is unavailable in this environment.
