### PR TITLE
Require OpenAI auth in Codex API key config

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -972,7 +972,7 @@ goals = true`
 
 function generateCodexProviderAuthConfig(): string {
   if (codexAuthMode.value === 'api-key') {
-    return `requires_openai_auth = false
+    return `requires_openai_auth = true
 http_headers = { "x-openai-actor-authorization" = "local-image-extension" }`
   }
 

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -352,7 +352,7 @@ describe('UseKeyModal', () => {
 
     expect(apiKeyMode.attributes('aria-checked')).toBe('true')
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('requires_openai_auth = false')
+    expect(configToml).toContain('requires_openai_auth = true')
     expect(configToml).toContain('http_headers = { "x-openai-actor-authorization" = "local-image-extension" }')
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
@@ -455,13 +455,14 @@ describe('UseKeyModal', () => {
 
     expect(wrapper.get('[data-testid="codex-auth-mode-api-key"]').attributes('aria-checked')).toBe('true')
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('requires_openai_auth = false')
+    expect(configToml).toContain('requires_openai_auth = true')
     expect(configToml).toContain('http_headers = { "x-openai-actor-authorization" = "local-image-extension" }')
     expect(configToml).not.toContain('env_key')
     expect(configToml).not.toContain('image_generation')
     expect(configToml).toContain('supports_websockets = true')
     expect(configToml).toContain('[features]\nresponses_websockets_v2 = true\ngoals = true')
     expect(codeBlocks).toContain('{\n  "OPENAI_API_KEY": "sk-test"\n}')
+    expect(wrapper.text()).toContain('auth.json')
   })
 
   it('resets Codex authentication mode when the modal reopens or platform changes', async () => {


### PR DESCRIPTION
Summary

Fix the generated Codex API Key Mode configuration so Codex continues to load the API key from `~/.codex/auth.json`.

- Set `requires_openai_auth = true` in Codex API Key Mode.
- Keep the `x-openai-actor-authorization = "local-image-extension"` header used by the client-side image executor.
- Update both HTTP and WebSocket configuration tests.
- Keep the existing `auth.json` output without introducing `env_key` or embedding a bearer token in `config.toml`.

## Problem

The generated API Key Mode configuration previously contained:

```toml
requires_openai_auth = false
http_headers = { "x-openai-actor-authorization" = "local-image-extension" }
```

At the same time, the API key was written only to:

```text
~/.codex/auth.json
```

With `requires_openai_auth = false`, Codex could skip the existing authentication file and send `/responses` requests without an API key.

This resulted in the gateway returning:

```text
401 Unauthorized
API_KEY_REQUIRED: API key is required in Authorization header
```

## Solution

Generate the following configuration for API Key Mode:

```toml
requires_openai_auth = true
http_headers = { "x-openai-actor-authorization" = "local-image-extension" }
```

This keeps authentication based on the existing `auth.json` file while preserving authorization for the local image executor.

Compatibility Mode remains unchanged and does not include the image executor header.

## Tests

Updated `UseKeyModal.spec.ts` to verify that both Codex HTTP and WebSocket configurations:

- Set `requires_openai_auth = true`.
- Preserve the `local-image-extension` header.
- Continue to generate `auth.json`.
- Do not add `env_key` or `image_generation` configuration.

Validation completed:

- `git diff --check` passed.

Not run:

- Vitest and TypeScript type checking could not be executed because the frontend dependencies were unavailable and the package registry could not be reached.
