### PR TITLE
fix(openai): refresh usage after quota reset

### DIFF
--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -27,6 +27,7 @@ type OpenAIOAuthHandler struct {
 type openAIQuotaService interface {
 	QueryUsage(ctx context.Context, accountID int64) (*service.OpenAIQuotaUsage, error)
 	CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *service.OpenAIRateLimitResetCredits) error
+	CachePostResetSnapshot(ctx context.Context, accountID int64, usage *service.OpenAIQuotaUsage) error
 	ResetCredit(ctx context.Context, accountID int64) (*service.OpenAIQuotaResetResult, error)
 }
 

--- a/backend/internal/handler/admin/openai_oauth_handler_reset_quota_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_reset_quota_test.go
@@ -48,6 +48,12 @@ func (s *openAIQuotaWorkflowStub) CacheResetCreditsSnapshot(ctx context.Context,
 	return s.cacheErr
 }
 
+func (s *openAIQuotaWorkflowStub) CachePostResetSnapshot(ctx context.Context, _ int64, _ *service.OpenAIQuotaUsage) error {
+	s.cacheCalls++
+	s.cacheCtxErr = ctx.Err()
+	return s.cacheErr
+}
+
 type openAIAccountStateRecovererStub struct {
 	err         error
 	calls       int

--- a/backend/internal/service/openai_quota_auto_reset.go
+++ b/backend/internal/service/openai_quota_auto_reset.go
@@ -54,6 +54,7 @@ type OpenAIAutoResetCreditState struct {
 type openAIAutoResetQuota interface {
 	QueryUsage(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error)
 	CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *OpenAIRateLimitResetCredits) error
+	CachePostResetSnapshot(ctx context.Context, accountID int64, usage *OpenAIQuotaUsage) error
 	ResetCreditTargeted(ctx context.Context, accountID int64, creditID, redeemRequestID string) (*OpenAIQuotaResetResult, error)
 }
 

--- a/backend/internal/service/openai_quota_auto_reset_test.go
+++ b/backend/internal/service/openai_quota_auto_reset_test.go
@@ -192,6 +192,10 @@ func (q *autoResetTestQuota) CacheResetCreditsSnapshot(context.Context, int64, *
 	return nil
 }
 
+func (q *autoResetTestQuota) CachePostResetSnapshot(context.Context, int64, *OpenAIQuotaUsage) error {
+	return nil
+}
+
 func (q *autoResetTestQuota) ResetCreditTargeted(_ context.Context, _ int64, creditID, redeemRequestID string) (*OpenAIQuotaResetResult, error) {
 	if creditID == "" || redeemRequestID == "" {
 		panic("targeted reset identifiers must be present")

--- a/backend/internal/service/openai_quota_reset_workflow.go
+++ b/backend/internal/service/openai_quota_reset_workflow.go
@@ -15,7 +15,7 @@ const (
 
 type openAIQuotaResetWorkflowQuota interface {
 	QueryUsage(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error)
-	CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *OpenAIRateLimitResetCredits) error
+	CachePostResetSnapshot(ctx context.Context, accountID int64, usage *OpenAIQuotaUsage) error
 }
 
 type openAIQuotaResetWorkflowRecoverer interface {
@@ -60,7 +60,7 @@ func RunOpenAIQuotaResetPostProcess(
 			slog.Warn("openai_quota_reset_cache_refresh_failed", "account_id", accountID, "error_code", infraerrors.Reason(usageErr))
 			result.WarningCode = OpenAIQuotaResetWarningCacheRefreshFailed
 		default:
-			if err := quota.CacheResetCreditsSnapshot(ctx, accountID, usage.RateLimitResetCredits); err != nil {
+			if err := quota.CachePostResetSnapshot(ctx, accountID, usage); err != nil {
 				slog.Warn("openai_quota_reset_cache_refresh_failed", "account_id", accountID, "error_code", infraerrors.Reason(err))
 				result.WarningCode = OpenAIQuotaResetWarningCacheRefreshFailed
 			} else {

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -225,6 +225,23 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 // consume) credits that already expired. Callers must treat this rejection as a
 // partial success — the upstream read itself is still valid.
 func (s *OpenAIQuotaService) CacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *OpenAIRateLimitResetCredits) error {
+	return s.cacheResetCreditsSnapshot(ctx, accountID, credits, nil)
+}
+
+// CachePostResetSnapshot persists the credits and usage windows observed after a reset.
+func (s *OpenAIQuotaService) CachePostResetSnapshot(ctx context.Context, accountID int64, usage *OpenAIQuotaUsage) error {
+	if usage == nil {
+		return s.cacheResetCreditsSnapshot(ctx, accountID, nil, nil)
+	}
+	return s.cacheResetCreditsSnapshot(
+		ctx,
+		accountID,
+		usage.RateLimitResetCredits,
+		buildOpenAIAutoResetUsageUpdates(usage, time.Now()),
+	)
+}
+
+func (s *OpenAIQuotaService) cacheResetCreditsSnapshot(ctx context.Context, accountID int64, credits *OpenAIRateLimitResetCredits, updates map[string]any) error {
 	if credits == nil || (credits.AvailableCount > 0 && len(credits.Credits) == 0) {
 		return infraerrors.New(
 			http.StatusBadGateway,
@@ -232,9 +249,11 @@ func (s *OpenAIQuotaService) CacheResetCreditsSnapshot(ctx context.Context, acco
 			"failed to refresh reset-credit expiration details; cached data was preserved",
 		)
 	}
-	if err := s.accountRepo.UpdateExtra(ctx, accountID, map[string]any{
-		openaiQuotaResetCreditsKey: credits,
-	}); err != nil {
+	if updates == nil {
+		updates = make(map[string]any, 1)
+	}
+	updates[openaiQuotaResetCreditsKey] = credits
+	if err := s.accountRepo.UpdateExtra(ctx, accountID, updates); err != nil {
 		return infraerrors.New(
 			http.StatusInternalServerError,
 			"OPENAI_QUOTA_CACHE_WRITE_FAILED",

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -27,9 +27,10 @@ import (
 // stubQuotaAccountRepo 是多账号 AccountRepository stub，仅实现 GetByID。
 type stubQuotaAccountRepo struct {
 	AccountRepository
-	accounts       map[int64]*Account
-	extraUpdates   map[int64]map[string]any
-	extraUpdateErr error
+	accounts         map[int64]*Account
+	extraUpdates     map[int64]map[string]any
+	extraUpdateCalls int
+	extraUpdateErr   error
 }
 
 func (r *stubQuotaAccountRepo) GetByID(_ context.Context, id int64) (*Account, error) {
@@ -53,6 +54,7 @@ func (r *stubQuotaAccountRepo) UpdateExtra(_ context.Context, id int64, updates 
 	if r.extraUpdateErr != nil {
 		return r.extraUpdateErr
 	}
+	r.extraUpdateCalls++
 	if r.extraUpdates == nil {
 		r.extraUpdates = make(map[int64]map[string]any)
 	}
@@ -692,6 +694,29 @@ func TestCacheResetCreditsSnapshot(t *testing.T) {
 
 		require.ErrorContains(t, err, "database unavailable")
 	})
+}
+
+func TestCachePostResetSnapshot(t *testing.T) {
+	repo := &stubQuotaAccountRepo{}
+	svc := &OpenAIQuotaService{accountRepo: repo}
+	credits := &OpenAIRateLimitResetCredits{AvailableCount: 0}
+	usage := &OpenAIQuotaUsage{
+		RateLimitResetCredits: credits,
+		RateLimit: &OpenAIRateLimit{
+			PrimaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent: 0, LimitWindowSeconds: 5 * 60 * 60, ResetAfterSeconds: 5 * 60 * 60,
+			},
+			SecondaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent: 0, LimitWindowSeconds: 7 * 24 * 60 * 60, ResetAfterSeconds: 7 * 24 * 60 * 60,
+			},
+		},
+	}
+
+	require.NoError(t, svc.CachePostResetSnapshot(context.Background(), 100, usage))
+	require.Equal(t, 1, repo.extraUpdateCalls)
+	require.Equal(t, credits, repo.extraUpdates[100][openaiQuotaResetCreditsKey])
+	require.Equal(t, 0.0, repo.extraUpdates[100]["codex_5h_used_percent"])
+	require.Equal(t, 0.0, repo.extraUpdates[100]["codex_7d_used_percent"])
 }
 
 // TestResetCreditGetByIDError_FailsClosed 验证守卫「失败关闭」语义：

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -656,8 +656,6 @@ import { cnQuotaCellVisible as cnQuotaCellVisibleFn, cnBalanceCellVisible as cnB
 // Module-level cache shared across all AccountUsageCell instances
 const _usageCache = new Map<number, { data: AccountUsageInfo; ts: number }>()
 const USAGE_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
-// How long a quota-reset response may suppress the row-patch usage refetch.
-const SUPPRESS_USAGE_REFRESH_WINDOW_MS = 5 * 1000
 
 const props = withDefaults(
   defineProps<{
@@ -699,7 +697,6 @@ const usageInfo = ref<AccountUsageInfo | null>(null)
 watch(usageInfo, (usage) => {
   if (usage) emit('usage-loaded', usage)
 })
-const suppressOpenAIUsageRefreshUntil = ref(0)
 const rootRef = ref<HTMLElement | null>(null)
 const isDesktopViewport = ref(
   typeof window === 'undefined' ? true : window.matchMedia(desktopViewportQuery).matches
@@ -1525,11 +1522,6 @@ const quotaTotalBar = computed((): QuotaBarInfo | null => {
 })
 
 const handleQuotaResetAccountUpdated = (account: Account) => {
-  // The reset response already carries authoritative quota and account data.
-  // Avoid turning the parent patch into a second automatic /usage request.
-  // The suppression is time-boxed so an unhandled emit (parent that ignores
-  // account-updated) cannot latch it and swallow a later, unrelated refresh.
-  suppressOpenAIUsageRefreshUntil.value = Date.now() + SUPPRESS_USAGE_REFRESH_WINDOW_MS
   emit('account-updated', account)
 }
 
@@ -1619,10 +1611,6 @@ watch(
 watch(openAIUsageRefreshKey, (nextKey, prevKey) => {
   if (!prevKey || nextKey === prevKey) return
   if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return
-  if (Date.now() < suppressOpenAIUsageRefreshUntil.value) {
-    suppressOpenAIUsageRefreshUntil.value = 0
-    return
-  }
 
   if (isBatchManaged.value) {
     requestParentBatchUsage({ force: true })

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -519,7 +519,7 @@ describe('AccountUsageCell', () => {
 	expect(wrapper.text()).toContain('5h|0|200')
   })
 
-  it('OpenAI 重置响应更新账号行时不会额外拉取 usage', async () => {
+  it('OpenAI 重置响应更新账号行后重新拉取 usage', async () => {
     getUsage.mockResolvedValue({
       five_hour: {
         utilization: 0,
@@ -560,7 +560,7 @@ describe('AccountUsageCell', () => {
     await wrapper.setProps({ account: updatedAccount as Account })
     await flushPromises()
 
-    expect(getUsage).toHaveBeenCalledTimes(1)
+    expect(getUsage).toHaveBeenCalledTimes(2)
   })
 
   it('OpenAI OAuth 已限额时显示 /usage API 返回的限额数据', async () => {


### PR DESCRIPTION
## 背景与动机

手动消费 OpenAI Reset Credit 后，重置卡数量会更新，但账号列表中的 5h/7d Usage 进度条可能继续显示重置前的数据。

一个明确的复现场景是：

1. 账号的 5h/7d Usage 已达到 100%。
2. 管理员手动消费一张 Reset Credit。
3. 上游消费成功。
4. 随后的 `/wham/usage` 已返回 0% 以及新的重置时间。
5. Reset Credit 卡片显示了新的剩余数量，但外层 Usage 进度条仍显示 100%。
6. 只有后续请求、额外刷新或组件重建后，进度条才可能恢复正确。

这里的预期不是由前端直接把进度设置为 0%，而是在 Reset 完成后通过现有后端 Usage API 获取最新状态，并以该结果更新界面。

## 根因

问题由两处状态衔接共同造成：

- Reset 后处理流程已经重新调用 `/wham/usage`，但此前只将 Reset Credit 数量写入 `account.extra`，没有持久化同次响应中的 5h/7d Usage 窗口。
- `AccountUsageCell` 收到更新后的账号后，本来可以通过现有 watcher 重新请求 Usage，但 Reset 路径设置了 5 秒 suppression，明确跳过了这次刷新。

因此，重置卡使用了新的 `result.quota`，而外层 Usage 进度条仍停留在旧的 `usageInfo`。

## 修复方式

- 在 Reset 后处理中，将新查询到的 5h/7d 窗口与 Reset Credit 快照合并到同一次 `UpdateExtra`。
- 移除 Reset 后对 Usage watcher 的 suppression。
- 继续使用现有 Usage 刷新链路：
  - 桌面端强制刷新批量 Usage API。
  - 移动端清除本地缓存后请求标准 Usage API。

前端不会直接注入 0%，最终显示值仍来自后端 Usage API。

## 变更范围

本 PR 不新增 Reset API 响应字段，不修改 `AccountsView` 缓存架构，也不增加额外的请求竞态处理。

最终变更为 9 个文件，新增 66 行、删除 22 行，主要包含内部接口适配和一个小型后端测试。

## 验证

- 完整 backend `internal/service` 测试
- OpenAI Reset handler 单元测试
- `AccountUsageCell` 组件测试：33/33
- Frontend typecheck
- 目标 ESLint
- `git diff --check`

<details>
<summary>English backup</summary>

## Motivation

After an OpenAI reset credit is consumed, the reset-credit count may update while the account 5h/7d usage bars continue showing the pre-reset values.

In the reproduced case, the post-reset `/wham/usage` response already reports 0% with new reset times, but the usage bars remain at 100% until another request or component refresh occurs.

The frontend should not hard-code the usage to 0%. It should refresh through the existing backend Usage API and display the value returned by that API.

## Root cause

- Reset post-processing queried `/wham/usage` again but persisted only the reset-credit snapshot, not the 5h/7d windows from the same response.
- `AccountUsageCell` suppressed the Usage refresh triggered by the updated account row.

## Fix

- Persist post-reset usage windows and reset credits in one `UpdateExtra`.
- Remove the Reset-specific refresh suppression.
- Reuse the existing desktop batch and mobile Usage API refresh paths.

This PR does not change the Reset response contract, add frontend quota injection, or introduce new cache/race-management logic.

</details>