### PR TITLE
fix(openai): 图片工具冷却不再由「模型回文字」这一请求级判据触发

### DIFF
--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -37,6 +37,13 @@ type OpenAIImagesUpstreamError struct {
 	Message           string
 	Param             string
 	UpstreamRequestID string
+
+	// SynthesizedFromModelText marks an error the gateway inferred from the
+	// model's plain-text output instead of reading it off a structured upstream
+	// error frame. Such a verdict describes this one turn ("the model answered
+	// with words instead of an image"), not the account — see
+	// shouldCoolOpenAIImagesToolForError.
+	SynthesizedFromModelText bool
 }
 
 func (e *OpenAIImagesUpstreamError) Error() string {
@@ -711,6 +718,10 @@ func openAIImagesTextFallbackErrorForText(text string) *OpenAIImagesUpstreamErro
 		ErrorType:  "upstream_error",
 		Code:       "image_generation_unavailable",
 		Message:    "Upstream did not execute image generation",
+		// Inferred from the model's own words, not from an upstream error frame:
+		// good enough to fail this turn over to another account, not evidence that
+		// this account's image tool is down for the next 30 minutes.
+		SynthesizedFromModelText: true,
 	}
 }
 
@@ -1922,6 +1933,26 @@ const (
 	openAIImagesOAuthUnavailableReason   = "openai_images_oauth_tool_unavailable"
 )
 
+// shouldCoolOpenAIImagesToolForError decides whether an image_generation_unavailable
+// verdict is durable enough to park the account's image tool for
+// openAIImagesOAuthUnavailableCooldown.
+//
+// Only an upstream error frame that names the condition qualifies. A verdict the
+// gateway synthesized from the model's plain-text reply does not: it merely says
+// this prompt produced words instead of an image, which is prompt-dependent and
+// happens on healthy accounts. Writing a 30-minute account-level cooldown from it
+// is doubly wrong because the very same error is classified retryable
+// (IsOpenAIImagesRetryableUpstreamError: status >= 500) and drives
+// newOpenAIAccountFailoverError — so one such reply walks the pool and cools every
+// account the retry touches.
+//
+// This mirrors the rule the alpha/search path already states in words: a
+// tool-endpoint failure "仍允许本次请求换号，但不修改任何账号状态"
+// (see shouldApplyOpenAIAlphaSearchAccountErrorSideEffects).
+func shouldCoolOpenAIImagesToolForError(upstreamErr *OpenAIImagesUpstreamError) bool {
+	return upstreamErr != nil && !upstreamErr.SynthesizedFromModelText
+}
+
 func (s *OpenAIGatewayService) coolOpenAIImagesOAuthTool(ctx context.Context, account *Account) {
 	if s == nil || s.accountRepo == nil || account == nil || account.Platform != PlatformOpenAI {
 		return
@@ -2017,7 +2048,9 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthResponseError(
 
 	responseBody := openAIImagesUpstreamErrorResponseBody(upstreamErr)
 	if upstreamErr.Code == "image_generation_unavailable" {
-		s.coolOpenAIImagesOAuthTool(ctx, account)
+		if shouldCoolOpenAIImagesToolForError(upstreamErr) {
+			s.coolOpenAIImagesOAuthTool(ctx, account)
+		}
 		if responseWritten {
 			return err
 		}

--- a/backend/internal/service/openai_images_tool_cooldown_test.go
+++ b/backend/internal/service/openai_images_tool_cooldown_test.go
@@ -1,0 +1,177 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// issue #6171：v0.1.181 起，/v1/images/generations 只要上游"回文字没回图"，账号就被
+// 写 30 分钟 openai:image_generation 模型级冷却。该判据是**请求级**的（这个 prompt
+// 这一轮模型选择了说话），却被当成**账号级**能力失效；又因为同一个错误被判为
+// 可重试（502）并驱动 failover，一次闲聊回复会沿着号池逐个把账号冷却掉。
+
+// countingModelRateLimitRepo 记录 SetModelRateLimit 调用，用于断言"没写账号状态"。
+type countingModelRateLimitRepo struct {
+	accountRepoStub
+	calls  int
+	scopes []string
+}
+
+func (r *countingModelRateLimitRepo) SetModelRateLimit(_ context.Context, _ int64, scope string, _ time.Time, _ ...string) error {
+	r.calls++
+	r.scopes = append(r.scopes, scope)
+	return nil
+}
+
+func newImagesCooldownContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	return c, rec
+}
+
+func imagesCooldownAccount() *Account {
+	return &Account{ID: 77, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Name: "img-oauth"}
+}
+
+func TestShouldCoolOpenAIImagesToolForError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *OpenAIImagesUpstreamError
+		want bool
+	}{
+		{
+			name: "nil_error",
+			err:  nil,
+			want: false,
+		},
+		{
+			// 网关从模型文字里推断出来的判据：只说明这一轮没出图。
+			name: "synthesized_from_model_text",
+			err: &OpenAIImagesUpstreamError{
+				StatusCode:               http.StatusBadGateway,
+				Code:                     "image_generation_unavailable",
+				SynthesizedFromModelText: true,
+			},
+			want: false,
+		},
+		{
+			// 上游自己在 error 帧里点名该状态：这才是账号级证据，保持冷却。
+			name: "structured_upstream_error_frame",
+			err: &OpenAIImagesUpstreamError{
+				StatusCode: http.StatusBadGateway,
+				Code:       "image_generation_unavailable",
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldCoolOpenAIImagesToolForError(tc.err))
+		})
+	}
+}
+
+// 主复现：文字兜底判据不得写账号级冷却。
+func TestHandleOpenAIImagesOAuthResponseError_TextFallbackDoesNotCoolAccount(t *testing.T) {
+	c, _ := newImagesCooldownContext(t)
+	repo := &countingModelRateLimitRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	account := imagesCooldownAccount()
+
+	upstreamErr := openAIImagesTextFallbackErrorForText("Here's a polished image prompt for your request.")
+	require.NotNil(t, upstreamErr)
+	require.Equal(t, "image_generation_unavailable", upstreamErr.Code)
+
+	err := svc.handleOpenAIImagesOAuthResponseError(
+		context.Background(), c, account, "gpt-image-2", "https://upstream.example/v1/responses",
+		&http.Response{StatusCode: http.StatusOK, Header: http.Header{}},
+		OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c), upstreamErr,
+	)
+
+	require.Zero(t, repo.calls, "模型闲聊不构成账号级证据，不得写 30 分钟冷却")
+
+	// 换号行为必须原样保留：本 PR 只撤销账号状态写入，不动 failover。
+	var failover *UpstreamFailoverError
+	require.True(t, errors.As(err, &failover), "仍应触发换号，got %T", err)
+}
+
+// 对照不变式：上游 error 帧点名该状态时仍然冷却，否则等于把功能整个废掉。
+func TestHandleOpenAIImagesOAuthResponseError_StructuredUnavailableStillCoolsAccount(t *testing.T) {
+	c, _ := newImagesCooldownContext(t)
+	repo := &countingModelRateLimitRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	account := imagesCooldownAccount()
+
+	upstreamErr := &OpenAIImagesUpstreamError{
+		StatusCode: http.StatusBadGateway,
+		ErrorType:  "upstream_error",
+		Code:       "image_generation_unavailable",
+		Message:    "image generation tool is not available for this account",
+	}
+
+	_ = svc.handleOpenAIImagesOAuthResponseError(
+		context.Background(), c, account, "gpt-image-2", "https://upstream.example/v1/responses",
+		&http.Response{StatusCode: http.StatusOK, Header: http.Header{}},
+		OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c), upstreamErr,
+	)
+
+	require.Equal(t, 1, repo.calls, "结构化上游证据仍须写冷却")
+	require.Equal(t, []string{openAIImageGenerationRateLimitKey}, repo.scopes)
+}
+
+// 标记必须打在文字兜底的两个入口上，且不影响违规拦截分支的判定。
+func TestOpenAIImagesTextFallback_MarksSynthesizedVerdicts(t *testing.T) {
+	t.Run("plain_text_reply_is_synthesized", func(t *testing.T) {
+		err := openAIImagesTextFallbackErrorForText("Here's a polished image prompt for your request.")
+		require.NotNil(t, err)
+		require.True(t, err.SynthesizedFromModelText)
+		require.Equal(t, "image_generation_unavailable", err.Code)
+		require.Equal(t, http.StatusBadGateway, err.StatusCode)
+	})
+
+	t.Run("body_entrypoint_is_synthesized", func(t *testing.T) {
+		body := []byte("event: response.completed\n" +
+			`data: {"type":"response.completed","response":{"id":"r","status":"completed",` +
+			`"output":[{"type":"message","content":[{"type":"output_text","text":"I drafted a prompt for you."}]}]}}` +
+			"\n\n")
+		err := openAIImagesTextFallbackError(body)
+		require.NotNil(t, err)
+		require.True(t, err.SynthesizedFromModelText)
+	})
+
+	t.Run("content_policy_branch_unchanged", func(t *testing.T) {
+		err := openAIImagesTextFallbackErrorForText("Blocked by our content policy.")
+		require.NotNil(t, err)
+		require.Equal(t, "content_policy_violation", err.Code)
+		require.Equal(t, http.StatusBadRequest, err.StatusCode)
+		// 该分支本来就不走冷却（Code 不匹配），标记与否都不改变行为；
+		// 断言它没有被顺手打标，避免语义漂移。
+		require.False(t, err.SynthesizedFromModelText)
+	})
+
+	t.Run("empty_text_yields_no_error", func(t *testing.T) {
+		require.Nil(t, openAIImagesTextFallbackErrorForText("   "))
+	})
+}
+
+// 级联的前提条件：该错误确实是可重试的，所以会带着"已写冷却"的副作用换号。
+// 这条用例把前提钉死，避免以后有人把 502 改成非重试后误以为本修复多余。
+func TestOpenAIImagesTextFallback_RemainsRetryableAndThusCascades(t *testing.T) {
+	err := openAIImagesTextFallbackErrorForText("Here's a polished image prompt for your request.")
+	require.NotNil(t, err)
+	require.True(t, IsOpenAIImagesRetryableUpstreamError(err),
+		"文字兜底判据是可重试的——正因如此，写账号冷却会沿号池级联")
+}

--- a/backend/internal/service/ratelimit_service_openai_image_test.go
+++ b/backend/internal/service/ratelimit_service_openai_image_test.go
@@ -120,7 +120,11 @@ func TestOpenAIGatewayServiceForwardImages_ImageRateLimitReturnsFailoverAndCools
 	require.Equal(t, openAIImageGenerationRateLimitKey, repo.modelRateLimitCalls[0].scope)
 }
 
-func TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability(t *testing.T) {
+// issue #6171：上游"回文字没回图"是**这一轮**的结果（模型选择了说话），不是账号能力
+// 失效。它同时被判为可重试（502）并驱动 failover，若还写 30 分钟账号级冷却，一次闲聊
+// 回复就会沿号池把每个被重试到的账号依次冷却掉。冷却仍保留给结构化上游证据，见
+// TestOpenAIGatewayServiceForwardImages_StructuredUnavailableCoolsImageCapability。
+func TestOpenAIGatewayServiceForwardImages_TextFallbackDoesNotCoolImageCapability(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	repo := &modelNotFoundAccountRepoStub{}
 	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat"}`)
@@ -154,7 +158,6 @@ func TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability(t *t
 		},
 	}
 
-	before := time.Now()
 	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
 
 	require.Nil(t, result)
@@ -162,6 +165,56 @@ func TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability(t *t
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.False(t, failoverErr.RetryableOnSameAccount)
+	// 换号行为不变：该判据仍足以放弃本账号重试这一次请求……
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	// ……但不再写任何账号级状态，否则重试会把冷却一路刷到整个号池。
+	require.Empty(t, repo.modelRateLimitCalls,
+		"模型回文字只说明这一轮没出图，不构成账号 30 分钟不可用的证据")
+}
+
+// 对照不变式：上游 error 帧点名 image_generation_unavailable 时仍写冷却，
+// 保证 #6171 的修复没有把这项能力保护整个废掉。
+func TestOpenAIGatewayServiceForwardImages_StructuredUnavailableCoolsImageCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &modelNotFoundAccountRepoStub{}
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat"}`)
+	upstreamSSE := "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"r\",\"error\":" +
+		"{\"type\":\"upstream_error\",\"code\":\"image_generation_unavailable\"," +
+		"\"message\":\"image generation tool is not available for this account\"}}}\n\n"
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{
+		accountRepo: repo,
+		httpUpstream: &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+			},
+		},
+	}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	account := &Account{
+		ID:       206,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	before := time.Now()
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+
+	require.Nil(t, result)
+	require.Error(t, err)
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	call := repo.modelRateLimitCalls[0]
 	require.Equal(t, account.ID, call.accountID)


### PR DESCRIPTION
Fixes #6171

## 问题

v0.1.181 起，`/v1/images/generations` 只要上游**回了文字而没回图**，就给账号写 30 分钟 `openai:image_generation` 模型级冷却。报告者的现象是「开启后没多久账号就全部被限制」，且「账号当前是没有问题的，模型也可以正常被调用」。

## 根因：判据是请求级的，处罚是账号级的，而且会沿号池级联

**冷却的唯一触发源，是整个函数里最弱的那个信号。**

`image_generation_unavailable` 这个 code 在全仓只有一个产生者 —— `openAIImagesTextFallbackErrorForText`，它从模型的自然语言输出**推断**而来：

```go
if isOpenAIImagesContentPolicyRefusal(text) {  // 违规 → 400
    ...
}
return &OpenAIImagesUpstreamError{             // 其余任何文字 → 502 image_generation_unavailable
    StatusCode: http.StatusBadGateway,
    Code:       "image_generation_unavailable",
}
```

结构化上游错误（`extractOpenAIImagesUpstreamError`）在更早的分支就返回了，**从不携带这个 code**。也就是说：冷却只可能由「模型这轮选择了说话」触发，永远不由上游明确声明触发。

仓库自己的既有用例 fixture 就说明了这有多容易命中 —— `TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability` 里上游回的是：

> `Here's a polished image prompt for your request.`

一句普通的闲聊/改写建议，就让账号 30 分钟不能生图。

### 级联：同一个错误既驱动 failover，又写账号状态

```go
func IsOpenAIImagesRetryableUpstreamError(err *OpenAIImagesUpstreamError) bool {
	return err != nil && err.StatusCode >= http.StatusInternalServerError   // 502 → 可重试
}
```

```go
if upstreamErr.Code == "image_generation_unavailable" {
    s.coolOpenAIImagesOAuthTool(ctx, account)          // ← 写 30 分钟账号级冷却
    ...
    return s.newOpenAIAccountFailoverError(...)        // ← 同时换号重试
}
```

于是：账号 A 回文字 → **冷却 A** → 换到 B → 同一个 prompt 同样回文字 → **冷却 B** → …… 一次请求就能把重试路径上的账号挨个冷却掉。这解释了「没多久就全部被限制」，也是比 issue 描述（「502 不该作为限制凭证」）更硬的一层。

## 修复：只认上游明确声明的证据

依据是**仓库自己已经写下的政策**（`openai_alpha_search.go` 原文）：

> alpha/search 是独立的工具端点，单次 401 不能证明账号的模型调用凭据全局失效……这里**仍允许本次请求换号，但不修改任何账号状态**

同一条规则套到这里：

- `OpenAIImagesUpstreamError` 新增 `SynthesizedFromModelText` 标记，由文字兜底分支置位
- 新增 `shouldCoolOpenAIImagesToolForError`：只有**上游 error 帧点名**该状态时才写冷却
- **换号行为一字未动** —— 该判据仍足以放弃本账号重试这一次请求

主改动 3 处、约 12 行有效代码。功能没有被废掉：上游若真的回 `error.code=image_generation_unavailable`，冷却照写（有端到端用例锁定）。

## 对既有测试的改动（重点说明）

`TestOpenAIGatewayServiceForwardImages_TextFallbackCoolsImageCapability` 把本次要修的行为编码成了预期，无法保留原断言。处理方式是**翻转并补齐，不做净删减**：

- 重命名为 `..._TextFallbackDoesNotCoolImageCapability`
- **保留**全部非冷却断言（result nil / 触发 failover / `RetryableOnSameAccount=false`），**新增** `failoverErr.StatusCode == 502`（把「可重试 → 会级联」这个前提钉死）
- 冷却断言从「1 次调用 + 4 项细节」改为 `require.Empty`，并写明理由
- **新增** `..._StructuredUnavailableCoolsImageCapability`：用 `response.failed` + `error.code=image_generation_unavailable` 的结构化帧走完整 `ForwardImages`，把上面那 4 项细节断言（accountID / scope / reason / resetAt 落在 30 分钟窗口）原样接住

净结果：该文件断言数增加，冷却能力的端到端覆盖没有下降。

## 新增测试

`openai_images_tool_cooldown_test.go`（5 组 / 10 例，`//go:build unit`）：

| 用例 | 作用 |
|---|---|
| `TestShouldCoolOpenAIImagesToolForError` | nil / 推断判据 / 结构化判据三态 |
| `..._TextFallbackDoesNotCoolAccount` | **主复现**：闲聊回复不写 `SetModelRateLimit`，且仍返回 failover 错误 |
| `..._StructuredUnavailableStillCoolsAccount` | **对照不变式**：同 code 的结构化错误仍冷却，scope 仍是 `openai:image_generation` |
| `..._MarksSynthesizedVerdicts` | 文字兜底两个入口都打标；违规拦截分支不受影响；空文本仍返回 nil |
| `..._RemainsRetryableAndThusCascades` | 把「502 可重试」这个级联前提钉死，防止日后有人误以为本修复多余 |

**回滚验证**：把守卫短路成 `if true || shouldCool...` 后重跑，主复现用例给出断言级红 —— `Should be zero, but was 1 / 模型闲聊不构成账号级证据`；恢复后全绿。

## 本次刻意不做

- **不改 failover 分类** —— 502 可重试对「这次请求」是正确的，改它会让偶发抖动直接把错误抛给客户端。本 PR 只解开「同一信号既换号又写账号状态」这个矛盾。
- **不引入连续计数阈值** —— 「N 次才冷却」需要新的计数存储，属于独立设计；若维护者希望保留对闲聊的兜底保护，这是自然的后续方案。
- **不动 30 分钟常量与其可配置性** —— issue 另一半诉求（时长可调）是配置项设计，与本次的误判修复分开。

## 验证

- `go build ./...` ✅
- `gofmt -l`（本次改动文件）干净 ✅
- `go vet -tags unit ./internal/service/` ✅
- `go test -tags unit ./internal/service/` ✅ `ok 160.846s`
- `go test ./internal/pkg/... ./internal/handler/...` ✅