### PR TITLE
fix(update): strip hyphenated pre-release/custom suffix in version comparison

### DIFF
--- a/backend/internal/service/update_service.go
+++ b/backend/internal/service/update_service.go
@@ -655,6 +655,9 @@ func compareVersions(current, latest string) int {
 
 func parseVersion(v string) [3]int {
 	v = strings.TrimPrefix(v, "v")
+	if idx := strings.IndexByte(v, '-'); idx != -1 {
+		v = v[:idx]
+	}
 	parts := strings.Split(v, ".")
 	result := [3]int{0, 0, 0}
 	for i := 0; i < len(parts) && i < 3; i++ {


### PR DESCRIPTION
### Summary
When running custom builds or pre-release tags containing hyphenated suffixes (such as \0.1.183-custom\), \parseVersion\ returned zero for the patch number due to non-digit characters, causing \compareVersions\ to treat the build as older than upstream release tags and triggering false 'New version available' notifications in the Web UI.

### Fix
Strip any hyphenated suffix (e.g. \-custom\, \-beta.1\) in \parseVersion\ before parsing SemVer integer parts.

Contributed by **WUJI-Labs**.