### PR TITLE
feat: 支持账号级温度三态策略

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1683,6 +1683,29 @@ func TestAnthropicToResponses_TemperatureStrippedForAllGpt5Variants(t *testing.T
 	}
 }
 
+func TestAnthropicToResponses_TemperaturePreservedForGPT56(t *testing.T) {
+	temp := 0.35
+	topP := 0.75
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		t.Run(model, func(t *testing.T) {
+			req := &AnthropicRequest{
+				Model:       model,
+				MaxTokens:   1024,
+				Messages:    []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"Hello"`)}},
+				Temperature: &temp,
+				TopP:        &topP,
+			}
+
+			resp, err := AnthropicToResponses(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.Temperature)
+			assert.InDelta(t, temp, *resp.Temperature, 1e-9)
+			require.NotNil(t, resp.TopP)
+			assert.InDelta(t, topP, *resp.TopP, 1e-9)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // AnthropicToResponsesResponse: Anthropic input_tokens excludes cached tokens
 // while OpenAI Responses input_tokens is the total including cached tokens.

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -28,11 +28,7 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 		Include: []string{"reasoning.encrypted_content"},
 	}
 
-	// Reasoning models (gpt-5.x) served via the Responses API do not accept
-	// sampling parameters. Sending temperature or top_p causes a 400
-	// "Unsupported parameter" error, so we only forward them for non-reasoning
-	// models.
-	if !isReasoningModel(req.Model) {
+	if !rejectsSamplingParameters(req.Model) {
 		out.Temperature = req.Temperature
 		out.TopP = req.TopP
 	}
@@ -465,12 +461,17 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
-// isReasoningModel reports whether model is a reasoning model that does not
-// support sampling parameters (temperature, top_p) via the Responses API.
-// All gpt-5.x models are reasoning-only; the Responses API returns
-// "Unsupported parameter: temperature" if these fields are present.
-func isReasoningModel(model string) bool {
-	return strings.HasPrefix(model, "gpt-5")
+// rejectsSamplingParameters reports GPT-5 families that reject temperature
+// and top_p. GPT-5.6 exposes both sampling parameters through the public API.
+func rejectsSamplingParameters(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if slash := strings.LastIndex(normalized, "/"); slash >= 0 {
+		normalized = normalized[slash+1:]
+	}
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	return strings.HasPrefix(normalized, "gpt-5") &&
+		normalized != "gpt-5.6" &&
+		!strings.HasPrefix(normalized, "gpt-5.6-")
 }
 
 // normalizeToolParameters ensures the tool parameter schema is valid for

--- a/backend/internal/pkg/apicompat/chatcompletions_anthropic_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_anthropic_bridge.go
@@ -55,8 +55,7 @@ func AnthropicToChatCompletionsRequest(req *AnthropicRequest) (*ChatCompletionsR
 		Stream:   req.Stream,
 	}
 
-	// Sampling params: reasoning models (gpt-5.x) reject temperature/top_p.
-	if !isReasoningModel(req.Model) {
+	if !rejectsSamplingParameters(req.Model) {
 		out.Temperature = req.Temperature
 		out.TopP = req.TopP
 	}

--- a/backend/internal/pkg/apicompat/chatcompletions_anthropic_bridge_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_anthropic_bridge_test.go
@@ -240,6 +240,25 @@ func TestAnthropicToChatCompletionsRequest_TemperaturePreservedForNonReasoningMo
 	require.Equal(t, 0.9, *out.TopP)
 }
 
+func TestAnthropicToChatCompletionsRequest_TemperaturePreservedForGPT56(t *testing.T) {
+	temp := 0.35
+	topP := 0.75
+	req := &AnthropicRequest{
+		Model:       "gpt-5.6-terra",
+		MaxTokens:   100,
+		Temperature: &temp,
+		TopP:        &topP,
+		Messages:    []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"hi"`)}},
+	}
+
+	out, err := AnthropicToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, out.Temperature)
+	require.InDelta(t, temp, *out.Temperature, 1e-9)
+	require.NotNil(t, out.TopP)
+	require.InDelta(t, topP, *out.TopP, 1e-9)
+}
+
 func TestAnthropicToChatCompletionsRequest_MaxTokensFloor(t *testing.T) {
 	req := &AnthropicRequest{
 		Model:     "claude-sonnet-4-20250514",

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -706,6 +706,28 @@ func TestChatCompletionsToResponses_TemperaturePreservedForNonReasoningModel(t *
 	assert.InDelta(t, 0.7, *resp.TopP, 1e-9)
 }
 
+func TestChatCompletionsToResponses_TemperaturePreservedForGPT56(t *testing.T) {
+	temp := 0.35
+	topP := 0.75
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		t.Run(model, func(t *testing.T) {
+			req := &ChatCompletionsRequest{
+				Model:       model,
+				Messages:    []ChatMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}},
+				Temperature: &temp,
+				TopP:        &topP,
+			}
+
+			resp, err := ChatCompletionsToResponses(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.Temperature)
+			assert.InDelta(t, temp, *resp.Temperature, 1e-9)
+			require.NotNil(t, resp.TopP)
+			assert.InDelta(t, topP, *resp.TopP, 1e-9)
+		})
+	}
+}
+
 func TestChatCompletionsToResponses_AssistantWithTextAndToolCalls(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model: "gpt-4o",

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -36,9 +36,7 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 		ParallelToolCalls: req.ParallelToolCalls,
 	}
 
-	// Reasoning models (gpt-5.x) do not accept sampling parameters.
-	// See isReasoningModel in anthropic_to_responses.go.
-	if !isReasoningModel(req.Model) {
+	if !rejectsSamplingParameters(req.Model) {
 		out.Temperature = req.Temperature
 		out.TopP = req.TopP
 	}

--- a/backend/internal/server/middleware/cors.go
+++ b/backend/internal/server/middleware/cors.go
@@ -83,7 +83,14 @@ func CORS(cfg config.CORSConfig) gin.HandlerFunc {
 			}
 			c.Writer.Header().Set("Access-Control-Allow-Headers", allowHeadersValue)
 			c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE, PATCH")
-			c.Writer.Header().Set("Access-Control-Expose-Headers", "ETag, Server-Timing")
+			c.Writer.Header().Set("Access-Control-Expose-Headers", strings.Join([]string{
+				"ETag",
+				"Server-Timing",
+				"X-Sub2API-Requested-Temperature",
+				"X-Sub2API-Forwarded-Temperature",
+				"X-Sub2API-Temperature-Policy",
+				"X-Sub2API-Temperature-Status",
+			}, ", "))
 			c.Writer.Header().Set("Access-Control-Max-Age", "86400")
 		}
 		// 处理预检请求

--- a/backend/internal/server/middleware/cors_test.go
+++ b/backend/internal/server/middleware/cors_test.go
@@ -108,6 +108,14 @@ func TestCORS_AllowedOrigin_HasAllowHeaders(t *testing.T) {
 			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Methods"),
 				"允许的 origin 应收到 Allow-Methods")
 			assert.Contains(t, w.Header().Get("Access-Control-Expose-Headers"), "Server-Timing")
+			for _, header := range []string{
+				"X-Sub2API-Requested-Temperature",
+				"X-Sub2API-Forwarded-Temperature",
+				"X-Sub2API-Temperature-Policy",
+				"X-Sub2API-Temperature-Status",
+			} {
+				assert.Contains(t, w.Header().Get("Access-Control-Expose-Headers"), header)
+			}
 			assert.Equal(t, "86400", w.Header().Get("Access-Control-Max-Age"),
 				"允许的 origin 应收到 Max-Age=86400")
 			assert.Equal(t, "https://allowed.example.com", w.Header().Get("Access-Control-Allow-Origin"),

--- a/backend/internal/service/account_temperature_policy.go
+++ b/backend/internal/service/account_temperature_policy.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type accountTemperatureMode string
+type temperaturePath string
+
+const (
+	accountTemperatureModeInherit  accountTemperatureMode = "inherit"
+	accountTemperatureModeOverride accountTemperatureMode = "override"
+	accountTemperatureModeOmit     accountTemperatureMode = "omit"
+
+	temperaturePathTopLevel temperaturePath = "temperature"
+	temperaturePathGemini   temperaturePath = "generationConfig.temperature"
+)
+
+type accountTemperaturePolicy struct {
+	mode        accountTemperatureMode
+	temperature float64
+}
+
+func validateAccountTemperatureCredentials(credentials map[string]any) error {
+	_, err := parseAccountTemperaturePolicy(credentials)
+	return err
+}
+
+func hasAccountTemperatureCredentialUpdate(credentials map[string]any) bool {
+	if credentials == nil {
+		return false
+	}
+	_, hasMode := credentials["temperature_mode"]
+	_, hasValue := credentials["temperature"]
+	return hasMode || hasValue
+}
+
+func parseAccountTemperaturePolicy(credentials map[string]any) (accountTemperaturePolicy, error) {
+	policy := accountTemperaturePolicy{mode: accountTemperatureModeInherit}
+	if credentials == nil {
+		return policy, nil
+	}
+
+	if rawMode, ok := credentials["temperature_mode"]; ok {
+		mode, valid := rawMode.(string)
+		if !valid {
+			return policy, invalidAccountTemperature("temperature_mode must be inherit, override, or omit")
+		}
+		policy.mode = accountTemperatureMode(strings.TrimSpace(mode))
+	}
+
+	switch policy.mode {
+	case accountTemperatureModeInherit, accountTemperatureModeOverride, accountTemperatureModeOmit:
+	default:
+		return policy, invalidAccountTemperature("temperature_mode must be inherit, override, or omit")
+	}
+
+	rawTemperature, hasTemperature := credentials["temperature"]
+	if !hasTemperature || rawTemperature == nil {
+		if policy.mode == accountTemperatureModeOverride {
+			return policy, invalidAccountTemperature("temperature is required when temperature_mode is override")
+		}
+		return policy, nil
+	}
+
+	temperature, valid := accountTemperatureNumber(rawTemperature)
+	if !valid {
+		return policy, invalidAccountTemperature("temperature must be a finite number")
+	}
+	policy.temperature = temperature
+	return policy, nil
+}
+
+func applyAccountTemperaturePolicy(body []byte, account *Account, path temperaturePath) ([]byte, error) {
+	if !gjson.ValidBytes(body) {
+		return nil, infraerrors.BadRequest("INVALID_REQUEST_BODY", "request body must be valid JSON")
+	}
+
+	var credentials map[string]any
+	if account != nil {
+		credentials = account.Credentials
+	}
+	policy, err := parseAccountTemperaturePolicy(credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	field := gjson.GetBytes(body, string(path))
+	if field.Exists() && field.Type != gjson.Number && field.Type != gjson.Null {
+		return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a number or null")
+	}
+	if field.Type == gjson.Number {
+		value := field.Float()
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a finite number")
+		}
+	}
+
+	normalized := body
+	if field.Exists() && field.Type == gjson.Null {
+		normalized, err = sjson.DeleteBytes(normalized, string(path))
+		if err != nil {
+			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
+		}
+	}
+
+	switch policy.mode {
+	case accountTemperatureModeInherit:
+		return normalized, nil
+	case accountTemperatureModeOmit:
+		updated, deleteErr := sjson.DeleteBytes(normalized, string(path))
+		if deleteErr != nil {
+			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
+		}
+		return updated, nil
+	case accountTemperatureModeOverride:
+		updated, setErr := sjson.SetBytes(normalized, string(path), policy.temperature)
+		if setErr != nil {
+			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be written to request body")
+		}
+		return updated, nil
+	default:
+		return nil, invalidAccountTemperature("temperature_mode must be inherit, override, or omit")
+	}
+}
+
+func applyResolvedAccountTemperaturePolicy(
+	ctx context.Context,
+	repo AccountRepository,
+	account *Account,
+	body []byte,
+	path temperaturePath,
+) ([]byte, error) {
+	credentialAccount, err := resolveCredentialAccount(ctx, repo, account)
+	if err != nil {
+		return nil, err
+	}
+	return applyAccountTemperaturePolicy(body, credentialAccount, path)
+}
+
+func accountTemperatureNumber(value any) (float64, bool) {
+	var number float64
+	switch v := value.(type) {
+	case json.Number:
+		parsed, err := v.Float64()
+		if err != nil {
+			return 0, false
+		}
+		number = parsed
+	case float64:
+		number = v
+	case float32:
+		number = float64(v)
+	case int:
+		number = float64(v)
+	case int8:
+		number = float64(v)
+	case int16:
+		number = float64(v)
+	case int32:
+		number = float64(v)
+	case int64:
+		number = float64(v)
+	case uint:
+		number = float64(v)
+	case uint8:
+		number = float64(v)
+	case uint16:
+		number = float64(v)
+	case uint32:
+		number = float64(v)
+	case uint64:
+		number = float64(v)
+	default:
+		return 0, false
+	}
+	return number, !math.IsNaN(number) && !math.IsInf(number, 0)
+}
+
+func invalidAccountTemperature(message string) error {
+	return infraerrors.BadRequest("INVALID_ACCOUNT_TEMPERATURE", message)
+}

--- a/backend/internal/service/account_temperature_policy.go
+++ b/backend/internal/service/account_temperature_policy.go
@@ -79,8 +79,13 @@ func parseAccountTemperaturePolicy(credentials map[string]any) (accountTemperatu
 }
 
 func applyAccountTemperaturePolicy(body []byte, account *Account, path temperaturePath) ([]byte, error) {
+	updated, _, err := applyAccountTemperaturePolicyWithResult(body, account, path)
+	return updated, err
+}
+
+func applyAccountTemperaturePolicyWithResult(body []byte, account *Account, path temperaturePath) ([]byte, accountTemperaturePolicy, error) {
 	if !gjson.ValidBytes(body) {
-		return nil, infraerrors.BadRequest("INVALID_REQUEST_BODY", "request body must be valid JSON")
+		return nil, accountTemperaturePolicy{}, infraerrors.BadRequest("INVALID_REQUEST_BODY", "request body must be valid JSON")
 	}
 
 	var credentials map[string]any
@@ -89,17 +94,17 @@ func applyAccountTemperaturePolicy(body []byte, account *Account, path temperatu
 	}
 	policy, err := parseAccountTemperaturePolicy(credentials)
 	if err != nil {
-		return nil, err
+		return nil, policy, err
 	}
 
 	field := gjson.GetBytes(body, string(path))
 	if field.Exists() && field.Type != gjson.Number && field.Type != gjson.Null {
-		return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a number or null")
+		return nil, policy, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a number or null")
 	}
 	if field.Type == gjson.Number {
 		value := field.Float()
 		if math.IsNaN(value) || math.IsInf(value, 0) {
-			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a finite number")
+			return nil, policy, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature must be a finite number")
 		}
 	}
 
@@ -107,27 +112,27 @@ func applyAccountTemperaturePolicy(body []byte, account *Account, path temperatu
 	if field.Exists() && field.Type == gjson.Null {
 		normalized, err = sjson.DeleteBytes(normalized, string(path))
 		if err != nil {
-			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
+			return nil, policy, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
 		}
 	}
 
 	switch policy.mode {
 	case accountTemperatureModeInherit:
-		return normalized, nil
+		return normalized, policy, nil
 	case accountTemperatureModeOmit:
 		updated, deleteErr := sjson.DeleteBytes(normalized, string(path))
 		if deleteErr != nil {
-			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
+			return nil, policy, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be removed from request body")
 		}
-		return updated, nil
+		return updated, policy, nil
 	case accountTemperatureModeOverride:
 		updated, setErr := sjson.SetBytes(normalized, string(path), policy.temperature)
 		if setErr != nil {
-			return nil, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be written to request body")
+			return nil, policy, infraerrors.BadRequest("INVALID_TEMPERATURE", "temperature could not be written to request body")
 		}
-		return updated, nil
+		return updated, policy, nil
 	default:
-		return nil, invalidAccountTemperature("temperature_mode must be inherit, override, or omit")
+		return nil, policy, invalidAccountTemperature("temperature_mode must be inherit, override, or omit")
 	}
 }
 
@@ -138,11 +143,22 @@ func applyResolvedAccountTemperaturePolicy(
 	body []byte,
 	path temperaturePath,
 ) ([]byte, error) {
+	updated, _, err := applyResolvedAccountTemperaturePolicyWithResult(ctx, repo, account, body, path)
+	return updated, err
+}
+
+func applyResolvedAccountTemperaturePolicyWithResult(
+	ctx context.Context,
+	repo AccountRepository,
+	account *Account,
+	body []byte,
+	path temperaturePath,
+) ([]byte, accountTemperaturePolicy, error) {
 	credentialAccount, err := resolveCredentialAccount(ctx, repo, account)
 	if err != nil {
-		return nil, err
+		return nil, accountTemperaturePolicy{}, err
 	}
-	return applyAccountTemperaturePolicy(body, credentialAccount, path)
+	return applyAccountTemperaturePolicyWithResult(body, credentialAccount, path)
 }
 
 func accountTemperatureNumber(value any) (float64, bool) {

--- a/backend/internal/service/account_temperature_policy_test.go
+++ b/backend/internal/service/account_temperature_policy_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestValidateAccountTemperatureCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials map[string]any
+		wantErr     bool
+	}{
+		{name: "legacy account inherits", credentials: map[string]any{}},
+		{name: "inherit without value", credentials: map[string]any{"temperature_mode": "inherit"}},
+		{name: "omit with stale value", credentials: map[string]any{"temperature_mode": "omit", "temperature": 0.7}},
+		{name: "override accepts zero", credentials: map[string]any{"temperature_mode": "override", "temperature": 0.0}},
+		{name: "override accepts json number", credentials: map[string]any{"temperature_mode": "override", "temperature": json.Number("0.75")}},
+		{name: "override requires value", credentials: map[string]any{"temperature_mode": "override"}, wantErr: true},
+		{name: "unknown mode", credentials: map[string]any{"temperature_mode": "automatic"}, wantErr: true},
+		{name: "mode must be string", credentials: map[string]any{"temperature_mode": true}, wantErr: true},
+		{name: "temperature must be numeric", credentials: map[string]any{"temperature_mode": "override", "temperature": "0.7"}, wantErr: true},
+		{name: "temperature must be finite", credentials: map[string]any{"temperature_mode": "override", "temperature": json.Number("1e9999")}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAccountTemperatureCredentials(tt.credentials)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, infraerrors.IsBadRequest(err))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestApplyAccountTemperaturePolicyTopLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials map[string]any
+		body        string
+		wantExists  bool
+		wantValue   float64
+		wantErr     bool
+	}{
+		{name: "inherit preserves caller value", credentials: map[string]any{}, body: `{"temperature":0}`, wantExists: true, wantValue: 0},
+		{name: "inherit leaves missing value absent", credentials: map[string]any{"temperature_mode": "inherit"}, body: `{}`},
+		{name: "inherit treats null as omitted", credentials: map[string]any{"temperature_mode": "inherit"}, body: `{"temperature":null}`},
+		{name: "override replaces caller value", credentials: map[string]any{"temperature_mode": "override", "temperature": 0.35}, body: `{"temperature":1}`, wantExists: true, wantValue: 0.35},
+		{name: "override adds missing value", credentials: map[string]any{"temperature_mode": "override", "temperature": 0.6}, body: `{}`, wantExists: true, wantValue: 0.6},
+		{name: "omit removes caller value", credentials: map[string]any{"temperature_mode": "omit"}, body: `{"temperature":0.8}`},
+		{name: "invalid caller type", credentials: map[string]any{}, body: `{"temperature":"0.8"}`, wantErr: true},
+		{name: "invalid caller non finite value", credentials: map[string]any{}, body: `{"temperature":1e9999}`, wantErr: true},
+		{name: "invalid account policy", credentials: map[string]any{"temperature_mode": "override"}, body: `{}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := applyAccountTemperaturePolicy([]byte(tt.body), &Account{Credentials: tt.credentials}, temperaturePathTopLevel)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			value := gjson.GetBytes(got, "temperature")
+			require.Equal(t, tt.wantExists, value.Exists())
+			if tt.wantExists {
+				require.InDelta(t, tt.wantValue, value.Float(), 1e-9)
+			}
+		})
+	}
+}
+
+func TestApplyAccountTemperaturePolicyGemini(t *testing.T) {
+	override := &Account{Credentials: map[string]any{"temperature_mode": "override", "temperature": 0.25}}
+	got, err := applyAccountTemperaturePolicy([]byte(`{"generationConfig":{"topP":0.9}}`), override, temperaturePathGemini)
+	require.NoError(t, err)
+	require.InDelta(t, 0.25, gjson.GetBytes(got, "generationConfig.temperature").Float(), 1e-9)
+	require.InDelta(t, 0.9, gjson.GetBytes(got, "generationConfig.topP").Float(), 1e-9)
+
+	omit := &Account{Credentials: map[string]any{"temperature_mode": "omit"}}
+	got, err = applyAccountTemperaturePolicy(got, omit, temperaturePathGemini)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(got, "generationConfig.temperature").Exists())
+	require.InDelta(t, 0.9, gjson.GetBytes(got, "generationConfig.topP").Float(), 1e-9)
+}
+
+func TestApplyResolvedAccountTemperaturePolicyUsesSparkParent(t *testing.T) {
+	parentID := int64(41)
+	parent := Account{
+		ID:       parentID,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"temperature_mode": "override",
+			"temperature":      0.15,
+		},
+	}
+	shadow := &Account{
+		ID:              42,
+		Platform:        PlatformOpenAI,
+		Type:            AccountTypeOAuth,
+		ParentAccountID: &parentID,
+		Credentials:     map[string]any{"temperature_mode": "omit"},
+	}
+
+	got, err := applyResolvedAccountTemperaturePolicy(
+		context.Background(),
+		stubOpenAIAccountRepo{accounts: []Account{parent}},
+		shadow,
+		[]byte(`{"temperature":0.9}`),
+		temperaturePathTopLevel,
+	)
+
+	require.NoError(t, err)
+	require.InDelta(t, 0.15, gjson.GetBytes(got, "temperature").Float(), 1e-9)
+}

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -502,6 +502,9 @@ func (s *adminServiceImpl) CreateAccount(ctx context.Context, input *CreateAccou
 	if err := NormalizeHeaderOverrideCredentials(input.Credentials); err != nil {
 		return nil, err
 	}
+	if err := validateAccountTemperatureCredentials(input.Credentials); err != nil {
+		return nil, err
+	}
 	// Never persist ephemeral SSO/password secrets after OAuth conversion.
 	input.Credentials = SanitizeStoredCredentials(input.Platform, input.Credentials)
 
@@ -621,6 +624,11 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		// 校验并规范化请求头覆写配置（header 名小写化、格式检查）
 		if err := NormalizeHeaderOverrideCredentials(account.Credentials); err != nil {
 			return nil, err
+		}
+		if hasAccountTemperatureCredentialUpdate(input.Credentials) {
+			if err := validateAccountTemperatureCredentials(account.Credentials); err != nil {
+				return nil, err
+			}
 		}
 		// Strip SSO/password residue that must never sit next to OAuth tokens.
 		account.Credentials = SanitizeStoredCredentials(account.Platform, account.Credentials)
@@ -1040,6 +1048,21 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 	// 校验并规范化请求头覆写配置（批量路径为 JSONB 顶层 key 合并，直接校验增量即可）
 	if err := NormalizeHeaderOverrideCredentials(input.Credentials); err != nil {
 		return nil, err
+	}
+	if hasAccountTemperatureCredentialUpdate(input.Credentials) {
+		for _, account := range cachedTargets {
+			if account == nil {
+				continue
+			}
+			merged := maps.Clone(account.Credentials)
+			if merged == nil {
+				merged = make(map[string]any, len(input.Credentials))
+			}
+			maps.Copy(merged, input.Credentials)
+			if err := validateAccountTemperatureCredentials(merged); err != nil {
+				return nil, err
+			}
+		}
 	}
 	// Bulk may mix platforms; always drop ephemeral SSO/password keys (cookie
 	// only when platform is known Grok — empty platform still strips password/*).

--- a/backend/internal/service/admin_service_bulk_update_test.go
+++ b/backend/internal/service/admin_service_bulk_update_test.go
@@ -244,6 +244,43 @@ func TestAdminService_BulkUpdateAccounts_NilGroupRepoReturnsError(t *testing.T) 
 	require.Contains(t, err.Error(), "group repository not configured")
 }
 
+func TestAdminService_BulkUpdateAccounts_ValidatesMergedTemperaturePolicy(t *testing.T) {
+	repo := &accountRepoStubForBulkUpdate{
+		getByIDsAccounts: []*Account{
+			{ID: 1, Credentials: map[string]any{"temperature": 0.45}},
+			{ID: 2, Credentials: map[string]any{"temperature": 0.8}},
+		},
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	result, err := svc.BulkUpdateAccounts(context.Background(), &BulkUpdateAccountsInput{
+		AccountIDs:  []int64{1, 2},
+		Credentials: map[string]any{"temperature_mode": "override"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Success)
+	require.Equal(t, 1, repo.bulkUpdateCalls)
+	require.Equal(t, "override", repo.lastBulkUpdate.Credentials["temperature_mode"])
+}
+
+func TestAdminService_BulkUpdateAccounts_RejectsInvalidTemperaturePolicyBeforeWrite(t *testing.T) {
+	repo := &accountRepoStubForBulkUpdate{
+		getByIDsAccounts: []*Account{{ID: 1, Credentials: map[string]any{}}},
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	result, err := svc.BulkUpdateAccounts(context.Background(), &BulkUpdateAccountsInput{
+		AccountIDs:  []int64{1},
+		Credentials: map[string]any{"temperature_mode": "override"},
+	})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.True(t, infraerrors.IsBadRequest(err))
+	require.Zero(t, repo.bulkUpdateCalls)
+}
+
 // TestAdminService_BulkUpdateAccounts_MixedChannelPreCheckBlocksOnExistingConflict verifies
 // that the global pre-check detects a conflict with existing group members and returns an
 // error before any DB write is performed.

--- a/backend/internal/service/admin_service_credentials_merge_test.go
+++ b/backend/internal/service/admin_service_credentials_merge_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -114,4 +115,27 @@ func TestUpdateAccount_EmptyCredentialsSkipsUpdate(t *testing.T) {
 
 	require.Equal(t, "rt-existing", repo.account.Credentials["refresh_token"], "空 credentials 不应触碰已有 token")
 	require.Equal(t, "renamed", repo.account.Name)
+}
+
+func TestUpdateAccount_RejectsInvalidTemperaturePolicyBeforeWrite(t *testing.T) {
+	accountID := int64(205)
+	repo := &updateAccountCredsRepoStub{
+		account: &Account{
+			ID:          accountID,
+			Platform:    PlatformAnthropic,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"api_key": "sk-existing"},
+		},
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	updated, err := svc.UpdateAccount(context.Background(), accountID, &UpdateAccountInput{
+		Credentials: map[string]any{"temperature_mode": "override"},
+	})
+
+	require.Nil(t, updated)
+	require.Error(t, err)
+	require.True(t, infraerrors.IsBadRequest(err))
+	require.Zero(t, repo.updateCalls)
 }

--- a/backend/internal/service/antigravity_gateway_claude.go
+++ b/backend/internal/service/antigravity_gateway_claude.go
@@ -29,6 +29,11 @@ import (
 //	          └─ 失败 → 设置模型限流 + 清除粘性绑定 → 切换账号
 func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte, isStickySession bool) (*ForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, s.writeClaudeError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+	}
+	body = policyBody
 	// 上游透传账号直接转发，不走 OAuth token 刷新
 	if account.Type == AccountTypeUpstream {
 		return s.ForwardUpstream(ctx, c, account, body)

--- a/backend/internal/service/antigravity_gateway_compat.go
+++ b/backend/internal/service/antigravity_gateway_compat.go
@@ -62,6 +62,11 @@ func (s *AntigravityGatewayService) ForwardAsChatCompletions(
 	if err := s.validateAntigravityCompatAccount(c, account); err != nil {
 		return nil, err
 	}
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+	}
+	body = policyBody
 
 	var request apicompat.ChatCompletionsRequest
 	if json.Unmarshal(body, &request) != nil {
@@ -109,6 +114,11 @@ func (s *AntigravityGatewayService) ForwardAsResponses(
 	if err := s.validateAntigravityCompatAccount(c, account); err != nil {
 		return nil, err
 	}
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+	}
+	body = policyBody
 
 	var request apicompat.ResponsesRequest
 	if json.Unmarshal(body, &request) != nil {

--- a/backend/internal/service/antigravity_gateway_compat_test.go
+++ b/backend/internal/service/antigravity_gateway_compat_test.go
@@ -339,11 +339,14 @@ func TestAntigravityCompatPreservesChatTokenLimit(t *testing.T) {
 			svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
 			body := []byte(tt.body)
 			c, _ := newAntigravityCompatContext(http.MethodPost, "/v1/chat/completions", body)
+			account := newAntigravityCompatAccount(AccountTypeOAuth)
+			account.Credentials["temperature_mode"] = "override"
+			account.Credentials["temperature"] = 0.3
 
 			result, err := svc.ForwardAsChatCompletions(
 				context.Background(),
 				c,
-				newAntigravityCompatAccount(AccountTypeOAuth),
+				account,
 				body,
 				nil,
 			)
@@ -352,6 +355,7 @@ func TestAntigravityCompatPreservesChatTokenLimit(t *testing.T) {
 			require.NotNil(t, result)
 			require.Len(t, upstream.requestBodies, 1)
 			require.Equal(t, tt.want, gjson.GetBytes(upstream.requestBodies[0], "request.generationConfig.maxOutputTokens").Int())
+			require.InDelta(t, 0.3, gjson.GetBytes(upstream.requestBodies[0], "request.generationConfig.temperature").Float(), 1e-9)
 		})
 	}
 }

--- a/backend/internal/service/antigravity_gateway_gemini.go
+++ b/backend/internal/service/antigravity_gateway_gemini.go
@@ -85,6 +85,11 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 	default:
 		return nil, s.writeGoogleError(c, http.StatusNotFound, "Unsupported action: "+action)
 	}
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathGemini)
+	if policyErr != nil {
+		return nil, s.writeGoogleError(c, http.StatusBadRequest, policyErr.Error())
+	}
+	body = policyBody
 
 	mappedModel := s.getMappedModel(account, originalModel)
 	if mappedModel == "" {

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // antigravityFailingWriter 模拟客户端断开连接的 gin.ResponseWriter
@@ -401,7 +402,7 @@ func TestAntigravityGatewayService_ForwardGemini_ImageUsesDefaultMappingAndOAuth
 
 func TestAntigravityGatewayService_ForwardGemini_PreservesServerSideToolInvocationConfig(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"tools":[{"functionDeclarations":[{"name":"get_weather","parameters":{"type":"object","additionalProperties":false}}]},{"googleSearch":{}}],"toolConfig":{"includeServerSideToolInvocations":true}}`)
+	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"generationConfig":{"temperature":0.8},"tools":[{"functionDeclarations":[{"name":"get_weather","parameters":{"type":"object","additionalProperties":false}}]},{"googleSearch":{}}],"toolConfig":{"includeServerSideToolInvocations":true}}`)
 	writer := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(writer)
 	body = bytes.ReplaceAll(body, []byte{92}, nil)
@@ -419,7 +420,7 @@ func TestAntigravityGatewayService_ForwardGemini_PreservesServerSideToolInvocati
 	}
 	account := &Account{
 		ID: 103, Name: "native-gemini", Platform: PlatformAntigravity, Type: AccountTypeOAuth, Status: StatusActive, Concurrency: 1,
-		Credentials: map[string]any{"access_token": "token", "project_id": "project-103", "model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"}},
+		Credentials: map[string]any{"access_token": "token", "project_id": "project-103", "model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"}, "temperature_mode": "omit"},
 	}
 
 	result, err := svc.ForwardGemini(context.Background(), c, account, "gemini-2.5-flash", "generateContent", false, body, false)
@@ -435,6 +436,7 @@ func TestAntigravityGatewayService_ForwardGemini_PreservesServerSideToolInvocati
 	require.True(t, ok)
 	require.Equal(t, true, toolConfig["includeServerSideToolInvocations"])
 	require.NotContains(t, toolConfig, "include_server_side_tool_invocations")
+	require.False(t, gjson.GetBytes(upstream.requestBodies[0], "request.generationConfig.temperature").Exists())
 }
 
 func TestAntigravityGatewayService_ForwardGemini_MissingProjectReturnsLocalError(t *testing.T) {

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -293,6 +293,11 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 	token string,
 ) (*http.Request, []byte, error) {
 	body = stripDeferredToolCacheControl(body)
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, nil, policyErr
+	}
+	body = policyBody
 	targetURL := claudeAPIURL
 	baseURL := account.GetBaseURL()
 	if baseURL != "" {

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -104,6 +104,14 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		}
 	}()
 	beginUpstreamResponseModelObservation(c)
+	policyBody, err := applyAccountTemperaturePolicy(parsed.Body.Bytes(), account, temperaturePathTopLevel)
+	if err != nil {
+		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return nil, err
+	}
+	if err := parsed.ReplaceBody(policyBody); err != nil {
+		return nil, fmt.Errorf("rewrite request body: %w", err)
+	}
 
 	// Web Search 模拟：纯 web_search 请求时，直接调用搜索 API 构造响应
 	if account != nil && s.shouldEmulateWebSearch(ctx, account, parsed.GroupID, parsed.Body.Bytes()) {

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -34,6 +34,12 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	parsed *ParsedRequest,
 ) (*ForwardResult, error) {
 	startTime := time.Now()
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		writeGatewayCCError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+		return nil, policyErr
+	}
+	body = policyBody
 
 	// 1. Parse Chat Completions request
 	var ccReq apicompat.ChatCompletionsRequest

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -36,6 +36,12 @@ func (s *GatewayService) ForwardAsResponses(
 	parsed *ParsedRequest,
 ) (*ForwardResult, error) {
 	startTime := time.Now()
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		writeResponsesError(c, http.StatusBadRequest, "invalid_temperature", policyErr.Error())
+		return nil, policyErr
+	}
+	body = policyBody
 
 	normalizedBody, normalized, err := normalizeOpenAIResponsesLegacyIngress(body)
 	if err != nil {

--- a/backend/internal/service/gateway_temperature_policy_test.go
+++ b/backend/internal/service/gateway_temperature_policy_test.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestGatewayBuildUpstreamRequestAppliesFinalTemperaturePolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name        string
+		credentials map[string]any
+		wantExists  bool
+		wantValue   float64
+	}{
+		{
+			name:        "override replaces Claude OAuth default",
+			credentials: map[string]any{"temperature_mode": "override", "temperature": 0.2},
+			wantExists:  true,
+			wantValue:   0.2,
+		},
+		{
+			name:        "omit removes Claude OAuth default",
+			credentials: map[string]any{"temperature_mode": "omit"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			account := &Account{
+				ID:          1,
+				Platform:    PlatformAnthropic,
+				Type:        AccountTypeOAuth,
+				Credentials: tt.credentials,
+			}
+
+			req, wireBody, err := (&GatewayService{}).buildUpstreamRequest(
+				context.Background(), c, account,
+				[]byte(`{"model":"claude-sonnet-4-5","temperature":1,"messages":[]}`),
+				"token", "oauth", "claude-sonnet-4-5", false, false,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			value := gjson.GetBytes(wireBody, "temperature")
+			require.Equal(t, tt.wantExists, value.Exists())
+			if tt.wantExists {
+				require.InDelta(t, tt.wantValue, value.Float(), 1e-9)
+			}
+		})
+	}
+}
+
+func TestOpenAIChatTemperaturePolicyRespectsResponsesModelCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name            string
+		requestModel    string
+		upstreamModel   string
+		wantTemperature bool
+	}{
+		{name: "supported model keeps account override", requestModel: "gpt-4.1", upstreamModel: "gpt-4.1", wantTemperature: true},
+		{name: "reasoning model removes unsupported override", requestModel: "gpt-5.4", upstreamModel: "gpt-5.4"},
+		{name: "mapped reasoning model removes unsupported override", requestModel: "gpt-4.1", upstreamModel: "gpt-5.4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"` + tt.requestModel + `","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+			}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := &Account{
+				ID:          2,
+				Name:        "openai-api-key",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":          "sk-test",
+					"temperature_mode": "override",
+					"temperature":      0.2,
+				},
+				Extra: map[string]any{"openai_responses_supported": true},
+			}
+
+			result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", tt.upstreamModel)
+
+			require.Error(t, err)
+			require.Nil(t, result)
+			temperature := gjson.GetBytes(upstream.lastBody, "temperature")
+			require.Equal(t, tt.wantTemperature, temperature.Exists())
+			if tt.wantTemperature {
+				require.InDelta(t, 0.2, temperature.Float(), 1e-9)
+			}
+		})
+	}
+}
+
+func TestOpenAIMessagesTemperaturePolicyUsesMappedModelCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"claude-sonnet-4","max_tokens":1024,"messages":[{"role":"user","content":"hello"}],"temperature":0.9}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-api-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":          "sk-test",
+			"temperature_mode": "override",
+			"temperature":      0.2,
+		},
+		Extra: map[string]any{"openai_responses_supported": true},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.4")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "temperature").Exists())
+}
+
+func TestOpenAIResponsesTemperaturePolicyRespectsModelCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name            string
+		model           string
+		wantTemperature bool
+	}{
+		{name: "supported model keeps account override", model: "gpt-4.1", wantTemperature: true},
+		{name: "reasoning model removes unsupported override", model: "gpt-5.4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"` + tt.model + `","input":"hello","stream":false}`)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+			}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := &Account{
+				ID:          2,
+				Name:        "openai-api-key",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":          "sk-test",
+					"temperature_mode": "override",
+					"temperature":      0.2,
+				},
+				Extra: map[string]any{"openai_responses_supported": true},
+			}
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+
+			require.Error(t, err)
+			require.Nil(t, result)
+			temperature := gjson.GetBytes(upstream.lastBody, "temperature")
+			require.Equal(t, tt.wantTemperature, temperature.Exists())
+			if tt.wantTemperature {
+				require.InDelta(t, 0.2, temperature.Float(), 1e-9)
+			}
+		})
+	}
+}

--- a/backend/internal/service/gateway_temperature_policy_test.go
+++ b/backend/internal/service/gateway_temperature_policy_test.go
@@ -283,3 +283,89 @@ func TestOpenAIResponsesTemperaturePolicyRespectsModelCapabilities(t *testing.T)
 		})
 	}
 }
+
+func TestOpenAIChatRetriesRejectedGPT56Temperature(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"temperature":0}`)
+	c := newOpenAIRejectedFieldTestContext(body)
+	c.Request.URL.Path = "/v1/chat/completions"
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: temperature","param":"temperature"}}`),
+		openAICompatSSECompletedResponse("resp_chat_temperature", "gpt-5.6-sol"),
+	}}
+	service := newOpenAIRejectedFieldTestService(upstream)
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Credentials["temperature_mode"] = "override"
+	account.Credentials["temperature"] = 0.2
+
+	result, err := service.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.6-sol")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.bodies[0], "model").String())
+	require.InDelta(t, 0.2, gjson.GetBytes(upstream.bodies[0], "temperature").Float(), 1e-9)
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "temperature").Exists())
+}
+
+func TestOpenAIMessagesRetriesRejectedGPT56Temperature(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4","max_tokens":1024,"messages":[{"role":"user","content":"hello"}],"temperature":0}`)
+	c := newOpenAIRejectedFieldTestContext(body)
+	c.Request.URL.Path = "/v1/messages"
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: temperature","param":"temperature"}}`),
+		openAICompatSSECompletedResponse("resp_messages_temperature", "gpt-5.6-terra"),
+	}}
+	service := newOpenAIRejectedFieldTestService(upstream)
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Credentials["temperature_mode"] = "override"
+	account.Credentials["temperature"] = 0.2
+
+	result, err := service.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.6-terra")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "gpt-5.6-terra", gjson.GetBytes(upstream.bodies[0], "model").String())
+	require.InDelta(t, 0.2, gjson.GetBytes(upstream.bodies[0], "temperature").Float(), 1e-9)
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "temperature").Exists())
+}
+
+func TestOpenAIRawChatCompletionsRetriesRejectedSamplingParameter(t *testing.T) {
+	tests := []struct {
+		name          string
+		rejectedParam string
+	}{
+		{name: "temperature", rejectedParam: "temperature"},
+		{name: "top_p", rejectedParam: "top_p"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hello"}],"stream":false,"temperature":0.35,"top_p":0.75}`)
+			c := newOpenAIRejectedFieldTestContext(body)
+			c.Request.URL.Path = "/v1/chat/completions"
+			upstream := &httpUpstreamRecorder{responses: []*http.Response{
+				newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: `+tt.rejectedParam+`","param":"`+tt.rejectedParam+`"}}`),
+				newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"chatcmpl_raw_temperature","object":"chat.completion","model":"gpt-5.6-sol","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`),
+			}}
+			service := newOpenAIRejectedFieldTestService(upstream)
+			account := newOpenAIRejectedFieldTestAccount()
+
+			result, err := service.forwardAsRawChatCompletions(context.Background(), c, account, body, "")
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, upstream.bodies, 2)
+			require.InDelta(t, 0.35, gjson.GetBytes(upstream.bodies[0], "temperature").Float(), 1e-9)
+			require.InDelta(t, 0.75, gjson.GetBytes(upstream.bodies[0], "top_p").Float(), 1e-9)
+			require.False(t, gjson.GetBytes(upstream.bodies[1], tt.rejectedParam).Exists())
+			preservedParam := "top_p"
+			preservedValue := 0.75
+			if tt.rejectedParam == "top_p" {
+				preservedParam = "temperature"
+				preservedValue = 0.35
+			}
+			require.InDelta(t, preservedValue, gjson.GetBytes(upstream.bodies[1], preservedParam).Float(), 1e-9)
+		})
+	}
+}

--- a/backend/internal/service/gateway_temperature_policy_test.go
+++ b/backend/internal/service/gateway_temperature_policy_test.go
@@ -72,6 +72,8 @@ func TestOpenAIChatTemperaturePolicyRespectsResponsesModelCapabilities(t *testin
 		wantTemperature bool
 	}{
 		{name: "supported model keeps account override", requestModel: "gpt-4.1", upstreamModel: "gpt-4.1", wantTemperature: true},
+		{name: "gpt 5.6 keeps account override", requestModel: "gpt-5.6-terra", upstreamModel: "gpt-5.6-terra", wantTemperature: true},
+		{name: "legacy gpt model mapped to gpt 5.6 keeps account override", requestModel: "gpt-5.4", upstreamModel: "gpt-5.6-sol", wantTemperature: true},
 		{name: "reasoning model removes unsupported override", requestModel: "gpt-5.4", upstreamModel: "gpt-5.4"},
 		{name: "mapped reasoning model removes unsupported override", requestModel: "gpt-4.1", upstreamModel: "gpt-5.4"},
 	}
@@ -153,14 +155,87 @@ func TestOpenAIMessagesTemperaturePolicyUsesMappedModelCapabilities(t *testing.T
 	require.False(t, gjson.GetBytes(upstream.lastBody, "temperature").Exists())
 }
 
+func TestOpenAIMessagesTemperaturePolicyKeepsGPT56Override(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-5.4","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-api-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":          "sk-test",
+			"temperature_mode": "override",
+			"temperature":      0.2,
+		},
+		Extra: map[string]any{"openai_responses_supported": true},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.6-terra")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "gpt-5.6-terra", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.InDelta(t, 0.2, gjson.GetBytes(upstream.lastBody, "temperature").Float(), 1e-9)
+}
+
+func TestOpenAIChatResponsesShapeTemperaturePolicyUsesMappedGPT56(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-5.4","input":"hello","stream":false}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-api-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":          "sk-test",
+			"temperature_mode": "override",
+			"temperature":      0.2,
+		},
+		Extra: map[string]any{"openai_responses_supported": true},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.6-sol")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.InDelta(t, 0.2, gjson.GetBytes(upstream.lastBody, "temperature").Float(), 1e-9)
+}
+
 func TestOpenAIResponsesTemperaturePolicyRespectsModelCapabilities(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
 		name            string
 		model           string
+		mappedModel     string
 		wantTemperature bool
 	}{
 		{name: "supported model keeps account override", model: "gpt-4.1", wantTemperature: true},
+		{name: "gpt 5.6 keeps account override", model: "gpt-5.6-luna", wantTemperature: true},
+		{name: "legacy gpt model mapped to gpt 5.6 keeps account override", model: "gpt-5.4", mappedModel: "gpt-5.6-terra", wantTemperature: true},
 		{name: "reasoning model removes unsupported override", model: "gpt-5.4"},
 	}
 
@@ -178,18 +253,22 @@ func TestOpenAIResponsesTemperaturePolicyRespectsModelCapabilities(t *testing.T)
 				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
 			}}
 			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			credentials := map[string]any{
+				"api_key":          "sk-test",
+				"temperature_mode": "override",
+				"temperature":      0.2,
+			}
+			if tt.mappedModel != "" {
+				credentials["model_mapping"] = map[string]any{tt.model: tt.mappedModel}
+			}
 			account := &Account{
 				ID:          2,
 				Name:        "openai-api-key",
 				Platform:    PlatformOpenAI,
 				Type:        AccountTypeAPIKey,
 				Concurrency: 1,
-				Credentials: map[string]any{
-					"api_key":          "sk-test",
-					"temperature_mode": "override",
-					"temperature":      0.2,
-				},
-				Extra: map[string]any{"openai_responses_supported": true},
+				Credentials: credentials,
+				Extra:       map[string]any{"openai_responses_supported": true},
 			}
 
 			result, err := svc.Forward(context.Background(), c, account, body)

--- a/backend/internal/service/gateway_upstream_request.go
+++ b/backend/internal/service/gateway_upstream_request.go
@@ -20,6 +20,11 @@ import (
 
 func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, tokenType, modelID string, reqStream bool, mimicClaudeCode bool) (*http.Request, []byte, error) {
 	body = stripDeferredToolCacheControl(body)
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, nil, policyErr
+	}
+	body = policyBody
 	if account.Platform == PlatformAnthropic && account.Type == AccountTypeServiceAccount {
 		req, err := s.buildUpstreamRequestAnthropicVertex(ctx, c, account, body, token, modelID, reqStream)
 		return req, body, err

--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -29,6 +29,11 @@ func (s *GeminiMessagesCompatService) ForwardAsChatCompletions(
 	body []byte,
 ) (*ForwardResult, error) {
 	startTime := time.Now()
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, s.writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+	}
+	body = policyBody
 
 	var ccReq apicompat.ChatCompletionsRequest
 	if err := json.Unmarshal(body, &ccReq); err != nil {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -584,6 +584,11 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	beginUpstreamResponseModelObservation(c)
 	beginGeminiImageOutputObservation(c)
 	startTime := time.Now()
+	policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathTopLevel)
+	if policyErr != nil {
+		return nil, s.writeClaudeError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+	}
+	body = policyBody
 
 	var req struct {
 		Model  string `json:"model"`
@@ -1150,6 +1155,13 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		// ok
 	default:
 		return nil, s.writeGoogleError(c, http.StatusNotFound, "Unsupported action: "+action)
+	}
+	if action != "countTokens" {
+		policyBody, policyErr := applyAccountTemperaturePolicy(body, account, temperaturePathGemini)
+		if policyErr != nil {
+			return nil, s.writeGoogleError(c, http.StatusBadRequest, policyErr.Error())
+		}
+		body = policyBody
 	}
 
 	// Some Gemini upstreams validate tool call parts strictly; ensure any `functionCall` part includes a

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type geminiCompatHTTPUpstreamStub struct {
@@ -115,6 +116,42 @@ func TestGeminiForwardAsChatCompletions_OAuthRoutesToGeminiAndReturnsChatFormat(
 	require.Equal(t, float64(7), usage["prompt_tokens"])
 	require.Equal(t, float64(3), usage["completion_tokens"])
 	require.Equal(t, float64(10), usage["total_tokens"])
+}
+
+func TestGeminiForwardAsChatCompletionsAppliesAccountTemperatureOverride(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstreamBody := "data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{}}}\n\n"
+	httpStub := &geminiCompatHTTPUpstreamStub{response: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &GeminiMessagesCompatService{
+		tokenProvider: &GeminiTokenProvider{},
+		httpUpstream:  httpStub,
+		cfg:           &config.Config{},
+	}
+	account := &Account{
+		ID: 201, Platform: PlatformGemini, Type: AccountTypeOAuth, Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":     "ya29.test-token",
+			"project_id":       "project-1",
+			"temperature_mode": "override",
+			"temperature":      0.25,
+		},
+	}
+	body := []byte(`{"model":"gemini-2.5-flash","temperature":0.9,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	sent, err := io.ReadAll(httpStub.lastReq.Body)
+	require.NoError(t, err)
+	require.InDelta(t, 0.25, gjson.GetBytes(sent, "request.generationConfig.temperature").Float(), 1e-9)
 }
 
 func TestGeminiForwardAsChatCompletions_StreamsOpenAIChunksFromGeminiSSE(t *testing.T) {

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -595,6 +595,15 @@ func isOpenAICodexReasoningGPTModel(modelID string) bool {
 	return strings.HasPrefix(normalized, "gpt-5")
 }
 
+func supportsOpenAICodexSamplingParameters(modelID string) bool {
+	normalized := canonicalizeOpenAIModelAliasSpelling(modelID)
+	return normalized == "gpt-5.6" || strings.HasPrefix(normalized, "gpt-5.6-")
+}
+
+func isOpenAICodexSamplingUnsupportedModel(modelID string) bool {
+	return isOpenAICodexReasoningGPTModel(modelID) && !supportsOpenAICodexSamplingParameters(modelID)
+}
+
 func isOpenAICodexImageInputModel(modelID string) bool {
 	normalized := canonicalizeOpenAIModelAliasSpelling(modelID)
 	return strings.HasPrefix(normalized, "gpt-5") ||

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -154,11 +154,20 @@ var openAIChatGPTInternalUnsupportedFields = []string{
 var openAICodexOAuthUnsupportedFields = append([]string{
 	"max_output_tokens",
 	"max_completion_tokens",
-	"temperature",
-	"top_p",
 	"frequency_penalty",
 	"presence_penalty",
 }, openAIChatGPTInternalUnsupportedFields...)
+
+var openAICodexOAuthSamplingFields = []string{"temperature", "top_p"}
+
+func openAICodexOAuthUnsupportedFieldsForModel(model string) []string {
+	if supportsOpenAICodexSamplingParameters(model) {
+		return openAICodexOAuthUnsupportedFields
+	}
+	fields := make([]string, 0, len(openAICodexOAuthUnsupportedFields)+len(openAICodexOAuthSamplingFields))
+	fields = append(fields, openAICodexOAuthUnsupportedFields...)
+	return append(fields, openAICodexOAuthSamplingFields...)
+}
 
 func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact bool) codexTransformResult {
 	return applyCodexOAuthTransformWithOptions(reqBody, codexOAuthTransformOptions{
@@ -211,7 +220,7 @@ func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuth
 	}
 
 	// Strip parameters unsupported by ChatGPT internal Codex endpoint.
-	for _, key := range openAICodexOAuthUnsupportedFields {
+	for _, key := range openAICodexOAuthUnsupportedFieldsForModel(normalizedModel) {
 		if _, ok := reqBody[key]; ok {
 			delete(reqBody, key)
 			result.Modified = true

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -154,20 +154,11 @@ var openAIChatGPTInternalUnsupportedFields = []string{
 var openAICodexOAuthUnsupportedFields = append([]string{
 	"max_output_tokens",
 	"max_completion_tokens",
+	"temperature",
+	"top_p",
 	"frequency_penalty",
 	"presence_penalty",
 }, openAIChatGPTInternalUnsupportedFields...)
-
-var openAICodexOAuthSamplingFields = []string{"temperature", "top_p"}
-
-func openAICodexOAuthUnsupportedFieldsForModel(model string) []string {
-	if supportsOpenAICodexSamplingParameters(model) {
-		return openAICodexOAuthUnsupportedFields
-	}
-	fields := make([]string, 0, len(openAICodexOAuthUnsupportedFields)+len(openAICodexOAuthSamplingFields))
-	fields = append(fields, openAICodexOAuthUnsupportedFields...)
-	return append(fields, openAICodexOAuthSamplingFields...)
-}
 
 func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact bool) codexTransformResult {
 	return applyCodexOAuthTransformWithOptions(reqBody, codexOAuthTransformOptions{
@@ -220,7 +211,7 @@ func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuth
 	}
 
 	// Strip parameters unsupported by ChatGPT internal Codex endpoint.
-	for _, key := range openAICodexOAuthUnsupportedFieldsForModel(normalizedModel) {
+	for _, key := range openAICodexOAuthUnsupportedFields {
 		if _, ok := reqBody[key]; ok {
 			delete(reqBody, key)
 			result.Modified = true

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1786,7 +1786,7 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 	}
 }
 
-func TestApplyCodexOAuthTransform_PreservesGPT56SamplingParameters(t *testing.T) {
+func TestApplyCodexOAuthTransform_StripsGPT56SamplingParameters(t *testing.T) {
 	reqBody := map[string]any{
 		"model":       "gpt-5.6-terra",
 		"temperature": 0.0,
@@ -1796,9 +1796,8 @@ func TestApplyCodexOAuthTransform_PreservesGPT56SamplingParameters(t *testing.T)
 
 	applyCodexOAuthTransform(reqBody, false, false)
 
-	require.Contains(t, reqBody, "temperature")
-	require.Zero(t, reqBody["temperature"])
-	require.InDelta(t, 0.75, reqBody["top_p"], 1e-9)
+	require.NotContains(t, reqBody, "temperature")
+	require.NotContains(t, reqBody, "top_p")
 }
 
 func TestApplyCodexOAuthTransform_StripsLegacySamplingParameters(t *testing.T) {

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1786,6 +1786,34 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 	}
 }
 
+func TestApplyCodexOAuthTransform_PreservesGPT56SamplingParameters(t *testing.T) {
+	reqBody := map[string]any{
+		"model":       "gpt-5.6-terra",
+		"temperature": 0.35,
+		"top_p":       0.75,
+		"input":       []any{map[string]any{"role": "user", "content": "hi"}},
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	require.InDelta(t, 0.35, reqBody["temperature"], 1e-9)
+	require.InDelta(t, 0.75, reqBody["top_p"], 1e-9)
+}
+
+func TestApplyCodexOAuthTransform_StripsLegacySamplingParameters(t *testing.T) {
+	reqBody := map[string]any{
+		"model":       "gpt-5.4",
+		"temperature": 0.35,
+		"top_p":       0.75,
+		"input":       []any{map[string]any{"role": "user", "content": "hi"}},
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	require.NotContains(t, reqBody, "temperature")
+	require.NotContains(t, reqBody, "top_p")
+}
+
 func TestApplyCodexOAuthTransform_NormalizesPromptAndCommands(t *testing.T) {
 	reqBody := map[string]any{
 		"model":    "gpt-5.5",

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1789,14 +1789,15 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 func TestApplyCodexOAuthTransform_PreservesGPT56SamplingParameters(t *testing.T) {
 	reqBody := map[string]any{
 		"model":       "gpt-5.6-terra",
-		"temperature": 0.35,
+		"temperature": 0.0,
 		"top_p":       0.75,
 		"input":       []any{map[string]any{"role": "user", "content": "hi"}},
 	}
 
 	applyCodexOAuthTransform(reqBody, false, false)
 
-	require.InDelta(t, 0.35, reqBody["temperature"], 1e-9)
+	require.Contains(t, reqBody, "temperature")
+	require.Zero(t, reqBody["temperature"])
 	require.InDelta(t, 0.75, reqBody["top_p"], 1e-9)
 }
 

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -180,6 +180,7 @@ func (s *OpenAIGatewayService) sendCCUpstreamRequest(
 	userAgent string,
 	grokCacheIdentity string,
 ) (*http.Response, error) {
+	observeOpenAIForwardedTemperature(c, body)
 	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 	upstreamReq, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, targetURL, bytes.NewReader(body))
 	releaseUpstreamCtx()

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -73,6 +73,12 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 ) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
 	ClearActualOpenAIUpstreamEndpoint(c)
+	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	if policyErr != nil {
+		writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+		return nil, policyErr
+	}
+	body = policyBody
 	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		SetActualOpenAIUpstreamEndpoint(c, "/v1/chat/completions")
 	}
@@ -213,6 +219,13 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 				responsesBody = stripped
 			}
 		}
+		if isOpenAICodexReasoningGPTModel(upstreamModel) {
+			for _, field := range []string{"temperature", "top_p"} {
+				if stripped, derr := sjson.DeleteBytes(responsesBody, field); derr == nil {
+					responsesBody = stripped
+				}
+			}
+		}
 		var normalizedServiceTier string
 		responsesBody, normalizedServiceTier, err = normalizeResponsesBodyServiceTier(responsesBody)
 		if err != nil {
@@ -235,6 +248,10 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 			return nil, fmt.Errorf("convert chat completions to responses: %w", err)
 		}
 		responsesReq.Model = upstreamModel
+		if isOpenAICodexReasoningGPTModel(upstreamModel) {
+			responsesReq.Temperature = nil
+			responsesReq.TopP = nil
+		}
 		normalizeResponsesRequestServiceTier(responsesReq)
 		responsesBody, err = json.Marshal(responsesReq)
 		if err != nil {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -74,13 +74,15 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 	compatPromptCacheTenantIsolated bool,
 ) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	beginOpenAITemperatureObservation(c, account, body)
 	ClearActualOpenAIUpstreamEndpoint(c)
-	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	policyBody, temperaturePolicy, policyErr := applyResolvedAccountTemperaturePolicyWithResult(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
 	if policyErr != nil {
 		writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
 		return nil, policyErr
 	}
 	body = policyBody
+	setOpenAITemperaturePolicyObservation(c, temperaturePolicy, body)
 	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		SetActualOpenAIUpstreamEndpoint(c, "/v1/chat/completions")
 	}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -349,31 +351,52 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 		return nil, fmt.Errorf("get access token: %w", err)
 	}
 
-	// 6. Build upstream request
-	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
-	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, promptCacheKey, false)
-	releaseUpstreamCtx()
-	if err != nil {
-		return nil, fmt.Errorf("build upstream request: %w", err)
-	}
-
-	if promptCacheKey != "" {
-		apiKeyID := getAPIKeyIDFromContext(c)
-		sessionKey := promptCacheKey
-		if !compatPromptCacheTenantIsolated {
-			sessionKey = isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey)
-		}
-		upstreamReq.Header.Set("session_id", generateSessionUUID(sessionKey))
-	}
-
-	// 7. Send request
+	// 6. Build and send the upstream request. Rebuild from the adjusted body
+	// when the upstream explicitly rejects one sampling field.
 	proxyURL := ""
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	resp, err := s.doOpenAIUpstream(upstreamReq, proxyURL, account)
-	if err != nil {
-		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+	rejectedFieldRetryState := newOpenAIResponsesRejectedFieldRetryState(responsesBody)
+	var resp *http.Response
+	for {
+		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+		upstreamReq, buildErr := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, promptCacheKey, false)
+		releaseUpstreamCtx()
+		if buildErr != nil {
+			return nil, fmt.Errorf("build upstream request: %w", buildErr)
+		}
+		if promptCacheKey != "" {
+			apiKeyID := getAPIKeyIDFromContext(c)
+			sessionKey := promptCacheKey
+			if !compatPromptCacheTenantIsolated {
+				sessionKey = isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey)
+			}
+			upstreamReq.Header.Set("session_id", generateSessionUUID(sessionKey))
+		}
+
+		resp, err = s.doOpenAIUpstream(upstreamReq, proxyURL, account)
+		if err != nil {
+			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+		}
+		if resp.StatusCode < http.StatusBadRequest {
+			break
+		}
+		respBody := s.readUpstreamErrorBody(resp)
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		retryBody, reason, changed, retryErr := normalizeOpenAIResponsesRejectedFieldRetryBody(resp.StatusCode, responsesBody, respBody)
+		if retryErr != nil {
+			return nil, fmt.Errorf("normalize chat rejected Responses field retry body: %w", retryErr)
+		}
+		if changed && rejectedFieldRetryState.Allow(retryBody) {
+			responsesBody = retryBody
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Retrying chat request after %s (account: %s)", reason, account.Name)
+			continue
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		break
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -219,7 +219,7 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 				responsesBody = stripped
 			}
 		}
-		if isOpenAICodexReasoningGPTModel(upstreamModel) {
+		if isOpenAICodexSamplingUnsupportedModel(upstreamModel) {
 			for _, field := range []string{"temperature", "top_p"} {
 				if stripped, derr := sjson.DeleteBytes(responsesBody, field); derr == nil {
 					responsesBody = stripped
@@ -248,9 +248,12 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 			return nil, fmt.Errorf("convert chat completions to responses: %w", err)
 		}
 		responsesReq.Model = upstreamModel
-		if isOpenAICodexReasoningGPTModel(upstreamModel) {
+		if isOpenAICodexSamplingUnsupportedModel(upstreamModel) {
 			responsesReq.Temperature = nil
 			responsesReq.TopP = nil
+		} else {
+			responsesReq.Temperature = chatReq.Temperature
+			responsesReq.TopP = chatReq.TopP
 		}
 		normalizeResponsesRequestServiceTier(responsesReq)
 		responsesBody, err = json.Marshal(responsesReq)

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -178,15 +178,30 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	if customUA == "" && account.IsGrokOAuth() {
 		customUA = defaultGrokUpstreamUserAgent()
 	}
-	resp, err := s.sendCCUpstreamRequest(ctx, c, account, targetURL, upstreamBody, clientStream, token, customUA, grokCacheIdentity)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
+	rejectedFieldRetryState := newOpenAIResponsesRejectedFieldRetryState(upstreamBody)
+	var resp *http.Response
+	for {
+		resp, err = s.sendCCUpstreamRequest(ctx, c, account, targetURL, upstreamBody, clientStream, token, customUA, grokCacheIdentity)
+		if err != nil {
+			return nil, err
+		}
+		defer func(response *http.Response) { _ = response.Body.Close() }(resp)
+		if resp.StatusCode < http.StatusBadRequest {
+			break
+		}
 
-	// 7. Handle error response with failover
-	if resp.StatusCode >= 400 {
 		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
+		retryBody, reason, changed, retryErr := normalizeOpenAIResponsesRejectedFieldRetryBody(resp.StatusCode, upstreamBody, respBody)
+		if retryErr != nil {
+			return nil, fmt.Errorf("normalize raw chat rejected sampling field retry body: %w", retryErr)
+		}
+		if changed && rejectedFieldRetryState.Allow(retryBody) {
+			upstreamBody = retryBody
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Retrying raw chat request after %s (account: %s)", reason, account.Name)
+			continue
+		}
+
+		// 7. Handle error response with failover
 		if account.Platform == PlatformGrok {
 			kind := "http_error"
 			if s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody) {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -20,6 +20,7 @@ import (
 // Forward forwards request to OpenAI API
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	beginOpenAITemperatureObservation(c, account, body)
 	ClearActualOpenAIUpstreamEndpoint(c)
 	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		SetActualOpenAIUpstreamEndpoint(c, "/v1/chat/completions")
@@ -33,12 +34,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	clearOpenAIResponsesClientToolMapping(c)
 	clearOpenAIResponsesNamespaceNames(c)
 	setCodexToolNameReverse(c, nil)
-	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	policyBody, temperaturePolicy, policyErr := applyResolvedAccountTemperaturePolicyWithResult(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
 	if policyErr != nil {
 		writeResponsesError(c, http.StatusBadRequest, "invalid_temperature", policyErr.Error())
 		return nil, policyErr
 	}
 	body = policyBody
+	setOpenAITemperaturePolicyObservation(c, temperaturePolicy, body)
 	if _, err := s.prepareCodexAccountIdentitySource(ctx, c, account); err != nil {
 		return nil, err
 	}
@@ -750,6 +752,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	// 命中 WS 时仅走 WebSocket Mode；不再自动回退 HTTP。
 	if wsDecision.Transport == OpenAIUpstreamTransportResponsesWebsocketV2 {
+		observeOpenAIForwardedTemperature(c, body)
 		// WS 分支需要结构化 payload 与重连恢复，命中后再触发 full-map decode。
 		wsReqBody, err := ensureReqBody()
 		if err != nil {
@@ -1334,6 +1337,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	// DeepSeek / Kimi 原生 Responses 端点为无状态实现：强制 store=false、清除
 	// previous_response_id，避免携带状态字段被上游拒绝。
 	body = normalizeDeepSeekResponsesRequestBody(account, body)
+	observeOpenAIForwardedTemperature(c, body)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -33,6 +33,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	clearOpenAIResponsesClientToolMapping(c)
 	clearOpenAIResponsesNamespaceNames(c)
 	setCodexToolNameReverse(c, nil)
+	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	if policyErr != nil {
+		writeResponsesError(c, http.StatusBadRequest, "invalid_temperature", policyErr.Error())
+		return nil, policyErr
+	}
+	body = policyBody
 	if _, err := s.prepareCodexAccountIdentitySource(ctx, c, account); err != nil {
 		return nil, err
 	}
@@ -378,6 +384,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	reqModel = billingModel
 	if upstreamModel != requestedModel {
 		markPatchSet("model", upstreamModel)
+	}
+	if isOpenAICodexReasoningGPTModel(upstreamModel) && gjson.GetBytes(body, "temperature").Exists() {
+		markPatchDelete("temperature")
 	}
 	if upstreamModel != billingModel {
 		if isCompactRequest {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -385,7 +385,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if upstreamModel != requestedModel {
 		markPatchSet("model", upstreamModel)
 	}
-	if isOpenAICodexReasoningGPTModel(upstreamModel) && gjson.GetBytes(body, "temperature").Exists() {
+	if isOpenAICodexSamplingUnsupportedModel(upstreamModel) && gjson.GetBytes(body, "temperature").Exists() {
 		markPatchDelete("temperature")
 	}
 	if upstreamModel != billingModel {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -147,9 +147,12 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	responsesReq.Model = upstreamModel
-	if isOpenAICodexReasoningGPTModel(upstreamModel) {
+	if isOpenAICodexSamplingUnsupportedModel(upstreamModel) {
 		responsesReq.Temperature = nil
 		responsesReq.TopP = nil
+	} else {
+		responsesReq.Temperature = anthropicReq.Temperature
+		responsesReq.TopP = anthropicReq.TopP
 	}
 	if responsesReq.Reasoning != nil {
 		responsesReq.Reasoning.Effort = openAICompatAnthropicReasoningEffort(&anthropicReq, upstreamModel, responsesReq.Reasoning.Effort)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -345,44 +345,45 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		// 既有 body/session/conversation 行为。身份头在 post-build 阶段统一恢复。
 		setOpenAICompatMessagesBridgeContext(c, true)
 	}
-	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
-	var upstreamReq *http.Request
-	if account.Platform == PlatformGrok {
-		upstreamReq, err = buildGrokResponsesRequest(upstreamCtx, c, account, responsesBody, token, grokCacheIdentity, s.cfg, s.settingService)
-	} else {
-		upstreamReq, err = s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, isStream, promptCacheKey, false)
-	}
-	releaseUpstreamCtx()
-	if err != nil {
-		return nil, fmt.Errorf("build upstream request: %w", err)
-	}
-
-	// Override session_id with a deterministic UUID derived from the isolated
-	// session key, ensuring different API keys produce different upstream sessions.
-	if account.Platform != PlatformGrok && promptCacheKey != "" {
-		isolatedSessionID := generateSessionUUID(isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey))
-		upstreamReq.Header.Set("session_id", isolatedSessionID)
-		if upstreamReq.Header.Get("conversation_id") != "" {
-			upstreamReq.Header.Set("conversation_id", isolatedSessionID)
+	buildMessagesUpstreamRequest := func(requestBody []byte) (*http.Request, error) {
+		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+		defer releaseUpstreamCtx()
+		var req *http.Request
+		var buildErr error
+		if account.Platform == PlatformGrok {
+			req, buildErr = buildGrokResponsesRequest(upstreamCtx, c, account, requestBody, token, grokCacheIdentity, s.cfg, s.settingService)
+		} else {
+			req, buildErr = s.buildUpstreamRequest(upstreamCtx, c, account, requestBody, token, isStream, promptCacheKey, false)
 		}
-	}
-	if account.UsesOpenAICodexProtocol() && account.Platform != PlatformGrok {
-		// buildUpstreamRequest 保留 Messages bridge 的 body/session 兼容行为，并会先
-		// 清除身份头。真正发送前恢复完整 Codex 身份，避免 ChatGPT Codex 上游因缺失
-		// originator/OpenAI-Beta 返回 404（issue #3901）。
-		ensureCodexIdentityHeaders(upstreamReq.Header)
-		enforceCodexIdentityHeaders(upstreamReq.Header)
-		logger.L().Debug("openai messages: upstream identity restored",
-			zap.Int64("account_id", account.ID),
-			zap.String("upstream_model", upstreamModel),
-			zap.Bool("compat_identity_restored", true),
-		)
-	}
-	if account.UsesOpenAICodexProtocol() && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
-		upstreamReq.Header.Del("conversation_id")
-	}
-	if compatTurnState != "" && upstreamReq.Header.Get("x-codex-turn-state") == "" {
-		upstreamReq.Header.Set("x-codex-turn-state", compatTurnState)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		// Override session_id with a deterministic UUID derived from the isolated
+		// session key, ensuring different API keys produce different upstream sessions.
+		if account.Platform != PlatformGrok && promptCacheKey != "" {
+			isolatedSessionID := generateSessionUUID(isolateOpenAIUpstreamSessionID(apiKeyID, codexAccountIdentitySource(c, account), promptCacheKey))
+			req.Header.Set("session_id", isolatedSessionID)
+			if req.Header.Get("conversation_id") != "" {
+				req.Header.Set("conversation_id", isolatedSessionID)
+			}
+		}
+		if account.UsesOpenAICodexProtocol() && account.Platform != PlatformGrok {
+			ensureCodexIdentityHeaders(req.Header)
+			enforceCodexIdentityHeaders(req.Header)
+			logger.L().Debug("openai messages: upstream identity restored",
+				zap.Int64("account_id", account.ID),
+				zap.String("upstream_model", upstreamModel),
+				zap.Bool("compat_identity_restored", true),
+			)
+		}
+		if account.UsesOpenAICodexProtocol() && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
+			req.Header.Del("conversation_id")
+		}
+		if compatTurnState != "" && req.Header.Get("x-codex-turn-state") == "" {
+			req.Header.Set("x-codex-turn-state", compatTurnState)
+		}
+		return req, nil
 	}
 
 	// 7. Send request
@@ -390,32 +391,39 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	// Grok may reject encrypted reasoning replayed under a different OAuth
-	// account/cache identity. Match forwardGrokResponses: one strip+retry before
-	// treating the 400 as a hard failure / failover trigger.
+	// Rebuild from the adjusted body after an explicit sampling-field rejection.
+	// Grok additionally keeps its existing one-time encrypted reasoning recovery.
+	rejectedFieldRetryState := newOpenAIResponsesRejectedFieldRetryState(responsesBody)
+	grokEncryptedRetryUsed := false
 	var resp *http.Response
-	for attempt := 0; ; attempt++ {
-		if attempt > 0 {
-			if account.Platform != PlatformGrok {
-				break
-			}
-			upstreamCtxRetry, releaseRetry := detachUpstreamContext(ctx)
-			upstreamReq, err = buildGrokResponsesRequest(upstreamCtxRetry, c, account, responsesBody, token, grokCacheIdentity, s.cfg, s.settingService)
-			releaseRetry()
-			if err != nil {
-				return nil, fmt.Errorf("build grok retry request: %w", err)
-			}
+	for {
+		upstreamReq, buildErr := buildMessagesUpstreamRequest(responsesBody)
+		if buildErr != nil {
+			return nil, fmt.Errorf("build upstream request: %w", buildErr)
 		}
 		resp, err = s.doOpenAIUpstream(upstreamReq, proxyURL, account)
 		if err != nil {
 			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 		}
-		if account.Platform != PlatformGrok || attempt > 0 || resp.StatusCode != http.StatusBadRequest {
+		if resp.StatusCode < http.StatusBadRequest {
 			break
 		}
 		respBody := s.readUpstreamErrorBody(resp)
 		if resp.Body != nil {
 			_ = resp.Body.Close()
+		}
+		retryBody, reason, changed, retryErr := normalizeOpenAIResponsesRejectedFieldRetryBody(resp.StatusCode, responsesBody, respBody)
+		if retryErr != nil {
+			return nil, fmt.Errorf("normalize messages rejected Responses field retry body: %w", retryErr)
+		}
+		if changed && rejectedFieldRetryState.Allow(retryBody) {
+			responsesBody = retryBody
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Retrying messages request after %s (account: %s)", reason, account.Name)
+			continue
+		}
+		if account.Platform != PlatformGrok || grokEncryptedRetryUsed || resp.StatusCode != http.StatusBadRequest {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			break
 		}
 		// Prefer explicit decrypt errors; also strip once on any 400 when the
 		// outbound body still carries reasoning.encrypted_content (account
@@ -426,15 +434,16 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			break
 		}
-		retryBody, changed, trimErr := trimGrokInvalidEncryptedContentRetryBody(responsesBody)
+		trimmedBody, trimmed, trimErr := trimGrokInvalidEncryptedContentRetryBody(responsesBody)
 		if trimErr != nil {
 			return nil, fmt.Errorf("prepare Grok invalid encrypted_content retry: %w", trimErr)
 		}
-		if !changed {
+		if !trimmed {
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			break
 		}
-		responsesBody = retryBody
+		responsesBody = trimmedBody
+		grokEncryptedRetryUsed = true
 		logger.L().Info("openai messages: retrying after stripping invalid Grok encrypted_content",
 			zap.Int64("account_id", account.ID),
 			zap.Bool("cache_identity_present", strings.TrimSpace(grokCacheIdentity) != ""),

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -34,13 +34,15 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
+	beginOpenAITemperatureObservation(c, account, body)
 	ClearActualOpenAIUpstreamEndpoint(c)
-	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	policyBody, temperaturePolicy, policyErr := applyResolvedAccountTemperaturePolicyWithResult(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
 	if policyErr != nil {
 		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
 		return nil, policyErr
 	}
 	body = policyBody
+	setOpenAITemperaturePolicyObservation(c, temperaturePolicy, body)
 	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		SetActualOpenAIUpstreamEndpoint(c, "/v1/chat/completions")
 	}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -35,6 +35,12 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 ) (*OpenAIForwardResult, error) {
 	beginUpstreamResponseModelObservation(c)
 	ClearActualOpenAIUpstreamEndpoint(c)
+	policyBody, policyErr := applyResolvedAccountTemperaturePolicy(ctx, s.accountRepo, account, body, temperaturePathTopLevel)
+	if policyErr != nil {
+		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", policyErr.Error())
+		return nil, policyErr
+	}
+	body = policyBody
 	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		SetActualOpenAIUpstreamEndpoint(c, "/v1/chat/completions")
 	}
@@ -141,6 +147,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	responsesReq.Model = upstreamModel
+	if isOpenAICodexReasoningGPTModel(upstreamModel) {
+		responsesReq.Temperature = nil
+		responsesReq.TopP = nil
+	}
 	if responsesReq.Reasoning != nil {
 		responsesReq.Reasoning.Effort = openAICompatAnthropicReasoningEffort(&anthropicReq, upstreamModel, responsesReq.Reasoning.Effort)
 	}

--- a/backend/internal/service/openai_gateway_messages_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native.go
@@ -154,6 +154,7 @@ func (s *OpenAIGatewayService) buildNativeAnthropicUpstreamRequest(
 	if sanitized, changed := sanitizeAnthropicBodyForBetaTokens(body, clientBeta); changed {
 		body = sanitized
 	}
+	observeOpenAIForwardedTemperature(c, body)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -606,6 +606,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 
 	// DeepSeek / Kimi 原生 Responses 端点为无状态实现（见 normalizeDeepSeekResponsesRequestBody）。
 	body = normalizeDeepSeekResponsesRequestBody(account, body)
+	observeOpenAIForwardedTemperature(c, body)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1219,8 +1219,7 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		changed = true
 	}
 
-	model := strings.TrimSpace(gjson.GetBytes(normalized, "model").String())
-	for _, field := range openAICodexOAuthUnsupportedFieldsForModel(model) {
+	for _, field := range openAICodexOAuthUnsupportedFields {
 		if value := gjson.GetBytes(normalized, field); !value.Exists() {
 			continue
 		}

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1219,7 +1219,7 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		changed = true
 	}
 
-	for _, field := range openAIChatGPTInternalUnsupportedFields {
+	for _, field := range openAICodexOAuthUnsupportedFields {
 		if value := gjson.GetBytes(normalized, field); !value.Exists() {
 			continue
 		}

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1219,7 +1219,8 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		changed = true
 	}
 
-	for _, field := range openAICodexOAuthUnsupportedFields {
+	model := strings.TrimSpace(gjson.GetBytes(normalized, "model").String())
+	for _, field := range openAICodexOAuthUnsupportedFieldsForModel(model) {
 		if value := gjson.GetBytes(normalized, field); !value.Exists() {
 			continue
 		}

--- a/backend/internal/service/openai_gpt56_temperature_deploy_test.go
+++ b/backend/internal/service/openai_gpt56_temperature_deploy_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIGatewayOmitsGPT56TemperatureForOAuthUpstream(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		credentials   map[string]any
+		wantRequested string
+		wantPolicy    string
+		wantStatus    string
+	}{
+		{name: "inherit explicit zero", body: `{"model":"gpt-5.6-sol","stream":false,"temperature":0,"input":"hello"}`, credentials: map[string]any{}, wantRequested: "0", wantPolicy: "inherit", wantStatus: "omitted-unsupported"},
+		{name: "inherit omitted temperature", body: `{"model":"gpt-5.6-sol","stream":false,"input":"hello"}`, credentials: map[string]any{}, wantRequested: "omitted", wantPolicy: "inherit", wantStatus: "omitted"},
+		{name: "inherit temperature one", body: `{"model":"gpt-5.6-sol","stream":false,"temperature":1,"input":"hello"}`, credentials: map[string]any{}, wantRequested: "1", wantPolicy: "inherit", wantStatus: "omitted-unsupported"},
+		{name: "inherit temperature two", body: `{"model":"gpt-5.6-sol","stream":false,"temperature":2,"input":"hello"}`, credentials: map[string]any{}, wantRequested: "2", wantPolicy: "inherit", wantStatus: "omitted-unsupported"},
+		{name: "account override", body: `{"model":"gpt-5.6-sol","stream":false,"temperature":0,"input":"hello"}`, credentials: map[string]any{"temperature_mode": "override", "temperature": 0.4}, wantRequested: "0", wantPolicy: "override", wantStatus: "omitted-unsupported"},
+		{name: "account omit", body: `{"model":"gpt-5.6-sol","stream":false,"temperature":0.65,"input":"hello"}`, credentials: map[string]any{"temperature_mode": "omit"}, wantRequested: "0.65", wantPolicy: "omit", wantStatus: "omitted-policy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			body := []byte(tt.body)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			upstream := &httpUpstreamRecorder{resp: newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_temperature","object":"response","status":"completed","model":"gpt-5.6-sol","temperature":1,"output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`)}
+			service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := newGPT56TemperatureOAuthAccount(tt.credentials)
+
+			result, err := service.Forward(context.Background(), c, account, body)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, gjson.GetBytes(upstream.lastBody, "temperature").Exists())
+			require.InDelta(t, 1, gjson.GetBytes(recorder.Body.Bytes(), "temperature").Float(), 1e-9)
+			require.Equal(t, tt.wantRequested, recorder.Header().Get(openAIRequestedTemperatureHeader))
+			require.Equal(t, "omitted", recorder.Header().Get(openAIForwardedTemperatureHeader))
+			require.Equal(t, tt.wantPolicy, recorder.Header().Get(openAITemperaturePolicyHeader))
+			require.Equal(t, tt.wantStatus, recorder.Header().Get(openAITemperatureStatusHeader))
+		})
+	}
+}
+
+func TestOpenAIGatewayReportsForwardedTemperatureForCompatibleAPIKey(t *testing.T) {
+	body := []byte(`{"model":"gpt-4.1","stream":false,"temperature":0,"input":"hello"}`)
+	c := newOpenAIRejectedFieldTestContext(body)
+	upstream := &httpUpstreamRecorder{resp: newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_forwarded_temperature","object":"response","status":"completed","model":"gpt-4.1","temperature":1,"output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`)}
+	service := newOpenAIRejectedFieldTestService(upstream)
+	account := newOpenAIRejectedFieldTestAccount()
+	account.Credentials["temperature_mode"] = "override"
+	account.Credentials["temperature"] = 0.4
+
+	result, err := service.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.InDelta(t, 0.4, gjson.GetBytes(upstream.lastBody, "temperature").Float(), 1e-9)
+	require.Equal(t, "0", c.Writer.Header().Get(openAIRequestedTemperatureHeader))
+	require.Equal(t, "0.4", c.Writer.Header().Get(openAIForwardedTemperatureHeader))
+	require.Equal(t, "override", c.Writer.Header().Get(openAITemperaturePolicyHeader))
+	require.Equal(t, "forwarded", c.Writer.Header().Get(openAITemperatureStatusHeader))
+}
+
+func TestOpenAITemperatureObservationPreservesOriginalRequestAcrossRetries(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	account := newOpenAIRejectedFieldTestAccount()
+
+	beginOpenAITemperatureObservation(c, account, []byte(`{"temperature":0}`))
+	setOpenAITemperaturePolicyObservation(c, accountTemperaturePolicy{mode: accountTemperatureModeOverride}, []byte(`{"temperature":0.4}`))
+	beginOpenAITemperatureObservation(c, account, []byte(`{"temperature":0.4}`))
+	observeOpenAIForwardedTemperature(c, []byte(`{}`))
+
+	require.Equal(t, "0", recorder.Header().Get(openAIRequestedTemperatureHeader))
+	require.Equal(t, "omitted-unsupported", recorder.Header().Get(openAITemperatureStatusHeader))
+}
+
+func TestOpenAITemperatureObservationIsDisabledForNonOpenAIAccounts(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	beginOpenAITemperatureObservation(c, newOpenAIRejectedFieldTestAccount(), []byte(`{"temperature":0}`))
+	setOpenAITemperaturePolicyObservation(c, accountTemperaturePolicy{mode: accountTemperatureModeInherit}, []byte(`{"temperature":0}`))
+	observeOpenAIForwardedTemperature(c, []byte(`{"temperature":0}`))
+	beginOpenAITemperatureObservation(c, &Account{Platform: PlatformGrok}, []byte(`{"temperature":0}`))
+
+	require.Empty(t, recorder.Header().Get(openAIRequestedTemperatureHeader))
+	require.Empty(t, recorder.Header().Get(openAIForwardedTemperatureHeader))
+	require.Empty(t, recorder.Header().Get(openAITemperaturePolicyHeader))
+	require.Empty(t, recorder.Header().Get(openAITemperatureStatusHeader))
+}
+
+func TestOpenAIChatCompletionsOmitsAccountTemperatureForMappedGPT56(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true,"temperature":0}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_chat_temperature", "gpt-5.6-sol")}
+	service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := newGPT56TemperatureOAuthAccount(map[string]any{"temperature_mode": "override", "temperature": 0.2})
+
+	result, err := service.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.6-sol")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "temperature").Exists())
+	require.Equal(t, "0", recorder.Header().Get(openAIRequestedTemperatureHeader))
+	require.Equal(t, "omitted", recorder.Header().Get(openAIForwardedTemperatureHeader))
+	require.Equal(t, "override", recorder.Header().Get(openAITemperaturePolicyHeader))
+	require.Equal(t, "omitted-unsupported", recorder.Header().Get(openAITemperatureStatusHeader))
+}
+
+func TestOpenAIMessagesOmitsAccountTemperatureForMappedGPT56(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4","max_tokens":1024,"messages":[{"role":"user","content":"hello"}],"temperature":0}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_messages_temperature", "gpt-5.6-terra")}
+	service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := newGPT56TemperatureOAuthAccount(map[string]any{"temperature_mode": "override", "temperature": 0.2})
+
+	result, err := service.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.6-terra")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "temperature").Exists())
+	require.Equal(t, "0", recorder.Header().Get(openAIRequestedTemperatureHeader))
+	require.Equal(t, "omitted", recorder.Header().Get(openAIForwardedTemperatureHeader))
+	require.Equal(t, "override", recorder.Header().Get(openAITemperaturePolicyHeader))
+	require.Equal(t, "omitted-unsupported", recorder.Header().Get(openAITemperatureStatusHeader))
+}
+
+func newGPT56TemperatureOAuthAccount(extraCredentials map[string]any) *Account {
+	credentials := map[string]any{
+		"access_token":       "oauth-token",
+		"chatgpt_account_id": "chatgpt-account",
+	}
+	for key, value := range extraCredentials {
+		credentials[key] = value
+	}
+	return &Account{
+		ID:          123,
+		Name:        "temperature-test",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: credentials,
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}

--- a/backend/internal/service/openai_model_alias_test.go
+++ b/backend/internal/service/openai_model_alias_test.go
@@ -34,3 +34,23 @@ func TestUsageBillingModelCandidates_BareGPT56IncludesSol(t *testing.T) {
 		usageBillingModelCandidates("openai/gpt-5.6"),
 	)
 }
+
+func TestSupportsOpenAICodexSamplingParametersMatchesOnlyGPT56Family(t *testing.T) {
+	tests := map[string]bool{
+		"gpt-5.6":                true,
+		"gpt-5.6-sol":            true,
+		"openai/GPT_5.6_TERRA":   true,
+		"gpt-5.6-cyber":          true,
+		"gpt-5.6-2026-07-09":     true,
+		"gpt-5.5":                false,
+		"gpt-5.60":               false,
+		"gpt-4.1":                false,
+		"third-party/gpt-5.6ish": false,
+	}
+
+	for model, expected := range tests {
+		t.Run(model, func(t *testing.T) {
+			require.Equal(t, expected, supportsOpenAICodexSamplingParameters(model))
+		})
+	}
+}

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -31,6 +31,16 @@ func TestNormalizeOpenAIPassthroughOAuthBody_RemovesSamplingParameters(t *testin
 	require.False(t, gjson.GetBytes(normalized, "top_p").Exists())
 }
 
+func TestNormalizeOpenAIPassthroughOAuthBody_PreservesGPT56SamplingParameters(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","temperature":0.35,"top_p":0.75,"input":"hello"}`)
+
+	normalized, _, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+	require.NoError(t, err)
+	require.InDelta(t, 0.35, gjson.GetBytes(normalized, "temperature").Float(), 1e-9)
+	require.InDelta(t, 0.75, gjson.GetBytes(normalized, "top_p").Float(), 1e-9)
+}
+
 func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesCompatibilityFields(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.5","prompt":"hello","commands":["unsupported"],"truncation":"auto","stop_sequences":["END"],"chat_template_kwargs":{"enable_thinking":true}}`)
 

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -31,14 +31,14 @@ func TestNormalizeOpenAIPassthroughOAuthBody_RemovesSamplingParameters(t *testin
 	require.False(t, gjson.GetBytes(normalized, "top_p").Exists())
 }
 
-func TestNormalizeOpenAIPassthroughOAuthBody_PreservesGPT56SamplingParameters(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.6-sol","temperature":0.35,"top_p":0.75,"input":"hello"}`)
+func TestNormalizeOpenAIPassthroughOAuthBody_RemovesGPT56SamplingParameters(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","temperature":0,"top_p":0.75,"input":"hello"}`)
 
 	normalized, _, err := normalizeOpenAIPassthroughOAuthBody(body, false)
 
 	require.NoError(t, err)
-	require.InDelta(t, 0.35, gjson.GetBytes(normalized, "temperature").Float(), 1e-9)
-	require.InDelta(t, 0.75, gjson.GetBytes(normalized, "top_p").Float(), 1e-9)
+	require.False(t, gjson.GetBytes(normalized, "temperature").Exists())
+	require.False(t, gjson.GetBytes(normalized, "top_p").Exists())
 }
 
 func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesCompatibilityFields(t *testing.T) {

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -13,11 +13,22 @@ func TestNormalizeOpenAIPassthroughOAuthBody_RemovesUnsupportedUser(t *testing.T
 	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
 	require.NoError(t, err)
 	require.True(t, changed)
-	for _, field := range openAIChatGPTInternalUnsupportedFields {
+	for _, field := range openAICodexOAuthUnsupportedFields {
 		require.False(t, gjson.GetBytes(normalized, field).Exists(), "%s should be stripped", field)
 	}
 	require.True(t, gjson.GetBytes(normalized, "stream").Bool())
 	require.False(t, gjson.GetBytes(normalized, "store").Bool())
+}
+
+func TestNormalizeOpenAIPassthroughOAuthBody_RemovesSamplingParameters(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","temperature":0.6,"top_p":0.8,"input":"hello"}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, gjson.GetBytes(normalized, "temperature").Exists())
+	require.False(t, gjson.GetBytes(normalized, "top_p").Exists())
 }
 
 func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesCompatibilityFields(t *testing.T) {

--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -21,7 +21,7 @@ var (
 	openAIResponsesRejectedStatusParamPattern     = regexp.MustCompile(`(?i)^input\[(\d+)\]\.status$`)
 	openAIResponsesRejectedContentParamPattern    = regexp.MustCompile(`(?i)^input\[(\d+)\]\.content$`)
 	openAIResponsesRejectedCacheParamPattern      = regexp.MustCompile(`(?i)^input\[(\d+)\]\.prompt_cache_breakpoint$`)
-	openAIResponsesRejectedMessageParamPattern    = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|truncation|input\[\d+\]\.(?:namespace|status))(?:["']|\b)`)
+	openAIResponsesRejectedMessageParamPattern    = regexp.MustCompile(`(?i)(?:unknown|unsupported)[ _-]+parameter\s*(?::|=|is)?\s*["']?(max_output_tokens|truncation|temperature|top_p|input\[\d+\]\.(?:namespace|status))(?:["']|\b)`)
 	openAIResponsesInvalidTypeMessageParamPattern = regexp.MustCompile(`(?i)invalid[ _-]+type\s+for\s+["']?(input\[\d+\]\.content)(?:["']|\b)[^\n]*\b(?:got|received)\s+null\b`)
 	openAIResponsesMaxZeroContentMessagePattern   = regexp.MustCompile(`(?i)invalid\s+["']?(input\[\d+\]\.content)["']?\s*:\s*array too long\.[^\n]*maximum length 0\b`)
 	openAIResponsesCacheModelRejectionPattern     = regexp.MustCompile(`(?i)["']?(prompt_cache_breakpoint|input\[\d+\]\.prompt_cache_breakpoint)["']?\s+is\s+not\s+supported\s+on\s+this\s+model\b`)
@@ -176,6 +176,13 @@ func normalizeOpenAIResponsesRejectedFieldRetryBody(statusCode int, body, respon
 				return nil, "", false, fmt.Errorf("delete rejected truncation: %w", err)
 			}
 			return retryBody, "truncation parameter rejection", true, nil
+		}
+		if (param == "temperature" || param == "top_p") && gjson.GetBytes(body, param).Exists() {
+			retryBody, err := sjson.DeleteBytes(body, param)
+			if err != nil {
+				return nil, "", false, fmt.Errorf("delete rejected %s: %w", param, err)
+			}
+			return retryBody, param + " parameter rejection", true, nil
 		}
 	}
 

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -101,6 +101,30 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRejectsAmbiguousErrors(t 
 	}
 }
 
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRemovesRejectedSamplingParameter(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-terra","temperature":0.35,"top_p":0.75,"input":[{"content":{"temperature":"keep","top_p":"keep"}}]}`)
+	tests := []struct {
+		param string
+		code  string
+	}{
+		{param: "temperature", code: "unsupported_parameter"},
+		{param: "top_p", code: "unknown_parameter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.param, func(t *testing.T) {
+			responseBody := []byte(fmt.Sprintf(`{"error":{"code":%q,"message":"Unsupported parameter: %s","param":%q}}`, tt.code, tt.param, tt.param))
+			retryBody, reason, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+
+			require.NoError(t, err)
+			require.True(t, changed)
+			require.Contains(t, reason, tt.param)
+			require.False(t, gjson.GetBytes(retryBody, tt.param).Exists())
+			require.Equal(t, "keep", gjson.GetBytes(retryBody, "input.0.content."+tt.param).String())
+		})
+	}
+}
+
 func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRepairsAutomationMissingRootType(t *testing.T) {
 	body := []byte(`{"tools":[{"type":"function","name":"automation_update","parameters":{"oneOf":[{"type":"object"},{"type":"object","properties":{}}]}}]}`)
 	responseBody := []byte(`{"error":{"code":"invalid_function_parameters","message":"Invalid schema for function 'automation_update': got 'type: \"None\"'.","param":"tools[0].parameters"}}`)
@@ -621,6 +645,28 @@ func TestOpenAIGatewayService_RetriesExplicitMaxOutputTokensRejection(t *testing
 	require.Equal(t, int64(4096), gjson.GetBytes(upstream.bodies[0], "max_output_tokens").Int())
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "max_output_tokens").Exists())
 	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.content.max_output_tokens").String())
+}
+
+func TestOpenAIGatewayService_RetriesExplicitTemperatureRejection(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-terra","stream":false,"temperature":0.35,"input":[{"type":"message","role":"user","content":{"temperature":"keep"}}]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: temperature","param":"temperature"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		newOpenAIRejectedFieldTestContext(body),
+		newOpenAIRejectedFieldTestAccount(),
+		body,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.InDelta(t, 0.35, gjson.GetBytes(upstream.bodies[0], "temperature").Float(), 1e-9)
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "temperature").Exists())
+	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.content.temperature").String())
 }
 
 func TestOpenAIGatewayService_ComposesProactiveNamespaceStripWithRejectedFieldRetry(t *testing.T) {

--- a/backend/internal/service/openai_temperature_observation.go
+++ b/backend/internal/service/openai_temperature_observation.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	openAITemperatureObservationContextKey = "openai_temperature_observation"
+
+	openAIRequestedTemperatureHeader = "X-Sub2API-Requested-Temperature"
+	openAIForwardedTemperatureHeader = "X-Sub2API-Forwarded-Temperature"
+	openAITemperaturePolicyHeader    = "X-Sub2API-Temperature-Policy"
+	openAITemperatureStatusHeader    = "X-Sub2API-Temperature-Status"
+
+	openAITemperatureOmitted = "omitted"
+)
+
+type openAITemperatureObservation struct {
+	requested   string
+	policy      accountTemperatureMode
+	afterPolicy string
+	forwarded   string
+}
+
+func beginOpenAITemperatureObservation(c *gin.Context, account *Account, body []byte) {
+	if c == nil {
+		return
+	}
+	if account == nil || account.Platform != PlatformOpenAI {
+		c.Set(openAITemperatureObservationContextKey, nil)
+		clearOpenAITemperatureObservationHeaders(c.Writer.Header())
+		return
+	}
+	if openAITemperatureObservationFromContext(c) != nil {
+		return
+	}
+	c.Set(openAITemperatureObservationContextKey, &openAITemperatureObservation{
+		requested: temperatureHeaderValue(body),
+		policy:    accountTemperatureModeInherit,
+		forwarded: openAITemperatureOmitted,
+	})
+}
+
+func clearOpenAITemperatureObservationHeaders(headers http.Header) {
+	if headers == nil {
+		return
+	}
+	headers.Del(openAIRequestedTemperatureHeader)
+	headers.Del(openAIForwardedTemperatureHeader)
+	headers.Del(openAITemperaturePolicyHeader)
+	headers.Del(openAITemperatureStatusHeader)
+}
+
+func setOpenAITemperaturePolicyObservation(c *gin.Context, policy accountTemperaturePolicy, body []byte) {
+	observation := openAITemperatureObservationFromContext(c)
+	if observation == nil {
+		return
+	}
+	observation.policy = policy.mode
+	observation.afterPolicy = temperatureHeaderValue(body)
+	observation.forwarded = openAITemperatureOmitted
+	writeOpenAITemperatureObservationHeaders(c.Writer.Header(), observation)
+}
+
+func observeOpenAIForwardedTemperature(c *gin.Context, body []byte) {
+	observation := openAITemperatureObservationFromContext(c)
+	if observation == nil {
+		return
+	}
+	observation.forwarded = temperatureHeaderValue(body)
+	writeOpenAITemperatureObservationHeaders(c.Writer.Header(), observation)
+}
+
+func openAITemperatureObservationFromContext(c *gin.Context) *openAITemperatureObservation {
+	if c == nil {
+		return nil
+	}
+	value, exists := c.Get(openAITemperatureObservationContextKey)
+	if !exists {
+		return nil
+	}
+	observation, _ := value.(*openAITemperatureObservation)
+	return observation
+}
+
+func temperatureHeaderValue(body []byte) string {
+	value := gjson.GetBytes(body, "temperature")
+	if !value.Exists() || value.Type == gjson.Null || value.Type != gjson.Number {
+		return openAITemperatureOmitted
+	}
+	return value.Raw
+}
+
+func writeOpenAITemperatureObservationHeaders(headers http.Header, observation *openAITemperatureObservation) {
+	if headers == nil || observation == nil {
+		return
+	}
+	headers.Set(openAIRequestedTemperatureHeader, observation.requested)
+	headers.Set(openAIForwardedTemperatureHeader, observation.forwarded)
+	headers.Set(openAITemperaturePolicyHeader, string(observation.policy))
+	headers.Set(openAITemperatureStatusHeader, observation.status())
+}
+
+func (o *openAITemperatureObservation) status() string {
+	if o.policy == accountTemperatureModeOmit {
+		return "omitted-policy"
+	}
+	if o.forwarded != openAITemperatureOmitted {
+		return "forwarded"
+	}
+	if o.afterPolicy != "" && o.afterPolicy != openAITemperatureOmitted {
+		return "omitted-unsupported"
+	}
+	return openAITemperatureOmitted
+}

--- a/frontend/src/components/account/AccountTemperaturePolicyField.vue
+++ b/frontend/src/components/account/AccountTemperaturePolicyField.vue
@@ -1,0 +1,76 @@
+<template>
+  <fieldset>
+    <legend class="input-label">{{ t('admin.accounts.temperature.label') }}</legend>
+    <div
+      class="grid gap-1 rounded-md bg-gray-100 p-1 dark:bg-dark-700"
+      :class="allowUnchanged ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'"
+    >
+      <button
+        v-for="option in modeOptions"
+        :key="option"
+        type="button"
+        :data-testid="`temperature-mode-${option}`"
+        :aria-pressed="mode === option"
+        :class="[
+          'min-h-9 rounded px-2 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1',
+          mode === option
+            ? 'bg-white text-primary-700 shadow-sm dark:bg-dark-600 dark:text-primary-300'
+            : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+        ]"
+        @click="emit('update:mode', option)"
+      >
+        {{ t(`admin.accounts.temperature.modes.${option}`) }}
+      </button>
+    </div>
+
+    <label v-if="mode === 'override'" class="mt-3 block">
+      <span class="input-label text-xs">{{ t('admin.accounts.temperature.value') }}</span>
+      <input
+        :value="temperature ?? ''"
+        type="number"
+        step="any"
+        required
+        class="input"
+        data-testid="temperature-value"
+        @input="handleTemperatureInput"
+      />
+    </label>
+  </fieldset>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { AccountTemperatureSelectionMode } from './credentialsBuilder'
+
+const props = withDefaults(
+  defineProps<{
+    mode: AccountTemperatureSelectionMode
+    temperature: number | null
+    allowUnchanged?: boolean
+  }>(),
+  { allowUnchanged: false }
+)
+
+const emit = defineEmits<{
+  'update:mode': [mode: AccountTemperatureSelectionMode]
+  'update:temperature': [temperature: number | null]
+}>()
+
+const { t } = useI18n()
+const modeOptions = computed<AccountTemperatureSelectionMode[]>(() =>
+  props.allowUnchanged
+    ? ['unchanged', 'inherit', 'override', 'omit']
+    : ['inherit', 'override', 'omit']
+)
+
+const handleTemperatureInput = (event: Event) => {
+  const rawValue = (event.target as HTMLInputElement).value
+  if (rawValue === '') {
+    emit('update:temperature', null)
+    return
+  }
+  const value = Number(rawValue)
+  emit('update:temperature', Number.isFinite(value) ? value : null)
+}
+</script>

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -31,6 +31,13 @@
         </p>
       </div>
 
+      <AccountTemperaturePolicyField
+        v-model:mode="temperatureMode"
+        v-model:temperature="temperatureValue"
+        allow-unchanged
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      />
+
       <!-- OpenAI passthrough -->
       <div
         v-if="allOpenAIPassthroughCapable"
@@ -1498,13 +1505,16 @@ import {
   getPresetMappingsByPlatform
 } from '@/composables/useModelWhitelist'
 import HeaderOverrideEditor from '@/components/account/HeaderOverrideEditor.vue'
+import AccountTemperaturePolicyField from '@/components/account/AccountTemperaturePolicyField.vue'
 import {
+  applyAccountTemperaturePolicy,
   buildHeaderOverridesObject,
   isHeaderOverrideCapable,
   validateHeaderOverrideRows,
   HEADER_OVERRIDE_ENABLED_CREDENTIAL_KEY,
   HEADER_OVERRIDES_CREDENTIAL_KEY,
-  type HeaderOverrideRow
+  type HeaderOverrideRow,
+  type AccountTemperatureSelectionMode
 } from '@/components/account/credentialsBuilder'
 import GrokBaseUrlPresets from '@/components/account/GrokBaseUrlPresets.vue'
 import {
@@ -1683,6 +1693,8 @@ const modelMappings = ref<ModelMapping[]>([])
 const selectedErrorCodes = ref<number[]>([])
 const customErrorCodeInput = ref<number | null>(null)
 const interceptWarmupRequests = ref(false)
+const temperatureMode = ref<AccountTemperatureSelectionMode>('unchanged')
+const temperatureValue = ref<number | null>(null)
 const headerOverrideEnabled = ref(false)
 const headerOverrideRows = ref<HeaderOverrideRow[]>([])
 const proxyId = ref<number | null>(null)
@@ -2043,6 +2055,13 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     credentialsChanged = true
   }
 
+  if (temperatureMode.value !== 'unchanged') {
+    if (!applyAccountTemperaturePolicy(credentials, temperatureMode.value, temperatureValue.value)) {
+      return null
+    }
+    credentialsChanged = true
+  }
+
   if (enableHeaderOverride.value) {
     // 后端使用 JSONB || merge 语义：关闭时显式写入 false + 空对象以清除旧配置
     credentials[HEADER_OVERRIDE_ENABLED_CREDENTIAL_KEY] = headerOverrideEnabled.value
@@ -2199,7 +2218,16 @@ const handleSubmit = async () => {
     return
   }
 
+  if (
+    temperatureMode.value === 'override' &&
+    (temperatureValue.value === null || !Number.isFinite(temperatureValue.value))
+  ) {
+    appStore.showError(t('admin.accounts.temperature.invalid'))
+    return
+  }
+
   const hasAnyFieldEnabled =
+    temperatureMode.value !== 'unchanged' ||
     enableBaseUrl.value ||
     enableOpenAIPassthrough.value ||
     enableOpenAIFlattenNamespaces.value ||
@@ -2392,6 +2420,8 @@ watch(
       selectedErrorCodes.value = []
       customErrorCodeInput.value = null
       interceptWarmupRequests.value = false
+      temperatureMode.value = 'unchanged'
+      temperatureValue.value = null
       headerOverrideEnabled.value = false
       headerOverrideRows.value = []
       proxyId.value = null

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2502,6 +2502,12 @@
         </div>
       </div>
 
+      <AccountTemperaturePolicyField
+        v-model:mode="temperatureMode"
+        v-model:temperature="temperatureValue"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      />
+
       <!-- Intercept Warmup Requests (Anthropic/Antigravity) -->
       <div
         v-if="form.platform === 'anthropic' || form.platform === 'antigravity'"
@@ -3809,8 +3815,10 @@ import Toggle from '@/components/common/Toggle.vue'
 import GrokBaseUrlPresets from '@/components/account/GrokBaseUrlPresets.vue'
 import CnBaseUrlPresets from '@/components/account/CnBaseUrlPresets.vue'
 import HeaderOverrideEditor from '@/components/account/HeaderOverrideEditor.vue'
+import AccountTemperaturePolicyField from '@/components/account/AccountTemperaturePolicyField.vue'
 import { allSelectedGroupsEnableLongContextPricing } from '@/components/account/longContextBilling'
 import {
+  applyAccountTemperaturePolicy,
   applyAntigravityProjectID,
   applyHeaderOverride,
   applyInterceptWarmup,
@@ -3822,7 +3830,8 @@ import {
   type CnAccountMode,
   type CnApiProtocol,
   type CnNativeApiProtocol,
-  type HeaderOverrideRow
+  type HeaderOverrideRow,
+  type AccountTemperatureMode
 } from '@/components/account/credentialsBuilder'
 import {
   formatDateTimeLocalInput,
@@ -4223,6 +4232,8 @@ const applyGrokOAuthUpstreamConfig = (credentials: Record<string, unknown>) => {
   applyHeaderOverride(credentials, headerOverrideEnabled.value, headerOverrideRows.value, 'create')
 }
 const interceptWarmupRequests = ref(false)
+const temperatureMode = ref<AccountTemperatureMode>('inherit')
+const temperatureValue = ref<number | null>(1)
 const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
@@ -5002,6 +5013,19 @@ const withAntigravityConfirmFlag = (payload: CreateAccountRequest): CreateAccoun
   return cloned
 }
 
+const createAccountWithTemperature = async (payload: CreateAccountRequest) => {
+  const credentials = { ...payload.credentials }
+  if (!applyAccountTemperaturePolicy(credentials, temperatureMode.value, temperatureValue.value)) {
+    throw new Error(t('admin.accounts.temperature.invalid'))
+  }
+  return adminAPI.accounts.create(
+    withAntigravityConfirmFlag({
+      ...payload,
+      credentials
+    })
+  )
+}
+
 const ensureAntigravityMixedChannelConfirmed = async (onConfirm: () => Promise<void>): Promise<boolean> => {
   if (!needsMixedChannelCheck(form.platform)) {
     return true
@@ -5035,7 +5059,7 @@ const ensureAntigravityMixedChannelConfirmed = async (onConfirm: () => Promise<v
 const submitCreateAccount = async (payload: CreateAccountRequest) => {
   submitting.value = true
   try {
-    const account = await adminAPI.accounts.create(withAntigravityConfirmFlag(payload))
+    const account = await createAccountWithTemperature(payload)
     const modelMapping = payload.credentials.model_mapping
     const hasConcreteMappedTarget = payload.type === 'apikey' &&
       typeof modelMapping === 'object' &&
@@ -5136,6 +5160,8 @@ const resetForm = () => {
   grokOAuthCustomBaseUrlEnabled.value = false
   grokOAuthBaseUrl.value = ''
   interceptWarmupRequests.value = false
+  temperatureMode.value = 'inherit'
+  temperatureValue.value = 1
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
@@ -5831,7 +5857,7 @@ const handleGrokValidateRT = async (refreshTokenInput: string) => {
           return
         }
 
-        await adminAPI.accounts.create({
+        await createAccountWithTemperature({
           name: accountName,
           notes: form.notes,
           platform: 'grok',
@@ -6008,7 +6034,7 @@ const handleGrokAuthorizePassword = async (emailPasswordInput: string) => {
           return
         }
 
-        await adminAPI.accounts.create({
+        await createAccountWithTemperature({
           name: accountName,
           notes: form.notes,
           platform: 'grok',
@@ -6107,7 +6133,7 @@ const handleOpenAIExchange = async (authCode: string) => {
     }
 
     if (shouldCreateOpenAI) {
-      await adminAPI.accounts.create({
+      await createAccountWithTemperature({
         name: form.name,
         notes: form.notes,
         platform: 'openai',
@@ -6155,6 +6181,10 @@ const buildOpenAICodexImportCredentialExtras = (): Record<string, unknown> | nul
   }
 
   if (!applyTempUnschedConfig(credentials)) {
+    return null
+  }
+  if (!applyAccountTemperaturePolicy(credentials, temperatureMode.value, temperatureValue.value)) {
+    appStore.showError(t('admin.accounts.temperature.invalid'))
     return null
   }
   return credentials
@@ -6388,7 +6418,7 @@ const handleOpenAIBatchRT = async (refreshTokenInput: string, clientId?: string)
         const accountName = refreshTokens.length > 1 ? `${baseName} #${i + 1}` : baseName
 
         if (shouldCreateOpenAI) {
-          await adminAPI.accounts.create({
+          await createAccountWithTemperature({
             name: accountName,
             notes: form.notes,
             platform: 'openai',
@@ -6503,7 +6533,7 @@ const handleAntigravityValidateRT = async (refreshTokenInput: string) => {
           expires_at: form.expires_at,
           auto_pause_on_expired: autoPauseOnExpired.value
         })
-        await adminAPI.accounts.create(createPayload)
+        await createAccountWithTemperature(createPayload)
         successCount++
       } catch (error: any) {
         failedCount++
@@ -6868,7 +6898,7 @@ const handleCookieAuth = async (sessionKey: string) => {
           credentials.temp_unschedulable_rules = tempUnschedPayload
         }
 
-        await adminAPI.accounts.create({
+        await createAccountWithTemperature({
           name: accountName,
           notes: form.notes,
           platform: form.platform,

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1535,6 +1535,13 @@
         </div>
       </div>
 
+      <AccountTemperaturePolicyField
+        v-if="!isSparkShadow"
+        v-model:mode="temperatureMode"
+        v-model:temperature="temperatureValue"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      />
+
       <div v-if="!isSparkShadow">
         <div class="mb-1 flex items-center gap-2">
           <label class="input-label mb-0">{{ t('admin.accounts.proxy') }}</label>
@@ -2898,12 +2905,15 @@ import GrokBaseUrlPresets from '@/components/account/GrokBaseUrlPresets.vue'
 import CnBaseUrlPresets from '@/components/account/CnBaseUrlPresets.vue'
 import HeaderOverrideEditor from '@/components/account/HeaderOverrideEditor.vue'
 import OllamaCloudUsageSettings from '@/components/account/OllamaCloudUsageSettings.vue'
+import AccountTemperaturePolicyField from '@/components/account/AccountTemperaturePolicyField.vue'
 import {
+  applyAccountTemperaturePolicy,
   applyAntigravityProjectID,
   applyHeaderOverride,
   applyInterceptWarmup,
   applyPlanType,
   buildPlanTypeOptions,
+  readAccountTemperaturePolicy,
   readPlanType,
   isCustomGrokBaseUrl,
   isHeaderOverrideCapable,
@@ -2917,7 +2927,8 @@ import {
   type CnAccountMode,
   type CnApiProtocol,
   type CnNativeApiProtocol,
-  type HeaderOverrideRow
+  type HeaderOverrideRow,
+  type AccountTemperatureMode
 } from '@/components/account/credentialsBuilder'
 import {
   formatDateTime,
@@ -3196,6 +3207,8 @@ const grokOAuthBaseUrl = ref('')
 const grokClientToolCacheEnabled = ref(true)
 
 const interceptWarmupRequests = ref(false)
+const temperatureMode = ref<AccountTemperatureMode>('inherit')
+const temperatureValue = ref<number | null>(null)
 const autoPauseOnExpired = ref(false)
 const autoPause5hThreshold = ref<number | null>(null)
 const autoPause7dThreshold = ref<number | null>(null)
@@ -3711,6 +3724,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load intercept warmup requests setting (applies to all account types)
   const credentials = newAccount.credentials as Record<string, unknown> | undefined
   interceptWarmupRequests.value = credentials?.intercept_warmup_requests === true
+  const temperaturePolicy = readAccountTemperaturePolicy(credentials)
+  temperatureMode.value = temperaturePolicy.mode
+  temperatureValue.value = temperaturePolicy.temperature
   autoPauseOnExpired.value = newAccount.auto_pause_on_expired === true
   editVertexProjectId.value = ''
   editVertexClientEmail.value = ''
@@ -5335,6 +5351,18 @@ const handleSubmit = async () => {
       // Quota notify config
       writeQuotaNotifyToExtra(newExtra, 'update')
       updatePayload.extra = newExtra
+    }
+
+    if (!isSparkShadow.value) {
+      const currentCredentials =
+        (updatePayload.credentials as Record<string, unknown>) ||
+        ((props.account.credentials as Record<string, unknown>) || {})
+      const newCredentials = { ...currentCredentials }
+      if (!applyAccountTemperaturePolicy(newCredentials, temperatureMode.value, temperatureValue.value)) {
+        appStore.showError(t('admin.accounts.temperature.invalid'))
+        return
+      }
+      updatePayload.credentials = newCredentials
     }
 
     const canContinue = await ensureAntigravityMixedChannelConfirmed(async () => {

--- a/frontend/src/components/account/__tests__/AccountTemperaturePolicyField.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountTemperaturePolicyField.spec.ts
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import AccountTemperaturePolicyField from '../AccountTemperaturePolicyField.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+describe('AccountTemperaturePolicyField', () => {
+  it('renders the three account modes and no unchanged mode by default', () => {
+    const wrapper = mount(AccountTemperaturePolicyField, {
+      props: { mode: 'inherit', temperature: null }
+    })
+
+    expect(wrapper.find('[data-testid="temperature-mode-inherit"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="temperature-mode-override"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="temperature-mode-omit"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="temperature-mode-unchanged"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="temperature-value"]').exists()).toBe(false)
+  })
+
+  it('emits mode changes and shows a numeric input for override', async () => {
+    const wrapper = mount(AccountTemperaturePolicyField, {
+      props: { mode: 'inherit', temperature: null }
+    })
+
+    await wrapper.get('[data-testid="temperature-mode-override"]').trigger('click')
+    expect(wrapper.emitted('update:mode')).toEqual([['override']])
+
+    await wrapper.setProps({ mode: 'override' })
+    const input = wrapper.get('[data-testid="temperature-value"]')
+    expect(input.attributes('type')).toBe('number')
+    expect(input.attributes('required')).toBeDefined()
+
+    await input.setValue('0')
+    expect(wrapper.emitted('update:temperature')?.at(-1)).toEqual([0])
+  })
+
+  it('emits null when the override input is cleared', async () => {
+    const wrapper = mount(AccountTemperaturePolicyField, {
+      props: { mode: 'override', temperature: 0.7 }
+    })
+
+    await wrapper.get('[data-testid="temperature-value"]').setValue('')
+    expect(wrapper.emitted('update:temperature')?.at(-1)).toEqual([null])
+  })
+
+  it('supports bulk unchanged mode when requested', () => {
+    const wrapper = mount(AccountTemperaturePolicyField, {
+      props: { mode: 'unchanged', temperature: null, allowUnchanged: true }
+    })
+
+    expect(wrapper.find('[data-testid="temperature-mode-unchanged"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="temperature-mode-unchanged"]').attributes('aria-pressed')).toBe(
+      'true'
+    )
+  })
+})

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -98,6 +98,25 @@ describe('BulkEditAccountModal', () => {
     } as any)
   })
 
+  it('keeps temperature unchanged by default and submits a zero override when selected', async () => {
+    const wrapper = mountModal()
+    expect(wrapper.get('[data-testid="temperature-mode-unchanged"]').attributes('aria-pressed')).toBe(
+      'true'
+    )
+
+    await wrapper.get('[data-testid="temperature-mode-override"]').trigger('click')
+    await wrapper.get('[data-testid="temperature-value"]').setValue('0')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      credentials: {
+        temperature_mode: 'override',
+        temperature: 0
+      }
+    })
+  })
+
   it('批量修改倍率时提示自动同步账号需要先关闭同步', async () => {
     const wrapper = mountModal()
 

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -212,6 +212,24 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     createOpenAICodexPATMock.mockReset().mockResolvedValue({})
   })
 
+  it('writes an account temperature override including zero on API key creation', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI account')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('[data-testid="temperature-mode-override"]').trigger('click')
+    await wrapper.get('[data-testid="temperature-value"]').setValue('0')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]?.credentials).toMatchObject({
+      temperature_mode: 'override',
+      temperature: 0
+    })
+  })
+
   it('hides only the redundant account toggle when every selected group enables tier pricing', async () => {
     authIsSimpleMode.value = false
     const wrapper = mountModal([
@@ -502,6 +520,22 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
 
     expect(importCodexSessionMock).toHaveBeenCalledTimes(1)
     expect(importCodexSessionMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBeUndefined()
+  })
+
+  it('passes the selected temperature policy through Codex import credential extras', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await wrapper.get('[data-testid="temperature-mode-override"]').trigger('click')
+    await wrapper.get('[data-testid="temperature-value"]').setValue('0')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('Codex import')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await wrapper.get('[data-testid="import-codex-session"]').trigger('click')
+    await flushPromises()
+
+    expect(importCodexSessionMock.mock.calls[0]?.[0]?.credential_extras).toMatchObject({
+      temperature_mode: 'override',
+      temperature: 0
+    })
   })
 
   it('leaves Codex PAT import billing ownership to the backend', async () => {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -324,6 +324,32 @@ function mountModal(account = buildAccount()) {
 }
 
 describe('EditAccountModal', () => {
+  it('loads and updates the stored account temperature policy', async () => {
+    const account = buildAccount()
+    account.credentials.temperature_mode = 'override'
+    account.credentials.temperature = 0.4
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    expect(wrapper.get<HTMLInputElement>('[data-testid="temperature-value"]').element.value).toBe(
+      '0.4'
+    )
+
+    await wrapper.get('[data-testid="temperature-mode-omit"]').trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    const credentials = updateAccountMock.mock.calls[0]?.[1]?.credentials
+    expect(credentials?.temperature_mode).toBe('omit')
+    expect(credentials).not.toHaveProperty('temperature')
+  })
+
+  it('does not expose temperature configuration on a Spark shadow account', () => {
+    const wrapper = mountModal(buildOpenAISparkShadowAccount())
+    expect(wrapper.find('[data-testid="temperature-mode-inherit"]').exists()).toBe(false)
+  })
+
   beforeEach(() => {
     authIsSimpleMode.value = true
   })

--- a/frontend/src/components/account/__tests__/credentialsBuilder.spec.ts
+++ b/frontend/src/components/account/__tests__/credentialsBuilder.spec.ts
@@ -3,6 +3,7 @@ import {
   ANTIGRAVITY_PROJECT_ID_CREDENTIAL_KEY,
   HEADER_OVERRIDE_ENABLED_CREDENTIAL_KEY,
   HEADER_OVERRIDES_CREDENTIAL_KEY,
+  applyAccountTemperaturePolicy,
   applyAntigravityProjectID,
   applyHeaderOverride,
   applyInterceptWarmup,
@@ -14,11 +15,66 @@ import {
   GROK_BASE_URL_PRESETS,
   parseHeaderOverridesJson,
   planTypeDisplayLabel,
+  readAccountTemperaturePolicy,
   readPlanType,
   serializeHeaderOverrideRows,
   splitHeaderOverridesObject,
   validateHeaderOverrideRows
 } from '../credentialsBuilder'
+
+describe('account temperature policy helpers', () => {
+  it('defaults missing or invalid stored policy to inherit', () => {
+    expect(readAccountTemperaturePolicy()).toEqual({ mode: 'inherit', temperature: null })
+    expect(readAccountTemperaturePolicy({ temperature_mode: 'unknown', temperature: 0.8 })).toEqual({
+      mode: 'inherit',
+      temperature: null
+    })
+  })
+
+  it('reads override temperature including zero', () => {
+    expect(readAccountTemperaturePolicy({ temperature_mode: 'override', temperature: 0 })).toEqual({
+      mode: 'override',
+      temperature: 0
+    })
+  })
+
+  it('writes inherit and omit without retaining a stale temperature', () => {
+    const inheritCredentials: Record<string, unknown> = { api_key: 'sk', temperature: 0.7 }
+    expect(applyAccountTemperaturePolicy(inheritCredentials, 'inherit', null)).toBe(true)
+    expect(inheritCredentials).toEqual({ api_key: 'sk', temperature_mode: 'inherit' })
+
+    const omitCredentials: Record<string, unknown> = { api_key: 'sk', temperature: 0.7 }
+    expect(applyAccountTemperaturePolicy(omitCredentials, 'omit', null)).toBe(true)
+    expect(omitCredentials).toEqual({ api_key: 'sk', temperature_mode: 'omit' })
+  })
+
+  it('writes a finite override temperature including zero', () => {
+    const credentials: Record<string, unknown> = { api_key: 'sk' }
+    expect(applyAccountTemperaturePolicy(credentials, 'override', 0)).toBe(true)
+    expect(credentials).toEqual({
+      api_key: 'sk',
+      temperature_mode: 'override',
+      temperature: 0
+    })
+  })
+
+  it('rejects a missing or non-finite override without mutating credentials', () => {
+    for (const temperature of [null, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const credentials: Record<string, unknown> = { api_key: 'sk' }
+      expect(applyAccountTemperaturePolicy(credentials, 'override', temperature)).toBe(false)
+      expect(credentials).toEqual({ api_key: 'sk' })
+    }
+  })
+
+  it('leaves credentials untouched in bulk unchanged mode', () => {
+    const credentials: Record<string, unknown> = {
+      temperature_mode: 'override',
+      temperature: 0.4
+    }
+    expect(applyAccountTemperaturePolicy(credentials, 'unchanged', null)).toBe(true)
+    expect(credentials).toEqual({ temperature_mode: 'override', temperature: 0.4 })
+  })
+})
 
 describe('applyInterceptWarmup', () => {
   it('create + enabled=true: should set intercept_warmup_requests to true', () => {

--- a/frontend/src/components/account/credentialsBuilder.ts
+++ b/frontend/src/components/account/credentialsBuilder.ts
@@ -1,3 +1,45 @@
+export type AccountTemperatureMode = 'inherit' | 'override' | 'omit'
+export type AccountTemperatureSelectionMode = AccountTemperatureMode | 'unchanged'
+
+export interface AccountTemperaturePolicy {
+  mode: AccountTemperatureMode
+  temperature: number | null
+}
+
+export function readAccountTemperaturePolicy(
+  credentials?: Record<string, unknown> | null
+): AccountTemperaturePolicy {
+  const mode = credentials?.temperature_mode
+  if (mode !== 'inherit' && mode !== 'override' && mode !== 'omit') {
+    return { mode: 'inherit', temperature: null }
+  }
+
+  const temperature = credentials?.temperature
+  if (mode === 'override' && typeof temperature === 'number' && Number.isFinite(temperature)) {
+    return { mode, temperature }
+  }
+  return { mode, temperature: null }
+}
+
+export function applyAccountTemperaturePolicy(
+  credentials: Record<string, unknown>,
+  mode: AccountTemperatureSelectionMode,
+  temperature: number | null
+): boolean {
+  if (mode === 'unchanged') return true
+  if (mode === 'override' && (temperature === null || !Number.isFinite(temperature))) {
+    return false
+  }
+
+  credentials.temperature_mode = mode
+  if (mode === 'override') {
+    credentials.temperature = temperature
+  } else {
+    delete credentials.temperature
+  }
+  return true
+}
+
 export function applyInterceptWarmup(
   credentials: Record<string, unknown>,
   enabled: boolean,

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -2,6 +2,17 @@ export default {
     accounts: {
       title: 'Account Management',
       description: 'Manage AI platform accounts and credentials',
+      temperature: {
+        label: 'Temperature policy',
+        value: 'Fixed temperature',
+        invalid: 'Fixed temperature must be a finite number',
+        modes: {
+          unchanged: 'Unchanged',
+          inherit: 'Default',
+          override: 'Fixed value',
+          omit: 'Do not send'
+        }
+      },
       createAccount: 'Create Account',
       autoRefresh: 'Auto Refresh',
       enableAutoRefresh: 'Enable auto refresh',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -2,6 +2,17 @@ export default {
     accounts: {
       title: '账号管理',
       description: '管理 AI 平台账号和 Cookie',
+      temperature: {
+        label: '温度策略',
+        value: '固定温度',
+        invalid: '固定温度必须是有限数值',
+        modes: {
+          unchanged: '不修改',
+          inherit: '默认',
+          override: '固定值',
+          omit: '不发送'
+        }
+      },
       createAccount: '添加账号',
       autoRefresh: '自动刷新',
       enableAutoRefresh: '启用自动刷新',


### PR DESCRIPTION
## 核心判断

ChatGPT Codex OAuth Responses 上游拒绝 `temperature` 和 `top_p`。GPT-5.6 请求携带温度不代表上游采用该温度；响应正文回显 `temperature=1` 时，该值属于上游响应元数据。

标准响应正文必须保持上游原值。代理不得把请求温度写回响应，否则会伪造实际实验条件。

## 改动

- 账号增加 `inherit`、`override`、`omit` 三态温度策略。
- OpenAI OAuth/Codex 在首次出站前删除 `temperature/top_p`，不再依赖上游返回 400 后重试。
- API Key、Anthropic、Gemini、Antigravity 等支持温度的渠道继续应用账号温度策略。
- 支持不传温度、显式 `null`、显式 `0` 和其他有限数值。
- Spark 影子账号读取母账号策略，策略状态归母账号所有。
- 上游明确以 `unknown_parameter` 或 `unsupported_parameter` 拒绝采样字段时，只删除被拒绝的顶层字段并进行有界重试；另一个采样字段和嵌套同名字段保持不变。

## 账号策略

| 模式 | 出站行为 |
| --- | --- |
| `inherit` | 保留客户端数值；客户端不传或传 `null` 时不补参数 |
| `override` | 使用账号固定值覆盖客户端参数，支持显式 `0` |
| `omit` | 删除客户端温度 |

固定值必须是有限数字，具体取值范围由目标上游协议校验。

## 诊断信息

响应增加以下头部：

- `X-Sub2API-Requested-Temperature`：客户端原始请求值或 `omitted`
- `X-Sub2API-Forwarded-Temperature`：最终出站值或 `omitted`
- `X-Sub2API-Temperature-Policy`：`inherit`、`override` 或 `omit`
- `X-Sub2API-Temperature-Status`：`forwarded`、`omitted`、`omitted-policy` 或 `omitted-unsupported`

诊断覆盖 OpenAI Responses、passthrough、Chat Completions、Anthropic Messages、原生 Anthropic、raw Chat Completions 和 Responses WebSocket v2。CORS 暴露全部四个头部。

响应 JSON 和 SSE 内容保持上游原样，不改写 `temperature`。

## 协议覆盖

- OpenAI Chat Completions、Responses、Messages 兼容入口
- Anthropic Messages、Chat/Responses 兼容入口和 API Key 透传
- Gemini Chat Completions、Messages 兼容入口和原生 `generationConfig.temperature`
- Antigravity Claude、Chat Completions、Responses 和 Gemini 路径

## 社区依据

- [OmniRoute #12585](https://github.com/diegosouzapw/OmniRoute/pull/12585)
- [MaiBot #2024](https://github.com/Mai-with-u/MaiBot/issues/2024)
- [LiteLLM #33177](https://github.com/BerriAI/litellm/pull/33177)
- [sub2api #2580](https://github.com/Wei-Shaw/sub2api/pull/2580)

## 验证

- GPT-5.6 OAuth：`temperature=0`、`1`、`2`、账号覆盖、账号省略和缺省温度测试通过
- API Key：继承与账号覆盖后的最终出站温度测试通过
- Responses、passthrough、Chat Completions、Anthropic Messages、raw Chat Completions 字段拒绝重试测试通过
- JSON 响应保持上游 `temperature=1` 的回归测试通过
- 原始请求值跨重试保留、非 OpenAI 平台不输出诊断头的测试通过
- `go test ./internal/pkg/apicompat -count=1` 通过
- `go test ./internal/server/middleware -count=1` 通过
- `go vet ./internal/pkg/apicompat ./internal/service ./internal/server/middleware` 通过
- `go build ./cmd/server` 通过
- 前端 252 个测试文件、1840 个用例通过
- `pnpm lint:check`、`pnpm typecheck`、`pnpm build` 通过
- `git diff --check` 通过

`go test ./internal/service -count=1` 完成全包执行，失败项为 1 个 content moderation 和 4 个 plugin package installer Windows 跨平台用例；修复与连续验证位于 #6342。
