### PR TITLE
fix(frontend): 批量编辑显式提交 codex_fingerprint_mode=off，修复无法关闭指纹收敛

### DIFF
--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -978,6 +978,7 @@
         <div class="mb-3 flex items-center justify-between">
           <label class="input-label mb-0">{{ t('admin.accounts.openai.codexFingerprintMode') }}</label>
           <input
+            id="bulk-edit-openai-codex-fingerprint-mode-enabled"
             v-model="enableCodexFingerprintMode"
             type="checkbox"
             class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
@@ -2089,12 +2090,23 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
 
   if (enableCodexFingerprintMode.value) {
     const extra = ensureExtra()
-    // off = 默认值，清键即可；device/session/full 是显式 opt-in，必须落键（#5610）。
-    if (codexFingerprintMode.value !== 'off') {
-      extra.codex_fingerprint_mode = codexFingerprintMode.value
-    } else {
-      delete extra.codex_fingerprint_mode
-    }
+    // off 必须显式落键，不能靠删本地键表达。批量更新走 JSONB 顶层合并
+    // （extra = COALESCE(extra,'{}') || payload），删掉 payload 里的键只表示
+    // "本次不更新该键"，清不掉账号上已有的 device/session/full；而且只删不写会让
+    // 整个 payload 退化成 {extra:{}}，被后端 len(req.Extra) > 0 判为空更新直接 400
+    // "No updates provided"（#6327）。
+    //
+    // Create/Edit 那两个表单可以删键，是因为它们提交完整 extra 对象、后端整体
+    // SetExtra 覆盖；批量接口只合并增量键，两种持久化语义不能共用同一套写法。
+    //
+    // 显式 off 与不设置在读取侧完全等价：codexFingerprintModeFromExtra 对空值/
+    // 非法值走 default 回落 off，对 "off" 命中同一分支，所以 #5610 定下的
+    // "不显式 opt-in 就保持旧客户端身份" 不受影响；ShouldEnsureCodexFingerprintSeed-
+    // ForExtraUpdates 同样只在 device/session/full 时要种子，off 不会触发。
+    //
+    // 与本函数里其它"关闭/清除"字段的写法一致：codex_cli_only 直接落 false，
+    // load_factor 落 0，proxy_id 落 0 —— 批量路径一律用显式哨兵值，不用省略。
+    extra.codex_fingerprint_mode = codexFingerprintMode.value
   }
 
   if (enableOpenAICompactMode.value) {

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -920,4 +920,75 @@ describe('BulkEditAccountModal', () => {
       status: 'active'
     })
   })
+  // issue #6327：批量编辑无法把 Codex 指纹收敛关掉。
+  //
+  // 批量更新走 JSONB 顶层合并（extra = COALESCE(extra,'{}') || payload），删掉 payload
+  // 里的键只表示「本次不更新该键」，清不掉账号已有的 device/session/full；而且只删不写会让
+  // payload 退化成 {extra:{}}，被后端 len(req.Extra) > 0 判为空更新直接 400
+  // "No updates provided"。Create/Edit 那两个表单能删键，是因为它们提交完整 extra 对象、
+  // 后端整体 SetExtra 覆盖——两种持久化语义不能共用同一套写法。
+  it('OpenAI OAuth 批量编辑选择「关闭」时应显式提交 codex_fingerprint_mode=off（issue #6327）', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    // 下拉框默认就是 off，用户只勾选「编辑该项」即提交——正是 issue 描述的操作路径。
+    await wrapper.get('#bulk-edit-openai-codex-fingerprint-mode-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        codex_fingerprint_mode: 'off'
+      }
+    })
+
+    // 缺陷时期的形状：extra 为空对象，后端必然回 400。显式钉死不得回退。
+    const payload = vi.mocked(adminAPI.accounts.bulkUpdate).mock.calls[0][1] as {
+      extra: Record<string, unknown>
+    }
+    expect(Object.keys(payload.extra).length).toBeGreaterThan(0)
+  })
+
+  // 与兄弟字段 codex_cli_only 的写法对齐：关闭态同样落显式值，不靠省略表达。
+  it('OpenAI OAuth 批量编辑显式 opt-in 模式仍原样提交', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-codex-fingerprint-mode-enabled').setValue(true)
+    await wrapper
+      .get('[data-testid="bulk-codex-fingerprint-mode-select"]')
+      .setValue('session')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        codex_fingerprint_mode: 'session'
+      }
+    })
+  })
+
+  // 未勾选「编辑该项」时不得写入该键，否则批量编辑别的字段会顺手清掉账号的收敛设置。
+  it('未勾选编辑该项时不写入 codex_fingerprint_mode', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-codex-cli-only-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-codex-cli-only-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        codex_cli_only: true
+      }
+    })
+  })
 })


### PR DESCRIPTION
Fixes #6327

## 问题

批量编辑账号时选「Codex 指纹收敛模式 → 关闭（默认）」，提交必然失败：

```
No updates provided   (HTTP 400)
```

`device` / `session` / `full` 都正常，只有 `off` 不行。

`BulkEditAccountModal.vue` 的 `buildUpdatePayload()` 先 `ensureExtra()` 建出 `extra`，
再 `delete` 掉其中唯一的键，payload 退化成：

```json
{ "account_ids": [1], "extra": {} }
```

后端 `len(req.Extra) > 0` 判为空更新，直接 400。

**而且就算后端放行空 `extra` 也修不好这个 bug。** 批量更新走 JSONB 顶层合并：

```sql
extra = COALESCE(extra, '{}'::jsonb) || $payload::jsonb
```

删掉 payload 里的键只表示「本次不更新该键」，**清不掉账号上已有的 `device`/`session`/`full`**。

## 根因：两种持久化语义共用了同一套写法

| 路径 | 后端写法 | 「删本地键」的含义 |
|---|---|---|
| Create / Edit（单账号） | `SetExtra(extra)` **整体覆盖** | = 清除该键 ✅ |
| **Bulk Edit** | `COALESCE(extra,'{}') \|\| payload` **增量合并** | = 不更新该键 ❌ |

`fce41e318`（把默认模式从 `session` 改为 `off`）统一了三个表单的「off 就删键」写法。
这对前两个成立，对 Bulk 不成立。

## 依据：仓库自己的写法早已如此

本仓库在批量路径上**一律用显式哨兵值表达「关闭/清除」，从不用省略**——就在同一个
`buildUpdatePayload()` 函数里：

```js
extra.codex_cli_only = codexCLIOnlyEnabled.value      // 关闭时落 false，不删键
updates.load_factor  = (lf > 0) ? lf : 0              // 「后端约定 <= 0 表示清除」
updates.proxy_id     = proxyId ?? 0                   // 「后端期望 0 表示清除代理，而不是 null」
```

`EditAccountModal.vue` 里紧邻指纹那段、往上 15 行的注释更是把这条规矩写死了：

> `// 关闭时显式写 false，避免 extra 为空被后端忽略导致旧值无法清除`

指纹模式是这条约定在批量路径上的**唯一违例**。

## 改动

`off` 也显式落键（`extra.codex_fingerprint_mode = codexFingerprintMode.value`）。

**读取侧完全等价，不动 #5610 的语义**：

- `codexFingerprintModeFromExtra` 对空值/非法值走 `default` 回落 `off`，对 `"off"` 命中
  `codexFingerprintOff` 分支——**显式 off 与不设置读出来是同一个值**，
  「不显式 opt-in 就保持 v0.1.175 之前的客户端身份」不受影响。
- `ShouldEnsureCodexFingerprintSeedForExtraUpdates` 走
  `codexFingerprintModeRequiresSeed`，只在 `device`/`session`/`full` 时要种子，
  **显式 off 不会触发种子创建**。

另给「编辑该项」勾选框补了 `id`（同区域 Select 早有 `data-testid`，兄弟开关
`codex_cli_only` 也有 `id`），否则新增用例无法定位该控件。

## 测试

`BulkEditAccountModal.spec.ts` 原本对指纹模式**零覆盖**，新增 3 条：

- **主复现**：默认 `off` + 勾选「编辑该项」→ 断言提交 `{extra:{codex_fingerprint_mode:'off'}}`，
  并额外断言 `extra` 非空，把触发 400 的那个形状显式钉死
- 显式 opt-in（`session`）仍原样提交
- 未勾选「编辑该项」时不写入该键——否则批量改别的字段会顺手清掉账号的收敛设置

已做回滚验证：把改动还原成删键写法后，**恰好主复现用例断言级变红**，其余 50 条保持绿。

`pnpm vitest run` 全绿（246 文件 / 1771 用例）；`pnpm typecheck`、`eslint`（未加 `--fix`）均干净。
