### PR TITLE
fix(openai): allow disabling bulk fingerprint mode

### DIFF
--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -978,6 +978,7 @@
         <div class="mb-3 flex items-center justify-between">
           <label class="input-label mb-0">{{ t('admin.accounts.openai.codexFingerprintMode') }}</label>
           <input
+            id="bulk-edit-codex-fingerprint-mode-enabled"
             v-model="enableCodexFingerprintMode"
             type="checkbox"
             class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
@@ -2089,12 +2090,8 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
 
   if (enableCodexFingerprintMode.value) {
     const extra = ensureExtra()
-    // off = 默认值，清键即可；device/session/full 是显式 opt-in，必须落键（#5610）。
-    if (codexFingerprintMode.value !== 'off') {
-      extra.codex_fingerprint_mode = codexFingerprintMode.value
-    } else {
-      delete extra.codex_fingerprint_mode
-    }
+    // 批量更新使用 JSONB merge 语义，off 也必须显式写入才能覆盖已有模式。
+    extra.codex_fingerprint_mode = codexFingerprintMode.value
   }
 
   if (enableOpenAICompactMode.value) {

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -368,6 +368,44 @@ describe('BulkEditAccountModal', () => {
     })
   })
 
+  it('OpenAI OAuth 批量编辑应显式提交关闭指纹收敛模式', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-codex-fingerprint-mode-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        codex_fingerprint_mode: 'off'
+      }
+    })
+  })
+
+  it('OpenAI OAuth 批量编辑应提交选中的指纹收敛模式', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    const select = wrapper.get('[data-testid="bulk-codex-fingerprint-mode-select"]')
+    await wrapper.get('#bulk-edit-codex-fingerprint-mode-enabled').setValue(true)
+    await select.setValue('session')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        codex_fingerprint_mode: 'session'
+      }
+    })
+  })
+
   it('OpenAI OAuth 批量编辑应提交 codex_cli_only_allow_app_server 字段（需同时开启父开关）', async () => {
     const wrapper = mountModal({
       selectedPlatforms: ['openai'],


### PR DESCRIPTION
## 问题

批量编辑账户时，指纹模式无法被明确关闭。

## 根因

批量编辑表单未将关闭状态作为可提交的显式值处理。

## 改动

支持在批量编辑中明确关闭指纹模式，并补充对应行为的测试覆盖。

## 验证

- 批量编辑弹窗定向测试 50/50 通过。
- 前端代码规范检查和类型检查通过。
- 前端完整测试套件通过，共 1780 项测试。
- 前端生产构建通过，保留已有的分块警告。
- 后端单元测试和集成测试套件通过。
- Go 静态检查报告 0 个问题。
- 前端生产依赖审计例外已验证。
- 部署脚本语法以及 Linux 兼容的编排、运行时和 Web 服务配置检查通过。
- 容器生命周期测试仅支持 macOS，本 Linux 主机无法执行，未将其计入通过项。

Fixes #6327
