### PR TITLE
fix: 修复 Windows 插件安装与 service 测试

### DIFF
--- a/backend/internal/service/content_moderation_runtime_cache_test.go
+++ b/backend/internal/service/content_moderation_runtime_cache_test.go
@@ -265,12 +265,18 @@ func TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig(t *testi
 		SettingKeyRiskControlEnabled:      "true",
 		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
 	}}
-	svc := runtimeCacheTestService(repo, time.Nanosecond)
+	svc := runtimeCacheTestService(repo, time.Minute)
 	input := runtimeCacheTestInput("blocked")
 
 	decision, err := svc.Check(context.Background(), input)
 	require.NoError(t, err)
 	require.True(t, decision.Blocked)
+
+	current := svc.runtimeSnapshot.Load()
+	require.NotNil(t, current)
+	expired := *current
+	expired.loadedAt = time.Now().Add(-2 * time.Minute)
+	svc.runtimeSnapshot.Store(&expired)
 
 	repo.failMultiple(errors.New("database unavailable"))
 	decision, err = svc.Check(context.Background(), input)

--- a/backend/internal/service/plugin_package.go
+++ b/backend/internal/service/plugin_package.go
@@ -107,7 +107,11 @@ func (i *PluginPackageInstaller) Install(ctx context.Context, reader io.Reader, 
 	if err != nil {
 		return nil, fmt.Errorf("插件包不是有效的 ZIP: %w", err)
 	}
-	defer func() { _ = archive.Close() }()
+	defer func() {
+		if archive != nil {
+			_ = archive.Close()
+		}
+	}()
 	manifest, _, signatureStatus, err := i.inspectArchive(&archive.Reader)
 	if err != nil {
 		return nil, err
@@ -137,6 +141,10 @@ func (i *PluginPackageInstaller) Install(ctx context.Context, reader io.Reader, 
 	if err := i.extractArchive(ctx, &archive.Reader, manifest, extractPath); err != nil {
 		return nil, err
 	}
+	if err := archive.Close(); err != nil {
+		return nil, fmt.Errorf("关闭插件归档: %w", err)
+	}
+	archive = nil
 	if err := os.Rename(extractPath, installPath); err != nil {
 		return nil, fmt.Errorf("提交插件安装目录: %w", err)
 	}

--- a/backend/internal/service/plugin_package_test.go
+++ b/backend/internal/service/plugin_package_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -33,7 +34,10 @@ func TestPluginPackageInstallerInstallUnsignedDevelopmentPackage(t *testing.T) {
 	assert.FileExists(t, installation.ArtifactPath)
 	info, statErr := os.Stat(installation.BinaryPath)
 	require.NoError(t, statErr)
-	assert.NotZero(t, info.Mode()&0o100)
+	assert.True(t, info.Mode().IsRegular())
+	if runtime.GOOS != "windows" {
+		assert.NotZero(t, info.Mode()&0o100)
+	}
 	assert.Contains(t, installation.InstallPath, filepath.Join("installed", "com.example.openai-transport"))
 }
 


### PR DESCRIPTION
## 问题

Windows 下 `go test ./internal/service` 暴露两类跨平台缺陷：

- 插件安装器使用 `zip.OpenReader` 打开上传临时包，ZIP 句柄直到函数返回才关闭；安装流程在句柄仍打开时执行 `os.Rename`，Windows 返回文件占用错误，真实插件安装和 4 个安装器测试失败。
- 内容审计快照测试用 `1ns` TTL 触发过期，依赖连续两次系统时钟读数不同；Windows 时钟分辨率会让测试间歇性无法触发后台刷新。
- 插件测试直接断言 POSIX 可执行位，Windows 不报告该权限位。

## 修复

- 插件归档完成校验和解压后立即关闭 ZIP 句柄，再提交安装目录和插件包文件。
- 关闭失败沿用现有 defer 清理上传临时包和解压目录，不留下已安装半成品。
- 插件产物在所有平台校验为普通文件，仅在非 Windows 平台校验可执行位。
- 内容审计测试使用稳定 TTL，并将已加载快照显式回拨到过期时间，继续验证刷新失败时保留旧配置。

## 验证

- 修复前：4 个插件安装器测试稳定返回 Windows 文件占用错误；内容审计刷新测试存在间歇失败。
- 5 项原失败测试连续运行 10 轮通过。
- 插件安装器与内容审计快照相关测试连续运行 3 轮通过。
- `go test -count=1 ./internal/service` 通过，耗时 127.790 秒。
- `go vet ./internal/service` 通过。
- `git diff --check` 通过。

当前 Windows 工具链未启用 CGO，未运行 `go test -race`。
