### PR TITLE
feat(settings): OpenAI 403 临时冷却参数改为后台可配置

### DIFF
--- a/backend/internal/handler/admin/setting_handler_runtime.go
+++ b/backend/internal/handler/admin/setting_handler_runtime.go
@@ -181,6 +181,66 @@ func (h *SettingHandler) UpdateOpenAIImagesOAuthUnavailableCooldownSettings(c *g
 	response.Success(c, dto.OpenAIImagesOAuthUnavailableCooldownSettings{CooldownMinutes: settings.CooldownMinutes})
 }
 
+// GetOpenAI403CooldownSettings 获取 OpenAI 403 临时冷却配置
+// GET /api/v1/admin/settings/openai-403-cooldown
+func (h *SettingHandler) GetOpenAI403CooldownSettings(c *gin.Context) {
+	settings, err := h.settingService.GetOpenAI403CooldownSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.OpenAI403CooldownSettings{
+		Enabled:          settings.Enabled,
+		CooldownMinutes:  settings.CooldownMinutes,
+		DisableThreshold: settings.DisableThreshold,
+		WindowMinutes:    settings.WindowMinutes,
+	})
+}
+
+// UpdateOpenAI403CooldownSettingsRequest 更新 OpenAI 403 临时冷却配置请求
+type UpdateOpenAI403CooldownSettingsRequest struct {
+	Enabled          bool `json:"enabled"`
+	CooldownMinutes  int  `json:"cooldown_minutes"`
+	DisableThreshold int  `json:"disable_threshold"`
+	WindowMinutes    int  `json:"window_minutes"`
+}
+
+// UpdateOpenAI403CooldownSettings 更新 OpenAI 403 临时冷却配置
+// PUT /api/v1/admin/settings/openai-403-cooldown
+func (h *SettingHandler) UpdateOpenAI403CooldownSettings(c *gin.Context) {
+	var req UpdateOpenAI403CooldownSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	settings := &service.OpenAI403CooldownSettings{
+		Enabled:          req.Enabled,
+		CooldownMinutes:  req.CooldownMinutes,
+		DisableThreshold: req.DisableThreshold,
+		WindowMinutes:    req.WindowMinutes,
+	}
+
+	if err := h.settingService.SetOpenAI403CooldownSettings(c.Request.Context(), settings); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	updatedSettings, err := h.settingService.GetOpenAI403CooldownSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.OpenAI403CooldownSettings{
+		Enabled:          updatedSettings.Enabled,
+		CooldownMinutes:  updatedSettings.CooldownMinutes,
+		DisableThreshold: updatedSettings.DisableThreshold,
+		WindowMinutes:    updatedSettings.WindowMinutes,
+	})
+}
+
 // GetPanelRateLimitSettings 获取面板 API 限流配置
 // GET /api/v1/admin/settings/panel-rate-limit
 func (h *SettingHandler) GetPanelRateLimitSettings(c *gin.Context) {

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -453,6 +453,14 @@ type OpenAIImagesOAuthUnavailableCooldownSettings struct {
 	CooldownMinutes int `json:"cooldown_minutes"`
 }
 
+// OpenAI403CooldownSettings OpenAI 403 临时冷却配置 DTO
+type OpenAI403CooldownSettings struct {
+	Enabled          bool `json:"enabled"`
+	CooldownMinutes  int  `json:"cooldown_minutes"`
+	DisableThreshold int  `json:"disable_threshold"`
+	WindowMinutes    int  `json:"window_minutes"`
+}
+
 // PanelRateLimitSettings 面板 API 限流配置 DTO
 type PanelRateLimitSettings struct {
 	Enabled     bool `json:"enabled"`

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -577,6 +577,8 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		// OpenAI OAuth image-tool unavailable cooldown configuration
 		adminSettings.GET("/openai-images-oauth-unavailable-cooldown", h.Admin.Setting.GetOpenAIImagesOAuthUnavailableCooldownSettings)
 		adminSettings.PUT("/openai-images-oauth-unavailable-cooldown", h.Admin.Setting.UpdateOpenAIImagesOAuthUnavailableCooldownSettings)
+		adminSettings.GET("/openai-403-cooldown", h.Admin.Setting.GetOpenAI403CooldownSettings)
+		adminSettings.PUT("/openai-403-cooldown", h.Admin.Setting.UpdateOpenAI403CooldownSettings)
 		// 面板 API 限流配置
 		adminSettings.GET("/panel-rate-limit", h.Admin.Setting.GetPanelRateLimitSettings)
 		adminSettings.PUT("/panel-rate-limit", h.Admin.Setting.UpdatePanelRateLimitSettings)

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -539,6 +539,9 @@ const (
 	SettingKeyRateLimit429CooldownSettings = "rate_limit_429_cooldown_settings"
 	// SettingKeyOpenAIImagesOAuthUnavailableCooldownSettings stores the cooldown applied when the OAuth image tool is unavailable.
 	SettingKeyOpenAIImagesOAuthUnavailableCooldownSettings = "openai_images_oauth_unavailable_cooldown_settings"
+
+	// SettingKeyOpenAI403CooldownSettings stores JSON config for OpenAI 403 temporary cooldown handling.
+	SettingKeyOpenAI403CooldownSettings = "openai_403_cooldown_settings"
 	// SettingKeyOpenAIAPIKeyHealthBreakerSettings stores the opt-in OpenAI pool API-key breaker config.
 	SettingKeyOpenAIAPIKeyHealthBreakerSettings = "openai_apikey_health_breaker_settings"
 

--- a/backend/internal/service/openai_403_cooldown_test.go
+++ b/backend/internal/service/openai_403_cooldown_test.go
@@ -1,0 +1,223 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type openAI403TempRecorder struct {
+	*rateLimitAccountRepoStub
+	until time.Time
+}
+
+func (r *openAI403TempRecorder) SetTempUnschedulable(ctx context.Context, id int64, until time.Time, reason string) error {
+	r.until = until
+	return r.rateLimitAccountRepoStub.SetTempUnschedulable(ctx, id, until, reason)
+}
+
+type openAI403WindowRecorder struct {
+	*countingOpenAI403CounterCache
+	windows []int
+}
+
+func (r *openAI403WindowRecorder) IncrementOpenAI403Count(ctx context.Context, accountID int64, window int) (int64, error) {
+	r.windows = append(r.windows, window)
+	return r.countingOpenAI403CounterCache.IncrementOpenAI403Count(ctx, accountID, window)
+}
+
+func setOpenAI403TestSettings(t *testing.T, h *openAI403TestHarness, settings OpenAI403CooldownSettings) {
+	t.Helper()
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+	repo.data[SettingKeyOpenAI403CooldownSettings] = string(data)
+	h.svc.SetSettingService(NewSettingService(repo, &config.Config{}))
+}
+
+func TestGetOpenAI403CooldownSettings_DefaultsWhenNotSet(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	settings, err := svc.GetOpenAI403CooldownSettings(context.Background())
+	require.NoError(t, err)
+	// MUTATION-SANITY: changing any OpenAI 403 default constant makes these assertions fail.
+	require.True(t, settings.Enabled)
+	require.Equal(t, 10, settings.CooldownMinutes)
+	require.Equal(t, 3, settings.DisableThreshold)
+	require.Equal(t, 180, settings.WindowMinutes)
+}
+
+func TestGetOpenAI403CooldownSettings_ClampsOutOfRange(t *testing.T) {
+	repo := newMockSettingRepo()
+	repo.data[SettingKeyOpenAI403CooldownSettings] = `{"enabled":true,"cooldown_minutes":99999,"disable_threshold":0,"window_minutes":-5}`
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetOpenAI403CooldownSettings(context.Background())
+	require.NoError(t, err)
+	// MUTATION-SANITY: removing the read-side clamps returns 99999, 0, and -5 here.
+	require.Equal(t, 1440, settings.CooldownMinutes)
+	require.Equal(t, 1, settings.DisableThreshold)
+	require.Equal(t, 1, settings.WindowMinutes)
+}
+
+func TestSetOpenAI403CooldownSettings_RejectsOutOfRangeWhenEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings OpenAI403CooldownSettings
+		field    string
+	}{
+		{
+			name: "cooldown_minutes",
+			settings: OpenAI403CooldownSettings{
+				Enabled: true, CooldownMinutes: 0, DisableThreshold: 3, WindowMinutes: 180,
+			},
+			field: "cooldown_minutes",
+		},
+		{
+			name: "disable_threshold",
+			settings: OpenAI403CooldownSettings{
+				Enabled: true, CooldownMinutes: 10, DisableThreshold: 101, WindowMinutes: 180,
+			},
+			field: "disable_threshold",
+		},
+		{
+			name: "window_minutes",
+			settings: OpenAI403CooldownSettings{
+				Enabled: true, CooldownMinutes: 10, DisableThreshold: 3, WindowMinutes: 1441,
+			},
+			field: "window_minutes",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+			err := svc.SetOpenAI403CooldownSettings(context.Background(), &test.settings)
+
+			// MUTATION-SANITY: removing the enabled-state validation makes this call succeed.
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.field)
+		})
+	}
+}
+
+func TestSetOpenAI403CooldownSettings_NormalizesWhenDisabled(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo, &config.Config{})
+	settings := &OpenAI403CooldownSettings{
+		Enabled:          false,
+		CooldownMinutes:  0,
+		DisableThreshold: 101,
+		WindowMinutes:    -1,
+	}
+
+	err := svc.SetOpenAI403CooldownSettings(context.Background(), settings)
+	require.NoError(t, err)
+	stored, err := svc.GetOpenAI403CooldownSettings(context.Background())
+	require.NoError(t, err)
+	// MUTATION-SANITY: changing the disabled branch to reject invalid values fails before this normalized result.
+	require.False(t, stored.Enabled)
+	require.Equal(t, 10, stored.CooldownMinutes)
+	require.Equal(t, 3, stored.DisableThreshold)
+	require.Equal(t, 180, stored.WindowMinutes)
+}
+
+func TestHandleOpenAI403_UsesConfiguredCooldownMinutes(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 601, 1)
+	setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+		Enabled: true, CooldownMinutes: 2, DisableThreshold: 3, WindowMinutes: 180,
+	})
+	recorder := &openAI403TempRecorder{rateLimitAccountRepoStub: h.repo}
+	h.svc.accountRepo = recorder
+	before := time.Now()
+
+	require.True(t, h.handle(`{"error":{"message":"temporary edge rejection"}}`))
+
+	// MUTATION-SANITY: replacing the configured cooldown with the 10-minute constant misses this window.
+	require.WithinDuration(t, before.Add(2*time.Minute), recorder.until, 5*time.Second)
+	require.Less(t, recorder.until.Sub(before), 5*time.Minute)
+}
+
+func TestHandleOpenAI403_UsesConfiguredThreshold(t *testing.T) {
+	t.Run("at_threshold_disables", func(t *testing.T) {
+		h := newOpenAI403TestHarness(t, 602, 2)
+		setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+			Enabled: true, CooldownMinutes: 10, DisableThreshold: 2, WindowMinutes: 180,
+		})
+
+		require.True(t, h.handle(`{"error":{"message":"workspace forbidden"}}`))
+		// MUTATION-SANITY: comparing against the original threshold of 3 leaves this account temporary instead.
+		require.Equal(t, 1, h.repo.setErrorCalls)
+		require.Equal(t, 0, h.repo.tempCalls)
+	})
+
+	t.Run("below_threshold_is_temporary", func(t *testing.T) {
+		h := newOpenAI403TestHarness(t, 603, 1)
+		setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+			Enabled: true, CooldownMinutes: 10, DisableThreshold: 2, WindowMinutes: 180,
+		})
+
+		require.True(t, h.handle(`{"error":{"message":"temporary edge rejection"}}`))
+		// MUTATION-SANITY: reversing the configured threshold comparison permanently disables this account.
+		require.Equal(t, 0, h.repo.setErrorCalls)
+		require.Equal(t, 1, h.repo.tempCalls)
+	})
+}
+
+func TestHandleOpenAI403_PassesConfiguredWindowToCounter(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 604, 1)
+	setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+		Enabled: true, CooldownMinutes: 10, DisableThreshold: 3, WindowMinutes: 30,
+	})
+	counter := &openAI403WindowRecorder{countingOpenAI403CounterCache: h.counter}
+	h.svc.SetOpenAI403CounterCache(counter)
+
+	require.True(t, h.handle(`{"error":{"message":"temporary edge rejection"}}`))
+
+	// MUTATION-SANITY: passing the original 180-minute constant records 180 instead of 30.
+	require.Equal(t, []int{30}, counter.windows)
+}
+
+func TestHandleOpenAI403_DisabledSkipsAccountPenalty(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 605, 1)
+	setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+		Enabled: false, CooldownMinutes: 10, DisableThreshold: 3, WindowMinutes: 180,
+	})
+
+	// MUTATION-SANITY: deleting the disabled guard returns true and records counter and penalty calls.
+	require.False(t, h.handle(`{"error":{"message":"temporary edge rejection"}}`))
+	h.requireNoAccountPenalty(t)
+}
+
+func TestHandleOpenAI403_FallsBackToDefaultsWithoutSettingService(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 606, 1)
+	recorder := &openAI403TempRecorder{rateLimitAccountRepoStub: h.repo}
+	h.svc.accountRepo = recorder
+	counter := &openAI403WindowRecorder{countingOpenAI403CounterCache: h.counter}
+	h.svc.SetOpenAI403CounterCache(counter)
+	before := time.Now()
+
+	require.True(t, h.handle(`{"error":{"message":"temporary edge rejection"}}`))
+
+	// MUTATION-SANITY: breaking the no-service fallback changes the 10-minute duration or 180-minute window.
+	require.WithinDuration(t, before.Add(10*time.Minute), recorder.until, 5*time.Second)
+	require.Equal(t, []int{180}, counter.windows)
+}
+
+func TestHandleOpenAI403_HTMLBodyStillSkipsPenaltyWhenEnabled(t *testing.T) {
+	h := newOpenAI403TestHarness(t, 607, 1)
+	setOpenAI403TestSettings(t, h, OpenAI403CooldownSettings{
+		Enabled: true, CooldownMinutes: 10, DisableThreshold: 3, WindowMinutes: 180,
+	})
+
+	// MUTATION-SANITY: moving the settings branch ahead of the HTML guard allows account penalty side effects.
+	require.False(t, h.handle(openAI403HTMLBody))
+	h.requireNoAccountPenalty(t)
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -89,6 +89,9 @@ const (
 	openAI403CooldownMinutesDefault = 10
 	openAI403DisableThreshold       = 3
 	openAI403CounterWindowMinutes   = 180
+	maxOpenAI403CooldownMinutes     = 1440
+	maxOpenAI403DisableThreshold    = 100
+	maxOpenAI403WindowMinutes       = 1440
 )
 
 // NewRateLimitService 创建RateLimitService实例
@@ -1023,6 +1026,12 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		return false
 	}
 
+	settings := s.getOpenAI403CooldownSettings(ctx, account)
+	if !settings.Enabled {
+		slog.Info("openai_403_cooldown_disabled_skip_account_penalty", "account_id", account.ID)
+		return false
+	}
+
 	msg := buildForbiddenErrorMessage(
 		"Access forbidden (403):",
 		upstreamMsg,
@@ -1035,21 +1044,21 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		return true
 	}
 
-	count, err := s.openAI403CounterCache.IncrementOpenAI403Count(ctx, account.ID, openAI403CounterWindowMinutes)
+	count, err := s.openAI403CounterCache.IncrementOpenAI403Count(ctx, account.ID, settings.WindowMinutes)
 	if err != nil {
 		slog.Warn("openai_403_increment_failed", "account_id", account.ID, "error", err)
 		s.handleAuthError(ctx, account, msg)
 		return true
 	}
 
-	if count >= openAI403DisableThreshold {
-		msg = fmt.Sprintf("%s | consecutive_403=%d/%d", msg, count, openAI403DisableThreshold)
+	if count >= int64(settings.DisableThreshold) {
+		msg = fmt.Sprintf("%s | consecutive_403=%d/%d", msg, count, settings.DisableThreshold)
 		s.handleAuthError(ctx, account, msg)
 		return true
 	}
 
-	until := time.Now().Add(time.Duration(openAI403CooldownMinutesDefault) * time.Minute)
-	reason := fmt.Sprintf("OpenAI 403 temporary cooldown (%d/%d): %s", count, openAI403DisableThreshold, msg)
+	until := time.Now().Add(time.Duration(settings.CooldownMinutes) * time.Minute)
+	reason := fmt.Sprintf("OpenAI 403 temporary cooldown (%d/%d): %s", count, settings.DisableThreshold, msg)
 	s.notifyAccountSchedulingBlocked(account, until, "openai_403_temp")
 	if err := s.accountRepo.SetTempUnschedulable(ctx, account.ID, until, reason); err != nil {
 		slog.Warn("openai_403_set_temp_unschedulable_failed", "account_id", account.ID, "error", err)
@@ -1062,9 +1071,21 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		"account_id", account.ID,
 		"until", until,
 		"count", count,
-		"threshold", openAI403DisableThreshold,
+		"threshold", settings.DisableThreshold,
+		"cooldown_minutes", settings.CooldownMinutes,
 	)
 	return true
+}
+
+func (s *RateLimitService) getOpenAI403CooldownSettings(ctx context.Context, account *Account) *OpenAI403CooldownSettings {
+	if s.settingService != nil {
+		settings, err := s.settingService.GetOpenAI403CooldownSettings(ctx)
+		if err == nil && settings != nil {
+			return settings
+		}
+		slog.Warn("openai_403_cooldown_settings_read_failed", "account_id", account.ID, "error", err)
+	}
+	return DefaultOpenAI403CooldownSettings()
 }
 
 // handleAntigravity403 处理 Antigravity 平台的 403 错误

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -798,6 +798,80 @@ func (s *SettingService) SetOpenAIImagesOAuthUnavailableCooldownSettings(ctx con
 	return s.settingRepo.Set(ctx, SettingKeyOpenAIImagesOAuthUnavailableCooldownSettings, string(data))
 }
 
+// GetOpenAI403CooldownSettings 获取 OpenAI 403 临时冷却配置
+func (s *SettingService) GetOpenAI403CooldownSettings(ctx context.Context) (*OpenAI403CooldownSettings, error) {
+	value, err := s.settingRepo.GetValue(ctx, SettingKeyOpenAI403CooldownSettings)
+	if err != nil {
+		if errors.Is(err, ErrSettingNotFound) {
+			return DefaultOpenAI403CooldownSettings(), nil
+		}
+		return nil, fmt.Errorf("get OpenAI 403 cooldown settings: %w", err)
+	}
+	if value == "" {
+		return DefaultOpenAI403CooldownSettings(), nil
+	}
+
+	var settings OpenAI403CooldownSettings
+	if err := json.Unmarshal([]byte(value), &settings); err != nil {
+		return DefaultOpenAI403CooldownSettings(), nil
+	}
+
+	if settings.CooldownMinutes < 1 {
+		settings.CooldownMinutes = 1
+	}
+	if settings.CooldownMinutes > maxOpenAI403CooldownMinutes {
+		settings.CooldownMinutes = maxOpenAI403CooldownMinutes
+	}
+	if settings.DisableThreshold < 1 {
+		settings.DisableThreshold = 1
+	}
+	if settings.DisableThreshold > maxOpenAI403DisableThreshold {
+		settings.DisableThreshold = maxOpenAI403DisableThreshold
+	}
+	if settings.WindowMinutes < 1 {
+		settings.WindowMinutes = 1
+	}
+	if settings.WindowMinutes > maxOpenAI403WindowMinutes {
+		settings.WindowMinutes = maxOpenAI403WindowMinutes
+	}
+
+	return &settings, nil
+}
+
+// SetOpenAI403CooldownSettings 设置 OpenAI 403 临时冷却配置
+func (s *SettingService) SetOpenAI403CooldownSettings(ctx context.Context, settings *OpenAI403CooldownSettings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+
+	defaults := DefaultOpenAI403CooldownSettings()
+	if settings.CooldownMinutes < 1 || settings.CooldownMinutes > maxOpenAI403CooldownMinutes {
+		if settings.Enabled {
+			return fmt.Errorf("cooldown_minutes must be between 1-1440")
+		}
+		settings.CooldownMinutes = defaults.CooldownMinutes
+	}
+	if settings.DisableThreshold < 1 || settings.DisableThreshold > maxOpenAI403DisableThreshold {
+		if settings.Enabled {
+			return fmt.Errorf("disable_threshold must be between 1-100")
+		}
+		settings.DisableThreshold = defaults.DisableThreshold
+	}
+	if settings.WindowMinutes < 1 || settings.WindowMinutes > maxOpenAI403WindowMinutes {
+		if settings.Enabled {
+			return fmt.Errorf("window_minutes must be between 1-1440")
+		}
+		settings.WindowMinutes = defaults.WindowMinutes
+	}
+
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshal OpenAI 403 cooldown settings: %w", err)
+	}
+
+	return s.settingRepo.Set(ctx, SettingKeyOpenAI403CooldownSettings, string(data))
+}
+
 // GetStreamTimeoutSettings 获取流超时处理配置
 func (s *SettingService) GetStreamTimeoutSettings(ctx context.Context) (*StreamTimeoutSettings, error) {
 	value, err := s.settingRepo.GetValue(ctx, SettingKeyStreamTimeoutSettings)

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -576,6 +576,19 @@ const (
 	openAIImagesOAuthUnavailableMaxCooldownMinutes     = 120
 )
 
+// OpenAI403CooldownSettings OpenAI 403 临时冷却配置
+type OpenAI403CooldownSettings struct {
+	// Enabled 是否对 OpenAI 403 启用计数式临时冷却。关闭时 403 只触发换号（failover），
+	// 不递增计数、不临时停调、不永久禁用账号——与 HTML 403（端点级错误）分支的处置一致。
+	Enabled bool `json:"enabled"`
+	// CooldownMinutes 单次临时冷却时长（分钟），范围 1-1440
+	CooldownMinutes int `json:"cooldown_minutes"`
+	// DisableThreshold 计数窗口内累计到该次数即转为永久错误状态，范围 1-100
+	DisableThreshold int `json:"disable_threshold"`
+	// WindowMinutes 连续 403 计数窗口（分钟），范围 1-1440
+	WindowMinutes int `json:"window_minutes"`
+}
+
 // OpenAIAPIKeyHealthBreakerSettings controls cross-instance failure counting for OpenAI pool API keys.
 type OpenAIAPIKeyHealthBreakerSettings struct {
 	Enabled          bool `json:"enabled"`
@@ -611,6 +624,16 @@ func DefaultRateLimit429CooldownSettings() *RateLimit429CooldownSettings {
 
 func DefaultOpenAIImagesOAuthUnavailableCooldownSettings() *OpenAIImagesOAuthUnavailableCooldownSettings {
 	return &OpenAIImagesOAuthUnavailableCooldownSettings{CooldownMinutes: openAIImagesOAuthUnavailableDefaultCooldownMinutes}
+}
+
+// DefaultOpenAI403CooldownSettings 返回默认的 OpenAI 403 冷却配置（启用，10 分钟 / 3 次 / 180 分钟窗口）
+func DefaultOpenAI403CooldownSettings() *OpenAI403CooldownSettings {
+	return &OpenAI403CooldownSettings{
+		Enabled:          true,
+		CooldownMinutes:  openAI403CooldownMinutesDefault,
+		DisableThreshold: openAI403DisableThreshold,
+		WindowMinutes:    openAI403CounterWindowMinutes,
+	}
 }
 
 // DefaultBetaPolicySettings 返回默认的 Beta 策略配置

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -1312,6 +1312,32 @@ export async function updateRateLimit429CooldownSettings(
   return data;
 }
 
+// ==================== OpenAI 403 Cooldown Settings ====================
+
+export interface OpenAI403CooldownSettings {
+  enabled: boolean;
+  cooldown_minutes: number;
+  disable_threshold: number;
+  window_minutes: number;
+}
+
+export async function getOpenAI403CooldownSettings(): Promise<OpenAI403CooldownSettings> {
+  const { data } = await apiClient.get<OpenAI403CooldownSettings>(
+    "/admin/settings/openai-403-cooldown",
+  );
+  return data;
+}
+
+export async function updateOpenAI403CooldownSettings(
+  settings: OpenAI403CooldownSettings,
+): Promise<OpenAI403CooldownSettings> {
+  const { data } = await apiClient.put<OpenAI403CooldownSettings>(
+    "/admin/settings/openai-403-cooldown",
+    settings,
+  );
+  return data;
+}
+
 // ==================== Panel Rate Limit Settings ====================
 
 /**
@@ -1571,6 +1597,8 @@ export const settingsAPI = {
   updateOverloadCooldownSettings,
   getRateLimit429CooldownSettings,
   updateRateLimit429CooldownSettings,
+  getOpenAI403CooldownSettings,
+  updateOpenAI403CooldownSettings,
   getPanelRateLimitSettings,
   updatePanelRateLimitSettings,
   getStreamTimeoutSettings,

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -1008,6 +1008,20 @@ export default {
         saved: '429 default cooldown settings saved',
         saveFailed: 'Failed to save 429 default cooldown settings'
       },
+      openAI403Cooldown: {
+        title: 'OpenAI 403 Temporary Cooldown',
+        description: 'Configure count-based temporary cooldowns for OpenAI accounts that receive 403 responses, escalating repeated failures to a permanent error',
+        enabled: 'Enable 403 Temporary Cooldown',
+        enabledHint: 'When disabled, a 403 only triggers failover without pausing, counting, or disabling the account',
+        cooldownMinutes: 'Cooldown Duration (minutes)',
+        cooldownMinutesHint: 'Duration to pause account scheduling after a 403 (1-1440 minutes, default 10)',
+        disableThreshold: 'Disable Threshold (count)',
+        disableThresholdHint: 'Mark the account as errored after this many 403 responses within the counting window (1-100, default 3)',
+        windowMinutes: 'Counting Window (minutes)',
+        windowMinutesHint: 'Time window used to count consecutive 403 responses (1-1440 minutes, default 180)',
+        saved: '403 cooldown settings saved',
+        saveFailed: 'Failed to save 403 cooldown settings'
+      },
       streamTimeout: {
         title: 'Stream Timeout Handling',
         description: 'Configure account handling strategy when upstream response times out',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -1002,6 +1002,20 @@ export default {
         saved: '429 默认回避设置保存成功',
         saveFailed: '保存 429 默认回避设置失败'
       },
+      openAI403Cooldown: {
+        title: 'OpenAI 403 临时冷却',
+        description: '配置 OpenAI 账号收到 403 时的计数式临时冷却策略（连续多次后转为永久错误）',
+        enabled: '启用 403 临时冷却',
+        enabledHint: '关闭后 403 仅触发换号，不再暂停调度、不计数、不禁用账号',
+        cooldownMinutes: '单次冷却时长（分钟）',
+        cooldownMinutesHint: '收到 403 后账号暂停调度的时长（1-1440 分钟，默认 10）',
+        disableThreshold: '禁用阈值（次）',
+        disableThresholdHint: '计数窗口内累计达到该次数即标记账号为错误状态（1-100 次，默认 3）',
+        windowMinutes: '计数窗口（分钟）',
+        windowMinutesHint: '连续 403 的统计窗口（1-1440 分钟，默认 180）',
+        saved: '403 冷却设置保存成功',
+        saveFailed: '保存 403 冷却设置失败'
+      },
       streamTimeout: {
         title: '流超时处理',
         description: '配置上游响应超时时的账户处理策略，避免问题账户持续被选中',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -411,6 +411,163 @@
             </div>
           </div>
 
+          <!-- OpenAI 403 Cooldown Settings -->
+          <div class="card">
+            <div
+              class="border-b border-gray-100 px-6 py-4 dark:border-dark-700"
+            >
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.openAI403Cooldown.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.openAI403Cooldown.description") }}
+              </p>
+            </div>
+            <div class="space-y-5 p-6">
+              <div
+                v-if="openAI403CooldownLoading"
+                class="flex items-center gap-2 text-gray-500"
+              >
+                <div
+                  class="h-4 w-4 animate-spin rounded-full border-b-2 border-primary-600"
+                ></div>
+                {{ t("common.loading") }}
+              </div>
+
+              <template v-else>
+                <div class="flex items-center justify-between">
+                  <div>
+                    <label class="font-medium text-gray-900 dark:text-white">{{
+                      t("admin.settings.openAI403Cooldown.enabled")
+                    }}</label>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.openAI403Cooldown.enabledHint") }}
+                    </p>
+                  </div>
+                  <Toggle v-model="openAI403CooldownForm.enabled" />
+                </div>
+
+                <div
+                  v-if="openAI403CooldownForm.enabled"
+                  class="space-y-4 border-t border-gray-100 pt-4 dark:border-dark-700"
+                >
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{
+                        t(
+                          "admin.settings.openAI403Cooldown.cooldownMinutes",
+                        )
+                      }}
+                    </label>
+                    <input
+                      v-model.number="openAI403CooldownForm.cooldown_minutes"
+                      type="number"
+                      min="1"
+                      max="1440"
+                      class="input w-32"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{
+                        t(
+                          "admin.settings.openAI403Cooldown.cooldownMinutesHint",
+                        )
+                      }}
+                    </p>
+                  </div>
+
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{
+                        t(
+                          "admin.settings.openAI403Cooldown.disableThreshold",
+                        )
+                      }}
+                    </label>
+                    <input
+                      v-model.number="openAI403CooldownForm.disable_threshold"
+                      type="number"
+                      min="1"
+                      max="100"
+                      class="input w-32"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{
+                        t(
+                          "admin.settings.openAI403Cooldown.disableThresholdHint",
+                        )
+                      }}
+                    </p>
+                  </div>
+
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{
+                        t("admin.settings.openAI403Cooldown.windowMinutes")
+                      }}
+                    </label>
+                    <input
+                      v-model.number="openAI403CooldownForm.window_minutes"
+                      type="number"
+                      min="1"
+                      max="1440"
+                      class="input w-32"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{
+                        t(
+                          "admin.settings.openAI403Cooldown.windowMinutesHint",
+                        )
+                      }}
+                    </p>
+                  </div>
+                </div>
+
+                <div
+                  class="flex justify-end border-t border-gray-100 pt-4 dark:border-dark-700"
+                >
+                  <button
+                    type="button"
+                    @click="saveOpenAI403CooldownSettings"
+                    :disabled="openAI403CooldownSaving"
+                    class="btn btn-primary btn-sm"
+                  >
+                    <svg
+                      v-if="openAI403CooldownSaving"
+                      class="mr-1 h-4 w-4 animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        class="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        stroke-width="4"
+                      ></circle>
+                      <path
+                        class="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    {{
+                      openAI403CooldownSaving
+                        ? t("common.saving")
+                        : t("common.save")
+                    }}
+                  </button>
+                </div>
+              </template>
+            </div>
+          </div>
+
           <!-- Stream Timeout Settings -->
           <div class="card">
             <div
@@ -8989,6 +9146,16 @@ const rateLimit429CooldownForm = reactive({
   cooldown_seconds: 5,
 });
 
+// OpenAI 403 Cooldown 状态
+const openAI403CooldownLoading = ref(true);
+const openAI403CooldownSaving = ref(false);
+const openAI403CooldownForm = reactive({
+  enabled: true,
+  cooldown_minutes: 10,
+  disable_threshold: 3,
+  window_minutes: 180,
+});
+
 // Panel API Rate Limit 状态
 const panelRateLimitLoading = ref(true);
 const panelRateLimitSaving = ref(false);
@@ -11908,6 +12075,42 @@ async function saveRateLimit429CooldownSettings() {
   }
 }
 
+// OpenAI 403 Cooldown 方法
+async function loadOpenAI403CooldownSettings() {
+  openAI403CooldownLoading.value = true;
+  try {
+    const settings = await adminAPI.settings.getOpenAI403CooldownSettings();
+    Object.assign(openAI403CooldownForm, settings);
+  } catch (_error: unknown) {
+    // Silent fail - settings will use defaults
+  } finally {
+    openAI403CooldownLoading.value = false;
+  }
+}
+
+async function saveOpenAI403CooldownSettings() {
+  openAI403CooldownSaving.value = true;
+  try {
+    const updated = await adminAPI.settings.updateOpenAI403CooldownSettings({
+      enabled: openAI403CooldownForm.enabled,
+      cooldown_minutes: openAI403CooldownForm.cooldown_minutes,
+      disable_threshold: openAI403CooldownForm.disable_threshold,
+      window_minutes: openAI403CooldownForm.window_minutes,
+    });
+    Object.assign(openAI403CooldownForm, updated);
+    appStore.showSuccess(t("admin.settings.openAI403Cooldown.saved"));
+  } catch (error: unknown) {
+    appStore.showError(
+      extractApiErrorMessage(
+        error,
+        t("admin.settings.openAI403Cooldown.saveFailed"),
+      ),
+    );
+  } finally {
+    openAI403CooldownSaving.value = false;
+  }
+}
+
 // Stream Timeout 方法
 async function loadStreamTimeoutSettings() {
   streamTimeoutLoading.value = true;
@@ -12550,6 +12753,7 @@ onMounted(() => {
   loadOllamaCloudUsageSettings();
   loadOverloadCooldownSettings();
   loadRateLimit429CooldownSettings();
+  loadOpenAI403CooldownSettings();
   loadPanelRateLimitSettings();
   loadStreamTimeoutSettings();
   loadRectifierSettings();


### PR DESCRIPTION
## 问题

#5280：OpenAI 账号只要收到 403 就被临时冷却 10 分钟，窗口内累计 3 次直接转永久错误。这三个数字全部硬编码在 `backend/internal/service/ratelimit_service.go`：

```go
openAI403CooldownMinutesDefault = 10
openAI403DisableThreshold       = 3
openAI403CounterWindowMinutes   = 180
```

不少部署里 403 是 IP / 代理出口被上游拒绝，和账号本身无关；管理员想把冷却调短、把阈值调高，或干脆只换号不罚号，目前都只能改代码重新构建。

## 修复

把这三个参数（外加一个总开关）做成系统设置，接线完全照仓库里已有的 **529 过载冷却**（`OverloadCooldownSettings`）和 **429 默认回避**（`RateLimit429CooldownSettings`）两条范本复制，没有引入新的模式：

**后端**
- `settings_view.go`：新增 `OpenAI403CooldownSettings { enabled, cooldown_minutes, disable_threshold, window_minutes }` 与 `DefaultOpenAI403CooldownSettings()`
- `domain_constants.go`：设置键 `openai_403_cooldown_settings`
- `setting_features.go`：`Get` 缺值 / 空值 / 坏 JSON 回默认，读到的数值 clamp 到范围；`Set` 启用状态下越界直接报错（错误信息带字段名），停用状态下越界归一化为默认值——与 529 的处理一致
- `ratelimit_service.go`：`handleOpenAI403` 在既有 HTML 403 守卫之后读取设置；`enabled=false` 时只换号不罚号（不递增计数、不临时停调、不写永久错误，和 HTML 403 分支同一口径）；冷却时长 / 阈值 / 计数窗口三处全部改走配置。读取失败或未注入 `SettingService` 时回落默认值
- `setting_handler_runtime.go` + `routes/admin.go`：`GET` / `PUT /api/v1/admin/settings/openai-403-cooldown`

**前端**
- 设置页「网关」分组内、429 卡片之后新增「OpenAI 403 临时冷却」卡片：开关 + 三个数字输入（带 min / max），中英文案

**范围与默认值**
- 默认值锁定为原常量：启用 / 10 分钟 / 3 次 / 180 分钟。**没有改过设置的部署升级后行为逐字不变。**
- 三个原常量保留、名字不改，作为唯一默认值来源；`ratelimit_cn_providers.go` 里 Kimi 并发限制借用 `openAI403CooldownMinutesDefault` 的路径不在本 PR 范围内，行为不变。
- 数值范围：分钟类 1-1440，阈值 1-100。

## 测试

新增 `backend/internal/service/openai_403_cooldown_test.go`（`-tags=unit`），10 个用例：

| 用例 | 断言 |
|---|---|
| `TestGetOpenAI403CooldownSettings_DefaultsWhenNotSet` | 未设置 ⇒ 启用 / 10 / 3 / 180 |
| `TestGetOpenAI403CooldownSettings_ClampsOutOfRange` | 存 99999 / 0 / -5 ⇒ 读回 1440 / 1 / 1 |
| `TestSetOpenAI403CooldownSettings_RejectsOutOfRangeWhenEnabled` | 三个字段各自越界 ⇒ 报错且信息含字段名 |
| `TestSetOpenAI403CooldownSettings_NormalizesWhenDisabled` | 停用 + 越界 ⇒ 不报错、存回默认 |
| `TestHandleOpenAI403_UsesConfiguredCooldownMinutes` | 配 2 分钟 ⇒ `SetTempUnschedulable` 的 `until` 落在 now+2min，不是 +10min |
| `TestHandleOpenAI403_UsesConfiguredThreshold` | 配阈值 2：count=2 ⇒ 永久错误；count=1 ⇒ 临时停调 |
| `TestHandleOpenAI403_PassesConfiguredWindowToCounter` | 配 30 分钟窗口 ⇒ `IncrementOpenAI403Count` 收到 30 |
| `TestHandleOpenAI403_DisabledSkipsAccountPenalty` | 停用 ⇒ 返回 false，零计数 / 零停调 / 零永久错误 / 零阻断通知 |
| `TestHandleOpenAI403_FallsBackToDefaultsWithoutSettingService` | 未注入 SettingService ⇒ 10 分钟 + 180 窗口 |
| `TestHandleOpenAI403_HTMLBodyStillSkipsPenaltyWhenEnabled` | 启用 + HTML 403 ⇒ 仍无处罚（守卫顺序没被破坏） |

红 → 绿验证（golang:1.27 容器）：
- 把 `handleOpenAI403` 的三处读取改回常量 ⇒ 冷却时长 / 阈值 / 窗口三个用例失败，其余通过
- 删掉 `enabled=false` 分支 ⇒ `DisabledSkipsAccountPenalty` 失败
- 把设置分支挪到 HTML 守卫之前 ⇒ `HTMLBodyStillSkipsPenaltyWhenEnabled` 等失败
- 还原后 10/10 通过；`go test -tags=unit ./...` 全绿；`gofmt -l` 空；`go vet` 通过
- 前端 `pnpm typecheck` / `pnpm lint:check` 通过

既有引用这三个常量的测试（`openai_gateway_cn_fixes_test.go`、`ratelimit_service_403_html_test.go` 等）未改动，默认值不变所以原样通过。

## 查重与已知限制

- 提交前搜过 open PR 与 issue #5280 的引用，没有人在做同一件事。
- `enabled=false` 意味着账号级 403（比如真的被封）也不会再自动进错误状态，只靠换号——这是把选择权交给管理员，默认仍是启用；文案里已写明。
- 没有加 DB migration，设置走既有 key-value 存储，与 529 / 429 一样。
