### PR TITLE
fix(admin): preserve saved SMTP TLS mode in test endpoints

### DIFF
--- a/backend/internal/handler/admin/setting_handler_email.go
+++ b/backend/internal/handler/admin/setting_handler_email.go
@@ -17,7 +17,14 @@ type TestSMTPRequest struct {
 	SMTPPort     int    `json:"smtp_port"`
 	SMTPUsername string `json:"smtp_username"`
 	SMTPPassword string `json:"smtp_password"`
-	SMTPUseTLS   bool   `json:"smtp_use_tls"`
+	SMTPUseTLS   *bool  `json:"smtp_use_tls"`
+}
+
+func resolveSMTPUseTLS(requested *bool, savedConfig *service.SMTPConfig) bool {
+	if requested != nil {
+		return *requested
+	}
+	return savedConfig != nil && savedConfig.UseTLS
 }
 
 // TestSMTPConnection 测试SMTP连接
@@ -64,7 +71,7 @@ func (h *SettingHandler) TestSMTPConnection(c *gin.Context) {
 		Port:     req.SMTPPort,
 		Username: req.SMTPUsername,
 		Password: password,
-		UseTLS:   req.SMTPUseTLS,
+		UseTLS:   resolveSMTPUseTLS(req.SMTPUseTLS, savedConfig),
 	}
 
 	err := h.emailService.TestSMTPConnectionWithConfig(config)
@@ -85,7 +92,7 @@ type SendTestEmailRequest struct {
 	SMTPPassword string `json:"smtp_password"`
 	SMTPFrom     string `json:"smtp_from_email"`
 	SMTPFromName string `json:"smtp_from_name"`
-	SMTPUseTLS   bool   `json:"smtp_use_tls"`
+	SMTPUseTLS   *bool  `json:"smtp_use_tls"`
 }
 
 // SendTestEmail 发送测试邮件
@@ -142,7 +149,7 @@ func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 		Password: password,
 		From:     req.SMTPFrom,
 		FromName: req.SMTPFromName,
-		UseTLS:   req.SMTPUseTLS,
+		UseTLS:   resolveSMTPUseTLS(req.SMTPUseTLS, savedConfig),
 	}
 
 	siteName := h.settingService.GetSiteName(c.Request.Context())

--- a/backend/internal/handler/admin/setting_handler_email_test.go
+++ b/backend/internal/handler/admin/setting_handler_email_test.go
@@ -1,0 +1,58 @@
+//go:build unit
+
+package admin
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func bindSMTPRequest[T any](t *testing.T, body string) T {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	var payload T
+	require.NoError(t, c.ShouldBindJSON(&payload))
+	return payload
+}
+
+func TestTestSMTPRequestUseTLSOmissionFallsBackToSavedSetting(t *testing.T) {
+	req := bindSMTPRequest[TestSMTPRequest](t, `{}`)
+
+	require.Nil(t, req.SMTPUseTLS)
+	require.True(t, resolveSMTPUseTLS(req.SMTPUseTLS, &service.SMTPConfig{UseTLS: true}))
+}
+
+func TestTestSMTPRequestExplicitFalseOverridesSavedUseTLS(t *testing.T) {
+	req := bindSMTPRequest[TestSMTPRequest](t, `{"smtp_use_tls":false}`)
+
+	require.NotNil(t, req.SMTPUseTLS)
+	require.False(t, resolveSMTPUseTLS(req.SMTPUseTLS, &service.SMTPConfig{UseTLS: true}))
+}
+
+func TestTestSMTPRequestExplicitTrueOverridesMissingSavedUseTLS(t *testing.T) {
+	req := bindSMTPRequest[TestSMTPRequest](t, `{"smtp_use_tls":true}`)
+
+	require.NotNil(t, req.SMTPUseTLS)
+	require.True(t, resolveSMTPUseTLS(req.SMTPUseTLS, nil))
+}
+
+func TestSendTestEmailRequestPreservesUseTLSOmissionSemantics(t *testing.T) {
+	omitted := bindSMTPRequest[SendTestEmailRequest](t, `{"email":"admin@example.com"}`)
+	explicitFalse := bindSMTPRequest[SendTestEmailRequest](t, `{"email":"admin@example.com","smtp_use_tls":false}`)
+	saved := &service.SMTPConfig{UseTLS: true}
+
+	require.True(t, resolveSMTPUseTLS(omitted.SMTPUseTLS, saved))
+	require.False(t, resolveSMTPUseTLS(explicitFalse.SMTPUseTLS, saved))
+}


### PR DESCRIPTION
## 问题
`POST /api/v1/admin/settings/test-smtp` 在请求未携带 `smtp_use_tls` 时，会把零值 `false` 当作显式配置，覆盖已保存的隐式 TLS 设置。保存为 465 + TLS 的配置因此走错明文/STARTTLS 路径并可能超时。相同的遗漏语义也存在于 `send-test-email`。

## 根因
两个请求结构都使用普通 `bool`，JSON 绑定后无法区分“字段未提供”和“显式 false”；处理器虽然会回填其他 SMTP 字段，却直接使用该布尔零值。

## 改动
- 将两个测试邮件请求中的 `smtp_use_tls` 改为可选布尔值。
- 字段未提供时继承已保存的 `UseTLS`；显式 `true` 或 `false` 仍以请求为准。
- 增加聚焦回归测试，覆盖省略、显式关闭和显式开启语义。

## 验证
- 已验证：后端完整单元测试通过。
- 已验证：后端完整集成测试通过。
- 已验证：Go 静态检查报告 0 个问题。
- 已验证：前端代码检查、类型检查及关键测试通过（167 项）。
- 已验证：后端漏洞扫描发现 0 个已调用漏洞。
- 已验证：Linux 兼容的部署检查通过。
- 当前主机为 Linux，因此未运行仅适用于 macOS 的容器生命周期测试。

重复/重叠检查：提交前未发现引用 #6354 或修复 test-smtp 的 smtp_use_tls 省略语义的开放 PR。

Fixes #6354