### PR TITLE
fix(frontend): prevent hidden cache tooltip from causing horizontal scroll on mobile

### DIFF
--- a/frontend/src/components/admin/usage/UsageStatsCards.vue
+++ b/frontend/src/components/admin/usage/UsageStatsCards.vue
@@ -36,7 +36,7 @@
               />
             </svg>
             <span
-              class="pointer-events-none absolute left-1/2 top-full z-30 mt-2 w-56 -translate-x-1/2 rounded-lg border border-gray-200 bg-white p-3 text-left text-xs text-gray-700 opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100 dark:border-dark-600 dark:bg-dark-800 dark:text-dark-200"
+              class="pointer-events-none absolute left-1/2 top-full z-30 mt-2 hidden w-56 -translate-x-1/2 rounded-lg border border-gray-200 bg-white p-3 text-left text-xs text-gray-700 shadow-lg group-hover:block group-focus:block dark:border-dark-600 dark:bg-dark-800 dark:text-dark-200"
             >
               <span class="mb-2 block font-medium text-gray-900 dark:text-white">
                 {{ cacheDetailLabel() }}

--- a/frontend/src/components/admin/usage/__tests__/UsageStatsCards.spec.ts
+++ b/frontend/src/components/admin/usage/__tests__/UsageStatsCards.spec.ts
@@ -64,4 +64,26 @@ describe('UsageStatsCards', () => {
     expect(text).toContain('Cache Read')
     expect(text).toContain('22')
   })
+
+  it('keeps the cache tooltip out of the layout while it is hidden', () => {
+    const wrapper = mount(UsageStatsCards, {
+      props: {
+        stats,
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    const tooltip = wrapper.findAll('span').find((el) => el.classes().includes('group-hover:block'))
+
+    expect(tooltip).toBeDefined()
+    // `opacity-0` hides the tooltip visually but keeps it in the layout, so its
+    // fixed width still widens the document and causes horizontal scrolling on
+    // narrow screens. `hidden` (display: none) takes it out of the flow.
+    expect(tooltip?.classes()).toContain('hidden')
+    expect(tooltip?.classes()).not.toContain('opacity-0')
+  })
 })


### PR DESCRIPTION
## Problem

On mobile viewports, `/usage` and `/admin/usage` can be scrolled horizontally even though nothing visible extends past the right edge. The page just feels "loose" — you can drag it sideways and only find empty space.

## Root cause

The cache token breakdown tooltip in `UsageStatsCards.vue` is hidden with `opacity-0`:

```
pointer-events-none absolute left-1/2 top-full z-30 mt-2 w-56 -translate-x-1/2 ...
opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100
```

`opacity: 0` makes an element invisible but keeps it in layout, so its fixed `w-56` (224px) width still contributes to the document's scrollable overflow.

It is anchored with `left-1/2 -translate-x-1/2`, and on mobile the stats grid falls back to `grid-cols-2`, which places the trigger icon near the right edge of the viewport. Centering a 224px box on that point pushes it past the edge, and since no ancestor clips it, `documentElement.scrollWidth` grows.

## Fix

Use `hidden` (`display: none`) for the hidden state, which removes the tooltip from the flow entirely, and restore visibility with `group-hover:block` / `group-focus:block` so hover and keyboard-focus behaviour are unchanged.

The 150ms opacity transition is dropped, since `display` cannot be transitioned. This felt like the right trade for a bugfix — happy to switch to the existing `HelpTooltip` component (`Teleport` + `v-show` + `position: fixed`, already used in ~44 places) instead if you would prefer the tooltip keep its fade and also stop overflowing while it is *shown*. That is a larger diff, as it changes the tooltip's visual style and requires the wrapping `<p>` to become a `<div>`.

## Verification

Measured over Chrome DevTools Protocol against a running instance, in mobile emulation:

| viewport | `clientWidth` | `scrollWidth` before | `scrollWidth` after |
|---|---|---|---|
| 360 | 360 | 409 | 360 |
| 390 | 390 | 424 | 390 |
| 414 | 414 | 440 | 414 |

After the change no other element extends past the viewport on either page, and the tooltip still renders (224x86, `display: block`) on hover/focus.

I also swept all 39 application routes at 390px to make sure this was not a wider pattern. `/usage` and `/admin/usage` — the two consumers of `UsageStatsCards` — were the only pages affected. Other `absolute` + `opacity-0` tooltips in the codebase anchor with `left-0` / `bottom-full left-0` (growing rightward from a left edge that stays inside the viewport) or live inside `overflow-x-auto` containers, so they do not widen the document. This centered-anchor + fixed-width combination is unique to this component.

## Tests

- Added a regression test asserting the tooltip carries `hidden` and not `opacity-0`. Confirmed it fails when the component change is reverted.
- `vitest run` green for `src/components/admin/usage` plus both `UsageView` specs (44 tests).
- `eslint` and `vue-tsc --noEmit` clean.
- `vite build` succeeds, and the production CSS contains the expected rules: `.hidden{display:none}`, `.group:hover .group-hover\:block{display:block}`, `.group:focus .group-focus\:block{display:block}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
