### PR TITLE
feat(tlsfingerprint): TLS/H2 fingerprint profiles across upstream paths + opt-in Codex rustls-fallback profile

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -49,6 +49,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 
 		// Privacy client factory for OpenAI training opt-out
 		providePrivacyClientFactory,
+		provideOpenAITLSProfileClientFactory,
 
 		// BuildInfo provider
 		provideServiceBuildInfo,
@@ -65,6 +66,10 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 
 func providePrivacyClientFactory() service.PrivacyClientFactory {
 	return repository.CreatePrivacyReqClient
+}
+
+func provideOpenAITLSProfileClientFactory() service.OpenAITLSProfileClientFactory {
+	return repository.CreateOpenAITLSProfileReqClient
 }
 
 func provideServiceBuildInfo(buildInfo handler.BuildInfo) service.BuildInfo {

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -146,12 +146,13 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	gatewayService := service.NewGatewayService(accountRepository, groupRepository, usageLogRepository, usageBillingRepository, userRepository, userSubscriptionRepository, userGroupRateRepository, gatewayCache, configConfig, schedulerSnapshotService, concurrencyService, billingService, rateLimitService, billingCacheService, identityService, httpUpstream, deferredService, claudeTokenProvider, sessionLimitCache, rpmCache, digestSessionStore, settingService, tlsFingerprintProfileService, channelService, modelPricingResolver, compositeRouteResolver, balanceNotifyService, serviceUserPlatformQuotaRepository)
 	openAIOAuthClient := repository.NewOpenAIOAuthClient()
 	privacyClientFactory := providePrivacyClientFactory()
-	openAIOAuthService := service.ProvideOpenAIOAuthService(proxyRepository, openAIOAuthClient, privacyClientFactory)
+	openAITLSProfileClientFactory := provideOpenAITLSProfileClientFactory()
+	openAIOAuthService := service.ProvideOpenAIOAuthService(proxyRepository, openAIOAuthClient, privacyClientFactory, tlsFingerprintProfileService)
 	openAITokenProvider := service.ProvideOpenAITokenProvider(accountRepository, geminiTokenCache, openAIOAuthService, oAuthRefreshAPI)
 	grokOAuthClient := repository.NewGrokOAuthClient()
 	grokOAuthService := service.ProvideGrokOAuthService(proxyRepository, grokOAuthClient, configConfig, redisClient)
 	grokTokenProvider := service.ProvideGrokTokenProvider(accountRepository, geminiTokenCache, grokOAuthService, oAuthRefreshAPI, tempUnschedCache)
-	openAIGatewayService := service.NewOpenAIGatewayService(accountRepository, usageLogRepository, usageBillingRepository, userRepository, userSubscriptionRepository, userGroupRateRepository, gatewayCache, configConfig, schedulerSnapshotService, concurrencyService, billingService, rateLimitService, billingCacheService, httpUpstream, deferredService, openAITokenProvider, grokTokenProvider, modelPricingResolver, channelService, balanceNotifyService, settingService, serviceUserPlatformQuotaRepository)
+	openAIGatewayService := service.ProvideOpenAIGatewayService(accountRepository, usageLogRepository, usageBillingRepository, userRepository, userSubscriptionRepository, userGroupRateRepository, gatewayCache, configConfig, schedulerSnapshotService, concurrencyService, billingService, rateLimitService, billingCacheService, httpUpstream, tlsFingerprintProfileService, deferredService, openAITokenProvider, grokTokenProvider, modelPricingResolver, channelService, balanceNotifyService, settingService, serviceUserPlatformQuotaRepository)
 	geminiOAuthClient := repository.NewGeminiOAuthClient(configConfig)
 	geminiCliCodeAssistClient := repository.NewGeminiCliCodeAssistClient()
 	driveClient := repository.NewGeminiDriveClient()
@@ -197,7 +198,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	antigravityQuotaFetcher := service.NewAntigravityQuotaFetcher(proxyRepository, configConfig)
 	grokQuotaFetcher := service.NewGrokQuotaFetcher()
 	grokQuotaService := service.ProvideGrokQuotaService(accountRepository, proxyRepository, grokTokenProvider, httpUpstream, configConfig, usageLogRepository, settingService)
-	openAIQuotaService := service.ProvideOpenAIQuotaService(accountRepository, proxyRepository, openAITokenProvider, privacyClientFactory, openAIGatewayService)
+	openAIQuotaService := service.ProvideOpenAIQuotaService(accountRepository, proxyRepository, openAITokenProvider, privacyClientFactory, openAITLSProfileClientFactory, tlsFingerprintProfileService, openAIGatewayService)
 	usageCache := service.NewUsageCache()
 	accountUsageService := service.ProvideAccountUsageService(accountRepository, usageLogRepository, claudeUsageFetcher, geminiQuotaService, antigravityQuotaFetcher, grokQuotaFetcher, grokQuotaService, openAIQuotaService, usageCache, identityCache, tlsFingerprintProfileService, openAIGatewayService)
 	pluginRepository := repository.NewPluginRepository(db)
@@ -368,6 +369,10 @@ type Application struct {
 
 func providePrivacyClientFactory() service.PrivacyClientFactory {
 	return repository.CreatePrivacyReqClient
+}
+
+func provideOpenAITLSProfileClientFactory() service.OpenAITLSProfileClientFactory {
+	return repository.CreateOpenAITLSProfileReqClient
 }
 
 func provideServiceBuildInfo(buildInfo handler.BuildInfo) service.BuildInfo {

--- a/backend/internal/handler/openai_codex_models_handler_test.go
+++ b/backend/internal/handler/openai_codex_models_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -54,7 +55,6 @@ func (r codexModelsFailoverAccountRepo) ListByGroup(_ context.Context, _ int64) 
 }
 
 type codexModelsFailoverHTTPUpstream struct {
-	service.HTTPUpstream
 	mu          sync.Mutex
 	accountIDs  []int64
 	firstErr    error
@@ -102,6 +102,10 @@ func (u *codexModelsFailoverHTTPUpstream) Do(_ *http.Request, _ string, accountI
 		Header:     make(http.Header),
 		Body:       io.NopCloser(strings.NewReader(`{"models":[{"slug":"gpt-5.6-sol"}]}`)),
 	}, nil
+}
+
+func (u *codexModelsFailoverHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func (u *codexModelsFailoverHTTPUpstream) calls() []int64 {

--- a/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
+++ b/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -311,7 +312,6 @@ func (r *grokCredentialHandlerRefresher) Refresh(ctx context.Context, _ *service
 }
 
 type grokCredentialHandlerUpstream struct {
-	service.HTTPUpstream
 	mu            sync.Mutex
 	hits          []int64
 	requestURLs   []string
@@ -388,6 +388,10 @@ func (u *grokCredentialHandlerUpstream) Do(req *http.Request, _ string, accountI
 			`{"id":"resp_healthy","object":"response","model":"grok-4.5","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`,
 		)),
 	}, nil
+}
+
+func (u *grokCredentialHandlerUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func (u *grokCredentialHandlerUpstream) accountHits() []int64 {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -1931,7 +1932,6 @@ type openAIWSFailoverHandlerAccountRepoStub struct {
 }
 
 type openAIHTTPPassthroughFailoverUpstream struct {
-	service.HTTPUpstream
 	mu         sync.Mutex
 	accountIDs []int64
 }
@@ -1947,6 +1947,10 @@ func (u *openAIHTTPPassthroughFailoverUpstream) Do(_ *http.Request, _ string, ac
 	}, nil
 }
 
+func (u *openAIHTTPPassthroughFailoverUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
 func (u *openAIHTTPPassthroughFailoverUpstream) calls() []int64 {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -1954,7 +1958,6 @@ func (u *openAIHTTPPassthroughFailoverUpstream) calls() []int64 {
 }
 
 type openAIHTTPPassthroughAuthFailoverUpstream struct {
-	service.HTTPUpstream
 	mu         sync.Mutex
 	accountIDs []int64
 	statusCode int
@@ -1978,6 +1981,10 @@ func (u *openAIHTTPPassthroughAuthFailoverUpstream) Do(_ *http.Request, _ string
 	}, nil
 }
 
+func (u *openAIHTTPPassthroughAuthFailoverUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
 func (u *openAIHTTPPassthroughAuthFailoverUpstream) calls() []int64 {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -1985,7 +1992,6 @@ func (u *openAIHTTPPassthroughAuthFailoverUpstream) calls() []int64 {
 }
 
 type openAIHTTPPassthroughSSERateLimitUpstream struct {
-	service.HTTPUpstream
 	mu         sync.Mutex
 	accountIDs []int64
 }
@@ -2010,6 +2016,10 @@ func (u *openAIHTTPPassthroughSSERateLimitUpstream) Do(_ *http.Request, _ string
 		},
 		Body: io.NopCloser(strings.NewReader(body)),
 	}, nil
+}
+
+func (u *openAIHTTPPassthroughSSERateLimitUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func (u *openAIHTTPPassthroughSSERateLimitUpstream) calls() []int64 {

--- a/backend/internal/handler/openai_images_failover_test.go
+++ b/backend/internal/handler/openai_images_failover_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -60,7 +61,6 @@ func (r openAIImagesFailoverAccountRepo) accountsForPlatform(platform string) []
 }
 
 type openAIImagesFailoverHTTPUpstream struct {
-	service.HTTPUpstream
 	mu         sync.Mutex
 	accountIDs []int64
 }
@@ -79,6 +79,10 @@ func (u *openAIImagesFailoverHTTPUpstream) Do(_ *http.Request, _ string, account
 			"data: {\"type\":\"error\",\"error\":{\"type\":\"server_error\",\"code\":\"server_error\",\"message\":\"image backend unavailable\"}}\n\n",
 		)),
 	}, nil
+}
+
+func (u *openAIImagesFailoverHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func (u *openAIImagesFailoverHTTPUpstream) calls() []int64 {

--- a/backend/internal/handler/openai_responses_failover_cancel_test.go
+++ b/backend/internal/handler/openai_responses_failover_cancel_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -22,7 +23,6 @@ import (
 // openAIResponsesFailoverCancelUpstream 固定返回 HTTP 520，可在首次上游调用时
 // 触发回调（用于模拟“上游在途期间客户端断开”）。
 type openAIResponsesFailoverCancelUpstream struct {
-	service.HTTPUpstream
 	mu         sync.Mutex
 	accountIDs []int64
 	onFirstDo  func()
@@ -41,6 +41,10 @@ func (u *openAIResponsesFailoverCancelUpstream) Do(_ *http.Request, _ string, ac
 		Header:     http.Header{"Content-Type": []string{"text/html"}},
 		Body:       io.NopCloser(bytes.NewBufferString("<html>520: unknown error</html>")),
 	}, nil
+}
+
+func (u *openAIResponsesFailoverCancelUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func (u *openAIResponsesFailoverCancelUpstream) calls() []int64 {

--- a/backend/internal/model/tls_fingerprint_profile.go
+++ b/backend/internal/model/tls_fingerprint_profile.go
@@ -2,6 +2,7 @@
 package model
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
@@ -31,6 +32,17 @@ type TLSFingerprintProfile struct {
 func (p *TLSFingerprintProfile) Validate() error {
 	if p.Name == "" {
 		return &ValidationError{Field: "name", Message: "name is required"}
+	}
+	for _, proto := range p.ALPNProtocols {
+		// Fail closed on HTTP/2 ALPN: the custom-profile upstream transport is
+		// HTTP/1.1-only today. A uTLS conn that negotiates "h2" cannot be handed
+		// to net/http's H2 stack (it fails the *tls.Conn type assertion), so
+		// advertising h2 would break every request at runtime. Reject at the
+		// validation layer instead of silently stripping, so a misconfigured
+		// profile surfaces as a clear error rather than a surprising downgrade.
+		if strings.EqualFold(proto, "h2") || strings.EqualFold(proto, "h2c") {
+			return &ValidationError{Field: "alpn_protocols", Message: "'" + proto + "' is not supported: custom profiles currently speak HTTP/1.1 only"}
+		}
 	}
 	return nil
 }

--- a/backend/internal/model/tls_fingerprint_profile.go
+++ b/backend/internal/model/tls_fingerprint_profile.go
@@ -2,7 +2,6 @@
 package model
 
 import (
-	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
@@ -33,16 +32,22 @@ func (p *TLSFingerprintProfile) Validate() error {
 	if p.Name == "" {
 		return &ValidationError{Field: "name", Message: "name is required"}
 	}
+	seenALPN := make(map[string]struct{}, len(p.ALPNProtocols))
 	for _, proto := range p.ALPNProtocols {
-		// Fail closed on HTTP/2 ALPN: the custom-profile upstream transport is
-		// HTTP/1.1-only today. A uTLS conn that negotiates "h2" cannot be handed
-		// to net/http's H2 stack (it fails the *tls.Conn type assertion), so
-		// advertising h2 would break every request at runtime. Reject at the
-		// validation layer instead of silently stripping, so a misconfigured
-		// profile surfaces as a clear error rather than a surprising downgrade.
-		if strings.EqualFold(proto, "h2") || strings.EqualFold(proto, "h2c") {
-			return &ValidationError{Field: "alpn_protocols", Message: "'" + proto + "' is not supported: custom profiles currently speak HTTP/1.1 only"}
+		// The runtime ALPN dispatcher recognizes these exact wire tokens only.
+		// Reject unknown/case-folded/blank values and duplicates at the CRUD
+		// boundary so the stored profile, cache identity, and negotiated protocol
+		// cannot disagree. An empty slice remains valid and selects the built-in
+		// HTTP/1.1 default.
+		switch proto {
+		case "h2", "http/1.1":
+		default:
+			return &ValidationError{Field: "alpn_protocols", Message: "each ALPN protocol must be exactly \"h2\" or \"http/1.1\""}
 		}
+		if _, duplicate := seenALPN[proto]; duplicate {
+			return &ValidationError{Field: "alpn_protocols", Message: "ALPN protocols must not contain duplicates"}
+		}
+		seenALPN[proto] = struct{}{}
 	}
 	return nil
 }

--- a/backend/internal/model/tls_fingerprint_profile_test.go
+++ b/backend/internal/model/tls_fingerprint_profile_test.go
@@ -6,18 +6,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTLSFingerprintProfileValidateRejectsHTTP2ALPN(t *testing.T) {
-	// The custom-profile upstream transport is HTTP/1.1-only: a uTLS connection
-	// that negotiates "h2" cannot be used by net/http's HTTP/2 stack, so h2/h2c
-	// ALPN must fail closed at validation time instead of breaking at runtime.
-	// Built-in presets (e.g. PresetChrome120HTTP1) are constructed in code and
-	// never pass through this validation, so they are unaffected.
+func TestTLSFingerprintProfileValidateRejectsUnsupportedOrAmbiguousALPN(t *testing.T) {
+	// The runtime dispatcher recognizes exactly these wire values. Empty,
+	// case-folded, unknown, and duplicate entries must fail at the CRUD boundary
+	// rather than produce a profile whose cache identity and negotiated protocol
+	// are ambiguous.
 	for _, alpn := range [][]string{
-		{"h2"},
+		{""},
+		{" "},
 		{"h2c"},
 		{"H2"},
-		{"h2", "http/1.1"},
-		{"http/1.1", "h2c"},
+		{"HTTP/1.1"},
+		{"http/1.0"},
+		{"spdy/3"},
+		{"h2", "h2"},
+		{"http/1.1", "http/1.1"},
+		{"h2", "http/1.1", "h2"},
 	} {
 		profile := &TLSFingerprintProfile{Name: "test", ALPNProtocols: alpn}
 		err := profile.Validate()
@@ -28,12 +32,17 @@ func TestTLSFingerprintProfileValidateRejectsHTTP2ALPN(t *testing.T) {
 	}
 }
 
-func TestTLSFingerprintProfileValidateAllowsHTTP1ALPN(t *testing.T) {
+func TestTLSFingerprintProfileValidateAllowsSupportedALPN(t *testing.T) {
+	// "h2" is supported via TLSRoundTripper's ALPN sniffing: the uTLS handshake
+	// negotiates the protocol and the request is dispatched to http2.Transport
+	// or http.Transport accordingly.
 	for _, alpn := range [][]string{
 		nil,
 		{},
 		{"http/1.1"},
-		{"http/1.1", "http/1.0"},
+		{"h2"},
+		{"h2", "http/1.1"},
+		{"http/1.1", "h2"},
 	} {
 		profile := &TLSFingerprintProfile{Name: "test", ALPNProtocols: alpn}
 		require.NoError(t, profile.Validate(), "ALPN %v must be accepted", alpn)

--- a/backend/internal/model/tls_fingerprint_profile_test.go
+++ b/backend/internal/model/tls_fingerprint_profile_test.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSFingerprintProfileValidateRejectsHTTP2ALPN(t *testing.T) {
+	// The custom-profile upstream transport is HTTP/1.1-only: a uTLS connection
+	// that negotiates "h2" cannot be used by net/http's HTTP/2 stack, so h2/h2c
+	// ALPN must fail closed at validation time instead of breaking at runtime.
+	// Built-in presets (e.g. PresetChrome120HTTP1) are constructed in code and
+	// never pass through this validation, so they are unaffected.
+	for _, alpn := range [][]string{
+		{"h2"},
+		{"h2c"},
+		{"H2"},
+		{"h2", "http/1.1"},
+		{"http/1.1", "h2c"},
+	} {
+		profile := &TLSFingerprintProfile{Name: "test", ALPNProtocols: alpn}
+		err := profile.Validate()
+		require.Error(t, err, "ALPN %v must be rejected", alpn)
+		validationErr, ok := err.(*ValidationError)
+		require.True(t, ok, "expected *ValidationError, got %T", err)
+		require.Equal(t, "alpn_protocols", validationErr.Field)
+	}
+}
+
+func TestTLSFingerprintProfileValidateAllowsHTTP1ALPN(t *testing.T) {
+	for _, alpn := range [][]string{
+		nil,
+		{},
+		{"http/1.1"},
+		{"http/1.1", "http/1.0"},
+	} {
+		profile := &TLSFingerprintProfile{Name: "test", ALPNProtocols: alpn}
+		require.NoError(t, profile.Validate(), "ALPN %v must be accepted", alpn)
+	}
+}
+
+func TestTLSFingerprintProfileValidateRequiresName(t *testing.T) {
+	profile := &TLSFingerprintProfile{}
+	err := profile.Validate()
+	require.Error(t, err)
+	validationErr, ok := err.(*ValidationError)
+	require.True(t, ok)
+	require.Equal(t, "name", validationErr.Field)
+}

--- a/backend/internal/pkg/httpclient/pool.go
+++ b/backend/internal/pkg/httpclient/pool.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
 )
 
@@ -41,12 +42,13 @@ const (
 
 // Options 定义共享 HTTP 客户端的构建参数
 type Options struct {
-	ProxyURL              string        // 代理 URL（支持 http/https/socks5/socks5h）
-	Timeout               time.Duration // 请求总超时时间
-	ResponseHeaderTimeout time.Duration // 等待响应头超时时间
-	InsecureSkipVerify    bool          // 是否跳过 TLS 证书验证（已禁用，不允许设置为 true）
-	ValidateResolvedIP    bool          // 是否校验解析后的 IP（防止 DNS Rebinding）
-	AllowPrivateHosts     bool          // 允许私有地址解析（与 ValidateResolvedIP 一起使用）
+	ProxyURL              string                  // 代理 URL（支持 http/https/socks5/socks5h）
+	Timeout               time.Duration           // 请求总超时时间
+	ResponseHeaderTimeout time.Duration           // 等待响应头超时时间
+	InsecureSkipVerify    bool                    // 是否跳过 TLS 证书验证（已禁用，不允许设置为 true）
+	ValidateResolvedIP    bool                    // 是否校验解析后的 IP（防止 DNS Rebinding）
+	AllowPrivateHosts     bool                    // 允许私有地址解析（与 ValidateResolvedIP 一起使用）
+	TLSProfile            *tlsfingerprint.Profile // 可选 uTLS ClientHello profile
 
 	// 可选的连接池参数（不设置则使用默认值）
 	MaxIdleConns        int // 最大空闲连接总数（默认 100）
@@ -132,10 +134,29 @@ func buildTransport(opts Options) (*http.Transport, error) {
 	if err != nil {
 		return nil, err
 	}
+	if opts.TLSProfile != nil {
+		transport.ForceAttemptHTTP2 = false
+		if parsed == nil {
+			transport.DialTLSContext = tlsfingerprint.NewDialer(opts.TLSProfile, nil).DialTLSContext
+			return transport, nil
+		}
+		switch strings.ToLower(parsed.Scheme) {
+		case "http":
+			transport.Proxy = proxyutil.PlainHTTPProxy(parsed)
+			transport.DialTLSContext = tlsfingerprint.NewHTTPProxyDialer(opts.TLSProfile, parsed).DialTLSContext
+			return transport, nil
+		case "socks5", "socks5h":
+			transport.Proxy = proxyutil.PlainHTTPProxy(parsed)
+			transport.DialTLSContext = tlsfingerprint.NewSOCKS5ProxyDialer(opts.TLSProfile, parsed).DialTLSContext
+			return transport, nil
+		}
+		// HTTPS and unknown proxy schemes keep the validated proxy route. The
+		// CONNECT-oriented uTLS dialers cannot establish TLS to an HTTPS proxy.
+	}
+
 	if parsed == nil {
 		return transport, nil
 	}
-
 	if err := proxyutil.ConfigureTransportProxy(transport, parsed); err != nil {
 		return nil, err
 	}
@@ -144,7 +165,7 @@ func buildTransport(opts Options) (*http.Transport, error) {
 }
 
 func buildClientKey(opts Options) string {
-	return fmt.Sprintf("%s|%s|%s|%t|%t|%t|%d|%d|%d",
+	key := fmt.Sprintf("%s|%s|%s|%t|%t|%t|%d|%d|%d",
 		strings.TrimSpace(opts.ProxyURL),
 		opts.Timeout.String(),
 		opts.ResponseHeaderTimeout.String(),
@@ -155,6 +176,10 @@ func buildClientKey(opts Options) string {
 		opts.MaxIdleConnsPerHost,
 		opts.MaxConnsPerHost,
 	)
+	if opts.TLSProfile != nil {
+		key += "|tls:" + opts.TLSProfile.StableID()
+	}
+	return key
 }
 
 type validatedTransport struct {

--- a/backend/internal/pkg/httpclient/pool.go
+++ b/backend/internal/pkg/httpclient/pool.go
@@ -66,6 +66,12 @@ var validateResolvedIP = urlvalidator.ValidateResolvedIP
 // 性能优化：相同配置复用同一客户端，避免重复创建 Transport
 // 安全说明：代理配置失败时直接返回错误，不会回退到直连，避免 IP 关联风险
 func GetClient(opts Options) (*http.Client, error) {
+	// The uTLS dialer paths in buildTransport install a bare fingerprinted
+	// dialer on a standard-library transport, which can only speak HTTP/1.1
+	// over those connections. Converge ALPN on a clone before deriving the
+	// cache key so an h2-advertising profile cannot negotiate a protocol the
+	// transport cannot serve, and the key always matches the effective profile.
+	opts.TLSProfile = tlsfingerprint.HTTP1OnlyProfile(opts.TLSProfile)
 	key := buildClientKey(opts)
 	if cached, ok := sharedClients.Load(key); ok {
 		if client, ok := cached.(*http.Client); ok {

--- a/backend/internal/pkg/httpclient/pool_test.go
+++ b/backend/internal/pkg/httpclient/pool_test.go
@@ -79,6 +79,22 @@ func TestGetClientKeysCacheByConvergedHTTP1Profile(t *testing.T) {
 		"profiles with identical effective HTTP/1.1 wire behavior must share one cache entry")
 }
 
+func TestGetClientSeparatesExtensionRandomizationProfiles(t *testing.T) {
+	sharedClients = sync.Map{}
+	fixed, err := GetClient(Options{TLSProfile: &tlsfingerprint.Profile{
+		Extensions: []uint16{0, 10, 16, 43},
+	}})
+	require.NoError(t, err)
+	randomized, err := GetClient(Options{TLSProfile: &tlsfingerprint.Profile{
+		Extensions:              []uint16{0, 10, 16, 43},
+		RandomizeExtensionOrder: true,
+	}})
+	require.NoError(t, err)
+
+	require.NotSame(t, fixed, randomized,
+		"fixed-order and per-connection-randomized profiles must not share a cached transport")
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/backend/internal/pkg/httpclient/pool_test.go
+++ b/backend/internal/pkg/httpclient/pool_test.go
@@ -1,10 +1,19 @@
 package httpclient
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,6 +57,26 @@ func TestBuildTransportWithTLSProfileProxiesPlainHTTPWithoutDoubleProxyingHTTPS(
 	proxyURL, err = transport.Proxy(httpsReq)
 	require.NoError(t, err)
 	require.Nil(t, proxyURL, "the fingerprint dialer already owns HTTPS proxy tunneling")
+}
+
+func TestGetClientKeysCacheByConvergedHTTP1Profile(t *testing.T) {
+	sharedClients = sync.Map{}
+	h2Profile := &tlsfingerprint.Profile{
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"h2", "http/1.1"},
+	}
+	h2Client, err := GetClient(Options{Timeout: time.Second, TLSProfile: h2Profile})
+	require.NoError(t, err)
+	require.Equal(t, []string{"h2", "http/1.1"}, h2Profile.ALPNProtocols,
+		"cache normalization must not mutate the caller's profile")
+
+	h1Client, err := GetClient(Options{Timeout: time.Second, TLSProfile: &tlsfingerprint.Profile{
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"http/1.1"},
+	}})
+	require.NoError(t, err)
+	require.Same(t, h2Client, h1Client,
+		"profiles with identical effective HTTP/1.1 wire behavior must share one cache entry")
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -150,4 +179,74 @@ func TestValidatedTransport_ValidationErrorStopsRoundTrip(t *testing.T) {
 	_, err = transport.RoundTrip(req)
 	require.ErrorIs(t, err, expectedErr)
 	require.Equal(t, int32(0), atomic.LoadInt32(&baseCalls))
+}
+
+func TestGetClientConvergesH2ProfileALPNForUTLSDialerPaths(t *testing.T) {
+	// A local TLS server that records the ALPN protocols the client offers in
+	// its ClientHello. The request is expected to fail certificate verification
+	// (self-signed); ALPN capture happens during ClientHello processing, before
+	// the certificate is verified.
+	cert := newSelfSignedTestCertificate(t)
+	offeredCh := make(chan []string, 1)
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			offeredCh <- append([]string(nil), hello.SupportedProtos...)
+			return nil, nil
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				tlsConn, ok := conn.(*tls.Conn)
+				if !ok {
+					return
+				}
+				if handshakeErr := tlsConn.Handshake(); handshakeErr != nil {
+					return
+				}
+			}()
+		}
+	}()
+
+	profile := &tlsfingerprint.Profile{ALPNProtocols: []string{"h2", "http/1.1"}}
+	client, err := GetClient(Options{Timeout: 2 * time.Second, TLSProfile: profile})
+	require.NoError(t, err)
+	_, _ = client.Get("https://" + ln.Addr().String())
+
+	select {
+	case offered := <-offeredCh:
+		require.Equal(t, []string{"http/1.1"}, offered,
+			"the h1-only uTLS dialer transport must never offer h2 to the server")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the client TLS handshake")
+	}
+	// Convergence happens on a clone: the caller's shared profile is untouched.
+	require.Equal(t, []string{"h2", "http/1.1"}, profile.ALPNProtocols)
+}
+
+func newSelfSignedTestCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
 }

--- a/backend/internal/pkg/httpclient/pool_test.go
+++ b/backend/internal/pkg/httpclient/pool_test.go
@@ -9,8 +9,46 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBuildTransportWithTLSProfileUsesContentKeyAndUTLSDialer(t *testing.T) {
+	firstProfile := &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}}
+	secondProfile := &tlsfingerprint.Profile{CipherSuites: []uint16{0x1302}}
+	base := Options{Timeout: time.Second, TLSProfile: firstProfile}
+
+	transport, err := buildTransport(base)
+	require.NoError(t, err)
+	require.NotNil(t, transport.DialTLSContext)
+	require.False(t, transport.ForceAttemptHTTP2)
+
+	changed := base
+	changed.TLSProfile = secondProfile
+	require.NotEqual(t, buildClientKey(base), buildClientKey(changed))
+}
+
+func TestBuildTransportWithTLSProfileProxiesPlainHTTPWithoutDoubleProxyingHTTPS(t *testing.T) {
+	transport, err := buildTransport(Options{
+		ProxyURL:   "http://proxy.example:8080",
+		TLSProfile: &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, transport.DialTLSContext)
+	require.NotNil(t, transport.Proxy)
+
+	httpReq, err := http.NewRequest(http.MethodGet, "http://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err := transport.Proxy(httpReq)
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	httpsReq, err := http.NewRequest(http.MethodGet, "https://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err = transport.Proxy(httpsReq)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL, "the fingerprint dialer already owns HTTPS proxy tunneling")
+}
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 

--- a/backend/internal/pkg/proxyutil/dialer.go
+++ b/backend/internal/pkg/proxyutil/dialer.go
@@ -39,6 +39,24 @@ var socks5ForwardDialer = &net.Dialer{
 	KeepAlive: socks5DialKeepAlive,
 }
 
+// PlainHTTPProxy returns a Transport proxy selector for requests whose
+// connection is not handled by a custom TLS dialer. This lets HTTP/WS traffic
+// use the configured proxy while HTTPS/WSS continues through a fingerprint
+// dialer that already owns proxy tunneling.
+func PlainHTTPProxy(proxyURL *url.URL) func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		if proxyURL == nil || req == nil || req.URL == nil {
+			return nil, nil
+		}
+		switch strings.ToLower(req.URL.Scheme) {
+		case "http", "ws":
+			return proxyURL, nil
+		default:
+			return nil, nil
+		}
+	}
+}
+
 // ConfigureTransportProxy 根据代理 URL 配置 Transport
 //
 // 支持的协议：

--- a/backend/internal/pkg/tlsfingerprint/codex_rustls_fallback.go
+++ b/backend/internal/pkg/tlsfingerprint/codex_rustls_fallback.go
@@ -1,0 +1,35 @@
+package tlsfingerprint
+
+import utls "github.com/refraction-networking/utls"
+
+// NewCodexRustlsFallbackProfile returns an opt-in cold-connection approximation of the
+// Codex 0.149.x rustls 0.23.36 fallback ClientHello. It does not describe the official
+// client's default platform-native TLS transport, which enables HTTP/2 and is selected when
+// available. Extension order is randomized independently for every new connection.
+//
+// Plugin-routed OAuth traffic (PluginManager.RoundTripOpenAIOAuth handled=true) bypasses the
+// TLS profile stack entirely. HTTPS-proxy fallback paths also keep proxy routing but lose
+// uTLS fingerprinting because the CONNECT-oriented dialer cannot establish TLS to the proxy.
+func NewCodexRustlsFallbackProfile() *Profile {
+	return &Profile{
+		Name: "Codex 0.149.x rustls fallback (cold connection) approximation",
+		CipherSuites: []uint16{
+			0x1302, 0x1301, 0x1303,
+			0xc02c, 0xc02b, 0xcca9,
+			0xc030, 0xc02f, 0xcca8,
+		},
+		SignatureAlgorithms: []uint16{
+			0x0403, 0x0503, 0x0603, 0x0807, 0x0806,
+			0x0805, 0x0804, 0x0601, 0x0501, 0x0401,
+		},
+		Curves:                  []uint16{0x11ec, 0x001d, 0x0017, 0x0018},
+		KeyShareGroups:          []uint16{0x11ec, 0x001d},
+		PointFormats:            []uint16{0x00},
+		SupportedVersions:       []uint16{utls.VersionTLS13, utls.VersionTLS12},
+		ALPNProtocols:           []string{"h2", "http/1.1"},
+		PSKModes:                []uint16{uint16(utls.PskModeDHE)},
+		Extensions:              []uint16{0, 5, 10, 11, 13, 16, 23, 35, 43, 45, 51},
+		EnableGREASE:            false,
+		RandomizeExtensionOrder: true,
+	}
+}

--- a/backend/internal/pkg/tlsfingerprint/codex_rustls_fallback_test.go
+++ b/backend/internal/pkg/tlsfingerprint/codex_rustls_fallback_test.go
@@ -1,0 +1,93 @@
+package tlsfingerprint
+
+import (
+	"testing"
+
+	utls "github.com/refraction-networking/utls"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexRustlsFallbackProfileWireShape(t *testing.T) {
+	profile := NewCodexRustlsFallbackProfile()
+	require.Equal(t, "Codex 0.149.x rustls fallback (cold connection) approximation", profile.Name)
+	require.Equal(t, []uint16{
+		0x1302, 0x1301, 0x1303, 0xc02c, 0xc02b, 0xcca9, 0xc030, 0xc02f, 0xcca8,
+	}, profile.CipherSuites)
+	require.NotContains(t, profile.CipherSuites, uint16(0x00ff), "rustls never sends SCSV")
+	require.Equal(t, []uint16{
+		0x0403, 0x0503, 0x0603, 0x0807, 0x0806, 0x0805, 0x0804, 0x0601, 0x0501, 0x0401,
+	}, profile.SignatureAlgorithms)
+	require.Equal(t, []uint16{0x11ec, 0x001d, 0x0017, 0x0018}, profile.Curves)
+	require.Equal(t, []uint16{0x11ec, 0x001d}, profile.KeyShareGroups)
+	require.Equal(t, []uint16{0x00}, profile.PointFormats)
+	require.Equal(t, []uint16{utls.VersionTLS13, utls.VersionTLS12}, profile.SupportedVersions)
+	require.Equal(t, []string{"h2", "http/1.1"}, profile.ALPNProtocols)
+	require.Equal(t, []uint16{uint16(utls.PskModeDHE)}, profile.PSKModes)
+	require.Equal(t, []uint16{0, 5, 10, 11, 13, 16, 23, 35, 43, 45, 51}, profile.Extensions)
+	require.False(t, profile.EnableGREASE)
+	require.True(t, profile.RandomizeExtensionOrder)
+
+	spec := buildClientHelloSpecFromProfile(profile)
+	require.Equal(t, profile.CipherSuites, spec.CipherSuites)
+
+	var extensionIDs []uint16
+	var signatureAlgorithms []utls.SignatureScheme
+	var keyShares []utls.KeyShare
+	var alpn []string
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *utls.SNIExtension:
+			extensionIDs = append(extensionIDs, 0)
+		case *utls.StatusRequestExtension:
+			extensionIDs = append(extensionIDs, 5)
+		case *utls.SupportedCurvesExtension:
+			extensionIDs = append(extensionIDs, 10)
+		case *utls.SupportedPointsExtension:
+			extensionIDs = append(extensionIDs, 11)
+		case *utls.SignatureAlgorithmsExtension:
+			extensionIDs = append(extensionIDs, 13)
+			signatureAlgorithms = typed.SupportedSignatureAlgorithms
+		case *utls.ALPNExtension:
+			extensionIDs = append(extensionIDs, 16)
+			alpn = typed.AlpnProtocols
+		case *utls.ExtendedMasterSecretExtension:
+			extensionIDs = append(extensionIDs, 23)
+		case *utls.SessionTicketExtension:
+			extensionIDs = append(extensionIDs, 35)
+		case *utls.SupportedVersionsExtension:
+			extensionIDs = append(extensionIDs, 43)
+		case *utls.PSKKeyExchangeModesExtension:
+			extensionIDs = append(extensionIDs, 45)
+		case *utls.KeyShareExtension:
+			extensionIDs = append(extensionIDs, 51)
+			keyShares = typed.KeyShares
+		default:
+			t.Fatalf("unexpected extension type %T", extension)
+		}
+	}
+
+	require.ElementsMatch(t, profile.Extensions, extensionIDs)
+	require.Equal(t, []utls.SignatureScheme{
+		0x0403, 0x0503, 0x0603, 0x0807, 0x0806, 0x0805, 0x0804, 0x0601, 0x0501, 0x0401,
+	}, signatureAlgorithms)
+	require.Equal(t, []utls.KeyShare{{Group: 0x11ec}, {Group: utls.X25519}}, keyShares,
+		"rustls predicts exactly two cold-connection key shares")
+	require.Equal(t, []string{"h2", "http/1.1"}, alpn, "ALPN extension must advertise h2 first")
+}
+
+func TestCodexRustlsFallbackHTTP1CloneKeepsALPNExtension(t *testing.T) {
+	profile := NewCodexRustlsFallbackProfile()
+	h1 := HTTP1OnlyProfile(profile)
+	require.Equal(t, []string{"http/1.1"}, h1.ALPNProtocols)
+	require.Contains(t, h1.Extensions, uint16(16))
+	require.Equal(t, profile.Extensions, h1.Extensions)
+
+	spec := buildClientHelloSpecFromProfile(h1)
+	var alpn []string
+	for _, extension := range spec.Extensions {
+		if typed, ok := extension.(*utls.ALPNExtension); ok {
+			alpn = typed.AlpnProtocols
+		}
+	}
+	require.Equal(t, []string{"http/1.1"}, alpn)
+}

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -6,11 +6,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/proxy"
@@ -18,6 +20,10 @@ import (
 
 // Profile contains TLS fingerprint configuration.
 // All slice fields use built-in defaults when empty.
+// defaultBaseDialTimeout bounds TCP dials made by fingerprint dialers when no
+// base dialer is supplied.
+const defaultBaseDialTimeout = 10 * time.Second
+
 type Profile struct {
 	Preset              Preset // Optional built-in ClientHello template
 	Name                string // Profile name for identification
@@ -43,6 +49,22 @@ const (
 	// cannot safely hand that connection to net/http's crypto/tls-only H2 hook.
 	PresetChrome120HTTP1 Preset = "chrome-120-http1"
 )
+
+// HTTP1OnlyProfile returns a clone of profile with ALPN converged to HTTP/1.1.
+// Bare uTLS dialer paths (the httpclient pool, WS proxy transports, the req
+// client pool) install the fingerprinted dialer on a standard-library transport
+// that can only speak HTTP/1.1 over those connections; an h2-advertising
+// profile would negotiate a protocol the transport cannot serve, so every such
+// caller must converge ALPN before deriving its cache key and dialer. Never
+// mutates the shared input; nil input returns nil.
+func HTTP1OnlyProfile(profile *Profile) *Profile {
+	if profile == nil {
+		return nil
+	}
+	clone := *profile
+	clone.ALPNProtocols = []string{"http/1.1"}
+	return &clone
+}
 
 // NewOpenAIChrome120Profile returns the built-in OpenAI account default.
 // Real Codex uses Rust/hyper rather than Chrome, so this is deliberately a
@@ -144,7 +166,10 @@ var (
 // If baseDialer is nil, direct TCP dial is used.
 func NewDialer(profile *Profile, baseDialer func(ctx context.Context, network, addr string) (net.Conn, error)) *Dialer {
 	if baseDialer == nil {
-		baseDialer = (&net.Dialer{}).DialContext
+		// A zero-value net.Dialer has no timeout and would let a black-holed
+		// upstream pin a goroutine until the caller's context ends. Bound the
+		// TCP dial; the TLS handshake itself still honors the caller's context.
+		baseDialer = (&net.Dialer{Timeout: defaultBaseDialTimeout}).DialContext
 	}
 	return &Dialer{profile: profile, baseDialer: baseDialer}
 }
@@ -161,10 +186,22 @@ func NewSOCKS5ProxyDialer(profile *Profile, proxyURL *url.URL) *SOCKS5ProxyDiale
 	return &SOCKS5ProxyDialer{profile: profile, proxyURL: proxyURL}
 }
 
+func withDefaultDialTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= defaultBaseDialTimeout {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultBaseDialTimeout)
+}
+
 // DialTLSContext establishes a TLS connection through SOCKS5 proxy with the configured fingerprint.
 // Flow: SOCKS5 CONNECT to target -> TLS handshake with utls on the tunnel
 func (d *SOCKS5ProxyDialer) DialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	slog.Debug("tls_fingerprint_socks5_connecting", "proxy", d.proxyURL.Host, "target", addr)
+	dialCtx, cancel := withDefaultDialTimeout(ctx)
+	defer cancel()
 
 	// Step 1: Create SOCKS5 dialer
 	var auth *proxy.Auth
@@ -183,7 +220,7 @@ func (d *SOCKS5ProxyDialer) DialTLSContext(ctx context.Context, network, addr st
 		proxyAddr = net.JoinHostPort(d.proxyURL.Hostname(), "1080") // Default SOCKS5 port
 	}
 
-	socksDialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, proxy.Direct)
+	socksDialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, &net.Dialer{Timeout: defaultBaseDialTimeout})
 	if err != nil {
 		slog.Debug("tls_fingerprint_socks5_dialer_failed", "error", err)
 		return nil, fmt.Errorf("create SOCKS5 dialer: %w", err)
@@ -191,7 +228,11 @@ func (d *SOCKS5ProxyDialer) DialTLSContext(ctx context.Context, network, addr st
 
 	// Step 2: Establish SOCKS5 tunnel to target
 	slog.Debug("tls_fingerprint_socks5_establishing_tunnel", "target", addr)
-	conn, err := socksDialer.Dial("tcp", addr)
+	contextDialer, ok := socksDialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, errors.New("SOCKS5 dialer does not support context cancellation")
+	}
+	conn, err := contextDialer.DialContext(dialCtx, "tcp", addr)
 	if err != nil {
 		slog.Debug("tls_fingerprint_socks5_connect_failed", "error", err)
 		return nil, fmt.Errorf("SOCKS5 connect: %w", err)
@@ -199,13 +240,20 @@ func (d *SOCKS5ProxyDialer) DialTLSContext(ctx context.Context, network, addr st
 	slog.Debug("tls_fingerprint_socks5_tunnel_established")
 
 	// Step 3: Perform TLS handshake on the tunnel with utls fingerprint
-	return performTLSHandshake(ctx, conn, d.profile, addr)
+	tlsConn, err := performTLSHandshake(dialCtx, conn, d.profile, addr)
+	if err != nil {
+		return nil, err
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+	return tlsConn, nil
 }
 
 // DialTLSContext establishes a TLS connection through HTTP proxy with the configured fingerprint.
 // Flow: TCP connect to proxy -> CONNECT tunnel -> TLS handshake with utls
 func (d *HTTPProxyDialer) DialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	slog.Debug("tls_fingerprint_http_proxy_connecting", "proxy", d.proxyURL.Host, "target", addr)
+	dialCtx, cancel := withDefaultDialTimeout(ctx)
+	defer cancel()
 
 	// Step 1: TCP connect to proxy server
 	var proxyAddr string
@@ -220,11 +268,17 @@ func (d *HTTPProxyDialer) DialTLSContext(ctx context.Context, network, addr stri
 		}
 	}
 
-	dialer := &net.Dialer{}
-	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr)
+	dialer := &net.Dialer{Timeout: defaultBaseDialTimeout}
+	conn, err := dialer.DialContext(dialCtx, "tcp", proxyAddr)
 	if err != nil {
 		slog.Debug("tls_fingerprint_http_proxy_connect_failed", "error", err)
 		return nil, fmt.Errorf("connect to proxy: %w", err)
+	}
+	if deadline, ok := dialCtx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("set proxy handshake deadline: %w", err)
+		}
 	}
 	slog.Debug("tls_fingerprint_http_proxy_connected", "proxy_addr", proxyAddr)
 
@@ -270,7 +324,12 @@ func (d *HTTPProxyDialer) DialTLSContext(ctx context.Context, network, addr stri
 	slog.Debug("tls_fingerprint_http_proxy_tunnel_established")
 
 	// Step 4: Perform TLS handshake on the tunnel with utls fingerprint
-	return performTLSHandshake(ctx, conn, d.profile, addr)
+	tlsConn, err := performTLSHandshake(dialCtx, conn, d.profile, addr)
+	if err != nil {
+		return nil, err
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+	return tlsConn, nil
 }
 
 // DialTLSContext establishes a TLS connection with the configured fingerprint.

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,12 +19,14 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-// Profile contains TLS fingerprint configuration.
-// All slice fields use built-in defaults when empty.
 // defaultBaseDialTimeout bounds TCP dials made by fingerprint dialers when no
 // base dialer is supplied.
 const defaultBaseDialTimeout = 10 * time.Second
 
+const preSharedKeyExtensionID uint16 = 41
+
+// Profile contains TLS fingerprint configuration.
+// All slice fields use built-in defaults when empty.
 type Profile struct {
 	Preset              Preset // Optional built-in ClientHello template
 	Name                string // Profile name for identification
@@ -36,7 +39,19 @@ type Profile struct {
 	SupportedVersions   []uint16 // Empty uses [TLS1.3, TLS1.2]
 	KeyShareGroups      []uint16 // Empty uses [X25519]
 	PSKModes            []uint16 // Empty uses [psk_dhe_ke]
-	Extensions          []uint16 // Extension type IDs in order; empty uses default Node.js 24.x order
+	// Extensions lists extension type IDs in order; empty uses the default Node.js 24.x
+	// order. An explicit list suppresses the default GREASE bookends even when EnableGREASE
+	// is true. Unknown IDs serialize as empty GenericExtension values, which is valid only
+	// for extensions whose wire body is genuinely empty.
+	Extensions []uint16
+
+	// RandomizeExtensionOrder, when true, shuffles a copy of the constructed extension list
+	// once per new TLS connection instead of using a fixed order. HTTP connection reuse means
+	// this is per connection, not per request. Real rustls clients reshuffle their ClientHello
+	// extension order as an anti-fingerprinting measure; a permanently fixed order is itself
+	// a distinguishing signal for such clients. Defaults to false so existing Profiles (for
+	// example the Node.js/Claude Code default) keep their fixed-order behavior unchanged.
+	RandomizeExtensionOrder bool
 }
 
 // Preset identifies a built-in ClientHello template. User-defined profiles
@@ -484,6 +499,9 @@ func buildClientHelloSpecFromProfile(profile *Profile) *utls.ClientHelloSpec {
 	if profile != nil && len(profile.Extensions) > 0 {
 		extOrder = profile.Extensions
 	}
+	if profile != nil && profile.RandomizeExtensionOrder {
+		extOrder = shuffleExtensionOrder(extOrder)
+	}
 
 	// Build extensions list from the ordered IDs.
 	// Parametric extensions (curves, sigalgs, etc.) are populated with resolved profile values.
@@ -571,6 +589,28 @@ func buildChrome120HTTP1Spec() (*utls.ClientHelloSpec, error) {
 	}
 	spec.Extensions = extensions
 	return &spec, nil
+}
+
+// shuffleExtensionOrder returns a new slice holding a random permutation of ids. It never
+// mutates ids: buildClientHelloSpecFromProfile can run concurrently for many new TLS
+// connections that share a Profile, and an in-place shuffle would race and corrupt the base
+// order. pre_shared_key (41), if present, is moved to the end after shuffling because TLS 1.3
+// requires real clients to send it last.
+//
+// Cryptographic randomness is unnecessary here: the shuffle only prevents every connection
+// from emitting an identical extension order.
+func shuffleExtensionOrder(ids []uint16) []uint16 {
+	shuffled := append([]uint16(nil), ids...)
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	for i, id := range shuffled {
+		if id == preSharedKeyExtensionID && i != len(shuffled)-1 {
+			shuffled[i], shuffled[len(shuffled)-1] = shuffled[len(shuffled)-1], shuffled[i]
+			break
+		}
+	}
+	return shuffled
 }
 
 // toUint8s converts []uint16 to []uint8 (for utls fields that require []uint8).

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -19,6 +19,7 @@ import (
 // Profile contains TLS fingerprint configuration.
 // All slice fields use built-in defaults when empty.
 type Profile struct {
+	Preset              Preset // Optional built-in ClientHello template
 	Name                string // Profile name for identification
 	CipherSuites        []uint16
 	Curves              []uint16
@@ -30,6 +31,28 @@ type Profile struct {
 	KeyShareGroups      []uint16 // Empty uses [X25519]
 	PSKModes            []uint16 // Empty uses [psk_dhe_ke]
 	Extensions          []uint16 // Extension type IDs in order; empty uses default Node.js 24.x order
+}
+
+// Preset identifies a built-in ClientHello template. User-defined profiles
+// leave this empty and continue to use the explicit fields above.
+type Preset string
+
+const (
+	// PresetChrome120HTTP1 is Chrome 120's uTLS template constrained to
+	// HTTP/1.1. The shared net/http transport uses a custom uTLS connection and
+	// cannot safely hand that connection to net/http's crypto/tls-only H2 hook.
+	PresetChrome120HTTP1 Preset = "chrome-120-http1"
+)
+
+// NewOpenAIChrome120Profile returns the built-in OpenAI account default.
+// Real Codex uses Rust/hyper rather than Chrome, so this is deliberately a
+// stable "not Go" compromise, not a claim of byte-for-byte Codex parity.
+// Chrome 120 also matches the existing OpenAI privacy-path impersonation.
+func NewOpenAIChrome120Profile() *Profile {
+	return &Profile{
+		Preset: PresetChrome120HTTP1,
+		Name:   "Built-in OpenAI Default (Chrome 120, HTTP/1.1)",
+	}
 }
 
 // Dialer creates TLS connections with custom fingerprints.
@@ -334,6 +357,17 @@ func isGREASEValue(v uint16) bool {
 // buildClientHelloSpecFromProfile constructs ClientHelloSpec from a Profile.
 // This is a standalone function that can be used by both Dialer and HTTPProxyDialer.
 func buildClientHelloSpecFromProfile(profile *Profile) *utls.ClientHelloSpec {
+	if profile != nil && profile.Preset == PresetChrome120HTTP1 {
+		if spec, err := buildChrome120HTTP1Spec(); err == nil {
+			return spec
+		} else {
+			// The preset is compiled into the pinned uTLS version, so this should
+			// only be reachable after an incompatible dependency change. Preserve
+			// availability with the existing non-Go Node.js template.
+			slog.Warn("tls_fingerprint_chrome_preset_failed", "error", err)
+		}
+	}
+
 	// Resolve effective values (profile overrides or built-in defaults)
 	cipherSuites := defaultCipherSuites
 	if profile != nil && len(profile.CipherSuites) > 0 {
@@ -454,6 +488,30 @@ func buildClientHelloSpecFromProfile(profile *Profile) *utls.ClientHelloSpec {
 		TLSVersMax:         utls.VersionTLS13,
 		TLSVersMin:         utls.VersionTLS10,
 	}
+}
+
+func buildChrome120HTTP1Spec() (*utls.ClientHelloSpec, error) {
+	spec, err := utls.UTLSIdToSpec(utls.HelloChrome_120)
+	if err != nil {
+		return nil, fmt.Errorf("build Chrome 120 ClientHello preset: %w", err)
+	}
+
+	extensions := make([]utls.TLSExtension, 0, len(spec.Extensions))
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *utls.ALPNExtension:
+			typed.AlpnProtocols = []string{"http/1.1"}
+			extensions = append(extensions, typed)
+		case *utls.ApplicationSettingsExtension:
+			// ALPS carries HTTP/2 settings and must not remain when the only
+			// advertised application protocol is HTTP/1.1.
+			continue
+		default:
+			extensions = append(extensions, extension)
+		}
+	}
+	spec.Extensions = extensions
+	return &spec, nil
 }
 
 // toUint8s converts []uint16 to []uint8 (for utls fields that require []uint8).

--- a/backend/internal/pkg/tlsfingerprint/dialer_randomize_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_randomize_test.go
@@ -1,0 +1,261 @@
+package tlsfingerprint
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+func TestRandomizedProfileChangesWireExtensionOrderPerConnection(t *testing.T) {
+	want := []uint16{0, 5, 10, 11, 13, 16, 23, 35, 43, 45, 51}
+	profile := &Profile{
+		Name:                    "wire-randomization",
+		Extensions:              append([]uint16(nil), want...),
+		ALPNProtocols:           []string{"h2", "http/1.1"},
+		RandomizeExtensionOrder: true,
+	}
+	before := cloneProfileForTest(profile)
+
+	orders := captureClientHelloExtensionOrders(t, profile, 12)
+	seen := make(map[string]struct{}, len(orders))
+	for i, order := range orders {
+		if !sameUint16Multiset(order, want) {
+			t.Fatalf("connection %d changed extension set: got %v want %v", i, order, want)
+		}
+		seen[fmt.Sprint(order)] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Fatalf("12 forced new connections produced only %d extension order; want at least 2", len(seen))
+	}
+	if !reflect.DeepEqual(before, profile) {
+		t.Fatalf("building ClientHellos mutated the shared profile:\nbefore: %#v\nafter:  %#v", before, profile)
+	}
+}
+
+func TestShuffleExtensionOrderPinsPreSharedKeyLast(t *testing.T) {
+	want := []uint16{41, 0, 5, 10, 11, 13, 16, 23, 35, 43, 45, 51}
+	for i := 0; i < 100; i++ {
+		got := shuffleExtensionOrder(want)
+		if !sameUint16Multiset(got, want) {
+			t.Fatalf("iteration %d changed extension set: got %v want %v", i, got, want)
+		}
+		if got[len(got)-1] != 41 {
+			t.Fatalf("iteration %d placed pre_shared_key at index %d: %v", i, indexUint16(got, 41), got)
+		}
+
+		spec := buildClientHelloSpecFromProfile(&Profile{
+			Extensions:              want,
+			RandomizeExtensionOrder: true,
+		})
+		last, ok := spec.Extensions[len(spec.Extensions)-1].(*utls.GenericExtension)
+		if !ok || last.Id != preSharedKeyExtensionID {
+			t.Fatalf("iteration %d did not serialize pre_shared_key last: %T %#v", i, spec.Extensions[len(spec.Extensions)-1], spec.Extensions[len(spec.Extensions)-1])
+		}
+	}
+}
+
+func TestExtensionRandomizationChangesV2StableID(t *testing.T) {
+	fixed := &Profile{Extensions: []uint16{0, 10, 16, 43}}
+	randomized := &Profile{
+		Extensions:              []uint16{0, 10, 16, 43},
+		RandomizeExtensionOrder: true,
+	}
+
+	if !strings.HasPrefix(fixed.StableID(), "v2:") || !strings.HasPrefix(randomized.StableID(), "v2:") {
+		t.Fatalf("StableID schema was not bumped to v2: fixed=%q randomized=%q", fixed.StableID(), randomized.StableID())
+	}
+	if fixed.StableID() == randomized.StableID() {
+		t.Fatalf("fixed and randomized profiles aliased to StableID %q", fixed.StableID())
+	}
+}
+
+func TestFixedProfileKeepsWireExtensionOrder(t *testing.T) {
+	want := []uint16{0, 5, 10, 11, 13, 16, 23, 35, 43, 45, 51}
+	profile := &Profile{
+		Name:          "wire-fixed-order",
+		Extensions:    append([]uint16(nil), want...),
+		ALPNProtocols: []string{"http/1.1"},
+	}
+
+	orders := captureClientHelloExtensionOrders(t, profile, 2)
+	for i, got := range orders {
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("connection %d changed fixed extension order: got %v want %v", i, got, want)
+		}
+	}
+}
+
+func captureClientHelloExtensionOrders(t *testing.T, profile *Profile, count int) [][]uint16 {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	captured := make(chan []uint16, count)
+	serverErr := make(chan error, 1)
+	go func() {
+		for i := 0; i < count; i++ {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverErr <- acceptErr
+				return
+			}
+			order, readErr := readClientHelloExtensionOrder(conn)
+			_ = conn.Close()
+			if readErr != nil {
+				serverErr <- readErr
+				return
+			}
+			captured <- order
+		}
+		serverErr <- nil
+	}()
+
+	dialer := NewDialer(profile, func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, listener.Addr().String())
+	})
+	for i := 0; i < count; i++ {
+		ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+		conn, dialErr := dialer.DialTLSContext(ctx, "tcp", "capture.example:443")
+		cancel()
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if dialErr == nil {
+			t.Fatalf("connection %d unexpectedly completed a TLS handshake against the capture-only listener", i)
+		}
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("capture ClientHello: %v", err)
+	}
+	orders := make([][]uint16, 0, count)
+	for i := 0; i < count; i++ {
+		orders = append(orders, <-captured)
+	}
+	return orders
+}
+
+func readClientHelloExtensionOrder(conn net.Conn) ([]uint16, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return nil, err
+	}
+	var handshake []byte
+	for {
+		var header [5]byte
+		if _, err := io.ReadFull(conn, header[:]); err != nil {
+			return nil, err
+		}
+		if header[0] != 22 {
+			return nil, fmt.Errorf("unexpected TLS record type %d", header[0])
+		}
+		record := make([]byte, int(binary.BigEndian.Uint16(header[3:5])))
+		if _, err := io.ReadFull(conn, record); err != nil {
+			return nil, err
+		}
+		handshake = append(handshake, record...)
+		if len(handshake) < 4 {
+			continue
+		}
+		if handshake[0] != 1 {
+			return nil, fmt.Errorf("unexpected handshake type %d", handshake[0])
+		}
+		messageLen := int(handshake[1])<<16 | int(handshake[2])<<8 | int(handshake[3])
+		if len(handshake) >= 4+messageLen {
+			return parseClientHelloExtensionOrder(handshake[4 : 4+messageLen])
+		}
+	}
+}
+
+func parseClientHelloExtensionOrder(hello []byte) ([]uint16, error) {
+	offset := 2 + 32 // legacy_version + random
+	if len(hello) < offset+1 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	offset += 1 + int(hello[offset]) // legacy_session_id
+	if len(hello) < offset+2 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	cipherLen := int(binary.BigEndian.Uint16(hello[offset : offset+2]))
+	offset += 2 + cipherLen
+	if len(hello) < offset+1 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	offset += 1 + int(hello[offset]) // legacy_compression_methods
+	if len(hello) < offset+2 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	extensionLen := int(binary.BigEndian.Uint16(hello[offset : offset+2]))
+	offset += 2
+	if len(hello) < offset+extensionLen {
+		return nil, io.ErrUnexpectedEOF
+	}
+	end := offset + extensionLen
+	order := make([]uint16, 0, 16)
+	for offset < end {
+		if end-offset < 4 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		id := binary.BigEndian.Uint16(hello[offset : offset+2])
+		bodyLen := int(binary.BigEndian.Uint16(hello[offset+2 : offset+4]))
+		offset += 4
+		if end-offset < bodyLen {
+			return nil, io.ErrUnexpectedEOF
+		}
+		order = append(order, id)
+		offset += bodyLen
+	}
+	return order, nil
+}
+
+func sameUint16Multiset(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[uint16]int, len(a))
+	for _, value := range a {
+		counts[value]++
+	}
+	for _, value := range b {
+		counts[value]--
+	}
+	for _, count := range counts {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneProfileForTest(profile *Profile) *Profile {
+	clone := *profile
+	clone.CipherSuites = append([]uint16(nil), profile.CipherSuites...)
+	clone.Curves = append([]uint16(nil), profile.Curves...)
+	clone.PointFormats = append([]uint16(nil), profile.PointFormats...)
+	clone.SignatureAlgorithms = append([]uint16(nil), profile.SignatureAlgorithms...)
+	clone.ALPNProtocols = append([]string(nil), profile.ALPNProtocols...)
+	clone.SupportedVersions = append([]uint16(nil), profile.SupportedVersions...)
+	clone.KeyShareGroups = append([]uint16(nil), profile.KeyShareGroups...)
+	clone.PSKModes = append([]uint16(nil), profile.PSKModes...)
+	clone.Extensions = append([]uint16(nil), profile.Extensions...)
+	return &clone
+}
+
+func indexUint16(values []uint16, target uint16) int {
+	for i, value := range values {
+		if value == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -234,6 +235,68 @@ func TestSOCKS5ProxyDialerBasic(t *testing.T) {
 	}
 	if dialer.proxyURL != proxyURL {
 		t.Error("expected proxyURL to be set")
+	}
+}
+
+func TestHTTPProxyDialerHonorsContextAfterTCPConnect(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	accepted := make(chan struct{})
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		close(accepted)
+		defer func() { _ = conn.Close() }()
+		// Simulate a proxy that accepts TCP but never answers CONNECT.
+		time.Sleep(400 * time.Millisecond)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	dialer := NewHTTPProxyDialer(&Profile{}, mustParseURL("http://"+ln.Addr().String()))
+	started := time.Now()
+	_, err = dialer.DialTLSContext(ctx, "tcp", "example.com:443")
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 250*time.Millisecond,
+		"context cancellation must interrupt a silent proxy after TCP connect")
+	select {
+	case <-accepted:
+	default:
+		t.Fatal("test did not reach the post-connect proxy handshake")
+	}
+}
+
+func TestSOCKS5ProxyDialerHonorsContextDuringHandshake(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	accepted := make(chan struct{})
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		close(accepted)
+		defer func() { _ = conn.Close() }()
+		// Simulate a SOCKS server that never completes method negotiation.
+		time.Sleep(400 * time.Millisecond)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	dialer := NewSOCKS5ProxyDialer(&Profile{}, mustParseURL("socks5://"+ln.Addr().String()))
+	started := time.Now()
+	_, err = dialer.DialTLSContext(ctx, "tcp", "example.com:443")
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 250*time.Millisecond,
+		"context cancellation must interrupt SOCKS negotiation")
+	select {
+	case <-accepted:
+	default:
+		t.Fatal("test did not reach the SOCKS handshake")
 	}
 }
 

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -20,6 +20,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	utls "github.com/refraction-networking/utls"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDialerBasicConnection tests that the dialer can establish TLS connections.
@@ -261,6 +264,75 @@ func TestBuildClientHelloSpec(t *testing.T) {
 
 	if len(spec.CipherSuites) != 2 {
 		t.Errorf("expected 2 cipher suites, got %d", len(spec.CipherSuites))
+	}
+}
+
+func TestOpenAIChrome120ProfileBuildsChromeLikeHTTP1ClientHello(t *testing.T) {
+	profile := NewOpenAIChrome120Profile()
+	spec := buildClientHelloSpecFromProfile(profile)
+
+	require.Equal(t, PresetChrome120HTTP1, profile.Preset)
+	require.NotEmpty(t, spec.CipherSuites)
+	require.Equal(t, uint16(utls.GREASE_PLACEHOLDER), spec.CipherSuites[0])
+
+	var alpn []string
+	var hasCertificateCompression bool
+	var hasHTTP2ApplicationSettings bool
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *utls.ALPNExtension:
+			alpn = typed.AlpnProtocols
+		case *utls.UtlsCompressCertExtension:
+			hasCertificateCompression = true
+		case *utls.ApplicationSettingsExtension:
+			hasHTTP2ApplicationSettings = true
+		}
+	}
+
+	require.Equal(t, []string{"http/1.1"}, alpn)
+	require.True(t, hasCertificateCompression, "Chrome template should retain Chrome certificate compression")
+	require.False(t, hasHTTP2ApplicationSettings, "HTTP/1.1-only template must not advertise HTTP/2 ALPS")
+}
+
+func TestProfileStableIDTracksClientHelloContentButNotDisplayName(t *testing.T) {
+	base := Profile{
+		Name:                "original display name",
+		CipherSuites:        []uint16{0x1301},
+		Curves:              []uint16{29},
+		PointFormats:        []uint16{0},
+		EnableGREASE:        true,
+		SignatureAlgorithms: []uint16{0x0403},
+		ALPNProtocols:       []string{"http/1.1"},
+		SupportedVersions:   []uint16{0x0304},
+		KeyShareGroups:      []uint16{29},
+		PSKModes:            []uint16{1},
+		Extensions:          []uint16{0, 10, 16, 43},
+	}
+	baseID := base.StableID()
+
+	renamed := base
+	renamed.Name = "renamed only"
+	require.Equal(t, baseID, renamed.StableID())
+
+	mutations := map[string]func(*Profile){
+		"preset":               func(p *Profile) { p.Preset = PresetChrome120HTTP1 },
+		"cipher suites":        func(p *Profile) { p.CipherSuites = []uint16{0x1302} },
+		"curves":               func(p *Profile) { p.Curves = []uint16{23} },
+		"point formats":        func(p *Profile) { p.PointFormats = []uint16{1} },
+		"grease":               func(p *Profile) { p.EnableGREASE = false },
+		"signature algorithms": func(p *Profile) { p.SignatureAlgorithms = []uint16{0x0804} },
+		"alpn":                 func(p *Profile) { p.ALPNProtocols = []string{"h2"} },
+		"supported versions":   func(p *Profile) { p.SupportedVersions = []uint16{0x0303} },
+		"key shares":           func(p *Profile) { p.KeyShareGroups = []uint16{23} },
+		"psk modes":            func(p *Profile) { p.PSKModes = []uint16{0} },
+		"extensions":           func(p *Profile) { p.Extensions = []uint16{0, 16, 43} },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			mutate(&changed)
+			require.NotEqual(t, baseID, changed.StableID())
+		})
 	}
 }
 

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -372,6 +372,7 @@ func TestProfileStableIDTracksClientHelloContentButNotDisplayName(t *testing.T) 
 		Extensions:          []uint16{0, 10, 16, 43},
 	}
 	baseID := base.StableID()
+	require.True(t, strings.HasPrefix(baseID, "v2:"), "StableID schema must be v2")
 
 	renamed := base
 	renamed.Name = "renamed only"
@@ -389,6 +390,9 @@ func TestProfileStableIDTracksClientHelloContentButNotDisplayName(t *testing.T) 
 		"key shares":           func(p *Profile) { p.KeyShareGroups = []uint16{23} },
 		"psk modes":            func(p *Profile) { p.PSKModes = []uint16{0} },
 		"extensions":           func(p *Profile) { p.Extensions = []uint16{0, 16, 43} },
+		"extension randomization": func(p *Profile) {
+			p.RandomizeExtensionOrder = true
+		},
 	}
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/pkg/tlsfingerprint/profile_cache.go
+++ b/backend/internal/pkg/tlsfingerprint/profile_cache.go
@@ -1,0 +1,66 @@
+package tlsfingerprint
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+)
+
+const stableProfileIDVersion = "sub2api-tls-profile-v1"
+
+// StableID returns a versioned content identity for every Profile field that
+// can change the emitted ClientHello. Name is intentionally excluded because
+// it is display-only and renaming a profile does not require a new transport.
+func (p *Profile) StableID() string {
+	digest := sha256.New()
+	writeStableString(digest, stableProfileIDVersion)
+	if p == nil {
+		_, _ = digest.Write([]byte{0})
+		return "v1:" + hex.EncodeToString(digest.Sum(nil))
+	}
+	_, _ = digest.Write([]byte{1})
+	writeStableString(digest, string(p.Preset))
+	writeStableUint16s(digest, p.CipherSuites)
+	writeStableUint16s(digest, p.Curves)
+	writeStableUint16s(digest, p.PointFormats)
+	if p.EnableGREASE {
+		_, _ = digest.Write([]byte{1})
+	} else {
+		_, _ = digest.Write([]byte{0})
+	}
+	writeStableUint16s(digest, p.SignatureAlgorithms)
+	writeStableStrings(digest, p.ALPNProtocols)
+	writeStableUint16s(digest, p.SupportedVersions)
+	writeStableUint16s(digest, p.KeyShareGroups)
+	writeStableUint16s(digest, p.PSKModes)
+	writeStableUint16s(digest, p.Extensions)
+	return "v1:" + hex.EncodeToString(digest.Sum(nil))
+}
+
+func writeStableString(digest hash.Hash, value string) {
+	writeStableLength(digest, len(value))
+	_, _ = digest.Write([]byte(value))
+}
+
+func writeStableStrings(digest hash.Hash, values []string) {
+	writeStableLength(digest, len(values))
+	for _, value := range values {
+		writeStableString(digest, value)
+	}
+}
+
+func writeStableUint16s(digest hash.Hash, values []uint16) {
+	writeStableLength(digest, len(values))
+	var encoded [2]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint16(encoded[:], value)
+		_, _ = digest.Write(encoded[:])
+	}
+}
+
+func writeStableLength(digest hash.Hash, length int) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], uint64(length))
+	_, _ = digest.Write(encoded[:])
+}

--- a/backend/internal/pkg/tlsfingerprint/profile_cache.go
+++ b/backend/internal/pkg/tlsfingerprint/profile_cache.go
@@ -7,7 +7,10 @@ import (
 	"hash"
 )
 
-const stableProfileIDVersion = "sub2api-tls-profile-v1"
+const (
+	stableProfileIDVersion = "sub2api-tls-profile-v2"
+	stableProfileIDPrefix  = "v2:"
+)
 
 // StableID returns a versioned content identity for every Profile field that
 // can change the emitted ClientHello. Name is intentionally excluded because
@@ -17,7 +20,7 @@ func (p *Profile) StableID() string {
 	writeStableString(digest, stableProfileIDVersion)
 	if p == nil {
 		_, _ = digest.Write([]byte{0})
-		return "v1:" + hex.EncodeToString(digest.Sum(nil))
+		return stableProfileIDPrefix + hex.EncodeToString(digest.Sum(nil))
 	}
 	_, _ = digest.Write([]byte{1})
 	writeStableString(digest, string(p.Preset))
@@ -35,7 +38,12 @@ func (p *Profile) StableID() string {
 	writeStableUint16s(digest, p.KeyShareGroups)
 	writeStableUint16s(digest, p.PSKModes)
 	writeStableUint16s(digest, p.Extensions)
-	return "v1:" + hex.EncodeToString(digest.Sum(nil))
+	if p.RandomizeExtensionOrder {
+		_, _ = digest.Write([]byte{1})
+	} else {
+		_, _ = digest.Write([]byte{0})
+	}
+	return stableProfileIDPrefix + hex.EncodeToString(digest.Sum(nil))
 }
 
 func writeStableString(digest hash.Hash, value string) {

--- a/backend/internal/pkg/tlsfingerprint/roundtripper.go
+++ b/backend/internal/pkg/tlsfingerprint/roundtripper.go
@@ -35,8 +35,8 @@ type UtlsDialFunc func(ctx context.Context, network, addr string) (net.Conn, err
 // handshake.
 //
 // The negotiated protocol is decided once per RoundTripper instance. Cached
-// upstream clients are keyed per account/proxy/profile and effectively serve a
-// single upstream host, so a per-instance decision matches that usage.
+// upstream clients that use this type must therefore include destination origin
+// in their cache key so each instance serves exactly one upstream host.
 //
 // Known trade-off: on the h2 path the HTTP/2 frames (SETTINGS, window sizes,
 // header order) are Go's x/net/http2 defaults, which do not match the browser

--- a/backend/internal/pkg/tlsfingerprint/roundtripper.go
+++ b/backend/internal/pkg/tlsfingerprint/roundtripper.go
@@ -1,0 +1,178 @@
+package tlsfingerprint
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	utls "github.com/refraction-networking/utls"
+	"golang.org/x/net/http2"
+)
+
+// UtlsDialFunc dials a uTLS-fingerprinted TLS connection to addr.
+// Dialer.DialTLSContext, HTTPProxyDialer.DialTLSContext and
+// SOCKS5ProxyDialer.DialTLSContext all satisfy this signature.
+type UtlsDialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// TLSRoundTripper is an http.RoundTripper that performs uTLS-fingerprinted
+// handshakes and routes traffic over HTTP/2 or HTTP/1.1 based on the ALPN
+// protocol negotiated during the handshake.
+//
+// Background: net/http.Transport cannot upgrade a custom DialTLSContext
+// connection to HTTP/2, because its H2 hook type-asserts the connection to
+// *tls.Conn and *utls.UConn fails that assertion. The negotiated ALPN is never
+// read and the connection silently degrades to HTTP/1.1 even when "h2" was
+// negotiated (refraction-networking/utls#16, golang/go#41236).
+// TLSRoundTripper works around this by performing a bootstrap uTLS dial on the
+// first HTTPS request, inspecting the negotiated ALPN, and then delegating to
+// http2.Transport (h2) or http.Transport (h1). The bootstrap connection is
+// handed to the winning transport so the first request does not pay a second
+// handshake.
+//
+// The negotiated protocol is decided once per RoundTripper instance. Cached
+// upstream clients are keyed per account/proxy/profile and effectively serve a
+// single upstream host, so a per-instance decision matches that usage.
+//
+// Known trade-off: on the h2 path the HTTP/2 frames (SETTINGS, window sizes,
+// header order) are Go's x/net/http2 defaults, which do not match the browser
+// implied by the ClientHello fingerprint. Frame-level browser alignment is only
+// provided by the built-in Chrome preset path (req ImpersonateChrome stack);
+// custom profiles trade frame-level consistency for protocol correctness.
+type TLSRoundTripper struct {
+	dial UtlsDialFunc
+
+	h1 *http.Transport  // h1 path; caller may pre-configure pool settings
+	h2 *http2.Transport // h2 path; caller may pre-configure keepalive settings
+
+	mu        sync.Mutex
+	decided   http.RoundTripper // non-nil once ALPN has been sniffed
+	bootstrap net.Conn          // sniffed connection, consumed by the winning transport
+}
+
+// NewTLSRoundTripper creates a RoundTripper that dials all TLS connections via
+// dial. h1 and h2 may be nil, in which case defaults are used; when provided,
+// only their dial hooks (and the h1 HTTP/2 kill switch) are overwritten, pool
+// and timeout settings are preserved.
+func NewTLSRoundTripper(dial UtlsDialFunc, h1 *http.Transport, h2 *http2.Transport) *TLSRoundTripper {
+	if h1 == nil {
+		h1 = &http.Transport{}
+	}
+	if h2 == nil {
+		h2 = &http2.Transport{}
+	}
+	rt := &TLSRoundTripper{dial: dial, h1: h1, h2: h2}
+
+	// The h1 transport must never attempt HTTP/2 on its own: its uTLS
+	// connections fail net/http's *tls.Conn assertion, so the built-in upgrade
+	// path cannot work. h2 dispatch is handled exclusively by this RoundTripper.
+	h1.DialTLSContext = rt.dialH1
+	h1.ForceAttemptHTTP2 = false
+	h1.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+
+	h2.DialTLSContext = rt.dialH2
+	h2.AllowHTTP = false
+	return rt
+}
+
+// RoundTrip implements http.RoundTripper. The first HTTPS request performs the
+// bootstrap dial and ALPN sniff; subsequent requests go directly to the
+// selected inner transport.
+func (rt *TLSRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil || !strings.EqualFold(req.URL.Scheme, "https") {
+		// No TLS handshake to fingerprint or sniff; plain HTTP goes through the
+		// h1 transport's default dial.
+		return rt.h1.RoundTrip(req)
+	}
+
+	rt.mu.Lock()
+	if rt.decided == nil {
+		if err := rt.sniffLocked(req); err != nil {
+			rt.mu.Unlock()
+			return nil, err
+		}
+	}
+	transport := rt.decided
+	rt.mu.Unlock()
+
+	return transport.RoundTrip(req)
+}
+
+// sniffLocked dials a bootstrap connection and selects the inner transport
+// based on the negotiated ALPN protocol. rt.mu must be held.
+func (rt *TLSRoundTripper) sniffLocked(req *http.Request) error {
+	conn, err := rt.dial(req.Context(), "tcp", canonicalTLSAddr(req.URL))
+	if err != nil {
+		return fmt.Errorf("bootstrap TLS dial: %w", err)
+	}
+
+	proto := ""
+	if state, ok := conn.(interface{ ConnectionState() utls.ConnectionState }); ok {
+		proto = state.ConnectionState().NegotiatedProtocol
+	}
+	rt.bootstrap = conn
+	if proto == "h2" {
+		rt.decided = rt.h2
+	} else {
+		rt.decided = rt.h1
+	}
+	return nil
+}
+
+// dialH1 is the DialTLSContext installed on the h1 transport.
+func (rt *TLSRoundTripper) dialH1(ctx context.Context, network, addr string) (net.Conn, error) {
+	if conn := rt.takeBootstrap(); conn != nil {
+		return conn, nil
+	}
+	return rt.dial(ctx, network, addr)
+}
+
+// dialH2 is the DialTLSContext installed on the h2 transport.
+func (rt *TLSRoundTripper) dialH2(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+	if conn := rt.takeBootstrap(); conn != nil {
+		return conn, nil
+	}
+	return rt.dial(ctx, network, addr)
+}
+
+// takeBootstrap returns the sniffed bootstrap connection exactly once.
+//
+// Concurrency note: RoundTrip releases rt.mu before delegating to the inner
+// transport, so a concurrent request B can win the bootstrap connection that
+// request A sniffed. This is intentional and safe: a cached upstream client
+// serves a single upstream host, so every dial — including the bootstrap one —
+// targets the same address; whoever receives the connection may use it.
+func (rt *TLSRoundTripper) takeBootstrap() net.Conn {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	conn := rt.bootstrap
+	rt.bootstrap = nil
+	return conn
+}
+
+// CloseIdleConnections closes idle connections on both inner transports so
+// client-cache eviction semantics match a plain *http.Transport.
+func (rt *TLSRoundTripper) CloseIdleConnections() {
+	rt.h1.CloseIdleConnections()
+	rt.h2.CloseIdleConnections()
+}
+
+// HTTP1Transport returns the inner HTTP/1.1 transport. It exists for tests
+// and introspection only (e.g. asserting pool/timeout settings); production
+// code should interact with TLSRoundTripper itself.
+func (rt *TLSRoundTripper) HTTP1Transport() *http.Transport {
+	return rt.h1
+}
+
+// canonicalTLSAddr returns host:port for the TLS dial, defaulting to 443.
+func canonicalTLSAddr(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}

--- a/backend/internal/pkg/tlsfingerprint/roundtripper_test.go
+++ b/backend/internal/pkg/tlsfingerprint/roundtripper_test.go
@@ -1,0 +1,147 @@
+//go:build unit
+
+package tlsfingerprint
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	utls "github.com/refraction-networking/utls"
+	"github.com/stretchr/testify/require"
+)
+
+// alpnReportingConn wraps a *tls.Conn and reports the negotiated protocol in
+// the utls ConnectionState shape that TLSRoundTripper inspects, mimicking a
+// *utls.UConn without requiring a real uTLS handshake against a loopback
+// server (performTLSHandshake verifies certificates against system roots).
+type alpnReportingConn struct {
+	*tls.Conn
+	proto string
+}
+
+func (c *alpnReportingConn) ConnectionState() utls.ConnectionState {
+	return utls.ConnectionState{NegotiatedProtocol: c.proto}
+}
+
+// sniffTestDialer dials addr with crypto/tls (skipping verification for the
+// loopback test server) and reports the actually negotiated ALPN protocol.
+func sniffTestDialer(dials *atomic.Int64) UtlsDialFunc {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		raw, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		tlsConn := tls.Client(raw, &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // loopback test server only
+			NextProtos:         []string{"h2", "http/1.1"},
+		})
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = raw.Close()
+			return nil, err
+		}
+		if dials != nil {
+			dials.Add(1)
+		}
+		return &alpnReportingConn{Conn: tlsConn, proto: tlsConn.ConnectionState().NegotiatedProtocol}, nil
+	}
+}
+
+func TestTLSRoundTripperNegotiatesHTTP2(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Saw-Proto", r.Proto)
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	var dials atomic.Int64
+	client := &http.Client{Transport: NewTLSRoundTripper(sniffTestDialer(&dials), nil, nil)}
+
+	for i := 0; i < 2; i++ {
+		resp, err := client.Get(server.URL)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, 2, resp.ProtoMajor, "response must speak HTTP/2: %s", string(body))
+		require.Equal(t, "HTTP/2.0", resp.Header.Get("X-Saw-Proto"))
+	}
+
+	// The bootstrap connection is handed to the h2 transport and multiplexes
+	// every request; no second handshake may happen.
+	require.Equal(t, int64(1), dials.Load())
+}
+
+func TestTLSRoundTripperFallsBackToHTTP1(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Saw-Proto", r.Proto)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var dials atomic.Int64
+	client := &http.Client{Transport: NewTLSRoundTripper(sniffTestDialer(&dials), nil, nil)}
+
+	for i := 0; i < 2; i++ {
+		resp, err := client.Get(server.URL)
+		require.NoError(t, err)
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, 1, resp.ProtoMajor, "response must speak HTTP/1.1")
+		require.Equal(t, "HTTP/1.1", resp.Header.Get("X-Saw-Proto"))
+	}
+
+	// h1 keep-alive reuses the bootstrap connection.
+	require.Equal(t, int64(1), dials.Load())
+}
+
+func TestTLSRoundTripperPreservesConfiguredTransports(t *testing.T) {
+	h1 := &http.Transport{MaxIdleConnsPerHost: 7}
+	rt := NewTLSRoundTripper(sniffTestDialer(nil), h1, nil)
+
+	require.Equal(t, 7, rt.h1.MaxIdleConnsPerHost, "caller pool settings must survive")
+	require.False(t, rt.h1.ForceAttemptHTTP2, "h1 transport must never attempt HTTP/2 on uTLS conns")
+	require.NotNil(t, rt.h1.DialTLSContext)
+	require.NotNil(t, rt.h1.TLSNextProto, "net/http's built-in H2 hook must be disabled")
+	require.NotNil(t, rt.h2, "nil h2 transport must be replaced with a default")
+	require.NotNil(t, rt.h2.DialTLSContext)
+	require.False(t, rt.h2.AllowHTTP)
+
+	rt.CloseIdleConnections() // must not panic before any request
+}
+
+func TestTLSRoundTripperSurfacesBootstrapDialError(t *testing.T) {
+	dialErr := errors.New("dial refused")
+	rt := NewTLSRoundTripper(func(context.Context, string, string) (net.Conn, error) {
+		return nil, dialErr
+	}, nil, nil)
+
+	req, err := http.NewRequest(http.MethodGet, "https://upstream.example/", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(req)
+	require.ErrorIs(t, err, dialErr)
+}
+
+func TestCustomProfileAdvertisesConfiguredALPN(t *testing.T) {
+	profile := &Profile{Name: "h2 profile", ALPNProtocols: []string{"h2", "http/1.1"}}
+	spec := buildClientHelloSpecFromProfile(profile)
+
+	var alpn []string
+	for _, extension := range spec.Extensions {
+		if typed, ok := extension.(*utls.ALPNExtension); ok {
+			alpn = typed.AlpnProtocols
+		}
+	}
+	require.Equal(t, []string{"h2", "http/1.1"}, alpn)
+}

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -272,7 +272,7 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 		return nil, err
 	}
 
-	entry, err := s.acquireClientWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile)
+	entry, err := s.acquireClientWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, tlsDestinationOrigin(req))
 	if err != nil {
 		slog.Debug("tls_fingerprint_acquire_client_failed", "account_id", accountID, "error", err)
 		return nil, err
@@ -485,13 +485,13 @@ func isSupportedGrokCLIVersion(version string) bool {
 }
 
 // acquireClientWithTLS 获取或创建带 TLS 指纹的客户端
-func (s *httpUpstreamService) acquireClientWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile) (*upstreamClientEntry, error) {
-	return s.getClientEntryWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, true, true)
+func (s *httpUpstreamService) acquireClientWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, origin string) (*upstreamClientEntry, error) {
+	return s.getClientEntryWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, origin, true, true)
 }
 
 // getClientEntryWithTLS 获取或创建带 TLS 指纹的客户端条目
 // TLS 指纹客户端使用独立的缓存键，与普通客户端隔离
-func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
+func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, origin string, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
 	isolation := s.getIsolationMode()
 	proxyKey, parsedProxy, err := normalizeProxyURL(proxyURL)
 	if err != nil {
@@ -500,11 +500,13 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	settings := s.resolvePoolSettings(isolation, accountConcurrency)
 	settings = s.applyProfilePoolSettings(settings, upstreamProfile)
 	protocolMode := s.resolveProtocolMode(upstreamProfile, proxyKey, parsedProxy)
+	effectiveProfile := convergeTLSProfileForProtocolMode(profile, protocolMode)
 	// TLS 指纹客户端使用独立的缓存键；profile 内容标识防止配置更新后
 	// 复用旧 ClientHello transport。协议模式也必须进入 key：代理 H2 回退
-	// 激活后，H1 fallback 不能继续复用已缓存的 Chrome H2 transport。
-	cacheBaseKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID, protocolMode)
-	cacheKey := cacheBaseKey + "|profile:" + profile.StableID()
+	// 激活后，H1 fallback 不能继续复用已缓存的 Chrome H2 transport。目的 origin
+	// 则隔离 TLSRoundTripper 的一次性 ALPN 决策，防止一个目的地的协议污染另一个目的地。
+	cacheBaseKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID, protocolMode) + "|origin:" + origin
+	cacheKey := cacheBaseKey + "|profile:" + effectiveProfile.StableID()
 	poolKey := buildPoolKey(settings, protocolMode) + ":tls"
 
 	now := time.Now()
@@ -561,10 +563,10 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	// 使用显式 uTLS dialer。
 	slog.Debug("tls_fingerprint_creating_new_client", "account_id", accountID, "cache_key", cacheKey, "proxy", proxyKey)
 	var transport http.RoundTripper
-	if profile.Preset == tlsfingerprint.PresetChrome120HTTP1 && protocolMode == upstreamProtocolModeOpenAIH2 {
+	if effectiveProfile.Preset == tlsfingerprint.PresetChrome120HTTP1 && protocolMode == upstreamProtocolModeOpenAIH2 {
 		transport = buildOpenAIChromeHTTP2Transport(settings, parsedProxy)
 	} else {
-		transport, err = buildUpstreamTransportWithTLSFingerprint(settings, parsedProxy, profile)
+		transport, err = buildUpstreamTransportWithTLSFingerprint(settings, parsedProxy, effectiveProfile)
 		if err != nil {
 			s.mu.Unlock()
 			return nil, fmt.Errorf("build TLS fingerprint transport: %w", err)
@@ -572,9 +574,7 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	}
 
 	client := &http.Client{Transport: transport}
-	if s.shouldValidateResolvedIP() {
-		client.CheckRedirect = s.redirectChecker
-	}
+	client.CheckRedirect = s.tlsFingerprintRedirectChecker
 
 	entry := &upstreamClientEntry{
 		client:       client,
@@ -592,6 +592,30 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	s.evictOverLimitLocked()
 	s.mu.Unlock()
 	return entry, nil
+}
+
+func convergeTLSProfileForProtocolMode(profile *tlsfingerprint.Profile, protocolMode string) *tlsfingerprint.Profile {
+	switch protocolMode {
+	case upstreamProtocolModeOpenAIH1, upstreamProtocolModeOpenAIH1Fallback:
+		return tlsfingerprint.HTTP1OnlyProfile(profile)
+	default:
+		return profile
+	}
+}
+
+func tlsDestinationOrigin(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(req.URL.Hostname()))
+	if host == "" {
+		return strings.ToLower(strings.TrimSpace(req.URL.Host))
+	}
+	port := req.URL.Port()
+	if port == "" {
+		port = "443"
+	}
+	return net.JoinHostPort(host, port)
 }
 
 // buildOpenAIChromeHTTP2Transport uses req's Chrome impersonation stack so the
@@ -618,7 +642,7 @@ func buildOpenAIChromeHTTP2Transport(settings poolSettings, proxyURL *url.URL) *
 }
 
 // removeSupersededTLSProfileClientsLocked removes transports for older
-// profile variants in the same isolation/proxy/account scope. http.Client's
+// profile variants in the same isolation/proxy/account/origin scope. http.Client's
 // CloseIdleConnections does not interrupt active requests; it closes current
 // idle connections and prevents their active connections from becoming a
 // reusable idle pool after they finish.
@@ -665,6 +689,19 @@ func (s *httpUpstreamService) validateRequestHost(req *http.Request) error {
 func (s *httpUpstreamService) redirectChecker(req *http.Request, via []*http.Request) error {
 	if len(via) >= 10 {
 		return errors.New("stopped after 10 redirects")
+	}
+	return s.validateRequestHost(req)
+}
+
+func (s *httpUpstreamService) tlsFingerprintRedirectChecker(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) > 0 && tlsDestinationOrigin(req) != tlsDestinationOrigin(via[0]) {
+		// A cached TLSRoundTripper owns one origin's ALPN decision. Returning
+		// ErrUseLastResponse preserves the redirect response for the caller instead
+		// of silently reusing that decision for a different destination.
+		return http.ErrUseLastResponse
 	}
 	return s.validateRequestHost(req)
 }

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -1412,39 +1412,35 @@ func enableOpenAIHTTP2KeepAlive(transport *http.Transport) (*http2.Transport, er
 	return h2, nil
 }
 
-// buildUpstreamTransportWithTLSFingerprint 构建带 TLS 指纹伪装的 Transport
-// 使用 utls 库模拟 Claude CLI 的 TLS 指纹
+// buildUpstreamTransportWithTLSFingerprint 构建带 TLS 指纹伪装的 RoundTripper。
+// 使用 utls 库模拟目标客户端的 TLS 指纹。
+//
+// 自定义 profile 返回 *tlsfingerprint.TLSRoundTripper：首次请求用 uTLS 引导
+// 连接嗅探 ALPN，协商出 h2 则委托 http2.Transport，否则委托 http.Transport。
+// 这绕开了 net/http 的 H2 升级钩子对 *tls.Conn 的类型断言（*utls.UConn 无法
+// 通过该断言，导致即使协商出 h2 也静默降级 H1）。注意 h2 路径的 HTTP/2 帧
+// （SETTINGS/窗口/header 顺序）是 Go x/net/http2 默认特征，与 ClientHello
+// 声称的浏览器在帧级并不一致——这是已知折衷；帧级对齐只有内置 Chrome
+// preset 路径（req ImpersonateChrome 全栈）才提供。
 //
 // 参数:
-//   - settings: 连接池配置
+//   - settings: 连接池配置（应用于 H1 transport；H2 使用 keepalive 探测参数）
 //   - proxyURL: 代理 URL（nil 表示直连）
 //   - profile: TLS 指纹配置
 //
-// 返回:
-//   - *http.Transport: 配置好的 Transport 实例
-//   - error: 配置错误
-//
 // 代理类型处理:
 //   - nil/空: 直连，使用 TLSFingerprintDialer
-//   - http/https: HTTP 代理，使用 HTTPProxyDialer（CONNECT 隧道 + utls 握手）
+//   - http: HTTP 代理，使用 HTTPProxyDialer（CONNECT 隧道 + utls 握手）
 //   - socks5: SOCKS5 代理，使用 SOCKS5ProxyDialer（SOCKS5 隧道 + utls 握手）
-func buildUpstreamTransportWithTLSFingerprint(settings poolSettings, proxyURL *url.URL, profile *tlsfingerprint.Profile) (*http.Transport, error) {
-	transport := &http.Transport{
-		MaxIdleConns:          settings.maxIdleConns,
-		MaxIdleConnsPerHost:   settings.maxIdleConnsPerHost,
-		MaxConnsPerHost:       settings.maxConnsPerHost,
-		IdleConnTimeout:       settings.idleConnTimeout,
-		ResponseHeaderTimeout: settings.responseHeaderTimeout,
-		// 禁用默认的 TLS，我们使用自定义的 DialTLSContext
-		ForceAttemptHTTP2: false,
-	}
-
+//   - https/未知: 回退普通代理配置（无 TLS 指纹），返回 *http.Transport
+func buildUpstreamTransportWithTLSFingerprint(settings poolSettings, proxyURL *url.URL, profile *tlsfingerprint.Profile) (http.RoundTripper, error) {
 	// 根据代理类型选择合适的 TLS 指纹 Dialer
+	var dial tlsfingerprint.UtlsDialFunc
 	if proxyURL == nil {
 		// 直连：使用 TLSFingerprintDialer
 		slog.Debug("tls_fingerprint_transport_direct")
 		dialer := tlsfingerprint.NewDialer(profile, nil)
-		transport.DialTLSContext = dialer.DialTLSContext
+		dial = dialer.DialTLSContext
 	} else {
 		scheme := strings.ToLower(proxyURL.Scheme)
 		switch scheme {
@@ -1452,26 +1448,39 @@ func buildUpstreamTransportWithTLSFingerprint(settings poolSettings, proxyURL *u
 			// SOCKS5 代理：使用 SOCKS5ProxyDialer
 			slog.Debug("tls_fingerprint_transport_socks5", "proxy", proxyURL.Host)
 			socks5Dialer := tlsfingerprint.NewSOCKS5ProxyDialer(profile, proxyURL)
-			transport.DialTLSContext = socks5Dialer.DialTLSContext
+			dial = socks5Dialer.DialTLSContext
 		case "https":
 			// The fingerprint dialer emits a plaintext CONNECT preface and cannot
 			// establish TLS to an HTTPS proxy. Keep proxy routing via net/http.
 			return buildUpstreamTransport(settings, proxyURL, upstreamProtocolModeDefault)
 		case "http":
-			// HTTP/HTTPS 代理：使用 HTTPProxyDialer（CONNECT 隧道）
+			// HTTP 代理：使用 HTTPProxyDialer（CONNECT 隧道）
 			slog.Debug("tls_fingerprint_transport_http_connect", "proxy", proxyURL.Host)
 			httpDialer := tlsfingerprint.NewHTTPProxyDialer(profile, proxyURL)
-			transport.DialTLSContext = httpDialer.DialTLSContext
+			dial = httpDialer.DialTLSContext
 		default:
 			// 未知代理类型，回退到普通代理配置（无 TLS 指纹）
 			slog.Debug("tls_fingerprint_transport_unknown_scheme_fallback", "scheme", scheme)
-			if err := proxyutil.ConfigureTransportProxy(transport, proxyURL); err != nil {
-				return nil, err
-			}
+			return buildUpstreamTransport(settings, proxyURL, upstreamProtocolModeDefault)
 		}
 	}
 
-	return transport, nil
+	h1 := &http.Transport{
+		MaxIdleConns:          settings.maxIdleConns,
+		MaxIdleConnsPerHost:   settings.maxIdleConnsPerHost,
+		MaxConnsPerHost:       settings.maxConnsPerHost,
+		IdleConnTimeout:       settings.idleConnTimeout,
+		ResponseHeaderTimeout: settings.responseHeaderTimeout,
+	}
+	// 与 OpenAI H2 路径一致：启用 PING 健康探测，剔除被代理/NAT 静默掐断的
+	// 死连接，避免请求挂到 TCP 重传超时。x/net/http2.Transport 没有
+	// ResponseHeaderTimeout 字段（该超时仅作用于 h1 transport）；h2 路径的
+	// 响应时限由调用方的 http.Client.Timeout / 请求 context 承担。
+	h2 := &http2.Transport{
+		ReadIdleTimeout: openAIHTTP2ReadIdleTimeout,
+		PingTimeout:     openAIHTTP2PingTimeout,
+	}
+	return tlsfingerprint.NewTLSRoundTripper(dial, h1, h2), nil
 }
 
 // trackedBody 带跟踪功能的响应体包装器

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
+	"github.com/imroc/req/v3"
 )
 
 // 默认配置常量
@@ -281,11 +282,13 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 	client = httpClientWithGrokAccessDeniedFallback(client)
 	resp, err := servertiming.Do(client, req)
 	if err != nil {
+		s.recordOpenAIHTTP2Failure(upstreamProfile, entry.protocolMode, entry.proxyKey, err)
 		atomic.AddInt64(&entry.inFlight, -1)
 		atomic.StoreInt64(&entry.lastUsed, time.Now().UnixNano())
 		slog.Debug("tls_fingerprint_request_failed", "account_id", accountID, "error", err)
 		return nil, err
 	}
+	s.recordOpenAIHTTP2Success(upstreamProfile, entry.protocolMode, entry.proxyKey)
 
 	decompressResponseBody(resp)
 
@@ -496,9 +499,13 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	}
 	settings := s.resolvePoolSettings(isolation, accountConcurrency)
 	settings = s.applyProfilePoolSettings(settings, upstreamProfile)
-	// TLS 指纹客户端使用独立的缓存键，加 "tls:" 前缀
-	cacheKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID, upstreamProtocolModeDefault)
-	poolKey := buildPoolKey(settings, upstreamProtocolModeDefault) + ":tls"
+	protocolMode := s.resolveProtocolMode(upstreamProfile, proxyKey, parsedProxy)
+	// TLS 指纹客户端使用独立的缓存键；profile 内容标识防止配置更新后
+	// 复用旧 ClientHello transport。协议模式也必须进入 key：代理 H2 回退
+	// 激活后，H1 fallback 不能继续复用已缓存的 Chrome H2 transport。
+	cacheBaseKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID, protocolMode)
+	cacheKey := cacheBaseKey + "|profile:" + profile.StableID()
+	poolKey := buildPoolKey(settings, protocolMode) + ":tls"
 
 	now := time.Now()
 	nowUnix := now.UnixNano()
@@ -518,6 +525,7 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 
 	// 写锁慢路径
 	s.mu.Lock()
+	s.removeSupersededTLSProfileClientsLocked(cacheBaseKey, cacheKey)
 	if entry, ok := s.clients[cacheKey]; ok {
 		if s.shouldReuseEntry(entry, isolation, proxyKey, poolKey) {
 			atomic.StoreInt64(&entry.lastUsed, nowUnix)
@@ -547,12 +555,20 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 		}
 	}
 
-	// 创建带 TLS 指纹的 Transport
+	// 创建带 TLS 指纹的 Transport。OpenAI 内置 Chrome profile 在 H2
+	// 模式下优先使用 req 的完整浏览器 transport，同时覆盖 ClientHello、
+	// SETTINGS、连接窗口与 header/pseudo-header 顺序；自定义 profile 继续
+	// 使用显式 uTLS dialer。
 	slog.Debug("tls_fingerprint_creating_new_client", "account_id", accountID, "cache_key", cacheKey, "proxy", proxyKey)
-	transport, err := buildUpstreamTransportWithTLSFingerprint(settings, parsedProxy, profile)
-	if err != nil {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("build TLS fingerprint transport: %w", err)
+	var transport http.RoundTripper
+	if profile.Preset == tlsfingerprint.PresetChrome120HTTP1 && protocolMode == upstreamProtocolModeOpenAIH2 {
+		transport = buildOpenAIChromeHTTP2Transport(settings, parsedProxy)
+	} else {
+		transport, err = buildUpstreamTransportWithTLSFingerprint(settings, parsedProxy, profile)
+		if err != nil {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("build TLS fingerprint transport: %w", err)
+		}
 	}
 
 	client := &http.Client{Transport: transport}
@@ -561,9 +577,10 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	}
 
 	entry := &upstreamClientEntry{
-		client:   client,
-		proxyKey: proxyKey,
-		poolKey:  poolKey,
+		client:       client,
+		proxyKey:     proxyKey,
+		poolKey:      poolKey,
+		protocolMode: protocolMode,
 	}
 	atomic.StoreInt64(&entry.lastUsed, nowUnix)
 	if markInFlight {
@@ -575,6 +592,47 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	s.evictOverLimitLocked()
 	s.mu.Unlock()
 	return entry, nil
+}
+
+// buildOpenAIChromeHTTP2Transport uses req's Chrome impersonation stack so the
+// wire identity covers both TLS and HTTP/2 frames. Returning the transport (not
+// req.Client) preserves HTTPUpstream.DoWithTLS and its account/profile cache.
+func buildOpenAIChromeHTTP2Transport(settings poolSettings, proxyURL *url.URL) *req.Transport {
+	client := req.C().ImpersonateChrome().EnableForceHTTP2()
+	transport := client.GetTransport()
+	transport.SetDial(newUpstreamDialer().DialContext)
+	transport.SetMaxIdleConns(settings.maxIdleConns)
+	transport.MaxIdleConnsPerHost = settings.maxIdleConnsPerHost
+	transport.SetMaxConnsPerHost(settings.maxConnsPerHost)
+	transport.SetIdleConnTimeout(settings.idleConnTimeout)
+	transport.SetTLSHandshakeTimeout(defaultUpstreamTLSHandshakeTimeout)
+	transport.SetResponseHeaderTimeout(settings.responseHeaderTimeout)
+	transport.SetHTTP2ReadIdleTimeout(openAIHTTP2ReadIdleTimeout)
+	transport.SetHTTP2PingTimeout(openAIHTTP2PingTimeout)
+	if proxyURL != nil {
+		client.SetProxyURL(proxyURL.String())
+	} else {
+		transport.SetProxy(nil)
+	}
+	return transport
+}
+
+// removeSupersededTLSProfileClientsLocked removes transports for older
+// profile variants in the same isolation/proxy/account scope. http.Client's
+// CloseIdleConnections does not interrupt active requests; it closes current
+// idle connections and prevents their active connections from becoming a
+// reusable idle pool after they finish.
+func (s *httpUpstreamService) removeSupersededTLSProfileClientsLocked(cacheBaseKey, currentCacheKey string) {
+	prefix := cacheBaseKey + "|profile:"
+	for key, entry := range s.clients {
+		if key == currentCacheKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		slog.Debug("tls_fingerprint_evicting_superseded_profile_client",
+			"cache_key", key,
+			"current_cache_key", currentCacheKey)
+		s.removeClientLocked(key, entry)
+	}
 }
 
 func (s *httpUpstreamService) shouldValidateResolvedIP() bool {

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -100,14 +100,42 @@ func TestHTTPUpstreamDoWithTLSPlainHTTPUsesConfiguredSOCKSProxy(t *testing.T) {
 func TestTLSFingerprintHTTPSProxyFallsBackWithoutBypassingProxy(t *testing.T) {
 	proxyURL, err := url.Parse("https://user:pass@proxy.example:8443")
 	require.NoError(t, err)
-	transport, err := buildUpstreamTransportWithTLSFingerprint(poolSettings{}, proxyURL, &tlsfingerprint.Profile{Name: "test"})
+	rt, err := buildUpstreamTransportWithTLSFingerprint(poolSettings{}, proxyURL, &tlsfingerprint.Profile{Name: "test"})
 	require.NoError(t, err)
+	transport, ok := rt.(*http.Transport)
+	require.True(t, ok, "HTTPS proxy fallback must keep the plain net/http transport, got %T", rt)
 	require.NotNil(t, transport.Proxy)
 	require.Nil(t, transport.DialTLSContext)
 	req := &http.Request{URL: &url.URL{Scheme: "https", Host: "upstream.example"}}
 	resolved, err := transport.Proxy(req)
 	require.NoError(t, err)
 	require.Equal(t, "https://user:pass@proxy.example:8443", resolved.String())
+}
+
+func TestTLSFingerprintTransportUsesALPNSniffingRoundTripper(t *testing.T) {
+	profile := &tlsfingerprint.Profile{Name: "test", ALPNProtocols: []string{"h2", "http/1.1"}}
+
+	t.Run("direct", func(t *testing.T) {
+		rt, err := buildUpstreamTransportWithTLSFingerprint(poolSettings{}, nil, profile)
+		require.NoError(t, err)
+		require.IsType(t, &tlsfingerprint.TLSRoundTripper{}, rt)
+	})
+
+	t.Run("http proxy", func(t *testing.T) {
+		proxyURL, err := url.Parse("http://user:pass@proxy.example:8080")
+		require.NoError(t, err)
+		rt, err := buildUpstreamTransportWithTLSFingerprint(poolSettings{}, proxyURL, profile)
+		require.NoError(t, err)
+		require.IsType(t, &tlsfingerprint.TLSRoundTripper{}, rt)
+	})
+
+	t.Run("socks5 proxy", func(t *testing.T) {
+		proxyURL, err := url.Parse("socks5://proxy.example:1080")
+		require.NoError(t, err)
+		rt, err := buildUpstreamTransportWithTLSFingerprint(poolSettings{}, proxyURL, profile)
+		require.NoError(t, err)
+		require.IsType(t, &tlsfingerprint.TLSRoundTripper{}, rt)
+	})
 }
 
 func startTestSOCKS5Proxy(t *testing.T) (string, *atomic.Int64) {
@@ -668,9 +696,9 @@ func (s *HTTPUpstreamSuite) TestOpenAIProfileTLSFingerprintDoesNotInheritGeneric
 	svc := s.newService()
 	entry, err := svc.getClientEntryWithTLS("", 1, 1, &tlsfingerprint.Profile{Name: "test"}, service.HTTPUpstreamProfileOpenAI, false, false)
 	require.NoError(s.T(), err)
-	transport, ok := entry.client.Transport.(*http.Transport)
-	require.True(s.T(), ok, "expected *http.Transport")
-	require.Equal(s.T(), time.Duration(0), transport.ResponseHeaderTimeout, "OpenAI TLS path should not inherit generic header timeout")
+	rt, ok := entry.client.Transport.(*tlsfingerprint.TLSRoundTripper)
+	require.True(s.T(), ok, "custom profiles use the ALPN-sniffing TLSRoundTripper, got %T", entry.client.Transport)
+	require.Equal(s.T(), time.Duration(0), rt.HTTP1Transport().ResponseHeaderTimeout, "OpenAI TLS path should not inherit generic header timeout")
 }
 
 func (s *HTTPUpstreamSuite) TestOpenAIBuiltInTLSFingerprintUsesChromeHTTP2Transport() {

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -550,6 +551,18 @@ type HTTPUpstreamSuite struct {
 	cfg *config.Config // 测试用配置
 }
 
+type closeIdleTrackingTransport struct {
+	closed atomic.Bool
+}
+
+func (t *closeIdleTrackingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("unexpected round trip")
+}
+
+func (t *closeIdleTrackingTransport) CloseIdleConnections() {
+	t.closed.Store(true)
+}
+
 // SetupTest 每个测试用例执行前的初始化
 // 创建空配置，各测试用例可按需覆盖
 func (s *HTTPUpstreamSuite) SetupTest() {
@@ -658,6 +671,125 @@ func (s *HTTPUpstreamSuite) TestOpenAIProfileTLSFingerprintDoesNotInheritGeneric
 	transport, ok := entry.client.Transport.(*http.Transport)
 	require.True(s.T(), ok, "expected *http.Transport")
 	require.Equal(s.T(), time.Duration(0), transport.ResponseHeaderTimeout, "OpenAI TLS path should not inherit generic header timeout")
+}
+
+func (s *HTTPUpstreamSuite) TestOpenAIBuiltInTLSFingerprintUsesChromeHTTP2Transport() {
+	s.cfg.Gateway = config.GatewayConfig{
+		OpenAIResponseHeaderTimeout: 1800,
+		OpenAIHTTP2: config.GatewayOpenAIHTTP2Config{
+			Enabled: true,
+		},
+	}
+	svc := s.newService()
+	profile := tlsfingerprint.NewOpenAIChrome120Profile()
+
+	first, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	transport, ok := first.client.Transport.(*req.Transport)
+	require.True(s.T(), ok, "built-in OpenAI profile should use req's Chrome H2 impersonation transport")
+	require.Equal(s.T(), 1800*time.Second, transport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 3, transport.MaxConnsPerHost)
+
+	h2Server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(s.T(), 2, r.ProtoMajor, "Chrome impersonation transport must negotiate HTTP/2")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	h2Server.EnableHTTP2 = true
+	h2Server.StartTLS()
+	s.T().Cleanup(h2Server.Close)
+	serverTransport, ok := h2Server.Client().Transport.(*http.Transport)
+	require.True(s.T(), ok)
+	transport.SetTLSClientConfig(serverTransport.TLSClientConfig.Clone())
+	resp, err := first.client.Get(h2Server.URL)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), 2, resp.ProtoMajor)
+	require.NoError(s.T(), resp.Body.Close())
+
+	second, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	require.Same(s.T(), first, second, "the existing DoWithTLS profile cache key must still reuse the transport")
+}
+
+func (s *HTTPUpstreamSuite) TestOpenAITLSFingerprintProxyCompatibilityErrorActivatesFallbackAndSeparatesCacheMode() {
+	s.cfg.Gateway = config.GatewayConfig{
+		OpenAIHTTP2: config.GatewayOpenAIHTTP2Config{
+			Enabled:                   true,
+			AllowProxyFallbackToHTTP1: true,
+			FallbackErrorThreshold:    1,
+			FallbackWindowSeconds:     60,
+			FallbackTTLSeconds:        600,
+		},
+	}
+	svc := s.newService()
+	profile := tlsfingerprint.NewOpenAIChrome120Profile()
+	proxyURL := "http://proxy.example:8080"
+
+	h2Entry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), upstreamProtocolModeOpenAIH2, h2Entry.protocolMode)
+	h2Entry.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("stream error: PROTOCOL_ERROR")
+	})
+
+	request, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
+	require.NoError(s.T(), err)
+	request = request.WithContext(service.WithHTTPUpstreamProfile(request.Context(), service.HTTPUpstreamProfileOpenAI))
+	_, err = svc.DoWithTLS(request, proxyURL, 82, 1, profile)
+	require.ErrorContains(s.T(), err, "PROTOCOL_ERROR")
+	require.True(s.T(), svc.isOpenAIHTTP2FallbackActive(proxyURL))
+
+	fallbackEntry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), upstreamProtocolModeOpenAIH1Fallback, fallbackEntry.protocolMode)
+	require.NotSame(s.T(), h2Entry, fallbackEntry, "H1 fallback must not reuse the cached H2 fingerprint transport")
+	_, stillChromeH2 := fallbackEntry.client.Transport.(*req.Transport)
+	require.False(s.T(), stillChromeH2)
+}
+
+func (s *HTTPUpstreamSuite) TestTLSFingerprintProfileChangeRebuildsTransportAndClosesOldIdleConnections() {
+	svc := s.newService()
+	firstProfile := &tlsfingerprint.Profile{
+		Name:         "first",
+		CipherSuites: []uint16{0x1301},
+	}
+	first, err := svc.getClientEntryWithTLS("", 71, 1, firstProfile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	oldTransport := &closeIdleTrackingTransport{}
+	first.client.Transport = oldTransport
+
+	secondProfile := &tlsfingerprint.Profile{
+		Name:         "second",
+		CipherSuites: []uint16{0x1302},
+	}
+	second, err := svc.getClientEntryWithTLS("", 71, 1, secondProfile, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+
+	require.NotSame(s.T(), first, second, "a changed ClientHello profile must rebuild the cached transport")
+	require.True(s.T(), oldTransport.closed.Load(), "the superseded transport must close idle connections")
+	require.Len(s.T(), svc.clients, 1, "only the current TLS profile variant should remain cached")
+}
+
+func (s *HTTPUpstreamSuite) TestTLSFingerprintEquivalentProfileContentReusesTransport() {
+	svc := s.newService()
+	first, err := svc.getClientEntryWithTLS("", 72, 1, &tlsfingerprint.Profile{
+		Name:                "display name one",
+		CipherSuites:        []uint16{0x1301, 0x1302},
+		ALPNProtocols:       []string{"http/1.1"},
+		SupportedVersions:   []uint16{0x0304, 0x0303},
+		SignatureAlgorithms: []uint16{0x0403},
+	}, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+
+	second, err := svc.getClientEntryWithTLS("", 72, 1, &tlsfingerprint.Profile{
+		Name:                "renamed only",
+		CipherSuites:        []uint16{0x1301, 0x1302},
+		ALPNProtocols:       []string{"http/1.1"},
+		SupportedVersions:   []uint16{0x0304, 0x0303},
+		SignatureAlgorithms: []uint16{0x0403},
+	}, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+
+	require.Same(s.T(), first, second, "display-only profile changes must not discard an equivalent transport")
 }
 
 func (s *HTTPUpstreamSuite) TestOpenAIProfileHTTP2DisabledUsesHTTP1Transport() {

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -694,7 +695,7 @@ func (s *HTTPUpstreamSuite) TestOpenAIProfileTLSFingerprintDoesNotInheritGeneric
 		},
 	}
 	svc := s.newService()
-	entry, err := svc.getClientEntryWithTLS("", 1, 1, &tlsfingerprint.Profile{Name: "test"}, service.HTTPUpstreamProfileOpenAI, false, false)
+	entry, err := svc.getClientEntryWithTLS("", 1, 1, &tlsfingerprint.Profile{Name: "test"}, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	rt, ok := entry.client.Transport.(*tlsfingerprint.TLSRoundTripper)
 	require.True(s.T(), ok, "custom profiles use the ALPN-sniffing TLSRoundTripper, got %T", entry.client.Transport)
@@ -711,7 +712,7 @@ func (s *HTTPUpstreamSuite) TestOpenAIBuiltInTLSFingerprintUsesChromeHTTP2Transp
 	svc := s.newService()
 	profile := tlsfingerprint.NewOpenAIChrome120Profile()
 
-	first, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	first, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	transport, ok := first.client.Transport.(*req.Transport)
 	require.True(s.T(), ok, "built-in OpenAI profile should use req's Chrome H2 impersonation transport")
@@ -733,7 +734,7 @@ func (s *HTTPUpstreamSuite) TestOpenAIBuiltInTLSFingerprintUsesChromeHTTP2Transp
 	require.Equal(s.T(), 2, resp.ProtoMajor)
 	require.NoError(s.T(), resp.Body.Close())
 
-	second, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	second, err := svc.getClientEntryWithTLS("", 81, 3, profile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	require.Same(s.T(), first, second, "the existing DoWithTLS profile cache key must still reuse the transport")
 }
@@ -752,7 +753,7 @@ func (s *HTTPUpstreamSuite) TestOpenAITLSFingerprintProxyCompatibilityErrorActiv
 	profile := tlsfingerprint.NewOpenAIChrome120Profile()
 	proxyURL := "http://proxy.example:8080"
 
-	h2Entry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	h2Entry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), upstreamProtocolModeOpenAIH2, h2Entry.protocolMode)
 	h2Entry.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
@@ -766,7 +767,7 @@ func (s *HTTPUpstreamSuite) TestOpenAITLSFingerprintProxyCompatibilityErrorActiv
 	require.ErrorContains(s.T(), err, "PROTOCOL_ERROR")
 	require.True(s.T(), svc.isOpenAIHTTP2FallbackActive(proxyURL))
 
-	fallbackEntry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, false, false)
+	fallbackEntry, err := svc.getClientEntryWithTLS(proxyURL, 82, 1, profile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), upstreamProtocolModeOpenAIH1Fallback, fallbackEntry.protocolMode)
 	require.NotSame(s.T(), h2Entry, fallbackEntry, "H1 fallback must not reuse the cached H2 fingerprint transport")
@@ -780,7 +781,7 @@ func (s *HTTPUpstreamSuite) TestTLSFingerprintProfileChangeRebuildsTransportAndC
 		Name:         "first",
 		CipherSuites: []uint16{0x1301},
 	}
-	first, err := svc.getClientEntryWithTLS("", 71, 1, firstProfile, service.HTTPUpstreamProfileOpenAI, false, false)
+	first, err := svc.getClientEntryWithTLS("", 71, 1, firstProfile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 	oldTransport := &closeIdleTrackingTransport{}
 	first.client.Transport = oldTransport
@@ -789,7 +790,7 @@ func (s *HTTPUpstreamSuite) TestTLSFingerprintProfileChangeRebuildsTransportAndC
 		Name:         "second",
 		CipherSuites: []uint16{0x1302},
 	}
-	second, err := svc.getClientEntryWithTLS("", 71, 1, secondProfile, service.HTTPUpstreamProfileOpenAI, false, false)
+	second, err := svc.getClientEntryWithTLS("", 71, 1, secondProfile, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 
 	require.NotSame(s.T(), first, second, "a changed ClientHello profile must rebuild the cached transport")
@@ -805,7 +806,7 @@ func (s *HTTPUpstreamSuite) TestTLSFingerprintEquivalentProfileContentReusesTran
 		ALPNProtocols:       []string{"http/1.1"},
 		SupportedVersions:   []uint16{0x0304, 0x0303},
 		SignatureAlgorithms: []uint16{0x0403},
-	}, service.HTTPUpstreamProfileOpenAI, false, false)
+	}, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 
 	second, err := svc.getClientEntryWithTLS("", 72, 1, &tlsfingerprint.Profile{
@@ -814,10 +815,128 @@ func (s *HTTPUpstreamSuite) TestTLSFingerprintEquivalentProfileContentReusesTran
 		ALPNProtocols:       []string{"http/1.1"},
 		SupportedVersions:   []uint16{0x0304, 0x0303},
 		SignatureAlgorithms: []uint16{0x0403},
-	}, service.HTTPUpstreamProfileOpenAI, false, false)
+	}, service.HTTPUpstreamProfileOpenAI, "api.openai.com:443", false, false)
 	require.NoError(s.T(), err)
 
 	require.Same(s.T(), first, second, "display-only profile changes must not discard an equivalent transport")
+}
+
+func (s *HTTPUpstreamSuite) TestTLSFingerprintCacheSeparatesDestinationOrigins() {
+	svc := s.newService()
+	profile := &tlsfingerprint.Profile{
+		Name:          "h2-capable custom profile",
+		ALPNProtocols: []string{"h2", "http/1.1"},
+		Extensions:    []uint16{0, 10, 13, 16, 43, 51},
+	}
+	apiRequest, err := http.NewRequest(http.MethodGet, "https://API.OpenAI.com/v1/responses", nil)
+	require.NoError(s.T(), err)
+	authRequest, err := http.NewRequest(http.MethodGet, "https://auth.openai.com:8443/oauth/token", nil)
+	require.NoError(s.T(), err)
+	apiOrigin := tlsDestinationOrigin(apiRequest)
+	authOrigin := tlsDestinationOrigin(authRequest)
+	require.Equal(s.T(), "api.openai.com:443", apiOrigin)
+	require.Equal(s.T(), "auth.openai.com:8443", authOrigin)
+
+	first, err := svc.getClientEntryWithTLS("", 73, 1, profile, service.HTTPUpstreamProfileOpenAI, apiOrigin, false, false)
+	require.NoError(s.T(), err)
+	second, err := svc.getClientEntryWithTLS("", 73, 1, profile, service.HTTPUpstreamProfileOpenAI, authOrigin, false, false)
+	require.NoError(s.T(), err)
+	again, err := svc.getClientEntryWithTLS("", 73, 1, profile, service.HTTPUpstreamProfileOpenAI, apiOrigin, false, false)
+	require.NoError(s.T(), err)
+
+	require.NotSame(s.T(), first, second,
+		"a TLSRoundTripper's one-time ALPN decision must never be shared across origins")
+	require.Same(s.T(), first, again, "the same normalized origin should reuse its transport")
+	require.Len(s.T(), svc.clients, 2)
+}
+
+func (s *HTTPUpstreamSuite) TestTLSProfileConvergesToHTTP1ForH1ProtocolModes() {
+	profile := tlsfingerprint.NewCodexRustlsFallbackProfile()
+	for _, mode := range []string{upstreamProtocolModeOpenAIH1, upstreamProtocolModeOpenAIH1Fallback} {
+		s.T().Run(string(mode), func(t *testing.T) {
+			effective := convergeTLSProfileForProtocolMode(profile, mode)
+			require.NotSame(t, profile, effective)
+			require.Equal(t, []string{"http/1.1"}, effective.ALPNProtocols)
+			require.Contains(t, effective.Extensions, uint16(16), "H1 convergence must keep the ALPN extension")
+			require.Equal(t, []string{"h2", "http/1.1"}, profile.ALPNProtocols,
+				"protocol convergence must not mutate the shared account profile")
+		})
+	}
+	require.Same(s.T(), profile, convergeTLSProfileForProtocolMode(profile, upstreamProtocolModeOpenAIH2))
+}
+
+func (s *HTTPUpstreamSuite) TestOpenAIH1ModeCodexProfileOffersOnlyHTTP1OnWire() {
+	offered := make(chan []string, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.TLS = &tls.Config{
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			offered <- append([]string(nil), hello.SupportedProtos...)
+			return nil, nil
+		},
+	}
+	server.StartTLS()
+	s.T().Cleanup(server.Close)
+
+	s.cfg.Gateway.OpenAIHTTP2.Enabled = false
+	svc := s.newService()
+	profile := tlsfingerprint.NewCodexRustlsFallbackProfile()
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(s.T(), err)
+	entry, err := svc.getClientEntryWithTLS("", 75, 1, profile, service.HTTPUpstreamProfileOpenAI, tlsDestinationOrigin(req), false, false)
+	require.NoError(s.T(), err)
+
+	_, _ = entry.client.Do(req) // self-signed certificate fails after ClientHello capture
+	select {
+	case got := <-offered:
+		require.Equal(s.T(), []string{"http/1.1"}, got)
+	case <-time.After(3 * time.Second):
+		s.T().Fatal("timed out waiting for ClientHello ALPN capture")
+	}
+	require.Equal(s.T(), []string{"h2", "http/1.1"}, profile.ALPNProtocols,
+		"wire convergence must not mutate the shared account profile")
+}
+
+func (s *HTTPUpstreamSuite) TestTLSFingerprintClientRejectsCrossOriginRedirectButFollowsSameOrigin() {
+	var crossOriginCalls atomic.Int64
+	crossOriginTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		crossOriginCalls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	s.T().Cleanup(crossOriginTarget.Close)
+	crossOriginSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, crossOriginTarget.URL, http.StatusFound)
+	}))
+	s.T().Cleanup(crossOriginSource.Close)
+
+	svc := s.newService()
+	entry, err := svc.getClientEntryWithTLS("", 74, 1, tlsfingerprint.NewCodexRustlsFallbackProfile(), service.HTTPUpstreamProfileOpenAI, "source.example:443", false, false)
+	require.NoError(s.T(), err)
+	entry.client.Transport = http.DefaultTransport
+
+	resp, err := entry.client.Get(crossOriginSource.URL)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), http.StatusFound, resp.StatusCode)
+	require.NoError(s.T(), resp.Body.Close())
+	require.Zero(s.T(), crossOriginCalls.Load(), "TLS clients must not follow a redirect into another origin")
+
+	var sameOriginFinalCalls atomic.Int64
+	sameOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		sameOriginFinalCalls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	s.T().Cleanup(sameOrigin.Close)
+
+	resp, err = entry.client.Get(sameOrigin.URL + "/start")
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), http.StatusNoContent, resp.StatusCode)
+	require.NoError(s.T(), resp.Body.Close())
+	require.Equal(s.T(), int64(1), sameOriginFinalCalls.Load(), "same-origin redirects must remain enabled")
 }
 
 func (s *HTTPUpstreamSuite) TestOpenAIProfileHTTP2DisabledUsesHTTP1Transport() {

--- a/backend/internal/repository/http_upstream_tls_capture_test.go
+++ b/backend/internal/repository/http_upstream_tls_capture_test.go
@@ -1,0 +1,111 @@
+//go:build tls_capture
+
+package repository
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/testutil/tlscapture"
+	"github.com/stretchr/testify/require"
+)
+
+// Run manually with:
+//
+//	go test -tags=tls_capture -v ./internal/repository \
+//	  -run TestHTTPUpstreamOpenAIDefaultTLSProfileCapture -count=1
+//
+// The loopback capture server intentionally stops after ClientHello, so both
+// HTTP calls return an EOF-like handshake error. The recorded handshake is the
+// assertion target; no external service or trusted test certificate is needed.
+func TestHTTPUpstreamOpenAIDefaultTLSProfileCapture(t *testing.T) {
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			OpenAIHTTP2: config.GatewayOpenAIHTTP2Config{Enabled: false},
+		},
+	}
+	upstream := NewHTTPUpstream(cfg)
+
+	goHello := captureHTTPUpstreamClientHello(t, func(ctx context.Context, captureURL string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, captureURL, nil)
+		if err != nil {
+			return err
+		}
+		req = req.WithContext(service.WithHTTPUpstreamProfile(req.Context(), service.HTTPUpstreamProfileOpenAI))
+		_, err = upstream.Do(req, "", 991, 1)
+		return err
+	})
+
+	chromeHello := captureHTTPUpstreamClientHello(t, func(ctx context.Context, captureURL string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, captureURL, nil)
+		if err != nil {
+			return err
+		}
+		req = req.WithContext(service.WithHTTPUpstreamProfile(req.Context(), service.HTTPUpstreamProfileOpenAI))
+		_, err = upstream.DoWithTLS(req, "", 991, 1, tlsfingerprint.NewOpenAIChrome120Profile())
+		return err
+	})
+
+	t.Logf("Go baseline cipher suites: %v", goHello.CipherSuites)
+	t.Logf("Go baseline extension order: %v", goHello.Extensions)
+	t.Logf("OpenAI uTLS cipher suites: %v", chromeHello.CipherSuites)
+	t.Logf("OpenAI uTLS extension order: %v", chromeHello.Extensions)
+
+	require.NotEqual(t, goHello.CipherSuites, chromeHello.CipherSuites,
+		"DoWithTLS must not emit the Go default cipher-suite sequence")
+	require.NotEqual(t, goHello.Extensions, chromeHello.Extensions,
+		"DoWithTLS must not emit the Go default extension sequence")
+	require.True(t, tlscapture.IsGREASE(chromeHello.CipherSuites[0]),
+		"Chrome ClientHello should begin with a GREASE cipher suite")
+	require.Contains(t, chromeHello.Extensions, uint16(27),
+		"Chrome ClientHello should advertise certificate compression")
+	require.Contains(t, chromeHello.Extensions, uint16(65037),
+		"Chrome ClientHello should carry GREASE ECH")
+}
+
+// Run manually with:
+//
+//	go test -tags=tls_capture -v ./internal/repository \
+//	  -run TestOpenAIOAuthRefreshTLSProfileCapture -count=1
+func TestOpenAIOAuthRefreshTLSProfileCapture(t *testing.T) {
+	goHello := captureHTTPUpstreamClientHello(t, func(ctx context.Context, captureURL string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, captureURL, nil)
+		if err != nil {
+			return err
+		}
+		_, err = (&http.Client{Transport: &http.Transport{Proxy: nil}}).Do(req)
+		return err
+	})
+
+	oauthHello := captureHTTPUpstreamClientHello(t, func(ctx context.Context, captureURL string) error {
+		client := &openaiOAuthService{tokenURL: captureURL}
+		_, err := client.RefreshToken(ctx, "capture-refresh-token", "")
+		return err
+	})
+
+	t.Logf("Go baseline cipher suites: %v", goHello.CipherSuites)
+	t.Logf("Go baseline extension order: %v", goHello.Extensions)
+	t.Logf("OAuth refresh cipher suites: %v", oauthHello.CipherSuites)
+	t.Logf("OAuth refresh extension order: %v", oauthHello.Extensions)
+
+	require.NotEqual(t, goHello.CipherSuites, oauthHello.CipherSuites,
+		"OAuth refresh must not emit the Go default cipher-suite sequence")
+	require.NotEqual(t, goHello.Extensions, oauthHello.Extensions,
+		"OAuth refresh must not emit the Go default extension sequence")
+	require.True(t, tlscapture.IsGREASE(oauthHello.CipherSuites[0]),
+		"OAuth refresh Chrome ClientHello should begin with GREASE")
+	require.Contains(t, oauthHello.Extensions, uint16(27),
+		"OAuth refresh Chrome ClientHello should advertise certificate compression")
+}
+
+func captureHTTPUpstreamClientHello(
+	t *testing.T,
+	send func(context.Context, string) error,
+) tlscapture.ClientHello {
+	t.Helper()
+	return tlscapture.Capture(t, "https", send)
+}

--- a/backend/internal/repository/openai_oauth_service.go
+++ b/backend/internal/repository/openai_oauth_service.go
@@ -10,6 +10,7 @@ import (
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/imroc/req/v3"
 )
@@ -24,7 +25,7 @@ type openaiOAuthService struct {
 }
 
 func (s *openaiOAuthService) ExchangeCode(ctx context.Context, code, codeVerifier, redirectURI, proxyURL, clientID string) (*openai.TokenResponse, error) {
-	client, err := createOpenAIReqClient(proxyURL)
+	client, err := createOpenAIReqClientForContext(ctx, proxyURL)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_OAUTH_CLIENT_INIT_FAILED", "create HTTP client: %v", err)
 	}
@@ -83,7 +84,7 @@ func (s *openaiOAuthService) RefreshTokenWithClientID(ctx context.Context, refre
 }
 
 func (s *openaiOAuthService) refreshTokenWithClientID(ctx context.Context, refreshToken, proxyURL, clientID string) (*openai.TokenResponse, error) {
-	client, err := createOpenAIReqClient(proxyURL)
+	client, err := createOpenAIReqClientForContext(ctx, proxyURL)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_OAUTH_CLIENT_INIT_FAILED", "create HTTP client: %v", err)
 	}
@@ -119,10 +120,15 @@ func (s *openaiOAuthService) refreshTokenWithClientID(ctx context.Context, refre
 	return &tokenResp, nil
 }
 
-func createOpenAIReqClient(proxyURL string) (*req.Client, error) {
+func createOpenAIReqClientForContext(ctx context.Context, proxyURL string) (*req.Client, error) {
+	profile := service.OpenAIUpstreamTLSProfileFromContext(ctx)
+	if profile == nil {
+		profile = tlsfingerprint.NewOpenAIChrome120Profile()
+	}
 	return getSharedReqClient(reqClientOptions{
-		ProxyURL: proxyURL,
-		Timeout:  120 * time.Second,
+		ProxyURL:   proxyURL,
+		Timeout:    120 * time.Second,
+		TLSProfile: profile,
 	})
 }
 

--- a/backend/internal/repository/req_client_pool.go
+++ b/backend/internal/repository/req_client_pool.go
@@ -41,6 +41,13 @@ var sharedReqClients sync.Map
 // getSharedReqClient 获取共享的 req 客户端实例
 // 性能优化：相同配置复用同一客户端，避免重复创建
 func getSharedReqClient(opts reqClientOptions) (*req.Client, error) {
+	// req 客户端路径通过 Transport.SetDialTLS 安装 uTLS dialer，没有 ALPN
+	// 嗅探，只讲 HTTP/1.1：profile 若广播 "h2"，TLS 层会协商出 h2 而
+	// transport 仍按 HTTP/1.1 写请求，所有请求在运行时失败。因此在派生
+	// 缓存键和 dialer 之前，先把 ALPN 收敛到 HTTP/1.1（在 clone 上修改，
+	// 不动调用方共享的 profile 对象），保证缓存键与实际使用的 profile 一致。
+	opts.TLSProfile = http1OnlyTLSProfile(opts.TLSProfile)
+
 	key := buildReqClientKey(opts)
 	if cached, ok := sharedReqClients.Load(key); ok {
 		if c, ok := cached.(*req.Client); ok {
@@ -95,6 +102,13 @@ func instrumentReqClient(client *req.Client) *req.Client {
 		return timed.RoundTrip
 	})
 	return client
+}
+
+// http1OnlyTLSProfile 返回 ALPN 收敛为 HTTP/1.1 的 profile 副本。
+// req 客户端路径（SetDialTLS）只讲 HTTP/1.1，见 getSharedReqClient 的说明。
+// 返回 clone，不修改传入的共享 profile；nil 输入返回 nil。
+func http1OnlyTLSProfile(profile *tlsfingerprint.Profile) *tlsfingerprint.Profile {
+	return tlsfingerprint.HTTP1OnlyProfile(profile)
 }
 
 func buildReqClientKey(opts reqClientOptions) string {

--- a/backend/internal/repository/req_client_pool.go
+++ b/backend/internal/repository/req_client_pool.go
@@ -8,17 +8,20 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 
 	"github.com/imroc/req/v3"
 )
 
 // reqClientOptions 定义 req 客户端的构建参数
 type reqClientOptions struct {
-	ProxyURL    string        // 代理 URL（支持 http/https/socks5）
-	Timeout     time.Duration // 请求超时时间
-	Impersonate bool          // 是否模拟 Chrome 浏览器指纹
-	ForceHTTP2  bool          // 是否强制使用 HTTP/2
+	ProxyURL    string                  // 代理 URL（支持 http/https/socks5）
+	Timeout     time.Duration           // 请求超时时间
+	Impersonate bool                    // 是否模拟 Chrome 浏览器指纹
+	ForceHTTP2  bool                    // 是否强制使用 HTTP/2
+	TLSProfile  *tlsfingerprint.Profile // 可选 uTLS ClientHello profile
 }
 
 // sharedReqClients 存储按配置参数缓存的 req 客户端实例
@@ -52,12 +55,27 @@ func getSharedReqClient(opts reqClientOptions) (*req.Client, error) {
 	if opts.Impersonate {
 		client = client.ImpersonateChrome()
 	}
-	trimmed, _, err := proxyurl.Parse(opts.ProxyURL)
+	trimmed, parsed, err := proxyurl.Parse(opts.ProxyURL)
 	if err != nil {
 		return nil, err
 	}
-	if trimmed != "" {
+	if opts.TLSProfile == nil && trimmed != "" {
 		client.SetProxyURL(trimmed)
+	} else if opts.TLSProfile != nil {
+		switch {
+		case parsed == nil:
+			client.GetTransport().SetDialTLS(tlsfingerprint.NewDialer(opts.TLSProfile, nil).DialTLSContext)
+		case strings.EqualFold(parsed.Scheme, "http"):
+			client.SetProxy(proxyutil.PlainHTTPProxy(parsed))
+			client.GetTransport().SetDialTLS(tlsfingerprint.NewHTTPProxyDialer(opts.TLSProfile, parsed).DialTLSContext)
+		case strings.EqualFold(parsed.Scheme, "socks5"), strings.EqualFold(parsed.Scheme, "socks5h"):
+			client.SetProxy(proxyutil.PlainHTTPProxy(parsed))
+			client.GetTransport().SetDialTLS(tlsfingerprint.NewSOCKS5ProxyDialer(opts.TLSProfile, parsed).DialTLSContext)
+		default:
+			// Preserve routing for HTTPS/unknown proxies; the CONNECT-oriented
+			// uTLS dialers cannot establish TLS to an HTTPS proxy.
+			client.SetProxyURL(trimmed)
+		}
 	}
 	client = instrumentReqClient(client)
 
@@ -80,12 +98,16 @@ func instrumentReqClient(client *req.Client) *req.Client {
 }
 
 func buildReqClientKey(opts reqClientOptions) string {
-	return fmt.Sprintf("%s|%s|%t|%t",
+	key := fmt.Sprintf("%s|%s|%t|%t",
 		strings.TrimSpace(opts.ProxyURL),
 		opts.Timeout.String(),
 		opts.Impersonate,
 		opts.ForceHTTP2,
 	)
+	if opts.TLSProfile != nil {
+		key += "|tls:" + opts.TLSProfile.StableID()
+	}
+	return key
 }
 
 // CreatePrivacyReqClient creates an HTTP client for OpenAI privacy settings API
@@ -96,5 +118,16 @@ func CreatePrivacyReqClient(proxyURL string) (*req.Client, error) {
 		ProxyURL:    proxyURL,
 		Timeout:     30 * time.Second,
 		Impersonate: true, // Enable Chrome TLS fingerprint impersonation
+	})
+}
+
+// CreateOpenAITLSProfileReqClient creates a shared req client whose TLS
+// transport is keyed by and configured from the resolved OpenAI account profile.
+func CreateOpenAITLSProfileReqClient(proxyURL string, profile *tlsfingerprint.Profile) (*req.Client, error) {
+	return getSharedReqClient(reqClientOptions{
+		ProxyURL:    proxyURL,
+		Timeout:     30 * time.Second,
+		Impersonate: true,
+		TLSProfile:  profile,
 	})
 }

--- a/backend/internal/repository/req_client_pool_test.go
+++ b/backend/internal/repository/req_client_pool_test.go
@@ -17,6 +17,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetSharedReqClient_ConstrainsH2ProfileToHTTP1(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	h2Profile := &tlsfingerprint.Profile{
+		Name:          "h2 profile",
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"h2", "http/1.1"},
+	}
+	h2Opts := reqClientOptions{Timeout: 7 * time.Second, TLSProfile: h2Profile}
+
+	h2Client, err := getSharedReqClient(h2Opts)
+	require.NoError(t, err)
+	require.NotNil(t, h2Client.GetTransport().DialTLSContext)
+
+	// The caller's shared profile object must not be mutated.
+	require.Equal(t, []string{"h2", "http/1.1"}, h2Profile.ALPNProtocols)
+
+	// The converged cache key matches an explicit HTTP/1.1 profile: both
+	// profiles resolve to the same shared client instead of two ambiguous
+	// cache entries for the same wire behavior.
+	h1Opts := reqClientOptions{Timeout: 7 * time.Second, TLSProfile: &tlsfingerprint.Profile{
+		Name:          "h1 profile",
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"http/1.1"},
+	}}
+	h1Client, err := getSharedReqClient(h1Opts)
+	require.NoError(t, err)
+	require.Same(t, h2Client, h1Client)
+}
+
+func TestHTTP1OnlyTLSProfile(t *testing.T) {
+	require.Nil(t, http1OnlyTLSProfile(nil))
+
+	profile := &tlsfingerprint.Profile{ALPNProtocols: []string{"h2", "http/1.1"}}
+	clone := http1OnlyTLSProfile(profile)
+	require.Equal(t, []string{"http/1.1"}, clone.ALPNProtocols)
+	require.Equal(t, []string{"h2", "http/1.1"}, profile.ALPNProtocols, "original profile must stay untouched")
+}
+
 func TestGetSharedReqClient_TLSProfileSeparatesCacheByContent(t *testing.T) {
 	sharedReqClients = sync.Map{}
 	first := reqClientOptions{Timeout: time.Second, TLSProfile: &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}}}

--- a/backend/internal/repository/req_client_pool_test.go
+++ b/backend/internal/repository/req_client_pool_test.go
@@ -12,9 +12,61 @@ import (
 	"unsafe"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetSharedReqClient_TLSProfileSeparatesCacheByContent(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	first := reqClientOptions{Timeout: time.Second, TLSProfile: &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}}}
+	second := reqClientOptions{Timeout: time.Second, TLSProfile: &tlsfingerprint.Profile{CipherSuites: []uint16{0x1302}}}
+
+	firstClient, err := getSharedReqClient(first)
+	require.NoError(t, err)
+	secondClient, err := getSharedReqClient(second)
+	require.NoError(t, err)
+
+	require.NotSame(t, firstClient, secondClient)
+	require.NotEqual(t, buildReqClientKey(first), buildReqClientKey(second))
+}
+
+func TestGetSharedReqClient_TLSProfileProxiesPlainHTTPWithoutDoubleProxyingHTTPS(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	client, err := getSharedReqClient(reqClientOptions{
+		ProxyURL:   "http://proxy.example:8080",
+		Timeout:    time.Second,
+		TLSProfile: &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}},
+	})
+	require.NoError(t, err)
+	transport := client.GetTransport()
+	require.NotNil(t, transport.DialTLSContext)
+	require.NotNil(t, transport.Proxy)
+
+	httpReq, err := http.NewRequest(http.MethodGet, "http://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err := transport.Proxy(httpReq)
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	httpsReq, err := http.NewRequest(http.MethodGet, "https://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err = transport.Proxy(httpsReq)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+}
+
+func TestCreateOpenAITLSProfileReqClientPreservesChromeImpersonation(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	profile := &tlsfingerprint.Profile{Name: "account override", CipherSuites: []uint16{0x1301}}
+
+	client, err := CreateOpenAITLSProfileReqClient("", profile)
+	require.NoError(t, err)
+	require.NotNil(t, client.GetTransport().DialTLSContext)
+	require.NotEmpty(t, client.Headers.Get("Sec-Ch-Ua"))
+	require.NotEmpty(t, client.Headers.Get("User-Agent"))
+}
 
 func forceHTTPVersion(t *testing.T, client *req.Client) string {
 	t.Helper()
@@ -110,9 +162,9 @@ func TestGetSharedReqClient_ProxyURLMissingHost(t *testing.T) {
 	require.Contains(t, err.Error(), "proxy URL missing host")
 }
 
-func TestCreateOpenAIReqClient_Timeout120Seconds(t *testing.T) {
+func TestCreateOpenAIReqClientForContext_Timeout120Seconds(t *testing.T) {
 	sharedReqClients = sync.Map{}
-	client, err := createOpenAIReqClient("http://proxy.local:8080")
+	client, err := createOpenAIReqClientForContext(context.Background(), "http://proxy.local:8080")
 	require.NoError(t, err)
 	require.Equal(t, 120*time.Second, client.GetClient().Timeout)
 }

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -758,7 +758,8 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		applyOpenAICodexProbeHeaders(req.Header)
 	}
 	if credentialAccount.IsOpenAIAgentIdentity() {
-		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
+		authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credentialAccount)
+		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
 		if authErr != nil {
 			return s.sendErrorAndEnd(c, "Failed to build Agent Identity authentication")
 		}
@@ -816,7 +817,8 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		body = redactAgentIdentitySensitiveBodyForAccount(ctx, s.accountRepo, credentialAccount, body)
 		if !agentIdentityTaskRecoveryWasTried(ctx) && credentialAccount.IsOpenAIAgentIdentity() && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, body) {
 			expectedTaskID := credentialAccount.GetCredential("task_id")
-			if err := ensureAgentIdentityTaskForAccount(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount, expectedTaskID); err != nil {
+			authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credentialAccount)
+			if err := ensureAgentIdentityTaskForAccount(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount, expectedTaskID); err != nil {
 				return s.sendErrorAndEnd(c, fmt.Sprintf("Agent Identity task recovery failed: %s", err.Error()))
 			}
 			c.Request = c.Request.WithContext(markAgentIdentityTaskRecoveryTried(ctx))
@@ -2096,7 +2098,8 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	req.Header.Set("Accept", "text/event-stream")
 	ensureOpenAIRemoteCompactionV2BetaFeature(req.Header)
 	if credentialAccount.IsOpenAIAgentIdentity() {
-		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
+		authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credentialAccount)
+		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
 		if authErr != nil {
 			return s.sendErrorAndEnd(c, "Failed to build Agent Identity authentication")
 		}
@@ -2150,7 +2153,8 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	body = redactAgentIdentitySensitiveBodyForAccount(ctx, s.accountRepo, credentialAccount, body)
 	if !agentIdentityTaskRecoveryWasTried(ctx) && credentialAccount.IsOpenAIAgentIdentity() && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, body) {
 		expectedTaskID := credentialAccount.GetCredential("task_id")
-		if err := ensureAgentIdentityTaskForAccount(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount, expectedTaskID); err != nil {
+		authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credentialAccount)
+		if err := ensureAgentIdentityTaskForAccount(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount, expectedTaskID); err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Agent Identity task recovery failed: %s", err.Error()))
 		}
 		c.Request = c.Request.WithContext(markAgentIdentityTaskRecoveryTried(ctx))
@@ -3005,7 +3009,8 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
 	req.Host = "chatgpt.com"
 	if credentialAccount.IsOpenAIAgentIdentity() {
-		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
+		authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credentialAccount)
+		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, credentialAccount)
 		if authErr != nil {
 			return s.sendErrorAndEnd(c, "Failed to build Agent Identity authentication")
 		}
@@ -3036,7 +3041,7 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 	if account.ProxyID != nil && account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	resp, err := s.doOpenAIAccountTestUpstream(req, proxyURL, account, false)
+	resp, err := s.doOpenAIAccountTestUpstream(req, proxyURL, credentialAccount, true)
 	if err != nil {
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Responses API request failed: %s", err.Error()))
 	}

--- a/backend/internal/service/account_test_service_openai_image_test.go
+++ b/backend/internal/service/account_test_service_openai_image_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -46,10 +47,61 @@ func TestAccountTestService_OpenAIImageOAuthHandlesOutputItemDoneFallback(t *tes
 	err := svc.testOpenAIImageOAuth(c, context.Background(), account, "gpt-image-2", "draw a cat")
 	require.NoError(t, err)
 	require.NotNil(t, upstream.lastReq)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.NotNil(t, upstream.lastTLSProfile)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.lastReq.Context()))
 	require.Contains(t, rec.Body.String(), "Calling Codex /responses image tool")
 	require.Contains(t, rec.Body.String(), "data:image/png;base64,aGVsbG8=")
 	require.Contains(t, rec.Body.String(), "\"success\":true")
+}
+
+func TestAccountTestService_OpenAIImageOAuthShadowUsesCredentialAccountTLSProfile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/1/test", nil)
+
+	parentID := int64(60)
+	shadowID := int64(61)
+	parent := &Account{
+		ID: parentID, Name: "parent", Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		Credentials: map[string]any{"access_token": "parent-token"},
+		Extra:       map[string]any{"tls_fingerprint_profile_id": int64(22)},
+	}
+	shadow := &Account{
+		ID: shadowID, Name: "shadow", Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		ParentAccountID: &parentID,
+		Extra:           map[string]any{"tls_fingerprint_profile_id": int64(11)},
+	}
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
+		parentID: parent,
+		shadowID: shadow,
+	}}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"ig_123\",\"type\":\"image_generation_call\",\"result\":\"aGVsbG8=\",\"output_format\":\"png\"}}\n\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000006,\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[]}}\n\n" +
+				"data: [DONE]\n\n",
+		)),
+	}}
+	tlsProfiles := &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+		11: {ID: 11, Name: "shadow-profile", CipherSuites: []uint16{0x1301}},
+		22: {ID: 22, Name: "credential-profile", CipherSuites: []uint16{0x1302}},
+	}}
+	svc := &AccountTestService{
+		accountRepo:         repo,
+		httpUpstream:        upstream,
+		tlsFPProfileService: tlsProfiles,
+	}
+
+	err := svc.testOpenAIImageOAuth(c, context.Background(), shadow, "gpt-image-2", "draw a cat")
+
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastTLSProfile)
+	require.Equal(t, "credential-profile", upstream.lastTLSProfile.Name)
 }
 
 func TestAccountTestService_OpenAIImageAPIKeyUsesConfiguredV1BaseURL(t *testing.T) {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -855,7 +855,8 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	req.Host = "chatgpt.com"
 	req.Header.Set("Content-Type", "application/json")
 	if account.IsOpenAIAgentIdentity() {
-		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, account)
+		authCtx := withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, account)
+		authHeaders, authErr := buildAgentIdentityAuthenticationHeaders(authCtx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, account)
 		if authErr != nil {
 			return nil, fmt.Errorf("build Agent Identity authentication: %w", authErr)
 		}
@@ -888,11 +889,7 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	if account.ProxyID != nil && account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	client, err := httppool.GetClient(httppool.Options{
-		ProxyURL:              proxyURL,
-		Timeout:               15 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-	})
+	client, err := httppool.GetClient(s.openAICodexProbeClientOptions(account, proxyURL))
 	if err != nil {
 		return nil, fmt.Errorf("build openai probe client: %w", err)
 	}
@@ -911,6 +908,21 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 		return updates, nil
 	}
 	return nil, nil
+}
+
+func (s *AccountUsageService) openAICodexProbeClientOptions(account *Account, proxyURL string) httppool.Options {
+	var profile *tlsfingerprint.Profile
+	if s != nil && s.tlsFPProfileService != nil {
+		profile = s.tlsFPProfileService.ResolveTLSProfile(account)
+	} else {
+		profile = (&TLSFingerprintProfileService{}).ResolveTLSProfile(account)
+	}
+	return httppool.Options{
+		ProxyURL:              proxyURL,
+		Timeout:               15 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		TLSProfile:            profile,
+	}
 }
 
 func (s *AccountUsageService) persistOpenAICodexProbeSnapshot(accountID int64, updates map[string]any) {

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/model"
 )
 
 type accountUsageCodexProbeRepo struct {
@@ -63,6 +65,32 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 		},
 	}, usage, now) {
 		t.Fatal("expected stale ws snapshot to trigger refresh")
+	}
+}
+
+func TestAccountUsageServiceOpenAICodexProbeClientOptionsUsesAccountTLSProfile(t *testing.T) {
+	const profileID int64 = 91
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"tls_fingerprint_profile_id": profileID},
+	}
+	svc := &AccountUsageService{
+		tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+			profileID: {ID: profileID, Name: "usage probe override", CipherSuites: []uint16{0x1301}},
+		}},
+	}
+
+	opts := svc.openAICodexProbeClientOptions(account, "http://proxy.local:8080")
+
+	if opts.ProxyURL != "http://proxy.local:8080" {
+		t.Fatalf("ProxyURL = %q, want configured proxy", opts.ProxyURL)
+	}
+	if opts.TLSProfile == nil {
+		t.Fatal("expected usage probe client options to carry an OpenAI TLS profile")
+	}
+	if opts.TLSProfile.Name != "usage probe override" {
+		t.Fatalf("TLS profile name = %q, want account override", opts.TLSProfile.Name)
 	}
 }
 

--- a/backend/internal/service/openai_agent_identity.go
+++ b/backend/internal/service/openai_agent_identity.go
@@ -189,6 +189,7 @@ func registerAgentIdentityTask(ctx context.Context, account *Account) (string, e
 		ProxyURL:              proxyURL,
 		Timeout:               agentIdentityTaskRegistrationTimeout,
 		ResponseHeaderTimeout: 15 * time.Second,
+		TLSProfile:            resolveOpenAIAuthTLSProfile(ctx),
 	})
 	if err != nil {
 		return "", errors.New("invalid proxy configuration for agent task registration")
@@ -317,6 +318,7 @@ func (s *OpenAIGatewayService) ensureAgentIdentityTask(ctx context.Context, acco
 	if s == nil {
 		return errors.New("openai gateway service is nil")
 	}
+	ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, account)
 	return ensureAgentIdentityTaskForAccount(ctx, s.accountRepo, s, &s.agentIdentityTaskMu, account, expectedTaskID)
 }
 
@@ -382,6 +384,7 @@ func (s *OpenAIGatewayService) buildOpenAIAuthenticationHeaders(ctx context.Cont
 	}
 	headers := make(http.Header)
 	if credAccount != nil && credAccount.IsOpenAIAgentIdentity() {
+		ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credAccount)
 		agentHeaders, err := buildAgentIdentityAuthenticationHeaders(ctx, s.accountRepo, s, &s.agentIdentityTaskMu, credAccount)
 		if err != nil {
 			return nil, err
@@ -427,6 +430,7 @@ func (s *OpenAIGatewayService) refreshOpenAIAgentIdentityHeaders(ctx context.Con
 	if !credAccount.IsOpenAIAgentIdentity() {
 		return cloneHeader(headers), nil
 	}
+	ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, credAccount)
 	refreshed := cloneHeader(headers)
 	if refreshed == nil {
 		refreshed = make(http.Header)

--- a/backend/internal/service/openai_agent_identity_test.go
+++ b/backend/internal/service/openai_agent_identity_test.go
@@ -16,10 +16,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/nacl/box"
 )
+
+func TestResolveOpenAIAuthTLSProfileDefaultsAndHonorsContext(t *testing.T) {
+	defaultProfile := resolveOpenAIAuthTLSProfile(context.Background())
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, defaultProfile.Preset)
+
+	override := &tlsfingerprint.Profile{Name: "agent override", CipherSuites: []uint16{0x1301}}
+	ctx := WithOpenAIUpstreamTLSProfile(context.Background(), override)
+	require.Same(t, override, resolveOpenAIAuthTLSProfile(ctx))
+}
 
 func newTestAgentIdentityKey(t *testing.T) (agentIdentityKey, string) {
 	t.Helper()

--- a/backend/internal/service/openai_alpha_search_test.go
+++ b/backend/internal/service/openai_alpha_search_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -102,6 +103,9 @@ func TestForwardAlphaSearchOAuthPreservesWire(t *testing.T) {
 		gjson.Get(upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"), "turn_id").String(),
 	)
 	require.JSONEq(t, string(body), string(upstream.lastBody))
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 }
 
 func TestForwardAlphaSearchPATUsesResponsesWebSearchFallback(t *testing.T) {
@@ -181,6 +185,9 @@ func TestForwardAlphaSearchPATUsesResponsesWebSearchFallback(t *testing.T) {
 	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Bool())
 	require.Equal(t, "web_search", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
 	require.Contains(t, gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String(), `"search_query"`)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 }
 
 func TestForwardAlphaSearchPATBackfillsMissingChatGPTAccountMetadata(t *testing.T) {

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -1653,7 +1653,13 @@ func (s *OpenAIGatewayService) fetchCodexModelsManifestUpstream(ctx context.Cont
 			return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_UPSTREAM_NOT_CONFIGURED", "Codex models upstream HTTP client is not configured")
 		}
 		req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
-		resp, err = s.httpUpstream.Do(req, request.proxyURL, request.accountID, request.accountConcurrency)
+		resp, err = s.httpUpstream.DoWithTLS(
+			req,
+			request.proxyURL,
+			request.accountID,
+			request.accountConcurrency,
+			s.resolveHTTPUpstreamTLSProfile(request.credentialAccount),
+		)
 	} else {
 		handled := false
 		if s.pluginManager != nil {
@@ -1664,6 +1670,7 @@ func (s *OpenAIGatewayService) fetchCodexModelsManifestUpstream(ctx context.Cont
 				ProxyURL:              request.proxyURL,
 				Timeout:               codexModelsManifestRequestTimeout,
 				ResponseHeaderTimeout: 10 * time.Second,
+				TLSProfile:            s.resolveHTTPUpstreamTLSProfile(request.credentialAccount),
 			})
 			if clientErr != nil {
 				return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_PROXY_INVALID", "invalid proxy configuration: %v", clientErr)

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
@@ -26,7 +27,10 @@ import (
 )
 
 type codexModelsHTTPUpstreamStub struct {
-	do func(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error)
+	do       func(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error)
+	profile  *tlsfingerprint.Profile
+	doCalls  int
+	tlsCalls int
 }
 
 type codexModelsVisibilityAccountRepo struct {
@@ -1209,11 +1213,14 @@ func (b *codexModelsBlockingBody) Read(p []byte) (int, error) {
 func (b *codexModelsBlockingBody) Close() error { return nil }
 
 func (s *codexModelsHTTPUpstreamStub) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	s.doCalls++
 	return s.do(req, proxyURL, accountID, accountConcurrency)
 }
 
-func (s *codexModelsHTTPUpstreamStub) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
-	return s.Do(req, proxyURL, accountID, accountConcurrency)
+func (s *codexModelsHTTPUpstreamStub) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	s.tlsCalls++
+	s.profile = profile
+	return s.do(req, proxyURL, accountID, accountConcurrency)
 }
 
 func TestIsRetryableCodexModelsManifestTransportError(t *testing.T) {
@@ -1616,9 +1623,14 @@ func TestFetchCodexModelsManifestAPIKeyCustomUpstream(t *testing.T) {
 	}}
 
 	s := newCodexModelsAPIKeyTestService(upstream)
+	s.tlsFPProfileService = &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+		75: {ID: 75, Name: "models custom base override", CipherSuites: []uint16{0x1301}},
+	}}
+	account := newCodexModelsAPIKeyTestAccount("https://upstream.example/v1")
+	account.Extra = map[string]any{"tls_fingerprint_profile_id": int64(75)}
 	manifest, err := s.FetchCodexModelsManifest(
 		context.Background(),
-		newCodexModelsAPIKeyTestAccount("https://upstream.example/v1"),
+		account,
 		"0.144.0",
 		"",
 	)
@@ -1660,6 +1672,12 @@ func TestFetchCodexModelsManifestAPIKeyCustomUpstream(t *testing.T) {
 	require.EqualValues(t, 1_000_000, models[0]["context_window"])
 	require.Equal(t, codexModelsManifestBodyETag(manifest.Body), manifest.ETag)
 	require.Equal(t, `W/"api-key-manifest"`, manifest.upstreamETag)
+	if upstream.doCalls != 0 || upstream.tlsCalls != 1 {
+		t.Fatalf("expected one TLS-aware upstream call, do=%d tls=%d", upstream.doCalls, upstream.tlsCalls)
+	}
+	if upstream.profile == nil || upstream.profile.Name != "models custom base override" {
+		t.Fatalf("expected configured OpenAI TLS profile, got %#v", upstream.profile)
+	}
 }
 
 // Scenario: 完整上游清单没有 ETag 时，最终正文仍生成强 ETag 并支持 304。

--- a/backend/internal/service/openai_codex_pat_service.go
+++ b/backend/internal/service/openai_codex_pat_service.go
@@ -47,6 +47,7 @@ func (s *OpenAIOAuthService) ValidateCodexPersonalAccessToken(ctx context.Contex
 		ProxyURL:              proxyURL,
 		Timeout:               20 * time.Second,
 		ResponseHeaderTimeout: 15 * time.Second,
+		TLSProfile:            resolveOpenAIAuthTLSProfile(ctx),
 	})
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadRequest, "OPENAI_CODEX_PAT_PROXY_INVALID", "invalid proxy configuration: %v", err)

--- a/backend/internal/service/openai_embeddings_test.go
+++ b/backend/internal/service/openai_embeddings_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -70,6 +71,9 @@ func TestForwardEmbeddings_APIKeyPassthroughRecordsUsageAndBatchInput(t *testing
 	svc := &OpenAIGatewayService{
 		cfg:          &config.Config{},
 		httpUpstream: upstream,
+		tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+			73: {ID: 73, Name: "embeddings custom base override", CipherSuites: []uint16{0x1301}},
+		}},
 	}
 	account := &Account{
 		ID:       42,
@@ -82,6 +86,7 @@ func TestForwardEmbeddings_APIKeyPassthroughRecordsUsageAndBatchInput(t *testing
 				"nowledge-embedding": "jina-embeddings-v5-text-small",
 			},
 		},
+		Extra: map[string]any{"tls_fingerprint_profile_id": int64(73)},
 	}
 
 	result, err := svc.ForwardEmbeddings(context.Background(), c, account, reqBody, "")
@@ -103,6 +108,10 @@ func TestForwardEmbeddings_APIKeyPassthroughRecordsUsageAndBatchInput(t *testing
 	require.Equal(t, "world", gjson.GetBytes(upstream.lastBody, "input.1").String())
 	require.Equal(t, "float", gjson.GetBytes(upstream.lastBody, "encoding_format").String())
 	require.Equal(t, int64(256), gjson.GetBytes(upstream.lastBody, "dimensions").Int())
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.NotNil(t, upstream.lastTLSProfile)
+	require.Equal(t, "embeddings custom base override", upstream.lastTLSProfile.Name)
 }
 
 func TestForwardEmbeddings_AccessStateUsesTypedFailover(t *testing.T) {

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -83,6 +84,9 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesI
 	require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.True(t, gjson.GetBytes(upstream.lastBody, "input").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "messages").Exists())
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 }
 
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPlatformEndpointUnsupported(t *testing.T) {
@@ -163,6 +167,9 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPl
 			require.Equal(t, "https://api.openai.com/v1/responses/input_tokens", upstream.lastReq.URL.String())
 			require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("authorization"))
 			require.Empty(t, upstream.lastReq.Header.Get("Chatgpt-Account-Id"))
+			require.Zero(t, upstream.doCalls)
+			require.Equal(t, 1, upstream.doWithTLSCalls)
+			require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 			require.Zero(t, repo.tempUnschedCalls, "OAuth input_tokens unsupported errors must not temp-unschedule the account")
 			require.Zero(t, repo.setErrorCalls, "OAuth input_tokens unsupported errors must not mark the account error")
 		})

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -163,6 +164,9 @@ func TestForwardAsAnthropic_ForceChatCompletionsNonStreaming(t *testing.T) {
 	require.Equal(t, 2, result.Usage.OutputTokens)
 	require.Equal(t, 1, result.Usage.CacheReadInputTokens)
 	require.False(t, result.Stream)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 }
 
 // Covers the fully-new streaming composition: text block is still open when

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -438,6 +438,7 @@ type OpenAIGatewayService struct {
 	userGroupRateResolver *userGroupRateResolver
 	httpUpstream          HTTPUpstream
 	pluginManager         *PluginManager
+	tlsFPProfileService   *TLSFingerprintProfileService
 	deferredService       *DeferredService
 	openAITokenProvider   *OpenAITokenProvider
 	grokTokenProvider     *GrokTokenProvider

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
@@ -848,6 +850,9 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
 	require.Equal(t, "acct-123", upstream.lastReq.Header.Get("chatgpt-account-id"))
 	require.Equal(t, "responses=experimental", upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 
 	require.Equal(t, openAIImagesResponsesMainModel, gjson.GetBytes(upstream.lastBody, "model").String())
 	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
@@ -1349,6 +1354,9 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyGenerationUsesConfiguredV1BaseU
 
 	svc := &OpenAIGatewayService{
 		cfg: &config.Config{},
+		tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+			74: {ID: 74, Name: "images custom base override", CipherSuites: []uint16{0x1301}},
+		}},
 		httpUpstream: &httpUpstreamRecorder{
 			resp: &http.Response{
 				StatusCode: http.StatusOK,
@@ -1372,6 +1380,7 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyGenerationUsesConfiguredV1BaseU
 			"api_key":  "test-api-key",
 			"base_url": "https://image-upstream.example/v1",
 		},
+		Extra: map[string]any{"tls_fingerprint_profile_id": int64(74)},
 	}
 
 	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
@@ -1388,6 +1397,9 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyGenerationUsesConfiguredV1BaseU
 	require.Equal(t, "Bearer test-api-key", upstream.lastReq.Header.Get("Authorization"))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
 	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, "images custom base override", upstream.lastTLSProfile.Name)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "aGVsbG8=", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 }

--- a/backend/internal/service/openai_live.go
+++ b/backend/internal/service/openai_live.go
@@ -451,7 +451,14 @@ func (s *OpenAIGatewayService) dialLiveSideband(ctx context.Context, record *Liv
 		return nil, err
 	}
 	target := strings.TrimRight(chatGPTLiveSidebandBaseURL, "/") + "/" + url.PathEscape(record.CallID)
-	conn, status, _, err := s.getOpenAIWSPassthroughDialer().Dial(ctx, target, headers, resolveAccountProxyURL(account))
+	conn, status, _, err := dialOpenAIWSClient(
+		s.getOpenAIWSPassthroughDialer(),
+		ctx,
+		target,
+		headers,
+		resolveAccountProxyURL(account),
+		s.resolveHTTPUpstreamTLSProfile(account),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("dial live sideband (status %d): %w", status, err)
 	}

--- a/backend/internal/service/openai_live_lifecycle_test.go
+++ b/backend/internal/service/openai_live_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	coderws "github.com/coder/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +86,18 @@ type liveTestDialer struct {
 	conn    *liveTestFrameConn
 	url     string
 	headers http.Header
+	profile *tlsfingerprint.Profile
+}
+
+func (d *liveTestDialer) DialWithTLS(
+	ctx context.Context,
+	wsURL string,
+	headers http.Header,
+	proxyURL string,
+	profile *tlsfingerprint.Profile,
+) (openAIWSClientConn, int, http.Header, error) {
+	d.profile = profile
+	return d.Dial(ctx, wsURL, headers, proxyURL)
 }
 
 func (d *liveTestDialer) Dial(
@@ -426,6 +439,8 @@ func TestProxyLiveSidebandForwardsTextAndBinary(t *testing.T) {
 	require.Equal(t, "Bearer test-access-token", dialer.headers.Get("Authorization"))
 	require.Equal(t, "acct_test", dialer.headers.Get("Chatgpt-Account-Id"))
 	require.Equal(t, `{"v":1,"s":0,"t":"v1.sideband"}`, dialer.headers.Get(liveAttestationHeader))
+	require.NotNil(t, dialer.profile)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, dialer.profile.Preset)
 	upstream.reads <- liveTestFrame{err: coderws.CloseError{Code: coderws.StatusNormalClosure}}
 	require.ErrorIs(t, <-proxyResult, ErrLiveCallNotFound)
 }

--- a/backend/internal/service/openai_live_test.go
+++ b/backend/internal/service/openai_live_test.go
@@ -17,8 +17,11 @@ import (
 )
 
 type liveHTTPUpstreamStub struct {
-	request *http.Request
-	body    []byte
+	request  *http.Request
+	body     []byte
+	profile  *tlsfingerprint.Profile
+	doCalls  int
+	tlsCalls int
 }
 
 type liveAttestationStub struct {
@@ -40,6 +43,7 @@ func (s *liveHTTPUpstreamStub) Do(
 	_ int64,
 	_ int,
 ) (*http.Response, error) {
+	s.doCalls++
 	s.request = request
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
@@ -60,9 +64,13 @@ func (s *liveHTTPUpstreamStub) DoWithTLS(
 	proxyURL string,
 	accountID int64,
 	accountConcurrency int,
-	_ *tlsfingerprint.Profile,
+	profile *tlsfingerprint.Profile,
 ) (*http.Response, error) {
-	return s.Do(request, proxyURL, accountID, accountConcurrency)
+	s.tlsCalls++
+	s.profile = profile
+	resp, err := s.Do(request, proxyURL, accountID, accountConcurrency)
+	s.doCalls--
+	return resp, err
 }
 
 func TestLiveCapabilityOnlyAllowsOpenAIOAuth(t *testing.T) {
@@ -123,6 +131,9 @@ func TestCreateUpstreamLiveCallPreservesSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "call_test", created.CallID)
 	require.Equal(t, []byte("v=0\r\n"), created.SDP)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.tlsCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.profile.Preset)
 
 	var forwarded struct {
 		SDP     string          `json:"sdp"`

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -27,11 +28,14 @@ import (
 func f64p(v float64) *float64 { return &v }
 
 type httpUpstreamRecorder struct {
-	lastReq      *http.Request
-	lastBody     []byte
-	lastProxyURL string
-	requests     []*http.Request
-	bodies       [][]byte
+	lastReq        *http.Request
+	lastBody       []byte
+	lastProxyURL   string
+	lastTLSProfile *tlsfingerprint.Profile
+	doCalls        int
+	doWithTLSCalls int
+	requests       []*http.Request
+	bodies         [][]byte
 
 	resp      *http.Response
 	responses []*http.Response
@@ -64,6 +68,11 @@ func (r passthroughErrReadCloser) Close() error {
 }
 
 func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	u.doCalls++
+	return u.record(req, proxyURL)
+}
+
+func (u *httpUpstreamRecorder) record(req *http.Request, proxyURL string) (*http.Response, error) {
 	u.lastReq = req
 	u.lastProxyURL = proxyURL
 	if req != nil && req.Body != nil {
@@ -86,7 +95,9 @@ func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID 
 }
 
 func (u *httpUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
-	return u.Do(req, proxyURL, accountID, accountConcurrency)
+	u.doWithTLSCalls++
+	u.lastTLSProfile = profile
+	return u.record(req, proxyURL)
 }
 
 func TestOpenAIGatewayService_ResponsesUnknownModelDoesNotFallbackToGPT54(t *testing.T) {
@@ -417,19 +428,25 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 	svc := &OpenAIGatewayService{
 		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
 		httpUpstream: upstream,
+		tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+			17: {ID: 17, Name: "operator compact override", CipherSuites: []uint16{0x1301}},
+		}},
 		openAITokenProvider: &OpenAITokenProvider{ // minimal: will be bypassed by nil cache/service, but GetAccessToken uses provider only if non-nil
 			accountRepo: nil,
 		},
 	}
 
 	account := &Account{
-		ID:             123,
-		Name:           "acc",
-		Platform:       PlatformOpenAI,
-		Type:           AccountTypeOAuth,
-		Concurrency:    1,
-		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
-		Extra:          map[string]any{"openai_passthrough": true},
+		ID:          123,
+		Name:        "acc",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra: map[string]any{
+			"openai_passthrough":         true,
+			"tls_fingerprint_profile_id": int64(17),
+		},
 		Status:         StatusActive,
 		Schedulable:    true,
 		RateMultiplier: f64p(1),
@@ -442,6 +459,10 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, "operator compact override", upstream.lastTLSProfile.Name)
+	require.Empty(t, upstream.lastTLSProfile.Preset)
 
 	// 1) 透传 OAuth 请求体与旧链路关键行为保持一致：store=false + stream=true。
 	require.Equal(t, false, gjson.GetBytes(upstream.lastBody, "store").Bool())
@@ -794,6 +815,9 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.Stream)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 
 	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "stream").Exists())
@@ -941,6 +965,9 @@ func TestOpenAIGatewayService_OAuthPassthrough_DisabledUsesLegacyTransform(t *te
 
 	_, err := svc.Forward(context.Background(), c, account, inputBody)
 	require.NoError(t, err)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, upstream.lastTLSProfile.Preset)
 
 	// legacy path rewrites request body (not byte-equal)
 	require.NotEqual(t, inputBody, upstream.lastBody)
@@ -2190,6 +2217,66 @@ func TestOpenAIGatewayService_CodexFingerprintMessagesBridgeDoesNotInjectBodyPro
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
 	require.Equal(t, wantSession, gjson.GetBytes(upstream.lastBody, "client_metadata.session_id").String())
 	require.Equal(t, wantSession, upstream.lastReq.Header.Get("session_id"))
+}
+
+func TestOpenAIGatewayService_OpenAICompatibilityHTTPPathsUseConfiguredTLSProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		body    []byte
+		forward func(*OpenAIGatewayService, *gin.Context, *Account, []byte) (*OpenAIForwardResult, error)
+	}{
+		{
+			name: "chat completions bridge",
+			path: "/v1/chat/completions",
+			body: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}]}`),
+			forward: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
+				return svc.ForwardAsChatCompletions(context.Background(), c, account, body, "chat-tls-profile", "")
+			},
+		},
+		{
+			name: "anthropic messages bridge",
+			path: "/v1/messages",
+			body: []byte(`{"model":"gpt-5.5","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`),
+			forward: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
+				return svc.ForwardAsAnthropic(context.Background(), c, account, body, "messages-tls-profile", "")
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, tt.path, bytes.NewReader(tt.body))
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after request capture"}}`)),
+			}}
+			svc := &OpenAIGatewayService{
+				cfg:           &config.Config{},
+				httpUpstream:  upstream,
+				toolCorrector: NewCodexToolCorrector(),
+				tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+					17: {ID: 17, Name: "operator compatibility override", CipherSuites: []uint16{0x1301}},
+				}},
+			}
+			account := newTestOAuthAccount(int64(6200+i), map[string]any{
+				codexFingerprintModeExtraKey: "off",
+				"tls_fingerprint_profile_id": int64(17),
+			})
+			account.Credentials = map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-account"}
+			account.Status, account.Schedulable, account.Concurrency = StatusActive, true, 1
+
+			_, _ = tt.forward(svc, c, account, tt.body)
+
+			require.Zero(t, upstream.doCalls)
+			require.Equal(t, 1, upstream.doWithTLSCalls)
+			require.NotNil(t, upstream.lastTLSProfile)
+			require.Equal(t, "operator compatibility override", upstream.lastTLSProfile.Name)
+		})
+	}
 }
 
 func TestOpenAIGatewayService_CodexCLIOnly_RejectsNonCodexClient(t *testing.T) {

--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -18,6 +18,7 @@ type OpenAIOAuthService struct {
 	proxyRepo            ProxyRepository
 	oauthClient          OpenAIOAuthClient
 	privacyClientFactory PrivacyClientFactory // 用于调用 chatgpt.com/backend-api（ImpersonateChrome）
+	tlsFPProfileService  *TLSFingerprintProfileService
 }
 
 // NewOpenAIOAuthService creates a new OpenAI OAuth service
@@ -343,6 +344,7 @@ func (s *OpenAIOAuthService) RefreshAccountToken(ctx context.Context, account *A
 	if account.Type != AccountTypeOAuth {
 		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_OAUTH_INVALID_ACCOUNT_TYPE", "account is not an OAuth account")
 	}
+	ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, account)
 
 	var proxyURL string
 	if account.ProxyID != nil && s.proxyRepo != nil {

--- a/backend/internal/service/openai_oauth_service_refresh_test.go
+++ b/backend/internal/service/openai_oauth_service_refresh_test.go
@@ -9,13 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
 
 type openaiOAuthClientRefreshStub struct {
 	refreshCalls int32
+	lastProfile  *tlsfingerprint.Profile
 }
 
 func (s *openaiOAuthClientRefreshStub) ExchangeCode(ctx context.Context, code, codeVerifier, redirectURI, proxyURL, clientID string) (*openai.TokenResponse, error) {
@@ -29,7 +32,28 @@ func (s *openaiOAuthClientRefreshStub) RefreshToken(ctx context.Context, refresh
 
 func (s *openaiOAuthClientRefreshStub) RefreshTokenWithClientID(ctx context.Context, refreshToken, proxyURL string, clientID string) (*openai.TokenResponse, error) {
 	atomic.AddInt32(&s.refreshCalls, 1)
-	return nil, errors.New("not implemented")
+	s.lastProfile = OpenAIUpstreamTLSProfileFromContext(ctx)
+	return &openai.TokenResponse{AccessToken: "refreshed", RefreshToken: "rotated", ExpiresIn: 3600}, nil
+}
+
+func TestOpenAIOAuthService_RefreshAccountTokenPassesConfiguredTLSProfile(t *testing.T) {
+	client := &openaiOAuthClientRefreshStub{}
+	svc := NewOpenAIOAuthService(nil, client)
+	svc.tlsFPProfileService = &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+		81: {ID: 81, Name: "oauth override", CipherSuites: []uint16{0x1301}},
+	}}
+	account := &Account{
+		ID: 81, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		Credentials: map[string]any{"refresh_token": "rt", "client_id": "client"},
+		Extra:       map[string]any{"tls_fingerprint_profile_id": int64(81)},
+	}
+
+	info, err := svc.RefreshAccountToken(context.Background(), account)
+
+	require.NoError(t, err)
+	require.Equal(t, "refreshed", info.AccessToken)
+	require.NotNil(t, client.lastProfile)
+	require.Equal(t, "oauth override", client.lastProfile.Name)
 }
 
 func TestOpenAIOAuthService_RefreshAccountToken_NoRefreshTokenUsesExistingAccessToken(t *testing.T) {

--- a/backend/internal/service/openai_plugin_transport.go
+++ b/backend/internal/service/openai_plugin_transport.go
@@ -8,6 +8,7 @@ func (s *OpenAIGatewayService) SetPluginManager(manager *PluginManager) {
 
 // doOpenAIUpstream 只在 OpenAI OAuth 能力绑定已启用时把真实请求交给插件。
 // 插件返回标准 http.Response，响应解析、错误映射、SSE 和计费仍由现有核心链处理。
+// 未命中插件时按账号解析 TLS/H2 指纹配置出站（无配置时与 Do 等价）。
 func (s *OpenAIGatewayService) doOpenAIUpstream(request *http.Request, proxyURL string, account *Account) (*http.Response, error) {
 	if s.pluginManager != nil {
 		response, handled, err := s.pluginManager.RoundTripOpenAIOAuth(request.Context(), request, proxyURL, account)
@@ -15,7 +16,7 @@ func (s *OpenAIGatewayService) doOpenAIUpstream(request *http.Request, proxyURL 
 			return response, err
 		}
 	}
-	return s.httpUpstream.Do(request, proxyURL, account.ID, account.Concurrency)
+	return s.httpUpstream.DoWithTLS(request, proxyURL, account.ID, account.Concurrency, s.resolveHTTPUpstreamTLSProfile(account))
 }
 
 // doOpenAIAccountTestUpstream 让 OpenAI OAuth 账号测试与真实转发使用同一插件路径。

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -12,8 +12,14 @@ import (
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/imroc/req/v3"
 )
+
+// OpenAITLSProfileClientFactory creates a req client whose TLS handshake uses
+// the already-resolved account profile. It is separate from PrivacyClientFactory
+// so existing privacy/browser impersonation callers retain their behavior.
+type OpenAITLSProfileClientFactory func(proxyURL string, profile *tlsfingerprint.Profile) (*req.Client, error)
 
 // ErrSparkShadowResetNotSupported is returned when ResetCredit is called on a
 // spark shadow account. Shadow accounts do not hold credentials of their own;
@@ -112,15 +118,17 @@ type OpenAIQuotaResetResult struct {
 }
 
 // OpenAIQuotaService queries and consumes ChatGPT/Codex rate-limit reset credits
-// for OpenAI OAuth accounts. It reuses the privacy client factory so all calls
-// flow through the impersonated HTTP client (Cloudflare-friendly TLS fingerprint).
+// for OpenAI OAuth accounts. Production calls use an account-profile-aware req
+// client; the privacy factory remains as a compatibility fallback for embedders.
 type OpenAIQuotaService struct {
-	accountRepo          AccountRepository
-	proxyRepo            ProxyRepository
-	tokenProvider        *OpenAITokenProvider
-	privacyClientFactory PrivacyClientFactory
-	agentIdentityTaskMu  sync.Mutex
-	agentIdentityWS      agentIdentityWSConnectionInvalidator
+	accountRepo             AccountRepository
+	proxyRepo               ProxyRepository
+	tokenProvider           *OpenAITokenProvider
+	privacyClientFactory    PrivacyClientFactory
+	tlsProfileClientFactory OpenAITLSProfileClientFactory
+	tlsFPProfileService     *TLSFingerprintProfileService
+	agentIdentityTaskMu     sync.Mutex
+	agentIdentityWS         agentIdentityWSConnectionInvalidator
 }
 
 // NewOpenAIQuotaService constructs a quota service. token provider is required —
@@ -144,12 +152,12 @@ func NewOpenAIQuotaService(
 // OAuth account. Returns infraerrors so the handler layer can map them to
 // stable error codes / HTTP statuses.
 func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error) {
-	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
+	account, accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := s.privacyClientFactory(proxyURL)
+	client, err := s.newQuotaClient(account, proxyURL)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_CLIENT_ERROR", "failed to build upstream client: %v", err)
 	}
@@ -336,12 +344,12 @@ func (s *OpenAIQuotaService) resetCredit(ctx context.Context, accountID int64, c
 		}
 	}
 
-	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
+	account, accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := s.privacyClientFactory(proxyURL)
+	client, err := s.newQuotaClient(account, proxyURL)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_CLIENT_ERROR", "failed to build upstream client: %v", err)
 	}
@@ -398,26 +406,41 @@ func (s *OpenAIQuotaService) resetCredit(ctx context.Context, accountID int64, c
 	return &payload, nil
 }
 
+func (s *OpenAIQuotaService) newQuotaClient(account *Account, proxyURL string) (*req.Client, error) {
+	if s != nil && s.tlsProfileClientFactory != nil {
+		var profile *tlsfingerprint.Profile
+		if s.tlsFPProfileService != nil {
+			profile = s.tlsFPProfileService.ResolveTLSProfile(account)
+		} else {
+			profile = (&TLSFingerprintProfileService{}).ResolveTLSProfile(account)
+		}
+		return s.tlsProfileClientFactory(proxyURL, profile)
+	}
+	return s.privacyClientFactory(proxyURL)
+}
+
 // prepareUpstreamCall loads the account, validates it, obtains a fresh access
 // token via the shared TokenProvider, and resolves the chatgpt-account-id and
-// proxy URL. Centralized so QueryUsage / ResetCredit share validation.
-func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID int64) (accessToken, chatGPTAccountID, proxyURL string, fedRAMP bool, err error) {
+// proxy URL. It returns the resolved credential account so the caller can reuse
+// the same row when selecting a TLS profile. Centralized so QueryUsage /
+// ResetCredit share validation.
+func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID int64) (account *Account, accessToken, chatGPTAccountID, proxyURL string, fedRAMP bool, err error) {
 	if s == nil || s.accountRepo == nil || s.privacyClientFactory == nil {
-		return "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota service is not configured")
+		return nil, "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota service is not configured")
 	}
 
-	account, err := s.accountRepo.GetByID(ctx, accountID)
+	account, err = s.accountRepo.GetByID(ctx, accountID)
 	if err != nil {
-		return "", "", "", false, infraerrors.Newf(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found: %v", err)
+		return nil, "", "", "", false, infraerrors.Newf(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found: %v", err)
 	}
 	if account == nil {
-		return "", "", "", false, infraerrors.New(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found")
+		return nil, "", "", "", false, infraerrors.New(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found")
 	}
 	if account.Platform != PlatformOpenAI {
-		return "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_PLATFORM", "account is not an OpenAI account")
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_PLATFORM", "account is not an OpenAI account")
 	}
 	if account.Type != AccountTypeOAuth {
-		return "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_TYPE", "account is not an OAuth account")
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_TYPE", "account is not an OAuth account")
 	}
 
 	// Spark shadow accounts do not hold their own credentials; resolve to the
@@ -426,7 +449,7 @@ func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID 
 	if account.IsShadow() {
 		resolved, rerr := resolveCredentialAccount(ctx, s.accountRepo, account)
 		if rerr != nil {
-			return "", "", "", false, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_SHADOW_RESOLVE_FAILED", "failed to resolve shadow account: %v", rerr)
+			return nil, "", "", "", false, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_SHADOW_RESOLVE_FAILED", "failed to resolve shadow account: %v", rerr)
 		}
 		account = resolved
 	}
@@ -437,19 +460,19 @@ func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID 
 		chatGPTAccountID = strings.TrimSpace(account.GetCredential("organization_id"))
 	}
 	if chatGPTAccountID == "" {
-		return "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_MISSING_ACCOUNT_ID", "chatgpt_account_id is missing; please re-authorize this account")
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_MISSING_ACCOUNT_ID", "chatgpt_account_id is missing; please re-authorize this account")
 	}
 
 	if !account.IsOpenAIAgentIdentity() {
 		if s.tokenProvider == nil {
-			return "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota token provider is not configured")
+			return nil, "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota token provider is not configured")
 		}
 		accessToken, err = s.tokenProvider.GetAccessToken(ctx, account)
 		if err != nil {
-			return "", "", "", false, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_TOKEN_UNAVAILABLE", "failed to acquire access token: %v", err)
+			return nil, "", "", "", false, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_TOKEN_UNAVAILABLE", "failed to acquire access token: %v", err)
 		}
 		if strings.TrimSpace(accessToken) == "" {
-			return "", "", "", false, infraerrors.New(http.StatusBadGateway, "OPENAI_QUOTA_TOKEN_UNAVAILABLE", "access token is empty")
+			return nil, "", "", "", false, infraerrors.New(http.StatusBadGateway, "OPENAI_QUOTA_TOKEN_UNAVAILABLE", "access token is empty")
 		}
 	}
 	fedRAMP = account.IsChatGPTAccountFedRAMP()
@@ -470,7 +493,7 @@ func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID 
 		}
 	}
 
-	return accessToken, chatGPTAccountID, proxyURL, fedRAMP, nil
+	return account, accessToken, chatGPTAccountID, proxyURL, fedRAMP, nil
 }
 
 func (s *OpenAIQuotaService) recoverAgentIdentityTask(ctx context.Context, accountID int64, expectedTaskID string) error {
@@ -490,6 +513,7 @@ func (s *OpenAIQuotaService) recoverAgentIdentityTask(ctx context.Context, accou
 	if !account.IsOpenAIAgentIdentity() {
 		return nil
 	}
+	ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, account)
 	return ensureAgentIdentityTaskForAccount(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, account, expectedTaskID)
 }
 
@@ -532,6 +556,7 @@ func (s *OpenAIQuotaService) buildCodexQuotaHeaders(ctx context.Context, account
 	if !account.IsOpenAIAgentIdentity() {
 		return headers, "", nil
 	}
+	ctx = withOpenAIAccountTLSProfile(ctx, s.tlsFPProfileService, account)
 	if err := ensureAgentIdentityTaskForAccount(ctx, s.accountRepo, s.agentIdentityWS, &s.agentIdentityTaskMu, account, ""); err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -13,9 +13,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 
@@ -31,9 +34,11 @@ type stubQuotaAccountRepo struct {
 	extraUpdates     map[int64]map[string]any
 	extraUpdateCalls int
 	extraUpdateErr   error
+	getByIDCalls     atomic.Int64
 }
 
 func (r *stubQuotaAccountRepo) GetByID(_ context.Context, id int64) (*Account, error) {
+	r.getByIDCalls.Add(1)
 	acc, ok := r.accounts[id]
 	if !ok {
 		return nil, fmt.Errorf("account %d not found", id)
@@ -378,7 +383,7 @@ func TestPrepareUpstreamCallShadowResolve(t *testing.T) {
 		return req.C(), nil
 	})
 
-	_, chatGPTAccountID, _, _, err := svc.prepareUpstreamCall(ctx, 200)
+	_, _, chatGPTAccountID, _, _, err := svc.prepareUpstreamCall(ctx, 200)
 	require.NoError(t, err, "shadow resolve should succeed; got error: %v", err)
 	require.Equal(t, "org-parent123", chatGPTAccountID,
 		"prepareUpstreamCall should use parent's chatgpt_account_id after shadow resolve")
@@ -537,6 +542,7 @@ func TestQueryUsageIncludesResetCreditExpirations_EndToEnd(t *testing.T) {
 		Credentials: map[string]any{
 			"chatgpt_account_id": "org-parent123",
 		},
+		Extra: map[string]any{"tls_fingerprint_profile_id": int64(76)},
 	}
 	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{100: account}}
 	tokenCache := &stubQuotaTokenCache{tokens: map[string]string{
@@ -565,6 +571,14 @@ func TestQueryUsageIncludesResetCreditExpirations_EndToEnd(t *testing.T) {
 	defer srv.Close()
 
 	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	svc.tlsFPProfileService = &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+		76: {ID: 76, Name: "quota account override", CipherSuites: []uint16{0x1301}},
+	}}
+	var capturedProfile *tlsfingerprint.Profile
+	svc.tlsProfileClientFactory = func(proxyURL string, profile *tlsfingerprint.Profile) (*req.Client, error) {
+		capturedProfile = profile
+		return newQuotaRedirectingFactory(srv)(proxyURL)
+	}
 	usage, err := svc.QueryUsage(ctx, 100)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
@@ -572,6 +586,9 @@ func TestQueryUsageIncludesResetCreditExpirations_EndToEnd(t *testing.T) {
 	require.Equal(t, 2, usage.RateLimitResetCredits.AvailableCount)
 	require.Equal(t, 1, detailCalls)
 	require.Equal(t, openaiQuotaCodexBeta, capturedBeta)
+	require.NotNil(t, capturedProfile)
+	require.Equal(t, "quota account override", capturedProfile.Name)
+	require.Equal(t, int64(4), repo.getByIDCalls.Load(), "quota query should reuse the account loaded by prepareUpstreamCall when building its client")
 	require.Equal(t, []OpenAIRateLimitResetCreditDetail{
 		{ExpiresAt: "2026-07-03T04:05:06Z"},
 		{ExpiresAt: "2026-07-04T04:05:06Z"},

--- a/backend/internal/service/openai_ws_client.go
+++ b/backend/internal/service/openai_ws_client.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	openaiwsv2 "github.com/Wei-Shaw/sub2api/internal/service/openai_ws_v2"
 	coderws "github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -50,6 +52,10 @@ type openAIWSIdlePingCapable interface {
 // openAIWSClientDialer 抽象 WS 建连器。
 type openAIWSClientDialer interface {
 	Dial(ctx context.Context, wsURL string, headers http.Header, proxyURL string) (openAIWSClientConn, int, http.Header, error)
+}
+
+type openAIWSTLSClientDialer interface {
+	DialWithTLS(ctx context.Context, wsURL string, headers http.Header, proxyURL string, profile *tlsfingerprint.Profile) (openAIWSClientConn, int, http.Header, error)
 }
 
 type openAIWSTransportMetricsDialer interface {
@@ -102,6 +108,16 @@ func (d *coderOpenAIWSClientDialer) Dial(
 	headers http.Header,
 	proxyURL string,
 ) (openAIWSClientConn, int, http.Header, error) {
+	return d.DialWithTLS(ctx, wsURL, headers, proxyURL, nil)
+}
+
+func (d *coderOpenAIWSClientDialer) DialWithTLS(
+	ctx context.Context,
+	wsURL string,
+	headers http.Header,
+	proxyURL string,
+	profile *tlsfingerprint.Profile,
+) (openAIWSClientConn, int, http.Header, error) {
 	targetURL := strings.TrimSpace(wsURL)
 	if targetURL == "" {
 		return nil, 0, nil, errors.New("ws url is empty")
@@ -111,8 +127,8 @@ func (d *coderOpenAIWSClientDialer) Dial(
 		HTTPHeader:      cloneHeader(headers),
 		CompressionMode: coderws.CompressionContextTakeover,
 	}
-	if proxy := strings.TrimSpace(proxyURL); proxy != "" {
-		proxyClient, err := d.proxyHTTPClient(proxy)
+	if profile != nil || strings.TrimSpace(proxyURL) != "" {
+		proxyClient, err := d.proxyHTTPClientWithTLS(proxyURL, profile)
 		if err != nil {
 			return nil, 0, nil, err
 		}
@@ -144,38 +160,81 @@ func (d *coderOpenAIWSClientDialer) Dial(
 	return &coderOpenAIWSClientConn{conn: conn}, 0, respHeaders, nil
 }
 
+func dialOpenAIWSClient(
+	dialer openAIWSClientDialer,
+	ctx context.Context,
+	wsURL string,
+	headers http.Header,
+	proxyURL string,
+	profile *tlsfingerprint.Profile,
+) (openAIWSClientConn, int, http.Header, error) {
+	if tlsDialer, ok := dialer.(openAIWSTLSClientDialer); ok {
+		return tlsDialer.DialWithTLS(ctx, wsURL, headers, proxyURL, profile)
+	}
+	return dialer.Dial(ctx, wsURL, headers, proxyURL)
+}
+
 func (d *coderOpenAIWSClientDialer) proxyHTTPClient(proxy string) (*http.Client, error) {
+	return d.proxyHTTPClientWithTLS(proxy, nil)
+}
+
+func (d *coderOpenAIWSClientDialer) proxyHTTPClientWithTLS(proxy string, profile *tlsfingerprint.Profile) (*http.Client, error) {
 	if d == nil {
 		return nil, errors.New("openai ws dialer is nil")
 	}
 	normalizedProxy := strings.TrimSpace(proxy)
-	if normalizedProxy == "" {
-		return nil, errors.New("proxy url is empty")
+	var parsedProxyURL *url.URL
+	if normalizedProxy != "" {
+		var err error
+		parsedProxyURL, err = url.Parse(normalizedProxy)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy url: %w", err)
+		}
 	}
-	parsedProxyURL, err := url.Parse(normalizedProxy)
-	if err != nil {
-		return nil, fmt.Errorf("invalid proxy url: %w", err)
+	cacheKey := normalizedProxy
+	if profile != nil {
+		cacheKey += "|profile:" + profile.StableID()
 	}
 	now := time.Now().UnixNano()
 
 	d.proxyMu.Lock()
 	defer d.proxyMu.Unlock()
-	if entry, ok := d.proxyClients[normalizedProxy]; ok && entry != nil && entry.client != nil {
+	if entry, ok := d.proxyClients[cacheKey]; ok && entry != nil && entry.client != nil {
 		entry.lastUsedUnixNano = now
 		d.proxyHits.Add(1)
 		return entry.client, nil
 	}
 	d.cleanupProxyClientsLocked(now)
 	transport := &http.Transport{
-		Proxy:               http.ProxyURL(parsedProxyURL),
 		MaxIdleConns:        openAIWSProxyTransportMaxIdleConns,
 		MaxIdleConnsPerHost: openAIWSProxyTransportMaxIdleConnsPerHost,
 		IdleConnTimeout:     openAIWSProxyTransportIdleConnTimeout,
 		TLSHandshakeTimeout: 10 * time.Second,
-		ForceAttemptHTTP2:   true,
+		ForceAttemptHTTP2:   profile == nil,
+	}
+	if profile == nil {
+		if parsedProxyURL != nil {
+			transport.Proxy = http.ProxyURL(parsedProxyURL)
+		}
+	} else if parsedProxyURL == nil {
+		transport.DialTLSContext = tlsfingerprint.NewDialer(profile, nil).DialTLSContext
+	} else {
+		switch strings.ToLower(parsedProxyURL.Scheme) {
+		case "http":
+			transport.Proxy = proxyutil.PlainHTTPProxy(parsedProxyURL)
+			transport.DialTLSContext = tlsfingerprint.NewHTTPProxyDialer(profile, parsedProxyURL).DialTLSContext
+		case "socks5", "socks5h":
+			transport.Proxy = proxyutil.PlainHTTPProxy(parsedProxyURL)
+			transport.DialTLSContext = tlsfingerprint.NewSOCKS5ProxyDialer(profile, parsedProxyURL).DialTLSContext
+		default:
+			// HTTPS/unknown proxies retain correct routing but cannot use the
+			// CONNECT-oriented fingerprint dialers.
+			transport.Proxy = http.ProxyURL(parsedProxyURL)
+			transport.ForceAttemptHTTP2 = true
+		}
 	}
 	client := &http.Client{Transport: transport}
-	d.proxyClients[normalizedProxy] = &openAIWSProxyClientEntry{
+	d.proxyClients[cacheKey] = &openAIWSProxyClientEntry{
 		client:           client,
 		lastUsedUnixNano: now,
 	}

--- a/backend/internal/service/openai_ws_client.go
+++ b/backend/internal/service/openai_ws_client.go
@@ -182,6 +182,11 @@ func (d *coderOpenAIWSClientDialer) proxyHTTPClientWithTLS(proxy string, profile
 	if d == nil {
 		return nil, errors.New("openai ws dialer is nil")
 	}
+	// WebSocket handshakes only need HTTP/1.1, and the bare uTLS dialers below
+	// sit on a standard-library transport that cannot drive HTTP/2 over them.
+	// Converge ALPN on a clone before the cache key so an h2-advertising
+	// profile cannot negotiate a protocol the transport cannot serve.
+	profile = tlsfingerprint.HTTP1OnlyProfile(profile)
 	normalizedProxy := strings.TrimSpace(proxy)
 	var parsedProxyURL *url.URL
 	if normalizedProxy != "" {

--- a/backend/internal/service/openai_ws_client_test.go
+++ b/backend/internal/service/openai_ws_client_test.go
@@ -51,6 +51,28 @@ func TestCoderOpenAIWSClientDialer_TLSProfileProxiesPlainHTTPWithoutDoubleProxyi
 	require.NoError(t, err)
 	require.Nil(t, proxyURL)
 }
+
+func TestCoderOpenAIWSClientDialer_TLSCacheUsesConvergedHTTP1Profile(t *testing.T) {
+	dialer := newDefaultOpenAIWSClientDialer()
+	impl, ok := dialer.(*coderOpenAIWSClientDialer)
+	require.True(t, ok)
+	h2Profile := &tlsfingerprint.Profile{
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"h2", "http/1.1"},
+	}
+
+	h2Client, err := impl.proxyHTTPClientWithTLS("", h2Profile)
+	require.NoError(t, err)
+	require.Equal(t, []string{"h2", "http/1.1"}, h2Profile.ALPNProtocols,
+		"cache normalization must not mutate the caller's profile")
+	h1Client, err := impl.proxyHTTPClientWithTLS("", &tlsfingerprint.Profile{
+		CipherSuites:  []uint16{0x1301},
+		ALPNProtocols: []string{"http/1.1"},
+	})
+	require.NoError(t, err)
+	require.Same(t, h2Client, h1Client,
+		"profiles with identical effective WebSocket ALPN must share one cache entry")
+}
 func TestCoderOpenAIWSClientDialer_ProxyHTTPClientInvalidURL(t *testing.T) {
 	dialer := newDefaultOpenAIWSClientDialer()
 	impl, ok := dialer.(*coderOpenAIWSClientDialer)

--- a/backend/internal/service/openai_ws_client_test.go
+++ b/backend/internal/service/openai_ws_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +26,31 @@ func TestCoderOpenAIWSClientDialer_ProxyHTTPClientReuse(t *testing.T) {
 	require.NotSame(t, c1, c3, "不同代理地址应分离客户端")
 }
 
+func TestCoderOpenAIWSClientDialer_TLSProfileProxiesPlainHTTPWithoutDoubleProxyingHTTPS(t *testing.T) {
+	dialer := newDefaultOpenAIWSClientDialer()
+	impl, ok := dialer.(*coderOpenAIWSClientDialer)
+	require.True(t, ok)
+	client, err := impl.proxyHTTPClientWithTLS("http://proxy.example:8080", &tlsfingerprint.Profile{
+		CipherSuites: []uint16{0x1301},
+	})
+	require.NoError(t, err)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.DialTLSContext)
+	require.NotNil(t, transport.Proxy)
+
+	httpReq, err := http.NewRequest(http.MethodGet, "http://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err := transport.Proxy(httpReq)
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	httpsReq, err := http.NewRequest(http.MethodGet, "https://upstream.example/v1", nil)
+	require.NoError(t, err)
+	proxyURL, err = transport.Proxy(httpsReq)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+}
 func TestCoderOpenAIWSClientDialer_ProxyHTTPClientInvalidURL(t *testing.T) {
 	dialer := newDefaultOpenAIWSClientDialer()
 	impl, ok := dialer.(*coderOpenAIWSClientDialer)

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -749,9 +749,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		return fmt.Errorf("build ws headers: %w", buildHdrErr)
 	}
 	baseAcquireReq := openAIWSAcquireRequest{
-		Account: account,
-		WSURL:   wsURL,
-		Headers: wsHeaders,
+		Account:    account,
+		WSURL:      wsURL,
+		Headers:    wsHeaders,
+		TLSProfile: s.resolveHTTPUpstreamTLSProfile(account),
 		HeadersFactory: func(factoryCtx context.Context, headers http.Header) (http.Header, error) {
 			return s.refreshOpenAIAgentIdentityHeaders(factoryCtx, account, headers)
 		},

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -196,9 +196,10 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	defer acquireCancel()
 
 	lease, err := s.getOpenAIWSConnPool().Acquire(acquireCtx, openAIWSAcquireRequest{
-		Account: account,
-		WSURL:   wsURL,
-		Headers: wsHeaders,
+		Account:    account,
+		WSURL:      wsURL,
+		Headers:    wsHeaders,
+		TLSProfile: s.resolveHTTPUpstreamTLSProfile(account),
 		HeadersFactory: func(factoryCtx context.Context, headers http.Header) (http.Header, error) {
 			return s.refreshOpenAIAgentIdentityHeaders(factoryCtx, account, headers)
 		},

--- a/backend/internal/service/openai_ws_http_bridge_test.go
+++ b/backend/internal/service/openai_ws_http_bridge_test.go
@@ -12,12 +12,52 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+func TestProxyOpenAIWSHTTPBridgeTurnUsesAccountTLSProfileForCustomBaseURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_tls\",\"model\":\"gpt-5\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}},
+		httpUpstream: upstream,
+		tlsFPProfileService: &TLSFingerprintProfileService{localCache: map[int64]*model.TLSFingerprintProfile{
+			71: {ID: 71, Name: "bridge override", CipherSuites: []uint16{0x1301}},
+		}},
+	}
+	account := &Account{
+		ID: 9_902, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://custom.example/v1"},
+		Extra:       map[string]any{"tls_fingerprint_profile_id": int64(71)},
+	}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	payload := []byte(`{"type":"response.create","model":"gpt-5","input":"hi"}`)
+
+	_, err := svc.proxyOpenAIWSHTTPBridgeTurn(
+		context.Background(), c, account, "sk-test", payload, len(payload),
+		"gpt-5", "", "", "", "", 1, func([]byte) error { return nil },
+	)
+
+	require.NoError(t, err)
+	require.Zero(t, upstream.doCalls)
+	require.Equal(t, 1, upstream.doWithTLSCalls)
+	require.NotNil(t, upstream.lastTLSProfile)
+	require.Equal(t, "bridge override", upstream.lastTLSProfile.Name)
+	require.Equal(t, "custom.example", upstream.lastReq.URL.Hostname())
+}
 
 func TestResolveOpenAIWSClientFirstMessageTimeout(t *testing.T) {
 	defaultTimeout := time.Duration(config.DefaultOpenAIWSClientFirstMessageTimeoutSeconds) * time.Second

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -64,6 +65,10 @@ type openAIWSAcquireRequest struct {
 	Account *Account
 	WSURL   string
 	Headers http.Header
+	// TLSProfile is part of the handshake compatibility key. A profile update
+	// must create a new upstream connection instead of reusing an older
+	// ClientHello from the same account pool.
+	TLSProfile *tlsfingerprint.Profile
 	// HeadersFactory is evaluated inside dialConn. It exists so credentials
 	// whose authorization is per-dial (Agent Identity) are never cached in
 	// lastAcquire or delayed prewarm state.
@@ -77,6 +82,7 @@ type openAIWSAcquireRequest struct {
 }
 
 type openAIWSHandshakeCompatibilityKey struct {
+	tlsProfileID        string
 	betaFeatures        string
 	codexInstallationID string
 	sessionIDHyphen     string
@@ -861,7 +867,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 
 retryAcquire:
 	accountID := req.Account.ID
-	compatibility := normalizeOpenAIWSHandshakeCompatibility(req.Account, req.Headers)
+	compatibility := normalizeOpenAIWSHandshakeCompatibility(req.Account, req.Headers, req.TLSProfile)
 	routingAffinity := normalizeOpenAIWSRoutingAffinity(req.Headers)
 	effectiveMaxConns := p.effectiveMaxConnsByAccount(req.Account)
 	if effectiveMaxConns <= 0 {
@@ -1784,7 +1790,7 @@ func (p *openAIWSConnPool) dialConn(ctx context.Context, req openAIWSAcquireRequ
 			return nil, err
 		}
 	}
-	conn, status, handshakeHeaders, err := p.clientDialer.Dial(ctx, req.WSURL, headers, req.ProxyURL)
+	conn, status, handshakeHeaders, err := dialOpenAIWSClient(p.clientDialer, ctx, req.WSURL, headers, req.ProxyURL, req.TLSProfile)
 	if err != nil {
 		var handshakeErr *openAIWSHandshakeError
 		var responseBody []byte
@@ -1807,7 +1813,7 @@ func (p *openAIWSConnPool) dialConn(ctx context.Context, req openAIWSAcquireRequ
 	}
 	id := p.nextConnID(req.Account.ID)
 	pooledConn := newOpenAIWSConn(id, req.Account.ID, conn, handshakeHeaders)
-	pooledConn.handshakeCompatibility = normalizeOpenAIWSHandshakeCompatibility(req.Account, req.Headers)
+	pooledConn.handshakeCompatibility = normalizeOpenAIWSHandshakeCompatibility(req.Account, req.Headers, req.TLSProfile)
 	pooledConn.routingAffinity = normalizeOpenAIWSRoutingAffinity(req.Headers)
 	return pooledConn, nil
 }
@@ -1990,7 +1996,7 @@ func cloneOpenAIWSAcquireRequestPtr(req *openAIWSAcquireRequest) *openAIWSAcquir
 func sameOpenAIWSPrewarmTarget(a, b openAIWSAcquireRequest) bool {
 	return stringsTrim(a.WSURL) == stringsTrim(b.WSURL) &&
 		stringsTrim(a.ProxyURL) == stringsTrim(b.ProxyURL) &&
-		normalizeOpenAIWSHandshakeCompatibility(a.Account, a.Headers) == normalizeOpenAIWSHandshakeCompatibility(b.Account, b.Headers)
+		normalizeOpenAIWSHandshakeCompatibility(a.Account, a.Headers, a.TLSProfile) == normalizeOpenAIWSHandshakeCompatibility(b.Account, b.Headers, b.TLSProfile)
 }
 
 func normalizeOpenAIWSBetaFeatures(headers http.Header) string {
@@ -2018,9 +2024,12 @@ func normalizeOpenAIWSBetaFeatures(headers http.Header) string {
 	return strings.Join(normalized, ",")
 }
 
-func normalizeOpenAIWSHandshakeCompatibility(account *Account, headers http.Header) openAIWSHandshakeCompatibilityKey {
+func normalizeOpenAIWSHandshakeCompatibility(account *Account, headers http.Header, profile *tlsfingerprint.Profile) openAIWSHandshakeCompatibilityKey {
 	key := openAIWSHandshakeCompatibilityKey{
 		betaFeatures: normalizeOpenAIWSBetaFeatures(headers),
+	}
+	if profile != nil {
+		key.tlsProfileID = profile.StableID()
 	}
 	mode := activeCodexFingerprintMode(account)
 	if mode == codexFingerprintOff {

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -11,8 +11,73 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOpenAIWSConnPool_TLSProfileContentSeparatesReusableConnections(t *testing.T) {
+	pool := newOpenAIWSConnPool(&config.Config{})
+	t.Cleanup(pool.Close)
+	dialer := &openAIWSTLSProfileCaptureDialer{}
+	pool.setClientDialerForTest(dialer)
+	account := &Account{ID: 9_901, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 2}
+
+	firstProfile := &tlsfingerprint.Profile{CipherSuites: []uint16{0x1301}}
+	first, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account: account, WSURL: "wss://example.com/v1/responses", TLSProfile: firstProfile,
+	})
+	require.NoError(t, err)
+	first.Release()
+
+	secondProfile := &tlsfingerprint.Profile{CipherSuites: []uint16{0x1302}}
+	second, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account: account, WSURL: "wss://example.com/v1/responses", TLSProfile: secondProfile,
+	})
+	require.NoError(t, err)
+	second.Release()
+
+	require.Equal(t, 2, dialer.DialCount(), "a changed profile must not reuse the old WS connection")
+	require.Equal(t, []string{firstProfile.StableID(), secondProfile.StableID()}, dialer.ProfileIDs())
+}
+
+type openAIWSTLSProfileCaptureDialer struct {
+	mu       sync.Mutex
+	profiles []string
+}
+
+func (d *openAIWSTLSProfileCaptureDialer) Dial(
+	_ context.Context,
+	_ string,
+	_ http.Header,
+	_ string,
+) (openAIWSClientConn, int, http.Header, error) {
+	return nil, 0, nil, errors.New("legacy dial path used")
+}
+
+func (d *openAIWSTLSProfileCaptureDialer) DialWithTLS(
+	_ context.Context,
+	_ string,
+	_ http.Header,
+	_ string,
+	profile *tlsfingerprint.Profile,
+) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.profiles = append(d.profiles, profile.StableID())
+	return &openAIWSFakeConn{}, 0, nil, nil
+}
+
+func (d *openAIWSTLSProfileCaptureDialer) DialCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.profiles)
+}
+
+func (d *openAIWSTLSProfileCaptureDialer) ProfileIDs() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.profiles...)
+}
 
 func TestOpenAIWSConnPool_CleanupStaleAndTrimIdle(t *testing.T) {
 	cfg := &config.Config{}

--- a/backend/internal/service/openai_ws_tls_capture_test.go
+++ b/backend/internal/service/openai_ws_tls_capture_test.go
@@ -1,0 +1,60 @@
+//go:build tls_capture
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/Wei-Shaw/sub2api/internal/testutil/tlscapture"
+	"github.com/stretchr/testify/require"
+)
+
+// Run manually with:
+//
+//	go test -tags='unit,tls_capture' -v ./internal/service \
+//	  -run TestOpenAIWSHandshakeTLSProfileCapture -count=1
+//
+// The loopback server reads only ClientHello and then closes, so both dials
+// fail by design. No external endpoint or trusted certificate is required.
+func TestOpenAIWSHandshakeTLSProfileCapture(t *testing.T) {
+	dialer := newDefaultOpenAIWSClientDialer()
+	tlsDialer, ok := dialer.(openAIWSTLSClientDialer)
+	require.True(t, ok, "default OpenAI WS dialer must support TLS profiles")
+
+	goHello := tlscapture.Capture(t, "https", func(ctx context.Context, captureURL string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, captureURL, nil)
+		if err != nil {
+			return err
+		}
+		_, err = (&http.Client{Transport: &http.Transport{Proxy: nil}}).Do(req)
+		return err
+	})
+
+	wsHello := tlscapture.Capture(t, "wss", func(ctx context.Context, captureURL string) error {
+		_, _, _, err := tlsDialer.DialWithTLS(
+			ctx,
+			captureURL,
+			http.Header{"Originator": []string{"codex_cli_rs"}},
+			"",
+			tlsfingerprint.NewOpenAIChrome120Profile(),
+		)
+		return err
+	})
+
+	t.Logf("Go baseline cipher suites: %v", goHello.CipherSuites)
+	t.Logf("Go baseline extension order: %v", goHello.Extensions)
+	t.Logf("OpenAI WS cipher suites: %v", wsHello.CipherSuites)
+	t.Logf("OpenAI WS extension order: %v", wsHello.Extensions)
+
+	require.NotEqual(t, goHello.CipherSuites, wsHello.CipherSuites,
+		"OpenAI WS handshake must not emit the Go default cipher-suite sequence")
+	require.NotEqual(t, goHello.Extensions, wsHello.Extensions,
+		"OpenAI WS handshake must not emit the Go default extension sequence")
+	require.True(t, tlscapture.IsGREASE(wsHello.CipherSuites[0]),
+		"OpenAI WS Chrome ClientHello should begin with GREASE")
+	require.Contains(t, wsHello.Extensions, uint16(27),
+		"OpenAI WS Chrome ClientHello should advertise certificate compression")
+}

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -876,7 +876,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			return fmt.Errorf("refresh ws authentication headers: %w", err)
 		}
 		dialCtx, cancelDial := context.WithTimeout(ctx, s.openAIWSDialTimeout())
-		upstreamConn, statusCode, handshakeHeaders, err = dialer.Dial(dialCtx, wsURL, headers, proxyURL)
+		upstreamConn, statusCode, handshakeHeaders, err = dialOpenAIWSClient(dialer, dialCtx, wsURL, headers, proxyURL, s.resolveHTTPUpstreamTLSProfile(account))
 		cancelDial()
 		if err == nil {
 			break

--- a/backend/internal/service/tls_fingerprint_profile_service.go
+++ b/backend/internal/service/tls_fingerprint_profile_service.go
@@ -11,6 +11,42 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 )
 
+type openAIUpstreamTLSProfileContextKey struct{}
+
+// WithOpenAIUpstreamTLSProfile carries an already-resolved account profile to
+// auth-domain helpers that intentionally do not depend on the profile service.
+func WithOpenAIUpstreamTLSProfile(ctx context.Context, profile *tlsfingerprint.Profile) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if profile == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, openAIUpstreamTLSProfileContextKey{}, profile)
+}
+
+func OpenAIUpstreamTLSProfileFromContext(ctx context.Context) *tlsfingerprint.Profile {
+	if ctx == nil {
+		return nil
+	}
+	profile, _ := ctx.Value(openAIUpstreamTLSProfileContextKey{}).(*tlsfingerprint.Profile)
+	return profile
+}
+
+func resolveOpenAIAuthTLSProfile(ctx context.Context) *tlsfingerprint.Profile {
+	if profile := OpenAIUpstreamTLSProfileFromContext(ctx); profile != nil {
+		return profile
+	}
+	return tlsfingerprint.NewOpenAIChrome120Profile()
+}
+
+func withOpenAIAccountTLSProfile(ctx context.Context, resolver *TLSFingerprintProfileService, account *Account) context.Context {
+	if resolver != nil {
+		return WithOpenAIUpstreamTLSProfile(ctx, resolver.ResolveTLSProfile(account))
+	}
+	return WithOpenAIUpstreamTLSProfile(ctx, (&TLSFingerprintProfileService{}).ResolveTLSProfile(account))
+}
+
 // TLSFingerprintProfileRepository 定义 TLS 指纹模板的数据访问接口
 type TLSFingerprintProfileRepository interface {
 	List(ctx context.Context) ([]*model.TLSFingerprintProfile, error)
@@ -171,13 +207,44 @@ func (s *TLSFingerprintProfileService) getRandomProfile() *tlsfingerprint.Profil
 // ResolveTLSProfile 根据 Account 的配置解析出运行时 TLS Profile
 //
 // 逻辑：
-//  1. 未启用 TLS 指纹 → 返回 nil（不伪装）
-//  2. 启用 + 绑定了 profile_id → 从缓存查找对应 profile
-//  3. 启用 + 未绑定或找不到 → 返回空 Profile（使用代码内置默认值）
+//  1. OpenAI OAuth/APIKey + 绑定了 profile_id → 使用绑定 profile
+//  2. OpenAI OAuth/APIKey + 未绑定或找不到 → 使用内置 Chrome 120 HTTP/1.1 profile
+//  3. 其他账号未启用 TLS 指纹 → 返回 nil（不伪装）
+//  4. 其他账号启用 + 绑定了 profile_id → 从缓存查找对应 profile
+//  5. 其他账号启用 + 未绑定或找不到 → 使用代码内置 Node.js 默认值
 func (s *TLSFingerprintProfileService) ResolveTLSProfile(account *Account) *tlsfingerprint.Profile {
-	if account == nil || !account.IsTLSFingerprintEnabled() {
+	if account == nil {
 		return nil
 	}
+
+	if account.Platform == PlatformOpenAI && (account.Type == AccountTypeOAuth || account.Type == AccountTypeAPIKey) {
+		if profile := s.resolveConfiguredTLSProfile(account); profile != nil {
+			return profile
+		}
+		return tlsfingerprint.NewOpenAIChrome120Profile()
+	}
+
+	if !account.IsTLSFingerprintEnabled() {
+		return nil
+	}
+	if profile := s.resolveConfiguredTLSProfile(account); profile != nil {
+		return profile
+	}
+	// TLS 启用但无绑定 profile → 空 Profile → dialer 使用内置默认值
+	return &tlsfingerprint.Profile{Name: "Built-in Default (Node.js 24.x)"}
+}
+
+func (s *OpenAIGatewayService) resolveHTTPUpstreamTLSProfile(account *Account) *tlsfingerprint.Profile {
+	if s != nil && s.tlsFPProfileService != nil {
+		return s.tlsFPProfileService.ResolveTLSProfile(account)
+	}
+	// Keep lightweight service tests and deliberately minimal embedders usable.
+	// Production construction injects the shared profile service below; without
+	// it, built-in defaults remain available but database-backed overrides do not.
+	return (&TLSFingerprintProfileService{}).ResolveTLSProfile(account)
+}
+
+func (s *TLSFingerprintProfileService) resolveConfiguredTLSProfile(account *Account) *tlsfingerprint.Profile {
 	id := account.GetTLSFingerprintProfileID()
 	if id > 0 {
 		if p := s.GetProfileByID(id); p != nil {
@@ -190,8 +257,7 @@ func (s *TLSFingerprintProfileService) ResolveTLSProfile(account *Account) *tlsf
 			return p
 		}
 	}
-	// TLS 启用但无绑定 profile → 空 Profile → dialer 使用内置默认值
-	return &tlsfingerprint.Profile{Name: "Built-in Default (Node.js 24.x)"}
+	return nil
 }
 
 // --- 缓存管理 ---

--- a/backend/internal/service/tls_fingerprint_profile_service.go
+++ b/backend/internal/service/tls_fingerprint_profile_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"math/rand/v2"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,6 +13,29 @@ import (
 )
 
 type openAIUpstreamTLSProfileContextKey struct{}
+
+type openAIOAuthTLSMode string
+
+const (
+	openAIOAuthTLSModeExtraKey                        = "openai_oauth_tls_mode"
+	openAIOAuthTLSModeLegacyChrome openAIOAuthTLSMode = "legacy_chrome"
+	openAIOAuthTLSModeCodexRustls  openAIOAuthTLSMode = "codex_rustls_fallback"
+)
+
+func openAIOAuthTLSModeFromExtra(extra map[string]any) openAIOAuthTLSMode {
+	if extra == nil {
+		return openAIOAuthTLSModeLegacyChrome
+	}
+	raw, _ := extra[openAIOAuthTLSModeExtraKey].(string)
+	switch openAIOAuthTLSMode(strings.TrimSpace(raw)) {
+	case openAIOAuthTLSModeCodexRustls:
+		return openAIOAuthTLSModeCodexRustls
+	case openAIOAuthTLSModeLegacyChrome:
+		return openAIOAuthTLSModeLegacyChrome
+	default:
+		return openAIOAuthTLSModeLegacyChrome
+	}
+}
 
 // WithOpenAIUpstreamTLSProfile carries an already-resolved account profile to
 // auth-domain helpers that intentionally do not depend on the profile service.
@@ -208,18 +232,27 @@ func (s *TLSFingerprintProfileService) getRandomProfile() *tlsfingerprint.Profil
 //
 // 逻辑：
 //  1. OpenAI OAuth/APIKey + 绑定了 profile_id → 使用绑定 profile
-//  2. OpenAI OAuth/APIKey + 未绑定或找不到 → 使用内置 Chrome 120 HTTP/1.1 profile
-//  3. 其他账号未启用 TLS 指纹 → 返回 nil（不伪装）
-//  4. 其他账号启用 + 绑定了 profile_id → 从缓存查找对应 profile
-//  5. 其他账号启用 + 未绑定或找不到 → 使用代码内置 Node.js 默认值
+//  2. OpenAI OAuth + opt-in codex_rustls_fallback → 使用 Codex rustls fallback profile
+//  3. OpenAI OAuth/APIKey + 未绑定或找不到 → 使用内置 Chrome 120 HTTP/1.1 profile
+//  4. 其他账号未启用 TLS 指纹 → 返回 nil（不伪装）
+//  5. 其他账号启用 + 绑定了 profile_id → 从缓存查找对应 profile
+//  6. 其他账号启用 + 未绑定或找不到 → 使用代码内置 Node.js 默认值
 func (s *TLSFingerprintProfileService) ResolveTLSProfile(account *Account) *tlsfingerprint.Profile {
 	if account == nil {
 		return nil
 	}
 
 	if account.Platform == PlatformOpenAI && (account.Type == AccountTypeOAuth || account.Type == AccountTypeAPIKey) {
-		if profile := s.resolveConfiguredTLSProfile(account); profile != nil {
-			return profile
+		if account.GetTLSFingerprintProfileID() != 0 {
+			if profile := s.resolveConfiguredTLSProfile(account); profile != nil {
+				return profile
+			}
+			// Preserve the legacy fallback when an operator explicitly selected a
+			// stale profile ID or an empty random pool; do not silently enable mode.
+			return tlsfingerprint.NewOpenAIChrome120Profile()
+		}
+		if account.Type == AccountTypeOAuth && openAIOAuthTLSModeFromExtra(account.Extra) == openAIOAuthTLSModeCodexRustls {
+			return tlsfingerprint.NewCodexRustlsFallbackProfile()
 		}
 		return tlsfingerprint.NewOpenAIChrome120Profile()
 	}

--- a/backend/internal/service/tls_fingerprint_profile_service_test.go
+++ b/backend/internal/service/tls_fingerprint_profile_service_test.go
@@ -58,4 +58,102 @@ func TestResolveTLSProfileDoesNotDefaultUnsupportedOpenAIAccountType(t *testing.
 	})
 
 	require.Nil(t, profile)
+
+	profile = service.ResolveTLSProfile(&Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"openai_oauth_tls_mode": "codex_rustls_fallback"},
+	})
+	require.Nil(t, profile, "the OpenAI-only mode must not change non-OpenAI accounts")
+}
+
+func TestResolveTLSProfileOpenAIOAuthTLSModePrecedence(t *testing.T) {
+	service := &TLSFingerprintProfileService{
+		localCache: map[int64]*model.TLSFingerprintProfile{
+			17: {ID: 17, Name: "operator override", CipherSuites: []uint16{0x1301}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		account    *Account
+		wantName   string
+		wantPreset tlsfingerprint.Preset
+		wantRandom bool
+	}{
+		{
+			name: "explicit profile wins over rustls mode",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				"tls_fingerprint_profile_id": int64(17),
+				"openai_oauth_tls_mode":      "codex_rustls_fallback",
+			}},
+			wantName: "operator override",
+		},
+		{
+			name: "random pool wins over rustls mode",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				"tls_fingerprint_profile_id": int64(-1),
+				"openai_oauth_tls_mode":      "codex_rustls_fallback",
+			}},
+			wantName: "operator override",
+		},
+		{
+			name: "stale explicit profile suppresses rustls mode and keeps legacy fallback",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				"tls_fingerprint_profile_id": int64(999),
+				"openai_oauth_tls_mode":      "codex_rustls_fallback",
+			}},
+			wantPreset: tlsfingerprint.PresetChrome120HTTP1,
+		},
+		{
+			name: "OAuth rustls mode is opt in",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				"openai_oauth_tls_mode": "codex_rustls_fallback",
+			}},
+			wantName:   "Codex 0.149.x rustls fallback (cold connection) approximation",
+			wantRandom: true,
+		},
+		{
+			name:       "unset OAuth mode keeps Chrome default",
+			account:    &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+			wantPreset: tlsfingerprint.PresetChrome120HTTP1,
+		},
+		{
+			name: "legacy Chrome mode keeps Chrome default",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+				"openai_oauth_tls_mode": "legacy_chrome",
+			}},
+			wantPreset: tlsfingerprint.PresetChrome120HTTP1,
+		},
+		{
+			name: "API key ignores rustls mode",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+				"openai_oauth_tls_mode": "codex_rustls_fallback",
+			}},
+			wantPreset: tlsfingerprint.PresetChrome120HTTP1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := service.ResolveTLSProfile(tt.account)
+			require.NotNil(t, profile)
+			if tt.wantName != "" {
+				require.Equal(t, tt.wantName, profile.Name)
+			}
+			require.Equal(t, tt.wantPreset, profile.Preset)
+			require.Equal(t, tt.wantRandom, profile.RandomizeExtensionOrder)
+		})
+	}
+
+	emptyPoolProfile := (&TLSFingerprintProfileService{}).ResolveTLSProfile(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"tls_fingerprint_profile_id": int64(-1),
+			"openai_oauth_tls_mode":      "codex_rustls_fallback",
+		},
+	})
+	require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, emptyPoolProfile.Preset,
+		"an explicitly selected but empty random pool must keep the legacy Chrome fallback")
 }

--- a/backend/internal/service/tls_fingerprint_profile_service_test.go
+++ b/backend/internal/service/tls_fingerprint_profile_service_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/model"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveTLSProfileOpenAIUsesDefaultAndHonorsExplicitProfile(t *testing.T) {
+	service := &TLSFingerprintProfileService{
+		localCache: map[int64]*model.TLSFingerprintProfile{
+			17: {
+				ID:           17,
+				Name:         "operator override",
+				CipherSuites: []uint16{0x1301},
+			},
+		},
+	}
+
+	for _, accountType := range []string{AccountTypeOAuth, AccountTypeAPIKey} {
+		t.Run(accountType+" default", func(t *testing.T) {
+			profile := service.ResolveTLSProfile(&Account{
+				Platform: PlatformOpenAI,
+				Type:     accountType,
+			})
+
+			require.NotNil(t, profile)
+			require.Equal(t, tlsfingerprint.PresetChrome120HTTP1, profile.Preset)
+		})
+
+		t.Run(accountType+" explicit override", func(t *testing.T) {
+			profile := service.ResolveTLSProfile(&Account{
+				Platform: PlatformOpenAI,
+				Type:     accountType,
+				Extra: map[string]any{
+					"tls_fingerprint_profile_id": int64(17),
+				},
+			})
+
+			require.NotNil(t, profile)
+			require.Equal(t, "operator override", profile.Name)
+			require.Empty(t, profile.Preset)
+			require.Equal(t, []uint16{0x1301}, profile.CipherSuites)
+		})
+	}
+}
+
+func TestResolveTLSProfileDoesNotDefaultUnsupportedOpenAIAccountType(t *testing.T) {
+	service := &TLSFingerprintProfileService{}
+
+	profile := service.ResolveTLSProfile(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeUpstream,
+	})
+
+	require.Nil(t, profile)
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -111,9 +111,11 @@ func ProvideOpenAIOAuthService(
 	proxyRepo ProxyRepository,
 	oauthClient OpenAIOAuthClient,
 	privacyClientFactory PrivacyClientFactory,
+	tlsFPProfileService *TLSFingerprintProfileService,
 ) *OpenAIOAuthService {
 	svc := NewOpenAIOAuthService(proxyRepo, oauthClient)
 	svc.SetPrivacyClientFactory(privacyClientFactory)
+	svc.tlsFPProfileService = tlsFPProfileService
 	return svc
 }
 
@@ -182,9 +184,13 @@ func ProvideOpenAIQuotaService(
 	proxyRepo ProxyRepository,
 	tokenProvider *OpenAITokenProvider,
 	privacyClientFactory PrivacyClientFactory,
+	tlsProfileClientFactory OpenAITLSProfileClientFactory,
+	tlsFPProfileService *TLSFingerprintProfileService,
 	openAIGatewayService *OpenAIGatewayService,
 ) *OpenAIQuotaService {
 	service := NewOpenAIQuotaService(accountRepo, proxyRepo, tokenProvider, privacyClientFactory)
+	service.tlsProfileClientFactory = tlsProfileClientFactory
+	service.tlsFPProfileService = tlsFPProfileService
 	service.agentIdentityWS = openAIGatewayService
 	return service
 }
@@ -799,6 +805,62 @@ func ProvideBillingCacheService(
 	return NewBillingCacheService(cache, userRepo, subRepo, apiKeyRepo, rpmCache, rateRepo, cfg, userPlatformQuotaRepo)
 }
 
+// ProvideOpenAIGatewayService injects TLS profile resolution into the OpenAI
+// HTTP forwarding paths while keeping the core constructor convenient for
+// focused unit tests.
+func ProvideOpenAIGatewayService(
+	accountRepo AccountRepository,
+	usageLogRepo UsageLogRepository,
+	usageBillingRepo UsageBillingRepository,
+	userRepo UserRepository,
+	userSubRepo UserSubscriptionRepository,
+	userGroupRateRepo UserGroupRateRepository,
+	cache GatewayCache,
+	cfg *config.Config,
+	schedulerSnapshot *SchedulerSnapshotService,
+	concurrencyService *ConcurrencyService,
+	billingService *BillingService,
+	rateLimitService *RateLimitService,
+	billingCacheService *BillingCacheService,
+	httpUpstream HTTPUpstream,
+	tlsFPProfileService *TLSFingerprintProfileService,
+	deferredService *DeferredService,
+	openAITokenProvider *OpenAITokenProvider,
+	grokTokenProvider *GrokTokenProvider,
+	resolver *ModelPricingResolver,
+	channelService *ChannelService,
+	balanceNotifyService *BalanceNotifyService,
+	settingService *SettingService,
+	userPlatformQuotaRepo UserPlatformQuotaRepository,
+) *OpenAIGatewayService {
+	service := NewOpenAIGatewayService(
+		accountRepo,
+		usageLogRepo,
+		usageBillingRepo,
+		userRepo,
+		userSubRepo,
+		userGroupRateRepo,
+		cache,
+		cfg,
+		schedulerSnapshot,
+		concurrencyService,
+		billingService,
+		rateLimitService,
+		billingCacheService,
+		httpUpstream,
+		deferredService,
+		openAITokenProvider,
+		grokTokenProvider,
+		resolver,
+		channelService,
+		balanceNotifyService,
+		settingService,
+		userPlatformQuotaRepo,
+	)
+	service.tlsFPProfileService = tlsFPProfileService
+	return service
+}
+
 // ProvideAPIKeyService wires APIKeyService and connects rate-limit cache invalidation.
 func ProvideAPIKeyService(
 	apiKeyRepo APIKeyRepository,
@@ -840,7 +902,7 @@ var ProviderSet = wire.NewSet(
 	NewAnnouncementService,
 	NewAdminService,
 	NewGatewayService,
-	NewOpenAIGatewayService,
+	ProvideOpenAIGatewayService,
 	ProvideImageStorageSettingService,
 	ProvideImageTaskService,
 	ProvideBatchImageModelPricingResolver,

--- a/backend/internal/testutil/tlscapture/capture.go
+++ b/backend/internal/testutil/tlscapture/capture.go
@@ -1,0 +1,158 @@
+//go:build tls_capture
+
+// Package tlscapture provides loopback-only ClientHello capture helpers for
+// manually enabled TLS fingerprint tests.
+package tlscapture
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+type ClientHello struct {
+	CipherSuites []uint16
+	Extensions   []uint16
+}
+
+type captureResult struct {
+	hello ClientHello
+	err   error
+}
+
+func Capture(
+	t testing.TB,
+	scheme string,
+	send func(context.Context, string) error,
+) ClientHello {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for ClientHello: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	result := make(chan captureResult, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			result <- captureResult{err: acceptErr}
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		hello, captureErr := readClientHello(conn)
+		result <- captureResult{hello: hello, err: captureErr}
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	sendErr := send(ctx, scheme+"://"+listener.Addr().String()+"/capture")
+	if sendErr == nil {
+		t.Fatal("capture server closes before completing the TLS handshake; expected request error")
+	}
+
+	select {
+	case captured := <-result:
+		if captured.err != nil {
+			t.Fatalf("capture ClientHello: %v", captured.err)
+		}
+		if len(captured.hello.CipherSuites) == 0 || len(captured.hello.Extensions) == 0 {
+			t.Fatalf("captured empty ClientHello: %#v", captured.hello)
+		}
+		return captured.hello
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for ClientHello capture: %v", ctx.Err())
+		return ClientHello{}
+	}
+}
+
+func readClientHello(conn net.Conn) (ClientHello, error) {
+	var handshake []byte
+	expectedLength := -1
+	for expectedLength < 0 || len(handshake) < expectedLength {
+		var recordHeader [5]byte
+		if _, err := io.ReadFull(conn, recordHeader[:]); err != nil {
+			return ClientHello{}, fmt.Errorf("read TLS record header: %w", err)
+		}
+		if recordHeader[0] != 22 {
+			return ClientHello{}, fmt.Errorf("unexpected TLS record type %d", recordHeader[0])
+		}
+		record := make([]byte, int(binary.BigEndian.Uint16(recordHeader[3:5])))
+		if _, err := io.ReadFull(conn, record); err != nil {
+			return ClientHello{}, fmt.Errorf("read TLS handshake record: %w", err)
+		}
+		handshake = append(handshake, record...)
+		if len(handshake) >= 4 && expectedLength < 0 {
+			if handshake[0] != 1 {
+				return ClientHello{}, fmt.Errorf("unexpected TLS handshake type %d", handshake[0])
+			}
+			expectedLength = 4 + int(handshake[1])<<16 + int(handshake[2])<<8 + int(handshake[3])
+		}
+	}
+	return parseClientHello(handshake[4:expectedLength])
+}
+
+func parseClientHello(body []byte) (ClientHello, error) {
+	const fixedPrefixLength = 2 + 32
+	if len(body) < fixedPrefixLength+1 {
+		return ClientHello{}, errors.New("truncated ClientHello fixed fields")
+	}
+	cursor := fixedPrefixLength
+
+	sessionIDLength := int(body[cursor])
+	cursor++
+	if cursor+sessionIDLength+2 > len(body) {
+		return ClientHello{}, errors.New("truncated ClientHello session ID")
+	}
+	cursor += sessionIDLength
+
+	cipherBytes := int(binary.BigEndian.Uint16(body[cursor : cursor+2]))
+	cursor += 2
+	if cipherBytes%2 != 0 || cursor+cipherBytes+1 > len(body) {
+		return ClientHello{}, errors.New("invalid ClientHello cipher suites")
+	}
+	cipherSuites := make([]uint16, 0, cipherBytes/2)
+	for end := cursor + cipherBytes; cursor < end; cursor += 2 {
+		cipherSuites = append(cipherSuites, binary.BigEndian.Uint16(body[cursor:cursor+2]))
+	}
+
+	compressionLength := int(body[cursor])
+	cursor++
+	if cursor+compressionLength+2 > len(body) {
+		return ClientHello{}, errors.New("truncated ClientHello compression methods")
+	}
+	cursor += compressionLength
+
+	extensionBytes := int(binary.BigEndian.Uint16(body[cursor : cursor+2]))
+	cursor += 2
+	if cursor+extensionBytes > len(body) {
+		return ClientHello{}, errors.New("truncated ClientHello extensions")
+	}
+	extensionEnd := cursor + extensionBytes
+	extensions := make([]uint16, 0, 16)
+	for cursor < extensionEnd {
+		if cursor+4 > extensionEnd {
+			return ClientHello{}, errors.New("truncated ClientHello extension header")
+		}
+		extensionType := binary.BigEndian.Uint16(body[cursor : cursor+2])
+		extensionLength := int(binary.BigEndian.Uint16(body[cursor+2 : cursor+4]))
+		cursor += 4
+		if cursor+extensionLength > extensionEnd {
+			return ClientHello{}, fmt.Errorf("truncated ClientHello extension %d", extensionType)
+		}
+		extensions = append(extensions, extensionType)
+		cursor += extensionLength
+	}
+
+	return ClientHello{CipherSuites: cipherSuites, Extensions: extensions}, nil
+}
+
+func IsGREASE(value uint16) bool {
+	return value&0x0f0f == 0x0a0a && value>>8 == value&0xff
+}


### PR DESCRIPTION
## Summary

A self-contained TLS fingerprint batch: four commits on top of current `main`, touching only the TLS fingerprint stack, upstream wiring, and their tests (+3351/−184, 63 files).

1. **`feat(openai): apply TLS/H2 fingerprint profiles across upstream paths`** — route HTTP forwarding, websocket, auth, quota, and auxiliary OpenAI upstream paths through `TLSFingerprintProfileService.ResolveTLSProfile` + `DoWithTLS`; key reusable upstream clients by full profile content and protocol mode; match Chrome HTTP/2 SETTINGS/window/header ordering beyond the ClientHello; ClientHello + H2 + WS + OAuth handshake capture tests.
2. **`fix(tlsfingerprint): fail closed on h2/h2c ALPN in custom profile validation`** — net/http cannot upgrade a uTLS connection to H2 (its H2 hook type-asserts `*tls.Conn`), so advertising `h2` from an H1-only transport fails every request at runtime. Reject h2/h2c at validation with a clear error instead of silently stripping it.
3. **`feat(tlsfingerprint): support HTTP/2 for custom profiles via ALPN sniffing`** — bootstrap uTLS dial, inspect negotiated ALPN, delegate to `http2.Transport` or `http.Transport`, and hand the bootstrap connection to the winning transport. Ports the `TLSRoundTripper` idea from #5907 with deviations: default ALPN stays `["http/1.1"]`, caller pool settings preserved, mutex-guarded selection, `CloseIdleConnections` delegation. Frame-level parity remains exclusive to the built-in Chrome preset (documented trade-off).
4. **`feat(tlsfingerprint): add per-connection extension shuffling and opt-in Codex rustls-fallback profile`** — incorporates #6300, adapted and corrected (details below).

## Relationship to #6300

This batch incorporates the idea and the `RandomizeExtensionOrder` mechanism from #6300 (thanks @JnyRoad, credited via `Co-authored-by`), but does **not** take its profile values or wiring as-is, for reasons verified against the official `openai/codex` source (codex-rs @ `bd194593`, reqwest 0.12.28 / rustls 0.23.36):

- **The "no http2 / no ALPN" premise does not hold**: codex-rs does not set `default-features = false`; reqwest 0.12 defaults include `http2`, and the lockfile resolves `h2`/`hyper`/`hyper-rustls`. The corrected profile advertises ALPN `h2,http/1.1`.
- **Default Codex TLS is platform-native, rustls is conditional** (custom CA / TLS-protocol fallback). This PR therefore adds the profile as an **opt-in** account mode (`extra.openai_oauth_tls_mode = codex_rustls_fallback`) rather than changing the default fingerprint of every OAuth account; unset/explicit-profile behavior is unchanged.
- **Signature algorithms**: the original profile fell through to Node.js defaults (contains `rsa_pkcs1_sha1`, omits `ed25519`) — a JA3/JA4 mismatch. The ported profile sets the explicit rustls aws-lc list (`0403,0503,0603,0807,0806,0805,0804,0601,0501,0401`).
- **Key shares**: one share per `KeyShareGroups` entry would emit 4 shares; rustls only sends predicted shares. Ported as `[X25519MLKEM768, X25519]`.
- **SCSV `0x00ff` dropped** — rustls never sends `TLS_EMPTY_RENEGOTIATION_INFO_SCSV`.
- Wiring from #6300 is dropped: this stack already centralizes profile resolution in `ResolveTLSProfile` (explicit profile > opt-in mode > built-in default).

Additional corrections made while integrating:

- `RandomizeExtensionOrder` shuffles a copy per **new connection**, pins a future `pre_shared_key` (41) last, and is part of the profile `StableID()` so fixed-order and shuffled profiles never alias to the same cached transport.
- The TLS transport cache key now includes the canonical destination origin; `openai_h1` protocol modes converge the effective profile before cache keying, and TLS-fingerprinted clients no longer auto-follow **cross-origin** redirects (same-origin redirects still work) so per-origin ALPN state stays correct.

## Residual-risk statement (also in the commit)

The opt-in profile is a cold-connection approximation of Codex's rustls fallback mode; it does not claim parity with the official client's default platform-native TLS transport. Plugin-routed and HTTPS-proxy fallback traffic may bypass the profile. Go HTTP/1.1/H2 framing, header serialization, TLS record behavior, certificate validation, session resumption, and connection reuse remain observable and can diverge from reqwest/hyper/rustls.

## Test plan

- [x] `go build ./...` (Go 1.27 container) — clean
- [x] `go test ./...` full suite — 0 failures
- [x] `go test -race ./internal/pkg/tlsfingerprint/...` — clean, including wire-order capture across forced new connections, PSK-last, cache separation, and profile immutability
- [x] Resolver precedence tests: explicit > mode > default; API-key accounts ignore the mode; stale profile IDs fall back to the legacy default
- [x] Loopback ClientHello capture + real-transport ALPN capture tests for the H1/H2 dispatch and redirect checker
