### PR TITLE
fix(admin): preserve quota limits on partial group updates

### DIFF
--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -81,8 +81,8 @@ func (f optionalLimitField) ToServiceInput() *float64 {
 	if f.value != nil {
 		return f.value
 	}
-	zero := 0.0
-	return &zero
+	unlimited := -1.0
+	return &unlimited
 }
 
 // NewGroupHandler creates a new admin group handler

--- a/backend/internal/handler/admin/group_handler_limit_test.go
+++ b/backend/internal/handler/admin/group_handler_limit_test.go
@@ -1,0 +1,33 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateGroupRequestLimitFieldsTriState(t *testing.T) {
+	t.Run("omitted means unchanged", func(t *testing.T) {
+		var req UpdateGroupRequest
+		require.NoError(t, json.Unmarshal([]byte(`{}`), &req))
+		require.Nil(t, req.DailyLimitUSD.ToServiceInput())
+		require.Nil(t, req.WeeklyLimitUSD.ToServiceInput())
+		require.Nil(t, req.MonthlyLimitUSD.ToServiceInput())
+	})
+
+	t.Run("null means unlimited", func(t *testing.T) {
+		var req UpdateGroupRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"daily_limit_usd":null}`), &req))
+		limit := req.DailyLimitUSD.ToServiceInput()
+		require.NotNil(t, limit)
+		require.Negative(t, *limit)
+	})
+
+	t.Run("number is preserved", func(t *testing.T) {
+		var req UpdateGroupRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"weekly_limit_usd":0,"monthly_limit_usd":42.5}`), &req))
+		require.Equal(t, 0.0, *req.WeeklyLimitUSD.ToServiceInput())
+		require.Equal(t, 42.5, *req.MonthlyLimitUSD.ToServiceInput())
+	})
+}

--- a/backend/internal/service/admin_group.go
+++ b/backend/internal/service/admin_group.go
@@ -680,11 +680,16 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	if input.SubscriptionType != "" {
 		group.SubscriptionType = input.SubscriptionType
 	}
-	// 限额字段：nil/负数 表示"无限制"，0 表示"不允许用量"，正数表示具体限额
-	// 前端始终发送这三个字段，无需 nil 守卫
-	group.DailyLimitUSD = normalizeLimit(input.DailyLimitUSD)
-	group.WeeklyLimitUSD = normalizeLimit(input.WeeklyLimitUSD)
-	group.MonthlyLimitUSD = normalizeLimit(input.MonthlyLimitUSD)
+	// 限额字段：nil 表示不修改，负数表示"无限制"，0 表示"不允许用量"，正数表示具体限额。
+	if input.DailyLimitUSD != nil {
+		group.DailyLimitUSD = normalizeLimit(input.DailyLimitUSD)
+	}
+	if input.WeeklyLimitUSD != nil {
+		group.WeeklyLimitUSD = normalizeLimit(input.WeeklyLimitUSD)
+	}
+	if input.MonthlyLimitUSD != nil {
+		group.MonthlyLimitUSD = normalizeLimit(input.MonthlyLimitUSD)
+	}
 	// 图片生成计费配置：负数表示清除（使用默认价格）
 	if input.AllowImageGeneration != nil {
 		group.AllowImageGeneration = *input.AllowImageGeneration

--- a/backend/internal/service/admin_service_group_test.go
+++ b/backend/internal/service/admin_service_group_test.go
@@ -603,6 +603,42 @@ func TestAdminService_UpdateGroup_PreservesImageGenerationControlsWhenOmitted(t 
 	require.InDelta(t, 0.5, repo.updated.ImageRateMultiplier, 1e-12)
 }
 
+func TestAdminService_UpdateGroup_LimitFieldsPartialUpdate(t *testing.T) {
+	daily, weekly, monthly := 10.0, 20.0, 30.0
+	existingGroup := &Group{
+		ID:              1,
+		Name:            "existing-group",
+		Platform:        PlatformOpenAI,
+		Status:          StatusActive,
+		DailyLimitUSD:   &daily,
+		WeeklyLimitUSD:  &weekly,
+		MonthlyLimitUSD: &monthly,
+	}
+	repo := &groupRepoStubForAdmin{getByID: existingGroup}
+	svc := &adminServiceImpl{groupRepo: repo}
+
+	t.Run("non-quota update preserves all limits", func(t *testing.T) {
+		description := "updated"
+		group, err := svc.UpdateGroup(context.Background(), existingGroup.ID, &UpdateGroupInput{Description: &description})
+		require.NoError(t, err)
+		require.Equal(t, 10.0, *group.DailyLimitUSD)
+		require.Equal(t, 20.0, *group.WeeklyLimitUSD)
+		require.Equal(t, 30.0, *group.MonthlyLimitUSD)
+	})
+
+	t.Run("explicit changes and unlimited clear only touched limits", func(t *testing.T) {
+		newDaily, unlimited := 15.0, -1.0
+		group, err := svc.UpdateGroup(context.Background(), existingGroup.ID, &UpdateGroupInput{
+			DailyLimitUSD:  &newDaily,
+			WeeklyLimitUSD: &unlimited,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 15.0, *group.DailyLimitUSD)
+		require.Nil(t, group.WeeklyLimitUSD)
+		require.Equal(t, 30.0, *group.MonthlyLimitUSD)
+	})
+}
+
 func TestAdminService_UpdateGroup_DisablesBatchImageWhenImageGenerationDisabled(t *testing.T) {
 	existingGroup := &Group{
 		ID:                        1,


### PR DESCRIPTION
## 背景

管理员对分组执行部分更新时，未提交的日、周、月额度字段应保留原值，避免无关配置更新意外改变已有额度。

## 根因

额度字段在请求与服务层之间未完整保留“未提供”的语义：缺省值可能被转换为具体额度并参与更新，导致部分更新覆盖已有配置。

## 改动

- 保留额度字段的可选状态，未提供时不修改已有值。
- 明确负数表示无限制、0 表示不允许用量、正数表示具体额度。
- 补充 handler 与 service 层回归测试，覆盖缺省额度及显式额度更新场景。

## 验证

- targeted handler/service regression tests passed
- backend unit and integration suites passed
- golangci-lint passed
- frontend lint/typecheck and focused test passed
- portable deployment shell tests passed
- git diff --check passed
- macOS-specific apple-container mode assertion could not run on Linux
- vulnerability database network lookup timed out; no pass result is claimed for this lookup

Fixes #6381