### PR TITLE
fix(openai): isolate passthrough websocket sessions

### DIFF
--- a/backend/internal/service/openai_ws_session_preemption.go
+++ b/backend/internal/service/openai_ws_session_preemption.go
@@ -56,6 +56,10 @@ func (s *OpenAIGatewayService) BeginOpenAIWSIngressSessionPreemption(
 	if armed, _ := ctx.Value(openAIWSSessionPreemptContextKey{}).(bool); armed {
 		return ctx, func() {}, true
 	}
+	if s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.ModeRouterV2Enabled &&
+		account != nil && account.ResolveOpenAIResponsesWebSocketV2Mode(s.cfg.Gateway.OpenAIWS.IngressModeDefault) == OpenAIWSIngressModePassthrough {
+		return ctx, func() {}, false
+	}
 
 	preemptSessionHash := ""
 	preemptGroupID := getOpenAIGroupIDFromContext(c)

--- a/backend/internal/service/openai_ws_session_preemption_test.go
+++ b/backend/internal/service/openai_ws_session_preemption_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -149,6 +150,59 @@ func TestOpenAIWSIngressSessionPreemptionSurvivesNestedForwardCleanup(t *testing
 	require.True(t, armed)
 	defer secondCleanup()
 	require.True(t, IsOpenAIWSSessionPreemptedError(context.Cause(firstCtx)))
+}
+
+func TestOpenAIWSIngressSessionPreemptionRespectsResolvedMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(7)
+	newContext := func() *gin.Context {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+		c.Set("api_key", &APIKey{ID: 11, GroupID: &groupID})
+		return c
+	}
+	newAccount := func(mode string) *Account {
+		return &Account{
+			ID:       1,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra: map[string]any{
+				"openai_oauth_responses_websockets_v2_mode": mode,
+			},
+		}
+	}
+	firstMessage := []byte(`{"type":"response.create","prompt_cache_key":"session-1","input":"hello"}`)
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModeCtxPool
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	passthrough := newAccount(OpenAIWSIngressModePassthrough)
+	firstCtx, firstCleanup, armed := svc.BeginOpenAIWSIngressSessionPreemption(
+		context.Background(), newContext(), passthrough, firstMessage,
+	)
+	require.False(t, armed)
+	defer firstCleanup()
+	secondCtx, secondCleanup, armed := svc.BeginOpenAIWSIngressSessionPreemption(
+		context.Background(), newContext(), passthrough, firstMessage,
+	)
+	require.False(t, armed)
+	defer secondCleanup()
+	require.NoError(t, firstCtx.Err(), "concurrent passthrough request must remain isolated")
+	require.NoError(t, secondCtx.Err())
+
+	ctxPool := newAccount(OpenAIWSIngressModeCtxPool)
+	sharedCtx, sharedCleanup, armed := svc.BeginOpenAIWSIngressSessionPreemption(
+		context.Background(), newContext(), ctxPool, firstMessage,
+	)
+	require.True(t, armed)
+	defer sharedCleanup()
+	_, replacementCleanup, armed := svc.BeginOpenAIWSIngressSessionPreemption(
+		context.Background(), newContext(), ctxPool, firstMessage,
+	)
+	require.True(t, armed)
+	defer replacementCleanup()
+	require.True(t, IsOpenAIWSSessionPreemptedError(context.Cause(sharedCtx)), "ctx_pool must retain shared-session preemption")
 }
 
 func TestOpenAIWSSessionPreemptRemoteClaimAndStaleReleaseAreAtomic(t *testing.T) {


### PR DESCRIPTION
## 背景

透传 WebSocket 会话需要与常规会话保持隔离，避免会话抢占逻辑影响不相关连接。

## 根因

现有会话抢占判断未区分透传 WebSocket 会话，导致不同类型的会话可能进入同一抢占路径。

## 改动

- 将透传 WebSocket 会话从常规会话抢占逻辑中隔离。
- 补充会话隔离与抢占行为的回归测试。

## 验证

- 聚焦的会话抢占测试通过。
- 后端单元测试和集成测试套件通过。
- golangci-lint 通过。
- 前端 lint、typecheck 和聚焦测试通过。
- 可移植部署 shell 测试通过。
- git diff --check 通过。
- macOS 专用的 apple-container 模式断言无法在 Linux 上运行，未计为通过。
- 漏洞数据库网络查询超时，未计为通过。

Fixes #6383