### PR TITLE
fix(openai): rearm persisted model circuit after expiry

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2457,6 +2457,32 @@ func (r *accountRepository) ClearModelRateLimits(ctx context.Context, id int64) 
 	return nil
 }
 
+func (r *accountRepository) ClearModelRateLimitIfMatch(ctx context.Context, id int64, modelID string, observed json.RawMessage) (bool, error) {
+	if modelID == "" || len(observed) == 0 {
+		return false, nil
+	}
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(ctx, `
+		UPDATE accounts
+		SET extra = COALESCE(extra, '{}'::jsonb) #- ARRAY['model_rate_limits', $1]::text[], updated_at = NOW()
+		WHERE id = $2
+			AND deleted_at IS NULL
+			AND extra #> ARRAY['model_rate_limits', $1]::text[] = $3::jsonb
+	`, modelID, id, string(observed))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional model recovery failed: account=%d model=%s err=%v", id, modelID, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
+}
+
 func (r *accountRepository) UpdateSessionWindow(ctx context.Context, id int64, start, end *time.Time, status string) error {
 	builder := r.client.Account.Update().
 		Where(dbaccount.IDEQ(id)).

--- a/backend/internal/service/openai_account_model_transient.go
+++ b/backend/internal/service/openai_account_model_transient.go
@@ -22,8 +22,10 @@ const (
 	openAIModelTransientStreakTTL     = 30 * time.Minute
 	openAIModelTransientShortCooldown = 10 * time.Second
 	openAIModelTransientLongCooldown  = 45 * time.Second
+	openAIModelTransientCircuitTTL    = 10 * time.Minute
 	openAIModelTransientDefaultMax    = 4096
 	openAIModelTransientMaxModelBytes = 512
+	openAIModelTransientMaxRequestIDs = 64
 )
 
 type openAIAccountModelKey struct {
@@ -32,22 +34,41 @@ type openAIAccountModelKey struct {
 }
 
 type openAIAccountModelTransientEntry struct {
-	failureStreak int
-	lastFailure   time.Time
-	blockUntil    time.Time
-	lastTouched   time.Time
+	failureStreak         int
+	lastFailure           time.Time
+	blockUntil            time.Time
+	lastTouched           time.Time
+	requestIDs            map[string]struct{}
+	durableStreak         int
+	persisting            bool
+	persisted             bool
+	persistenceUntil      time.Time
+	persistenceGeneration uint64
+	mutationGeneration    uint64
 }
 
 type openAIAccountModelTransientDecision struct {
-	FailureStreak int
-	Cooldown      time.Duration
-	BlockUntil    time.Time
+	FailureStreak         int
+	Cooldown              time.Duration
+	BlockUntil            time.Time
+	Counted               bool
+	OpenCircuit           bool
+	PersistenceGeneration uint64
+}
+
+type openAIAccountModelTransientKeyLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 type openAIAccountModelTransientState struct {
-	mu         sync.Mutex
-	entries    map[openAIAccountModelKey]openAIAccountModelTransientEntry
-	maxEntries int
+	mu                        sync.Mutex
+	entries                   map[openAIAccountModelKey]openAIAccountModelTransientEntry
+	keyLocks                  map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock
+	persistenceLocks          map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock
+	maxEntries                int
+	nextPersistenceGeneration uint64
+	nextMutationGeneration    uint64
 }
 
 func newOpenAIAccountModelTransientState(maxEntries int) *openAIAccountModelTransientState {
@@ -55,8 +76,63 @@ func newOpenAIAccountModelTransientState(maxEntries int) *openAIAccountModelTran
 		maxEntries = openAIModelTransientDefaultMax
 	}
 	return &openAIAccountModelTransientState{
-		entries:    make(map[openAIAccountModelKey]openAIAccountModelTransientEntry),
-		maxEntries: maxEntries,
+		entries:          make(map[openAIAccountModelKey]openAIAccountModelTransientEntry),
+		keyLocks:         make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock),
+		persistenceLocks: make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock),
+		maxEntries:       maxEntries,
+	}
+}
+
+func (s *openAIAccountModelTransientState) lockKey(key openAIAccountModelKey) func() {
+	s.mu.Lock()
+	if s.keyLocks == nil {
+		s.keyLocks = make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock)
+	}
+	keyLock := s.keyLocks[key]
+	if keyLock == nil {
+		keyLock = &openAIAccountModelTransientKeyLock{}
+		s.keyLocks[key] = keyLock
+	}
+	keyLock.refs++
+	s.mu.Unlock()
+
+	keyLock.mu.Lock()
+	return func() {
+		keyLock.mu.Unlock()
+		s.mu.Lock()
+		keyLock.refs--
+		if keyLock.refs == 0 {
+			delete(s.keyLocks, key)
+		}
+		if s.maxEntries > 0 && len(s.entries) > s.maxEntries {
+			s.evictOldestLocked()
+		}
+		s.mu.Unlock()
+	}
+}
+
+func (s *openAIAccountModelTransientState) lockPersistenceKey(key openAIAccountModelKey) func() {
+	s.mu.Lock()
+	if s.persistenceLocks == nil {
+		s.persistenceLocks = make(map[openAIAccountModelKey]*openAIAccountModelTransientKeyLock)
+	}
+	keyLock := s.persistenceLocks[key]
+	if keyLock == nil {
+		keyLock = &openAIAccountModelTransientKeyLock{}
+		s.persistenceLocks[key] = keyLock
+	}
+	keyLock.refs++
+	s.mu.Unlock()
+
+	keyLock.mu.Lock()
+	return func() {
+		keyLock.mu.Unlock()
+		s.mu.Lock()
+		keyLock.refs--
+		if keyLock.refs == 0 {
+			delete(s.persistenceLocks, key)
+		}
+		s.mu.Unlock()
 	}
 }
 
@@ -76,7 +152,7 @@ func openAIAccountModelTransientKey(accountID int64, model string) (openAIAccoun
 	return openAIAccountModelKey{AccountID: accountID, Model: model}, true
 }
 
-func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model string, now time.Time) openAIAccountModelTransientDecision {
+func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model string, now time.Time, requestID ...string) openAIAccountModelTransientDecision {
 	key, ok := openAIAccountModelTransientKey(accountID, model)
 	if s == nil || !ok {
 		return openAIAccountModelTransientDecision{}
@@ -85,6 +161,8 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 		now = time.Now()
 	}
 
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.entries == nil {
@@ -98,13 +176,52 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 	if !exists {
 		s.evictOldestLocked()
 	}
-	// The streak is cleared by recordSuccess. Only drop it here when the entry
-	// is stale beyond the TTL, or when the clock moved backwards.
-	if !exists || entry.lastFailure.IsZero() || now.Sub(entry.lastFailure) > openAIModelTransientStreakTTL || now.Before(entry.lastFailure) {
+	if !exists || entry.lastFailure.IsZero() || now.Sub(entry.lastFailure) > openAIModelTransientStreakTTL || now.Before(entry.lastFailure) ||
+		(entry.persisted && !entry.persistenceUntil.IsZero() && !now.Before(entry.persistenceUntil)) {
 		entry.failureStreak = 0
 		entry.blockUntil = time.Time{}
+		entry.requestIDs = nil
+		entry.durableStreak = 0
+		entry.persisting = false
+		entry.persisted = false
+		entry.persistenceUntil = time.Time{}
+		entry.persistenceGeneration = 0
+	}
+	currentRequestID := ""
+	openCircuit := false
+	if len(requestID) > 0 {
+		currentRequestID = strings.TrimSpace(requestID[0])
+	}
+	if currentRequestID != "" {
+		if _, duplicate := entry.requestIDs[currentRequestID]; duplicate {
+			return openAIAccountModelTransientDecision{
+				FailureStreak: entry.failureStreak,
+				BlockUntil:    entry.blockUntil,
+			}
+		}
+		if entry.requestIDs == nil {
+			entry.requestIDs = make(map[string]struct{})
+		}
+		if len(entry.requestIDs) >= openAIModelTransientMaxRequestIDs {
+			for oldestID := range entry.requestIDs {
+				delete(entry.requestIDs, oldestID)
+				break
+			}
+		}
+		entry.requestIDs[currentRequestID] = struct{}{}
+		if !entry.persisted && !entry.persisting {
+			entry.durableStreak++
+			if entry.durableStreak >= 3 {
+				s.nextPersistenceGeneration++
+				entry.persisting = true
+				entry.persistenceGeneration = s.nextPersistenceGeneration
+				openCircuit = true
+			}
+		}
 	}
 	entry.failureStreak++
+	s.nextMutationGeneration++
+	entry.mutationGeneration = s.nextMutationGeneration
 	entry.lastFailure = now
 	entry.lastTouched = now
 
@@ -122,20 +239,104 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 	}
 	s.entries[key] = entry
 	return openAIAccountModelTransientDecision{
-		FailureStreak: entry.failureStreak,
-		Cooldown:      cooldown,
-		BlockUntil:    entry.blockUntil,
+		FailureStreak:         entry.failureStreak,
+		Cooldown:              cooldown,
+		BlockUntil:            entry.blockUntil,
+		Counted:               true,
+		OpenCircuit:           openCircuit,
+		PersistenceGeneration: entry.persistenceGeneration,
 	}
 }
 
-func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model string) {
+func (s *openAIAccountModelTransientState) mutationGeneration(accountID int64, model string) uint64 {
 	key, ok := openAIAccountModelTransientKey(accountID, model)
 	if s == nil || !ok {
-		return
+		return 0
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.entries[key].mutationGeneration
+}
+
+func (s *openAIAccountModelTransientState) mutationGenerations(accountID int64) map[string]uint64 {
+	if s == nil || accountID <= 0 {
+		return nil
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[string]uint64)
+	for key, entry := range s.entries {
+		if key.AccountID == accountID {
+			result[key.Model] = entry.mutationGeneration
+		}
+	}
+	return result
+}
+
+func (s *openAIAccountModelTransientState) clearCircuitIfGeneration(
+	accountID int64,
+	model string,
+	observedGeneration uint64,
+	clear func() (bool, error),
+) (bool, error) {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return clear()
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	if entry, exists := s.entries[key]; exists && entry.mutationGeneration != observedGeneration {
+		s.mu.Unlock()
+		return false, nil
+	}
+	s.mu.Unlock()
+	cleared, err := clear()
+	if err == nil && cleared {
+		s.mu.Lock()
+		delete(s.entries, key)
+		s.mu.Unlock()
+	}
+	return cleared, err
+}
+
+func (s *openAIAccountModelTransientState) finishCircuitPersistence(accountID int64, model string, generation uint64, persisted bool, persistenceUntil ...time.Time) bool {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return false
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, exists := s.entries[key]
+	if !exists || !entry.persisting || entry.persistenceGeneration != generation {
+		return false
+	}
+	entry.persisting = false
+	entry.persisted = persisted
+	entry.persistenceUntil = time.Time{}
+	if persisted && len(persistenceUntil) > 0 {
+		entry.persistenceUntil = persistenceUntil[0]
+	}
+	s.entries[key] = entry
+	return true
+}
+
+func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model string) (uint64, bool) {
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if s == nil || !ok {
+		return 0, false
+	}
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
+	s.mu.Lock()
+	entry := s.entries[key]
 	delete(s.entries, key)
 	s.mu.Unlock()
+	return entry.persistenceGeneration, entry.persisted
 }
 
 func (s *openAIAccountModelTransientState) isBlocked(accountID int64, model string, now time.Time) bool {
@@ -147,6 +348,8 @@ func (s *openAIAccountModelTransientState) isBlocked(accountID int64, model stri
 		now = time.Now()
 	}
 
+	unlockKey := s.lockKey(key)
+	defer unlockKey()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	entry, exists := s.entries[key]
@@ -179,6 +382,9 @@ func (s *openAIAccountModelTransientState) evictOldestLocked() {
 	var oldestTime time.Time
 	found := false
 	for key, entry := range s.entries {
+		if keyLock := s.keyLocks[key]; keyLock != nil && keyLock.refs > 0 {
+			continue
+		}
 		if !found || entry.lastTouched.Before(oldestTime) {
 			oldestKey = key
 			oldestTime = entry.lastTouched

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -2,11 +2,15 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 )
 
 const (
@@ -188,8 +192,13 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		if len(canonicalModel) > 0 {
 			model = canonicalModel[0]
 		}
-		decision := s.recordOpenAIAccountModelTransientFailure(account, model, time.Now())
-		if decision.FailureStreak > 0 {
+		now := time.Now()
+		requestID := ""
+		if shouldPersistOpenAITransientCircuit(statusCode) {
+			requestID = openAITransientRequestID(ctx)
+		}
+		decision := s.recordOpenAIAccountModelTransientFailure(account, model, now, requestID)
+		if decision.Counted {
 			slog.Warn("openai_model_transient_state",
 				"account_id", account.ID,
 				"model", openAIAccountModelTransientModel(model),
@@ -198,8 +207,42 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 				"block_scope", "account_model",
 			)
 		}
+		if decision.OpenCircuit && strings.TrimSpace(model) != "" {
+			s.persistOpenAIAccountModelTransientCircuit(stateCtx, account, model, now, decision)
+		}
 	}
 	return shouldDisable
+}
+
+func openAITransientRequestID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	requestID, _ := ctx.Value(ctxkey.RequestID).(string)
+	return strings.TrimSpace(requestID)
+}
+
+func openAITransientCircuitReason(generation uint64) string {
+	return fmt.Sprintf("openai_transient_failure_circuit:%d", generation)
+}
+
+func (s *OpenAIGatewayService) persistOpenAIAccountModelTransientCircuit(ctx context.Context, account *Account, model string, now time.Time, decision openAIAccountModelTransientDecision) {
+	unlock := s.lockOpenAIAccountModelTransientPersistence(account.ID, model)
+	defer unlock()
+	persisted := false
+	resetAt := now.Add(openAIModelTransientCircuitTTL)
+	reason := openAITransientCircuitReason(decision.PersistenceGeneration)
+	if s.rateLimitService.accountRepo != nil {
+		if err := s.rateLimitService.accountRepo.SetModelRateLimit(ctx, account.ID, model, resetAt, reason); err != nil {
+			slog.Warn("openai_model_transient_circuit_persist_failed", "account_id", account.ID, "model", model, "error", err)
+		} else {
+			persisted = true
+			slog.Warn("openai_model_transient_circuit_opened", "account_id", account.ID, "model", model, "failure_streak", decision.FailureStreak, "reset_at", resetAt)
+		}
+	}
+	if current := s.finishOpenAIAccountModelTransientPersistence(account.ID, model, decision.PersistenceGeneration, persisted, resetAt); persisted && !current {
+		s.clearOpenAITransientCircuitIfMatch(ctx, account.ID, model, reason)
+	}
 }
 
 func shouldCooldownOpenAITransientUpstreamError(statusCode int, responseBody []byte) bool {
@@ -208,6 +251,15 @@ func shouldCooldownOpenAITransientUpstreamError(statusCode int, responseBody []b
 		return true
 	case http.StatusBadRequest:
 		return isOpenAITransientProcessingError(statusCode, "", responseBody)
+	default:
+		return false
+	}
+}
+
+func shouldPersistOpenAITransientCircuit(statusCode int) bool {
+	switch statusCode {
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, 520, 521, 522, 523, 524:
+		return true
 	default:
 		return false
 	}
@@ -442,7 +494,7 @@ func openAIAccountModelTransientModel(canonicalModel string) string {
 	return normalizeOpenAIAccountModelTransientModel(canonicalModel)
 }
 
-func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time) openAIAccountModelTransientDecision {
+func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time, requestID ...string) openAIAccountModelTransientDecision {
 	if s == nil || account == nil {
 		return openAIAccountModelTransientDecision{}
 	}
@@ -450,7 +502,7 @@ func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account 
 	if state == nil {
 		return openAIAccountModelTransientDecision{}
 	}
-	return state.recordFailure(account.ID, openAIAccountModelTransientModel(canonicalModel), now)
+	return state.recordFailure(account.ID, openAIAccountModelTransientModel(canonicalModel), now, requestID...)
 }
 
 func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID int64, model string) {
@@ -458,7 +510,82 @@ func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID i
 	if state == nil {
 		return
 	}
-	state.recordSuccess(accountID, model)
+	generation, persisted := state.recordSuccess(accountID, model)
+	if !persisted {
+		return
+	}
+	unlock := state.lockPersistenceKey(openAIAccountModelKey{AccountID: accountID, Model: normalizeOpenAIAccountModelTransientModel(model)})
+	defer unlock()
+	s.clearOpenAITransientCircuitIfMatch(context.Background(), accountID, model, openAITransientCircuitReason(generation))
+}
+
+func (s *OpenAIGatewayService) openAIAccountModelTransientGenerations(accountID int64) map[string]uint64 {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return nil
+	}
+	return state.mutationGenerations(accountID)
+}
+
+func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientStateIfGeneration(
+	accountID int64,
+	model string,
+	observedGeneration uint64,
+	clear func() (bool, error),
+) (bool, error) {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return clear()
+	}
+	return state.clearCircuitIfGeneration(accountID, model, observedGeneration, clear)
+}
+
+func (s *OpenAIGatewayService) finishOpenAIAccountModelTransientPersistence(accountID int64, model string, generation uint64, persisted bool, persistenceUntil ...time.Time) bool {
+	state := s.getOpenAIAccountModelTransientState()
+	if state == nil {
+		return false
+	}
+	return state.finishCircuitPersistence(accountID, model, generation, persisted, persistenceUntil...)
+}
+
+func (s *OpenAIGatewayService) lockOpenAIAccountModelTransientPersistence(accountID int64, model string) func() {
+	state := s.getOpenAIAccountModelTransientState()
+	key, ok := openAIAccountModelTransientKey(accountID, model)
+	if state == nil || !ok {
+		return func() {}
+	}
+	return state.lockPersistenceKey(key)
+}
+
+func (s *OpenAIGatewayService) clearOpenAITransientCircuitIfMatch(ctx context.Context, accountID int64, model string, reason string) {
+	type conditionalModelRateLimitClearer interface {
+		ClearModelRateLimitIfMatch(context.Context, int64, string, json.RawMessage) (bool, error)
+	}
+	if s == nil || s.rateLimitService == nil || s.rateLimitService.accountRepo == nil {
+		return
+	}
+	repo, ok := s.rateLimitService.accountRepo.(conditionalModelRateLimitClearer)
+	if !ok {
+		return
+	}
+	cleanupCtx, cancel := openAIAccountStateContext(ctx)
+	defer cancel()
+	account, err := s.rateLimitService.accountRepo.GetByID(cleanupCtx, accountID)
+	if err != nil || account == nil {
+		return
+	}
+	limits, _ := account.Extra[modelRateLimitsKey].(map[string]any)
+	limit, _ := limits[model].(map[string]any)
+	if limit["reason"] != reason {
+		return
+	}
+	observed, err := json.Marshal(limit)
+	if err != nil {
+		return
+	}
+	if _, err := repo.ClearModelRateLimitIfMatch(cleanupCtx, accountID, model, observed); err != nil {
+		slog.Warn("openai_model_transient_stale_circuit_clear_failed", "account_id", accountID, "model", model, "error", err)
+	}
 }
 
 func (s *OpenAIGatewayService) isOpenAIAccountModelRuntimeBlocked(account *Account, requestedModel string) bool {

--- a/backend/internal/service/openai_account_runtime_transient_test.go
+++ b/backend/internal/service/openai_account_runtime_transient_test.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,6 +19,375 @@ type transientCooldownAccountRepo struct {
 
 func (transientCooldownAccountRepo) SetOverloaded(context.Context, int64, time.Time) error {
 	return nil
+}
+
+type transientCircuitRateLimitCall struct {
+	accountID int64
+	model     string
+	resetAt   time.Time
+}
+
+type transientCircuitAccountRepo struct {
+	AccountRepository
+	calls []transientCircuitRateLimitCall
+}
+
+type blockingTransientCircuitAccountRepo struct {
+	AccountRepository
+	mu                 sync.Mutex
+	account            *Account
+	writeCount         int
+	firstWriteStarted  chan struct{}
+	secondWriteStarted chan struct{}
+	releaseFirstWrite  chan struct{}
+}
+
+func (r *blockingTransientCircuitAccountRepo) SetModelRateLimit(_ context.Context, _ int64, model string, resetAt time.Time, reason ...string) error {
+	r.mu.Lock()
+	r.writeCount++
+	writeSequence := r.writeCount
+	r.mu.Unlock()
+	if writeSequence == 1 {
+		close(r.firstWriteStarted)
+		<-r.releaseFirstWrite
+	} else if writeSequence == 2 {
+		close(r.secondWriteStarted)
+	}
+	limit := map[string]any{
+		"rate_limited_at":     time.Now().UTC().Format(time.RFC3339),
+		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+		"updated_at":          time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if len(reason) > 0 {
+		limit["reason"] = reason[0]
+	}
+	r.mu.Lock()
+	r.account.Extra = map[string]any{modelRateLimitsKey: map[string]any{model: limit}}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *blockingTransientCircuitAccountRepo) GetByID(_ context.Context, _ int64) (*Account, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.account, nil
+}
+
+func (r *blockingTransientCircuitAccountRepo) ClearModelRateLimitIfMatch(_ context.Context, _ int64, model string, observed json.RawMessage) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	limits := r.account.Extra[modelRateLimitsKey].(map[string]any)
+	current, _ := json.Marshal(limits[model])
+	if string(current) != string(observed) {
+		return false, nil
+	}
+	delete(limits, model)
+	return true, nil
+}
+
+func (r *transientCircuitAccountRepo) SetOverloaded(context.Context, int64, time.Time) error {
+	return nil
+}
+
+func (r *transientCircuitAccountRepo) SetModelRateLimit(_ context.Context, accountID int64, model string, resetAt time.Time, _ ...string) error {
+	r.calls = append(r.calls, transientCircuitRateLimitCall{accountID: accountID, model: model, resetAt: resetAt})
+	return nil
+}
+
+func TestHandleOpenAITransientError_ThreeDistinctRequestsPersistModelCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5110, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	startedAt := time.Now()
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Len(t, repo.calls, 1)
+	require.Equal(t, account.ID, repo.calls[0].accountID)
+	require.Equal(t, "gpt-5.6-sol", repo.calls[0].model)
+	require.WithinDuration(t, startedAt.Add(10*time.Minute), repo.calls[0].resetAt, 2*time.Second)
+}
+
+func TestHandleOpenAITransientError_RearmsAfterPersistedCircuitExpires(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5118, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"initial-1", "initial-2", "initial-3"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	require.Len(t, repo.calls, 1)
+
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "before-expiry")
+	svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	require.Len(t, repo.calls, 1)
+
+	state := svc.getOpenAIAccountModelTransientState()
+	key, ok := openAIAccountModelTransientKey(account.ID, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	entry := state.entries[key]
+	persistenceUntil := entry.persistenceUntil
+	state.mu.Unlock()
+	require.Equal(t, repo.calls[0].resetAt, persistenceUntil)
+
+	state.mu.Lock()
+	entry = state.entries[key]
+	entry.persistenceUntil = time.Now().Add(-time.Second)
+	state.entries[key] = entry
+	state.mu.Unlock()
+
+	for _, requestID := range []string{"rearmed-1", "rearmed-2"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	require.Len(t, repo.calls, 1)
+
+	ctx = context.WithValue(context.Background(), ctxkey.RequestID, "rearmed-3")
+	svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	require.Len(t, repo.calls, 2)
+
+	state.mu.Lock()
+	entry = state.entries[key]
+	state.mu.Unlock()
+	require.Equal(t, 3, entry.failureStreak)
+	require.Equal(t, uint64(2), entry.persistenceGeneration)
+	require.True(t, entry.persisted)
+}
+
+func TestHandleOpenAITransientError_StalePersistenceDoesNotOverwriteNewCircuit(t *testing.T) {
+	account := &Account{ID: 5117, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{}}
+	repo := &blockingTransientCircuitAccountRepo{
+		account:            account,
+		firstWriteStarted:  make(chan struct{}),
+		secondWriteStarted: make(chan struct{}),
+		releaseFirstWrite:  make(chan struct{}),
+	}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+
+	for _, requestID := range []string{"request-1", "request-2"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, "request-3")
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}()
+	<-repo.firstWriteStarted
+	state := svc.getOpenAIAccountModelTransientState()
+	key, ok := openAIAccountModelTransientKey(account.ID, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	persistenceLock := state.persistenceLocks[key]
+	state.mu.Unlock()
+	require.NotNil(t, persistenceLock)
+	lockWasFree := persistenceLock.mu.TryLock()
+	if lockWasFree {
+		persistenceLock.mu.Unlock()
+	}
+	require.False(t, lockWasFree)
+
+	svc.ReportOpenAIAccountScheduleResult(account, "gpt-5.6-sol", true, nil)
+	for _, requestID := range []string{"new-request-1", "new-request-2"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	secondWriteDone := make(chan struct{})
+	now := time.Now()
+	decision := svc.recordOpenAIAccountModelTransientFailure(account, "gpt-5.6-sol", now, "new-request-3")
+	require.True(t, decision.OpenCircuit)
+	require.Equal(t, uint64(2), decision.PersistenceGeneration)
+	go func() {
+		defer close(secondWriteDone)
+		svc.persistOpenAIAccountModelTransientCircuit(context.Background(), account, "gpt-5.6-sol", now, decision)
+	}()
+	state.mu.Lock()
+	entry := state.entries[key]
+	state.mu.Unlock()
+	require.Equal(t, uint64(2), entry.persistenceGeneration)
+	require.True(t, entry.persisting)
+	select {
+	case <-repo.secondWriteStarted:
+		require.Fail(t, "new generation reached the DB writer before the stale generation finished")
+	default:
+	}
+	close(repo.releaseFirstWrite)
+	<-writeDone
+	<-secondWriteDone
+
+	repo.mu.Lock()
+	limits, _ := repo.account.Extra[modelRateLimitsKey].(map[string]any)
+	limit, persisted := limits["gpt-5.6-sol"].(map[string]any)
+	repo.mu.Unlock()
+	require.True(t, persisted)
+	require.Equal(t, "openai_transient_failure_circuit:2", limit["reason"])
+}
+
+func TestRecoverOpenAIAccountModelStateUsesCanonicalModelAndCAS(t *testing.T) {
+	account := &Account{
+		ID:       5119,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"public-alias": "upstream-a",
+			},
+		},
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				"upstream-a": map[string]any{
+					"rate_limit_reset_at": time.Now().Add(time.Hour).Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	repo := &blockingTransientCircuitAccountRepo{account: account}
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var claim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"request-1", "request-2", "request-3"} {
+		claim = state.recordFailure(account.ID, "upstream-a", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.finishCircuitPersistence(account.ID, "upstream-a", claim.PersistenceGeneration, true)
+	gateway := &OpenAIGatewayService{openaiModelTransient: state}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(gateway)
+
+	result, err := svc.RecoverAccountAfterSuccessfulTest(context.Background(), account.ID, "public-alias")
+
+	require.NoError(t, err)
+	require.True(t, result.ClearedRateLimit)
+	require.Zero(t, state.size())
+	limits, _ := account.Extra[modelRateLimitsKey].(map[string]any)
+	require.Empty(t, limits)
+}
+
+func TestHandleOpenAITransientError_RetriesWithinOneRequestCountOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5111, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "same-request")
+
+	for range 3 {
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Empty(t, repo.calls)
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "gpt-5.6-sol"))
+}
+
+func TestHandleOpenAITransientError_MissingRequestIDDoesNotAdvanceDurableCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5112, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for range 2 {
+		svc.handleOpenAIAccountUpstreamError(context.Background(), account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "first-proven-request")
+	svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+
+	require.Empty(t, repo.calls)
+}
+
+func TestHandleOpenAITransientError_OpenCircuitPersistsOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5113, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3", "request-4", "request-5"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	require.Len(t, repo.calls, 1)
+}
+
+func TestHandleOpenAITransientError_RetriesAfterCircuitThresholdCountOnce(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5114, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3", "request-4", "request-4"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusGatewayTimeout, http.Header{}, []byte(`{"error":{"message":"gateway timeout"}}`), "gpt-5.6-sol")
+	}
+
+	state := svc.getOpenAIAccountModelTransientState()
+	key, ok := openAIAccountModelTransientKey(account.ID, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	entry := state.entries[key]
+	state.mu.Unlock()
+	require.Equal(t, 4, entry.failureStreak)
+}
+
+func TestOpenAIModelTransientState_StalePersistenceCompletionDoesNotMutateNewClaim(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(1)
+	now := time.Now()
+	var oldClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"old-1", "old-2", "old-3"} {
+		oldClaim = state.recordFailure(5115, "gpt-5.6-sol", now.Add(time.Duration(i)*time.Millisecond), requestID)
+	}
+	state.recordSuccess(5115, "gpt-5.6-sol")
+
+	var newClaim openAIAccountModelTransientDecision
+	for i, requestID := range []string{"new-1", "new-2", "new-3"} {
+		newClaim = state.recordFailure(5115, "gpt-5.6-sol", now.Add(time.Duration(i+3)*time.Millisecond), requestID)
+	}
+	require.NotEqual(t, oldClaim.PersistenceGeneration, newClaim.PersistenceGeneration)
+
+	state.finishCircuitPersistence(5115, "gpt-5.6-sol", oldClaim.PersistenceGeneration, true)
+	key, ok := openAIAccountModelTransientKey(5115, "gpt-5.6-sol")
+	require.True(t, ok)
+	state.mu.Lock()
+	entry := state.entries[key]
+	state.mu.Unlock()
+	require.True(t, entry.persisting)
+	require.False(t, entry.persisted)
+	require.Equal(t, newClaim.PersistenceGeneration, entry.persistenceGeneration)
+}
+
+func TestOpenAIModelTransientState_RecoveryClearDoesNotBlockOtherAccount(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(2)
+	now := time.Now()
+	state.recordFailure(5201, "gpt-5.6-sol", now, "request-a")
+	observed := state.mutationGeneration(5201, "gpt-5.6-sol")
+	clearStarted := make(chan struct{})
+	releaseClear := make(chan struct{})
+	clearDone := make(chan struct{})
+	go func() {
+		defer close(clearDone)
+		_, _ = state.clearCircuitIfGeneration(5201, "gpt-5.6-sol", observed, func() (bool, error) {
+			close(clearStarted)
+			<-releaseClear
+			return true, nil
+		})
+	}()
+	<-clearStarted
+
+	otherDone := make(chan struct{})
+	go func() {
+		state.recordFailure(5202, "gpt-5.6-sol", now, "request-b")
+		close(otherDone)
+	}()
+	otherCompleted := false
+	select {
+	case <-otherDone:
+		otherCompleted = true
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(releaseClear)
+	<-clearDone
+
+	require.True(t, otherCompleted)
+	require.Equal(t, 1, state.size())
 }
 
 func TestHandleOpenAITransientError_BlocksOnlyRequestedModel(t *testing.T) {
@@ -61,6 +433,20 @@ func TestHandleOpenAITransientError_TransientStatusesUseModelScope(t *testing.T)
 
 func TestHandleOpenAITransientError_529RemainsOverloadOnly(t *testing.T) {
 	require.False(t, shouldCooldownOpenAITransientUpstreamError(529, []byte(`{"error":{"message":"overloaded"}}`)))
+}
+
+func TestHandleOpenAITransientError_Transient400DoesNotPersistDurableCircuit(t *testing.T) {
+	repo := &transientCircuitAccountRepo{}
+	svc := &OpenAIGatewayService{rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil)}
+	account := &Account{ID: 5116, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	for _, requestID := range []string{"request-1", "request-2", "request-3"} {
+		ctx := context.WithValue(context.Background(), ctxkey.RequestID, requestID)
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusBadRequest, http.Header{}, []byte(`{"error":{"message":"An error occurred while processing your request"}}`), "gpt-5.6-sol")
+	}
+
+	require.Empty(t, repo.calls)
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "gpt-5.6-sol"))
 }
 
 func TestHandleOpenAITransientError_CanonicalModelIsNotMappedTwice(t *testing.T) {

--- a/backend/internal/service/openai_account_runtime_transient_test.go
+++ b/backend/internal/service/openai_account_runtime_transient_test.go
@@ -47,10 +47,11 @@ func (r *blockingTransientCircuitAccountRepo) SetModelRateLimit(_ context.Contex
 	r.writeCount++
 	writeSequence := r.writeCount
 	r.mu.Unlock()
-	if writeSequence == 1 {
+	switch writeSequence {
+	case 1:
 		close(r.firstWriteStarted)
 		<-r.releaseFirstWrite
-	} else if writeSequence == 2 {
+	case 2:
 		close(r.secondWriteStarted)
 	}
 	limit := map[string]any{
@@ -77,7 +78,10 @@ func (r *blockingTransientCircuitAccountRepo) ClearModelRateLimitIfMatch(_ conte
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	limits := r.account.Extra[modelRateLimitsKey].(map[string]any)
-	current, _ := json.Marshal(limits[model])
+	current, err := json.Marshal(limits[model])
+	if err != nil {
+		return false, err
+	}
 	if string(current) != string(observed) {
 		return false, nil
 	}

--- a/backend/internal/service/openai_account_runtime_transient_test.go
+++ b/backend/internal/service/openai_account_runtime_transient_test.go
@@ -77,7 +77,10 @@ func (r *blockingTransientCircuitAccountRepo) GetByID(_ context.Context, _ int64
 func (r *blockingTransientCircuitAccountRepo) ClearModelRateLimitIfMatch(_ context.Context, _ int64, model string, observed json.RawMessage) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	limits := r.account.Extra[modelRateLimitsKey].(map[string]any)
+	limits, ok := r.account.Extra[modelRateLimitsKey].(map[string]any)
+	if !ok {
+		return false, nil
+	}
 	current, err := json.Marshal(limits[model])
 	if err != nil {
 		return false, err

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -2092,8 +2092,97 @@ func (s *RateLimitService) RecoverAccountState(ctx context.Context, accountID in
 
 // RecoverAccountAfterSuccessfulTest 将一次成功测试视为正常请求，
 // 按需恢复 error / rate-limit / overload / temp-unsched / model-rate-limit 等运行时状态。
-func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64) (*SuccessfulTestRecoveryResult, error) {
-	return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+// 传入 modelID 时仅恢复该 OpenAI model，避免旧测试结果清掉新一轮熔断。
+func (s *RateLimitService) RecoverAccountAfterSuccessfulTest(ctx context.Context, accountID int64, modelID ...string) (*SuccessfulTestRecoveryResult, error) {
+	if len(modelID) == 0 || strings.TrimSpace(modelID[0]) == "" {
+		return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+	}
+	return s.recoverOpenAIAccountModelState(ctx, accountID, modelID[0])
+}
+
+func (s *RateLimitService) recoverOpenAIAccountModelState(ctx context.Context, accountID int64, requestedModel string) (*SuccessfulTestRecoveryResult, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeAPIKey || account.Status == StatusError || hasAccountLevelRecoverableRuntimeState(account) {
+		return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+	}
+
+	canonicalModel := canonicalOpenAIAccountSchedulingModel(account, requestedModel)
+	modelID, observed, ok := openAIModelRateLimitSnapshot(account, canonicalModel)
+	if !ok {
+		return &SuccessfulTestRecoveryResult{}, nil
+	}
+
+	type conditionalModelRateLimitClearer interface {
+		ClearModelRateLimitIfMatch(context.Context, int64, string, json.RawMessage) (bool, error)
+	}
+	repo, ok := s.accountRepo.(conditionalModelRateLimitClearer)
+	if !ok {
+		return s.RecoverAccountState(ctx, accountID, AccountRecoveryOptions{})
+	}
+	clear := func() (bool, error) {
+		return repo.ClearModelRateLimitIfMatch(ctx, accountID, modelID, observed)
+	}
+	cleared, err := clearOpenAIModelRateLimitWithGeneration(s.runtimeBlocker, accountID, modelID, clear)
+	if err != nil {
+		return nil, err
+	}
+	result := &SuccessfulTestRecoveryResult{ClearedRateLimit: cleared}
+	if cleared {
+		s.ResetOpenAI403Counter(ctx, accountID)
+		s.notifyAccountSchedulingBlockCleared(accountID)
+	}
+	return result, nil
+}
+
+func hasAccountLevelRecoverableRuntimeState(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	return account.RateLimitedAt != nil || account.RateLimitResetAt != nil || account.OverloadUntil != nil || account.TempUnschedulableUntil != nil ||
+		hasNonEmptyMapValue(account.Extra, "antigravity_quota_scopes")
+}
+
+func openAIModelRateLimitSnapshot(account *Account, canonicalModel string) (string, json.RawMessage, bool) {
+	if account == nil || account.Extra == nil {
+		return "", nil, false
+	}
+	limits, ok := account.Extra[modelRateLimitsKey].(map[string]any)
+	if !ok {
+		return "", nil, false
+	}
+	for modelID, limit := range limits {
+		if !strings.EqualFold(strings.TrimSpace(modelID), strings.TrimSpace(canonicalModel)) || !account.isRateLimitActiveForKey(modelID) {
+			continue
+		}
+		observed, err := json.Marshal(limit)
+		if err != nil {
+			return "", nil, false
+		}
+		return modelID, observed, true
+	}
+	return "", nil, false
+}
+
+func clearOpenAIModelRateLimitWithGeneration(
+	runtimeBlocker AccountRuntimeBlocker,
+	accountID int64,
+	modelID string,
+	clear func() (bool, error),
+) (bool, error) {
+	if guard, ok := runtimeBlocker.(interface {
+		openAIAccountModelTransientGenerations(int64) map[string]uint64
+	}); ok {
+		generation := guard.openAIAccountModelTransientGenerations(accountID)[normalizeOpenAIAccountModelTransientModel(modelID)]
+		if clearer, ok := runtimeBlocker.(interface {
+			clearOpenAIAccountModelTransientStateIfGeneration(int64, string, uint64, func() (bool, error)) (bool, error)
+		}); ok {
+			return clearer.clearOpenAIAccountModelTransientStateIfGeneration(accountID, modelID, generation, clear)
+		}
+	}
+	return clear()
 }
 
 func (s *RateLimitService) ClearTempUnschedulable(ctx context.Context, accountID int64) error {

--- a/backend/internal/service/scheduled_test_runner_service.go
+++ b/backend/internal/service/scheduled_test_runner_service.go
@@ -132,7 +132,7 @@ func (s *ScheduledTestRunnerService) runOnePlan(ctx context.Context, plan *Sched
 
 	// Auto-recover account if test succeeded and auto_recover is enabled.
 	if result.Status == "success" && plan.AutoRecover {
-		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID)
+		s.tryRecoverAccount(ctx, plan.AccountID, plan.ID, plan.ModelID)
 	}
 
 	nextRun, err := computeNextRun(plan.CronExpression, time.Now())
@@ -147,12 +147,12 @@ func (s *ScheduledTestRunnerService) runOnePlan(ctx context.Context, plan *Sched
 }
 
 // tryRecoverAccount attempts to recover an account from recoverable runtime state.
-func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64) {
+func (s *ScheduledTestRunnerService) tryRecoverAccount(ctx context.Context, accountID int64, planID int64, modelID string) {
 	if s.rateLimitSvc == nil {
 		return
 	}
 
-	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID)
+	recovery, err := s.rateLimitSvc.RecoverAccountAfterSuccessfulTest(ctx, accountID, modelID)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduled_test_runner", "[ScheduledTestRunner] plan=%d auto-recover failed: %v", planID, err)
 		return


### PR DESCRIPTION
## Summary
- re-arm the persisted OpenAI account/model circuit after its cooldown expires
- deduplicate repeated upstream failures by request ID before advancing the durable streak
- make scheduled-test recovery model-scoped and conditional so stale results cannot clear a newer circuit

## Root cause
The transient runtime state could remain marked as persisted after the durable model rate-limit entry expired. Subsequent failures were therefore no longer eligible to open a new durable circuit, so repeated CII/AIINPUT failures could continue without the expected model-level circuit breaker.

## Validation
- `go test ./internal/service ./internal/repository`
- focused OpenAI transient circuit tests
- independent reviewer: PASS
- GitHub CI: test, golangci-lint, frontend, shell, and security scans passed
