### PR TITLE
backend: hydrate durable OpenAI health generation

### DIFF
--- a/backend/ent/account.go
+++ b/backend/ent/account.go
@@ -81,6 +81,8 @@ type Account struct {
 	ParentAccountID *int64 `json:"parent_account_id,omitempty"`
 	// 'global' (default) or 'spark' (shadow reads codex_bengalfox).
 	QuotaDimension account.QuotaDimension `json:"quota_dimension,omitempty"`
+	// OpenAiHealthRouteGeneration holds the value of the "open_ai_health_route_generation" field.
+	OpenAiHealthRouteGeneration *int64 `json:"open_ai_health_route_generation,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AccountQuery when eager-loading is set.
 	Edges        AccountEdges `json:"edges"`
@@ -175,7 +177,7 @@ func (*Account) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case account.FieldRateMultiplier:
 			values[i] = new(sql.NullFloat64)
-		case account.FieldID, account.FieldProxyID, account.FieldProxyFallbackOriginID, account.FieldConcurrency, account.FieldLoadFactor, account.FieldPriority, account.FieldParentAccountID:
+		case account.FieldID, account.FieldProxyID, account.FieldProxyFallbackOriginID, account.FieldConcurrency, account.FieldLoadFactor, account.FieldPriority, account.FieldParentAccountID, account.FieldOpenAiHealthRouteGeneration:
 			values[i] = new(sql.NullInt64)
 		case account.FieldName, account.FieldNotes, account.FieldPlatform, account.FieldType, account.FieldStatus, account.FieldErrorMessage, account.FieldTempUnschedulableReason, account.FieldSessionWindowStatus, account.FieldQuotaDimension:
 			values[i] = new(sql.NullString)
@@ -409,6 +411,13 @@ func (_m *Account) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.QuotaDimension = account.QuotaDimension(value.String)
 			}
+		case account.FieldOpenAiHealthRouteGeneration:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field open_ai_health_route_generation", values[i])
+			} else if value.Valid {
+				_m.OpenAiHealthRouteGeneration = new(int64)
+				*_m.OpenAiHealthRouteGeneration = value.Int64
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -601,6 +610,11 @@ func (_m *Account) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("quota_dimension=")
 	builder.WriteString(fmt.Sprintf("%v", _m.QuotaDimension))
+	builder.WriteString(", ")
+	if v := _m.OpenAiHealthRouteGeneration; v != nil {
+		builder.WriteString("open_ai_health_route_generation=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/account/account.go
+++ b/backend/ent/account/account.go
@@ -78,6 +78,8 @@ const (
 	FieldParentAccountID = "parent_account_id"
 	// FieldQuotaDimension holds the string denoting the quota_dimension field in the database.
 	FieldQuotaDimension = "quota_dimension"
+	// FieldOpenAiHealthRouteGeneration holds the string denoting the open_ai_health_route_generation field in the database.
+	FieldOpenAiHealthRouteGeneration = "auv_openai_health_route_generation"
 	// EdgeGroups holds the string denoting the groups edge name in mutations.
 	EdgeGroups = "groups"
 	// EdgeProxy holds the string denoting the proxy edge name in mutations.
@@ -162,6 +164,7 @@ var Columns = []string{
 	FieldSessionWindowStatus,
 	FieldParentAccountID,
 	FieldQuotaDimension,
+	FieldOpenAiHealthRouteGeneration,
 }
 
 var (
@@ -399,6 +402,11 @@ func ByParentAccountID(opts ...sql.OrderTermOption) OrderOption {
 // ByQuotaDimension orders the results by the quota_dimension field.
 func ByQuotaDimension(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldQuotaDimension, opts...).ToFunc()
+}
+
+// ByOpenAiHealthRouteGeneration orders the results by the open_ai_health_route_generation field.
+func ByOpenAiHealthRouteGeneration(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOpenAiHealthRouteGeneration, opts...).ToFunc()
 }
 
 // ByGroupsCount orders the results by groups count.

--- a/backend/ent/account/where.go
+++ b/backend/ent/account/where.go
@@ -195,6 +195,11 @@ func ParentAccountID(v int64) predicate.Account {
 	return predicate.Account(sql.FieldEQ(FieldParentAccountID, v))
 }
 
+// OpenAiHealthRouteGeneration applies equality check predicate on the "open_ai_health_route_generation" field. It's identical to OpenAiHealthRouteGenerationEQ.
+func OpenAiHealthRouteGeneration(v int64) predicate.Account {
+	return predicate.Account(sql.FieldEQ(FieldOpenAiHealthRouteGeneration, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Account {
 	return predicate.Account(sql.FieldEQ(FieldCreatedAt, v))
@@ -1603,6 +1608,56 @@ func QuotaDimensionIn(vs ...QuotaDimension) predicate.Account {
 // QuotaDimensionNotIn applies the NotIn predicate on the "quota_dimension" field.
 func QuotaDimensionNotIn(vs ...QuotaDimension) predicate.Account {
 	return predicate.Account(sql.FieldNotIn(FieldQuotaDimension, vs...))
+}
+
+// OpenAiHealthRouteGenerationEQ applies the EQ predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationEQ(v int64) predicate.Account {
+	return predicate.Account(sql.FieldEQ(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationNEQ applies the NEQ predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationNEQ(v int64) predicate.Account {
+	return predicate.Account(sql.FieldNEQ(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationIn applies the In predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationIn(vs ...int64) predicate.Account {
+	return predicate.Account(sql.FieldIn(FieldOpenAiHealthRouteGeneration, vs...))
+}
+
+// OpenAiHealthRouteGenerationNotIn applies the NotIn predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationNotIn(vs ...int64) predicate.Account {
+	return predicate.Account(sql.FieldNotIn(FieldOpenAiHealthRouteGeneration, vs...))
+}
+
+// OpenAiHealthRouteGenerationGT applies the GT predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationGT(v int64) predicate.Account {
+	return predicate.Account(sql.FieldGT(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationGTE applies the GTE predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationGTE(v int64) predicate.Account {
+	return predicate.Account(sql.FieldGTE(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationLT applies the LT predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationLT(v int64) predicate.Account {
+	return predicate.Account(sql.FieldLT(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationLTE applies the LTE predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationLTE(v int64) predicate.Account {
+	return predicate.Account(sql.FieldLTE(FieldOpenAiHealthRouteGeneration, v))
+}
+
+// OpenAiHealthRouteGenerationIsNil applies the IsNil predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationIsNil() predicate.Account {
+	return predicate.Account(sql.FieldIsNull(FieldOpenAiHealthRouteGeneration))
+}
+
+// OpenAiHealthRouteGenerationNotNil applies the NotNil predicate on the "open_ai_health_route_generation" field.
+func OpenAiHealthRouteGenerationNotNil() predicate.Account {
+	return predicate.Account(sql.FieldNotNull(FieldOpenAiHealthRouteGeneration))
 }
 
 // HasGroups applies the HasEdge predicate on the "groups" edge.

--- a/backend/ent/account_create.go
+++ b/backend/ent/account_create.go
@@ -419,6 +419,20 @@ func (_c *AccountCreate) SetNillableQuotaDimension(v *account.QuotaDimension) *A
 	return _c
 }
 
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (_c *AccountCreate) SetOpenAiHealthRouteGeneration(v int64) *AccountCreate {
+	_c.mutation.SetOpenAiHealthRouteGeneration(v)
+	return _c
+}
+
+// SetNillableOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field if the given value is not nil.
+func (_c *AccountCreate) SetNillableOpenAiHealthRouteGeneration(v *int64) *AccountCreate {
+	if v != nil {
+		_c.SetOpenAiHealthRouteGeneration(*v)
+	}
+	return _c
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (_c *AccountCreate) AddGroupIDs(ids ...int64) *AccountCreate {
 	_c.mutation.AddGroupIDs(ids...)
@@ -800,6 +814,10 @@ func (_c *AccountCreate) createSpec() (*Account, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
 		_node.QuotaDimension = value
+	}
+	if value, ok := _c.mutation.OpenAiHealthRouteGeneration(); ok {
+		_spec.SetField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64, value)
+		_node.OpenAiHealthRouteGeneration = &value
 	}
 	if nodes := _c.mutation.GroupsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1431,6 +1449,30 @@ func (u *AccountUpsert) UpdateQuotaDimension() *AccountUpsert {
 	return u
 }
 
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (u *AccountUpsert) SetOpenAiHealthRouteGeneration(v int64) *AccountUpsert {
+	u.Set(account.FieldOpenAiHealthRouteGeneration, v)
+	return u
+}
+
+// UpdateOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field to the value that was provided on create.
+func (u *AccountUpsert) UpdateOpenAiHealthRouteGeneration() *AccountUpsert {
+	u.SetExcluded(account.FieldOpenAiHealthRouteGeneration)
+	return u
+}
+
+// AddOpenAiHealthRouteGeneration adds v to the "open_ai_health_route_generation" field.
+func (u *AccountUpsert) AddOpenAiHealthRouteGeneration(v int64) *AccountUpsert {
+	u.Add(account.FieldOpenAiHealthRouteGeneration, v)
+	return u
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (u *AccountUpsert) ClearOpenAiHealthRouteGeneration() *AccountUpsert {
+	u.SetNull(account.FieldOpenAiHealthRouteGeneration)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -2047,6 +2089,34 @@ func (u *AccountUpsertOne) SetQuotaDimension(v account.QuotaDimension) *AccountU
 func (u *AccountUpsertOne) UpdateQuotaDimension() *AccountUpsertOne {
 	return u.Update(func(s *AccountUpsert) {
 		s.UpdateQuotaDimension()
+	})
+}
+
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (u *AccountUpsertOne) SetOpenAiHealthRouteGeneration(v int64) *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) {
+		s.SetOpenAiHealthRouteGeneration(v)
+	})
+}
+
+// AddOpenAiHealthRouteGeneration adds v to the "open_ai_health_route_generation" field.
+func (u *AccountUpsertOne) AddOpenAiHealthRouteGeneration(v int64) *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) {
+		s.AddOpenAiHealthRouteGeneration(v)
+	})
+}
+
+// UpdateOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field to the value that was provided on create.
+func (u *AccountUpsertOne) UpdateOpenAiHealthRouteGeneration() *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) {
+		s.UpdateOpenAiHealthRouteGeneration()
+	})
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (u *AccountUpsertOne) ClearOpenAiHealthRouteGeneration() *AccountUpsertOne {
+	return u.Update(func(s *AccountUpsert) {
+		s.ClearOpenAiHealthRouteGeneration()
 	})
 }
 
@@ -2832,6 +2902,34 @@ func (u *AccountUpsertBulk) SetQuotaDimension(v account.QuotaDimension) *Account
 func (u *AccountUpsertBulk) UpdateQuotaDimension() *AccountUpsertBulk {
 	return u.Update(func(s *AccountUpsert) {
 		s.UpdateQuotaDimension()
+	})
+}
+
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (u *AccountUpsertBulk) SetOpenAiHealthRouteGeneration(v int64) *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) {
+		s.SetOpenAiHealthRouteGeneration(v)
+	})
+}
+
+// AddOpenAiHealthRouteGeneration adds v to the "open_ai_health_route_generation" field.
+func (u *AccountUpsertBulk) AddOpenAiHealthRouteGeneration(v int64) *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) {
+		s.AddOpenAiHealthRouteGeneration(v)
+	})
+}
+
+// UpdateOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field to the value that was provided on create.
+func (u *AccountUpsertBulk) UpdateOpenAiHealthRouteGeneration() *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) {
+		s.UpdateOpenAiHealthRouteGeneration()
+	})
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (u *AccountUpsertBulk) ClearOpenAiHealthRouteGeneration() *AccountUpsertBulk {
+	return u.Update(func(s *AccountUpsert) {
+		s.ClearOpenAiHealthRouteGeneration()
 	})
 }
 

--- a/backend/ent/account_openai_health_route_generation_test.go
+++ b/backend/ent/account_openai_health_route_generation_test.go
@@ -1,0 +1,47 @@
+package ent
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/ent/account"
+)
+
+func TestAccountQuerySelectsAndScansOpenAIHealthRouteGeneration(t *testing.T) {
+	columnIndex := -1
+	for i, column := range account.Columns {
+		if column == account.FieldOpenAiHealthRouteGeneration {
+			columnIndex = i
+			break
+		}
+	}
+	if columnIndex < 0 {
+		t.Fatal("account query columns omit durable generation storage key")
+	}
+
+	model := &Account{}
+	values, err := model.scanValues(account.Columns)
+	if err != nil {
+		t.Fatalf("scan values: %v", err)
+	}
+	nullValue, ok := values[columnIndex].(*sql.NullInt64)
+	if !ok {
+		t.Fatalf("generation scan target = %T, want *sql.NullInt64", values[columnIndex])
+	}
+
+	if err := model.assignValues(account.Columns, values); err != nil {
+		t.Fatalf("assign NULL values: %v", err)
+	}
+	if model.OpenAiHealthRouteGeneration != nil {
+		t.Fatalf("NULL durable generation hydrated as %v", *model.OpenAiHealthRouteGeneration)
+	}
+
+	nullValue.Int64 = 41
+	nullValue.Valid = true
+	if err := model.assignValues(account.Columns, values); err != nil {
+		t.Fatalf("assign non-NULL values: %v", err)
+	}
+	if model.OpenAiHealthRouteGeneration == nil || *model.OpenAiHealthRouteGeneration != 41 {
+		t.Fatalf("non-NULL durable generation = %v, want 41", model.OpenAiHealthRouteGeneration)
+	}
+}

--- a/backend/ent/account_update.go
+++ b/backend/ent/account_update.go
@@ -564,6 +564,33 @@ func (_u *AccountUpdate) SetNillableQuotaDimension(v *account.QuotaDimension) *A
 	return _u
 }
 
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (_u *AccountUpdate) SetOpenAiHealthRouteGeneration(v int64) *AccountUpdate {
+	_u.mutation.ResetOpenAiHealthRouteGeneration()
+	_u.mutation.SetOpenAiHealthRouteGeneration(v)
+	return _u
+}
+
+// SetNillableOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field if the given value is not nil.
+func (_u *AccountUpdate) SetNillableOpenAiHealthRouteGeneration(v *int64) *AccountUpdate {
+	if v != nil {
+		_u.SetOpenAiHealthRouteGeneration(*v)
+	}
+	return _u
+}
+
+// AddOpenAiHealthRouteGeneration adds value to the "open_ai_health_route_generation" field.
+func (_u *AccountUpdate) AddOpenAiHealthRouteGeneration(v int64) *AccountUpdate {
+	_u.mutation.AddOpenAiHealthRouteGeneration(v)
+	return _u
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (_u *AccountUpdate) ClearOpenAiHealthRouteGeneration() *AccountUpdate {
+	_u.mutation.ClearOpenAiHealthRouteGeneration()
+	return _u
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (_u *AccountUpdate) AddGroupIDs(ids ...int64) *AccountUpdate {
 	_u.mutation.AddGroupIDs(ids...)
@@ -945,6 +972,15 @@ func (_u *AccountUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenAiHealthRouteGeneration(); ok {
+		_spec.SetField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64, value)
+	}
+	if value, ok := _u.mutation.AddedOpenAiHealthRouteGeneration(); ok {
+		_spec.AddField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64, value)
+	}
+	if _u.mutation.OpenAiHealthRouteGenerationCleared() {
+		_spec.ClearField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1704,6 +1740,33 @@ func (_u *AccountUpdateOne) SetNillableQuotaDimension(v *account.QuotaDimension)
 	return _u
 }
 
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (_u *AccountUpdateOne) SetOpenAiHealthRouteGeneration(v int64) *AccountUpdateOne {
+	_u.mutation.ResetOpenAiHealthRouteGeneration()
+	_u.mutation.SetOpenAiHealthRouteGeneration(v)
+	return _u
+}
+
+// SetNillableOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field if the given value is not nil.
+func (_u *AccountUpdateOne) SetNillableOpenAiHealthRouteGeneration(v *int64) *AccountUpdateOne {
+	if v != nil {
+		_u.SetOpenAiHealthRouteGeneration(*v)
+	}
+	return _u
+}
+
+// AddOpenAiHealthRouteGeneration adds value to the "open_ai_health_route_generation" field.
+func (_u *AccountUpdateOne) AddOpenAiHealthRouteGeneration(v int64) *AccountUpdateOne {
+	_u.mutation.AddOpenAiHealthRouteGeneration(v)
+	return _u
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (_u *AccountUpdateOne) ClearOpenAiHealthRouteGeneration() *AccountUpdateOne {
+	_u.mutation.ClearOpenAiHealthRouteGeneration()
+	return _u
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (_u *AccountUpdateOne) AddGroupIDs(ids ...int64) *AccountUpdateOne {
 	_u.mutation.AddGroupIDs(ids...)
@@ -2115,6 +2178,15 @@ func (_u *AccountUpdateOne) sqlSave(ctx context.Context) (_node *Account, err er
 	}
 	if value, ok := _u.mutation.QuotaDimension(); ok {
 		_spec.SetField(account.FieldQuotaDimension, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.OpenAiHealthRouteGeneration(); ok {
+		_spec.SetField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64, value)
+	}
+	if value, ok := _u.mutation.AddedOpenAiHealthRouteGeneration(); ok {
+		_spec.AddField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64, value)
+	}
+	if _u.mutation.OpenAiHealthRouteGenerationCleared() {
+		_spec.ClearField(account.FieldOpenAiHealthRouteGeneration, field.TypeInt64)
 	}
 	if _u.mutation.GroupsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -125,6 +125,7 @@ var (
 		{Name: "session_window_end", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "session_window_status", Type: field.TypeString, Nullable: true, Size: 20},
 		{Name: "quota_dimension", Type: field.TypeEnum, Enums: []string{"global", "spark"}, Default: "global"},
+		{Name: "auv_openai_health_route_generation", Type: field.TypeInt64, Nullable: true},
 		{Name: "proxy_id", Type: field.TypeInt64, Nullable: true},
 		{Name: "parent_account_id", Type: field.TypeInt64, Nullable: true},
 	}
@@ -136,13 +137,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "accounts_proxies_proxy",
-				Columns:    []*schema.Column{AccountsColumns[30]},
+				Columns:    []*schema.Column{AccountsColumns[31]},
 				RefColumns: []*schema.Column{ProxiesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "accounts_accounts_children",
-				Columns:    []*schema.Column{AccountsColumns[31]},
+				Columns:    []*schema.Column{AccountsColumns[32]},
 				RefColumns: []*schema.Column{AccountsColumns[0]},
 				OnDelete:   schema.Restrict,
 			},
@@ -166,7 +167,7 @@ var (
 			{
 				Name:    "account_proxy_id",
 				Unique:  false,
-				Columns: []*schema.Column{AccountsColumns[30]},
+				Columns: []*schema.Column{AccountsColumns[31]},
 			},
 			{
 				Name:    "account_priority",
@@ -216,7 +217,7 @@ var (
 			{
 				Name:    "account_parent_account_id",
 				Unique:  false,
-				Columns: []*schema.Column{AccountsColumns[31]},
+				Columns: []*schema.Column{AccountsColumns[32]},
 			},
 		},
 	}

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -2282,60 +2282,62 @@ func (m *APIKeyMutation) ResetEdge(name string) error {
 // AccountMutation represents an operation that mutates the Account nodes in the graph.
 type AccountMutation struct {
 	config
-	op                          Op
-	typ                         string
-	id                          *int64
-	created_at                  *time.Time
-	updated_at                  *time.Time
-	deleted_at                  *time.Time
-	name                        *string
-	notes                       *string
-	platform                    *string
-	_type                       *string
-	credentials                 *map[string]interface{}
-	extra                       *map[string]interface{}
-	proxy_fallback_origin_id    *int64
-	addproxy_fallback_origin_id *int64
-	concurrency                 *int
-	addconcurrency              *int
-	load_factor                 *int
-	addload_factor              *int
-	priority                    *int
-	addpriority                 *int
-	rate_multiplier             *float64
-	addrate_multiplier          *float64
-	status                      *string
-	error_message               *string
-	last_used_at                *time.Time
-	expires_at                  *time.Time
-	auto_pause_on_expired       *bool
-	schedulable                 *bool
-	rate_limited_at             *time.Time
-	rate_limit_reset_at         *time.Time
-	overload_until              *time.Time
-	temp_unschedulable_until    *time.Time
-	temp_unschedulable_reason   *string
-	session_window_start        *time.Time
-	session_window_end          *time.Time
-	session_window_status       *string
-	quota_dimension             *account.QuotaDimension
-	clearedFields               map[string]struct{}
-	groups                      map[int64]struct{}
-	removedgroups               map[int64]struct{}
-	clearedgroups               bool
-	proxy                       *int64
-	clearedproxy                bool
-	parent                      *int64
-	clearedparent               bool
-	children                    map[int64]struct{}
-	removedchildren             map[int64]struct{}
-	clearedchildren             bool
-	usage_logs                  map[int64]struct{}
-	removedusage_logs           map[int64]struct{}
-	clearedusage_logs           bool
-	done                        bool
-	oldValue                    func(context.Context) (*Account, error)
-	predicates                  []predicate.Account
+	op                                 Op
+	typ                                string
+	id                                 *int64
+	created_at                         *time.Time
+	updated_at                         *time.Time
+	deleted_at                         *time.Time
+	name                               *string
+	notes                              *string
+	platform                           *string
+	_type                              *string
+	credentials                        *map[string]interface{}
+	extra                              *map[string]interface{}
+	proxy_fallback_origin_id           *int64
+	addproxy_fallback_origin_id        *int64
+	concurrency                        *int
+	addconcurrency                     *int
+	load_factor                        *int
+	addload_factor                     *int
+	priority                           *int
+	addpriority                        *int
+	rate_multiplier                    *float64
+	addrate_multiplier                 *float64
+	status                             *string
+	error_message                      *string
+	last_used_at                       *time.Time
+	expires_at                         *time.Time
+	auto_pause_on_expired              *bool
+	schedulable                        *bool
+	rate_limited_at                    *time.Time
+	rate_limit_reset_at                *time.Time
+	overload_until                     *time.Time
+	temp_unschedulable_until           *time.Time
+	temp_unschedulable_reason          *string
+	session_window_start               *time.Time
+	session_window_end                 *time.Time
+	session_window_status              *string
+	quota_dimension                    *account.QuotaDimension
+	open_ai_health_route_generation    *int64
+	addopen_ai_health_route_generation *int64
+	clearedFields                      map[string]struct{}
+	groups                             map[int64]struct{}
+	removedgroups                      map[int64]struct{}
+	clearedgroups                      bool
+	proxy                              *int64
+	clearedproxy                       bool
+	parent                             *int64
+	clearedparent                      bool
+	children                           map[int64]struct{}
+	removedchildren                    map[int64]struct{}
+	clearedchildren                    bool
+	usage_logs                         map[int64]struct{}
+	removedusage_logs                  map[int64]struct{}
+	clearedusage_logs                  bool
+	done                               bool
+	oldValue                           func(context.Context) (*Account, error)
+	predicates                         []predicate.Account
 }
 
 var _ ent.Mutation = (*AccountMutation)(nil)
@@ -3875,6 +3877,76 @@ func (m *AccountMutation) ResetQuotaDimension() {
 	m.quota_dimension = nil
 }
 
+// SetOpenAiHealthRouteGeneration sets the "open_ai_health_route_generation" field.
+func (m *AccountMutation) SetOpenAiHealthRouteGeneration(i int64) {
+	m.open_ai_health_route_generation = &i
+	m.addopen_ai_health_route_generation = nil
+}
+
+// OpenAiHealthRouteGeneration returns the value of the "open_ai_health_route_generation" field in the mutation.
+func (m *AccountMutation) OpenAiHealthRouteGeneration() (r int64, exists bool) {
+	v := m.open_ai_health_route_generation
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOpenAiHealthRouteGeneration returns the old "open_ai_health_route_generation" field's value of the Account entity.
+// If the Account object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AccountMutation) OldOpenAiHealthRouteGeneration(ctx context.Context) (v *int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOpenAiHealthRouteGeneration is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOpenAiHealthRouteGeneration requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOpenAiHealthRouteGeneration: %w", err)
+	}
+	return oldValue.OpenAiHealthRouteGeneration, nil
+}
+
+// AddOpenAiHealthRouteGeneration adds i to the "open_ai_health_route_generation" field.
+func (m *AccountMutation) AddOpenAiHealthRouteGeneration(i int64) {
+	if m.addopen_ai_health_route_generation != nil {
+		*m.addopen_ai_health_route_generation += i
+	} else {
+		m.addopen_ai_health_route_generation = &i
+	}
+}
+
+// AddedOpenAiHealthRouteGeneration returns the value that was added to the "open_ai_health_route_generation" field in this mutation.
+func (m *AccountMutation) AddedOpenAiHealthRouteGeneration() (r int64, exists bool) {
+	v := m.addopen_ai_health_route_generation
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOpenAiHealthRouteGeneration clears the value of the "open_ai_health_route_generation" field.
+func (m *AccountMutation) ClearOpenAiHealthRouteGeneration() {
+	m.open_ai_health_route_generation = nil
+	m.addopen_ai_health_route_generation = nil
+	m.clearedFields[account.FieldOpenAiHealthRouteGeneration] = struct{}{}
+}
+
+// OpenAiHealthRouteGenerationCleared returns if the "open_ai_health_route_generation" field was cleared in this mutation.
+func (m *AccountMutation) OpenAiHealthRouteGenerationCleared() bool {
+	_, ok := m.clearedFields[account.FieldOpenAiHealthRouteGeneration]
+	return ok
+}
+
+// ResetOpenAiHealthRouteGeneration resets all changes to the "open_ai_health_route_generation" field.
+func (m *AccountMutation) ResetOpenAiHealthRouteGeneration() {
+	m.open_ai_health_route_generation = nil
+	m.addopen_ai_health_route_generation = nil
+	delete(m.clearedFields, account.FieldOpenAiHealthRouteGeneration)
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by ids.
 func (m *AccountMutation) AddGroupIDs(ids ...int64) {
 	if m.groups == nil {
@@ -4138,7 +4210,7 @@ func (m *AccountMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AccountMutation) Fields() []string {
-	fields := make([]string, 0, 31)
+	fields := make([]string, 0, 32)
 	if m.created_at != nil {
 		fields = append(fields, account.FieldCreatedAt)
 	}
@@ -4232,6 +4304,9 @@ func (m *AccountMutation) Fields() []string {
 	if m.quota_dimension != nil {
 		fields = append(fields, account.FieldQuotaDimension)
 	}
+	if m.open_ai_health_route_generation != nil {
+		fields = append(fields, account.FieldOpenAiHealthRouteGeneration)
+	}
 	return fields
 }
 
@@ -4302,6 +4377,8 @@ func (m *AccountMutation) Field(name string) (ent.Value, bool) {
 		return m.ParentAccountID()
 	case account.FieldQuotaDimension:
 		return m.QuotaDimension()
+	case account.FieldOpenAiHealthRouteGeneration:
+		return m.OpenAiHealthRouteGeneration()
 	}
 	return nil, false
 }
@@ -4373,6 +4450,8 @@ func (m *AccountMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldParentAccountID(ctx)
 	case account.FieldQuotaDimension:
 		return m.OldQuotaDimension(ctx)
+	case account.FieldOpenAiHealthRouteGeneration:
+		return m.OldOpenAiHealthRouteGeneration(ctx)
 	}
 	return nil, fmt.Errorf("unknown Account field %s", name)
 }
@@ -4599,6 +4678,13 @@ func (m *AccountMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetQuotaDimension(v)
 		return nil
+	case account.FieldOpenAiHealthRouteGeneration:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOpenAiHealthRouteGeneration(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)
 }
@@ -4622,6 +4708,9 @@ func (m *AccountMutation) AddedFields() []string {
 	if m.addrate_multiplier != nil {
 		fields = append(fields, account.FieldRateMultiplier)
 	}
+	if m.addopen_ai_health_route_generation != nil {
+		fields = append(fields, account.FieldOpenAiHealthRouteGeneration)
+	}
 	return fields
 }
 
@@ -4640,6 +4729,8 @@ func (m *AccountMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedPriority()
 	case account.FieldRateMultiplier:
 		return m.AddedRateMultiplier()
+	case account.FieldOpenAiHealthRouteGeneration:
+		return m.AddedOpenAiHealthRouteGeneration()
 	}
 	return nil, false
 }
@@ -4683,6 +4774,13 @@ func (m *AccountMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddRateMultiplier(v)
+		return nil
+	case account.FieldOpenAiHealthRouteGeneration:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOpenAiHealthRouteGeneration(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Account numeric field %s", name)
@@ -4742,6 +4840,9 @@ func (m *AccountMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(account.FieldParentAccountID) {
 		fields = append(fields, account.FieldParentAccountID)
+	}
+	if m.FieldCleared(account.FieldOpenAiHealthRouteGeneration) {
+		fields = append(fields, account.FieldOpenAiHealthRouteGeneration)
 	}
 	return fields
 }
@@ -4807,6 +4908,9 @@ func (m *AccountMutation) ClearField(name string) error {
 		return nil
 	case account.FieldParentAccountID:
 		m.ClearParentAccountID()
+		return nil
+	case account.FieldOpenAiHealthRouteGeneration:
+		m.ClearOpenAiHealthRouteGeneration()
 		return nil
 	}
 	return fmt.Errorf("unknown Account nullable field %s", name)
@@ -4908,6 +5012,9 @@ func (m *AccountMutation) ResetField(name string) error {
 		return nil
 	case account.FieldQuotaDimension:
 		m.ResetQuotaDimension()
+		return nil
+	case account.FieldOpenAiHealthRouteGeneration:
+		m.ResetOpenAiHealthRouteGeneration()
 		return nil
 	}
 	return fmt.Errorf("unknown Account field %s", name)

--- a/backend/ent/schema/account.go
+++ b/backend/ent/schema/account.go
@@ -201,6 +201,11 @@ func (Account) Fields() []ent.Field {
 			Comment("Parent account id for a linked spark shadow (NULL = normal)."),
 		field.Enum("quota_dimension").Values("global", "spark").Default("global").
 			Comment("'global' (default) or 'spark' (shadow reads codex_bengalfox)."),
+
+		field.Int64("open_ai_health_route_generation").
+			Optional().
+			Nillable().
+			StorageKey("auv_openai_health_route_generation"),
 	}
 }
 

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -327,6 +327,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -365,6 +367,8 @@ github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJm
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -399,6 +403,8 @@ github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEv
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -434,6 +440,8 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -3368,7 +3368,7 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 
 	rateMultiplier := m.RateMultiplier
 
-	return &service.Account{
+	out := &service.Account{
 		ID:                      m.ID,
 		Name:                    m.Name,
 		Notes:                   m.Notes,
@@ -3401,6 +3401,8 @@ func accountEntityToService(m *dbent.Account) *service.Account {
 		ParentAccountID:         m.ParentAccountID,
 		QuotaDimension:          string(m.QuotaDimension),
 	}
+	out.SetOpenAIHealthRouteGenerationFromDurable(m.OpenAiHealthRouteGeneration)
+	return out
 }
 
 func normalizeJSONMap(in map[string]any) map[string]any {

--- a/backend/internal/repository/account_repo_openai_health_route_generation_test.go
+++ b/backend/internal/repository/account_repo_openai_health_route_generation_test.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"testing"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func TestAccountEntityToServiceHydratesOnlyDurableGeneration(t *testing.T) {
+	positive := int64(23)
+	zero := int64(0)
+	negative := int64(-1)
+	tests := []struct {
+		name     string
+		value    *int64
+		want     int64
+		wantOkay bool
+	}{
+		{name: "null", value: nil},
+		{name: "zero", value: &zero},
+		{name: "negative", value: &negative},
+		{name: "durable", value: &positive, want: positive, wantOkay: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := accountEntityToService(&dbent.Account{
+				ID:                          1,
+				Name:                        "account",
+				Platform:                    service.PlatformOpenAI,
+				Type:                        service.AccountTypeAPIKey,
+				Credentials:                 map[string]any{},
+				Extra:                       map[string]any{"openai_health_route_generation": "v1:999"},
+				OpenAiHealthRouteGeneration: tt.value,
+			})
+			got, ok := account.OpenAIHealthRouteGeneration()
+			if got != tt.want || ok != tt.wantOkay {
+				t.Fatalf("hydrated generation = (%d, %v), want (%d, %v)", got, ok, tt.want, tt.wantOkay)
+			}
+		})
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -82,6 +82,38 @@ type Account struct {
 	headerOverrideCacheRawPtr         uintptr
 	headerOverrideCacheRawLen         int
 	headerOverrideCacheRawSig         uint64
+
+	// openAIHealthRouteGenerationCarrier is intentionally private so it is
+	// absent from JSON and scheduler-cache snapshots. A cache/deserialized
+	// account therefore remains unavailable until a database query hydrates it.
+	openAIHealthRouteGenerationCarrier *openAIHealthRouteGenerationCarrier
+}
+
+type openAIHealthRouteGenerationCarrier struct {
+	value int64
+}
+
+// SetOpenAIHealthRouteGenerationFromDurable installs only a positive value
+// read from the nullable durable account column. Invalid input clears the
+// carrier and must remain unavailable to any future consumer.
+func (a *Account) SetOpenAIHealthRouteGenerationFromDurable(value *int64) {
+	if a == nil {
+		return
+	}
+	a.openAIHealthRouteGenerationCarrier = nil
+	if value == nil || *value <= 0 {
+		return
+	}
+	a.openAIHealthRouteGenerationCarrier = &openAIHealthRouteGenerationCarrier{value: *value}
+}
+
+// OpenAIHealthRouteGeneration returns the private durable carrier, if a
+// positive generation was hydrated from the database.
+func (a *Account) OpenAIHealthRouteGeneration() (int64, bool) {
+	if a == nil || a.openAIHealthRouteGenerationCarrier == nil || a.openAIHealthRouteGenerationCarrier.value <= 0 {
+		return 0, false
+	}
+	return a.openAIHealthRouteGenerationCarrier.value, true
 }
 
 type OpenAIEndpointCapability string

--- a/backend/internal/service/account_openai_health_route_generation_test.go
+++ b/backend/internal/service/account_openai_health_route_generation_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestAccountOpenAIHealthRouteGenerationIsPrivateAndFailClosed(t *testing.T) {
+	for _, value := range []*int64{nil, int64Pointer(0), int64Pointer(-1)} {
+		account := &Account{}
+		account.SetOpenAIHealthRouteGenerationFromDurable(value)
+		if got, ok := account.OpenAIHealthRouteGeneration(); ok || got != 0 {
+			t.Fatalf("invalid durable value %v = (%d, %v), want (0, false)", value, got, ok)
+		}
+	}
+
+	value := int64(17)
+	account := &Account{}
+	account.SetOpenAIHealthRouteGenerationFromDurable(&value)
+	if got, ok := account.OpenAIHealthRouteGeneration(); !ok || got != value {
+		t.Fatalf("durable value = (%d, %v), want (%d, true)", got, ok, value)
+	}
+
+	payload, err := json.Marshal(account)
+	if err != nil {
+		t.Fatalf("marshal account: %v", err)
+	}
+	if bytes.Contains(payload, []byte("openai_health_route_generation")) {
+		t.Fatalf("private durable carrier appeared in JSON: %s", payload)
+	}
+	var decoded Account
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal account cache payload: %v", err)
+	}
+	if _, ok := decoded.OpenAIHealthRouteGeneration(); ok {
+		t.Fatal("cache-deserialized account retained private durable carrier")
+	}
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}


### PR DESCRIPTION
Adds a nullable schema-owned account generation field, generated Ent hydration, and a non-serializing private service carrier. This preserves the existing Account query path without a second lookup; nil/non-positive/cache-deserialized values remain unavailable. No runtime authority or release behavior is enabled by this upstream-only change.