### PR TITLE
feat(usage): 用量记录落库 upstream_request_id 并在管理端明细展示

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -717,6 +717,7 @@ func UsageLogFromServiceAdmin(l *service.UsageLog) *AdminUsageLog {
 		UpstreamReasoningEffort: adminUpstreamReasoningEffort(l),
 		UpstreamResponseModel:   l.UpstreamResponseModel,
 		UpstreamModelMismatch:   l.UpstreamModelMismatch,
+		UpstreamRequestID:       l.UpstreamRequestID,
 		ChannelID:               l.ChannelID,
 		ModelMappingChain:       l.ModelMappingChain,
 		BillingTier:             l.BillingTier,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -574,6 +574,9 @@ type AdminUsageLog struct {
 	UpstreamResponseModel *string `json:"upstream_response_model,omitempty"`
 	// UpstreamModelMismatch is nil when the upstream did not declare a model.
 	UpstreamModelMismatch *bool `json:"upstream_model_mismatch,omitempty"`
+	// UpstreamRequestID is the request identifier declared by the upstream
+	// response (e.g. x-request-id). Omitted when the path recorded none.
+	UpstreamRequestID *string `json:"upstream_request_id,omitempty"`
 
 	// ChannelID 渠道 ID
 	ChannelID *int64 `json:"channel_id,omitempty"`

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -33,6 +33,7 @@ var usageLogInsertArgTypes = [...]string{
 	"text",        // upstream_model
 	"text",        // upstream_response_model
 	"boolean",     // upstream_model_mismatch
+	"text",        // upstream_request_id
 	"bigint",      // group_id
 	"bigint",      // subscription_id
 	"integer",     // input_tokens
@@ -232,6 +233,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -289,7 +291,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -690,6 +692,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -783,6 +786,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				upstream_model,
 				upstream_response_model,
 				upstream_model_mismatch,
+				upstream_request_id,
 				group_id,
 				subscription_id,
 				input_tokens,
@@ -845,6 +849,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				upstream_model,
 				upstream_response_model,
 				upstream_model_mismatch,
+				upstream_request_id,
 				group_id,
 				subscription_id,
 				input_tokens,
@@ -947,6 +952,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -1035,6 +1041,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -1097,6 +1104,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -1167,6 +1175,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			upstream_model,
 			upstream_response_model,
 			upstream_model_mismatch,
+			upstream_request_id,
 			group_id,
 			subscription_id,
 			input_tokens,
@@ -1224,7 +1233,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 	`, prepared.args...)
@@ -1274,6 +1283,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 	upstreamModel := nullString(log.UpstreamModel)
 	upstreamResponseModel := nullString(log.UpstreamResponseModel)
 	upstreamModelMismatch := nullBool(log.UpstreamModelMismatch)
+	upstreamRequestID := nullString(log.UpstreamRequestID)
 
 	var requestIDArg any
 	if requestID != "" {
@@ -1295,6 +1305,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			upstreamModel,
 			upstreamResponseModel,
 			upstreamModelMismatch,
+			upstreamRequestID,
 			groupID,
 			subscriptionID,
 			log.InputTokens,

--- a/backend/internal/repository/usage_log_repo_insert_shape_unit_test.go
+++ b/backend/internal/repository/usage_log_repo_insert_shape_unit_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	usageLogStaticInsertRe      = regexp.MustCompile(`(?s)INSERT INTO usage_logs \((.*?)\) VALUES \((.*?)\)`)
+	usageLogInsertPlaceholderRe = regexp.MustCompile(`\$(\d+)`)
+)
+
+// newCapturingSQLMock 返回一个把实际下发 SQL 记录到 captured 的 sqlmock，
+// 任何语句都视为匹配，参数校验仍由 WithArgs 承担。
+func newCapturingSQLMock(t *testing.T, captured *[]string) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	matcher := sqlmock.QueryMatcherFunc(func(_, actualSQL string) error {
+		*captured = append(*captured, actualSQL)
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db, mock
+}
+
+// requireUsageLogStaticInsertShape 断言静态拼写的 INSERT：列清单长度与
+// VALUES 占位符数量都等于 usageLogInsertArgTypes，且占位符恰为 $1..$N 各一次。
+func requireUsageLogStaticInsertShape(t *testing.T, query string) {
+	t.Helper()
+	m := usageLogStaticInsertRe.FindStringSubmatch(query)
+	require.Len(t, m, 3, "unrecognised INSERT shape:\n%s", query)
+
+	want := len(usageLogInsertArgTypes)
+
+	columns := 0
+	for _, col := range strings.Split(m[1], ",") {
+		if strings.TrimSpace(col) != "" {
+			columns++
+		}
+	}
+	require.Equal(t, want, columns, "INSERT column list must match usageLogInsertArgTypes")
+
+	seen := make(map[int]struct{}, want)
+	for _, ph := range usageLogInsertPlaceholderRe.FindAllStringSubmatch(m[2], -1) {
+		n, err := strconv.Atoi(ph[1])
+		require.NoError(t, err)
+		_, dup := seen[n]
+		require.False(t, dup, "duplicate placeholder $%d", n)
+		seen[n] = struct{}{}
+	}
+	require.Len(t, seen, want, "VALUES placeholder count must match usageLogInsertArgTypes")
+	for i := 1; i <= want; i++ {
+		_, ok := seen[i]
+		require.True(t, ok, "missing placeholder $%d", i)
+	}
+}
+
+// TestUsageLogStaticInsertQueries_PlaceholdersMatchArgTypes 覆盖两条不经
+// 占位符生成器、直接手写 $1..$N 的 INSERT 路径，防止列清单加列后占位符漏补。
+func TestUsageLogStaticInsertQueries_PlaceholdersMatchArgTypes(t *testing.T) {
+	log := &service.UsageLog{
+		UserID:      1,
+		APIKeyID:    2,
+		AccountID:   3,
+		RequestID:   "client:req-static-insert-shape",
+		Model:       "claude-3",
+		InputTokens: 10,
+		CreatedAt:   time.Date(2025, 1, 7, 12, 0, 0, 0, time.UTC),
+	}
+	prepared := prepareUsageLogInsert(log)
+	args := anySliceToDriverValues(prepared.args)
+
+	t.Run("createSingle", func(t *testing.T) {
+		var captured []string
+		db, mock := newCapturingSQLMock(t, &captured)
+		repo := &usageLogRepository{sql: db}
+
+		mock.ExpectQuery("INSERT INTO usage_logs").
+			WithArgs(args...).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), log.CreatedAt))
+
+		inserted, err := repo.Create(context.Background(), log)
+		require.NoError(t, err)
+		require.True(t, inserted)
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Len(t, captured, 1)
+		requireUsageLogStaticInsertShape(t, captured[0])
+	})
+
+	t.Run("execUsageLogInsertNoResult", func(t *testing.T) {
+		var captured []string
+		db, mock := newCapturingSQLMock(t, &captured)
+
+		mock.ExpectExec("INSERT INTO usage_logs").
+			WithArgs(args...).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, execUsageLogInsertNoResult(context.Background(), db, prepared))
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.Len(t, captured, 1)
+		requireUsageLogStaticInsertShape(t, captured[0])
+	})
+}

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, requested_reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, upstream_request_id, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, requested_reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
 
 func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *service.UsageLog, err error) {
 	query := "SELECT " + usageLogSelectColumns + " FROM usage_logs WHERE id = $1"
@@ -449,6 +449,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		upstreamModel             sql.NullString
 		upstreamResponseModel     sql.NullString
 		upstreamModelMismatch     sql.NullBool
+		upstreamRequestID         sql.NullString
 		groupID                   sql.NullInt64
 		subscriptionID            sql.NullInt64
 		inputTokens               int
@@ -513,6 +514,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&upstreamModel,
 		&upstreamResponseModel,
 		&upstreamModelMismatch,
+		&upstreamRequestID,
 		&groupID,
 		&subscriptionID,
 		&inputTokens,
@@ -676,6 +678,9 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	if upstreamModelMismatch.Valid {
 		value := upstreamModelMismatch.Bool
 		log.UpstreamModelMismatch = &value
+	}
+	if upstreamRequestID.Valid {
+		log.UpstreamRequestID = &upstreamRequestID.String
 	}
 	if channelID.Valid {
 		value := channelID.Int64

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -50,6 +50,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			sqlmock.AnyArg(), // upstream_model
 			sqlmock.AnyArg(), // upstream_response_model
 			sqlmock.AnyArg(), // upstream_model_mismatch
+			sqlmock.AnyArg(), // upstream_request_id
 			sqlmock.AnyArg(), // group_id
 			sqlmock.AnyArg(), // subscription_id
 			log.InputTokens,
@@ -143,6 +144,7 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			sqlmock.AnyArg(), // upstream_model
 			sqlmock.AnyArg(), // upstream_response_model
 			sqlmock.AnyArg(), // upstream_model_mismatch
+			sqlmock.AnyArg(), // upstream_request_id
 			sqlmock.AnyArg(), // group_id
 			sqlmock.AnyArg(), // subscription_id
 			log.InputTokens,
@@ -279,11 +281,11 @@ func TestPrepareUsageLogInsert_PersistsImageSizeMetadata(t *testing.T) {
 		CreatedAt:          time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC),
 	})
 
-	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[38])
-	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[39])
-	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[40])
-	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[41])
-	breakdownJSON, ok := prepared.args[42].(string)
+	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[39])
+	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[40])
+	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[41])
+	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[42])
+	breakdownJSON, ok := prepared.args[43].(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"1K":1,"4K":1}`, breakdownJSON)
 }
@@ -804,6 +806,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			sql.NullBool{},
+			sql.NullString{}, // upstream_request_id
 			sql.NullInt64{},
 			sql.NullInt64{},
 			0, 0, 0, 0, 0, 0,
@@ -870,6 +873,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // upstream_model
 			sql.NullString{},  // upstream_response_model
 			sql.NullBool{},    // upstream_model_mismatch
+			sql.NullString{},  // upstream_request_id
 			sql.NullInt64{},   // group_id
 			sql.NullInt64{},   // subscription_id
 			1,                 // input_tokens
@@ -943,6 +947,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			sql.NullBool{},
+			sql.NullString{}, // upstream_request_id
 			sql.NullInt64{},
 			sql.NullInt64{},
 			1, 2, 3, 4, 5, 6,
@@ -1004,6 +1009,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			sql.NullBool{},
+			sql.NullString{}, // upstream_request_id
 			sql.NullInt64{},
 			sql.NullInt64{},
 			1, 2, 3, 4, 5, 6,

--- a/backend/internal/repository/usage_log_session_id_unit_test.go
+++ b/backend/internal/repository/usage_log_session_id_unit_test.go
@@ -32,7 +32,7 @@ func newSessionIDUsageLog(sessionID *string) *service.UsageLog {
 // arg slice / arg-type table so the five INSERT column lists stay in sync. session_id
 // is the penultimate arg (created_at is always last).
 func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
-	require.Len(t, usageLogInsertArgTypes, 60, "arg-type table must include session_id")
+	require.Len(t, usageLogInsertArgTypes, 61, "arg-type table must include session_id")
 
 	sessionID := "sess-persisted-123"
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(&sessionID))
@@ -81,15 +81,15 @@ func TestPrepareUsageLogInsert_RequestedReasoningEffortArgWiring(t *testing.T) {
 	})
 
 	require.Len(t, prepared.args, len(usageLogInsertArgTypes))
-	require.Equal(t, "text", usageLogInsertArgTypes[48], "requested_reasoning_effort must follow reasoning_effort")
-	require.Equal(t, "text", usageLogInsertArgTypes[47], "reasoning_effort arg type must stay text")
+	require.Equal(t, "text", usageLogInsertArgTypes[49], "requested_reasoning_effort must follow reasoning_effort")
+	require.Equal(t, "text", usageLogInsertArgTypes[48], "reasoning_effort arg type must stay text")
 
-	forwardedArg, ok := prepared.args[47].(sql.NullString)
+	forwardedArg, ok := prepared.args[48].(sql.NullString)
 	require.True(t, ok)
 	require.True(t, forwardedArg.Valid)
 	require.Equal(t, forwarded, forwardedArg.String)
 
-	requestedArg, ok := prepared.args[48].(sql.NullString)
+	requestedArg, ok := prepared.args[49].(sql.NullString)
 	require.True(t, ok)
 	require.True(t, requestedArg.Valid)
 	require.Equal(t, requested, requestedArg.String)

--- a/backend/internal/repository/usage_log_upstream_request_id_unit_test.go
+++ b/backend/internal/repository/usage_log_upstream_request_id_unit_test.go
@@ -1,0 +1,98 @@
+//go:build unit
+
+package repository
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func newUpstreamRequestIDUsageLog(upstreamRequestID *string) *service.UsageLog {
+	return &service.UsageLog{
+		UserID:            1,
+		APIKeyID:          2,
+		AccountID:         3,
+		RequestID:         "client:req-upstream-id",
+		Model:             "claude-3",
+		InputTokens:       10,
+		OutputTokens:      5,
+		TotalCost:         1.0,
+		ActualCost:        1.0,
+		UpstreamRequestID: upstreamRequestID,
+		CreatedAt:         time.Now().UTC(),
+	}
+}
+
+// upstreamRequestIDArgIndex 是 upstream_request_id 在插入参数表中的位置：
+// 紧跟 upstream_model_mismatch（boolean）之后。
+func upstreamRequestIDArgIndex(t *testing.T) int {
+	t.Helper()
+	for i, typ := range usageLogInsertArgTypes {
+		if typ == "boolean" {
+			return i + 1
+		}
+	}
+	t.Fatal("upstream_model_mismatch boolean arg not found")
+	return -1
+}
+
+// TestPrepareUsageLogInsert_UpstreamRequestIDArgWiring pins upstream_request_id to
+// the arg slice / arg-type table so the five INSERT column lists stay in sync.
+func TestPrepareUsageLogInsert_UpstreamRequestIDArgWiring(t *testing.T) {
+	idx := upstreamRequestIDArgIndex(t)
+	require.Equal(t, "text", usageLogInsertArgTypes[idx],
+		"upstream_request_id arg type must be text")
+
+	upstreamRequestID := "req_011CRJabc"
+	prepared := prepareUsageLogInsert(newUpstreamRequestIDUsageLog(&upstreamRequestID))
+	require.Len(t, prepared.args, len(usageLogInsertArgTypes))
+
+	arg := prepared.args[idx]
+	ns, ok := arg.(sql.NullString)
+	require.True(t, ok, "upstream_request_id arg should be a sql.NullString, got %T", arg)
+	require.True(t, ns.Valid)
+	require.Equal(t, upstreamRequestID, ns.String)
+}
+
+// TestPrepareUsageLogInsert_UpstreamRequestIDNullWhenAbsent proves an absent
+// upstream request id is persisted as SQL NULL rather than an empty string.
+func TestPrepareUsageLogInsert_UpstreamRequestIDNullWhenAbsent(t *testing.T) {
+	idx := upstreamRequestIDArgIndex(t)
+
+	prepared := prepareUsageLogInsert(newUpstreamRequestIDUsageLog(nil))
+	ns, ok := prepared.args[idx].(sql.NullString)
+	require.True(t, ok, "upstream_request_id arg should be a sql.NullString, got %T", prepared.args[idx])
+	require.False(t, ns.Valid, "absent upstream request id must be NULL, not empty string")
+
+	empty := ""
+	preparedEmpty := prepareUsageLogInsert(newUpstreamRequestIDUsageLog(&empty))
+	nsEmpty := preparedEmpty.args[idx].(sql.NullString)
+	require.False(t, nsEmpty.Valid, "empty upstream request id must also be NULL")
+}
+
+// TestUsageLogQueries_IncludeUpstreamRequestID guards that every generated INSERT
+// path and the SELECT column list reference upstream_request_id.
+func TestUsageLogQueries_IncludeUpstreamRequestID(t *testing.T) {
+	require.Contains(t, usageLogSelectColumns, "upstream_request_id",
+		"SELECT column list must include upstream_request_id")
+
+	upstreamRequestID := "req-in-query"
+	log := newUpstreamRequestIDUsageLog(&upstreamRequestID)
+	prepared := prepareUsageLogInsert(log)
+	key := usageLogBatchKey(log.RequestID, log.APIKeyID)
+
+	batchQuery, batchArgs := buildUsageLogBatchInsertQuery([]string{key},
+		map[string]usageLogInsertPrepared{key: prepared})
+	// CTE 定义 + INSERT 列清单 + SELECT ... FROM input 三处引用。
+	require.GreaterOrEqual(t, strings.Count(batchQuery, "upstream_request_id"), 3)
+	require.Len(t, batchArgs, len(prepared.args)+1)
+
+	bestEffortQuery, bestEffortArgs := buildUsageLogBestEffortInsertQuery([]usageLogInsertPrepared{prepared})
+	require.GreaterOrEqual(t, strings.Count(bestEffortQuery, "upstream_request_id"), 3)
+	require.Len(t, bestEffortArgs, len(prepared.args))
+}

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -233,6 +233,29 @@ func isForcedUsageBillingRequestID(requestID string) bool {
 		strings.HasPrefix(id, "grok_realtime:")
 }
 
+// maxUsageUpstreamRequestIDLen 与 usage_logs.upstream_request_id VARCHAR(128) 对齐；
+// 超长时截断而不是让整条用量行插入失败。
+const maxUsageUpstreamRequestIDLen = 128
+
+// usageUpstreamRequestIDPtr 提取可落库到 usage_logs.upstream_request_id 的上游请求标识。
+// 各转发路径的 result.RequestID 承载上游响应头的请求 ID（x-request-id / xai-request-id /
+// x-goog-request-id 等）；本地合成的计费去重 ID 一律是 label:uuid 形态（web_search: /
+// x_search: / grok_audio: 等），而真实上游标识不含冒号，据此排除。WS 轮次的 RequestID
+// 是上游 response id（resp_...），不是请求标识，由调用方经 wsMode 排除。
+func usageUpstreamRequestIDPtr(rawRequestID string, wsMode bool) *string {
+	if wsMode {
+		return nil
+	}
+	id := strings.TrimSpace(rawRequestID)
+	if id == "" || strings.ContainsRune(id, ':') {
+		return nil
+	}
+	if len(id) > maxUsageUpstreamRequestIDLen {
+		id = id[:maxUsageUpstreamRequestIDLen]
+	}
+	return &id
+}
+
 // StableGrokAudioBillingRequestID is the durable usage_logs / dedup key for one
 // voice HTTP call (TTS/STT). Prefer an upstream request id when present.
 func StableGrokAudioBillingRequestID(upstreamRequestID string) string {
@@ -1220,6 +1243,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		UpstreamModel:            optionalTrimmedStringPtr(result.UpstreamModel),
 		UpstreamResponseModel:    optionalTrimmedStringPtr(result.UpstreamResponseModel),
 		UpstreamModelMismatch:    upstreamModelMismatch(sentModel, result.UpstreamResponseModel),
+		UpstreamRequestID:        usageUpstreamRequestIDPtr(result.RequestID, false),
 		ServiceTier:              result.ServiceTier,
 		ReasoningEffort:          result.ReasoningEffort,
 		RequestedReasoningEffort: coalesceRequestedReasoningEffort(result.RequestedReasoningEffort, result.ReasoningEffort),

--- a/backend/internal/service/gateway_usage_billing_request_id_test.go
+++ b/backend/internal/service/gateway_usage_billing_request_id_test.go
@@ -57,3 +57,30 @@ func TestResolveUsageBillingRequestID_ForcedGrokAudioBeatsClientID(t *testing.T)
 	got := resolveUsageBillingRequestID(ctx, StableGrokAudioBillingRequestID("up-9"))
 	require.Equal(t, "grok_audio:up-9", got)
 }
+
+func TestUsageUpstreamRequestIDPtr(t *testing.T) {
+	t.Parallel()
+
+	// 真实上游响应头 ID 原样落库（含首尾空白清理）。
+	got := usageUpstreamRequestIDPtr("  req_011CRJabc  ", false)
+	require.NotNil(t, got)
+	require.Equal(t, "req_011CRJabc", *got)
+
+	// 空值与本地合成的 label:uuid 形态一律不落。
+	require.Nil(t, usageUpstreamRequestIDPtr("", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("   ", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("web_search:uuid-1", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("x_search:uuid-2", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("grok_audio:up-1", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("grok-video:task-1", false))
+	require.Nil(t, usageUpstreamRequestIDPtr("grok_realtime:sess-1", false))
+
+	// WS 轮次的 RequestID 是上游 response id，不是请求标识。
+	require.Nil(t, usageUpstreamRequestIDPtr("resp_abc", true))
+
+	// 超长防御性截断到列宽，避免整行插入失败。
+	long := strings.Repeat("a", maxUsageUpstreamRequestIDLen+10)
+	truncated := usageUpstreamRequestIDPtr(long, false)
+	require.NotNil(t, truncated)
+	require.Len(t, *truncated, maxUsageUpstreamRequestIDLen)
+}

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -330,6 +330,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		UpstreamModel:            optionalTrimmedStringPtr(result.UpstreamModel),
 		UpstreamResponseModel:    optionalTrimmedStringPtr(result.UpstreamResponseModel),
 		UpstreamModelMismatch:    upstreamModelMismatch(sentModel, result.UpstreamResponseModel),
+		UpstreamRequestID:        usageUpstreamRequestIDPtr(result.RequestID, result.OpenAIWSMode),
 		ServiceTier:              result.ServiceTier,
 		ReasoningEffort:          result.ReasoningEffort,
 		RequestedReasoningEffort: coalesceRequestedReasoningEffort(result.RequestedReasoningEffort, result.ReasoningEffort),

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -120,6 +120,11 @@ type UsageLog struct {
 	// UpstreamModelMismatch is nil when no upstream model was observed. Otherwise
 	// it compares UpstreamResponseModel with the actual model sent upstream.
 	UpstreamModelMismatch *bool
+	// UpstreamRequestID is the request identifier declared by the upstream
+	// response (x-request-id / xai-request-id / x-goog-request-id headers),
+	// stored verbatim. Nil when the path has no upstream request id (WS turns,
+	// locally synthesized billing ids) or for historical rows.
+	UpstreamRequestID *string
 	// ChannelID 渠道 ID
 	ChannelID *int64
 	// ModelMappingChain 模型映射链，如 "a→b→c"

--- a/backend/migrations/231_usage_log_upstream_request_id.sql
+++ b/backend/migrations/231_usage_log_upstream_request_id.sql
@@ -1,0 +1,5 @@
+-- usage_logs.upstream_request_id 记录成功请求的上游响应请求标识
+-- （x-request-id / xai-request-id / x-goog-request-id 等响应头，原样落库）。
+-- NULL 表示历史行或该路径无上游请求标识（WS 轮次、本地合成计费 ID 等）。
+ALTER TABLE usage_logs
+    ADD COLUMN IF NOT EXISTS upstream_request_id VARCHAR(128);

--- a/frontend/src/components/admin/usage/UsageTable.vue
+++ b/frontend/src/components/admin/usage/UsageTable.vue
@@ -264,6 +264,24 @@
           <span v-else class="text-sm text-gray-400 dark:text-gray-500">-</span>
         </template>
 
+        <template #cell-upstream_request_id="{ row }">
+          <div v-if="row.upstream_request_id" class="flex max-w-[160px] items-center gap-1.5">
+            <span class="truncate font-mono text-xs text-gray-500 dark:text-gray-400" :title="row.upstream_request_id">
+              {{ row.upstream_request_id }}
+            </span>
+            <button
+              type="button"
+              class="shrink-0 rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-dark-700 dark:hover:text-gray-300"
+              :class="copiedRequestId === row.upstream_request_id ? 'text-green-500 hover:text-green-500' : ''"
+              :title="copiedRequestId === row.upstream_request_id ? t('keys.copied') : t('keys.copyToClipboard')"
+              @click="copyRequestId(row.upstream_request_id)"
+            >
+              <Icon :name="copiedRequestId === row.upstream_request_id ? 'check' : 'copy'" size="sm" class="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <span v-else class="text-sm text-gray-400 dark:text-gray-500">-</span>
+        </template>
+
         <template #cell-user_agent="{ row }">
           <span v-if="row.user_agent" class="text-sm text-gray-600 dark:text-gray-400 block max-w-[320px] truncate" :title="row.user_agent">{{ formatUserAgent(row.user_agent) }}</span>
           <span v-else class="text-sm text-gray-400 dark:text-gray-500">-</span>

--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -520,6 +520,7 @@ export default {
       group: 'Group',
       requestId: 'Request ID',
       requestIdCopied: 'Request ID copied',
+      upstreamRequestId: 'Upstream Request ID',
       allModels: 'All Models',
       allAccounts: 'All Accounts',
       allGroups: 'All Groups',

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -517,6 +517,7 @@ export default {
       group: '分组',
       requestId: '请求ID',
       requestIdCopied: '请求ID已复制',
+      upstreamRequestId: '上游请求ID',
       allModels: '全部模型',
       allAccounts: '全部账户',
       allGroups: '全部分组',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1723,6 +1723,8 @@ export interface AdminUsageLog extends UsageLog {
   upstream_reasoning_effort?: string | null
   upstream_response_model?: string | null
   upstream_model_mismatch?: boolean | null
+  // 上游响应声明的请求标识（x-request-id 等响应头），仅管理员可见
+  upstream_request_id?: string | null
   model_mapping_chain?: string | null
 
   // 账号计费倍率（仅管理员可见）

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -586,7 +586,7 @@ const exportToExcel = async () => {
       t('admin.usage.cacheReadCost'), t('admin.usage.cacheCreationCost'),
       t('usage.rate'), t('usage.accountMultiplier'), t('usage.original'), t('usage.userBilled'), t('usage.accountBilled'),
       t('usage.firstToken'), t('usage.duration'),
-      t('admin.usage.requestId'), t('usage.userAgent'), t('admin.usage.ipAddress')
+      t('admin.usage.requestId'), t('admin.usage.upstreamRequestId'), t('usage.userAgent'), t('admin.usage.ipAddress')
     ]
     const ws = XLSX.utils.aoa_to_sheet([headers])
     while (true) {
@@ -605,7 +605,7 @@ const exportToExcel = async () => {
         log.rate_multiplier?.toPrecision(4) || '1.00', (log.account_rate_multiplier ?? 1).toPrecision(4),
         log.total_cost?.toFixed(6) || '0.000000', log.actual_cost?.toFixed(6) || '0.000000',
         ((log.account_stats_cost ?? log.total_cost) * (log.account_rate_multiplier ?? 1)).toFixed(6), log.first_token_ms ?? '', log.duration_ms,
-        log.request_id || '', log.user_agent || '', log.ip_address || ''
+        log.request_id || '', log.upstream_request_id || '', log.user_agent || '', log.ip_address || ''
       ])
       if (rows.length) {
         XLSX.utils.sheet_add_aoa(ws, rows, { origin: -1 })
@@ -627,10 +627,13 @@ const exportToExcel = async () => {
 
 // Column visibility
 const ALWAYS_VISIBLE = ['user', 'created_at']
-const DEFAULT_HIDDEN_COLUMNS = ['reasoning_effort', 'request_id', 'user_agent']
+const DEFAULT_HIDDEN_COLUMNS = ['reasoning_effort', 'request_id', 'upstream_request_id', 'user_agent']
 const HIDDEN_COLUMNS_KEY = 'usage-hidden-columns'
 const HIDDEN_COLUMNS_VERSION_KEY = 'usage-hidden-columns-version'
-const HIDDEN_COLUMNS_CURRENT_VERSION = 'request-id-hidden-by-default'
+// 版本链：无版本 → request-id-hidden-by-default → upstream-request-id-hidden-by-default。
+// 每级迁移只把当级新增列加入隐藏集，不重置用户已显式打开的列。
+const HIDDEN_COLUMNS_PREV_VERSION = 'request-id-hidden-by-default'
+const HIDDEN_COLUMNS_CURRENT_VERSION = 'upstream-request-id-hidden-by-default'
 
 const allColumns = computed(() => [
   { key: 'user', label: t('admin.usage.user'), sortable: false },
@@ -647,6 +650,7 @@ const allColumns = computed(() => [
   { key: 'latency', label: t('usage.latency'), sortable: false },
   { key: 'created_at', label: t('usage.time'), sortable: true },
   { key: 'request_id', label: t('admin.usage.requestId'), sortable: false },
+  { key: 'upstream_request_id', label: t('admin.usage.upstreamRequestId'), sortable: false },
   { key: 'user_agent', label: t('usage.userAgent'), sortable: false },
   { key: 'ip_address', label: t('admin.usage.ipAddress'), sortable: false }
 ])
@@ -754,8 +758,12 @@ const loadSavedColumns = () => {
       (JSON.parse(saved) as string[]).forEach((key) => {
         hiddenColumns.add(key)
       })
-      if (localStorage.getItem(HIDDEN_COLUMNS_VERSION_KEY) !== HIDDEN_COLUMNS_CURRENT_VERSION) {
-        hiddenColumns.add('request_id')
+      const savedVersion = localStorage.getItem(HIDDEN_COLUMNS_VERSION_KEY)
+      if (savedVersion !== HIDDEN_COLUMNS_CURRENT_VERSION) {
+        if (savedVersion !== HIDDEN_COLUMNS_PREV_VERSION) {
+          hiddenColumns.add('request_id')
+        }
+        hiddenColumns.add('upstream_request_id')
         localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify([...hiddenColumns]))
         localStorage.setItem(HIDDEN_COLUMNS_VERSION_KEY, HIDDEN_COLUMNS_CURRENT_VERSION)
       }

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -33,6 +33,7 @@ const messages: Record<string, string> = {
   'admin.dashboard.hour': 'Hour',
   'admin.usage.failedToLoadUser': 'Failed to load user',
 	'admin.usage.requestId': 'Request ID',
+	'admin.usage.upstreamRequestId': 'Upstream Request ID',
 	'usage.requestedModel': 'Requested model',
 	'usage.sentUpstreamModel': 'Sent upstream model',
 	'usage.upstreamResponseModel': 'Upstream response model',
@@ -454,7 +455,98 @@ describe('admin UsageView request ID column visibility', () => {
     )
     expect(localStorage.setItem).toHaveBeenCalledWith(
       'usage-hidden-columns-version',
-      'request-id-hidden-by-default',
+      'upstream-request-id-hidden-by-default',
+    )
+  })
+
+  it('keeps upstream request ID hidden by default and allows enabling it from column settings', async () => {
+    const wrapper = mount(UsageView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          UsageStatsCards: true,
+          UsageFilters: UsageFiltersStub,
+          UsageTable: UsageTableStub,
+          UsageExportProgress: true,
+          UsageCleanupDialog: true,
+          UserBalanceHistoryModal: true,
+          AuditLogModal: true,
+          Pagination: true,
+          Select: true,
+          DateRangePicker: true,
+          Icon: true,
+          TokenUsageTrend: true,
+          ModelDistributionChart: true,
+          GroupDistributionChart: true,
+          EndpointDistributionChart: true,
+          UserTokenRanking: true,
+        },
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const usageTable = wrapper.findComponent(UsageTableStub)
+    expect(usageTable.props('columns')).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'upstream_request_id' })]),
+    )
+
+    await wrapper.get('button[title="admin.users.columnSettings"]').trigger('click')
+    const upstreamRequestIdToggle = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Upstream Request ID')
+    expect(upstreamRequestIdToggle).toBeDefined()
+    await upstreamRequestIdToggle!.trigger('click')
+
+    expect(usageTable.props('columns')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'upstream_request_id', label: 'Upstream Request ID' }),
+      ]),
+    )
+  })
+
+  it('migrates saved column settings from the previous version without re-hiding request ID', async () => {
+    vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+      if (key === 'usage-hidden-columns') return JSON.stringify(['user_agent'])
+      if (key === 'usage-hidden-columns-version') return 'request-id-hidden-by-default'
+      return null
+    })
+
+    const wrapper = mount(UsageView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          UsageStatsCards: true,
+          UsageFilters: UsageFiltersStub,
+          UsageTable: UsageTableStub,
+          UsageExportProgress: true,
+          UsageCleanupDialog: true,
+          UserBalanceHistoryModal: true,
+          AuditLogModal: true,
+          Pagination: true,
+          Select: true,
+          DateRangePicker: true,
+          Icon: true,
+          TokenUsageTrend: true,
+          ModelDistributionChart: true,
+          GroupDistributionChart: true,
+          EndpointDistributionChart: true,
+          UserTokenRanking: true,
+        },
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const usageTable = wrapper.findComponent(UsageTableStub)
+    // 旧版本迁移只隐藏新增的 upstream_request_id；用户此前显式打开的 request_id 保持可见。
+    expect(usageTable.props('columns')).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'request_id' })]),
+    )
+    expect(usageTable.props('columns')).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'upstream_request_id' })]),
+    )
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'usage-hidden-columns-version',
+      'upstream-request-id-hidden-by-default',
     )
   })
 })


### PR DESCRIPTION
## 背景
成功请求的上游请求标识目前在落库时被丢弃：各转发路径的 ForwardResult.RequestID 已承载上游响应头返回的请求 ID（x-request-id / xai-request-id / x-goog-request-id，Anthropic/OpenAI/Gemini/Antigravity/Grok 各端点与 passthrough 均如此），但 resolveUsageBillingRequestID 优先取 client:/local: 本地 ID 写入 request_id 列，上游 ID 无处可查。导致与上游联调、排障时无法做请求链路追踪——向上游反馈某条请求的问题时，给不出对方系统里可检索的请求标识。

## 改动
- 新增 usage_logs.upstream_request_id 列（VARCHAR(128)，迁移 231，幂等），原样保留上游响应头请求 ID；仅 AdminUsageLog DTO 暴露，用户侧接口不返回
- 两个 RecordUsage 落点（Anthropic 侧 buildRecordUsageLog、OpenAI 侧RecordUsage）经 usageUpstreamRequestIDPtr 提取：本地合成计费 ID 一律是label:uuid 形态（web_search: / x_search: / grok_audio: 等）而真实上游标识不含冒号，含冒号即排除；WS 轮次的 RequestID 是上游 response id 且已写入request_id 列，经 wsMode排除；超长截断到列宽，避免整行插入失败
- 裸 SQL 仓储的 8 处列清单、参数类型表、占位符与 scan 路径同步
- /admin/usage 用量明细新增"上游请求ID"列（截断展示+复制），默认隐藏，可在列设置打开；列设置版本链迁移到 upstream-request-id-hidden-by-default，存量用户只追加隐藏新列，不重置已显式打开的 request_id；Excel 导出同步补列

## 测试
- 后端 make test-unit 全量通过。新增 TestUsageUpstreamRequestIDPtr 覆盖提取规则（冒号排除 / WS 排除 / 截断），新增 usage_log_upstream_request_id_unit_test.go钉住插入参数接线、NULL 语义与 SELECT/INSERT 列清单
- 前端 vitest run 全量通过（248 文件 / 1786 用例）。UsageView.spec.ts 补充新列默认隐藏、可从列设置打开、以及版本迁移不重置已显式打开的 request_id 用例