### PR TITLE
fix(apicompat): Anthropic→Responses 流式转换丢失助手文本（thinking 块顶掉未关闭的 message item + content_index 从不推进）

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -280,6 +280,16 @@ func anthToResHandleContentBlockStart(evt *AnthropicStreamEvent, state *Anthropi
 
 	switch evt.ContentBlock.Type {
 	case "thinking":
+		// 开新 item 前必须先关掉在开的那个，与下面的 tool_use 分支一致。
+		// 一个 message item 在它的 text 块 content_block_stop 时是刻意保持打开的
+		// （同一 item 里可能还有后续 text 块），所以 thinking 块到来时它仍然开着：
+		// 不关就直接被 CurrentItemType/CurrentItemID 覆盖，累积在 CurrentContent
+		// 里的助手文本既不会进 state.Outputs，也拿不到 output_item.done，
+		// response.completed 于是只带 reasoning——客户端看到的是「成功但无输出」。
+		// 交错思考（interleaved-thinking，本仓库在 anthropic-beta 透传里明确支持）
+		// 会稳定产生 text → thinking 这个顺序。
+		events = append(events, closeCurrentResponsesItem(state)...)
+
 		state.CurrentItemID = generateItemID()
 		state.CurrentItemType = "reasoning"
 		state.ContentIndex = 0
@@ -295,6 +305,11 @@ func anthToResHandleContentBlockStart(evt *AnthropicStreamEvent, state *Anthropi
 	case "text":
 		// If we don't have an open message item, open one
 		if state.CurrentItemType != "message" {
+			// 走到这里时 CurrentItemType 只可能是 ""（前一个 reasoning/function_call
+			// 已在自己的 content_block_stop 里关闭）；保留这次关闭是为了让三个分支
+			// 的「开新 item 前先关旧的」保持同一条不变式，而不是留一个仅 text 例外。
+			events = append(events, closeCurrentResponsesItem(state)...)
+
 			state.CurrentItemID = generateItemID()
 			state.CurrentItemType = "message"
 			state.ContentIndex = 0
@@ -434,17 +449,25 @@ func anthToResHandleContentBlockStop(evt *AnthropicStreamEvent, state *Anthropic
 		// item itself stays open since more blocks may follow.
 		text := state.TextAccum
 		state.TextAccum = ""
+		contentIndex := state.ContentIndex
 		state.CurrentContent = append(state.CurrentContent, ResponsesContentPart{Type: "output_text", Text: text})
+		// 关掉一个 part 就推进 content_index：上面那句注释说的「item 保持打开，
+		// 因为后面可能还有块」正是这里的触发条件。不推进的话，同一 item 里第二个
+		// text 块会再发一次 content_part.added(content_index=0)，与第一个 part 撞在
+		// 同一下标上——SDK 的累积式 stream helper 按 content[content_index] 写入，
+		// 后一个 part 直接覆盖前一个，可见文本丢失。
+		// 只在这里推进：新 item 的 content_index 由 closeCurrentResponsesItem 归 0。
+		state.ContentIndex++
 		return []ResponsesStreamEvent{
 			makeResponsesEvent(state, "response.output_text.done", &ResponsesStreamEvent{
 				OutputIndex:  state.OutputIndex,
-				ContentIndex: state.ContentIndex,
+				ContentIndex: contentIndex,
 				ItemID:       state.CurrentItemID,
 				Text:         text,
 			}),
 			makeResponsesEvent(state, "response.content_part.done", &ResponsesStreamEvent{
 				OutputIndex:  state.OutputIndex,
-				ContentIndex: state.ContentIndex,
+				ContentIndex: contentIndex,
 				ItemID:       state.CurrentItemID,
 				Part:         &ResponsesContentPart{Type: "output_text", Text: text},
 			}),

--- a/backend/internal/pkg/apicompat/anthropic_to_responses_stream_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_stream_test.go
@@ -185,3 +185,212 @@ func TestAnthropicEventToResponses_ToolCallCompletedCarriesArguments(t *testing.
 		t.Errorf("name = %q, want get_weather", fc.Name)
 	}
 }
+
+// TestAnthropicEventToResponses_ThinkingAfterTextKeepsMessageOutput pins that a
+// thinking block arriving after a text block closes the open message item
+// instead of silently replacing it.
+//
+// Why: a message item is deliberately left open when its text block stops
+// (more text blocks may follow in the same item). content_block_start therefore
+// has to close whatever is open before starting a new item — tool_use already
+// did, thinking did not, so it overwrote CurrentItemType/CurrentItemID and the
+// accumulated CurrentContent never reached state.Outputs. response.completed
+// then carried only the reasoning item and the client saw a successful response
+// with no assistant text. Interleaved thinking (anthropic-beta
+// interleaved-thinking-2025-05-14, forwarded by this gateway) produces exactly
+// this text → thinking ordering.
+func TestAnthropicEventToResponses_ThinkingAfterTextKeepsMessageOutput(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+	state.Model = "claude-sonnet-4-5"
+
+	var events []ResponsesStreamEvent
+	feed := func(evt *AnthropicStreamEvent) {
+		events = append(events, AnthropicEventToResponsesEvents(evt, state)...)
+	}
+
+	i0, i1 := 0, 1
+	feed(&AnthropicStreamEvent{Type: "message_start", Message: &AnthropicResponse{ID: "msg_1"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &i0, ContentBlock: &AnthropicContentBlock{Type: "text"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &i0, Delta: &AnthropicDelta{Type: "text_delta", Text: "answer"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &i0})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &i1, ContentBlock: &AnthropicContentBlock{Type: "thinking"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &i1, Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: "hmm"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &i1})
+	feed(&AnthropicStreamEvent{Type: "message_stop"})
+
+	var completed *ResponsesStreamEvent
+	for i := range events {
+		if events[i].Type == "response.completed" {
+			completed = &events[i]
+		}
+	}
+	if completed == nil || completed.Response == nil {
+		t.Fatalf("response.completed was not emitted")
+	}
+	outputs := completed.Response.Output
+	if len(outputs) != 2 {
+		t.Fatalf("response.completed carries %d output items, want 2 (message + reasoning): %+v", len(outputs), outputs)
+	}
+	if outputs[0].Type != "message" {
+		t.Fatalf("output[0].type = %q, want message", outputs[0].Type)
+	}
+	if len(outputs[0].Content) != 1 || outputs[0].Content[0].Text != "answer" {
+		t.Errorf("assistant text lost: output[0].content = %+v", outputs[0].Content)
+	}
+	if outputs[1].Type != "reasoning" {
+		t.Errorf("output[1].type = %q, want reasoning", outputs[1].Type)
+	}
+
+	// The two items must also occupy distinct output_index values; sharing one
+	// index is how the reasoning item used to land on top of the message item.
+	var addedIndexes []int
+	for _, evt := range events {
+		if evt.Type == "response.output_item.added" {
+			addedIndexes = append(addedIndexes, evt.OutputIndex)
+		}
+	}
+	if len(addedIndexes) != 2 || addedIndexes[0] == addedIndexes[1] {
+		t.Errorf("output_item.added indexes = %v, want two distinct values", addedIndexes)
+	}
+}
+
+// TestAnthropicEventToResponses_MultipleTextBlocksAdvanceContentIndex pins that
+// each text block within one message item gets its own content_index.
+//
+// Why: content_index was assigned when the item opened and never advanced, so a
+// second text block re-emitted content_part.added at index 0. The OpenAI SDK's
+// accumulating stream helper writes parts at output.content[content_index], so
+// the second part overwrote the first and the earlier text disappeared from the
+// accumulated response.
+func TestAnthropicEventToResponses_MultipleTextBlocksAdvanceContentIndex(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+	state.Model = "claude-sonnet-4-5"
+
+	var events []ResponsesStreamEvent
+	feed := func(evt *AnthropicStreamEvent) {
+		events = append(events, AnthropicEventToResponsesEvents(evt, state)...)
+	}
+
+	i0, i1 := 0, 1
+	feed(&AnthropicStreamEvent{Type: "message_start", Message: &AnthropicResponse{ID: "msg_1"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &i0, ContentBlock: &AnthropicContentBlock{Type: "text"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &i0, Delta: &AnthropicDelta{Type: "text_delta", Text: "first"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &i0})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &i1, ContentBlock: &AnthropicContentBlock{Type: "text"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &i1, Delta: &AnthropicDelta{Type: "text_delta", Text: "second"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &i1})
+	feed(&AnthropicStreamEvent{Type: "message_stop"})
+
+	var partAdded []int
+	for _, evt := range events {
+		if evt.Type == "response.content_part.added" {
+			partAdded = append(partAdded, evt.ContentIndex)
+		}
+	}
+	if len(partAdded) != 2 {
+		t.Fatalf("content_part.added emitted %d times, want 2", len(partAdded))
+	}
+	if partAdded[0] != 0 || partAdded[1] != 1 {
+		t.Errorf("content_part.added indexes = %v, want [0 1]", partAdded)
+	}
+
+	// Every delta/done for a part must carry that part's index, otherwise the
+	// SDK appends the text to the wrong slot.
+	byIndex := map[int]string{}
+	for _, evt := range events {
+		if evt.Type == "response.output_text.delta" {
+			byIndex[evt.ContentIndex] += evt.Delta
+		}
+	}
+	if byIndex[0] != "first" || byIndex[1] != "second" {
+		t.Errorf("output_text.delta grouped by content_index = %v, want {0:first 1:second}", byIndex)
+	}
+}
+
+// TestAnthropicEventToResponses_ItemLifecycleIsBalanced is the invariant behind
+// both regressions above: the converter must never leave an item that was
+// announced with response.output_item.added without a matching
+// response.output_item.done, and the terminal event must carry one output entry
+// per announced item. Any future block type that forgets to close the open item
+// breaks this, whatever the symptom looks like.
+func TestAnthropicEventToResponses_ItemLifecycleIsBalanced(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		blocks []*AnthropicContentBlock
+	}{
+		{"text then thinking", []*AnthropicContentBlock{{Type: "text"}, {Type: "thinking"}}},
+		{"thinking then text", []*AnthropicContentBlock{{Type: "thinking"}, {Type: "text"}}},
+		{"text then tool_use", []*AnthropicContentBlock{{Type: "text"}, {Type: "tool_use", ID: "toolu_1", Name: "t"}}},
+		{"text thinking text", []*AnthropicContentBlock{{Type: "text"}, {Type: "thinking"}, {Type: "text"}}},
+		{"thinking text tool_use", []*AnthropicContentBlock{{Type: "thinking"}, {Type: "text"}, {Type: "tool_use", ID: "toolu_2", Name: "t"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewAnthropicEventToResponsesState()
+			state.Model = "claude-sonnet-4-5"
+
+			var events []ResponsesStreamEvent
+			feed := func(evt *AnthropicStreamEvent) {
+				events = append(events, AnthropicEventToResponsesEvents(evt, state)...)
+			}
+
+			feed(&AnthropicStreamEvent{Type: "message_start", Message: &AnthropicResponse{ID: "msg_1"}})
+			for i, block := range tc.blocks {
+				idx := i
+				feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &idx, ContentBlock: block})
+				switch block.Type {
+				case "text":
+					feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &idx, Delta: &AnthropicDelta{Type: "text_delta", Text: "t"}})
+				case "thinking":
+					feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &idx, Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: "r"}})
+				case "tool_use":
+					feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &idx, Delta: &AnthropicDelta{Type: "input_json_delta", PartialJSON: "{}"}})
+				}
+				feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &idx})
+			}
+			feed(&AnthropicStreamEvent{Type: "message_stop"})
+
+			openIDs := map[string]int{}
+			var order []string
+			for _, evt := range events {
+				switch evt.Type {
+				case "response.output_item.added":
+					if evt.Item == nil {
+						t.Fatalf("output_item.added without item")
+					}
+					openIDs[evt.Item.ID]++
+					order = append(order, evt.Item.ID)
+				case "response.output_item.done":
+					if evt.Item == nil {
+						t.Fatalf("output_item.done without item")
+					}
+					openIDs[evt.Item.ID]--
+				}
+			}
+			for id, n := range openIDs {
+				if n != 0 {
+					t.Errorf("item %s: output_item.added/done imbalance %+d", id, n)
+				}
+			}
+
+			var completed *ResponsesStreamEvent
+			for i := range events {
+				if events[i].Type == "response.completed" {
+					completed = &events[i]
+				}
+			}
+			if completed == nil || completed.Response == nil {
+				t.Fatalf("response.completed was not emitted")
+			}
+			if len(completed.Response.Output) != len(order) {
+				t.Fatalf("response.completed carries %d outputs, want %d (one per announced item)",
+					len(completed.Response.Output), len(order))
+			}
+			for i, id := range order {
+				if completed.Response.Output[i].ID != id {
+					t.Errorf("output[%d].id = %q, want %q (announcement order must be preserved)",
+						i, completed.Response.Output[i].ID, id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

Anthropic SSE → OpenAI Responses 的流式转换器有两处 item/part 生命周期缺陷，都会让**助手的可见文本从 `response.completed` 里消失**，客户端表现为「请求成功、状态 completed、但没有输出」。

与 #6375 的现象一致（`status: completed` + 空 `output_text`），本 PR 修的是该 issue 指名的 Anthropic→Responses 转换路径。

---

## 缺陷 1：thinking 块开始时不关闭已打开的 message item

`anthToResHandleContentBlockStart` 的三个分支里，**只有 `tool_use` 会先关闭在开的 item**：

| case | 是否 `closeCurrentResponsesItem(state)` |
|---|---|
| `"tool_use"` | ✅ |
| `"thinking"` | ❌ 直接覆盖 `CurrentItemType` / `CurrentItemID` |
| `"text"` | ❌ |

而 message item 在它的 text 块 `content_block_stop` 时是**刻意保持打开**的——这条前提就写在原有注释里：

```go
// The message item itself stays open since more blocks may follow.
```

于是 `text → thinking` 时，那个开着的 message item 被直接顶掉：`state.CurrentContent` 里累积的文本既不会进 `state.Outputs`，也拿不到 `response.output_item.done`。`response.completed` 只带 reasoning 项。

修复前的事件序列（`text("answer") → thinking`）：

```
response.output_item.added        ← message
response.content_part.added
response.output_text.delta
response.output_text.done
response.content_part.done
response.output_item.added        ← reasoning，message 的 done 从未发出
response.reasoning_summary_text.done
response.output_item.done
response.completed                → Output = [reasoning]   ← "answer" 没了
```

两个 `output_item.added` 还共用同一个 `output_index=0`。

修复后 `Output = [message("answer"), reasoning]`，两项 `output_index` 分别为 0/1。

**触发条件**：交错思考会稳定产生 `text → thinking`。本仓库明确支持并透传该 beta——`anthropic-beta: interleaved-thinking-2025-05-14` 在 Vertex/Bedrock 的 beta 过滤与透传里都有专门处理（`gateway_anthropic_vertex_beta_filter_test.go`、`bedrock_signer_test.go`）。

## 缺陷 2：`content_index` 从不推进

`ContentIndex` 在本文件里被置 0 三次、读取四次、**自增零次**。同一 message item 内的第二个 text 块因此再发一次 `content_part.added(content_index=0)`，与第一个 part 撞在同一下标。

这正是本文件既有注释警告过的那类 SDK 累积问题：

```go
// the OpenAI SDK's accumulating stream helper (client.responses.stream) only
// appends a content part when it sees content_part.added ... the following
// output_text.delta indexes output.content[content_index]
```

按 `content[content_index]` 写入时，后一个 part 直接覆盖前一个。

修复前后对照（同一 item 内两个 text 块 `"first"` / `"second"`）：

| | content_part.added 下标 | 按下标聚合的 delta |
|---|---|---|
| 修复前 | `[0, 0]` | `{0: "firstsecond"}` |
| 修复后 | `[0, 1]` | `{0: "first", 1: "second"}` |

**往返不对称**：反方向 `responses_to_anthropic.go` 有三处 `state.ContentBlockIndex++`（:600、:620、:702），正方向一处都没有。

---

## 影响面

`AnthropicEventToResponsesEvents` 有 7 个生产调用点，覆盖所有把 Anthropic 形态的流转成 Responses 事件的路径：

- `openai_gateway_responses_anthropic_native.go`（/v1/responses × Anthropic 上游）
- `openai_gateway_chat_completions_anthropic_native.go`
- `gateway_forward_as_responses.go` / `gateway_forward_as_chat_completions.go`
- `antigravity_gateway_compat_stream.go`
- `gemini_chat_completions_compat_service.go`

## 改动

`anthropic_to_responses_response.go`（+27/-2）

1. `case "thinking"` 开新 item 前调 `closeCurrentResponsesItem(state)`，与 `case "tool_use"` 对齐。
2. `case "text"` 的开新 item 分支同样调一次。走到那里时 `CurrentItemType` 只可能是 `""`（前一个 reasoning/function_call 已在自己的 `content_block_stop` 里关闭），所以这次是等价变换；保留它是为了让三个分支共用同一条「开新 item 前先关旧的」不变式，而不是留一个仅 text 例外——缺陷 1 正是这种例外造成的。
3. `content_block_stop` 的 `case "message"` 分支：先取 `contentIndex := state.ContentIndex` 给两个 done 事件用，再 `state.ContentIndex++`。新 item 的归 0 仍由 `closeCurrentResponsesItem` 负责，未新增归零点。

## 测试

`anthropic_to_responses_stream_test.go`（+209）

- `TestAnthropicEventToResponses_ThinkingAfterTextKeepsMessageOutput` — 缺陷 1 主复现：断言 `response.completed` 带 message + reasoning 两项、文本为 `"answer"`、两个 `output_item.added` 的 `output_index` 互不相同。
- `TestAnthropicEventToResponses_MultipleTextBlocksAdvanceContentIndex` — 缺陷 2 主复现：断言下标为 `[0 1]`，并按 `content_index` 聚合 delta 验证文本没有串到同一 part。
- `TestAnthropicEventToResponses_ItemLifecycleIsBalanced` — 不变式用例，5 种块序列的表驱动：`output_item.added` 与 `output_item.done` 必须逐 ID 配平，且 terminal 事件按 announce 顺序逐项携带。这条不依赖具体症状，任何以后忘记关闭 item 的新块类型都会被它拦下。

**回滚验证**：把实现改回主线原状，三条新用例全部在断言层变红（非编译失败）：

```
--- FAIL: ..._ThinkingAfterTextKeepsMessageOutput
    response.completed carries 1 output items, want 2 (message + reasoning)
--- FAIL: ..._MultipleTextBlocksAdvanceContentIndex
    content_part.added indexes = [0 0], want [0 1]
    output_text.delta grouped by content_index = map[0:firstsecond], want {0:first 1:second}
--- FAIL: ..._ItemLifecycleIsBalanced/text_then_thinking
    item item_5d52a...: output_item.added/done imbalance +1
--- FAIL: ..._ItemLifecycleIsBalanced/text_thinking_text
    ...imbalance +1
```

不变式用例的 `thinking_then_text`、`text_then_tool_use`、`thinking_text_tool_use` 三个子用例在**旧代码下依然通过** —— 断言钉的正是那两条坏顺序，没有过度收紧。

`go test -tags=unit ./...` 全量通过；改动文件 `gofmt` 干净。

## 未纳入本次改动

`content_block_start` 的 switch 不认识 `server_tool_use` / `web_search_tool_result` / `redacted_thinking`，这些块在 message item 开着时到达，其 `content_block_stop` 会落进 `case "message"` 并追加一个空 part。这是既有行为，与本 PR 的两条缺陷正交；本次 `content_index` 推进不会让它变差（原先是撞在 0 上，现在各占一个下标），故未一并改动以保持 diff 聚焦。
