### PR TITLE
fix(repository): PostgreSQL 恢复期间退避重试，避免首次启动退出

### DIFF
--- a/backend/internal/repository/ent.go
+++ b/backend/internal/repository/ent.go
@@ -5,7 +5,10 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/ent"
@@ -17,6 +20,72 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/lib/pq"
 )
+
+const (
+	maxDatabaseInitializationAttempts = 8
+	databaseInitializationRetryBase   = time.Second
+	databaseInitializationRetryMax    = 30 * time.Second
+)
+
+// initializeDatabaseWithRetry retries only errors that indicate PostgreSQL is
+// temporarily unavailable during startup. Permanent configuration, migration,
+// and data errors are returned immediately so they remain visible to operators.
+func initializeDatabaseWithRetry(ctx context.Context, initialize func(context.Context) error) error {
+	return initializeDatabaseWithRetryWithWait(ctx, initialize, waitForDatabaseInitializationRetry)
+}
+
+func initializeDatabaseWithRetryWithWait(
+	ctx context.Context,
+	initialize func(context.Context) error,
+	wait func(context.Context, time.Duration) error,
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxDatabaseInitializationAttempts; attempt++ {
+		if err := initialize(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			if !isTransientDatabaseInitializationError(err) || attempt == maxDatabaseInitializationAttempts {
+				return err
+			}
+		}
+
+		delay := databaseInitializationRetryBase * time.Duration(1<<(attempt-1))
+		if delay > databaseInitializationRetryMax {
+			delay = databaseInitializationRetryMax
+		}
+		slog.Warn("database initialization temporarily unavailable; retrying",
+			"attempt", attempt,
+			"max_attempts", maxDatabaseInitializationAttempts,
+			"retry_in", delay,
+			"error", lastErr,
+		)
+		if err := wait(ctx, delay); err != nil {
+			return err
+		}
+	}
+	return lastErr
+}
+
+func waitForDatabaseInitializationRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isTransientDatabaseInitializationError(err error) bool {
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) {
+		return false
+	}
+	code := string(pqErr.Code)
+	return code == "57P03" || strings.HasPrefix(code, "08")
+}
 
 // InitEnt 初始化 Ent ORM 客户端并返回客户端实例和底层的 *sql.DB。
 //
@@ -69,7 +138,9 @@ func InitEnt(cfg *config.Config) (*ent.Client, *sql.DB, error) {
 	// 这种方式比 Ent 的自动迁移更可控，支持复杂的迁移场景。
 	migrationCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
-	if err := applyMigrationsFS(migrationCtx, drv.DB(), migrations.FS); err != nil {
+	if err := initializeDatabaseWithRetry(migrationCtx, func(ctx context.Context) error {
+		return applyMigrationsFS(ctx, drv.DB(), migrations.FS)
+	}); err != nil {
 		_ = drv.Close() // 迁移失败时关闭驱动，避免资源泄露
 		return nil, nil, err
 	}

--- a/backend/internal/repository/ent.go
+++ b/backend/internal/repository/ent.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	maxDatabaseInitializationAttempts = 8
-	databaseInitializationRetryBase   = time.Second
-	databaseInitializationRetryMax    = 30 * time.Second
+	maxDatabaseInitializationRetries = 8
+	databaseInitializationRetryBase  = time.Second
+	databaseInitializationRetryMax   = 30 * time.Second
 )
 
 // initializeDatabaseWithRetry retries only errors that indicate PostgreSQL is
@@ -39,32 +39,29 @@ func initializeDatabaseWithRetryWithWait(
 	initialize func(context.Context) error,
 	wait func(context.Context, time.Duration) error,
 ) error {
-	var lastErr error
-	for attempt := 1; attempt <= maxDatabaseInitializationAttempts; attempt++ {
+	for attempt := 1; ; attempt++ {
 		if err := initialize(ctx); err == nil {
 			return nil
 		} else {
-			lastErr = err
-			if !isTransientDatabaseInitializationError(err) || attempt == maxDatabaseInitializationAttempts {
+			if !isTransientDatabaseInitializationError(err) || attempt > maxDatabaseInitializationRetries {
+				return err
+			}
+
+			delay := databaseInitializationRetryBase * time.Duration(1<<(attempt-1))
+			if delay > databaseInitializationRetryMax {
+				delay = databaseInitializationRetryMax
+			}
+			slog.Warn("database initialization temporarily unavailable; retrying",
+				"retry", attempt,
+				"max_retries", maxDatabaseInitializationRetries,
+				"retry_in", delay,
+				"error", err,
+			)
+			if err := wait(ctx, delay); err != nil {
 				return err
 			}
 		}
-
-		delay := databaseInitializationRetryBase * time.Duration(1<<(attempt-1))
-		if delay > databaseInitializationRetryMax {
-			delay = databaseInitializationRetryMax
-		}
-		slog.Warn("database initialization temporarily unavailable; retrying",
-			"attempt", attempt,
-			"max_attempts", maxDatabaseInitializationAttempts,
-			"retry_in", delay,
-			"error", lastErr,
-		)
-		if err := wait(ctx, delay); err != nil {
-			return err
-		}
 	}
-	return lastErr
 }
 
 func waitForDatabaseInitializationRetry(ctx context.Context, delay time.Duration) error {

--- a/backend/internal/repository/ent_init_retry_test.go
+++ b/backend/internal/repository/ent_init_retry_test.go
@@ -99,8 +99,8 @@ func TestInitializeDatabaseWithRetryReturnsLastErrorAfterLimit(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, lastErr)
-	require.Equal(t, maxDatabaseInitializationAttempts, attempts)
-	require.Len(t, delays, maxDatabaseInitializationAttempts-1)
+	require.Equal(t, maxDatabaseInitializationRetries+1, attempts)
+	require.Len(t, delays, maxDatabaseInitializationRetries)
 	require.Equal(t, databaseInitializationRetryMax, delays[len(delays)-1])
 }
 

--- a/backend/internal/repository/ent_init_retry_test.go
+++ b/backend/internal/repository/ent_init_retry_test.go
@@ -1,0 +1,122 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func transientDatabaseError(code string) error {
+	return &pq.Error{Code: pq.ErrorCode(code), Message: "database is temporarily unavailable"}
+}
+
+func TestIsTransientDatabaseInitializationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "postgres is starting", err: transientDatabaseError("57P03"), want: true},
+		{name: "connection failure", err: fmt.Errorf("wrapped: %w", transientDatabaseError("08006")), want: true},
+		{name: "authentication failure", err: transientDatabaseError("28P01"), want: false},
+		{name: "migration error", err: errors.New("migration checksum mismatch"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isTransientDatabaseInitializationError(tt.err))
+		})
+	}
+}
+
+func TestInitializeDatabaseWithRetryEventuallySucceeds(t *testing.T) {
+	attempts := 0
+	var delays []time.Duration
+	err := initializeDatabaseWithRetryWithWait(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts <= 3 {
+			return transientDatabaseError("57P03")
+		}
+		return nil
+	}, func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 4, attempts)
+	require.Equal(t, []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}, delays)
+}
+
+func TestInitializeDatabaseWithRetryFailsFastForPermanentError(t *testing.T) {
+	attempts := 0
+	waitCalled := false
+	permanentErr := transientDatabaseError("28P01")
+	err := initializeDatabaseWithRetryWithWait(context.Background(), func(context.Context) error {
+		attempts++
+		return permanentErr
+	}, func(_ context.Context, _ time.Duration) error {
+		waitCalled = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, permanentErr)
+	require.Equal(t, 1, attempts)
+	require.False(t, waitCalled)
+}
+
+func TestInitializeDatabaseWithRetryStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	attempts := 0
+	err := initializeDatabaseWithRetryWithWait(ctx, func(context.Context) error {
+		attempts++
+		return transientDatabaseError("57P03")
+	}, func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		return ctx.Err()
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+}
+
+func TestInitializeDatabaseWithRetryReturnsLastErrorAfterLimit(t *testing.T) {
+	attempts := 0
+	lastErr := transientDatabaseError("08006")
+	var delays []time.Duration
+	err := initializeDatabaseWithRetryWithWait(context.Background(), func(context.Context) error {
+		attempts++
+		return lastErr
+	}, func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	})
+
+	require.ErrorIs(t, err, lastErr)
+	require.Equal(t, maxDatabaseInitializationAttempts, attempts)
+	require.Len(t, delays, maxDatabaseInitializationAttempts-1)
+	require.Equal(t, databaseInitializationRetryMax, delays[len(delays)-1])
+}
+
+func TestInitializeDatabaseWithRetryAllowsIdempotentMigrationRetry(t *testing.T) {
+	applied := make(map[string]bool)
+	attempts := 0
+	err := initializeDatabaseWithRetryWithWait(context.Background(), func(context.Context) error {
+		attempts++
+		if !applied["001_init.sql"] {
+			applied["001_init.sql"] = true
+			return transientDatabaseError("57P03")
+		}
+		return nil
+	}, func(_ context.Context, _ time.Duration) error { return nil })
+
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+	require.True(t, applied["001_init.sql"])
+}

--- a/deploy/DOCKER.md
+++ b/deploy/DOCKER.md
@@ -49,6 +49,20 @@ volumes:
   redis_data:
 ```
 
+## Startup and Database Recovery
+
+Sub2API runs database migrations while starting. PostgreSQL may still be
+recovering briefly after a host or Docker daemon restart. The application
+retries transient PostgreSQL startup and connection errors with bounded
+exponential backoff, then continues startup when the database is ready.
+Permanent errors such as invalid credentials, migration checksum mismatches,
+SQL errors, and incompatible data fail immediately.
+
+The Compose deployment also checks PostgreSQL readiness with both `pg_isready`
+and a simple SQL query. `depends_on: condition: service_healthy` helps order a
+fresh Compose start, but application-level retries are still required when
+Docker restores existing containers after a host restart.
+
 ## Environment Variables
 
 | Variable | Description | Required | Default |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -146,6 +146,28 @@ When using Docker Compose with `AUTO_SETUP=true`:
    docker compose logs sub2api | grep "admin password"
    ```
 
+### Startup and Database Recovery
+
+Sub2API applies database migrations during application startup. PostgreSQL can
+remain in its recovery/startup phase briefly after a host or Docker daemon
+restart. The application retries transient PostgreSQL startup and connection
+errors with bounded exponential backoff, then starts automatically when the
+database becomes ready. Authentication errors, migration checksum mismatches,
+SQL errors, and other permanent configuration or data errors fail immediately.
+
+The Compose example also uses a PostgreSQL health check that verifies both
+server readiness and a simple SQL query. `depends_on: condition: service_healthy`
+controls dependency ordering for a fresh Compose start, but it is not a
+replacement for application-level retries when Docker restores existing
+containers after a host restart.
+
+For systemd deployments, keep `Restart=always` and `RestartSec` configured in
+`sub2api.service`; the application retry covers transient database startup,
+while systemd remains the supervisor for permanent process exits. For
+Kubernetes, use a PostgreSQL readiness probe and retain the Sub2API startup
+retry behavior; configure the application liveness probe separately so a
+database recovery period is not treated as a permanent process failure.
+
 ### Database Migration Notes (PostgreSQL)
 
 - Migrations are applied in lexicographic order (e.g. `001_...sql`, `002_...sql`).

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -221,7 +221,9 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      # The application also retries transient database startup errors. This
+      # grace period keeps Compose from declaring it unhealthy during bootstrap.
+      start_period: 120s
 
   # ===========================================================================
   # PostgreSQL Database
@@ -260,12 +262,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${POSTGRES_USER:-sub2api} -d ${POSTGRES_DB:-sub2api}",
+          "pg_isready -U ${POSTGRES_USER:-sub2api} -d ${POSTGRES_DB:-sub2api} && psql -U ${POSTGRES_USER:-sub2api} -d ${POSTGRES_DB:-sub2api} -Atqc 'SELECT 1' >/dev/null",
         ]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 18
+      start_period: 60s
     # 注意：不暴露端口到宿主机，应用通过内部网络连接
     # 如需调试，可临时添加：ports: ["127.0.0.1:5433:5432"]
 


### PR DESCRIPTION
## 问题

宿主机重启后，Docker 会恢复已有的 Compose 容器，但此时 PostgreSQL 可能仍在执行启动恢复。Sub2API `0.1.169` 在现场首次启动时因此退出：

```text
Failed to initialize application: acquire migrations lock connection: pq: the database system is starting up
```

虽然 `restart: unless-stopped` 最终拉起了第二个进程，但服务恢复依赖容器监管器再次启动应用；应用本身没有处理数据库启动阶段的短暂不可用。

## 根因

`InitEnt` 会在服务启动时连接 PostgreSQL 并执行迁移。迁移执行器获取连接遇到第一条错误就直接返回，`main` 随后因初始化失败退出。

Compose 的 `depends_on: condition: service_healthy` 只能约束正常的 Compose 启动顺序，无法保证 Docker daemon 在宿主机重启后恢复已有容器时，数据库一定先于应用完成恢复。因此数据库初始化边界仍需具备应用级有限重试。

## 改动

- 在迁移初始化外增加有上限的重试，仅接受 PostgreSQL `57P03`（服务正在启动）和 `08xxx`（连接异常）SQLSTATE；错误分类基于 `pq.Error`，不做字符串模糊匹配。
- 首次失败后最多重试 8 次，退避序列为 `1s / 2s / 4s / 8s / 16s / 30s / 30s / 30s`；单次启动最多额外等待 121 秒。
- 每次重试输出结构化 warning，包含当前重试次数、上限、下次等待时间和原始错误。
- 官方 Compose 的 PostgreSQL 健康检查在 `pg_isready` 之后执行 `SELECT 1`，并延长 PostgreSQL 与应用的启动宽限时间。
- 补充 Docker、systemd 和 Kubernetes 部署说明，明确依赖健康检查不能替代应用级重试。

## 兼容性说明

- 认证失败（如 `28P01`）、迁移 checksum 不匹配、SQL、配置和数据错误仍在第一次失败时直接返回，不会被重试掩盖。
- 迁移仍复用现有 `schema_migrations`、checksum 和 advisory lock 机制，没有修改迁移语义。
- 现有 10 分钟迁移上下文上限保持不变。
- 没有新增配置项、数据库迁移、公开 API 或前端改动。

## 本次未包含

- 不改变服务运行期间的数据库断线处理；#2733 讨论的是运行时错误处理，与本次启动迁移竞态是不同边界。
- 不把当前部署的 watchdog、外部监控或服务器专用配置提交到上游。

## 测试

新增 repository 回归用例，覆盖：

- PostgreSQL 前三次返回 `57P03`、随后成功；
- `08xxx` 连接异常重试至上限，并验证完整退避序列；
- `28P01` 和迁移错误立即失败；
- 上下文取消后停止等待；
- 初始化函数在首次调用留下部分进度后，可以再次进入并成功完成。

本地验证：

```bash
go test ./...
go vet ./internal/repository ./cmd/server
go build ./cmd/server
POSTGRES_PASSWORD=test docker compose -f deploy/docker-compose.yml config --quiet
git diff --check
```

以上检查均通过。

Fixes #6412
