### PR TITLE
feat (User)(I18n)(API): 持久化用户通知邮件语言偏好

### DIFF
--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -75,6 +75,10 @@ type ChangePasswordRequest struct {
 	NewPassword string `json:"new_password" binding:"required,min=6"`
 }
 
+type UpdateNotificationEmailLocaleRequest struct {
+	Locale string `json:"locale" binding:"required,oneof=en zh"`
+}
+
 // UpdateProfileRequest represents the update profile request payload
 type UpdateProfileRequest struct {
 	Username               *string  `json:"username"`
@@ -192,6 +196,53 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 	}
 
 	response.Success(c, profileResp)
+}
+
+// UpdateNotificationEmailLocale persists an explicit language choice for the
+// current user's notification emails.
+// PUT /api/v1/user/notification-email-locale
+func (h *UserHandler) UpdateNotificationEmailLocale(c *gin.Context) {
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+
+	var req UpdateNotificationEmailLocaleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	if err := h.userService.SaveNotificationEmailLocale(c.Request.Context(), subject.UserID, req.Locale); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, gin.H{"locale": req.Locale})
+}
+
+// InitializeNotificationEmailLocale initializes the current user's
+// notification email locale without replacing an existing preference.
+// PUT /api/v1/user/notification-email-locale/initialize
+func (h *UserHandler) InitializeNotificationEmailLocale(c *gin.Context) {
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+
+	var req UpdateNotificationEmailLocaleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	initialized, err := h.userService.InitializeNotificationEmailLocale(c.Request.Context(), subject.UserID, req.Locale)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, gin.H{"initialized": initialized})
 }
 
 // GetAffiliate returns the current user's affiliate details.

--- a/backend/internal/handler/user_handler_test.go
+++ b/backend/internal/handler/user_handler_test.go
@@ -19,6 +19,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type localeSettingRepoStub struct {
+	service.SettingRepository
+	values map[string]string
+}
+
+func newLocaleSettingRepoStub() *localeSettingRepoStub {
+	return &localeSettingRepoStub{values: make(map[string]string)}
+}
+
+func (s *localeSettingRepoStub) GetValue(_ context.Context, key string) (string, error) {
+	value, ok := s.values[key]
+	if !ok {
+		return "", service.ErrSettingNotFound
+	}
+	return value, nil
+}
+
+func (s *localeSettingRepoStub) Set(_ context.Context, key, value string) error {
+	s.values[key] = value
+	return nil
+}
+
 type userHandlerRepoStub struct {
 	user       *service.User
 	identities []service.UserAuthIdentityRecord
@@ -192,6 +214,68 @@ func TestUserHandlerUpdateProfileReturnsAvatarURL(t *testing.T) {
 	require.Equal(t, 0, resp.Code)
 	require.Equal(t, "https://cdn.example.com/avatar.png", resp.Data.AvatarURL)
 	require.Equal(t, "handler-avatar", resp.Data.Username)
+}
+
+func TestUserHandlerUpdateNotificationEmailLocaleOverwritesPreference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := &userHandlerRepoStub{user: &service.User{
+		ID:     11,
+		Email:  "locale@example.com",
+		Role:   service.RoleUser,
+		Status: service.StatusActive,
+	}}
+	settingRepo := newLocaleSettingRepoStub()
+	settingRepo.values["notification_email_locale:user:11"] = "en"
+	handler := NewUserHandler(service.NewUserService(repo, settingRepo, nil, nil), nil, nil, nil, nil, nil)
+
+	body := []byte(`{"locale":"zh"}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api/v1/user/notification-email-locale", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 11})
+
+	handler.UpdateNotificationEmailLocale(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "zh", settingRepo.values["notification_email_locale:user:11"])
+}
+
+func TestUserHandlerInitializeNotificationEmailLocalePreservesPreference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := &userHandlerRepoStub{user: &service.User{
+		ID:     11,
+		Email:  "locale@example.com",
+		Role:   service.RoleUser,
+		Status: service.StatusActive,
+	}}
+	settingRepo := newLocaleSettingRepoStub()
+	settingRepo.values["notification_email_locale:user:11"] = "en"
+	handler := NewUserHandler(service.NewUserService(repo, settingRepo, nil, nil), nil, nil, nil, nil, nil)
+
+	body := []byte(`{"locale":"zh"}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api/v1/user/notification-email-locale/initialize", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 11})
+
+	handler.InitializeNotificationEmailLocale(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "en", settingRepo.values["notification_email_locale:user:11"])
+
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Initialized bool `json:"initialized"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Code)
+	require.False(t, resp.Data.Initialized)
 }
 
 func TestUserHandlerGetProfileReturnsIdentitySummaries(t *testing.T) {

--- a/backend/internal/server/routes/user.go
+++ b/backend/internal/server/routes/user.go
@@ -31,6 +31,8 @@ func RegisterUserRoutes(
 			user.GET("/profile", h.User.GetProfile)
 			user.PUT("/password", h.User.ChangePassword)
 			user.PUT("", h.User.UpdateProfile)
+			user.PUT("/notification-email-locale", h.User.UpdateNotificationEmailLocale)
+			user.PUT("/notification-email-locale/initialize", h.User.InitializeNotificationEmailLocale)
 			user.GET("/aff", h.User.GetAffiliate)
 			user.POST("/aff/transfer", h.User.TransferAffiliateQuota)
 			user.POST("/account-bindings/email/send-code", h.User.SendEmailBindingCode)

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -297,6 +298,7 @@ type UserService struct {
 	billingCache         BillingCache
 	lastActiveTouchL1    sync.Map
 	lastActiveTouchSF    singleflight.Group
+	notificationLocaleSF singleflight.Group
 }
 
 // NewUserService 创建用户服务实例
@@ -307,6 +309,52 @@ func NewUserService(userRepo UserRepository, settingRepo SettingRepository, auth
 		authCacheInvalidator: authCacheInvalidator,
 		billingCache:         billingCache,
 	}
+}
+
+// SaveNotificationEmailLocale persists an explicit account-level notification
+// email locale selection.
+func (s *UserService) SaveNotificationEmailLocale(ctx context.Context, userID int64, rawLocale string) error {
+	if s == nil || s.settingRepo == nil || userID <= 0 || strings.TrimSpace(rawLocale) == "" {
+		return nil
+	}
+
+	key := notificationEmailLocaleUserKeyPrefix + strconv.FormatInt(userID, 10)
+	locale := normalizeNotificationLocale(rawLocale)
+	if err := s.settingRepo.Set(ctx, key, locale); err != nil {
+		return fmt.Errorf("save notification email locale: %w", err)
+	}
+	return nil
+}
+
+// InitializeNotificationEmailLocale persists an account-level notification
+// email locale only when the user's setting does not already exist. The
+// singleflight group provides process-local serialization for the read-then-
+// write sequence; the initialization path is intentionally not a distributed
+// concurrency primitive.
+func (s *UserService) InitializeNotificationEmailLocale(ctx context.Context, userID int64, rawLocale string) (bool, error) {
+	if s == nil || s.settingRepo == nil || userID <= 0 || strings.TrimSpace(rawLocale) == "" {
+		return false, nil
+	}
+
+	key := notificationEmailLocaleUserKeyPrefix + strconv.FormatInt(userID, 10)
+	locale := normalizeNotificationLocale(rawLocale)
+	result, err, _ := s.notificationLocaleSF.Do(key, func() (any, error) {
+		if _, err := s.settingRepo.GetValue(ctx, key); err == nil {
+			return false, nil
+		} else if !errors.Is(err, ErrSettingNotFound) {
+			return false, fmt.Errorf("check notification email locale: %w", err)
+		}
+
+		if err := s.settingRepo.Set(ctx, key, locale); err != nil {
+			return false, fmt.Errorf("initialize notification email locale: %w", err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	initialized, _ := result.(bool)
+	return initialized, nil
 }
 
 // GetFirstAdmin 获取首个管理员用户（用于 Admin API Key 认证）

--- a/backend/internal/service/user_service_test.go
+++ b/backend/internal/service/user_service_test.go
@@ -92,6 +92,94 @@ func (m *mockUserSettingRepo) Delete(context.Context, string) error {
 	panic("unexpected Delete call")
 }
 
+func TestSaveNotificationEmailLocaleNormalizesAndOverwrites(t *testing.T) {
+	ctx := context.Background()
+	repo := newNotificationEmailMemorySettingRepo()
+	svc := NewUserService(nil, repo, nil, nil)
+	key := notificationEmailLocaleUserKeyPrefix + "42"
+
+	require.NoError(t, repo.Set(ctx, key, "en"))
+	require.NoError(t, svc.SaveNotificationEmailLocale(ctx, 42, "zh-CN,zh;q=0.9"))
+	value, err := repo.GetValue(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, "zh", value)
+}
+
+func TestSaveNotificationEmailLocaleIgnoresMissingLocale(t *testing.T) {
+	ctx := context.Background()
+	repo := newNotificationEmailMemorySettingRepo()
+	svc := NewUserService(nil, repo, nil, nil)
+
+	require.NoError(t, svc.SaveNotificationEmailLocale(ctx, 42, ""))
+	_, err := repo.GetValue(ctx, notificationEmailLocaleUserKeyPrefix+"42")
+	require.ErrorIs(t, err, ErrSettingNotFound)
+}
+
+func TestInitializeNotificationEmailLocaleOnlyWritesMissingPreference(t *testing.T) {
+	ctx := context.Background()
+	repo := newNotificationEmailMemorySettingRepo()
+	svc := NewUserService(nil, repo, nil, nil)
+	key := notificationEmailLocaleUserKeyPrefix + "42"
+
+	initialized, err := svc.InitializeNotificationEmailLocale(ctx, 42, "zh-CN,zh;q=0.9")
+	require.NoError(t, err)
+	require.True(t, initialized)
+	value, err := repo.GetValue(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, "zh", value)
+
+	initialized, err = svc.InitializeNotificationEmailLocale(ctx, 42, "en")
+	require.NoError(t, err)
+	require.False(t, initialized)
+	value, err = repo.GetValue(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, "zh", value)
+}
+
+type notificationEmailLocaleInitRepo struct {
+	SettingRepository
+	getCalls atomic.Int32
+	setCalls atomic.Int32
+}
+
+func (r *notificationEmailLocaleInitRepo) GetValue(context.Context, string) (string, error) {
+	r.getCalls.Add(1)
+	time.Sleep(20 * time.Millisecond)
+	return "", ErrSettingNotFound
+}
+
+func (r *notificationEmailLocaleInitRepo) Set(context.Context, string, string) error {
+	r.setCalls.Add(1)
+	return nil
+}
+
+func TestInitializeNotificationEmailLocaleCoalescesLocalConcurrentRequests(t *testing.T) {
+	repo := &notificationEmailLocaleInitRepo{}
+	svc := NewUserService(nil, repo, nil, nil)
+	start := make(chan struct{})
+	errCh := make(chan error, 8)
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.InitializeNotificationEmailLocale(context.Background(), 42, "zh")
+			errCh <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 1, repo.getCalls.Load())
+	require.EqualValues(t, 1, repo.setCalls.Load())
+}
+
 func (m *mockUserRepo) Create(context.Context, *User) error                    { return nil }
 func (m *mockUserRepo) CreateWithEmailAliasGuard(context.Context, *User) error { return nil }
 func (m *mockUserRepo) GetByID(ctx context.Context, _ int64) (*User, error) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,8 @@ import { resolveRouteDocumentTitle } from '@/router/title'
 import AnnouncementPopup from '@/components/common/AnnouncementPopup.vue'
 import { useAppStore, useAuthStore, useSubscriptionStore, useAnnouncementStore, useAdminComplianceStore, useAdminSettingsStore } from '@/stores'
 import { getSetupStatus } from '@/api/setup'
+import { getLocale } from '@/i18n'
+import { initializeNotificationEmailLocaleOnce } from '@/i18n/notificationEmailLocale'
 import { updateFavicon } from '@/utils/branding'
 
 const router = useRouter()
@@ -68,6 +70,13 @@ watch(
   () => authStore.isAuthenticated,
   (isAuthenticated, oldValue) => {
     if (isAuthenticated) {
+      const userID = authStore.user?.id
+      if (userID) {
+        initializeNotificationEmailLocaleOnce(userID, getLocale()).catch((error) => {
+          console.warn('Failed to initialize notification email locale:', error)
+        })
+      }
+
       if (authStore.isAdmin) {
         adminComplianceStore.fetchStatus().catch((error) => {
           console.error('Failed to fetch admin compliance status:', error)

--- a/frontend/src/api/__tests__/userNotificationEmailLocale.spec.ts
+++ b/frontend/src/api/__tests__/userNotificationEmailLocale.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { apiClient } from '../client'
+import { initializeNotificationEmailLocale, updateNotificationEmailLocale } from '../user'
+
+describe('updateNotificationEmailLocale', () => {
+  afterEach(() => {
+    apiClient.defaults.adapter = undefined
+  })
+
+  it('sends the explicit locale to the authenticated user endpoint', async () => {
+    const adapter = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { code: 0, data: { locale: 'zh' } },
+      headers: {},
+      config: {},
+      statusText: 'OK',
+    })
+    apiClient.defaults.adapter = adapter
+
+    await updateNotificationEmailLocale('zh')
+
+    expect(adapter).toHaveBeenCalledOnce()
+    const config = adapter.mock.calls[0][0]
+    expect(config.method).toBe('put')
+    expect(config.url).toBe('/user/notification-email-locale')
+    expect(JSON.parse(config.data)).toEqual({ locale: 'zh' })
+  })
+
+  it('sends the fallback locale to the non-overwriting initialization endpoint', async () => {
+    const adapter = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { code: 0, data: { initialized: true } },
+      headers: {},
+      config: {},
+      statusText: 'OK',
+    })
+    apiClient.defaults.adapter = adapter
+
+    await initializeNotificationEmailLocale('zh')
+
+    expect(adapter).toHaveBeenCalledOnce()
+    const config = adapter.mock.calls[0][0]
+    expect(config.method).toBe('put')
+    expect(config.url).toBe('/user/notification-email-locale/initialize')
+    expect(JSON.parse(config.data)).toEqual({ locale: 'zh' })
+  })
+})

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -44,6 +44,16 @@ export async function updateProfile(profile: {
   return data
 }
 
+/** Persist the current user's notification email locale. */
+export async function updateNotificationEmailLocale(locale: 'en' | 'zh'): Promise<void> {
+  await apiClient.put('/user/notification-email-locale', { locale })
+}
+
+/** Initialize the current user's notification email locale without overwriting it. */
+export async function initializeNotificationEmailLocale(locale: 'en' | 'zh'): Promise<void> {
+  await apiClient.put('/user/notification-email-locale/initialize', { locale })
+}
+
 /**
  * Change current user password
  * @param passwords - Old and new password
@@ -197,6 +207,8 @@ export async function getMyPlatformQuotas(): Promise<PlatformQuotasResponse> {
 export const userAPI = {
   getProfile,
   updateProfile,
+  updateNotificationEmailLocale,
+  initializeNotificationEmailLocale,
   changePassword,
   sendNotifyEmailCode,
   verifyNotifyEmail,

--- a/frontend/src/i18n/__tests__/localePersistence.spec.ts
+++ b/frontend/src/i18n/__tests__/localePersistence.spec.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  authStore: {
+    isAuthenticated: false,
+    isAdmin: false,
+    user: null as { id: number } | null,
+  },
+  appStore: {
+    cachedPublicSettings: null as { custom_menu_items?: unknown[] } | null,
+    siteName: 'Sub2API',
+    showError: vi.fn(),
+  },
+  adminSettingsStore: {
+    customMenuItems: [] as unknown[],
+  },
+  updateNotificationEmailLocale: vi.fn(),
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    currentRoute: {
+      value: { name: 'dashboard', meta: {} },
+    },
+  },
+}))
+
+vi.mock('@/router/title', () => ({
+  resolveRouteDocumentTitle: () => 'Sub2API',
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => mocks.appStore,
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mocks.authStore,
+}))
+
+vi.mock('@/stores/adminSettings', () => ({
+  useAdminSettingsStore: () => mocks.adminSettingsStore,
+}))
+
+vi.mock('@/api/user', () => ({
+  updateNotificationEmailLocale: mocks.updateNotificationEmailLocale,
+}))
+
+import { getLocale, setLocale } from '../index'
+
+describe('notification email locale persistence', () => {
+  beforeEach(() => {
+    mocks.authStore.isAuthenticated = false
+    mocks.authStore.user = null
+    mocks.updateNotificationEmailLocale.mockReset()
+    mocks.appStore.showError.mockReset()
+    localStorage.clear()
+  })
+
+  it('persists an explicit locale switch for an authenticated user', async () => {
+    mocks.authStore.isAuthenticated = true
+    mocks.authStore.user = { id: 42 }
+
+    await setLocale('zh')
+
+    expect(getLocale()).toBe('zh')
+    expect(localStorage.getItem('sub2api_locale')).toBe('zh')
+    expect(mocks.updateNotificationEmailLocale).toHaveBeenCalledOnce()
+    expect(mocks.updateNotificationEmailLocale).toHaveBeenCalledWith('zh')
+    expect(
+      localStorage.getItem('notification_email_locale_initialized:v1:user:42'),
+    ).toBe('1')
+  })
+
+  it('keeps anonymous locale switches local', async () => {
+    await setLocale('en')
+
+    expect(getLocale()).toBe('en')
+    expect(mocks.updateNotificationEmailLocale).not.toHaveBeenCalled()
+  })
+
+  it('keeps the local switch and reports a persistence failure', async () => {
+    mocks.authStore.isAuthenticated = true
+    mocks.authStore.user = { id: 42 }
+    mocks.updateNotificationEmailLocale.mockRejectedValueOnce(new Error('request failed'))
+
+    await setLocale('zh')
+
+    expect(getLocale()).toBe('zh')
+    expect(mocks.appStore.showError).toHaveBeenCalledOnce()
+    expect(
+      localStorage.getItem('notification_email_locale_initialized:v1:user:42'),
+    ).toBeNull()
+  })
+})

--- a/frontend/src/i18n/__tests__/notificationEmailLocaleInitialization.spec.ts
+++ b/frontend/src/i18n/__tests__/notificationEmailLocaleInitialization.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  initializeNotificationEmailLocale: vi.fn(),
+}))
+
+vi.mock('@/api/user', () => ({
+  initializeNotificationEmailLocale: mocks.initializeNotificationEmailLocale,
+}))
+
+import { initializeNotificationEmailLocaleOnce } from '../notificationEmailLocale'
+
+describe('notification email locale initialization', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mocks.initializeNotificationEmailLocale.mockReset()
+  })
+
+  it('records a per-user marker and skips later initialization calls', async () => {
+    mocks.initializeNotificationEmailLocale.mockResolvedValue(undefined)
+
+    await initializeNotificationEmailLocaleOnce(42, 'zh')
+    await initializeNotificationEmailLocaleOnce(42, 'zh')
+
+    expect(mocks.initializeNotificationEmailLocale).toHaveBeenCalledOnce()
+    expect(mocks.initializeNotificationEmailLocale).toHaveBeenCalledWith('zh')
+    expect(
+      localStorage.getItem('notification_email_locale_initialized:v1:user:42'),
+    ).toBe('1')
+  })
+
+  it('coalesces concurrent initialization calls for the same user', async () => {
+    let resolveRequest: (() => void) | undefined
+    mocks.initializeNotificationEmailLocale.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+
+    const first = initializeNotificationEmailLocaleOnce(42, 'zh')
+    const second = initializeNotificationEmailLocaleOnce(42, 'zh')
+
+    expect(mocks.initializeNotificationEmailLocale).toHaveBeenCalledOnce()
+    resolveRequest?.()
+    await Promise.all([first, second])
+  })
+
+  it('does not mark failures so a later authenticated session can retry', async () => {
+    mocks.initializeNotificationEmailLocale
+      .mockRejectedValueOnce(new Error('request failed'))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(initializeNotificationEmailLocaleOnce(42, 'zh')).rejects.toThrow(
+      'request failed',
+    )
+    expect(
+      localStorage.getItem('notification_email_locale_initialized:v1:user:42'),
+    ).toBeNull()
+
+    await initializeNotificationEmailLocaleOnce(42, 'zh')
+
+    expect(mocks.initializeNotificationEmailLocale).toHaveBeenCalledTimes(2)
+    expect(
+      localStorage.getItem('notification_email_locale_initialized:v1:user:42'),
+    ).toBe('1')
+  })
+})

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -84,6 +84,22 @@ export async function setLocale(locale: string): Promise<void> {
     ...(authStore.isAdmin ? adminSettingsStore.customMenuItems : []),
   ]
   document.title = resolveRouteDocumentTitle(route, appStore.siteName, customMenuItems)
+
+  if (authStore.isAuthenticated) {
+    try {
+      const { updateNotificationEmailLocale } = await import('@/api/user')
+      await updateNotificationEmailLocale(locale)
+      if (authStore.user?.id) {
+        const { markNotificationEmailLocaleInitialized } = await import(
+          './notificationEmailLocale'
+        )
+        markNotificationEmailLocaleInitialized(authStore.user.id)
+      }
+    } catch {
+      // Keep the local language switch effective, but make persistence failures visible.
+      appStore.showError(String(i18n.global.t('common.error')))
+    }
+  }
 }
 
 export function getLocale(): LocaleCode {

--- a/frontend/src/i18n/notificationEmailLocale.ts
+++ b/frontend/src/i18n/notificationEmailLocale.ts
@@ -1,0 +1,42 @@
+import { initializeNotificationEmailLocale } from '@/api/user'
+
+type NotificationEmailLocale = 'en' | 'zh'
+
+const INITIALIZATION_VERSION = 'v1'
+const INITIALIZED_MARKER_VALUE = '1'
+const initializationRequests = new Map<number, Promise<void>>()
+
+function markerKey(userID: number): string {
+  return `notification_email_locale_initialized:${INITIALIZATION_VERSION}:user:${userID}`
+}
+
+export function markNotificationEmailLocaleInitialized(userID: number): void {
+  if (!Number.isInteger(userID) || userID <= 0) return
+  localStorage.setItem(markerKey(userID), INITIALIZED_MARKER_VALUE)
+}
+
+export function initializeNotificationEmailLocaleOnce(
+  userID: number,
+  locale: NotificationEmailLocale,
+): Promise<void> {
+  if (!Number.isInteger(userID) || userID <= 0) return Promise.resolve()
+  if (localStorage.getItem(markerKey(userID)) === INITIALIZED_MARKER_VALUE) {
+    return Promise.resolve()
+  }
+
+  const inFlight = initializationRequests.get(userID)
+  if (inFlight) return inFlight
+
+  const request = initializeNotificationEmailLocale(locale).then(() => {
+    markNotificationEmailLocaleInitialized(userID)
+  })
+  initializationRequests.set(userID, request)
+
+  const clearRequest = () => {
+    if (initializationRequests.get(userID) === request) {
+      initializationRequests.delete(userID)
+    }
+  }
+  request.then(clearRequest, clearRequest)
+  return request
+}


### PR DESCRIPTION
## Summary

  实现用户通知邮件语言偏好的账户级持久化，使认证用户的前端界面语言选择能够同步影响通知邮件语言。

  首次认证时，系统会使用当前前端语言初始化通知邮件语言，但不会覆盖用户已经保存的偏好；用户后续主动切换语言时，则会显式更新该偏好。

  ## Motivation
  当前系统已实现邮件多语言模版和用户邮件语言偏好，但是只有在用户支付订单才会触发持久化，否则只剩下如忘记密码的 `Accept-Language` 透传链路 （ #2599 ），后端缺少对应的用户级通知邮件语言设置持久化，导致界面语言与通知邮件语言无法稳定同步。

  本次变更补充后端持久化接口，并将其接入前端语言切换和认证初始化流程，避免未支付的用户全部落到英文版本邮件。

  ## Changes

  ### Backend

  - 新增显式保存通知邮件语言的接口：

    PUT /api/v1/user/notification-email-locale

  - 新增非覆盖式初始化接口：

    PUT /api/v1/user/notification-email-locale/initialize

  - 新增 UserService 通知邮件语言偏好保存逻辑：
      - 显式保存时覆盖已有值
      - 初始化时仅在用户没有已有设置的情况下写入
      - 对保存值进行语言归一化
      - 使用进程内 singleflight 合并同一用户的并发初始化请求

  - 增加请求参数校验，目前接口接受 en 和 zh。

  ### Frontend

  - 新增通知邮件语言保存和初始化 API 封装。
  - 用户切换界面语言时：
      - 先保持本地语言切换生效
      - 对认证用户同步保存通知邮件语言
      - 持久化失败时通过页面错误提示反馈，但不阻断本地语言切换

  - 用户认证成功后：
      - 使用当前界面语言执行通知邮件语言初始化
      - 通过用户 ID 和版本化 localStorage 标记避免重复初始化
      - 合并同一用户的并发初始化请求
      - 初始化失败时不写入完成标记，使后续认证会话能够重试

  ### API behavior

   Endpoint                                                 Behavior
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  
   PUT /api/v1/user/notification-email-locale               显式保存并覆盖当前用户的通知邮件语言
  ──────────────────────────────────────────────
   PUT /api/v1/user/notification-email-locale/initialize    仅在当前用户没有已有偏好时写入语言

  ## Impact

  - 影响认证用户的界面语言切换和通知邮件语言设置。
  - 匿名用户的语言切换仍然只保存在本地，不会调用通知邮件语言持久化接口。
  - 用户偏好写入现有设置存储，不需要新增数据库迁移。
  - 新增认证用户接口请求，语言切换和首次认证流程会产生额外的后端请求。
  - 不涉及视觉布局或页面结构变化，因此无需 UI 截图。

  ## Compatibility and Risk

  - 初始化接口不会覆盖已有的通知邮件语言偏好。
  - 显式保存接口会覆盖已有值，符合用户主动切换语言的预期。
  - 当前仅支持 en 和 zh，与现有前端语言范围保持一致。
  - 设置项按需写入，不需要数据迁移或回填。
  - singleflight 只提供单进程内的并发合并能力，多实例部署下仍可能发生重复初始化写入，但不会覆盖已有偏好。
  - 后端持久化失败不会阻止前端本地语言切换；初始化失败不会记录完成标记，后续可以重试。

  ## Testing

  ### Local verification

  - [x] pnpm exec vitest run src/api/__tests__/userNotificationEmailLocale.spec.ts src/i18n/__tests__/localePersistence.spec.ts src/i18n/__tests__/
    notificationEmailLocaleInitialization.spec.ts
      - 3 个测试文件通过
      - 8 个测试通过

  - [x] go test ./internal/handler ./internal/service
      - internal/handler 测试通过
      - internal/service 测试通过

  - [x] git diff --check
