### PR TITLE
fix(openai): ctx_pool WS ingress 下发前改写上游容量降载错误码（Codex 会话被硬终止）

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -1125,7 +1125,24 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					}
 				}
 				replayCollector.AddEvent(eventType, upstreamMessage)
-				if err := writeClientMessage(upstreamMessage); err != nil {
+				// 客户端写出副本改写容量降载码：Codex 对 error/response.failed 中的
+				// server_is_overloaded / slow_down 判致命并终止会话，改写后走客户端
+				// 内置退避重试。HTTP/SSE（openai_gateway_response_handling.go）与
+				// http_bridge（openai_ws_http_bridge.go）两条路径早已这么做，
+				// ctx_pool 的 ingress 直写路径是唯一漏掉的一条 —— 同一个上游降载
+				// 事件在这里会让会话就地终止，切到 http_bridge 却能正常退避重试。
+				//
+				// 必须写进独立变量而不是原地改 upstreamMessage：下面的
+				// markOpenAIWSClientVisibleFailure 与 handleOpenAIWSTerminalTransientFailure
+				// 仍要按未改写的原始 payload 判定账号状态，这正是
+				// sanitizeOpenAICapacityShedErrorCodeForClient 注释里写明的前提。
+				clientMessage := upstreamMessage
+				if eventType == "error" || eventType == "response.failed" {
+					if rewritten, changed := sanitizeOpenAICapacityShedErrorCodeForClient(clientMessage); changed {
+						clientMessage = rewritten
+					}
+				}
+				if err := writeClientMessage(clientMessage); err != nil {
 					if isOpenAIWSClientDisconnectError(err) {
 						clientDisconnected = true
 						closeStatus, closeReason := summarizeOpenAIWSReadCloseError(err)

--- a/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
+++ b/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	coderws "github.com/coder/websocket"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// openAIWSIngressCapacityShedRepo 补齐 SetError，避免非容量类错误（如
+// workspace_suspended）走到账号状态副作用时打空指针。
+type openAIWSIngressCapacityShedRepo struct {
+	stubOpenAIAccountRepo
+}
+
+func (r *openAIWSIngressCapacityShedRepo) SetError(context.Context, int64, string) error { return nil }
+
+func (r *openAIWSIngressCapacityShedRepo) SetRateLimited(context.Context, int64, time.Time) error {
+	return nil
+}
+
+func (r *openAIWSIngressCapacityShedRepo) UpdateExtra(context.Context, int64, map[string]any) error {
+	return nil
+}
+
+// ctx_pool 的 ingress 直写路径把 error / response.failed 交给 WS 客户端前，必须和
+// HTTP/SSE（openai_gateway_response_handling.go）与 http_bridge
+// （openai_ws_http_bridge.go）两条路径一样，把容量降载码改写为可重试的
+// server_error：Codex 按闭集判定，server_is_overloaded / slow_down 属致命集，
+// 客户端会打印 "Selected model is at capacity" 并直接终止会话而不是退避重试。
+//
+// 第二个用例锁住改写范围：非容量类错误码必须原样下发，客户端依赖原码各自处理。
+func TestProxyResponsesWebSocketFromClient_RewritesCapacityShedCodeForClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		upstreamEvents [][]byte
+		wantContains   []string
+		wantAbsent     []string
+	}{
+		{
+			name: "capacity_shed_error_and_failed_are_rewritten",
+			upstreamEvents: [][]byte{
+				[]byte(`{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}`),
+				[]byte(`{"type":"response.failed","response":{"id":"resp_shed","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}`),
+			},
+			wantContains: []string{
+				`"code":"server_error"`,
+				"Our servers are currently overloaded",
+			},
+			wantAbsent: []string{"server_is_overloaded"},
+		},
+		{
+			name: "non_capacity_error_code_is_passed_through",
+			upstreamEvents: [][]byte{
+				[]byte(`{"type":"error","error":{"type":"invalid_request_error","code":"workspace_suspended","message":"workspace is suspended"}}`),
+				[]byte(`{"type":"response.failed","response":{"id":"resp_suspended","status":"failed","error":{"code":"workspace_suspended","message":"workspace is suspended"}}}`),
+			},
+			wantContains: []string{
+				`"code":"workspace_suspended"`,
+				"workspace is suspended",
+			},
+			wantAbsent: []string{"server_error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newOpenAIWSV2TestConfig()
+			cfg.Security.URLAllowlist.Enabled = false
+			cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+			cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+			cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+			cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+			cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+			cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+			cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+			cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+			events := make([][]byte, 0, len(tt.upstreamEvents))
+			for _, event := range tt.upstreamEvents {
+				events = append(events, append([]byte(nil), event...))
+			}
+			captureConn := &openAIWSCaptureConn{events: events}
+			pool := newOpenAIWSConnPool(cfg)
+			pool.setClientDialerForTest(&openAIWSCaptureDialer{conn: captureConn})
+
+			account := Account{
+				ID:          5401,
+				Name:        "openai-ingress-capacity-shed",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Credentials: map[string]any{"api_key": "sk-test"},
+				Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+			}
+			repo := &openAIWSIngressCapacityShedRepo{stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}}
+			svc := &OpenAIGatewayService{
+				accountRepo:      repo,
+				rateLimitService: &RateLimitService{accountRepo: repo},
+				httpUpstream:     &httpUpstreamRecorder{},
+				cache:            &stubGatewayCache{},
+				cfg:              cfg,
+				openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+				toolCorrector:    NewCodexToolCorrector(),
+				openaiWSPool:     pool,
+			}
+
+			serverDone := make(chan struct{})
+			wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(serverDone)
+				conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+				if err != nil {
+					return
+				}
+				defer func() { _ = conn.CloseNow() }()
+
+				rec := httptest.NewRecorder()
+				ginCtx, _ := gin.CreateTestContext(rec)
+				req := r.Clone(r.Context())
+				req.Header = req.Header.Clone()
+				req.Header.Set("User-Agent", "unit-test-agent/1.0")
+				ginCtx.Request = req
+
+				readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+				msgType, firstMessage, readErr := conn.Read(readCtx)
+				cancel()
+				if readErr != nil || (msgType != coderws.MessageText && msgType != coderws.MessageBinary) {
+					return
+				}
+				_ = svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, &account, "sk-test", firstMessage, nil)
+			}))
+			defer wsServer.Close()
+
+			dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+			clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+			cancelDial()
+			require.NoError(t, err)
+			defer func() { _ = clientConn.CloseNow() }()
+
+			writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+			err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false}`))
+			cancelWrite()
+			require.NoError(t, err)
+
+			var frames []string
+			for len(frames) < len(tt.upstreamEvents) {
+				readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				_, message, readErr := clientConn.Read(readCtx)
+				cancel()
+				if readErr != nil {
+					break
+				}
+				frames = append(frames, string(message))
+			}
+			// 本轮已终止，主动断开客户端让 ingress 退出 turn 循环。
+			_ = clientConn.CloseNow()
+
+			require.NotEmpty(t, frames, "客户端应至少收到一个下发事件")
+			joined := strings.Join(frames, "\n")
+			for _, want := range tt.wantContains {
+				require.Contains(t, joined, want, "客户端收到的事件:\n%s", joined)
+			}
+			for _, absent := range tt.wantAbsent {
+				require.NotContains(t, joined, absent, "客户端收到的事件:\n%s", joined)
+			}
+
+			select {
+			case <-serverDone:
+			case <-time.After(5 * time.Second):
+				t.Fatal("等待 ingress websocket 结束超时")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5840

## 问题

`ctx_pool` 模式下，上游 OpenAI 容量降载事件（`server_is_overloaded` / `slow_down`）被 **原样** 转发给 WS 客户端。Codex CLI 按闭集判定错误码，这两个属致命集：客户端打印 `Selected model is at capacity. Please try a different model.` 并**直接终止会话**，不进入退避重试。

同一账号、同一时刻切到 `http_bridge` 就能正常重试并完成任务 —— 两条路径对同一种上游错误的处理不一致。

## 仓库里已经有正确处理，只是漏了一条路径

`sanitizeOpenAICapacityShedErrorCodeForClient`（`openai_gateway_passthrough.go:1335`）正是为此而写，其注释已经写死了政策：

```go
// openAICapacityShedRetryableClientCode 是把上游容量降载错误转发给客户端时改写
// 使用的错误码。Codex CLI 按闭集对错误码分类：server_is_overloaded / slow_down
// 被判为致命错误（客户端提示 "Selected model is at capacity. Please try a
// different model." 并直接终止会话），而 server_error 等致命集之外的错误码会进入
// 客户端内置的退避重试。
```

它此前的调用点：

| 路径 | 文件 | 是否调用 |
|---|---|---|
| HTTP / SSE | `openai_gateway_response_handling.go:1850` | ✅ |
| http_bridge | `openai_ws_http_bridge.go:702` / `:852` | ✅ |
| **ctx_pool WS ingress 直写** | `openai_ws_forwarder_ingress.go` | ❌ |

`openai_ws_forwarder_ingress.go` 里 `overload` / `capacity` **零匹配**：该文件的错误恢复分支只有 `previous_response_not_found` 重放与 `isOpenAIWSRateLimitError` 触发的 429 failover，容量降载两者都不命中，于是直落客户端。

## 改动

`openai_ws_forwarder_ingress.go`（+16/-1）—— 在下发收敛点补上同一个改写器：

```go
clientMessage := upstreamMessage
if eventType == "error" || eventType == "response.failed" {
    if rewritten, changed := sanitizeOpenAICapacityShedErrorCodeForClient(clientMessage); changed {
        clientMessage = rewritten
    }
}
if err := writeClientMessage(clientMessage); err != nil {
```

三点说明：

1. **落点是唯一的下发收敛点**。该 `if !clientDisconnected {}` 块里本来就有两处针对客户端副本的改写（模型名还原 `replaceOpenAIWSMessageModel`、工具调用纠正 `CorrectToolCallsInSSEBytes`），新增改写与既有结构一致。

2. **必须写进独立变量，不能原地改 `upstreamMessage`**。写出点之后仍有两处使用原始 payload：
   - `markOpenAIWSClientVisibleFailure(c, eventType, upstreamMessage)`
   - `handleOpenAIWSTerminalTransientFailure(ctx, account, mappedModel, ..., upstreamMessage)` ← **账号状态判定**

   这正是改写器注释里「监控与账号状态判定都基于改写前的原始 payload，不受影响」所要求的前提。`http_bridge:852` 的写法也是另建 `clientMessage`，本次与之逐字对齐。

3. **不影响任何账号侧判定与失败归因**：`handleOpenAIWSErrorEventTransientFailure`、`persistOpenAIWSRateLimitSignal`、`classifyOpenAIWSErrorEventFromRaw` 都在下发点之前执行，读的是未改写的 `upstreamMessage`。`replayCollector.AddEvent` 只响应 `response.output_item.done` / `response.completed` / `response.done`，对 error / response.failed 不做任何事，故仍传原始值（与 http_bridge 一致）。

## 测试

新增 `openai_ws_ingress_capacity_shed_test.go`，沿用既有 ingress 测试桩（`openAIWSCaptureConn` + `setClientDialerForTest` + 真实 WS 双端），**直接断言客户端收到的帧**：

- `capacity_shed_error_and_failed_are_rewritten` —— 上游连发 `error` 与 `response.failed` 两帧容量降载，断言客户端侧 `"code":"server_error"`、不含 `server_is_overloaded`、原始 message 文案保留。
- `non_capacity_error_code_is_passed_through` —— 锁住改写范围：`workspace_suspended` 必须原样下发，且不得出现 `server_error`。

这与 http_bridge 侧既有的 `TestProxyOpenAIWSHTTPBridgeTurnRewritesCapacityShedCodeForClient` 是同一形状的断言，便于两条路径对读。

**回滚验证**：把实现改回主线原状，只有容量用例变红，报文即缺陷本身：

```
--- FAIL: .../capacity_shed_error_and_failed_are_rewritten
    "{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded",...}}
     {"type":"response.failed","response":{...,"error":{"code":"server_is_overloaded",...}}}"
      does not contain ""code":"server_error""
```

`non_capacity_error_code_is_passed_through` 在旧代码下**依然通过** —— 断言只钉容量码这一条，没有过度收紧。

`go test -tags=unit ./...` 全量通过；改动文件 `gofmt` 干净。

## 未纳入本次改动

issue 还提到一条更彻底的路线：ingress 侧对容量降载做同账号有限重试 / 账号 failover（其数据显示 68% 的容量错误发生在 `turn=1`，即尚未写出语义输出的安全重放窗口）。这需要改 `classifyOpenAIWSErrorEventFromRaw` 的可 fallback 判定 —— 目前 `server_error` 返回 `("upstream_error_event", true)`，而 `server_is_overloaded` 落 `default` 返回 `("event_error", false)`，比前者更不可恢复，与 HTTP 侧「把降载码改写成 server_error」的口径正好相反。

但该分类器同时被 `openai_ws_forwarder_support.go:140`（prewarm）与 `openai_ws_forwarder_v2.go:609` 使用，改它会一并改变三条路径的 failover 行为，需要独立评估。本 PR 只做 issue 里标为「至少」的那一半：让客户端不再因为一个瞬时容量事件就地终止会话。这一半独立成立，不依赖上述改造。
