### PR TITLE
fix(billing): 补上 glm-5.3 / glm-5.3-flash 兜底价，避免被 glm-5 子串匹配抢走

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -538,7 +538,20 @@ func (s *BillingService) initFallbackPricing() {
 	// Source: https://docs.z.ai/guides/overview/pricing (USD per 1M tokens)
 	// 注意：CacheReadPricePerToken 即"缓存命中"价格，CacheCreationPricePerToken 留空（智谱未公开写入价，按 0 处理）。
 	// GLM-4.6 与 GLM-4.5 在 z.ai 国际版上定价一致；GLM-4.5 国内按 ¥0.8/¥2，汇率换算后约 $0.112/$0.28，与国际版 $0.6/$2.2 不同，本分支采用国际版 USD 口径与现有 Claude/GPT 一致。
-	// GLM-5.2 与 GLM-5.1 在 z.ai 上同价。
+	// GLM-5.3 / GLM-5.2 与 GLM-5.1 在 z.ai 上同价。
+	// GLM-5.3-Flash 列表价 $0.15/$0.50（2026-09-09 前五折促销，此处按列表价，与其它模型口径一致）。
+	s.fallbackPrices["glm-5.3-flash"] = &ModelPricing{
+		InputPricePerToken:     0.15e-6, // $0.15 per MTok
+		OutputPricePerToken:    0.5e-6,  // $0.50 per MTok
+		CacheReadPricePerToken: 0.03e-6,
+		SupportsCacheBreakdown: false,
+	}
+	s.fallbackPrices["glm-5.3"] = &ModelPricing{
+		InputPricePerToken:     1.4e-6, // $1.40 per MTok
+		OutputPricePerToken:    4.4e-6, // $4.40 per MTok
+		CacheReadPricePerToken: 0.26e-6,
+		SupportsCacheBreakdown: false,
+	}
 	s.fallbackPrices["glm-5.2"] = &ModelPricing{
 		InputPricePerToken:     1.4e-6, // $1.40 per MTok
 		OutputPricePerToken:    4.4e-6, // $4.40 per MTok
@@ -870,9 +883,16 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	// 匹配策略：长 key 优先（具体模型 → 系列 / 厂商），未知型号不回退以避免误计价。
 	// 与 DeepSeek 一样采用"白名单"语义：未在本表命中的国产模型 alias 一律不返回兜底价。
 
-	// 智谱 GLM（z.ai 公开 SKU：glm-5.2 / glm-5.1 / glm-5 / glm-5-turbo / glm-4.7 / glm-4.6 / glm-4.5 等）
+	// 智谱 GLM（z.ai 公开 SKU：glm-5.3 / glm-5.3-flash / glm-5.2 / glm-5.1 / glm-5 / glm-5-turbo / glm-4.7 / glm-4.6 / glm-4.5 等）
 	// 匹配顺序：先判别最高 tier，再依次降级。
-	// 注意：带小数点的型号必须排在裸 "glm-5" 之前，否则会被 strings.Contains 抢走。
+	// 注意：带小数点的型号必须排在裸 "glm-5" 之前，否则会被 strings.Contains 抢走；
+	// glm-5.3-flash 必须排在 glm-5.3 之前（前者包含后者子串）。
+	if strings.Contains(modelLower, "glm-5.3-flash") || strings.Contains(modelLower, "glm-5.3flash") {
+		return s.fallbackPrices["glm-5.3-flash"]
+	}
+	if strings.Contains(modelLower, "glm-5.3") {
+		return s.fallbackPrices["glm-5.3"]
+	}
 	if strings.Contains(modelLower, "glm-5.2") {
 		return s.fallbackPrices["glm-5.2"]
 	}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -533,6 +533,20 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 
 		// ---- 智谱 GLM（z.ai USD 口径）----
 		{
+			name:              "glm 5.3 flagship",
+			model:             "glm-5.3",
+			expectedInput:     1.4e-6,
+			expectedOutput:    floatPtr(4.4e-6),
+			expectedCacheRead: floatPtr(0.26e-6),
+		},
+		{
+			name:              "glm 5.3 flash",
+			model:             "glm-5.3-flash",
+			expectedInput:     0.15e-6,
+			expectedOutput:    floatPtr(0.5e-6),
+			expectedCacheRead: floatPtr(0.03e-6),
+		},
+		{
 			name:              "glm 5.2 flagship",
 			model:             "glm-5.2",
 			expectedInput:     1.4e-6,
@@ -622,7 +636,21 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 			expectedInput:  0.1e-6,
 			expectedOutput: floatPtr(0.1e-6),
 		},
-		// 关键：5.1 / 5.2 必须先于 5 匹配（避免被 glm-5 抢走）
+		// 关键：5.1 / 5.2 / 5.3 必须先于 5 匹配（避免被 glm-5 抢走）
+		{
+			name:              "glm 5.3-flash vs glm 5.3 ordering (verbatim 5.3-flash)",
+			model:             "glm-5.3-flash",
+			expectedInput:     0.15e-6, // = glm-5.3-flash 价格（不是 glm-5.3 的 1.4e-6，更不是 glm-5 的 1e-6）
+			expectedOutput:    floatPtr(0.5e-6),
+			expectedCacheRead: floatPtr(0.03e-6),
+		},
+		{
+			name:              "glm 5.3 vs glm 5 ordering (verbatim 5.3)",
+			model:             "glm-5.3",
+			expectedInput:     1.4e-6, // = glm-5.3 价格（不是 glm-5 的 1e-6）
+			expectedOutput:    floatPtr(4.4e-6),
+			expectedCacheRead: floatPtr(0.26e-6),
+		},
 		{
 			name:              "glm 5.1 vs glm 5 ordering (verbatim 5.1)",
 			model:             "glm-5.1",

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -90,7 +90,10 @@ const antigravityModels = [
 const zhipuModels = [
   'glm-4', 'glm-4v', 'glm-4-plus', 'glm-4-0520',
   'glm-4-air', 'glm-4-airx', 'glm-4-long', 'glm-4-flash',
-  'glm-4v-plus', 'glm-4.5', 'glm-4.6',
+  'glm-4v-plus', 'glm-4.5', 'glm-4.5-x', 'glm-4.5-air', 'glm-4.5-flash',
+  'glm-4.6', 'glm-4.7', 'glm-4.7-flash', 'glm-4.7-flashx',
+  'glm-5', 'glm-5-turbo', 'glm-5.1', 'glm-5.2',
+  'glm-5.3', 'glm-5.3-flash',
   'glm-3-turbo', 'glm-4-alltools',
   'chatglm_turbo', 'chatglm_pro', 'chatglm_std', 'chatglm_lite',
   'cogview-3', 'cogvideo'


### PR DESCRIPTION
## 问题

智谱已于近日上线 `glm-5.3` 与 `glm-5.3-flash`（GLM Coding Plan 同步开放），但 `getFallbackPricing` 的 GLM 兜底价表没有这两个条目，匹配时会穿透到裸 `strings.Contains(modelLower, "glm-5")` 分支，按 **GLM-5 的价** 计费：

| | 实际计费（glm-5 价） | z.ai 官方 | 偏差 |
|---|---|---|---|
| glm-5.3-flash Input | $1.00 /MTok | **$0.15** | 多收 566% |
| glm-5.3-flash Output | $3.20 /MTok | **$0.50** | 多收 540% |
| glm-5.3 Input | $1.00 /MTok | **$1.40** | 少收 28.6% |
| glm-5.3 Output | $3.20 /MTok | **$4.40** | 少收 27.3% |

glm-5.3-flash 是官方主打的新普惠档（约为 GLM-5.3 十分之一价），落到 glm-5 价对使用统计的失真最明显。

LiteLLM 价格数据里也兜不住：目前没有 `glm-5.3` / `glm-5.3-flash` 条目，所以请求必然落到兜底路径。

## 改动

1. 兜底价表新增两条（与 #5018 补 glm-5.2 同一模式）：
   - `glm-5.3`：$1.40 in / $4.40 out / $0.26 cache read —— 与 GLM-5.2 / GLM-5.1 同价
   - `glm-5.3-flash`：$0.15 in / $0.50 out / $0.03 cache read —— 官方列表价（2026-09-09 前有五折促销，按列表价与现有各模型口径一致）
2. 匹配分支加在 `glm-5.2` 之前，并补注释：`glm-5.3-flash` 必须排在 `glm-5.3` 之前（前者包含后者子串），避免再踩同一类坑
3. 前端 `useModelWhitelist.ts` 的 zhipu 模型白名单同步补齐（原表停在 glm-4.6，补上 5 / 5-turbo / 5.1 / 5.2 / 5.3 / 5.3-flash 及 4.7 / 4.5 变体）

定价来源：https://docs.z.ai/guides/overview/pricing

## 测试

`TestGetFallbackPricing_FamilyMatching` 补四个 case：`glm 5.3 flagship`、`glm 5.3 flash`、`glm 5.3-flash vs glm 5.3 ordering`、`glm 5.3 vs glm 5 ordering`（守住 flash → 5.3 → 5.2 → 5 的匹配顺序）。

## 验证

均在本分支（基于当前 main）本地跑过：

- `go build ./...` ✅
- `go test -tags=unit ./...` ✅ 8526 passed（107 packages）
- `golangci-lint run --new-from-rev=main ./...` ✅ 0 issues
- 前端 `typecheck`（vue-tsc）✅、`eslint`（改动文件）✅、composables vitest（94 tests）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)