### PR TITLE
fix(scheduling): replace repeated window-cost scans with incremental state

### DIFF
--- a/backend/internal/repository/usage_log_repo_window_cost.go
+++ b/backend/internal/repository/usage_log_repo_window_cost.go
@@ -1,0 +1,205 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// GetAccountWindowCostsBatch returns the durable incremental scheduling cost for
+// accounts that share a window start. A state row is rebuilt from usage_logs only
+// on its first read or after the account window/source rows change.
+func (r *usageLogRepository) GetAccountWindowCostsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]float64, error) {
+	result := make(map[int64]float64)
+	ids := normalizePositiveInt64IDs(accountIDs)
+	if len(ids) == 0 {
+		return result, nil
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	rows, err := r.sql.QueryContext(ctx, `
+		SELECT account_id, standard_cost
+		FROM account_window_cost_state
+		WHERE account_id = ANY($1)
+			AND window_start = $2
+			AND initialized IS TRUE
+	`, pq.Array(ids), startTime)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var accountID int64
+		var cost float64
+		if err := rows.Scan(&accountID, &cost); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		result[accountID] = cost
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	missing := make([]int64, 0, len(ids)-len(result))
+	for _, accountID := range ids {
+		if _, ok := result[accountID]; ok {
+			continue
+		}
+		missing = append(missing, accountID)
+	}
+	if len(missing) == 0 {
+		return result, nil
+	}
+
+	initialized, err := r.initializeAccountWindowCosts(ctx, missing, startTime)
+	if err != nil {
+		return nil, err
+	}
+	for accountID, cost := range initialized {
+		result[accountID] = cost
+	}
+	return result, nil
+}
+
+func (r *usageLogRepository) initializeAccountWindowCosts(ctx context.Context, accountIDs []int64, startTime time.Time) (_ map[int64]float64, err error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("usage log repository db is nil")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO account_window_cost_state (
+			account_id, window_start, standard_cost, initialized, updated_at
+		)
+		SELECT input.account_id, $2, 0, FALSE, NOW()
+		FROM UNNEST($1::bigint[]) AS input(account_id)
+		ORDER BY input.account_id
+		ON CONFLICT (account_id) DO NOTHING
+	`, pq.Array(accountIDs), startTime); err != nil {
+		return nil, err
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT account_id, window_start, standard_cost, initialized
+		FROM account_window_cost_state
+		WHERE account_id = ANY($1)
+		ORDER BY account_id
+		FOR UPDATE
+	`, pq.Array(accountIDs))
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[int64]float64, len(accountIDs))
+	rebuildIDs := make([]int64, 0, len(accountIDs))
+	for rows.Next() {
+		var (
+			accountID   int64
+			storedStart time.Time
+			storedCost  float64
+			initialized bool
+		)
+		if err := rows.Scan(&accountID, &storedStart, &storedCost, &initialized); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if initialized && storedStart.Equal(startTime) {
+			result[accountID] = storedCost
+			continue
+		}
+		rebuildIDs = append(rebuildIDs, accountID)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if len(result)+len(rebuildIDs) != len(accountIDs) {
+		return nil, fmt.Errorf("account window cost state count mismatch: got=%d want=%d", len(result)+len(rebuildIDs), len(accountIDs))
+	}
+
+	if len(rebuildIDs) > 0 {
+		// Reset provisional trigger totals before scanning. The ordered row locks
+		// serialize concurrent INSERT triggers: committed rows are included by this
+		// scan, while in-flight rows wait and increment state after commit.
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE account_window_cost_state
+			SET window_start = $2,
+				standard_cost = 0,
+				initialized = FALSE,
+				updated_at = NOW()
+			WHERE account_id = ANY($1)
+		`, pq.Array(rebuildIDs), startTime); err != nil {
+			return nil, err
+		}
+
+		rows, err = tx.QueryContext(ctx, `
+			WITH targets AS (
+				SELECT UNNEST($1::bigint[]) AS account_id
+			), totals AS (
+				SELECT usage_logs.account_id, SUM(usage_logs.total_cost) AS standard_cost
+				FROM usage_logs
+				JOIN targets USING (account_id)
+				WHERE usage_logs.created_at >= $2
+				GROUP BY usage_logs.account_id
+			)
+			UPDATE account_window_cost_state AS state
+			SET standard_cost = COALESCE(totals.standard_cost, 0),
+				initialized = TRUE,
+				updated_at = NOW()
+			FROM targets
+			LEFT JOIN totals USING (account_id)
+			WHERE state.account_id = targets.account_id
+			RETURNING state.account_id, state.standard_cost
+		`, pq.Array(rebuildIDs), startTime)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var accountID int64
+			var cost float64
+			if err := rows.Scan(&accountID, &cost); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			result[accountID] = cost
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+	}
+	if len(result) != len(accountIDs) {
+		return nil, fmt.Errorf("initialized account window cost count mismatch: got=%d want=%d", len(result), len(accountIDs))
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	tx = nil
+	return result, nil
+}
+
+var _ interface {
+	GetAccountWindowCostsBatch(context.Context, []int64, time.Time) (map[int64]float64, error)
+} = (*usageLogRepository)(nil)

--- a/backend/internal/repository/usage_log_repo_window_cost_test.go
+++ b/backend/internal/repository/usage_log_repo_window_cost_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAccountWindowCostsBatchReadsInitializedState(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newUsageLogRepositoryWithSQL(nil, db)
+	start := time.Date(2026, 8, 31, 8, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`(?s)SELECT account_id, standard_cost.*FROM account_window_cost_state`).
+		WithArgs("{3,9}", start).
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "standard_cost"}).
+			AddRow(int64(3), 1.25).
+			AddRow(int64(9), 8.75))
+
+	costs, err := repo.GetAccountWindowCostsBatch(context.Background(), []int64{9, 3, 9, 0}, start)
+	require.NoError(t, err)
+	require.Equal(t, map[int64]float64{3: 1.25, 9: 8.75}, costs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetAccountWindowCostsBatchInitializesMissingWindowOnce(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newUsageLogRepositoryWithSQL(nil, db)
+	start := time.Date(2026, 8, 31, 8, 0, 0, 0, time.UTC)
+	oldStart := start.Add(-5 * time.Hour)
+
+	mock.ExpectQuery(`(?s)SELECT account_id, standard_cost.*FROM account_window_cost_state`).
+		WithArgs("{7}", start).
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "standard_cost"}))
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)INSERT INTO account_window_cost_state`).
+		WithArgs("{7}", start).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(`(?s)SELECT account_id, window_start, standard_cost, initialized.*FOR UPDATE`).
+		WithArgs("{7}").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "window_start", "standard_cost", "initialized"}).
+			AddRow(int64(7), oldStart, 99.0, false))
+	mock.ExpectExec(`(?s)UPDATE account_window_cost_state.*standard_cost = 0`).
+		WithArgs("{7}", start).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)WITH targets AS.*SUM\(usage_logs.total_cost\).*UPDATE account_window_cost_state`).
+		WithArgs("{7}", start).
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "standard_cost"}).AddRow(int64(7), 12.5))
+	mock.ExpectCommit()
+
+	costs, err := repo.GetAccountWindowCostsBatch(context.Background(), []int64{7}, start)
+	require.NoError(t, err)
+	require.Equal(t, map[int64]float64{7: 12.5}, costs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInitializeAccountWindowCostReusesConcurrentInitializerResult(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newUsageLogRepositoryWithSQL(nil, db)
+	start := time.Date(2026, 8, 31, 8, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)INSERT INTO account_window_cost_state`).
+		WithArgs("{11}", start).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(`(?s)SELECT account_id, window_start, standard_cost, initialized.*FOR UPDATE`).
+		WithArgs("{11}").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "window_start", "standard_cost", "initialized"}).
+			AddRow(int64(11), start, 4.75, true))
+	mock.ExpectCommit()
+
+	costs, err := repo.initializeAccountWindowCosts(context.Background(), []int64{11}, start)
+	require.NoError(t, err)
+	require.Equal(t, map[int64]float64{11: 4.75}, costs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/repository/usage_log_window_cost_integration_test.go
+++ b/backend/internal/repository/usage_log_window_cost_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func TestAccountWindowCostStateBackfillsThenTracksIncrementally(t *testing.T) {
+	ctx := context.Background()
+	client := testEntClient(t)
+	repo := NewUsageLogRepository(client, integrationDB).(*usageLogRepository)
+
+	user := mustCreateUser(t, client, &service.User{
+		Email:        fmt.Sprintf("window-cost-%s@example.com", uuid.NewString()),
+		PasswordHash: "hash",
+	})
+	apiKey := mustCreateApiKey(t, client, &service.APIKey{
+		UserID: user.ID,
+		Key:    "sk-window-cost-" + uuid.NewString(),
+		Name:   "window-cost",
+	})
+	windowStart := time.Now().UTC().Add(-time.Hour).Truncate(time.Minute)
+	windowEnd := windowStart.Add(5 * time.Hour)
+	account := mustCreateAccount(t, client, &service.Account{
+		Name:               "window-cost-" + uuid.NewString(),
+		Platform:           service.PlatformAnthropic,
+		Type:               service.AccountTypeOAuth,
+		Extra:              map[string]any{"window_cost_limit": 100.0},
+		SessionWindowStart: &windowStart,
+		SessionWindowEnd:   &windowEnd,
+	})
+
+	insert := func(requestID string, createdAt time.Time, cost float64) int64 {
+		t.Helper()
+		log := &service.UsageLog{
+			UserID:     user.ID,
+			APIKeyID:   apiKey.ID,
+			AccountID:  account.ID,
+			RequestID:  requestID,
+			Model:      "claude-test",
+			TotalCost:  cost,
+			ActualCost: cost,
+			CreatedAt:  createdAt,
+		}
+		inserted, err := repo.Create(ctx, log)
+		require.NoError(t, err)
+		require.True(t, inserted)
+		return log.ID
+	}
+
+	firstID := insert(uuid.NewString(), windowStart.Add(10*time.Minute), 1.25)
+	_, err := integrationDB.ExecContext(ctx, "DELETE FROM account_window_cost_state WHERE account_id = $1", account.ID)
+	require.NoError(t, err)
+
+	costs, err := repo.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, windowStart)
+	require.NoError(t, err)
+	require.InDelta(t, 1.25, costs[account.ID], 0.0000001)
+
+	secondCreatedAt := windowStart.Add(40 * time.Minute)
+	secondID := insert(uuid.NewString(), secondCreatedAt, 2.5)
+	costs, err = repo.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, windowStart)
+	require.NoError(t, err)
+	require.InDelta(t, 3.75, costs[account.ID], 0.0000001)
+
+	_, err = integrationDB.ExecContext(ctx, `
+		UPDATE accounts
+		SET extra = jsonb_set(extra, '{window_cost_limit}', '200'::jsonb)
+		WHERE id = $1
+	`, account.ID)
+	require.NoError(t, err)
+	var initialized bool
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT initialized
+		FROM account_window_cost_state
+		WHERE account_id = $1
+	`, account.ID).Scan(&initialized))
+	require.False(t, initialized)
+	costs, err = repo.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, windowStart)
+	require.NoError(t, err)
+	require.InDelta(t, 3.75, costs[account.ID], 0.0000001)
+
+	correctedStart := windowStart.Add(30 * time.Minute)
+	costs, err = repo.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, correctedStart)
+	require.NoError(t, err)
+	require.InDelta(t, 2.5, costs[account.ID], 0.0000001)
+
+	require.NoError(t, repo.Delete(ctx, secondID))
+	costs, err = repo.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, correctedStart)
+	require.NoError(t, err)
+	require.Zero(t, costs[account.ID])
+
+	require.NoError(t, repo.Delete(ctx, firstID))
+}

--- a/backend/internal/service/gateway_hotpath_optimization_test.go
+++ b/backend/internal/service/gateway_hotpath_optimization_test.go
@@ -41,10 +41,25 @@ type usageLogWindowBatchRepoStub struct {
 	batchResult map[int64]*usagestats.AccountStats
 	batchErr    error
 	batchCalls  atomic.Int64
+	stateCalls  atomic.Int64
 
 	singleResult map[int64]*usagestats.AccountStats
 	singleErr    error
 	singleCalls  atomic.Int64
+}
+
+func (s *usageLogWindowBatchRepoStub) GetAccountWindowCostsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]float64, error) {
+	s.stateCalls.Add(1)
+	if s.batchErr != nil {
+		return nil, s.batchErr
+	}
+	out := make(map[int64]float64, len(accountIDs))
+	for _, id := range accountIDs {
+		if stats, ok := s.batchResult[id]; ok && stats != nil {
+			out[id] = stats.StandardCost
+		}
+	}
+	return out, nil
 }
 
 func (s *usageLogWindowBatchRepoStub) GetAccountWindowStatsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error) {
@@ -193,7 +208,6 @@ func resetGatewayHotpathStatsForTest() {
 	windowCostPrefetchCacheHitTotal.Store(0)
 	windowCostPrefetchCacheMissTotal.Store(0)
 	windowCostPrefetchBatchSQLTotal.Store(0)
-	windowCostPrefetchFallbackTotal.Store(0)
 	windowCostPrefetchErrorTotal.Store(0)
 
 	userGroupRateCacheHitTotal.Store(0)
@@ -387,14 +401,14 @@ func TestWithWindowCostPrefetch_BatchReadAndContextReuse(t *testing.T) {
 	_, ok3 := windowCostFromPrefetchContext(outCtx, 3)
 	require.False(t, ok3)
 
-	require.Equal(t, int64(1), repo.batchCalls.Load())
+	require.Equal(t, int64(1), repo.stateCalls.Load())
+	require.Equal(t, int64(0), repo.batchCalls.Load())
 	require.Equal(t, 22.0, cache.setData[2])
 
-	hit, miss, batchSQL, fallback, errCount := GatewayWindowCostPrefetchStats()
+	hit, miss, batchSQL, errCount := GatewayWindowCostPrefetchStats()
 	require.Equal(t, int64(1), hit)
 	require.Equal(t, int64(1), miss)
 	require.Equal(t, int64(1), batchSQL)
-	require.Equal(t, int64(0), fallback)
 	require.Equal(t, int64(0), errCount)
 }
 
@@ -442,17 +456,17 @@ func TestWithWindowCostPrefetch_AllHitNoSQL(t *testing.T) {
 	require.Equal(t, 11.0, cost1)
 	require.Equal(t, 22.0, cost2)
 	require.Equal(t, int64(0), repo.batchCalls.Load())
+	require.Equal(t, int64(0), repo.stateCalls.Load())
 	require.Equal(t, int64(0), repo.singleCalls.Load())
 
-	hit, miss, batchSQL, fallback, errCount := GatewayWindowCostPrefetchStats()
+	hit, miss, batchSQL, errCount := GatewayWindowCostPrefetchStats()
 	require.Equal(t, int64(2), hit)
 	require.Equal(t, int64(0), miss)
 	require.Equal(t, int64(0), batchSQL)
-	require.Equal(t, int64(0), fallback)
 	require.Equal(t, int64(0), errCount)
 }
 
-func TestWithWindowCostPrefetch_BatchErrorFallbackSingleQuery(t *testing.T) {
+func TestWithWindowCostPrefetch_StateErrorFailsOpenWithoutSingleQuery(t *testing.T) {
 	resetGatewayHotpathStatsForTest()
 
 	windowStart := time.Now().Add(-30 * time.Minute).Truncate(time.Hour)
@@ -483,13 +497,35 @@ func TestWithWindowCostPrefetch_BatchErrorFallbackSingleQuery(t *testing.T) {
 	outCtx := svc.withWindowCostPrefetch(context.Background(), accounts)
 	cost, ok := windowCostFromPrefetchContext(outCtx, 2)
 	require.True(t, ok)
-	require.Equal(t, 33.0, cost)
-	require.Equal(t, int64(1), repo.batchCalls.Load())
-	require.Equal(t, int64(1), repo.singleCalls.Load())
+	require.Zero(t, cost)
+	require.Equal(t, int64(1), repo.stateCalls.Load())
+	require.Equal(t, int64(0), repo.batchCalls.Load())
+	require.Equal(t, int64(0), repo.singleCalls.Load())
 
-	_, _, _, fallback, errCount := GatewayWindowCostPrefetchStats()
-	require.Equal(t, int64(1), fallback)
+	_, _, _, errCount := GatewayWindowCostPrefetchStats()
 	require.Equal(t, int64(1), errCount)
+}
+
+func TestIsAccountSchedulableForWindowCost_StateErrorDoesNotScanUsageLogs(t *testing.T) {
+	windowStart := time.Now().Add(-30 * time.Minute).Truncate(time.Hour)
+	windowEnd := windowStart.Add(5 * time.Hour)
+	account := &Account{
+		ID:                 2,
+		Platform:           PlatformAnthropic,
+		Type:               AccountTypeSetupToken,
+		Extra:              map[string]any{"window_cost_limit": 10.0},
+		SessionWindowStart: &windowStart,
+		SessionWindowEnd:   &windowEnd,
+	}
+	repo := &usageLogWindowBatchRepoStub{
+		batchErr:     errors.New("state unavailable"),
+		singleResult: map[int64]*usagestats.AccountStats{2: {StandardCost: 999}},
+	}
+	svc := &GatewayService{usageLogRepo: repo}
+
+	require.True(t, svc.isAccountSchedulableForWindowCost(context.Background(), account, false))
+	require.Equal(t, int64(1), repo.stateCalls.Load())
+	require.Equal(t, int64(0), repo.singleCalls.Load())
 }
 
 func TestGetAvailableModels_UsesShortCacheAndSupportsInvalidation(t *testing.T) {

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 )
 
 // SelectAccount 选择账号（粘性会话+优先级）
@@ -1131,8 +1130,8 @@ func (s *GatewayService) tryAcquireAccountSlot(ctx context.Context, accountID in
 	return s.concurrencyService.AcquireAccountSlot(ctx, accountID, maxConcurrency)
 }
 
-type usageLogWindowStatsBatchProvider interface {
-	GetAccountWindowStatsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error)
+type accountWindowCostBatchProvider interface {
+	GetAccountWindowCostsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]float64, error)
 }
 
 type windowCostPrefetchContextKeyType struct{}
@@ -1209,43 +1208,37 @@ func (s *GatewayService) withWindowCostPrefetch(ctx context.Context, accounts []
 		return context.WithValue(ctx, windowCostPrefetchContextKey, costs)
 	}
 
-	batchReader, hasBatch := s.usageLogRepo.(usageLogWindowStatsBatchProvider)
+	windowCostReader, hasWindowCostState := s.usageLogRepo.(accountWindowCostBatchProvider)
 	for startKey, ids := range missingByStart {
 		startTime := startTimes[startKey]
-
-		if hasBatch {
-			windowCostPrefetchBatchSQLTotal.Add(1)
-			queryStart := time.Now()
-			statsByAccount, err := batchReader.GetAccountWindowStatsBatch(ctx, ids, startTime)
-			if err == nil {
-				slog.Debug("window_cost_batch_query_ok",
-					"accounts", len(ids),
-					"window_start", startTime.Format(time.RFC3339),
-					"duration_ms", time.Since(queryStart).Milliseconds())
-				for _, accountID := range ids {
-					stats := statsByAccount[accountID]
-					cost := 0.0
-					if stats != nil {
-						cost = stats.StandardCost
-					}
-					costs[accountID] = cost
-					_ = s.sessionLimitCache.SetWindowCost(ctx, accountID, cost)
-				}
-				continue
-			}
+		if !hasWindowCostState {
 			windowCostPrefetchErrorTotal.Add(1)
-			logger.LegacyPrintf("service.gateway", "window_cost batch db query failed: start=%s err=%v", startTime.Format(time.RFC3339), err)
+			logger.LegacyPrintf("service.gateway", "window_cost state reader unavailable")
+			for _, accountID := range ids {
+				costs[accountID] = 0
+			}
+			continue
 		}
 
-		// 回退路径：缺少批量仓储能力或批量查询失败时，按账号单查（失败开放）。
-		windowCostPrefetchFallbackTotal.Add(int64(len(ids)))
-		for _, accountID := range ids {
-			stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, accountID, startTime)
-			if err != nil {
-				windowCostPrefetchErrorTotal.Add(1)
-				continue
+		windowCostPrefetchBatchSQLTotal.Add(1)
+		queryStart := time.Now()
+		costsByAccount, err := windowCostReader.GetAccountWindowCostsBatch(ctx, ids, startTime)
+		if err != nil {
+			// Do not resurrect the expensive usage_logs scan when incremental state
+			// is unavailable. Window-cost enforcement is explicitly fail-open.
+			windowCostPrefetchErrorTotal.Add(1)
+			logger.LegacyPrintf("service.gateway", "window_cost state query failed: start=%s err=%v", startTime.Format(time.RFC3339), err)
+			for _, accountID := range ids {
+				costs[accountID] = 0
 			}
-			cost := stats.StandardCost
+			continue
+		}
+		slog.Debug("window_cost_state_query_ok",
+			"accounts", len(ids),
+			"window_start", startTime.Format(time.RFC3339),
+			"duration_ms", time.Since(queryStart).Milliseconds())
+		for _, accountID := range ids {
+			cost := costsByAccount[accountID]
 			costs[accountID] = cost
 			_ = s.sessionLimitCache.SetWindowCost(ctx, accountID, cost)
 		}
@@ -1294,17 +1287,16 @@ func (s *GatewayService) isAccountSchedulableForWindowCost(ctx context.Context, 
 	{
 		// 使用统一的窗口开始时间计算逻辑（考虑窗口过期情况）
 		startTime := account.GetCurrentWindowStartTime()
-
-		stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, startTime)
-		if err != nil {
-			// 失败开放：查询失败时允许调度
+		reader, ok := s.usageLogRepo.(accountWindowCostBatchProvider)
+		if !ok {
 			return true
 		}
-
-		// 使用标准费用（不含账号倍率）
-		currentCost = stats.StandardCost
-
-		// 设置缓存（忽略错误）
+		costs, err := reader.GetAccountWindowCostsBatch(ctx, []int64{account.ID}, startTime)
+		if err != nil {
+			// 增量状态不可用时失败开放，不回退扫描 usage_logs。
+			return true
+		}
+		currentCost = costs[account.ID]
 		if s.sessionLimitCache != nil {
 			_ = s.sessionLimitCache.SetWindowCost(ctx, account.ID, currentCost)
 		}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -92,7 +92,6 @@ var (
 	windowCostPrefetchCacheHitTotal  atomic.Int64
 	windowCostPrefetchCacheMissTotal atomic.Int64
 	windowCostPrefetchBatchSQLTotal  atomic.Int64
-	windowCostPrefetchFallbackTotal  atomic.Int64
 	windowCostPrefetchErrorTotal     atomic.Int64
 
 	userGroupRateCacheHitTotal      atomic.Int64
@@ -121,11 +120,10 @@ var (
 	userPlatformQuotaSentinelSetCacheErrorTotal atomic.Int64
 )
 
-func GatewayWindowCostPrefetchStats() (cacheHit, cacheMiss, batchSQL, fallback, errCount int64) {
+func GatewayWindowCostPrefetchStats() (cacheHit, cacheMiss, batchSQL, errCount int64) {
 	return windowCostPrefetchCacheHitTotal.Load(),
 		windowCostPrefetchCacheMissTotal.Load(),
 		windowCostPrefetchBatchSQLTotal.Load(),
-		windowCostPrefetchFallbackTotal.Load(),
 		windowCostPrefetchErrorTotal.Load()
 }
 

--- a/backend/migrations/232_account_window_cost_state.sql
+++ b/backend/migrations/232_account_window_cost_state.sql
@@ -1,0 +1,193 @@
+-- Maintain the Anthropic scheduling window cost as bounded incremental state.
+--
+-- Existing rows are intentionally not backfilled during startup. The first read for
+-- an account/window rebuilds that single state row from usage_logs while holding the
+-- row lock; later inserts update it incrementally. This keeps deployment migrations
+-- independent of usage_logs volume and turns cache misses into point reads.
+
+CREATE TABLE IF NOT EXISTS account_window_cost_state (
+    account_id BIGINT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+    window_start TIMESTAMPTZ NOT NULL,
+    standard_cost DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    initialized BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE account_window_cost_state IS
+    'Incremental standard-cost total for each account current scheduling window.';
+COMMENT ON COLUMN account_window_cost_state.initialized IS
+    'False means the row must be rebuilt once from usage_logs before it is authoritative.';
+
+-- INSERT is the gateway hot path. A transition table folds every batch into at most
+-- one upsert per account instead of running a row-level trigger for every usage log.
+CREATE OR REPLACE FUNCTION accumulate_account_window_cost_after_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO account_window_cost_state (
+        account_id,
+        window_start,
+        standard_cost,
+        initialized,
+        updated_at
+    )
+    WITH candidates AS (
+        SELECT
+            inserted.account_id,
+            inserted.created_at,
+            inserted.total_cost,
+            CASE
+                WHEN accounts.session_window_start IS NOT NULL
+                    AND accounts.session_window_end IS NOT NULL
+                    AND statement_timestamp() < accounts.session_window_end
+                THEN accounts.session_window_start
+                ELSE date_trunc('hour', statement_timestamp())
+            END AS window_start
+        FROM inserted_usage_logs AS inserted
+        JOIN accounts ON accounts.id = inserted.account_id
+        WHERE accounts.deleted_at IS NULL
+            AND accounts.platform = 'anthropic'
+            AND accounts.type IN ('oauth', 'setup-token')
+            AND accounts.extra ? 'window_cost_limit'
+    ), aggregated AS (
+        SELECT
+            account_id,
+            window_start,
+            SUM(total_cost) AS standard_cost
+        FROM candidates
+        WHERE created_at >= window_start
+        GROUP BY account_id, window_start
+    )
+    SELECT
+        account_id,
+        window_start,
+        standard_cost,
+        FALSE,
+        NOW()
+    FROM aggregated
+    ORDER BY account_id
+    ON CONFLICT (account_id) DO UPDATE
+    SET
+        window_start = EXCLUDED.window_start,
+        standard_cost = CASE
+            WHEN account_window_cost_state.window_start = EXCLUDED.window_start
+            THEN account_window_cost_state.standard_cost + EXCLUDED.standard_cost
+            ELSE EXCLUDED.standard_cost
+        END,
+        initialized = CASE
+            WHEN account_window_cost_state.window_start = EXCLUDED.window_start
+            THEN account_window_cost_state.initialized
+            ELSE FALSE
+        END,
+        updated_at = NOW();
+
+    RETURN NULL;
+END;
+$$;
+
+-- Enabling/disabling the limit or correcting a response-derived window changes
+-- which source rows belong to the state. Invalidate once and let the reader rebuild
+-- under lock instead of trying to migrate a possibly partial provisional total.
+CREATE OR REPLACE FUNCTION invalidate_account_window_cost_on_account_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.session_window_start IS DISTINCT FROM NEW.session_window_start
+        OR OLD.session_window_end IS DISTINCT FROM NEW.session_window_end
+        OR OLD.platform IS DISTINCT FROM NEW.platform
+        OR OLD.type IS DISTINCT FROM NEW.type
+        OR (OLD.extra -> 'window_cost_limit') IS DISTINCT FROM (NEW.extra -> 'window_cost_limit')
+    THEN
+        UPDATE account_window_cost_state
+        SET initialized = FALSE,
+            updated_at = NOW()
+        WHERE account_id = NEW.id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Deletes and updates are uncommon. Marking the affected current state stale is
+-- simpler and safer than trying to reverse an amount that may predate activation;
+-- the next read rebuilds it once under the same row lock used by first-time reads.
+CREATE OR REPLACE FUNCTION invalidate_account_window_cost_state()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE account_window_cost_state
+        SET initialized = FALSE,
+            updated_at = NOW()
+        WHERE account_id = OLD.account_id
+            AND OLD.created_at >= window_start;
+        RETURN OLD;
+    END IF;
+
+    UPDATE account_window_cost_state
+    SET initialized = FALSE,
+        updated_at = NOW()
+    WHERE account_id = OLD.account_id
+        AND OLD.created_at >= window_start;
+
+    IF NEW.account_id IS DISTINCT FROM OLD.account_id
+        OR NEW.created_at IS DISTINCT FROM OLD.created_at
+        OR NEW.total_cost IS DISTINCT FROM OLD.total_cost
+    THEN
+        UPDATE account_window_cost_state
+        SET initialized = FALSE,
+            updated_at = NOW()
+        WHERE account_id = NEW.account_id
+            AND NEW.created_at >= window_start;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS usage_logs_account_window_cost_insert ON usage_logs;
+CREATE TRIGGER usage_logs_account_window_cost_insert
+AFTER INSERT ON usage_logs
+REFERENCING NEW TABLE AS inserted_usage_logs
+FOR EACH STATEMENT
+EXECUTE FUNCTION accumulate_account_window_cost_after_insert();
+
+DROP TRIGGER IF EXISTS usage_logs_account_window_cost_delete ON usage_logs;
+CREATE TRIGGER usage_logs_account_window_cost_delete
+AFTER DELETE ON usage_logs
+FOR EACH ROW
+WHEN (OLD.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 hours')
+EXECUTE FUNCTION invalidate_account_window_cost_state();
+
+DROP TRIGGER IF EXISTS accounts_window_cost_state_invalidate ON accounts;
+CREATE TRIGGER accounts_window_cost_state_invalidate
+AFTER UPDATE OF platform, type, session_window_start, session_window_end, extra ON accounts
+FOR EACH ROW
+WHEN (
+    OLD.session_window_start IS DISTINCT FROM NEW.session_window_start
+    OR OLD.session_window_end IS DISTINCT FROM NEW.session_window_end
+    OR OLD.platform IS DISTINCT FROM NEW.platform
+    OR OLD.type IS DISTINCT FROM NEW.type
+    OR (OLD.extra -> 'window_cost_limit') IS DISTINCT FROM (NEW.extra -> 'window_cost_limit')
+)
+EXECUTE FUNCTION invalidate_account_window_cost_on_account_update();
+
+DROP TRIGGER IF EXISTS usage_logs_account_window_cost_update ON usage_logs;
+CREATE TRIGGER usage_logs_account_window_cost_update
+AFTER UPDATE OF account_id, created_at, total_cost ON usage_logs
+FOR EACH ROW
+WHEN (
+    (
+        OLD.account_id IS DISTINCT FROM NEW.account_id
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at
+        OR OLD.total_cost IS DISTINCT FROM NEW.total_cost
+    )
+    AND (
+        OLD.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 hours'
+        OR NEW.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 hours'
+    )
+)
+EXECUTE FUNCTION invalidate_account_window_cost_state();

--- a/backend/migrations/account_window_cost_state_migration_test.go
+++ b/backend/migrations/account_window_cost_state_migration_test.go
@@ -1,0 +1,43 @@
+//go:build unit
+
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigration232CreatesBoundedWindowCostState(t *testing.T) {
+	content, err := FS.ReadFile("232_account_window_cost_state.sql")
+	require.NoError(t, err)
+
+	sql := strings.Join(strings.Fields(string(content)), " ")
+	require.Contains(t, sql, "CREATE TABLE IF NOT EXISTS account_window_cost_state")
+	require.Contains(t, sql, "account_id BIGINT PRIMARY KEY")
+	require.Contains(t, sql, "standard_cost DECIMAL(20, 10)")
+	require.Contains(t, sql, "initialized BOOLEAN NOT NULL DEFAULT FALSE")
+	require.NotContains(t, sql, "INSERT INTO account_window_cost_state SELECT")
+}
+
+func TestMigration232AggregatesInsertsAndInvalidatesMutations(t *testing.T) {
+	content, err := FS.ReadFile("232_account_window_cost_state.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "REFERENCING NEW TABLE AS inserted_usage_logs")
+	require.Contains(t, sql, "FOR EACH STATEMENT")
+	require.Contains(t, sql, "SUM(total_cost) AS standard_cost")
+	require.Contains(t, sql, "ORDER BY account_id")
+	require.Contains(t, sql, "accounts.platform = 'anthropic'")
+	require.Contains(t, sql, "accounts.type IN ('oauth', 'setup-token')")
+	require.Contains(t, sql, "accounts.extra ? 'window_cost_limit'")
+	require.Contains(t, sql, "ON CONFLICT (account_id) DO UPDATE")
+	require.Contains(t, sql, "CREATE TRIGGER usage_logs_account_window_cost_delete")
+	require.Contains(t, sql, "CREATE TRIGGER usage_logs_account_window_cost_update")
+	require.Contains(t, sql, "CURRENT_TIMESTAMP - INTERVAL '6 hours'")
+	require.Contains(t, sql, "CREATE TRIGGER accounts_window_cost_state_invalidate")
+	require.Contains(t, sql, "AFTER UPDATE OF platform, type, session_window_start, session_window_end, extra ON accounts")
+	require.Contains(t, sql, "SET initialized = FALSE")
+}


### PR DESCRIPTION
## Summary

- replace repeated scheduling-time aggregation over `usage_logs` with a bounded, durable per-account window-cost state row
- maintain the state from successful `usage_logs` inserts with one statement-level upsert per account in each insert batch
- lazily rebuild missing or invalidated state once per account/window instead of backfilling the full history during deployment
- fail open without falling back to the expensive detail-table scan when the incremental state path is unavailable

## Root cause

Window-cost scheduling currently caches each account total for 30 seconds. Every cache miss executes `COUNT`/`SUM` aggregation against all matching `usage_logs` rows since the current window start. The query is correct, but its work scales with retained detail rows and is repeated indefinitely, so a normal scheduling safeguard becomes sustained database read amplification.

## Design

The migration adds `account_window_cost_state`, which is bounded to one row per account. It deliberately performs no startup backfill.

An `AFTER INSERT` transition-table trigger aggregates each usage-log batch before updating state, so the hot write path performs at most one narrow upsert per eligible Anthropic OAuth/setup-token account. Duplicate usage-log inserts remain excluded because the trigger sees only rows actually inserted by PostgreSQL.

The first read for a missing window acquires state rows in account-ID order, resets provisional totals, and rebuilds all missing accounts in one grouped query. The row locks provide the handoff with concurrent inserts: committed rows are included in the rebuild, while in-flight insert triggers wait and increment the initialized state after commit. Window/config changes and recent source updates or deletes invalidate the row and use the same rebuild path.

Steady-state cache misses are point reads from the state table. Keeping the existing Redis cache preserves current request-path behavior while removing the historical scan from production scheduling. State failures remain fail-open, but no longer reactivate the query that caused the load amplification.

## Validation

- `go test -tags unit ./internal/repository ./internal/service ./migrations`
- `go test -tags integration ./internal/repository -run '^TestAccountWindowCostStateBackfillsThenTracksIncrementally$' -count=1`
- `go vet ./internal/repository ./internal/service ./migrations`

The PostgreSQL integration test covers lazy backfill, incremental inserts, account-setting invalidation, corrected window starts, and source-row deletion.
