### PR TITLE
fix(openai-ws): recycle stale idle pool connections without reader liveness

### DIFF
--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -18,8 +18,11 @@ import (
 )
 
 const (
-	openAIWSConnMaxAge             = 60 * time.Minute
-	openAIWSConnHealthCheckIdle    = 90 * time.Second
+	openAIWSConnMaxAge          = 60 * time.Minute
+	openAIWSConnHealthCheckIdle = 90 * time.Second
+	// coder/websocket cannot consume pong frames without a reader. Recycle
+	// unsupported idle sockets before the upstream keepalive window expires.
+	openAIWSConnIdleRecycleAfter   = 90 * time.Second
 	openAIWSConnHealthCheckTO      = 2 * time.Second
 	openAIWSConnPrewarmExtraDelay  = 2 * time.Second
 	openAIWSAcquireCleanupInterval = 3 * time.Second
@@ -1351,6 +1354,17 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 		default:
 		}
 		if p.isConnPinnedLocked(ap, id) {
+			continue
+		}
+		if !conn.isLeased() && conn.waiters.Load() == 0 &&
+			!conn.supportsIdlePingWithoutReader() &&
+			conn.idleDuration(now) >= openAIWSConnIdleRecycleAfter {
+			delete(ap.conns, id)
+			if len(ap.pinnedConns) > 0 {
+				delete(ap.pinnedConns, id)
+			}
+			evicted = append(evicted, conn)
+			p.metrics.scaleDownTotal.Add(1)
 			continue
 		}
 		if maxAge > 0 && !conn.isLeased() && conn.age(now) > maxAge {

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -1307,6 +1307,32 @@ func TestOpenAIWSConnPool_BackgroundCleanupSweep_WithoutAcquire(t *testing.T) {
 	require.False(t, exists, "后台清理应在无新 acquire 时也回收过期连接")
 }
 
+func TestOpenAIWSConnPool_RecyclesUnsupportedIdlePingConnection(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+	pool := &openAIWSConnPool{cfg: cfg}
+
+	accountID := int64(303)
+	ap := &openAIWSAccountPool{conns: make(map[string]*openAIWSConn)}
+	conn := newOpenAIWSConn("stale_unsupported_idle_ping", accountID, &openAIWSIdlePingUnsupportedConn{}, nil)
+	conn.lastUsedNano.Store(time.Now().Add(-openAIWSConnIdleRecycleAfter - time.Second).UnixNano())
+	ap.conns[conn.id] = conn
+	pool.accounts.Store(accountID, ap)
+
+	pool.runBackgroundCleanupSweep(time.Now())
+
+	ap.mu.Lock()
+	_, exists := ap.conns[conn.id]
+	ap.mu.Unlock()
+	require.False(t, exists, "不支持无 reader idle ping 的陈旧连接应被主动回收")
+	select {
+	case <-conn.closedCh:
+	default:
+		t.Fatal("被回收的陈旧连接应已关闭")
+	}
+}
+
 func TestOpenAIWSConnPool_BackgroundWorkerGuardBranches(t *testing.T) {
 	var nilPool *openAIWSConnPool
 	require.NotPanics(t, func() {


### PR DESCRIPTION
## Summary

- recycle idle OpenAI Responses WebSocket pool connections that cannot perform a reliable Ping/Pong health check without a reader
- remove stale, unleased, waiter-free connections before they are selected for a new turn
- preserve existing behavior for leased connections, queued connections, and transports that support idle Ping/Pong
- add a focused background-cleanup regression test

## Problem

The pool already skips idle Ping health checks for WebSocket implementations that require a reader to consume Pong frames. Those connections can remain in the reusable idle pool after the upstream has closed them because of its keepalive timeout. A later request may acquire the stale connection and only discover the failure during its first business read/write, causing avoidable reconnects and user-visible stream failures.

This is the failure mode reported in #5900: the pool has no reliable liveness signal for an idle connection without an active reader, so stale connections need an explicit bounded idle lifetime.

## Behavior

- apply the recycle check during the existing account cleanup sweep
- only recycle connections that are not leased, have no waiters, do not support reader-independent idle Ping/Pong, and have been idle for at least 90 seconds
- remove the connection from the account pool before closing it, and increment the existing scale-down metric
- leave pinned connections, active leases, queued connections, and reader-independent Ping-capable connections unchanged

The 90-second threshold is intentionally below the upstream keepalive failure window and is not a new deployment-specific setting.

## Compatibility

- no API, database migration, or wire-protocol change
- no change to connection selection or queue semantics for healthy connections
- existing idle Ping/Pong handling remains authoritative where supported

## Validation

- `go test ./internal/service -run TestOpenAIWSConnPool_RecyclesUnsupportedIdlePingConnection -count=1`
- `go test ./internal/service -run TestOpenAIWSConnPool_ -count=1`
- `git diff --check origin/main...HEAD`

Related: #5900