### PR TITLE
fix: keep release version metadata consistent across build paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,8 @@ backend/migrations/*.sql text eol=lf
 
 # Dockerfile
 Dockerfile text eol=lf
+
+# Preserve the exact release tag in GitHub-generated source archives. The
+# resolver ignores the placeholder in normal checkouts and uses the expanded
+# value when a release archive is built without a .git directory.
+backend/cmd/server/VERSION_TAG export-subst

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Check deployment scripts
         run: |
           /bin/bash -n deploy/apple-container.sh
+          /bin/sh backend/scripts/test-resolve-version.sh
           /bin/bash deploy/tests/apple-container-test.sh
           /bin/sh deploy/tests/docker-compose-security-test.sh
           /bin/sh deploy/tests/docker-compose-gateway-env-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ CLAUDE.md
 scripts
 !backend/scripts/
 !backend/scripts/resolve-version.sh
+!backend/scripts/test-resolve-version.sh
 .code-review-state
 #openspec/
 code-reviews/

--- a/.goreleaser.simple.yaml
+++ b/.goreleaser.simple.yaml
@@ -22,6 +22,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
+      - -X main.Version={{.Version}}
       - -X main.Commit={{.Commit}}
       - -X main.Date={{.Date}}
       - -X main.BuildType=release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
+      - -X main.Version={{.Version}}
       - -X main.Commit={{.Commit}}
       - -X main.Date={{.Date}}
       - -X main.BuildType=release

--- a/README.md
+++ b/README.md
@@ -519,6 +519,11 @@ cp ../deploy/config.example.yaml ./config.yaml
 nano config.yaml
 ```
 
+`resolve-version.sh` prefers the exact release tag and also understands the
+version metadata carried by GitHub source archives, so builds from a release
+source snapshot keep the release version even when the archive has no `.git`
+directory. Set `VERSION=...` explicitly when producing a custom build.
+
 > **Note:** The `-tags embed` flag embeds the frontend into the binary. Without this flag, the binary will not serve the frontend UI.
 
 **Key configuration in `config.yaml`:**

--- a/README_CN.md
+++ b/README_CN.md
@@ -533,6 +533,10 @@ cp ../deploy/config.example.yaml ./config.yaml
 nano config.yaml
 ```
 
+`resolve-version.sh` 会优先读取精确的发布 tag，也能识别 GitHub 源码归档
+携带的版本元数据。因此，即使源码归档不包含 `.git` 目录，从发布源码构建
+仍会保留正确的版本号。生成自定义构建时可以显式设置 `VERSION=...`。
+
 > **注意：** `-tags embed` 参数会将前端嵌入到二进制文件中。不使用此参数编译的程序将不包含前端界面。
 
 **`config.yaml` 关键配置：**

--- a/README_JA.md
+++ b/README_JA.md
@@ -515,6 +515,11 @@ cp ../deploy/config.example.yaml ./config.yaml
 nano config.yaml
 ```
 
+`resolve-version.sh` は正確なリリース tag を優先し、GitHub のソースアーカイブ
+に含まれるバージョンメタデータも認識します。そのため、`.git` ディレクトリを
+含まないリリースソースからビルドしても正しいバージョンが保持されます。
+カスタムビルドでは `VERSION=...` を明示的に指定できます。
+
 > **注意:** `-tags embed` フラグはフロントエンドをバイナリに組み込みます。このフラグがない場合、バイナリはフロントエンド UI を提供しません。
 
 **`config.yaml` の主要設定:**

--- a/backend/cmd/server/VERSION_TAG
+++ b/backend/cmd/server/VERSION_TAG
@@ -1,0 +1,1 @@
+$Format:%(describe:tags)$

--- a/backend/scripts/resolve-version.sh
+++ b/backend/scripts/resolve-version.sh
@@ -5,6 +5,33 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 BACKEND_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
 REPO_DIR="$(CDPATH= cd -- "$BACKEND_DIR/.." && pwd)"
 VERSION_FILE="$BACKEND_DIR/cmd/server/VERSION"
+ARCHIVE_VERSION_FILE="$BACKEND_DIR/cmd/server/VERSION_TAG"
+
+normalize_version() {
+  VALUE="$(printf '%s' "$1" | tr -d '\r\n')"
+  case "$VALUE" in
+    ''|'$Format:'*|*-[0-9]*-g[0-9a-f]*)
+      return 1
+      ;;
+  esac
+
+  if printf '%s' "$VALUE" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+    printf '%s\n' "${VALUE#v}"
+    return 0
+  fi
+
+  return 1
+}
+
+# GitHub's source archives are created with `git archive` semantics. The
+# export-subst marker carries the exact tag even though those archives omit
+# the .git directory needed by `git describe`.
+if [ -f "$ARCHIVE_VERSION_FILE" ]; then
+  ARCHIVE_VERSION="$(cat "$ARCHIVE_VERSION_FILE")"
+  if normalize_version "$ARCHIVE_VERSION"; then
+    exit 0
+  fi
+fi
 
 # Prefer the exact release tag when building from a tagged checkout so
 # source builds from vX.Y.Z don't inherit the previous VERSION file value.
@@ -15,9 +42,14 @@ if command -v git >/dev/null 2>&1; then
     true
   )"
   if [ -n "$TAG" ]; then
-    printf '%s\n' "${TAG#v}"
-    exit 0
+    if normalize_version "$TAG"; then
+      exit 0
+    fi
   fi
 fi
 
-printf '%s\n' "$(tr -d '\r\n' < "$VERSION_FILE")"
+normalize_version "$(cat "$VERSION_FILE")" || {
+  # Preserve the historical fallback for development checkouts that use a
+  # non-semver local VERSION value.
+  tr -d '\r\n' < "$VERSION_FILE"
+}

--- a/backend/scripts/test-resolve-version.sh
+++ b/backend/scripts/test-resolve-version.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+RESOLVER="$SCRIPT_DIR/resolve-version.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+
+make_tree() {
+  mkdir -p "$1/backend/cmd/server" "$1/backend/scripts"
+  cp "$RESOLVER" "$1/backend/scripts/resolve-version.sh"
+  chmod +x "$1/backend/scripts/resolve-version.sh"
+  printf '%s\n' '9.9.9' > "$1/backend/cmd/server/VERSION"
+}
+
+assert_version() {
+  EXPECTED="$1"
+  ROOT="$2"
+  ACTUAL="$(cd "$ROOT/backend" && ./scripts/resolve-version.sh)"
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "expected $EXPECTED, got $ACTUAL" >&2
+    exit 1
+  fi
+}
+
+# A source archive carries the exact tag through export-subst and has no .git.
+ARCHIVE_TREE="$TMP_DIR/archive"
+make_tree "$ARCHIVE_TREE"
+printf '%s\n' 'v1.2.3' > "$ARCHIVE_TREE/backend/cmd/server/VERSION_TAG"
+assert_version '1.2.3' "$ARCHIVE_TREE"
+
+# Unexpanded markers and decorated non-tag descriptions must fall back safely.
+FALLBACK_TREE="$TMP_DIR/fallback"
+make_tree "$FALLBACK_TREE"
+printf '%s\n' '$Format:%(describe:tags)$' > "$FALLBACK_TREE/backend/cmd/server/VERSION_TAG"
+assert_version '9.9.9' "$FALLBACK_TREE"
+printf '%s\n' 'v1.2.3-1-gdeadbeef' > "$FALLBACK_TREE/backend/cmd/server/VERSION_TAG"
+assert_version '9.9.9' "$FALLBACK_TREE"
+
+# A tagged checkout still takes precedence over the tracked VERSION file.
+TAGGED_TREE="$TMP_DIR/tagged"
+make_tree "$TAGGED_TREE"
+printf '%s\n' '$Format:%(describe:tags)$' > "$TAGGED_TREE/backend/cmd/server/VERSION_TAG"
+(cd "$TAGGED_TREE" && git init -q && git config user.email test@example.com && git config user.name test && git add . && git commit -qm initial && git tag v2.3.4)
+assert_version '2.3.4' "$TAGGED_TREE"
+
+echo 'resolve-version.sh tests passed'


### PR DESCRIPTION
## Summary

Release tags currently point to commits whose tracked
`backend/cmd/server/VERSION` still contains the previous release number.
The release workflow fixes this temporarily for official artifacts, but
source builds from GitHub archives have no `.git` directory and therefore
fall back to the stale file.

This can make a Docker/source build of `v0.1.185` report `0.1.184` in the
web UI even though the release artifact itself is correct.

## Changes

- add an `export-subst` version marker so GitHub/git archive source snapshots
  carry the exact release tag without requiring `.git`
- make `resolve-version.sh` accept only exact release versions from archive
  metadata and exact Git tags, while safely falling back for development
  snapshots
- inject `main.Version` directly from `.Version` in both GoReleaser configs
- add shell regression coverage for archive, tagged-checkout, decorated-tag,
  and fallback cases
- document the version resolution behavior in the EN/CN/JA source-build docs

## Why this fixes the issue

The existing tag-aware resolver works when `.git` is available. Docker build
contexts and GitHub source archives intentionally omit `.git`, so they could
still use the previous value from `VERSION`. The archive marker closes that
gap without rewriting historical tags.

## Validation

Passed:

- `./backend/scripts/test-resolve-version.sh`
- `sh -n backend/scripts/resolve-version.sh`
- `sh -n backend/scripts/test-resolve-version.sh`
- YAML parsing for the modified workflow and GoReleaser configs
- `git diff --check`
- real `git archive` verification for an exact release tag

Note: the local `go test ./internal/service/...` run reached an existing,
unrelated failure in
`TestRecordCyberPolicyEvent_RuntimeSnapshotRefreshFailureKeepsStaleScope`.