### PR TITLE
fix(scheduler): keep OpenAI passthrough flag in the scheduler snapshot projection

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1000,6 +1000,13 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_ws_force_http",
 		"openai_responses_mode",
 		"openai_responses_supported",
+		// 透传开关必须进投影：候选过滤(ListSchedulableAccounts)读的是本投影，
+		// 而 Account.IsModelSupported 靠 extra 上的这两个键短路 model_mapping 白名单。
+		// 裁掉它们，透传账号在选号阶段会退回按(常为过期的)白名单判定并被误判为
+		// model_not_supported —— 转发阶段却仍按透传工作，表现为"单独测账号能通、
+		// 走网关报 no available accounts"。
+		"openai_passthrough",
+		"openai_oauth_passthrough",
 		"codex_fingerprint_mode",
 		"codex_fingerprint_seed",
 		"codex_5h_used_percent",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -1079,3 +1079,45 @@ func schedulerCacheBenchmarkAccounts(size int) []service.Account {
 	}
 	return accounts
 }
+
+// 调度投影必须保留 OpenAI 透传开关。
+//
+// 候选过滤走 ListSchedulableAccounts，读的是 buildSchedulerMetadataAccount 产出的精简投影；
+// Account.IsModelSupported 又靠 extra 上的透传开关短路 model_mapping 白名单（#4936）。
+// 一旦投影把开关裁掉、却保留了白名单，透传账号在选号阶段就会退回白名单判定并被误判成
+// model_not_supported，而转发阶段（读完整账号）仍按透传工作 —— 表现为"单独测这个账号能通、
+// 走网关却报 no available accounts"。#4936 修的是判定逻辑，这里守的是喂给判定的输入。
+func TestBuildSchedulerMetadataAccount_KeepsOpenAIPassthroughForModelGate(t *testing.T) {
+	for _, key := range []string{"openai_passthrough", "openai_oauth_passthrough"} {
+		t.Run(key, func(t *testing.T) {
+			account := service.Account{
+				ID:       383,
+				Platform: service.PlatformOpenAI,
+				Type:     service.AccountTypeOAuth,
+				Credentials: map[string]any{
+					// 账号从白名单模式切到透传后常见的残留映射，未列出请求的模型。
+					"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"},
+					"access_token":  "drop-me",
+				},
+				Extra: map[string]any{key: true},
+			}
+			require.True(t, account.IsModelSupported("gpt-5.6-sol"),
+				"前置条件：透传账号本应放行白名单外的模型")
+
+			meta := buildSchedulerMetadataAccount(account)
+
+			// 走一遍真实的序列化/反序列化路径（写入 sched:meta 再由 decodeCachedAccount 读回）。
+			payload, err := json.Marshal(meta)
+			require.NoError(t, err)
+			var restored service.Account
+			require.NoError(t, json.Unmarshal(payload, &restored))
+
+			require.Equal(t, true, restored.Extra[key])
+			require.True(t, restored.IsOpenAIPassthroughEnabled())
+			require.True(t, restored.IsModelSupported("gpt-5.6-sol"),
+				"投影裁掉透传开关会让透传账号在候选过滤阶段被误判为 model_not_supported")
+			// 白名单本身仍需保留：非透传账号依赖它做模型门。
+			require.Equal(t, map[string]any{"gpt-5.5": "gpt-5.5"}, restored.Credentials["model_mapping"])
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6457

## 问题

`filterSchedulerExtra` 是白名单式裁剪，从来没有包含 `openai_passthrough` / `openai_oauth_passthrough`；而 `filterSchedulerCredentials` 完整保留了 `credentials.model_mapping`。候选过滤（`ListSchedulableAccounts`）读的正是这份精简投影 `sched:meta:<id>`，于是**透传账号在选号阶段看起来跟白名单模式账号一模一样**：`Account.IsModelSupported` 退回按 `model_mapping` 判定，账号被计入 `model_not_supported` 过滤掉。

转发阶段从 `sched:acc:<id>` hydrate 完整账号，透传仍然生效——两阶段行为不一致，表现为"单独测这个账号能通、走网关却报 no available accounts supporting model X"。

实际影响：账号从白名单模式切到透传后残留的旧 `model_mapping` 会持续悄悄缩小候选池；当分组里没有任何账号的白名单列出所请求的模型时，整个分组对该模型完全不可用，尽管每个账号其实都能服务它。

**这不是 #4936 的回归**：#4936 修的是判定逻辑（把透传短路提到 mapping 判定之前），本 PR 修的是喂给该判定的输入。投影白名单比 #4936 早三个半月引入，`git log -S openai_passthrough -- backend/internal/repository/scheduler_cache.go` 零命中，所以那次修复在快照路径上从未生效过。

## 改动

- `filterSchedulerExtra` 白名单补上 `openai_passthrough` 和 `openai_oauth_passthrough`，并就近写明"为什么这两个键必须进投影"。
- 新增回归测试 `TestBuildSchedulerMetadataAccount_KeepsOpenAIPassthroughForModelGate`：构造"透传开启 + 残留白名单不含目标模型"的账号，把投影产物**经 JSON 往返**（即真实的 `sched:meta` 写入/读回路径）后，断言**模型门仍然放行**——断的是行为而不只是键存在；同时断言 `model_mapping` 本身仍被保留（非透传账号还要靠它做模型门）。

两个键都覆盖（`IsOpenAIPassthroughEnabled` 会依次读这两个）。

## 验证

```
$ go test -tags=unit -run TestBuildSchedulerMetadataAccount ./internal/repository/
ok      github.com/Wei-Shaw/sub2api/internal/repository

$ go test -tags=unit ./internal/repository/... ./internal/service/...
ok  (全部通过)
```

Red→green 已确认：临时 stash 掉 `scheduler_cache.go` 的改动后，新测试两个子用例都失败（`expected: bool(true) / actual: <nil>`），恢复后转绿。

## 备注（不在本 PR 范围）

同一次排查里还注意到 `handler/no_account_error.go` 的 `classifySelectionFailureError`：只要选号失败的错误串里正则匹配到 `model_rate_limited=(\d+)` 且大于 0，就**无条件**改判成 429 `All available accounts are currently rate-limited`，盖掉本该返回的 404 `model_not_found`。当池子里恰好有一个账号处于模型级冷却、其余都是"模型确实不支持"时，客户端会拿到一个具误导性的 429（Codex 之类客户端还会把它当限流猛重试）。需要的话我另开 issue/PR。
