### PR TITLE
fix(gateway): stop a per-model cooldown from turning 404 model_not_found into 429

### DIFF
--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -42,6 +42,23 @@ func classifySelectionFailureError(err error, fallback noAccountErrorClassificat
 	if err == nil {
 		return fallback
 	}
+	// A 404 model_not_found fallback is authoritative and must not be downgraded
+	// to a rate-limit verdict. classifyNoAccountError only reaches it through
+	// DiagnoseModelAvailabilityForPlatform, a dedicated database query over
+	// persistent eligibility (active + schedulable + model_mapping) that already
+	// established no account in the group can serve this model at all. A transient
+	// per-model cooldown on one of the remaining candidates does not make "all
+	// available accounts are rate-limited" true.
+	//
+	// Reporting 429 here is actively harmful: retrying can never succeed, and
+	// clients that treat 429 as a rate limit retry hard and swallow the body
+	// (Codex surfaces only "exceeded retry limit, last status: 429"), losing the
+	// one message that names the real problem. It also flips the ops attribution
+	// from a local model-configuration issue to routing capacity, because call
+	// sites gate markOpsRoutingCapacityLimitedIfNoAvailable on ModelNotFound.
+	if fallback.ModelNotFound {
+		return fallback
+	}
 	match := selectionModelRateLimitedPattern.FindStringSubmatch(strings.ToLower(err.Error()))
 	if len(match) != 2 {
 		return fallback

--- a/backend/internal/handler/no_account_error_test.go
+++ b/backend/internal/handler/no_account_error_test.go
@@ -234,3 +234,72 @@ func TestClassifyNoAccountError_FromGin_NilContextStillSafe(t *testing.T) {
 	require.False(t, service.HasOpsClientBusinessLimited(nil))
 	require.Empty(t, service.OpsClientBusinessLimitedReason(nil))
 }
+
+// 权威的 404 model_not_found 不能被"账号被限流"的 429 盖掉。
+//
+// 选号失败的错误串同时携带多种过滤原因，例如
+// "pool=9, filtered: model_not_supported=8 model_rate_limited=1"：8 个账号根本不支持该模型，
+// 剩下 1 个恰好处于模型级冷却。此时 classifyNoAccountError 已通过持久化判据确认整个分组
+// 没有账号能服务该模型（ModelNotFound=true），改判成 429 "All available accounts are
+// currently rate-limited" 是错误诊断——重试永远不会成功，而把 429 当限流的客户端会反复
+// 重试并吞掉 body（Codex 只显示 "exceeded retry limit"），恰好丢掉唯一说明真实原因的信息。
+func TestClassifySelectionFailureError_ModelNotFoundIsNotOverriddenByRateLimited(t *testing.T) {
+	modelNotFound := noAccountErrorClassification{
+		Status:        http.StatusNotFound,
+		ErrType:       "model_not_found",
+		Message:       `Model "gpt-5.3-codex" is not supported by any configured account in this group`,
+		ModelNotFound: true,
+	}
+
+	got := classifySelectionFailureError(
+		fmt.Errorf("no available OpenAI accounts supporting model: gpt-5.3-codex "+
+			"(pool=9, filtered: model_not_supported=8 model_rate_limited=1)"),
+		modelNotFound,
+	)
+
+	require.Equal(t, modelNotFound, got,
+		"分组里没有任何账号能服务该模型时，模型级冷却不该把 404 改判成 429")
+}
+
+// 真实调用点的顺序：先 classifyNoAccountErrorFromGin，再 classifySelectionFailureError。
+// 覆盖这条链路是为了同时锁住 ops 归因——调用点用 ModelNotFound 决定是否标记
+// routing capacity limited，一旦 404 被改判成 429，同一个请求会既被标成
+// local model configuration 又被标成容量问题，自相矛盾。
+func TestClassifySelectionFailureError_CallSiteChainKeepsModelNotFoundAttribution(t *testing.T) {
+	c := newTestGinContextWithRequest()
+	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{HasAccountsInPool: true, HasModelSupport: false}}
+	apiKey := &service.APIKey{GroupID: ptrInt64(43)}
+
+	cls := classifyNoAccountErrorFromGin(c, fd, apiKey, "gpt-5.3-codex", "gpt-5.3-codex", service.PlatformOpenAI)
+	cls = classifySelectionFailureError(
+		fmt.Errorf("no available OpenAI accounts supporting model: gpt-5.3-codex "+
+			"(pool=9, filtered: model_not_supported=8 model_rate_limited=1)"),
+		cls,
+	)
+
+	require.Equal(t, http.StatusNotFound, cls.Status)
+	require.Equal(t, "model_not_found", cls.ErrType)
+	require.True(t, cls.ModelNotFound)
+	require.Contains(t, cls.Message, "gpt-5.3-codex")
+	require.True(t, service.HasOpsClientBusinessLimited(c))
+	require.Equal(t, service.OpsClientBusinessLimitedReasonLocalModelConfiguration, service.OpsClientBusinessLimitedReason(c))
+}
+
+// 池子里确实存在能服务该模型、只是全部在冷却的账号时，429 改判仍需保留：
+// 这种情况 fallback 是 503（HasModelSupport=true），重试是有意义的。
+func TestClassifySelectionFailureError_StillUpgradesNonModelNotFoundFallback(t *testing.T) {
+	fallback := noAccountErrorClassification{
+		Status:  http.StatusServiceUnavailable,
+		ErrType: "api_error",
+		Message: "Service temporarily unavailable",
+	}
+
+	got := classifySelectionFailureError(
+		fmt.Errorf("no available accounts supporting model: gpt-5.6-sol (total=3 eligible=0 model_rate_limited=3)"),
+		fallback,
+	)
+
+	require.Equal(t, http.StatusTooManyRequests, got.Status)
+	require.Equal(t, "rate_limit_error", got.ErrType)
+	require.False(t, got.ModelNotFound)
+}


### PR DESCRIPTION
Fixes #6459

## 问题

`classifySelectionFailureError` 只要在选号失败的错误串里正则命中 `model_rate_limited=(\d+)` 且大于 0，就**无条件**改判成 429 `rate_limit_error`，**包括 fallback 本身就是权威 404 `model_not_found` 的情况**。

选号失败的原因是可以叠加的，例如 `pool=9, filtered: model_not_supported=8 model_rate_limited=1`：8 个账号根本不支持该模型，第 9 个恰好在模型级冷却里。而 `ModelNotFound` 只可能来自 `DiagnoseModelAvailabilityForPlatform` —— 一次专门的、只看持久化可用性（active + schedulable + `model_mapping`）的数据库查询，刻意绕开调度快照和一切临时过滤。它已经确认整个分组没有账号能服务该模型；一个临时冷却并不能让"所有可用账号都被限流"变成真的。

这不只是文案问题：

- **重试永远不会成功，但 429 明确在邀请重试。**
- **客户端会吞掉 body**：Codex 反复重试后只显示 `exceeded retry limit, last status: 429`，恰好丢掉唯一说明真实原因的那句话，排查方向被带到并发/容量上。
- **ops 归因自相矛盾**：`classifyNoAccountErrorFromGin` 已把请求标为 `LocalModelConfiguration`，而调用点用 `!cls.ModelNotFound` 决定是否 `markOpsRoutingCapacityLimitedIfNoAvailable`；改判后新结构体的 `ModelNotFound` 是零值 false，同一个请求于是**既算配置问题又算容量问题**，容量指标被配置错误污染。

另外，冷却窗口内外表现不同（**窗内 429、窗外 404**），同一个配置问题会呈现成两个看似无关的现象。

## 改动

`fallback.ModelNotFound` 为真时原样返回，不做 429 改判，并就近说明为什么这个 fallback 是权威的。**其余情况行为完全不变** —— 那正是这段代码本来要覆盖的场景：确实存在能服务该模型的账号、只是全部在冷却，此时 fallback 是 503，重试有意义。

三个用例：

- `..._ModelNotFoundIsNotOverriddenByRateLimited`：404 fallback + 同时带 `model_not_supported=8 model_rate_limited=1` 的真实错误串 → 保持 404。
- `..._CallSiteChainKeepsModelNotFoundAttribution`：按调用点真实顺序（先 `classifyNoAccountErrorFromGin` 再 `classifySelectionFailureError`）走一遍，同时锁住 ops 归因不被翻转。
- `..._StillUpgradesNonModelNotFoundFallback`：守住保留下来的 429 行为，避免被"修"过头。

## 验证

```
$ go test -tags=unit ./internal/handler/...
ok  (全部通过)
```

Red→green 已确认：临时 stash 掉 `no_account_error.go` 的改动后，前两个用例失败（`actual: 429 rate_limit_error / ModelNotFound:false`），恢复后转绿；第三个用例前后都绿，说明既有行为未被破坏。

## 关联

和 #6457 / #6458 来自同一次线上排查，但**是两个独立缺陷**：#6457 是调度投影裁掉透传开关导致账号被误判为不支持模型（根因），本 PR 是这类失败被**上报**成 429 而不是 404（诊断信息丢失）。两者互不依赖，可分别评审合并。
