### PR TITLE
feat: 支持 Composite 复用 OpenAI 原始 Codex 模型描述

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -203,7 +203,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	pluginRepository := repository.NewPluginRepository(db)
 	pluginHostInfo := providePluginHostInfo(buildInfo)
 	pluginManager := service.NewPluginManager(pluginRepository, secretEncryptor, configConfig, pluginHostInfo)
-	accountTestService := service.ProvideAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, grokTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, openAIGatewayService, settingService, pluginManager)
+	accountTestService := service.ProvideAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, grokTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, openAIGatewayService, gatewayService, settingService, pluginManager)
 	crsSyncService := service.NewCRSSyncService(accountRepository, proxyRepository, oAuthService, openAIOAuthService, geminiOAuthService, configConfig)
 	accountHandler := admin.ProvideAccountHandler(adminService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, rateLimitService, accountUsageService, accountTestService, concurrencyService, crsSyncService, sessionLimitCache, rpmCache, compositeTokenCacheInvalidator, grokQuotaService)
 	adminAnnouncementHandler := admin.NewAnnouncementHandler(announcementService)

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -203,7 +203,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	pluginRepository := repository.NewPluginRepository(db)
 	pluginHostInfo := providePluginHostInfo(buildInfo)
 	pluginManager := service.NewPluginManager(pluginRepository, secretEncryptor, configConfig, pluginHostInfo)
-	accountTestService := service.ProvideAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, grokTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, openAIGatewayService, gatewayService, settingService, pluginManager)
+	accountTestService := service.ProvideAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, grokTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, openAIGatewayService, gatewayService, geminiMessagesCompatService, settingService, pluginManager)
 	crsSyncService := service.NewCRSSyncService(accountRepository, proxyRepository, oAuthService, openAIOAuthService, geminiOAuthService, configConfig)
 	accountHandler := admin.ProvideAccountHandler(adminService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, rateLimitService, accountUsageService, accountTestService, concurrencyService, crsSyncService, sessionLimitCache, rpmCache, compositeTokenCacheInvalidator, grokQuotaService)
 	adminAnnouncementHandler := admin.NewAnnouncementHandler(announcementService)

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -175,6 +175,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
+	if channelMapping.Mapped && strings.TrimSpace(channelMapping.MappedModel) != "" {
+		ctx := service.WithUpstreamModelAvailabilityTarget(c.Request.Context(), channelMapping.MappedModel)
+		c.Request = c.Request.WithContext(ctx)
+	}
 
 	// 设置 max_tokens=1 + haiku 探测请求标识到 context 中
 	// 必须在 SetClaudeCodeClientContext 之前设置，因为 ClaudeCodeValidator 需要读取此标识进行绕过判断
@@ -1074,6 +1078,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 // Returns models based on account configurations (model_mapping whitelist)
 // Falls back to default models if no whitelist is configured
 func (h *GatewayHandler) Models(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), service.GatewayModelsCatalogTimeout)
+	defer cancel()
+
 	apiKey, _ := middleware2.GetAPIKeyFromContext(c)
 
 	var groupID *int64
@@ -1088,7 +1095,7 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 	}
 
 	if platform == service.PlatformComposite {
-		availableModels := h.compositeAvailableModels(c.Request.Context(), groupID)
+		availableModels := h.compositeAvailableModels(ctx, groupID)
 		if apiKey != nil && apiKey.Group != nil && apiKey.Group.CustomModelsListEnabled() {
 			availableModels = filterModelsByCustomList(availableModels, defaultModelIDsForPlatform(service.PlatformComposite), apiKey.Group.ModelsListConfig.Models)
 			writeCustomModelsList(c, service.PlatformComposite, availableModels)
@@ -1103,7 +1110,7 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 	}
 
 	// Get available models from account configurations for the selected group platform.
-	availableModels := h.gatewayService.GetAvailableModels(c.Request.Context(), groupID, platform)
+	availableModels := h.gatewayService.GetAvailableModels(ctx, groupID, platform)
 	if apiKey != nil && apiKey.Group != nil && apiKey.Group.CustomModelsListEnabled() {
 		fallbackModels := defaultModelIDsForPlatform(platform)
 		availableModels = filterModelsByCustomList(customModelsListSource(platform, availableModels, fallbackModels), fallbackModels, apiKey.Group.ModelsListConfig.Models)
@@ -1147,6 +1154,9 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 // expected by Codex custom providers. Official OpenAI groups continue to use
 // OpenAIGatewayHandler.CodexModels so their live upstream metadata is preserved.
 func (h *GatewayHandler) CodexModels(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), service.GatewayModelsCatalogTimeout)
+	defer cancel()
+
 	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
 	if !ok || apiKey == nil || apiKey.Group == nil {
 		h.errorResponse(c, http.StatusUnauthorized, "invalid_request_error", "API key group is required")
@@ -1157,10 +1167,10 @@ func (h *GatewayHandler) CodexModels(c *gin.Context) {
 	if value, exists := middleware2.GetForcePlatformFromContext(c); exists {
 		forcedPlatform = strings.TrimSpace(value)
 	}
-	modelIDs := h.codexModelIDsForGroup(c.Request.Context(), apiKey.Group, forcedPlatform)
+	modelIDs := h.codexModelIDsForGroup(ctx, apiKey.Group, forcedPlatform)
 	modelIDs = service.FilterCodexModelIDsForGroup(modelIDs, apiKey.Group)
 	body, err := h.gatewayService.BuildCodexModelsManifestForGroup(
-		c.Request.Context(),
+		ctx,
 		apiKey.Group,
 		forcedPlatform,
 		modelIDs,

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -59,7 +59,11 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 	var lastUpstreamErr error
 
 	for {
-		account, err := h.gatewayService.SelectAccountForModelWithExclusions(c.Request.Context(), apiKey.GroupID, "", "", failedAccountIDs)
+		account, err := h.gatewayService.SelectCodexModelsManifestAccountWithExclusions(
+			c.Request.Context(),
+			apiKey.GroupID,
+			failedAccountIDs,
+		)
 		if err != nil {
 			if c.Request.Context().Err() != nil {
 				return

--- a/backend/internal/handler/openai_codex_models_handler_test.go
+++ b/backend/internal/handler/openai_codex_models_handler_test.go
@@ -200,6 +200,72 @@ func TestCodexModelsAppliesLocalFiltersBeforeClientETag(t *testing.T) {
 	}
 }
 
+func TestCodexModelsUsesPrimaryManifestWhenSparkShadowHasMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(44)
+	parentID := int64(1)
+	repo := &codexModelsFailoverAccountRepo{accounts: []service.Account{
+		{
+			ID:              2,
+			Name:            "spark-shadow",
+			Platform:        service.PlatformOpenAI,
+			Type:            service.AccountTypeOAuth,
+			Status:          service.StatusActive,
+			Schedulable:     true,
+			Priority:        0,
+			Concurrency:     1,
+			ParentAccountID: &parentID,
+			QuotaDimension:  service.QuotaDimensionSpark,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+				},
+			},
+		},
+		{
+			ID:          parentID,
+			Name:        "primary-api-key",
+			Platform:    service.PlatformOpenAI,
+			Type:        service.AccountTypeAPIKey,
+			Status:      service.StatusActive,
+			Schedulable: true,
+			Priority:    1,
+			Concurrency: 1,
+			Credentials: map[string]any{
+				"api_key":  "sk-test",
+				"base_url": "https://upstream.example/v1",
+			},
+		},
+	}}
+	upstream := &codexModelsFailoverHTTPUpstream{
+		firstBody: `{"models":[{"slug":"gpt-5.6-sol","display_name":"Official GPT-5.6 Sol","future_capability":{"preserved":true}}]}`,
+	}
+	gatewayService := service.NewOpenAIGatewayService(
+		repo,
+		nil, nil, nil, nil, nil, nil, &config.Config{RunMode: config.RunModeSimple}, nil, nil, nil, nil, nil,
+		upstream,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	handler := &OpenAIGatewayHandler{gatewayService: gatewayService}
+
+	response := performCodexModelsRequestForGroup(
+		t,
+		handler,
+		&service.Group{ID: groupID, Platform: service.PlatformOpenAI},
+		"",
+	)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	require.Equal(t, []int64{parentID}, upstream.calls())
+	require.Equal(t, []string{"gpt-5.6-sol", "gpt-5.3-codex-spark"}, codexHandlerManifestSlugs(t, response))
+
+	var envelope struct {
+		Models []map[string]any `json:"models"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &envelope))
+	require.Equal(t, "Official GPT-5.6 Sol", envelope.Models[0]["display_name"])
+	require.Equal(t, map[string]any{"preserved": true}, envelope.Models[0]["future_capability"])
+}
+
 func TestCodexModelsAPIKeyCacheDoesNotLeakGroupFilters(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	repo := &codexModelsFailoverAccountRepo{accounts: []service.Account{

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2239,6 +2239,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	if channelMappingWS.Mapped && strings.TrimSpace(channelMappingWS.MappedModel) != "" {
 		wsForwardModel = strings.TrimSpace(channelMappingWS.MappedModel)
 	}
+	ctx = service.WithUpstreamModelAvailabilityTarget(ctx, wsForwardModel)
 
 	var currentUserRelease func()
 	var currentAccountRelease func()
@@ -2604,7 +2605,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				if previous := turnChannelMapping.Load(); previous != nil && previous.turn < turn {
 					mappedModelUnchanged = strings.TrimSpace(previous.mapping.MappedModel) == strings.TrimSpace(mapping.MappedModel)
 				}
-				if turn > 1 && !mappedModelUnchanged && !account.IsModelSupported(model) && !account.IsModelSupported(mapping.MappedModel) {
+				if turn > 1 && !mappedModelUnchanged && !h.gatewayService.IsModelSupportedByAccount(account, model) && !h.gatewayService.IsModelSupportedByAccount(account, mapping.MappedModel) {
 					return "", newOpenAIWSUnsupportedModelSwitchError(mapping.MappedModel)
 				}
 				turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{turn: turn, mapping: mapping})

--- a/backend/internal/service/gateway_hotpath_optimization_test.go
+++ b/backend/internal/service/gateway_hotpath_optimization_test.go
@@ -117,6 +117,26 @@ type modelsListAccountRepoStub struct {
 	listAllCalls     atomic.Int64
 }
 
+type modelsListUpstreamFetcherStub struct {
+	models map[int64][]string
+	errors map[int64]error
+	calls  map[int64]int
+	mu     sync.Mutex
+}
+
+func (s *modelsListUpstreamFetcherStub) FetchUpstreamSupportedModels(_ context.Context, account *Account) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if account == nil {
+		return nil, errors.New("account is required")
+	}
+	s.calls[account.ID]++
+	if err := s.errors[account.ID]; err != nil {
+		return nil, err
+	}
+	return append([]string(nil), s.models[account.ID]...), nil
+}
+
 type stickyGatewayCacheHotpathStub struct {
 	GatewayCache
 
@@ -562,6 +582,51 @@ func TestGetAvailableModels_UsesShortCacheAndSupportsInvalidation(t *testing.T) 
 	require.Equal(t, int64(2), hit)
 	require.Equal(t, int64(2), miss)
 	require.Equal(t, int64(2), store)
+}
+
+func TestGetAvailableModelsDiscoversUnmappedAccountsFromUpstream(t *testing.T) {
+	groupID := int64(12)
+	repo := &modelsListAccountRepoStub{
+		byGroup: map[int64][]Account{
+			groupID: {
+				{
+					ID:       1,
+					Platform: PlatformOpenAI,
+					Credentials: map[string]any{
+						"model_mapping": map[string]any{
+							"configured-model": "configured-upstream",
+						},
+					},
+				},
+				{ID: 2, Platform: PlatformOpenAI},
+				{ID: 3, Platform: PlatformDeepseek},
+			},
+		},
+	}
+	fetcher := &modelsListUpstreamFetcherStub{
+		models: map[int64][]string{
+			2: {"gpt-5.6-terra", "gpt-5.6-sol"},
+			3: {"deepseek-chat"},
+		},
+		calls: make(map[int64]int),
+	}
+	svc := &GatewayService{
+		accountRepo:          repo,
+		modelsListCache:      gocache.New(time.Minute, time.Minute),
+		modelsListCacheTTL:   time.Minute,
+		upstreamModelFetcher: fetcher,
+	}
+
+	models := svc.GetAvailableModels(context.Background(), &groupID, "")
+	require.Equal(t, []string{"configured-model", "deepseek-chat", "gpt-5.6-sol", "gpt-5.6-terra"}, models)
+	require.Equal(t, 0, fetcher.calls[1], "configured accounts must not be discovered upstream")
+	require.Equal(t, 1, fetcher.calls[2])
+	require.Equal(t, 1, fetcher.calls[3])
+
+	models = svc.GetAvailableModels(context.Background(), &groupID, "")
+	require.Equal(t, []string{"configured-model", "deepseek-chat", "gpt-5.6-sol", "gpt-5.6-terra"}, models)
+	require.Equal(t, 1, fetcher.calls[2], "group cache should prevent repeated discovery")
+	require.Equal(t, 1, fetcher.calls[3], "group cache should prevent repeated discovery")
 }
 
 // Scenario: 账号模型变更会失效所属平台缓存

--- a/backend/internal/service/gateway_hotpath_optimization_test.go
+++ b/backend/internal/service/gateway_hotpath_optimization_test.go
@@ -124,6 +124,35 @@ type modelsListUpstreamFetcherStub struct {
 	mu     sync.Mutex
 }
 
+type blockingModelsListUpstreamFetcherStub struct {
+	started chan int64
+	release <-chan struct{}
+	active  atomic.Int64
+	max     atomic.Int64
+}
+
+func (s *blockingModelsListUpstreamFetcherStub) FetchUpstreamSupportedModels(ctx context.Context, account *Account) ([]string, error) {
+	active := s.active.Add(1)
+	defer s.active.Add(-1)
+	for {
+		currentMax := s.max.Load()
+		if active <= currentMax || s.max.CompareAndSwap(currentMax, active) {
+			break
+		}
+	}
+	select {
+	case s.started <- account.ID:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-s.release:
+		return []string{"discovered-model"}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 func (s *modelsListUpstreamFetcherStub) FetchUpstreamSupportedModels(_ context.Context, account *Account) ([]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -627,6 +656,148 @@ func TestGetAvailableModelsDiscoversUnmappedAccountsFromUpstream(t *testing.T) {
 	require.Equal(t, []string{"configured-model", "deepseek-chat", "gpt-5.6-sol", "gpt-5.6-terra"}, models)
 	require.Equal(t, 1, fetcher.calls[2], "group cache should prevent repeated discovery")
 	require.Equal(t, 1, fetcher.calls[3], "group cache should prevent repeated discovery")
+}
+
+func TestGetAvailableModelsBoundsConcurrentUpstreamDiscovery(t *testing.T) {
+	groupID := int64(13)
+	accounts := make([]Account, 6)
+	for i := range accounts {
+		accounts[i] = Account{ID: int64(i + 1), Platform: PlatformOpenAI}
+	}
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	fetcher := &blockingModelsListUpstreamFetcherStub{
+		started: make(chan int64, len(accounts)),
+		release: release,
+	}
+	svc := &GatewayService{
+		accountRepo:          &modelsListAccountRepoStub{byGroup: map[int64][]Account{groupID: accounts}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	result := make(chan []string, 1)
+	go func() {
+		result <- svc.GetAvailableModels(context.Background(), &groupID, PlatformOpenAI)
+	}()
+
+	for i := 0; i < gatewayUpstreamModelsFetchConcurrency; i++ {
+		select {
+		case <-fetcher.started:
+		case <-time.After(time.Second):
+			t.Fatal("upstream discovery did not reach the configured concurrency")
+		}
+	}
+	select {
+	case accountID := <-fetcher.started:
+		t.Fatalf("account %d started above the concurrency limit", accountID)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case models := <-result:
+		require.Equal(t, []string{"discovered-model"}, models)
+	case <-time.After(time.Second):
+		t.Fatal("upstream discovery did not finish after release")
+	}
+	require.Equal(t, int64(gatewayUpstreamModelsFetchConcurrency), fetcher.max.Load())
+}
+
+func TestFetchUpstreamModelCatalogSingleflightWaiterHonorsContext(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	fetcher := &blockingModelsListUpstreamFetcherStub{
+		started: make(chan int64, 1),
+		release: release,
+	}
+	svc := &GatewayService{upstreamModelFetcher: fetcher}
+	account := Account{ID: 21, Platform: PlatformOpenAI}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := svc.fetchUpstreamModelCatalogForAccount(context.Background(), account)
+		firstDone <- err
+	}()
+	select {
+	case <-fetcher.started:
+	case <-time.After(time.Second):
+		t.Fatal("first upstream fetch did not start")
+	}
+
+	waiterCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	_, err := svc.fetchUpstreamModelCatalogForAccount(waiterCtx, account)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(startedAt), 250*time.Millisecond)
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("first upstream fetch did not finish after release")
+	}
+}
+
+func TestDiscoveredUpstreamCatalogConstrainsSchedulersOnlyWhenKnown(t *testing.T) {
+	cache := gocache.New(time.Minute, time.Minute)
+	gateway := &GatewayService{upstreamModelCatalogCache: cache}
+	account := &Account{ID: 31, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true}
+
+	require.True(t, gateway.isModelSupportedByAccount(account, "gpt-b"), "cache miss keeps legacy eligibility")
+	cache.Set(gatewayUpstreamModelCatalogCacheKey(account.ID), &gatewayUpstreamModelCatalog{models: []string{"gpt-a"}}, time.Minute)
+	require.True(t, gateway.isModelSupportedByAccount(account, "gpt-a"))
+	require.False(t, gateway.isModelSupportedByAccount(account, "gpt-b"))
+	mappedTargetCtx := WithUpstreamModelAvailabilityTarget(context.Background(), "gpt-a")
+	require.True(t, gateway.isModelSupportedByAccountWithContext(mappedTargetCtx, account, "public-alias"),
+		"channel-mapped upstream target, not the public alias, must be checked against the catalog")
+	emptyCatalogAccount := &Account{ID: 33, Platform: PlatformOpenAI}
+	cache.Set(gatewayUpstreamModelCatalogCacheKey(emptyCatalogAccount.ID), &gatewayUpstreamModelCatalog{}, time.Minute)
+	require.False(t, gateway.isModelSupportedByAccount(emptyCatalogAccount, "gpt-a"), "a successful empty catalog is authoritative")
+
+	openAIGateway := &OpenAIGatewayService{upstreamModelResolver: gateway}
+	scheduler := &defaultOpenAIAccountScheduler{service: openAIGateway}
+	compatible, reason := scheduler.isAccountRequestCompatibleReason(
+		context.Background(), account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-b"},
+	)
+	require.False(t, compatible)
+	require.Equal(t, "model_not_supported", reason)
+	compatible, reason = scheduler.isAccountRequestCompatibleReason(
+		mappedTargetCtx, account, OpenAIAccountScheduleRequest{RequestedModel: "public-alias"},
+	)
+	require.True(t, compatible)
+	require.Empty(t, reason)
+	compactMapped := *account
+	compactMapped.ID = 34
+	compactMapped.Credentials = map[string]any{
+		"compact_model_mapping": map[string]any{"public-alias": "gpt-a"},
+	}
+	cache.Set(gatewayUpstreamModelCatalogCacheKey(compactMapped.ID), &gatewayUpstreamModelCatalog{models: []string{"gpt-a"}}, time.Minute)
+	compactCtx := WithOpenAIForwardModel(context.Background(), "public-alias", true)
+	require.True(t, openAIGateway.isModelSupportedByAccountForRequest(compactCtx, &compactMapped, "public-alias"),
+		"catalog lookup must follow the same compact mapping chain as forwarding")
+	require.Equal(t, "model_not_supported", openAIGateway.openAICompatibleAccountEligibilityFailureReason(
+		context.Background(), account, PlatformOpenAI, "gpt-b", false, OpenAIEndpointCapabilityResponses,
+	))
+
+	mapped := *account
+	mapped.Credentials = map[string]any{"model_mapping": map[string]any{"gpt-b": "gpt-b"}}
+	require.True(t, openAIGateway.IsModelSupportedByAccount(&mapped, "gpt-b"), "explicit mapping remains authoritative")
+
+	passthrough := *account
+	passthrough.Extra = map[string]any{"openai_passthrough": true}
+	require.True(t, openAIGateway.IsModelSupportedByAccount(&passthrough, "gpt-b"), "passthrough remains unrestricted")
+
+	geminiAccount := &Account{ID: 32, Platform: PlatformGemini}
+	cache.Set(gatewayUpstreamModelCatalogCacheKey(geminiAccount.ID), &gatewayUpstreamModelCatalog{models: []string{"gemini-a"}}, time.Minute)
+	gemini := &GeminiMessagesCompatService{upstreamModelResolver: gateway}
+	require.True(t, gemini.isModelSupportedByAccount(geminiAccount, "gemini-a"))
+	require.False(t, gemini.isModelSupportedByAccount(geminiAccount, "gemini-b"))
+	geminiTargetCtx := WithUpstreamModelAvailabilityTarget(context.Background(), "gemini-a")
+	require.True(t, gemini.isModelSupportedByAccountForRequest(geminiTargetCtx, geminiAccount, "public-gemini-alias"))
 }
 
 // Scenario: 账号模型变更会失效所属平台缓存

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2561,7 +2561,7 @@ func (s *GatewayService) isModelSupportedByAccountWithContext(ctx context.Contex
 
 // isModelSupportedByAccount 根据账户平台检查模型支持（无 context，用于非 Antigravity 平台）
 func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedModel string) bool {
-	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+	return s.isModelSupportedByAccountForRequest(context.Background(), account, requestedModel)
 }
 
 func (s *GatewayService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2552,15 +2552,19 @@ func (s *GatewayService) isModelSupportedByAccountWithContext(ctx context.Contex
 			if finalModel == mapped {
 				return true // thinking 后缀未改变模型名，映射已通过
 			}
-			return account.IsModelSupported(finalModel)
+			return account.IsModelSupported(finalModel) && s.supportsDiscoveredUpstreamModelForRequest(ctx, account, finalModel)
 		}
 		return true
 	}
-	return s.isModelSupportedByAccount(account, requestedModel)
+	return s.isModelSupportedByAccountForRequest(ctx, account, requestedModel)
 }
 
 // isModelSupportedByAccount 根据账户平台检查模型支持（无 context，用于非 Antigravity 平台）
 func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedModel string) bool {
+	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+}
+
+func (s *GatewayService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {
 	if account.Platform == PlatformAntigravity {
 		if strings.TrimSpace(requestedModel) == "" {
 			return true
@@ -2584,5 +2588,5 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		}
 	}
 	// 其他平台使用账户的模型支持检查
-	return account.IsModelSupported(requestedModel)
+	return account.IsModelSupported(requestedModel) && s.supportsDiscoveredUpstreamModelForRequest(ctx, account, requestedModel)
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -27,6 +27,7 @@ import (
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -75,7 +76,9 @@ const (
 	cacheTTLTarget1h                       = "1h"
 	compositeModelOwnershipCachePrefix     = "composite-owner|"
 	gatewayUpstreamModelCatalogCachePrefix = "models-catalog|"
-	gatewayUpstreamModelsFetchTimeout      = 10 * time.Second
+	gatewayUpstreamModelsFetchConcurrency  = 4
+	// GatewayModelsCatalogTimeout bounds one client-visible model catalog operation.
+	GatewayModelsCatalogTimeout = 10 * time.Second
 )
 
 type gatewayUpstreamModelFetcher interface {
@@ -89,6 +92,31 @@ type gatewayUpstreamModelCatalog struct {
 
 type gatewayUpstreamModelCatalogFetcher interface {
 	fetchUpstreamModelCatalog(ctx context.Context, account *Account) (*gatewayUpstreamModelCatalog, error)
+}
+
+type upstreamModelAvailabilityResolver interface {
+	supportsDiscoveredUpstreamModelForRequest(ctx context.Context, account *Account, requestedModel string) bool
+}
+
+type upstreamModelAvailabilityTargetContextKey struct{}
+
+// WithUpstreamModelAvailabilityTarget records the model that will be present in
+// the forwarded request after channel mapping. Account mappings still match the
+// public model; a discovered upstream catalog is checked against this target.
+func WithUpstreamModelAvailabilityTarget(ctx context.Context, model string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, upstreamModelAvailabilityTargetContextKey{}, strings.TrimSpace(model))
+}
+
+func upstreamModelAvailabilityTargetFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	model, ok := ctx.Value(upstreamModelAvailabilityTargetContextKey{}).(string)
+	model = strings.TrimSpace(model)
+	return model, ok && model != ""
 }
 
 // ForceCacheBillingContextKey 强制缓存计费上下文键
@@ -1442,6 +1470,7 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 	// Collect unique models from all accounts
 	modelSet := make(map[string]struct{})
 
+	unmappedAccounts := make([]Account, 0, len(accounts))
 	for _, acc := range accounts {
 		// Passthrough routing accepts models independently of model_mapping. A stale
 		// mapping on any eligible passthrough account therefore cannot define the
@@ -1461,8 +1490,14 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 			}
 			continue
 		}
+		unmappedAccounts = append(unmappedAccounts, acc)
+	}
 
-		for _, model := range s.fetchUpstreamModelsForAccount(ctx, acc) {
+	for _, catalog := range s.fetchUpstreamModelCatalogsForAccounts(ctx, unmappedAccounts) {
+		if catalog == nil {
+			continue
+		}
+		for _, model := range catalog.models {
 			modelSet[model] = struct{}{}
 		}
 	}
@@ -1491,20 +1526,35 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 	return cloneStringSlice(models)
 }
 
-func (s *GatewayService) fetchUpstreamModelsForAccount(ctx context.Context, account Account) []string {
-	catalog, err := s.fetchUpstreamModelCatalogForAccount(ctx, account)
-	if err != nil {
-		slog.Debug("upstream model discovery failed",
-			"account_id", account.ID,
-			"platform", account.Platform,
-			"error", err,
-		)
+func (s *GatewayService) fetchUpstreamModelCatalogsForAccounts(ctx context.Context, accounts []Account) []*gatewayUpstreamModelCatalog {
+	if s == nil || len(accounts) == 0 {
 		return nil
 	}
-	if catalog == nil {
-		return nil
+
+	fetchCtx, cancel := context.WithTimeout(ctx, GatewayModelsCatalogTimeout)
+	defer cancel()
+
+	catalogs := make([]*gatewayUpstreamModelCatalog, len(accounts))
+	group, groupCtx := errgroup.WithContext(fetchCtx)
+	group.SetLimit(gatewayUpstreamModelsFetchConcurrency)
+	for i := range accounts {
+		i := i
+		group.Go(func() error {
+			catalog, err := s.fetchUpstreamModelCatalogForAccount(groupCtx, accounts[i])
+			if err != nil {
+				slog.Debug("upstream model discovery failed",
+					"account_id", accounts[i].ID,
+					"platform", accounts[i].Platform,
+					"error", err,
+				)
+				return nil
+			}
+			catalogs[i] = catalog
+			return nil
+		})
 	}
-	return cloneStringSlice(catalog.models)
+	_ = group.Wait()
+	return catalogs
 }
 
 func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context, account Account) (*gatewayUpstreamModelCatalog, error) {
@@ -1514,7 +1564,7 @@ func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context
 
 	cacheKey := ""
 	if account.ID > 0 {
-		cacheKey = gatewayUpstreamModelCatalogCachePrefix + strconv.FormatInt(account.ID, 10)
+		cacheKey = gatewayUpstreamModelCatalogCacheKey(account.ID)
 		if s.upstreamModelCatalogCache != nil {
 			if cached, found := s.upstreamModelCatalogCache.Get(cacheKey); found {
 				if catalog, ok := cached.(*gatewayUpstreamModelCatalog); ok {
@@ -1525,7 +1575,7 @@ func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context
 	}
 
 	fetch := func() (any, error) {
-		fetchCtx, cancel := context.WithTimeout(ctx, gatewayUpstreamModelsFetchTimeout)
+		fetchCtx, cancel := context.WithTimeout(ctx, GatewayModelsCatalogTimeout)
 		defer cancel()
 
 		accountSnapshot := account
@@ -1548,7 +1598,12 @@ func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context
 		err   error
 	)
 	if account.ID > 0 {
-		value, err, _ = s.modelsListFetchSF.Do(cacheKey, fetch)
+		select {
+		case result := <-s.modelsListFetchSF.DoChan(cacheKey, fetch):
+			value, err = result.Val, result.Err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	} else {
 		value, err = fetch()
 	}
@@ -1564,6 +1619,51 @@ func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context
 		s.upstreamModelCatalogCache.Set(cacheKey, cloneGatewayUpstreamModelCatalog(catalog), s.modelsListCacheTTL)
 	}
 	return cloneGatewayUpstreamModelCatalog(catalog), nil
+}
+
+func gatewayUpstreamModelCatalogCacheKey(accountID int64) string {
+	return gatewayUpstreamModelCatalogCachePrefix + strconv.FormatInt(accountID, 10)
+}
+
+// supportsDiscoveredUpstreamModel adds a strict account-level constraint only
+// after that account has a successfully cached upstream catalog. Unknown
+// catalogs keep the legacy allow behavior; explicit mappings and passthrough
+// remain authoritative.
+func (s *GatewayService) supportsDiscoveredUpstreamModel(account *Account, requestedModel string) bool {
+	requestedModel = strings.TrimPrefix(strings.TrimSpace(requestedModel), "models/")
+	if s == nil || account == nil || account.ID <= 0 || requestedModel == "" ||
+		len(account.GetModelMapping()) > 0 || account.IsOpenAIPassthroughEnabled() ||
+		s.upstreamModelCatalogCache == nil {
+		return true
+	}
+
+	cached, found := s.upstreamModelCatalogCache.Get(gatewayUpstreamModelCatalogCacheKey(account.ID))
+	if !found {
+		return true
+	}
+	catalog, ok := cached.(*gatewayUpstreamModelCatalog)
+	if !ok || catalog == nil {
+		return true
+	}
+	for _, model := range catalog.models {
+		if strings.TrimPrefix(strings.TrimSpace(model), "models/") == requestedModel {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *GatewayService) supportsDiscoveredUpstreamModelForRequest(ctx context.Context, account *Account, requestedModel string) bool {
+	if targetModel, ok := upstreamModelAvailabilityTargetFromContext(ctx); ok {
+		requestedModel = targetModel
+	} else if forwardModel, ok := openAIForwardModelFromContext(ctx); ok && strings.TrimSpace(forwardModel.model) != "" {
+		requestedModel = resolveOpenAIAccountUpstreamModelForRequest(
+			account,
+			forwardModel.model,
+			forwardModel.useCompactModelMapping,
+		)
+	}
+	return s.supportsDiscoveredUpstreamModel(account, requestedModel)
 }
 
 func cloneGatewayUpstreamModelCatalog(catalog *gatewayUpstreamModelCatalog) *gatewayUpstreamModelCatalog {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -71,10 +71,25 @@ const (
 )
 
 const (
-	cacheTTLTarget5m                   = "5m"
-	cacheTTLTarget1h                   = "1h"
-	compositeModelOwnershipCachePrefix = "composite-owner|"
+	cacheTTLTarget5m                       = "5m"
+	cacheTTLTarget1h                       = "1h"
+	compositeModelOwnershipCachePrefix     = "composite-owner|"
+	gatewayUpstreamModelCatalogCachePrefix = "models-catalog|"
+	gatewayUpstreamModelsFetchTimeout      = 10 * time.Second
 )
+
+type gatewayUpstreamModelFetcher interface {
+	FetchUpstreamSupportedModels(ctx context.Context, account *Account) ([]string, error)
+}
+
+type gatewayUpstreamModelCatalog struct {
+	models  []string
+	rawBody []byte
+}
+
+type gatewayUpstreamModelCatalogFetcher interface {
+	fetchUpstreamModelCatalog(ctx context.Context, account *Account) (*gatewayUpstreamModelCatalog, error)
+}
 
 // ForceCacheBillingContextKey 强制缓存计费上下文键
 // 用于粘性会话切换时，将 input_tokens 转为 cache_read_input_tokens 计费
@@ -758,43 +773,46 @@ func (s *GatewayService) TempUnscheduleRetryableError(ctx context.Context, accou
 
 // GatewayService handles API gateway operations
 type GatewayService struct {
-	accountRepo           AccountRepository
-	groupRepo             GroupRepository
-	usageLogRepo          UsageLogRepository
-	usageBillingRepo      UsageBillingRepository
-	userRepo              UserRepository
-	userSubRepo           UserSubscriptionRepository
-	userGroupRateRepo     UserGroupRateRepository
-	cache                 GatewayCache
-	digestStore           *DigestSessionStore
-	cfg                   *config.Config
-	schedulerSnapshot     *SchedulerSnapshotService
-	billingService        *BillingService
-	rateLimitService      *RateLimitService
-	billingCacheService   *BillingCacheService
-	identityService       *IdentityService
-	httpUpstream          HTTPUpstream
-	deferredService       *DeferredService
-	concurrencyService    *ConcurrencyService
-	claudeTokenProvider   *ClaudeTokenProvider
-	sessionLimitCache     SessionLimitCache // 会话数量限制缓存（仅 Anthropic OAuth/SetupToken）
-	rpmCache              RPMCache          // RPM 计数缓存（仅 Anthropic OAuth/SetupToken）
-	userGroupRateResolver *userGroupRateResolver
-	userGroupRateCache    *gocache.Cache
-	userGroupRateSF       singleflight.Group
-	modelsListCache       *gocache.Cache
-	modelsListCacheTTL    time.Duration
-	settingService        *SettingService
-	responseHeaderFilter  *responseheaders.CompiledHeaderFilter
-	debugModelRouting     atomic.Bool
-	debugClaudeMimic      atomic.Bool
-	channelService        *ChannelService
-	resolver              *ModelPricingResolver
-	compositeResolver     *CompositeRouteResolver
-	debugGatewayBodyFile  atomic.Pointer[os.File] // non-nil when SUB2API_DEBUG_GATEWAY_BODY is set
-	tlsFPProfileService   *TLSFingerprintProfileService
-	balanceNotifyService  *BalanceNotifyService
-	userPlatformQuotaRepo UserPlatformQuotaRepository
+	accountRepo               AccountRepository
+	groupRepo                 GroupRepository
+	usageLogRepo              UsageLogRepository
+	usageBillingRepo          UsageBillingRepository
+	userRepo                  UserRepository
+	userSubRepo               UserSubscriptionRepository
+	userGroupRateRepo         UserGroupRateRepository
+	cache                     GatewayCache
+	digestStore               *DigestSessionStore
+	cfg                       *config.Config
+	schedulerSnapshot         *SchedulerSnapshotService
+	billingService            *BillingService
+	rateLimitService          *RateLimitService
+	billingCacheService       *BillingCacheService
+	identityService           *IdentityService
+	httpUpstream              HTTPUpstream
+	deferredService           *DeferredService
+	concurrencyService        *ConcurrencyService
+	claudeTokenProvider       *ClaudeTokenProvider
+	sessionLimitCache         SessionLimitCache // 会话数量限制缓存（仅 Anthropic OAuth/SetupToken）
+	rpmCache                  RPMCache          // RPM 计数缓存（仅 Anthropic OAuth/SetupToken）
+	userGroupRateResolver     *userGroupRateResolver
+	userGroupRateCache        *gocache.Cache
+	userGroupRateSF           singleflight.Group
+	modelsListCache           *gocache.Cache
+	modelsListCacheTTL        time.Duration
+	modelsListFetchSF         singleflight.Group
+	upstreamModelCatalogCache *gocache.Cache
+	upstreamModelFetcher      gatewayUpstreamModelFetcher
+	settingService            *SettingService
+	responseHeaderFilter      *responseheaders.CompiledHeaderFilter
+	debugModelRouting         atomic.Bool
+	debugClaudeMimic          atomic.Bool
+	channelService            *ChannelService
+	resolver                  *ModelPricingResolver
+	compositeResolver         *CompositeRouteResolver
+	debugGatewayBodyFile      atomic.Pointer[os.File] // non-nil when SUB2API_DEBUG_GATEWAY_BODY is set
+	tlsFPProfileService       *TLSFingerprintProfileService
+	balanceNotifyService      *BalanceNotifyService
+	userPlatformQuotaRepo     UserPlatformQuotaRepository
 }
 
 // NewGatewayService creates a new GatewayService
@@ -832,38 +850,39 @@ func NewGatewayService(
 	modelsListTTL := resolveModelsListCacheTTL(cfg)
 
 	svc := &GatewayService{
-		accountRepo:           accountRepo,
-		groupRepo:             groupRepo,
-		usageLogRepo:          usageLogRepo,
-		usageBillingRepo:      usageBillingRepo,
-		userRepo:              userRepo,
-		userSubRepo:           userSubRepo,
-		userGroupRateRepo:     userGroupRateRepo,
-		cache:                 cache,
-		digestStore:           digestStore,
-		cfg:                   cfg,
-		schedulerSnapshot:     schedulerSnapshot,
-		concurrencyService:    concurrencyService,
-		billingService:        billingService,
-		rateLimitService:      rateLimitService,
-		billingCacheService:   billingCacheService,
-		identityService:       identityService,
-		httpUpstream:          httpUpstream,
-		deferredService:       deferredService,
-		claudeTokenProvider:   claudeTokenProvider,
-		sessionLimitCache:     sessionLimitCache,
-		rpmCache:              rpmCache,
-		userGroupRateCache:    gocache.New(userGroupRateTTL, time.Minute),
-		settingService:        settingService,
-		modelsListCache:       gocache.New(modelsListTTL, time.Minute),
-		modelsListCacheTTL:    modelsListTTL,
-		responseHeaderFilter:  compileResponseHeaderFilter(cfg),
-		tlsFPProfileService:   tlsFPProfileService,
-		channelService:        channelService,
-		resolver:              resolver,
-		compositeResolver:     compositeResolver,
-		balanceNotifyService:  balanceNotifyService,
-		userPlatformQuotaRepo: userPlatformQuotaRepo,
+		accountRepo:               accountRepo,
+		groupRepo:                 groupRepo,
+		usageLogRepo:              usageLogRepo,
+		usageBillingRepo:          usageBillingRepo,
+		userRepo:                  userRepo,
+		userSubRepo:               userSubRepo,
+		userGroupRateRepo:         userGroupRateRepo,
+		cache:                     cache,
+		digestStore:               digestStore,
+		cfg:                       cfg,
+		schedulerSnapshot:         schedulerSnapshot,
+		concurrencyService:        concurrencyService,
+		billingService:            billingService,
+		rateLimitService:          rateLimitService,
+		billingCacheService:       billingCacheService,
+		identityService:           identityService,
+		httpUpstream:              httpUpstream,
+		deferredService:           deferredService,
+		claudeTokenProvider:       claudeTokenProvider,
+		sessionLimitCache:         sessionLimitCache,
+		rpmCache:                  rpmCache,
+		userGroupRateCache:        gocache.New(userGroupRateTTL, time.Minute),
+		settingService:            settingService,
+		modelsListCache:           gocache.New(modelsListTTL, time.Minute),
+		modelsListCacheTTL:        modelsListTTL,
+		upstreamModelCatalogCache: gocache.New(modelsListTTL, time.Minute),
+		responseHeaderFilter:      compileResponseHeaderFilter(cfg),
+		tlsFPProfileService:       tlsFPProfileService,
+		channelService:            channelService,
+		resolver:                  resolver,
+		compositeResolver:         compositeResolver,
+		balanceNotifyService:      balanceNotifyService,
+		userPlatformQuotaRepo:     userPlatformQuotaRepo,
 	}
 	if compositeResolver != nil {
 		compositeResolver.SetModelOwnershipResolver(svc.resolveCompositeModelOwnership)
@@ -881,6 +900,14 @@ func NewGatewayService(
 		svc.initDebugGatewayBodyFile(path)
 	}
 	return svc
+}
+
+// SetUpstreamModelFetcher wires the shared account-level upstream model
+// discovery used by GetAvailableModels when an account has no model_mapping.
+func (s *GatewayService) SetUpstreamModelFetcher(fetcher gatewayUpstreamModelFetcher) {
+	if s != nil {
+		s.upstreamModelFetcher = fetcher
+	}
 }
 
 // GenerateSessionHash 从预解析请求计算粘性会话 hash
@@ -1373,6 +1400,9 @@ func (s *GatewayService) DoGrokNativeResponsesJSON(ctx context.Context, account 
 	return respBytes, nil
 }
 
+// GetAvailableModels returns the list of models available for a group.
+// Explicit model_mapping entries remain authoritative; accounts without a
+// mapping are discovered from their upstream model catalog.
 func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64, platform string) []string {
 	cacheKey := modelsListCacheKey(groupID, platform)
 	if s.modelsListCache != nil {
@@ -1411,7 +1441,6 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 
 	// Collect unique models from all accounts
 	modelSet := make(map[string]struct{})
-	hasAnyMapping := false
 
 	for _, acc := range accounts {
 		// Passthrough routing accepts models independently of model_mapping. A stale
@@ -1427,15 +1456,20 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 
 		mapping := acc.GetModelMapping()
 		if len(mapping) > 0 {
-			hasAnyMapping = true
 			for model := range mapping {
 				modelSet[model] = struct{}{}
 			}
+			continue
+		}
+
+		for _, model := range s.fetchUpstreamModelsForAccount(ctx, acc) {
+			modelSet[model] = struct{}{}
 		}
 	}
 
-	// If no account has model_mapping, return nil (use default)
-	if !hasAnyMapping {
+	// If no account has a configured or discovered model, return nil so the
+	// handler can use its provider-specific default model set.
+	if len(modelSet) == 0 {
 		if s.modelsListCache != nil {
 			s.modelsListCache.Set(cacheKey, []string(nil), s.modelsListCacheTTL)
 			modelsListCacheStoreTotal.Add(1)
@@ -1455,6 +1489,91 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 		modelsListCacheStoreTotal.Add(1)
 	}
 	return cloneStringSlice(models)
+}
+
+func (s *GatewayService) fetchUpstreamModelsForAccount(ctx context.Context, account Account) []string {
+	catalog, err := s.fetchUpstreamModelCatalogForAccount(ctx, account)
+	if err != nil {
+		slog.Debug("upstream model discovery failed",
+			"account_id", account.ID,
+			"platform", account.Platform,
+			"error", err,
+		)
+		return nil
+	}
+	if catalog == nil {
+		return nil
+	}
+	return cloneStringSlice(catalog.models)
+}
+
+func (s *GatewayService) fetchUpstreamModelCatalogForAccount(ctx context.Context, account Account) (*gatewayUpstreamModelCatalog, error) {
+	if s == nil || s.upstreamModelFetcher == nil {
+		return nil, nil
+	}
+
+	cacheKey := ""
+	if account.ID > 0 {
+		cacheKey = gatewayUpstreamModelCatalogCachePrefix + strconv.FormatInt(account.ID, 10)
+		if s.upstreamModelCatalogCache != nil {
+			if cached, found := s.upstreamModelCatalogCache.Get(cacheKey); found {
+				if catalog, ok := cached.(*gatewayUpstreamModelCatalog); ok {
+					return cloneGatewayUpstreamModelCatalog(catalog), nil
+				}
+			}
+		}
+	}
+
+	fetch := func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(ctx, gatewayUpstreamModelsFetchTimeout)
+		defer cancel()
+
+		accountSnapshot := account
+		if fetcher, ok := s.upstreamModelFetcher.(gatewayUpstreamModelCatalogFetcher); ok {
+			catalog, fetchErr := fetcher.fetchUpstreamModelCatalog(fetchCtx, &accountSnapshot)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			return cloneGatewayUpstreamModelCatalog(catalog), nil
+		}
+		models, fetchErr := s.upstreamModelFetcher.FetchUpstreamSupportedModels(fetchCtx, &accountSnapshot)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+		return &gatewayUpstreamModelCatalog{models: dedupeAndSortModelIDs(models)}, nil
+	}
+
+	var (
+		value any
+		err   error
+	)
+	if account.ID > 0 {
+		value, err, _ = s.modelsListFetchSF.Do(cacheKey, fetch)
+	} else {
+		value, err = fetch()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	catalog, ok := value.(*gatewayUpstreamModelCatalog)
+	if !ok {
+		return nil, fmt.Errorf("invalid upstream model catalog result")
+	}
+	if cacheKey != "" && s.upstreamModelCatalogCache != nil {
+		s.upstreamModelCatalogCache.Set(cacheKey, cloneGatewayUpstreamModelCatalog(catalog), s.modelsListCacheTTL)
+	}
+	return cloneGatewayUpstreamModelCatalog(catalog), nil
+}
+
+func cloneGatewayUpstreamModelCatalog(catalog *gatewayUpstreamModelCatalog) *gatewayUpstreamModelCatalog {
+	if catalog == nil {
+		return nil
+	}
+	return &gatewayUpstreamModelCatalog{
+		models:  cloneStringSlice(catalog.models),
+		rawBody: append([]byte(nil), catalog.rawBody...),
+	}
 }
 
 func (s *GatewayService) resolveCompositeModelOwnership(ctx context.Context, groupID int64, model string) (CompositeModelOwnership, error) {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -415,7 +415,7 @@ func (s *GeminiMessagesCompatService) isBetterGeminiAccount(candidate, current *
 
 // isModelSupportedByAccount 根据账户平台检查模型支持
 func (s *GeminiMessagesCompatService) isModelSupportedByAccount(account *Account, requestedModel string) bool {
-	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+	return s.isModelSupportedByAccountForRequest(context.Background(), account, requestedModel)
 }
 
 func (s *GeminiMessagesCompatService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -55,6 +55,13 @@ type GeminiMessagesCompatService struct {
 	antigravityGatewayService *AntigravityGatewayService
 	cfg                       *config.Config
 	responseHeaderFilter      *responseheaders.CompiledHeaderFilter
+	upstreamModelResolver     upstreamModelAvailabilityResolver
+}
+
+func (s *GeminiMessagesCompatService) setUpstreamModelAvailabilityResolver(resolver upstreamModelAvailabilityResolver) {
+	if s != nil {
+		s.upstreamModelResolver = resolver
+	}
 }
 
 func (s *GeminiMessagesCompatService) readUpstreamErrorBody(resp *http.Response) []byte {
@@ -263,7 +270,7 @@ func (s *GeminiMessagesCompatService) isAccountUsableForRequestWithPrecheck(
 
 	// 检查模型支持
 	// Check model support
-	if requestedModel != "" && !s.isModelSupportedByAccount(account, requestedModel) {
+	if requestedModel != "" && !s.isModelSupportedByAccountForRequest(ctx, account, requestedModel) {
 		return false
 	}
 
@@ -408,13 +415,21 @@ func (s *GeminiMessagesCompatService) isBetterGeminiAccount(candidate, current *
 
 // isModelSupportedByAccount 根据账户平台检查模型支持
 func (s *GeminiMessagesCompatService) isModelSupportedByAccount(account *Account, requestedModel string) bool {
+	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+}
+
+func (s *GeminiMessagesCompatService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {
 	if account.Platform == PlatformAntigravity {
 		if strings.TrimSpace(requestedModel) == "" {
 			return true
 		}
 		return mapAntigravityModel(account, requestedModel) != ""
 	}
-	return account.IsModelSupported(requestedModel)
+	if !account.IsModelSupported(requestedModel) {
+		return false
+	}
+	return s.upstreamModelResolver == nil ||
+		s.upstreamModelResolver.supportsDiscoveredUpstreamModelForRequest(ctx, account, requestedModel)
 }
 
 // GetAntigravityGatewayService 返回 AntigravityGatewayService

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1797,8 +1797,14 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx con
 	}) {
 		return false, "shadow_parent_unhealthy"
 	}
-	if req.RequestedModel != "" && !account.IsModelSupported(req.RequestedModel) {
-		return false, "model_not_supported"
+	if req.RequestedModel != "" {
+		modelSupported := account.IsModelSupported(req.RequestedModel)
+		if s != nil && s.service != nil {
+			modelSupported = s.service.isModelSupportedByAccountForRequest(ctx, account, req.RequestedModel)
+		}
+		if !modelSupported {
+			return false, "model_not_supported"
+		}
 	}
 	if req.GroupID != nil && s != nil && s.service != nil &&
 		s.service.needsUpstreamChannelRestrictionCheck(ctx, req.GroupID) &&

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -830,6 +830,7 @@ func (s *GatewayService) BuildCodexModelsManifestForGroup(
 	}
 	rawOpenAIModels := s.fetchCompositeRawOpenAIModels(
 		ctx,
+		group,
 		effectivePlatform,
 		modelIDs,
 		catalog,
@@ -848,6 +849,7 @@ func (s *GatewayService) BuildCodexModelsManifestForGroup(
 
 func (s *GatewayService) fetchCompositeRawOpenAIModels(
 	ctx context.Context,
+	group *Group,
 	platform string,
 	modelIDs []string,
 	accounts []Account,
@@ -858,81 +860,200 @@ func (s *GatewayService) fetchCompositeRawOpenAIModels(
 		return nil
 	}
 
-	rawModels := make(map[string]json.RawMessage)
-	for i := range accounts {
-		account := accounts[i]
-		if account.Platform != PlatformOpenAI || !account.IsOpenAIOAuth() {
+	type rawModelPlan struct {
+		publicModel string
+		targetModel string
+		accountIDs  []int64
+	}
+
+	// Raw reuse is all-or-nothing for every account that can serve a public
+	// model. Any route, target, account-type, or descriptor disagreement falls
+	// back to the existing generated manifest and its capability intersection.
+	plans := make([]rawModelPlan, 0, len(modelIDs))
+	seenFetchAccountIDs := make(map[int64]struct{})
+	accountsToFetch := make([]Account, 0)
+	for _, modelID := range modelIDs {
+		publicModel := strings.TrimSpace(modelID)
+		candidates, ok := compositeRawOpenAIModelCandidates(publicModel, accounts, routes, routesAvailable)
+		if !ok {
 			continue
 		}
 
-		catalog, err := s.fetchUpstreamModelCatalogForAccount(ctx, account)
-		if err != nil || catalog == nil || len(catalog.rawBody) == 0 {
-			continue
+		plan := rawModelPlan{publicModel: publicModel}
+		valid := true
+		seenAccountIDs := make(map[int64]struct{}, len(candidates))
+		for _, candidate := range candidates {
+			account := candidate.account
+			if account.ID <= 0 || !account.IsOpenAIOAuth() || account.IsOpenAIPassthroughEnabled() {
+				valid = false
+				break
+			}
+			if plan.targetModel == "" {
+				plan.targetModel = candidate.targetModel
+			} else if plan.targetModel != candidate.targetModel {
+				valid = false
+				break
+			}
+			if _, exists := seenAccountIDs[account.ID]; exists {
+				continue
+			}
+			seenAccountIDs[account.ID] = struct{}{}
+			plan.accountIDs = append(plan.accountIDs, account.ID)
+			if _, exists := seenFetchAccountIDs[account.ID]; !exists {
+				seenFetchAccountIDs[account.ID] = struct{}{}
+				accountsToFetch = append(accountsToFetch, account)
+			}
 		}
-		upstreamModels, err := extractCodexManifestModelEntries(catalog.rawBody)
-		if err != nil {
-			continue
+		if valid && plan.publicModel != "" && plan.targetModel != "" && len(plan.accountIDs) > 0 {
+			plans = append(plans, plan)
 		}
+	}
+	if len(plans) == 0 {
+		return nil
+	}
 
-		for _, publicModel := range modelIDs {
-			targetModel, ok := compositeOpenAIModelSource(account, publicModel, routes, routesAvailable)
-			if !ok {
-				continue
+	entriesByAccountID := make(map[int64]map[string]json.RawMessage, len(accountsToFetch))
+	for i, catalog := range s.fetchUpstreamModelCatalogsForAccounts(ctx, accountsToFetch) {
+		if catalog == nil || len(catalog.rawBody) == 0 {
+			continue
+		}
+		entries, err := extractCodexManifestModelEntries(catalog.rawBody)
+		if err == nil {
+			entriesByAccountID[accountsToFetch[i].ID] = entries
+		}
+	}
+
+	rawModels := make(map[string]json.RawMessage, len(plans))
+	for _, plan := range plans {
+		var selected json.RawMessage
+		var canonicalSelected []byte
+		consistent := true
+		for _, accountID := range plan.accountIDs {
+			rawModel, found := entriesByAccountID[accountID][plan.targetModel]
+			if !found {
+				consistent = false
+				break
 			}
-			rawModel, ok := upstreamModels[targetModel]
-			if !ok {
-				continue
-			}
-			if targetModel != publicModel {
-				rawModel, err = codexManifestModelWithSlug(rawModel, publicModel)
+			var err error
+			if plan.targetModel != plan.publicModel {
+				rawModel, err = codexManifestModelWithSlug(rawModel, plan.publicModel)
 				if err != nil {
-					continue
+					consistent = false
+					break
 				}
 			}
-			if _, exists := rawModels[publicModel]; !exists {
-				rawModels[publicModel] = append([]byte(nil), rawModel...)
+			if codexAutoModelExplicitlyEnabled(group, plan.publicModel) {
+				rawModel, _, err = codexModelWithVisibility(rawModel, "list")
+				if err != nil {
+					consistent = false
+					break
+				}
 			}
+			canonicalModel, err := canonicalCodexManifestModel(rawModel)
+			if err != nil {
+				consistent = false
+				break
+			}
+			if selected == nil {
+				selected = append([]byte(nil), rawModel...)
+				canonicalSelected = canonicalModel
+				continue
+			}
+			if !bytes.Equal(canonicalSelected, canonicalModel) {
+				consistent = false
+				break
+			}
+		}
+		if consistent && selected != nil {
+			rawModels[plan.publicModel] = selected
 		}
 	}
 	return rawModels
 }
 
-func compositeOpenAIModelSource(
-	account Account,
+type compositeRawOpenAIModelCandidate struct {
+	account     Account
+	targetModel string
+}
+
+func compositeRawOpenAIModelCandidates(
 	publicModel string,
+	accounts []Account,
 	routes []CompositeModelRoute,
 	routesAvailable bool,
-) (string, bool) {
+) ([]compositeRawOpenAIModelCandidate, bool) {
 	publicModel = strings.TrimSpace(publicModel)
 	if publicModel == "" || !routesAvailable {
-		return "", false
+		return nil, false
 	}
 
-	if route, matched := matchCompositeRoute(routes, publicModel, CompositeRouteEndpointResponses); matched {
-		if route.TargetPlatform != PlatformOpenAI {
-			return "", false
-		}
-		targetModel := strings.TrimSpace(route.UpstreamModel)
-		if targetModel == "" {
-			targetModel = publicModel
-		}
-		return targetModel, true
-	}
-	if codexCompositeRouteMatchesModel(routes, publicModel) {
-		return "", false
+	targetPlatform, upstreamModel, resolved := resolveCodexCompositeModelTarget(publicModel, accounts, routes, routesAvailable)
+	if !resolved || targetPlatform != PlatformOpenAI {
+		return nil, false
 	}
 
-	if mapping := account.GetModelMapping(); len(mapping) > 0 {
-		targetModel, matched := account.ResolveMappedModel(publicModel)
-		if !matched || strings.TrimSpace(targetModel) == "" {
-			return "", false
+	_, hasExplicitRoute := matchCompositeRoute(routes, publicModel, CompositeRouteEndpointResponses)
+	explicitClaims := false
+	if !hasExplicitRoute && upstreamModel == publicModel {
+		for _, account := range accounts {
+			if account.Platform == PlatformOpenAI && codexExplicitModelMappingClaims(account, publicModel) {
+				explicitClaims = true
+				break
+			}
 		}
-		return strings.TrimSpace(targetModel), true
 	}
-	if detectedPlatform, detected := DetectModelPlatform(publicModel); detected && detectedPlatform != PlatformOpenAI {
-		return "", false
+
+	candidates := make([]compositeRawOpenAIModelCandidate, 0)
+	for _, account := range accounts {
+		if account.Platform != PlatformOpenAI {
+			continue
+		}
+		targetModel := upstreamModel
+		if explicitClaims {
+			if !codexExplicitModelMappingClaims(account, publicModel) {
+				continue
+			}
+			targetModel = account.GetMappedModel(publicModel)
+		} else {
+			if !account.IsModelSupported(upstreamModel) {
+				continue
+			}
+			targetModel = account.GetMappedModel(upstreamModel)
+		}
+		targetModel = strings.TrimSpace(targetModel)
+		if targetModel != "" {
+			candidates = append(candidates, compositeRawOpenAIModelCandidate{account: account, targetModel: targetModel})
+		}
 	}
-	return publicModel, true
+	return candidates, len(candidates) > 0
+}
+
+func codexAutoModelExplicitlyEnabled(group *Group, modelID string) bool {
+	if group == nil || !group.CustomModelsListEnabled() || !strings.HasPrefix(modelID, codexAutoModelPrefix) {
+		return false
+	}
+	for _, selectedModel := range group.ModelsListConfig.Models {
+		if strings.TrimSpace(selectedModel) == modelID {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalCodexManifestModel(rawModel json.RawMessage) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(rawModel))
+	decoder.UseNumber()
+	var model any
+	if err := decoder.Decode(&model); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("multiple JSON values in Codex manifest model")
+		}
+		return nil, err
+	}
+	return json.Marshal(model)
 }
 
 func extractCodexManifestModelEntries(body []byte) (map[string]json.RawMessage, error) {

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -1008,7 +1008,7 @@ func compositeRawOpenAIModelCandidates(
 		if account.Platform != PlatformOpenAI {
 			continue
 		}
-		targetModel := upstreamModel
+		var targetModel string
 		if explicitClaims {
 			if !codexExplicitModelMappingClaims(account, publicModel) {
 				continue

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -103,9 +103,11 @@ type CodexModelsManifest struct {
 }
 
 // BuildGroupConfiguredCodexModelsManifest builds a Codex catalog exclusively
-// from the public model names configured on accounts in an OpenAI group. The
-// boolean result distinguishes "no explicit configuration" from a configured
-// catalog that becomes empty after group-level filtering.
+// from administrator-configured public model names in an OpenAI group. A
+// system-generated shadow mapping alone does not suppress upstream discovery
+// when the group also has an unmapped credential-bearing account. The boolean
+// result distinguishes "no explicit configuration" from a configured catalog
+// that becomes empty after group-level filtering.
 func (s *OpenAIGatewayService) BuildGroupConfiguredCodexModelsManifest(
 	ctx context.Context,
 	group *Group,
@@ -121,6 +123,12 @@ func (s *OpenAIGatewayService) BuildGroupConfiguredCodexModelsManifest(
 	}
 	configuredModels := openAIConfiguredCodexModelIDsForGroup(visible, group)
 	if len(configuredModels) == 0 {
+		return nil, false, nil
+	}
+	// Spark shadows carry a system-generated single-model mapping. When every
+	// credential-bearing OpenAI account is otherwise unmapped, that mapping must
+	// not suppress the live upstream catalog for the whole group.
+	if openAIGroupShouldFetchUpstreamCodexManifest(visible) {
 		return nil, false, nil
 	}
 
@@ -152,6 +160,53 @@ func (s *OpenAIGatewayService) BuildGroupConfiguredCodexModelsManifest(
 		manifest.NotModified = true
 	}
 	return manifest, true, nil
+}
+
+func openAIGroupShouldFetchUpstreamCodexManifest(accounts []Account) bool {
+	hasPrimaryAccount := false
+	for i := range accounts {
+		account := &accounts[i]
+		if account.Platform != PlatformOpenAI || account.IsShadow() {
+			continue
+		}
+		hasPrimaryAccount = true
+		if len(account.GetModelMapping()) > 0 {
+			return false
+		}
+	}
+	return hasPrimaryAccount
+}
+
+// SelectCodexModelsManifestAccountWithExclusions prefers a credential-bearing
+// account as the source of the group-wide manifest. A shadow remains a fallback
+// for groups that have no eligible primary account.
+func (s *OpenAIGatewayService) SelectCodexModelsManifestAccountWithExclusions(
+	ctx context.Context,
+	groupID *int64,
+	excludedIDs map[int64]struct{},
+) (*Account, error) {
+	candidateExclusions := make(map[int64]struct{}, len(excludedIDs)+1)
+	for accountID := range excludedIDs {
+		candidateExclusions[accountID] = struct{}{}
+	}
+
+	var shadowFallback *Account
+	for {
+		account, err := s.SelectAccountForModelWithExclusions(ctx, groupID, "", "", candidateExclusions)
+		if err != nil {
+			if shadowFallback != nil {
+				return shadowFallback, nil
+			}
+			return nil, err
+		}
+		if !account.IsShadow() || account.ID <= 0 {
+			return account, nil
+		}
+		if shadowFallback == nil {
+			shadowFallback = account
+		}
+		candidateExclusions[account.ID] = struct{}{}
+	}
 }
 
 // MergeGroupConfiguredCodexModels adds account model aliases that are visible

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -738,9 +738,10 @@ func BuildCodexModelsManifest(modelIDs []string) ([]byte, error) {
 }
 
 // BuildCodexModelsManifestForGroup derives input capabilities from the
-// concrete Responses route and group accounts behind a group. Unknown or mixed
-// capabilities fail closed to the text-only descriptor used by the standalone
-// builder. Caller-supplied model IDs still decide which slugs appear; advertised
+// concrete Responses route and group accounts behind a group. Composite models
+// that safely match an OpenAI OAuth upstream entry retain that raw descriptor;
+// all other models use the generated descriptor and its conservative capability
+// rules. Caller-supplied model IDs still decide which slugs appear; generated
 // capabilities intersect all active group members that map the alias, including
 // accounts that are not currently schedulable.
 func (s *GatewayService) BuildCodexModelsManifestForGroup(
@@ -772,13 +773,148 @@ func (s *GatewayService) BuildCodexModelsManifestForGroup(
 			compositeRoutesAvailable = false
 		}
 	}
-	return buildCodexModelsManifestForAccounts(
+	rawOpenAIModels := s.fetchCompositeRawOpenAIModels(
+		ctx,
 		effectivePlatform,
 		modelIDs,
 		catalog,
 		compositeRoutes,
 		compositeRoutesAvailable,
 	)
+	return buildCodexModelsManifestForAccountsWithRaw(
+		effectivePlatform,
+		modelIDs,
+		catalog,
+		compositeRoutes,
+		compositeRoutesAvailable,
+		rawOpenAIModels,
+	)
+}
+
+func (s *GatewayService) fetchCompositeRawOpenAIModels(
+	ctx context.Context,
+	platform string,
+	modelIDs []string,
+	accounts []Account,
+	routes []CompositeModelRoute,
+	routesAvailable bool,
+) map[string]json.RawMessage {
+	if s == nil || platform != PlatformComposite || !routesAvailable || len(modelIDs) == 0 {
+		return nil
+	}
+
+	rawModels := make(map[string]json.RawMessage)
+	for i := range accounts {
+		account := accounts[i]
+		if account.Platform != PlatformOpenAI || !account.IsOpenAIOAuth() {
+			continue
+		}
+
+		catalog, err := s.fetchUpstreamModelCatalogForAccount(ctx, account)
+		if err != nil || catalog == nil || len(catalog.rawBody) == 0 {
+			continue
+		}
+		upstreamModels, err := extractCodexManifestModelEntries(catalog.rawBody)
+		if err != nil {
+			continue
+		}
+
+		for _, publicModel := range modelIDs {
+			targetModel, ok := compositeOpenAIModelSource(account, publicModel, routes, routesAvailable)
+			if !ok {
+				continue
+			}
+			rawModel, ok := upstreamModels[targetModel]
+			if !ok {
+				continue
+			}
+			if targetModel != publicModel {
+				rawModel, err = codexManifestModelWithSlug(rawModel, publicModel)
+				if err != nil {
+					continue
+				}
+			}
+			if _, exists := rawModels[publicModel]; !exists {
+				rawModels[publicModel] = append([]byte(nil), rawModel...)
+			}
+		}
+	}
+	return rawModels
+}
+
+func compositeOpenAIModelSource(
+	account Account,
+	publicModel string,
+	routes []CompositeModelRoute,
+	routesAvailable bool,
+) (string, bool) {
+	publicModel = strings.TrimSpace(publicModel)
+	if publicModel == "" || !routesAvailable {
+		return "", false
+	}
+
+	if route, matched := matchCompositeRoute(routes, publicModel, CompositeRouteEndpointResponses); matched {
+		if route.TargetPlatform != PlatformOpenAI {
+			return "", false
+		}
+		targetModel := strings.TrimSpace(route.UpstreamModel)
+		if targetModel == "" {
+			targetModel = publicModel
+		}
+		return targetModel, true
+	}
+	if codexCompositeRouteMatchesModel(routes, publicModel) {
+		return "", false
+	}
+
+	if mapping := account.GetModelMapping(); len(mapping) > 0 {
+		targetModel, matched := account.ResolveMappedModel(publicModel)
+		if !matched || strings.TrimSpace(targetModel) == "" {
+			return "", false
+		}
+		return strings.TrimSpace(targetModel), true
+	}
+	if detectedPlatform, detected := DetectModelPlatform(publicModel); detected && detectedPlatform != PlatformOpenAI {
+		return "", false
+	}
+	return publicModel, true
+}
+
+func extractCodexManifestModelEntries(body []byte) (map[string]json.RawMessage, error) {
+	var envelope struct {
+		Models []json.RawMessage `json:"models"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	models := make(map[string]json.RawMessage, len(envelope.Models))
+	for _, rawModel := range envelope.Models {
+		var descriptor struct {
+			Slug string `json:"slug"`
+		}
+		if err := json.Unmarshal(rawModel, &descriptor); err != nil {
+			continue
+		}
+		slug := strings.TrimSpace(descriptor.Slug)
+		if slug == "" {
+			continue
+		}
+		models[slug] = append([]byte(nil), rawModel...)
+	}
+	return models, nil
+}
+
+func codexManifestModelWithSlug(rawModel json.RawMessage, slug string) (json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawModel, &fields); err != nil {
+		return nil, err
+	}
+	encodedSlug, err := json.Marshal(strings.TrimSpace(slug))
+	if err != nil {
+		return nil, err
+	}
+	fields["slug"] = encodedSlug
+	return json.Marshal(fields)
 }
 
 func buildCodexModelsManifestForAccounts(
@@ -787,6 +923,24 @@ func buildCodexModelsManifestForAccounts(
 	accounts []Account,
 	compositeRoutes []CompositeModelRoute,
 	compositeRoutesAvailable bool,
+) ([]byte, error) {
+	return buildCodexModelsManifestForAccountsWithRaw(
+		effectivePlatform,
+		modelIDs,
+		accounts,
+		compositeRoutes,
+		compositeRoutesAvailable,
+		nil,
+	)
+}
+
+func buildCodexModelsManifestForAccountsWithRaw(
+	effectivePlatform string,
+	modelIDs []string,
+	accounts []Account,
+	compositeRoutes []CompositeModelRoute,
+	compositeRoutesAvailable bool,
+	rawModels map[string]json.RawMessage,
 ) ([]byte, error) {
 	imageInputModels := make(map[string]bool, len(modelIDs))
 	metadataModels := codexCatalogMetadataModels(
@@ -818,7 +972,7 @@ func buildCodexModelsManifestForAccounts(
 			modelMetadata[modelID] = metadata
 		}
 	}
-	return buildCodexModelsManifest(modelIDs, imageInputModels, metadataModels, modelMetadata)
+	return buildCodexModelsManifestWithRaw(modelIDs, imageInputModels, metadataModels, modelMetadata, rawModels)
 }
 
 func buildCodexModelsManifest(
@@ -827,8 +981,18 @@ func buildCodexModelsManifest(
 	metadataModels map[string]string,
 	modelMetadata map[string]codexModelMetadataOverride,
 ) ([]byte, error) {
+	return buildCodexModelsManifestWithRaw(modelIDs, imageInputModels, metadataModels, modelMetadata, nil)
+}
+
+func buildCodexModelsManifestWithRaw(
+	modelIDs []string,
+	imageInputModels map[string]bool,
+	metadataModels map[string]string,
+	modelMetadata map[string]codexModelMetadataOverride,
+	rawModels map[string]json.RawMessage,
+) ([]byte, error) {
 	seen := make(map[string]struct{}, len(modelIDs))
-	models := make([]configuredCodexModelDescriptor, 0, len(modelIDs))
+	models := make([]json.RawMessage, 0, len(modelIDs))
 	for _, modelID := range modelIDs {
 		modelID = strings.TrimSpace(modelID)
 		if modelID == "" {
@@ -845,6 +1009,10 @@ func buildCodexModelsManifest(
 			continue
 		}
 		seen[modelID] = struct{}{}
+		if rawModel, ok := rawModels[modelID]; ok {
+			models = append(models, append([]byte(nil), rawModel...))
+			continue
+		}
 		descriptor := newConfiguredCodexModelDescriptor(metadataModelID)
 		descriptor.Slug = modelID
 		if imageInputModels[modelID] {
@@ -857,10 +1025,14 @@ func buildCodexModelsManifest(
 			descriptor.DisplayName = modelID
 			descriptor.Description = configuredCodexCustomDescription
 		}
-		models = append(models, descriptor)
+		rawDescriptor, err := json.Marshal(descriptor)
+		if err != nil {
+			return nil, err
+		}
+		models = append(models, rawDescriptor)
 	}
 	return json.Marshal(struct {
-		Models []configuredCodexModelDescriptor `json:"models"`
+		Models []json.RawMessage `json:"models"`
 	}{Models: models})
 }
 

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -266,6 +266,187 @@ func TestBuildCodexModelsManifestForCompositePreservesRawOpenAIFieldsForAlias(t 
 	require.Equal(t, map[string]any{"mode": "preserved"}, models[0]["future_capability"])
 }
 
+func TestBuildCodexModelsManifestForCompositeAcceptsSemanticallyIdenticalRawDescriptors(t *testing.T) {
+	const groupID int64 = 145
+	newAccount := func(id int64) Account {
+		return Account{
+			ID:       id,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{"gpt-5.6-sol": "gpt-5.6-sol"},
+			},
+		}
+	}
+	first := newAccount(48)
+	second := newAccount(49)
+	fetcher := &rawOpenAIModelCatalogFetcherStub{catalogs: map[int64]*gatewayUpstreamModelCatalog{
+		first.ID: {
+			models:  []string{"gpt-5.6-sol"},
+			rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","display_name":"Official GPT-5.6 Sol","future_capability":{"enabled":true,"limit":12345678901234567890},"raw_only_field":true}]}`),
+		},
+		second.ID: {
+			models:  []string{"gpt-5.6-sol"},
+			rawBody: []byte(`{"models":[{"raw_only_field":true,"future_capability":{"limit":12345678901234567890,"enabled":true},"display_name":"Official GPT-5.6 Sol","slug":"gpt-5.6-sol"}]}`),
+		},
+	}}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {first, second}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformComposite},
+		"",
+		[]string{"gpt-5.6-sol"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, true, models[0]["raw_only_field"])
+	require.Contains(t, string(body), "12345678901234567890")
+}
+
+func TestBuildCodexModelsManifestForCompositeRejectsRawFieldsForCrossPlatformAlias(t *testing.T) {
+	const groupID int64 = 142
+	openAIAccount := Account{
+		ID:       43,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"shared-alias": "gpt-5.6-sol"},
+		},
+	}
+	grokAccount := Account{
+		ID:       44,
+		Platform: PlatformGrok,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"shared-alias": "grok-4.6"},
+		},
+	}
+	fetcher := &rawOpenAIModelCatalogFetcherStub{catalogs: map[int64]*gatewayUpstreamModelCatalog{
+		openAIAccount.ID: {
+			models:  []string{"gpt-5.6-sol"},
+			rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","raw_only_field":true,"input_modalities":["text","image"]}]}`),
+		},
+	}}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {openAIAccount, grokAccount}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformComposite},
+		"",
+		[]string{"shared-alias"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	_, rawFieldPresent := models[0]["raw_only_field"]
+	require.False(t, rawFieldPresent)
+	require.Equal(t, []any{"text"}, models[0]["input_modalities"])
+}
+
+func TestBuildCodexModelsManifestForCompositeFallsBackToIntersectedCapabilities(t *testing.T) {
+	const groupID int64 = 143
+	reasoning := true
+	newAccount := func(id int64, levels, modalities []string, contextWindow int64) Account {
+		account := Account{
+			ID:       id,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{"team-gpt": "gpt-5.6-sol"},
+			},
+		}
+		account.SetUpstreamModelMetadataSnapshot(UpstreamModelMetadataSnapshot{Models: map[string]UpstreamModelMetadata{
+			"gpt-5.6-sol": {
+				ID:                       "gpt-5.6-sol",
+				Reasoning:                &reasoning,
+				SupportedReasoningLevels: levels,
+				InputModalities:          modalities,
+				ContextWindow:            contextWindow,
+			},
+		}})
+		return account
+	}
+	first := newAccount(45, []string{"low", "high"}, []string{"text", "image"}, 256_000)
+	second := newAccount(46, []string{"high", "max"}, []string{"text"}, 128_000)
+	fetcher := &rawOpenAIModelCatalogFetcherStub{catalogs: map[int64]*gatewayUpstreamModelCatalog{
+		first.ID: {
+			models:  []string{"gpt-5.6-sol"},
+			rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","raw_only_field":true,"supported_reasoning_levels":[{"effort":"low"},{"effort":"high"}],"input_modalities":["text","image"],"context_window":256000}]}`),
+		},
+		second.ID: {
+			models:  []string{"gpt-5.6-sol"},
+			rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","raw_only_field":true,"supported_reasoning_levels":[{"effort":"high"},{"effort":"max"}],"input_modalities":["text"],"context_window":128000}]}`),
+		},
+	}}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {first, second}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformComposite},
+		"",
+		[]string{"team-gpt"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	_, rawFieldPresent := models[0]["raw_only_field"]
+	require.False(t, rawFieldPresent)
+	require.Equal(t, []string{"high"}, effortsFromManifestModel(t, models[0]))
+	require.Equal(t, []any{"text"}, models[0]["input_modalities"])
+	require.EqualValues(t, 128_000, models[0]["context_window"])
+}
+
+func TestBuildCodexModelsManifestForCompositeMakesExplicitRawAutoModelVisible(t *testing.T) {
+	const groupID int64 = 144
+	account := Account{
+		ID:       47,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"codex-auto-review": "codex-auto-review"},
+		},
+	}
+	fetcher := &rawOpenAIModelCatalogFetcherStub{catalogs: map[int64]*gatewayUpstreamModelCatalog{
+		account.ID: {
+			models:  []string{"codex-auto-review"},
+			rawBody: []byte(`{"models":[{"slug":"codex-auto-review","visibility":"hide","raw_only_field":true}]}`),
+		},
+	}}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {account}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{
+			ID:       groupID,
+			Platform: PlatformComposite,
+			ModelsListConfig: GroupModelsListConfig{
+				Enabled: true,
+				Models:  []string{"codex-auto-review"},
+			},
+		},
+		"",
+		[]string{"codex-auto-review"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, "list", models[0]["visibility"])
+	require.Equal(t, true, models[0]["raw_only_field"])
+}
+
 func decodeCodexManifestModels(t *testing.T, body []byte) []map[string]any {
 	t.Helper()
 

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -171,6 +171,101 @@ func TestFilterCodexModelIDsForGroupOmitsWildcardKeys(t *testing.T) {
 	require.Equal(t, []string{"deepseek-v4-pro", "gpt-5.5"}, got)
 }
 
+type rawOpenAIModelCatalogFetcherStub struct {
+	catalogs map[int64]*gatewayUpstreamModelCatalog
+}
+
+func (s *rawOpenAIModelCatalogFetcherStub) FetchUpstreamSupportedModels(_ context.Context, account *Account) ([]string, error) {
+	catalog := s.catalogs[account.ID]
+	if catalog == nil {
+		return nil, nil
+	}
+	return cloneStringSlice(catalog.models), nil
+}
+
+func (s *rawOpenAIModelCatalogFetcherStub) fetchUpstreamModelCatalog(_ context.Context, account *Account) (*gatewayUpstreamModelCatalog, error) {
+	return cloneGatewayUpstreamModelCatalog(s.catalogs[account.ID]), nil
+}
+
+func TestBuildCodexModelsManifestForCompositePreservesRawOpenAIModelFields(t *testing.T) {
+	const groupID int64 = 140
+	account := Account{
+		ID:          41,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{"access_token": "oauth-token"},
+	}
+	fetcher := &rawOpenAIModelCatalogFetcherStub{
+		catalogs: map[int64]*gatewayUpstreamModelCatalog{
+			account.ID: {
+				models:  []string{"gpt-5.6-sol"},
+				rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","display_name":"Official GPT-5.6 Sol","description":"Official description","future_capability":{"enabled":true},"input_modalities":["text","image"]}]}`),
+			},
+		},
+	}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {account}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformComposite},
+		"",
+		[]string{"gpt-5.6-sol"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, "Official GPT-5.6 Sol", models[0]["display_name"])
+	require.Equal(t, "Official description", models[0]["description"])
+	require.Equal(t, map[string]any{"enabled": true}, models[0]["future_capability"])
+	require.Equal(t, []any{"text", "image"}, models[0]["input_modalities"])
+	_, generatedFieldPresent := models[0]["shell_type"]
+	require.False(t, generatedFieldPresent, "raw upstream fields should not be replaced by the local descriptor")
+}
+
+func TestBuildCodexModelsManifestForCompositePreservesRawOpenAIFieldsForAlias(t *testing.T) {
+	const groupID int64 = 141
+	account := Account{
+		ID:       42,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"access_token":  "oauth-token",
+			"model_mapping": map[string]any{"team-gpt": "gpt-5.6-sol"},
+		},
+	}
+	fetcher := &rawOpenAIModelCatalogFetcherStub{
+		catalogs: map[int64]*gatewayUpstreamModelCatalog{
+			account.ID: {
+				models:  []string{"gpt-5.6-sol"},
+				rawBody: []byte(`{"models":[{"slug":"gpt-5.6-sol","display_name":"Official GPT-5.6 Sol","future_capability":{"mode":"preserved"}}]}`),
+			},
+		},
+	}
+	svc := &GatewayService{
+		accountRepo:          codexModelsVisibilityAccountRepo{byGroup: map[int64][]Account{groupID: {account}}},
+		upstreamModelFetcher: fetcher,
+	}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformComposite},
+		"",
+		[]string{"team-gpt"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, "team-gpt", models[0]["slug"])
+	require.Equal(t, "Official GPT-5.6 Sol", models[0]["display_name"])
+	require.Equal(t, map[string]any{"mode": "preserved"}, models[0]["future_capability"])
+}
+
 func decodeCodexManifestModels(t *testing.T, body []byte) []map[string]any {
 	t.Helper()
 

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -1358,6 +1358,77 @@ func TestBuildGroupConfiguredCodexModelsManifestFallsThroughWithoutConfiguration
 	require.Nil(t, manifest)
 }
 
+func TestBuildGroupConfiguredCodexModelsManifestFallsThroughWhenOnlyShadowHasMapping(t *testing.T) {
+	t.Parallel()
+
+	const groupID int64 = 81
+	parentID := int64(51)
+	svc := &OpenAIGatewayService{accountRepo: codexModelsVisibilityAccountRepo{
+		byGroup: map[int64][]Account{
+			groupID: {
+				{
+					ID:       parentID,
+					Platform: PlatformOpenAI,
+					Type:     AccountTypeOAuth,
+				},
+				{
+					ID:              52,
+					Platform:        PlatformOpenAI,
+					Type:            AccountTypeOAuth,
+					ParentAccountID: &parentID,
+					QuotaDimension:  QuotaDimensionSpark,
+					Credentials: map[string]any{
+						"model_mapping": map[string]any{
+							"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	manifest, configured, err := svc.BuildGroupConfiguredCodexModelsManifest(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformOpenAI},
+		"",
+	)
+	require.NoError(t, err)
+	require.False(t, configured)
+	require.Nil(t, manifest)
+}
+
+func TestBuildGroupConfiguredCodexModelsManifestKeepsShadowOnlyGroupConfigured(t *testing.T) {
+	t.Parallel()
+
+	const groupID int64 = 82
+	parentID := int64(61)
+	svc := &OpenAIGatewayService{accountRepo: codexModelsVisibilityAccountRepo{
+		byGroup: map[int64][]Account{
+			groupID: {{
+				ID:              62,
+				Platform:        PlatformOpenAI,
+				Type:            AccountTypeOAuth,
+				ParentAccountID: &parentID,
+				QuotaDimension:  QuotaDimensionSpark,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{
+						"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+					},
+				},
+			}},
+		},
+	}}
+
+	manifest, configured, err := svc.BuildGroupConfiguredCodexModelsManifest(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformOpenAI},
+		"",
+	)
+	require.NoError(t, err)
+	require.True(t, configured)
+	require.Equal(t, []string{"gpt-5.3-codex-spark"}, codexManifestModelSlugs(t, manifest.Body))
+}
+
 func TestMergeGroupConfiguredCodexModelsFiltersAutoReviewByDefault(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_gateway_model_availability.go
+++ b/backend/internal/service/openai_gateway_model_availability.go
@@ -57,10 +57,10 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 	for i := range accounts {
 		diag.HasAccountsInPool = true
 		// Mirrors the per-candidate filter used during account selection
-		// (openai_account_scheduler.isAccountRequestCompatible): empty
-		// model_mapping accepts everything; otherwise the explicit / wildcard
-		// mapping must match.
-		if accounts[i].IsModelSupported(requestedModel) {
+		// (openai_account_scheduler.isAccountRequestCompatible): explicit mappings
+		// stay authoritative, while an empty mapping is narrowed only when a
+		// successful account-level upstream catalog is cached.
+		if s.isModelSupportedByAccountForRequest(ctx, &accounts[i], requestedModel) {
 			diag.HasModelSupport = true
 			return diag
 		}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -380,6 +380,26 @@ func openAICompatibleAccountEligibilityFailureReason(ctx context.Context, accoun
 	return ""
 }
 
+func (s *OpenAIGatewayService) openAICompatibleAccountEligibilityFailureReason(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) string {
+	if reason := openAICompatibleAccountEligibilityFailureReasonBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability); reason != "" {
+		return reason
+	}
+	if requestedModel != "" && !s.isModelSupportedByAccountForRequest(ctx, account, requestedModel) {
+		return "model_not_supported"
+	}
+	if vetoed, reason := openAIProfitControlVetoReason(ctx, account); vetoed {
+		return reason
+	}
+	return ""
+}
+
+func (s *OpenAIGatewayService) isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
+	if reason := openAICompatibleAccountEligibilityFailureReasonBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability); reason != "" {
+		return false
+	}
+	return requestedModel == "" || s.isModelSupportedByAccountForRequest(ctx, account, requestedModel)
+}
+
 // isOpenAICompatibleAccountEligibleForRequestBeforeProfit applies every
 // ordinary scheduling gate. Legacy selection uses it before classifying the
 // profit veto so earlier failures retain their actual reason.
@@ -1254,7 +1274,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		// Scheduler snapshots can be temporarily stale (bucket rebuild is throttled);
 		// re-check schedulability here so recently rate-limited/overloaded accounts
 		// are not selected again before the bucket is rebuilt.
-		if reason := openAICompatibleAccountEligibilityFailureReason(ctx, acc, platform, requestedModel, false, requiredCapability); reason != "" {
+		if reason := s.openAICompatibleAccountEligibilityFailureReason(ctx, acc, platform, requestedModel, false, requiredCapability); reason != "" {
 			filterStats.exclude(reason)
 			continue
 		}
@@ -1534,7 +1554,7 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountBeforeProfit(
 		fresh = current
 	}
 
-	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
+	if !s.isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
@@ -1586,7 +1606,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfit(ct
 		if s.openAIGroupRequiresPrivacySet(ctx, groupID) && !account.IsPrivacySet() {
 			return nil
 		}
-		if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
+		if !s.isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability) {
 			return nil
 		}
 		if s.isOpenAIAccountBlockedBySchedulingThreshold(ctx, account) {
@@ -1611,7 +1631,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBeforeProfit(ct
 	if s.openAIGroupRequiresPrivacySet(ctx, groupID) && !latest.IsPrivacySet() {
 		return nil
 	}
-	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
+	if !s.isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
 	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -393,18 +393,14 @@ func (s *OpenAIGatewayService) openAICompatibleAccountEligibilityFailureReason(c
 	return ""
 }
 
+// isOpenAICompatibleAccountEligibleForRequestBeforeProfit applies every
+// ordinary scheduling gate. Legacy selection uses it before classifying the
+// profit veto so earlier failures retain their actual reason.
 func (s *OpenAIGatewayService) isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
 	if reason := openAICompatibleAccountEligibilityFailureReasonBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability); reason != "" {
 		return false
 	}
 	return requestedModel == "" || s.isModelSupportedByAccountForRequest(ctx, account, requestedModel)
-}
-
-// isOpenAICompatibleAccountEligibleForRequestBeforeProfit applies every
-// ordinary scheduling gate. Legacy selection uses it before classifying the
-// profit veto so earlier failures retain their actual reason.
-func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
-	return openAICompatibleAccountEligibilityFailureReasonBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability) == ""
 }
 
 func openAICompatibleAccountEligibilityFailureReasonBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) string {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -579,7 +579,7 @@ func (s *OpenAIGatewayService) setUpstreamModelAvailabilityResolver(resolver ups
 // IsModelSupportedByAccount applies configured mappings plus any successfully
 // cached account-level upstream catalog used by model discovery.
 func (s *OpenAIGatewayService) IsModelSupportedByAccount(account *Account, requestedModel string) bool {
-	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+	return s.isModelSupportedByAccountForRequest(context.Background(), account, requestedModel)
 }
 
 func (s *OpenAIGatewayService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -451,6 +451,7 @@ type OpenAIGatewayService struct {
 	userPlatformQuotaRepo UserPlatformQuotaRepository
 	liveAttestation       liveattestation.Provider
 	liveAttestationCipher SecretEncryptor
+	upstreamModelResolver upstreamModelAvailabilityResolver
 
 	openaiWSPoolOnce               sync.Once
 	openaiWSStateStoreOnce         sync.Once
@@ -567,6 +568,26 @@ func NewOpenAIGatewayService(
 	}
 	svc.logOpenAIWSModeBootstrap()
 	return svc
+}
+
+func (s *OpenAIGatewayService) setUpstreamModelAvailabilityResolver(resolver upstreamModelAvailabilityResolver) {
+	if s != nil {
+		s.upstreamModelResolver = resolver
+	}
+}
+
+// IsModelSupportedByAccount applies configured mappings plus any successfully
+// cached account-level upstream catalog used by model discovery.
+func (s *OpenAIGatewayService) IsModelSupportedByAccount(account *Account, requestedModel string) bool {
+	return s.isModelSupportedByAccountForRequest(nil, account, requestedModel)
+}
+
+func (s *OpenAIGatewayService) isModelSupportedByAccountForRequest(ctx context.Context, account *Account, requestedModel string) bool {
+	if account == nil || !account.IsModelSupported(requestedModel) {
+		return false
+	}
+	return s == nil || s.upstreamModelResolver == nil ||
+		s.upstreamModelResolver.supportsDiscoveredUpstreamModelForRequest(ctx, account, requestedModel)
 }
 
 // ResolveChannelMapping 解析渠道级模型映射（代理到 ChannelService）

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -571,7 +571,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
 	}
-	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
+	if requestedModel != "" && !s.isModelSupportedByAccountForRequest(ctx, account, requestedModel) {
 		return 0, nil, "", nil
 	}
 	if !account.SupportsOpenAIEndpointCapability(requiredCapability) {
@@ -610,7 +610,7 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 			return 0, nil, "", nil
 		}
-		if requestedModel != "" && !latest.IsModelSupported(requestedModel) {
+		if requestedModel != "" && !s.isModelSupportedByAccountForRequest(ctx, latest, requestedModel) {
 			return 0, nil, "", nil
 		}
 		if !latest.SupportsOpenAIEndpointCapability(requiredCapability) {

--- a/backend/internal/service/upstream_models.go
+++ b/backend/internal/service/upstream_models.go
@@ -188,11 +188,26 @@ func newUpstreamModelSyncInternalError(message string, err error) error {
 	return &UpstreamModelSyncError{Kind: UpstreamModelSyncErrorInternal, Message: message, Err: err}
 }
 
-// FetchUpstreamSupportedModels fetches only live model IDs. The admin sync path
-// uses SyncUpstreamModelCatalog so capability metadata can also be persisted.
+func (s *AccountTestService) fetchUpstreamModelCatalog(ctx context.Context, account *Account) (*gatewayUpstreamModelCatalog, error) {
+	models, body, err := s.fetchUpstreamModelList(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	return &gatewayUpstreamModelCatalog{
+		models:  dedupeAndSortModelIDs(models),
+		rawBody: append([]byte(nil), body...),
+	}, nil
+}
+
+// FetchUpstreamSupportedModels fetches only live model IDs. The gateway also
+// uses the shared internal catalog method above when it needs raw Codex model
+// descriptors for an OpenAI OAuth account.
 func (s *AccountTestService) FetchUpstreamSupportedModels(ctx context.Context, account *Account) ([]string, error) {
-	models, _, err := s.fetchUpstreamModelList(ctx, account)
-	return models, err
+	catalog, err := s.fetchUpstreamModelCatalog(ctx, account)
+	if err != nil || catalog == nil {
+		return nil, err
+	}
+	return catalog.models, nil
 }
 
 // SyncUpstreamModelCatalog fetches the account's live model list, enriches

--- a/backend/internal/service/upstream_models_test.go
+++ b/backend/internal/service/upstream_models_test.go
@@ -229,6 +229,31 @@ func TestFetchUpstreamSupportedModelsParsesOpenAIOAuthManifest(t *testing.T) {
 	require.Equal(t, "Bearer openai-oauth-token", upstream.lastReq.Header.Get("Authorization"))
 }
 
+func TestFetchUpstreamModelCatalogPreservesOpenAIOAuthManifestBody(t *testing.T) {
+	rawBody := `{"models":[{"slug":"gpt-5.6-sol","future_capability":{"enabled":true}}]}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(rawBody)),
+	}}
+	svc := &AccountTestService{
+		httpUpstream: upstream,
+		cfg:          upstreamModelSyncTestConfig(),
+	}
+
+	catalog, err := svc.fetchUpstreamModelCatalog(context.Background(), &Account{
+		ID:       13,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "openai-oauth-token",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6-sol"}, catalog.models)
+	require.Equal(t, []byte(rawBody), catalog.rawBody)
+}
+
 func TestExtractGrokUpstreamModelIDs(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -253,6 +253,7 @@ func ProvideAccountTestService(
 	cfg *config.Config,
 	tlsFPProfileService *TLSFingerprintProfileService,
 	openAIGatewayService *OpenAIGatewayService,
+	gatewayService *GatewayService,
 	settingService *SettingService,
 	pluginManager *PluginManager,
 ) *AccountTestService {
@@ -269,6 +270,9 @@ func ProvideAccountTestService(
 	service.agentIdentityWS = openAIGatewayService
 	service.SetSettingService(settingService)
 	service.SetPluginManager(pluginManager)
+	if gatewayService != nil {
+		gatewayService.SetUpstreamModelFetcher(service)
+	}
 	return service
 }
 

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -254,6 +254,7 @@ func ProvideAccountTestService(
 	tlsFPProfileService *TLSFingerprintProfileService,
 	openAIGatewayService *OpenAIGatewayService,
 	gatewayService *GatewayService,
+	geminiMessagesCompatService *GeminiMessagesCompatService,
 	settingService *SettingService,
 	pluginManager *PluginManager,
 ) *AccountTestService {
@@ -272,6 +273,12 @@ func ProvideAccountTestService(
 	service.SetPluginManager(pluginManager)
 	if gatewayService != nil {
 		gatewayService.SetUpstreamModelFetcher(service)
+		if openAIGatewayService != nil {
+			openAIGatewayService.setUpstreamModelAvailabilityResolver(gatewayService)
+		}
+		if geminiMessagesCompatService != nil {
+			geminiMessagesCompatService.setUpstreamModelAvailabilityResolver(gatewayService)
+		}
 	}
 	return service
 }


### PR DESCRIPTION
## 概述

本 PR 为 Composite 分组增加 OpenAI Codex 原始模型描述复用能力。

当 Composite 模型能够安全、唯一地路由到一致的 OpenAI OAuth 上游时，
模型 Manifest 将保留 OpenAI 返回的完整 raw descriptor，包括本地模板
尚未识别的字段。无法确认组内一致性时，继续使用现有的本地生成与能力求交逻辑。

同时完善上游模型目录发现、Manifest 账号选择和账号级模型调度，确保模型列表、
实际路由和 Codex 客户端展示保持一致。

## 主要改动

### 保留上游原始模型描述

上游模型目录结果现在同时包含：

- 去重排序后的模型 ID
- 上游返回的原始响应体

普通模型列表继续使用模型 ID；Composite Codex Manifest 可以从原始响应中提取
完整的模型 descriptor。

### 获取并复用 OpenAI raw descriptor

模型目录请求首先获取各账号的上游 catalog。一次 catalog 响应中同时包含：

- 上游模型 ID
- 每个模型的 raw descriptor

系统先汇总模型 ID，得到分组可展示的模型列表。生成 Composite Codex
Manifest 时，再根据 Composite 路由和账号 mapping 找出每个公开模型的
实际候选账号，并检查这些账号已经返回的 raw descriptor。

满足以下条件时，复用上游 raw descriptor：

- 该公开模型只会路由到 OpenAI
- 所有实际候选账号均为 OpenAI OAuth
- 所有候选账号指向同一个上游模型
- 每个候选账号的 catalog 都包含该模型
- 各账号返回的 descriptor 在 JSON 语义上完全一致

满足条件时，各账号对该模型的描述相同，任取一份 raw descriptor 都能准确
代表整个分组。模型使用公开别名时，只替换 `slug`，其他上游字段保持不变。

如果候选账号来自不同平台、指向不同模型，或者返回的 descriptor 不一致，
则不采用任何单个账号的 raw 数据，回退到本地生成并对账号能力进行保守求交。

### 不一致时保守回退

出现以下情况时，不复用任意单个账号的 raw descriptor：

- 同一公开模型可能路由到多个平台
- 不同账号映射到不同上游模型
- 候选账号类型不一致
- 任一账号缺少对应 descriptor
- descriptor 的字段或能力声明不同
- Composite 路由信息无法可靠解析

此时回退到原有本地 Manifest 生成逻辑，并对所有候选账号执行能力求交，
避免向 Codex 客户端声明实际无法稳定提供的能力。

### 优先使用主账号获取 OpenAI Manifest

OpenAI 分组获取实时 Codex Manifest 时：

- 优先选择非影子的凭据主账号
- 没有可用主账号时才回退到影子账号
- 主账号未配置 mapping 时，Spark 影子账号的系统生成 mapping 不再阻止实时上游目录获取

### 完善模型目录发现

对于未配置 `model_mapping` 的账号，从上游实时发现可用模型。

发现过程增加以下约束：

- 单次客户端模型目录请求总超时为 10 秒
- 最多并发探测 4 个账号
- Composite 各平台共享同一个请求 deadline
- 相同账号的并发探测通过 singleflight 合并
- singleflight 等待者可以响应自身 context 取消
- 仅缓存成功结果，失败结果后续可以重新探测

如果没有配置或成功发现任何模型，继续回退到对应平台的默认模型列表。

### 对齐模型列表与账号调度

组模型列表继续展示所有账号模型的并集。

账号调度时：

- 已成功缓存 catalog 的未映射账号，按 catalog 严格过滤模型
- catalog 尚未获取或获取失败时保持 fail-open
- 显式 `model_mapping` 继续以管理员配置为准
- OpenAI passthrough 继续交由上游判断模型
- 渠道映射和 compact mapping 按最终实际转发模型校验 catalog

该约束覆盖通用网关、OpenAI 调度器、Gemini 兼容调度、粘性账号、
previous response 复用、DB 终检和 WebSocket 模型切换。

### 修正自动模型可见性

管理员在组自定义模型列表中显式启用 `codex-auto-*` 模型时：

- 将 raw descriptor 的 `visibility` 修正为 `list`
- 保留 descriptor 的其他原始字段
- 未显式启用的自动模型继续按现有规则过滤

## 最终行为

- 安全且一致的 OpenAI Composite 模型：使用完整上游 raw descriptor
- 混合平台或能力不一致的模型：使用本地保守生成结果
- 模型列表：展示账号模型并集
- 账号调度：优先依据已知账号 catalog 精确过滤
- 上游发现失败：保持 fail-open，并允许后续重新探测
- 无可用发现结果：回退平台默认模型列表

## 验证

- [x] `go test ./...`
- [x] 受影响服务用例通过 `-race`
- [x] `go vet ./internal/service ./internal/handler ./cmd/server`
- [x] `git diff --check`