### PR TITLE
fix(openai-ws): reject passthrough close before terminal event

### DIFF
--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -533,17 +533,26 @@ func runUpstreamToClient(
 		msgType, payload, err := upstreamConn.ReadFrame(ctx)
 		if err != nil {
 			emitTurnComplete(onTurnComplete, state, finalizePendingBareError(state, nowFn()))
+			graceful := isDisconnectError(err)
+			// A clean WebSocket close only describes the transport handshake. Once
+			// the upstream has started a Responses turn, success still requires a
+			// terminal protocol event. Treat an early 1000/EOF as a relay failure so
+			// the adapter does not report relay_completed with an active turn.
+			if graceful && openAIWSRelayActiveTurnID(state) != "" {
+				graceful = false
+				err = errors.New("upstream websocket closed before terminal event: " + err.Error())
+			}
 			emitRelayTrace(onTrace, RelayTraceEvent{
 				Stage:           "read_upstream_failed",
 				Direction:       "upstream_to_client",
 				Error:           err.Error(),
-				Graceful:        isDisconnectError(err),
+				Graceful:        graceful,
 				WroteDownstream: wroteDownstream,
 			})
 			exitCh <- relayExitSignal{
 				stage:           "read_upstream",
 				err:             err,
-				graceful:        isDisconnectError(err),
+				graceful:        graceful,
 				wroteDownstream: wroteDownstream,
 			}
 			return

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -41,6 +41,11 @@ type closeSpyFrameConn struct {
 	closeCalls atomic.Int32
 }
 
+type eofReplacementFrameConn struct {
+	FrameConn
+	err error
+}
+
 type cancelJoinProbeFrameConn struct {
 	readStarted  chan struct{}
 	readCanceled chan struct{}
@@ -63,6 +68,14 @@ func newPassthroughTestFrameConn(frames []passthroughTestFrame, autoClose bool) 
 		close(c.readCh)
 	}
 	return c
+}
+
+func (c *eofReplacementFrameConn) ReadFrame(ctx context.Context) (coderws.MessageType, []byte, error) {
+	msgType, payload, err := c.FrameConn.ReadFrame(ctx)
+	if errors.Is(err, io.EOF) {
+		return msgType, payload, c.err
+	}
+	return msgType, payload, err
 }
 
 func (c *passthroughTestFrameConn) ReadFrame(ctx context.Context) (coderws.MessageType, []byte, error) {
@@ -299,6 +312,38 @@ func TestRelay_UpstreamDisconnect(t *testing.T) {
 	// 上游 EOF 属于 disconnect，标记为 graceful
 	require.Nil(t, relayExit, "上游 EOF 应被视为 graceful disconnect")
 	require.Equal(t, "gpt-4o", result.RequestModel)
+}
+
+func TestRelay_UpstreamNormalCloseBeforeTerminalIsFailure(t *testing.T) {
+	t.Parallel()
+
+	clientConn := newPassthroughTestFrameConn(nil, false)
+	upstreamConn := &eofReplacementFrameConn{
+		FrameConn: newPassthroughTestFrameConn([]passthroughTestFrame{
+			{
+				msgType: coderws.MessageText,
+				payload: []byte(`{"type":"response.created","response":{"id":"resp_incomplete","status":"in_progress"}}`),
+			},
+			{
+				msgType: coderws.MessageText,
+				payload: []byte(`{"type":"response.in_progress","response":{"id":"resp_incomplete","status":"in_progress"}}`),
+			},
+		}, true),
+		err: coderws.CloseError{Code: coderws.StatusNormalClosure},
+	}
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-5.6-sol","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{})
+	require.NotNil(t, relayExit)
+	require.Equal(t, "read_upstream", relayExit.Stage)
+	require.False(t, relayExit.Graceful)
+	require.True(t, relayExit.WroteDownstream)
+	require.ErrorContains(t, relayExit.Err, "upstream websocket closed before terminal event")
+	require.Empty(t, result.TerminalEventType)
+	require.Len(t, clientConn.Writes(), 2)
 }
 
 func TestRelay_ClientDisconnect(t *testing.T) {


### PR DESCRIPTION
## Problem

In OpenAI WS v2 passthrough mode, an upstream can emit `response.created` / `response.in_progress` and then close with WebSocket status 1000 before any terminal event.

`isDisconnectError` classifies that transport close as graceful. The relay therefore returns success even though an active Responses turn is still pending. The adapter then logs a misleading result such as:

```text
relay_complete graceful=true wrote_downstream=true
relay_completed request_id=- terminal_event=- turns=0
```

Strict Responses clients correctly reject the downstream stream because it ended before `response.completed`, but Sub2API records the relay as completed and sends a normal close.

This is the WebSocket passthrough counterpart of the missing-terminal behavior discussed in #2245 and #3084. It is separate from the passthrough session-preemption bug fixed by #6386.

## Fix

When the relay has already recognized an active Responses turn, a disconnect before a terminal event is no longer treated as graceful completion, even if the transport close code is 1000.

The relay now returns a non-graceful `read_upstream` exit with an explicit `upstream websocket closed before terminal event` error. Existing adapter behavior can then report the failed turn and close with an error instead of recording `relay_completed` with an empty terminal event.

Normal closes after a terminal event remain successful. Client disconnect and opaque binary-frame passthrough behavior are unchanged.

## Tests

- Added a regression test for `response.created` + `response.in_progress` + status 1000 without a terminal event.
- `go test ./internal/service/openai_ws_v2 -count=1`
- `go test ./internal/service -run '^TestPassthroughLifecycle_' -count=1`
- `go test -race ./internal/service/openai_ws_v2 -run '^TestRelay_UpstreamNormalCloseBeforeTerminalIsFailure$' -count=50`
- `git diff --check`
