### PR TITLE
feat(gateway): expose strict model availability

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1143,6 +1143,57 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 	})
 }
 
+const maxModelAvailabilityBatch = 50
+
+// ModelAvailability reports current model schedulability for the authenticated
+// API-key group. Unlike /models, it never falls back to a static catalogue when
+// the live pool is empty.
+func (h *GatewayHandler) ModelAvailability(c *gin.Context) {
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok || apiKey == nil || apiKey.Group == nil {
+		h.errorResponse(c, http.StatusUnauthorized, "invalid_request_error", "API key group is required")
+		return
+	}
+	var body struct {
+		Models []string `json:"models"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Invalid request body")
+		return
+	}
+	seen := make(map[string]struct{}, len(body.Models))
+	models := make([]string, 0, len(body.Models))
+	for _, model := range body.Models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if _, exists := seen[model]; exists {
+			continue
+		}
+		seen[model] = struct{}{}
+		models = append(models, model)
+	}
+	if len(models) == 0 || len(models) > maxModelAvailabilityBatch {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "models must contain between 1 and 50 unique values")
+		return
+	}
+
+	groupID := apiKey.GroupID
+	if groupID == nil {
+		id := apiKey.Group.ID
+		groupID = &id
+	}
+	availability, err := h.gatewayService.CurrentModelAvailabilityForPlatform(
+		c.Request.Context(), groupID, apiKey.Group.Platform, models,
+	)
+	if err != nil {
+		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Model availability is temporarily unavailable")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"object": "model_availability", "data": availability})
+}
+
 // CodexModels returns the effective group model list using the manifest shape
 // expected by Codex custom providers. Official OpenAI groups continue to use
 // OpenAIGatewayHandler.CodexModels so their live upstream metadata is preserved.

--- a/backend/internal/handler/gateway_models_test.go
+++ b/backend/internal/handler/gateway_models_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -68,6 +70,20 @@ func (s *gatewayModelsAccountRepoStub) ListSchedulableByGroupID(ctx context.Cont
 	return out, nil
 }
 
+func (s *gatewayModelsAccountRepoStub) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]service.Account, error) {
+	accounts, err := s.ListSchedulableByGroupID(ctx, groupID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]service.Account, 0, len(accounts))
+	for _, account := range accounts {
+		if account.Platform == platform && account.IsSchedulable() {
+			out = append(out, account)
+		}
+	}
+	return out, nil
+}
+
 func (s *gatewayModelsAccountRepoStub) ListByGroup(ctx context.Context, groupID int64) ([]service.Account, error) {
 	return s.ListSchedulableByGroupID(ctx, groupID)
 }
@@ -105,6 +121,55 @@ func TestDefaultModelIDsForAnthropicExcludeAntigravityGemini(t *testing.T) {
 
 	antigravityIDs := defaultModelIDsForPlatform(service.PlatformAntigravity)
 	require.Contains(t, antigravityIDs, "gemini-2.5-flash")
+}
+
+func TestGatewayModelAvailability_ReturnsOnlyCurrentSchedulability(t *testing.T) {
+	groupID := int64(24)
+	resetAt := time.Now().Add(time.Hour).Format(time.RFC3339)
+	h := newGatewayModelsHandlerForTest(
+		&gatewayModelsAccountRepoStub{
+			byGroup: map[int64][]service.Account{
+				groupID: {
+					{
+						ID:          1,
+						Platform:    service.PlatformOpenAI,
+						Status:      service.StatusActive,
+						Schedulable: true,
+						Credentials: map[string]any{
+							"model_mapping": map[string]any{"gpt-ready": "gpt-ready", "gpt-limited": "gpt-limited"},
+						},
+						Extra: map[string]any{
+							"model_rate_limits": map[string]any{
+								"gpt-limited": map[string]any{"rate_limit_reset_at": resetAt},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/models/availability", strings.NewReader(`{"models":["gpt-ready","gpt-limited","gpt-unknown"]}`))
+	c.Request.Header.Set("content-type", "application/json")
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		GroupID: &groupID,
+		Group:   &service.Group{ID: groupID, Platform: service.PlatformOpenAI},
+	})
+
+	h.ModelAvailability(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got struct {
+		Data []service.ModelAvailability `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, []service.ModelAvailability{
+		{Model: "gpt-ready", Available: true},
+		{Model: "gpt-limited", Available: false},
+		{Model: "gpt-unknown", Available: false},
+	}, got.Data)
 }
 
 // Scenario: non-OpenAI groups return a Codex manifest instead of a standard model list.

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -189,6 +189,7 @@ func RegisterGatewayRoutes(
 	gateway.Use(endpointNorm)
 	gateway.Use(gin.HandlerFunc(apiKeyAuth))
 	gateway.GET("/sub2api/billing", h.Gateway.KeyBillingInfo)
+	gateway.POST("/models/availability", requireGroupAnthropic, h.Gateway.ModelAvailability)
 	gateway.Use(compositeTarget)
 	gateway.Use(requireGroupAnthropic)
 	{

--- a/backend/internal/server/routes/gateway_codex_models_test.go
+++ b/backend/internal/server/routes/gateway_codex_models_test.go
@@ -27,6 +27,20 @@ func TestGatewayRoutesCodexModelsManifestPathIsRegistered(t *testing.T) {
 	require.Equal(t, registered["/v1/models"], registered["/models"], "root alias should use the same platform-aware handler")
 }
 
+func TestGatewayRoutesModelAvailabilityPathIsRegistered(t *testing.T) {
+	router := newGatewayRoutesTestRouter()
+
+	registered := false
+	for _, route := range router.Routes() {
+		if route.Method == http.MethodPost && route.Path == "/v1/models/availability" {
+			registered = true
+			break
+		}
+	}
+
+	require.True(t, registered, "POST /v1/models/availability should be registered")
+}
+
 func TestDispatchCodexModelsGatewayKeepsOnlyOpenAIOnLiveManifestHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {

--- a/backend/internal/server/routes/prompt_audit_route_coverage_test.go
+++ b/backend/internal/server/routes/prompt_audit_route_coverage_test.go
@@ -52,6 +52,7 @@ func TestEveryGatewayPOSTRouteIsClassifiedForPromptAuditCoverage(t *testing.T) {
 	}
 	excluded := map[string]string{
 		"/messages/count_tokens":     "tokenization only; it does not execute a model request",
+		"/models/availability":       "model schedulability lookup with no user prompt",
 		"/images/batches/:id/cancel": "control-plane cancellation with no user prompt",
 		"/stt":                       "speech transcription is not a text-generation prompt",
 		"/custom-voices":             "voice profile management has no model prompt",

--- a/backend/internal/service/gateway_model_availability.go
+++ b/backend/internal/service/gateway_model_availability.go
@@ -23,6 +23,13 @@ type ModelAvailabilityDiagnosis struct {
 	HasModelSupport bool
 }
 
+// ModelAvailability is the current, side-effect-free schedulability of one
+// requested model. It intentionally exposes no account identity or pool size.
+type ModelAvailability struct {
+	Model     string `json:"model"`
+	Available bool   `json:"available"`
+}
+
 // ModelAvailabilityDiagnoser is implemented by gateway services that can
 // report whether the requested model is configured to be served by any
 // account. Both *GatewayService and *OpenAIGatewayService implement this so
@@ -34,6 +41,49 @@ type ModelAvailabilityDiagnoser interface {
 		requestedModel string,
 		platform string,
 	) ModelAvailabilityDiagnosis
+}
+
+// CurrentModelAvailabilityForPlatform applies the same cheap gates used before
+// account selection, without acquiring a concurrency slot or binding a sticky
+// session. It is intended for callers choosing among fallback models.
+func (s *GatewayService) CurrentModelAvailabilityForPlatform(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	models []string,
+) ([]ModelAvailability, error) {
+	accounts, useMixed, err := s.listSchedulableAccounts(ctx, groupID, platform, false)
+	if err != nil {
+		return nil, err
+	}
+	ctx = s.withWindowCostPrefetch(ctx, accounts)
+	ctx = s.withRPMPrefetch(ctx, accounts)
+
+	result := make([]ModelAvailability, 0, len(models))
+	for _, requestedModel := range models {
+		requestedModel = strings.TrimSpace(requestedModel)
+		if requestedModel == "" {
+			continue
+		}
+		available := false
+		for i := range accounts {
+			account := &accounts[i]
+			if !s.isAccountAllowedForPlatform(account, platform, useMixed) ||
+				!s.isAccountSchedulableForSelection(account) ||
+				!s.isGatewayAccountProfitEligible(ctx, account) ||
+				!s.isModelSupportedByAccountWithContext(ctx, account, requestedModel) ||
+				!s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) ||
+				!s.isAccountSchedulableForQuota(account) ||
+				!s.isAccountSchedulableForWindowCost(ctx, account, false) ||
+				!s.isAccountSchedulableForRPM(ctx, account, false) {
+				continue
+			}
+			available = true
+			break
+		}
+		result = append(result, ModelAvailability{Model: requestedModel, Available: available})
+	}
+	return result, nil
 }
 
 // DiagnoseModelAvailabilityForPlatform inspects accounts enabled for scheduling

--- a/backend/internal/service/gateway_model_availability_test.go
+++ b/backend/internal/service/gateway_model_availability_test.go
@@ -249,3 +249,51 @@ func TestDiagnoseModelAvailabilityForPlatform_WrongPlatformFiltersOut(t *testing
 	require.False(t, diag.HasAccountsInPool, "OpenAI route must not see Anthropic accounts in pool")
 	require.False(t, diag.HasModelSupport)
 }
+
+func TestCurrentModelAvailabilityForPlatform_ExcludesUnsupportedAndRateLimitedModels(t *testing.T) {
+	groupID := int64(42)
+	resetAt := time.Now().Add(time.Hour).Format(time.RFC3339)
+	repo := &mockAccountRepoForPlatform{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Status:      StatusActive,
+				Schedulable: true,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gpt-limited": "gpt-limited"},
+				},
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"gpt-limited": map[string]any{"rate_limit_reset_at": resetAt},
+					},
+				},
+			},
+			{
+				ID:          2,
+				Platform:    PlatformOpenAI,
+				Status:      StatusActive,
+				Schedulable: true,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gpt-ready": "gpt-ready"},
+				},
+			},
+		},
+		accountsByID: map[int64]*Account{},
+	}
+	svc := &GatewayService{accountRepo: repo, cfg: testConfig()}
+
+	got, err := svc.CurrentModelAvailabilityForPlatform(
+		context.Background(),
+		&groupID,
+		PlatformOpenAI,
+		[]string{"gpt-limited", "gpt-ready", "gpt-unknown"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []ModelAvailability{
+		{Model: "gpt-limited", Available: false},
+		{Model: "gpt-ready", Available: true},
+		{Model: "gpt-unknown", Available: false},
+	}, got)
+}


### PR DESCRIPTION
## Problem

Clients that fall back across models have no way to ask whether a model can be
served *right now*.

`GET /v1/models` answers a different question: it lists the group's configured
catalogue, and falls back to a static list when the live pool is empty. A model
it returns may still have no schedulable account behind it. So the only way to
find out was to send a real request and read the failure — which costs a round
trip and can burn a retry budget on a model that was never going to work.

## Change

Add `POST /v1/models/availability`. It runs the same cheap gates the scheduler
applies *before* account selection:

- platform allowance (incl. mixed groups)
- schedulability for selection
- profit eligibility
- model support for the account
- per-model scheduling
- quota
- window cost
- RPM

and reports, per requested model, whether at least one account would currently
be eligible.

```http
POST /v1/models/availability
{"models": ["claude-sonnet-4-5", "deepseek-v4-pro"]}
```

```json
{"object": "model_availability", "data": [
  {"model": "claude-sonnet-4-5", "available": true},
  {"model": "deepseek-v4-pro",   "available": false}
]}
```

## Safety / scope

- **Side-effect free.** Acquires no concurrency slot, binds no sticky session,
  mutates no account state. It reuses the window-cost and RPM prefetch contexts
  so a batch costs one pass, not one pass per model.
- **Leaks nothing.** The response carries no account identity, no pool size, no
  per-account reason — only `{model, available}`.
- **Bounded.** Input is trimmed, de-duplicated, and capped at 50 unique models;
  an empty or oversized list is a 400.
- **Same auth surface as the rest of the gateway.** Requires an API key with a
  group, behind the existing `requireGroupAnthropic` guard.

Unlike `/models`, it never falls back to a static catalogue when the live pool
is empty — an unschedulable model reports `false` rather than being listed.

## Tests

- `gateway_model_availability_test.go` — gate composition, per-model isolation
- `gateway_models_test.go` — handler validation (auth, empty list, batch cap,
  de-duplication, response shape)
- `gateway_codex_models_test.go`, `prompt_audit_route_coverage_test.go` — route
  registration coverage

Full backend suite passes on top of current `main` (50 packages, `go test ./...`
exit 0), plus `go build` and `go vet` clean on Go 1.27.0.
