### PR TITLE
fix(openai): end streaming at terminal event instead of waiting for u…

### DIFF
--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -2186,6 +2186,14 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			responseFailedPending = false
 			failureDelivered = true
 		}
+		// Terminal 事件（response.completed / [DONE] 等）随空行完整刷出后不再等上游
+		// EOF：上游在 keep-alive/HTTP2 复用连接上可能拖延关闭连接（观测到 8~46s 不等），
+		// 空等期间只能靠 keepalive 维持，白白拉长尾延迟。usage 已在 terminal 事件中解析。
+		// Codex bare error 序列（error 后可能跟 response.failed 或翻盘的 completed）
+		// 必须继续读取，不适用提前结束。
+		if (sawDone || sawTerminalEvent) && line == "" && !(codexFailureTerminal && sawBareError) {
+			break
+		}
 	}
 	ensureResponseFailedTerminal()
 	if err := documentScanner.Err(); err != nil {

--- a/backend/internal/service/openai_gateway_response_flush_test.go
+++ b/backend/internal/service/openai_gateway_response_flush_test.go
@@ -644,3 +644,47 @@ func waitOpenAIResponseFlushSignal(t *testing.T, signal <-chan struct{}) {
 		t.Fatal("timed out waiting for stream signal")
 	}
 }
+
+// hangingOpenAISSEAfterTerminal 模拟上游在发完 terminal 事件后拖延关闭连接
+// （keep-alive/HTTP2 复用连接上观测到 8~46s 不 EOF）。
+type hangingOpenAISSEAfterTerminal struct {
+	payload   []byte
+	sent      bool
+	release   chan struct{}
+	closeOnce sync.Once
+}
+
+func (r *hangingOpenAISSEAfterTerminal) Read(data []byte) (int, error) {
+	if !r.sent {
+		r.sent = true
+		return copy(data, r.payload), nil
+	}
+	<-r.release
+	return 0, io.EOF
+}
+
+func (r *hangingOpenAISSEAfterTerminal) Close() error {
+	r.closeOnce.Do(func() { close(r.release) })
+	return nil
+}
+
+func TestOpenAIResponseFlush_TerminalEventEndsStreamWithoutEOF(t *testing.T) {
+	body := "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":7,\"output_tokens\":5}}}\n\n"
+	reader := &hangingOpenAISSEAfterTerminal{payload: []byte(body), release: make(chan struct{})}
+	recorder := newOpenAIResponseFlushRecorder()
+	resultCh, errCh := runOpenAIResponseFlushTestAsync(recorder, reader, config.GatewayConfig{StreamKeepaliveInterval: 1, StreamDataIntervalTimeout: 30})
+	t.Cleanup(func() { _ = reader.Close() })
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+		result := <-resultCh
+		require.NotNil(t, result)
+		require.Equal(t, 7, result.usage.InputTokens)
+		require.Equal(t, 5, result.usage.OutputTokens)
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream did not end after terminal event; still waiting for upstream EOF")
+	}
+	gotBody, _ := recorder.snapshot()
+	require.Equal(t, body, gotBody)
+}

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -798,6 +798,12 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			if streamEarlyErr != nil {
 				return resultWithUsage(), streamEarlyErr
 			}
+			// Terminal 事件完整写出后直接结束，不等上游 EOF（见下方异步循环同款说明）。
+			// Codex bare error 序列（error 后可能跟 response.failed 或翻盘的 completed）
+			// 必须继续读取，不适用提前结束。
+			if sawTerminalEvent && !eventInProgress && !(codexFailureTerminal && sawBareError) {
+				return finalizeStream()
+			}
 		}
 		if result, err, done := handleScanErr(documentScanner.Err()); done {
 			return result, err
@@ -876,6 +882,15 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			markEventProcessed(ev)
 			if streamEarlyErr != nil {
 				return resultWithUsage(), streamEarlyErr
+			}
+			// Terminal 事件（response.completed 等）已完整写出后不再等上游 EOF：
+			// 上游在 keep-alive/HTTP2 复用连接上可能拖延关闭连接，空等期间只能
+			// 靠 keepalive 维持，白白拉长尾延迟。usage 已在 terminal 事件中解析。
+			// Codex bare error 序列（error 后可能跟 response.failed 或翻盘的 completed）
+			// 必须继续读取，不适用提前结束。
+			if sawTerminalEvent && !eventInProgress && !(codexFailureTerminal && sawBareError) {
+				_ = resp.Body.Close()
+				return finalizeStream()
 			}
 
 		case <-intervalCh:


### PR DESCRIPTION
     ### Problem                                                                                                                                                                                                                             
                                                                                                                                                                                                                                             
     When relaying a streaming OpenAI Responses request, the gateway treats                                                                                                                                                                  
     upstream connection EOF as the only normal end-of-stream condition.                                                                                                                                                                     
     `response.completed` (and `[DONE]`) only set an internal flag                                                                                                                                                                           
     (`sawTerminalEvent`); the read loop keeps waiting for the upstream to                                                                                                                                                                   
     close the connection.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
     The gateway's upstream transport enables keep-alive / HTTP/2 connection                                                                                                                                                                 
     reuse (`backend/internal/repository/http_upstream.go`,                                                                                                                                                                                  
     `buildUpstreamTransport`). On such reused connections, some upstreams                                                                                                                                                                   
     (relays/reverse proxies in particular) do not close the stream promptly                                                                                                                                                                 
     after the terminal event. Observed in production with packet captures:                                                                                                                                                                  
                                                                                                                                                                                                                                             
     - Upstream sends `response.completed` at ~T+500ms; the response body is                                                                                                                                                                 
       fully delivered.                                                                                                                                                                                                                      
     - The gateway then emits SSE keepalive comments (`:` every                                                                                                                                                                              
       `gateway.stream_keepalive_interval`, default 10s) to the downstream                                                                                                                                                                   
       client for another **8–46s (non-deterministic)** until the upstream                                                                                                                                                                   
       finally closes the connection.                                                                                                                                                                                                        
     - Direct connection to the same upstream (single-use connection) EOFs                                                                                                                                                                   
       immediately after `response.completed`, so the delay only appears                                                                                                                                                                     
       behind the gateway.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
     Impact per streaming request: 8–46s of dead time added to total latency,                                                                                                                                                                
     while holding the upstream connection, downstream connection, goroutine,                                                                                                                                                                
     and the account concurrency slot. Clients that treat stream close as                                                                                                                                                                    
     completion (scripts, agents, tool-call chains) see the full delay, and                                                                                                                                                                  
     clients with read timeouts may misjudge a successful request as failed                                                                                                                                                                  
     and retry. Billing is unaffected (usage is parsed from the terminal                                                                                                                                                                     
     event), but throughput under concurrency is eroded by the piled-up                                                                                                                                                                      
     half-finished requests.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
     ### Root cause                                                                                                                                                                                                                          
                                                                                                                                                                                                                                             
     - `handleStreamingResponseWithReasoning`                                                                                                                                                                                                
       (`openai_gateway_response_handling.go`): the async select loop and the                                                                                                                                                                
       synchronous scan loop only return on events-channel close (EOF), scan                                                                                                                                                                 
       error, or timeout. Terminal events never break the loop.                                                                                                                                                                              
     - `handleStreamingResponsePassthrough`                                                                                                                                                                                                  
       (`openai_gateway_passthrough.go`): same pattern — `for                                                                                                                                                                                
       documentScanner.Scan()` runs until EOF.                                                                                                                                                                                               
     - The WS→HTTP bridge (`openai_ws_http_bridge.go`) already returns                                                                                                                                                                       
       immediately on the terminal event; this PR aligns the HTTP/SSE paths                                                                                                                                                                  
       with that behavior.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
     ### Fix                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
     Once the terminal event frame (`response.completed`, `response.done`,                                                                                                                                                                   
     `response.failed`, `response.incomplete`, `response.cancelled`,                                                                                                                                                                         
     `[DONE]`, …) has been fully written and flushed downstream, finalize the                                                                                                                                                                
     stream immediately instead of waiting for EOF:                                                                                                                                                                                          
                                                                                                                                                                                                                                             
     - Async loop: after processing a line, if `sawTerminalEvent &&                                                                                                                                                                          
       !eventInProgress`, close `resp.Body` (also unblocks the reader                                                                                                                                                                        
       goroutine) and `return finalizeStream()`.                                                                                                                                                                                             
     - Sync loop: same check after each scanned line.                                                                                                                                                                                        
     - Passthrough loop: `break` once a terminal/`[DONE]` event has been                                                                                                                                                                     
       flushed at its blank-line boundary.                                                                                                                                                                                                   
     - Guard: Codex bare-`error` sequences (`error` may be followed by                                                                                                                                                                       
       `response.failed`, or superseded by a later `response.completed`)                                                                                                                                                                     
       keep reading; early finalize is skipped while `codexFailureTerminal &&                                                                                                                                                                
       sawBareError`.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
     Usage is already parsed from the terminal event itself                                                                                                                                                                                  
     (`parseSSEUsageBytes`), so nothing is lost by not draining the rest of                                                                                                                                                                  
     the stream.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                             
     ### Tests                                                                                                                                                                                                                               
                                                                                                                                                                                                                                             
     - New regression test                                                                                                                                                                                                                   
       `TestOpenAIResponseFlush_TerminalEventEndsStreamWithoutEOF`: upstream                                                                                                                                                                 
       sends `response.completed` then hangs without EOF; asserts the handler                                                                                                                                                                
       returns promptly with correct usage and body (previously it would                                                                                                                                                                     
       block until the read timeout).                                                                                                                                                                                                        
     - All existing `OpenAIResponseFlush*` and stream/passthrough tests pass.                                                                                                                                                                
       (`TestForwardStreaming_ServiceTierPropagatedToResult` fails on a clean                                                                                                                                                                
       checkout of `main` too — pre-existing, unrelated to this change.)                                                                                                                                                                     
                                                                                                                                                                                                                                             
     ### Out of scope                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
     The WS passthrough relay                                                                                                                                                                                                                
     (`internal/service/openai_ws_v2/passthrough_relay.go`,                                                                                                                                                                                  
     `runUpstreamToClient`) has the same wait-for-EOF pattern. Left unchanged                                                                                                                                                                
     here to keep the PR focused; happy to follow up if wanted.  