### PR TITLE
feat(anthropic): add per-account Fable scheduling toggle

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1020,6 +1020,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"auto_pause_7d_threshold",
 		"auto_pause_5h_disabled",
 		"auto_pause_7d_disabled",
+		service.AnthropicFableSchedulingEnabledExtraKey,
 		"model_rate_limits",
 		service.UpstreamBillingProbeExtraKey,
 		service.GrokMediaEligibleExtraKey,

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -552,6 +552,25 @@ func TestBuildSchedulerMetadataAccount_KeepsModelRateLimits(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestBuildSchedulerMetadataAccount_KeepsAnthropicFableSchedulingFlag(t *testing.T) {
+	account := service.Account{
+		ID:       91,
+		Platform: service.PlatformAnthropic,
+		Type:     service.AccountTypeOAuth,
+		Extra: map[string]any{
+			service.AnthropicFableSchedulingEnabledExtraKey: false,
+			"unused_large_field":                            "drop-me",
+		},
+	}
+
+	got := buildSchedulerMetadataAccount(account)
+
+	require.Equal(t, false, got.Extra[service.AnthropicFableSchedulingEnabledExtraKey])
+	require.False(t, got.IsModelSupported("claude-fable-5"))
+	require.True(t, got.IsModelSupported("claude-sonnet-5"))
+	require.Nil(t, got.Extra["unused_large_field"])
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsSparkShadowRoutingIdentity(t *testing.T) {
 	parentID := int64(100)
 	account := service.Account{

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -86,7 +86,12 @@ type Account struct {
 
 type OpenAIEndpointCapability string
 
-const openAILongContextBillingEnabledKey = "openai_long_context_billing_enabled"
+const (
+	openAILongContextBillingEnabledKey = "openai_long_context_billing_enabled"
+	// AnthropicFableSchedulingEnabledExtraKey stores the durable administrator
+	// override that controls whether a subscription account may serve Fable.
+	AnthropicFableSchedulingEnabledExtraKey = "anthropic_fable_scheduling_enabled"
+)
 
 const (
 	OpenAIEndpointCapabilityChatCompletions OpenAIEndpointCapability = "chat_completions"
@@ -836,6 +841,16 @@ func resolveRequestedModelInMapping(mapping map[string]string, requestedModel st
 // 请求卡死在该账号上、无法 failover 到真正支持该模型的 API Key 账号（#3662）。
 // 未知/自定义别名仍保持允许（兼容渠道级映射），见 isOpenAIOAuthServableModel。
 func (a *Account) IsModelSupported(requestedModel string) bool {
+	if a == nil {
+		return false
+	}
+	if a.IsAnthropicOAuthOrSetupToken() && !a.IsAnthropicFableSchedulingEnabled() {
+		mappedModel := a.GetMappedModel(requestedModel)
+		if isAnthropicFableModel(requestedModel) || isAnthropicFableModel(mappedModel) {
+			return false
+		}
+	}
+
 	// 透传模式仅替换认证、模型语义完全交由上游决定，因此放行所有模型。
 	// 该短路必须在 model_mapping 判定之前：账号从"白名单模式"切换到透传后，
 	// credentials 里常残留旧的非空 model_mapping，若不在此放行，透传账号会被
@@ -855,6 +870,17 @@ func (a *Account) IsModelSupported(requestedModel string) bool {
 	}
 	normalized := normalizeRequestedModelForLookup(a.Platform, requestedModel)
 	return normalized != requestedModel && mappingSupportsRequestedModel(mapping, normalized)
+}
+
+// IsAnthropicFableSchedulingEnabled reports whether an Anthropic subscription
+// account may participate in Fable scheduling. Missing or malformed values
+// preserve the historical behavior and allow scheduling.
+func (a *Account) IsAnthropicFableSchedulingEnabled() bool {
+	if a == nil || !a.IsAnthropicOAuthOrSetupToken() || a.Extra == nil {
+		return true
+	}
+	enabled, ok := a.Extra[AnthropicFableSchedulingEnabledExtraKey].(bool)
+	return !ok || enabled
 }
 
 // GetMappedModel 获取映射后的模型名（支持通配符，最长优先匹配）

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -159,7 +159,9 @@ func TestAccountIsModelSupported(t *testing.T) {
 	tests := []struct {
 		name           string
 		platform       string
+		typ            string
 		credentials    map[string]any
+		extra          map[string]any
 		requestedModel string
 		expected       bool
 	}{
@@ -174,6 +176,48 @@ func TestAccountIsModelSupported(t *testing.T) {
 			name:           "empty mapping allows all",
 			credentials:    map[string]any{},
 			requestedModel: "any-model",
+			expected:       true,
+		},
+		{
+			name:           "anthropic oauth can disable Fable scheduling",
+			platform:       PlatformAnthropic,
+			typ:            AccountTypeOAuth,
+			extra:          map[string]any{AnthropicFableSchedulingEnabledExtraKey: false},
+			requestedModel: "claude-fable-5[1m]",
+			expected:       false,
+		},
+		{
+			name:           "anthropic setup token Fable switch does not affect Sonnet",
+			platform:       PlatformAnthropic,
+			typ:            AccountTypeSetupToken,
+			extra:          map[string]any{AnthropicFableSchedulingEnabledExtraKey: false},
+			requestedModel: "claude-sonnet-5",
+			expected:       true,
+		},
+		{
+			name:     "anthropic Fable switch checks mapped target",
+			platform: PlatformAnthropic,
+			typ:      AccountTypeOAuth,
+			credentials: map[string]any{
+				"model_mapping": map[string]any{"premium-model": "claude-fable-5"},
+			},
+			extra:          map[string]any{AnthropicFableSchedulingEnabledExtraKey: false},
+			requestedModel: "premium-model",
+			expected:       false,
+		},
+		{
+			name:           "missing Anthropic Fable switch preserves scheduling",
+			platform:       PlatformAnthropic,
+			typ:            AccountTypeOAuth,
+			requestedModel: "claude-fable-5",
+			expected:       true,
+		},
+		{
+			name:           "Anthropic API key ignores subscription Fable switch",
+			platform:       PlatformAnthropic,
+			typ:            AccountTypeAPIKey,
+			extra:          map[string]any{AnthropicFableSchedulingEnabledExtraKey: false},
+			requestedModel: "claude-fable-5",
 			expected:       true,
 		},
 
@@ -237,7 +281,9 @@ func TestAccountIsModelSupported(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			account := &Account{
 				Platform:    tt.platform,
+				Type:        tt.typ,
 				Credentials: tt.credentials,
+				Extra:       tt.extra,
 			}
 			result := account.IsModelSupported(tt.requestedModel)
 			if result != tt.expected {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2370,6 +2370,35 @@
           </p>
         </div>
 
+        <div class="rounded-lg border border-gray-200 p-4 dark:border-dark-600">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <label class="input-label mb-0">{{ t('admin.accounts.quotaControl.fableScheduling.label') }}</label>
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ t('admin.accounts.quotaControl.fableScheduling.hint') }}
+              </p>
+            </div>
+            <button
+              type="button"
+              data-testid="anthropic-fable-scheduling-toggle"
+              role="switch"
+              :aria-checked="fableSchedulingEnabled"
+              @click="fableSchedulingEnabled = !fableSchedulingEnabled"
+              :class="[
+                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+                fableSchedulingEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+              ]"
+            >
+              <span
+                :class="[
+                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                  fableSchedulingEnabled ? 'translate-x-5' : 'translate-x-0'
+                ]"
+              />
+            </button>
+          </div>
+        </div>
+
         <!-- Window Cost Limit -->
         <div class="rounded-lg border border-gray-200 p-4 dark:border-dark-600">
           <div class="mb-3 flex items-center justify-between">
@@ -3259,6 +3288,8 @@ const cacheTTLOverrideEnabled = ref(false)
 const cacheTTLOverrideTarget = ref<string>('5m')
 const customBaseUrlEnabled = ref(false)
 const customBaseUrl = ref('')
+const ANTHROPIC_FABLE_SCHEDULING_ENABLED_EXTRA_KEY = 'anthropic_fable_scheduling_enabled'
+const fableSchedulingEnabled = ref(true)
 
 // OpenAI 自动透传开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
@@ -4429,6 +4460,7 @@ function loadQuotaControlSettings(account: Account) {
   cacheTTLOverrideTarget.value = '5m'
   customBaseUrlEnabled.value = false
   customBaseUrl.value = ''
+  fableSchedulingEnabled.value = true
 
   // Remaining quota control settings only apply to Anthropic accounts
   if (account.platform !== 'anthropic') {
@@ -4439,6 +4471,8 @@ function loadQuotaControlSettings(account: Account) {
   if (account.type !== 'oauth' && account.type !== 'setup-token') {
     return
   }
+
+  fableSchedulingEnabled.value = account.extra?.[ANTHROPIC_FABLE_SCHEDULING_ENABLED_EXTRA_KEY] !== false
 
   // Load from extra field (via backend DTO fields)
   if (account.window_cost_limit != null && account.window_cost_limit > 0) {
@@ -5051,6 +5085,12 @@ const handleSubmit = async () => {
     if (props.account.platform === 'anthropic' && (props.account.type === 'oauth' || props.account.type === 'setup-token')) {
       const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
+
+      if (fableSchedulingEnabled.value) {
+        delete newExtra[ANTHROPIC_FABLE_SCHEDULING_ENABLED_EXTRA_KEY]
+      } else {
+        newExtra[ANTHROPIC_FABLE_SCHEDULING_ENABLED_EXTRA_KEY] = false
+      }
 
       // Window cost limit settings
       if (windowCostEnabled.value && windowCostLimit.value != null && windowCostLimit.value > 0) {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -279,6 +279,18 @@ function buildGrokAPIKeyAccount() {
   } as any
 }
 
+function buildAnthropicOAuthAccount() {
+  return {
+    ...buildAccount(),
+    id: 8,
+    name: 'Anthropic OAuth',
+    platform: 'anthropic',
+    type: 'oauth',
+    credentials: { access_token: 'oauth-token' },
+    extra: {}
+  } as any
+}
+
 function buildOpenAISetupTokenAccount() {
   return {
     ...buildAccount(),
@@ -326,6 +338,39 @@ function mountModal(account = buildAccount()) {
 describe('EditAccountModal', () => {
   beforeEach(() => {
     authIsSimpleMode.value = true
+  })
+
+  it('defaults Anthropic OAuth accounts to allowing Fable scheduling and persists opt-out', async () => {
+    const account = buildAnthropicOAuthAccount()
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="anthropic-fable-scheduling-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('true')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.anthropic_fable_scheduling_enabled).toBe(false)
+  })
+
+  it('loads an Anthropic Fable opt-out and removes it when scheduling is re-enabled', async () => {
+    const account = buildAnthropicOAuthAccount()
+    account.extra = { anthropic_fable_scheduling_enabled: false }
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="anthropic-fable-scheduling-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('false')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty('anthropic_fable_scheduling_enabled')
   })
 
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -850,6 +850,10 @@ export default {
       quotaControl: {
         title: 'Quota Control',
         hint: 'Configure cost window, session limits, client affinity and other scheduling controls.',
+        fableScheduling: {
+          label: 'Allow Fable Scheduling',
+          hint: 'When disabled, this account will not be selected for Fable requests. Other Claude models are unaffected. Disable this for Pro plans without usage credits.'
+        },
         windowCost: {
           label: '5h Window Cost Limit',
           hint: 'Limit account cost usage within the 5-hour window',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -921,6 +921,10 @@ export default {
       quotaControl: {
         title: '配额控制',
         hint: '配置费用窗口、会话限制、客户端亲和等调度控制。',
+        fableScheduling: {
+          label: '允许调度 Fable',
+          hint: '关闭后，该账号不会参与 Fable 请求调度，其他 Claude 模型不受影响。Pro 套餐未启用 usage credits 时建议关闭。'
+        },
         windowCost: {
           label: '5h窗口费用控制',
           hint: '限制账号在5小时窗口内的费用使用',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1154,6 +1154,7 @@ export interface Account {
   // Extra fields including Codex usage, OpenAI compact capability, and model-level rate limits.
   extra?: (CodexUsageSnapshot & OpenAICompactState & {
     model_rate_limits?: Record<string, { rate_limited_at: string; rate_limit_reset_at: string }>
+    anthropic_fable_scheduling_enabled?: boolean
     antigravity_credits_overages?: Record<string, { activated_at: string; active_until: string }>
     upstream_billing_probe_enabled?: boolean
     upstream_billing_rate_sync_enabled?: boolean


### PR DESCRIPTION
## Summary

- add an **Allow Fable Scheduling** switch to Anthropic OAuth and Setup Token account settings
- keep the switch enabled by default for backward compatibility and persist only an explicit opt-out
- carry the setting into scheduler snapshots and reject both directly requested and mapped Fable models while leaving other Claude models available

## Why

Claude Pro plans without usage credits cannot serve Fable 5. Sub2API cannot currently express that per-account capability, so the first Fable request must reach upstream before the limitation is discovered. This switch lets administrators proactively keep Fable traffic away from those accounts.

This is independent of and complementary to #6484: the switch prevents known-ineligible accounts from receiving Fable requests, while #6484 keeps an unexpected upstream `credits_required` response model-scoped.

## Behavior

- missing setting: Fable scheduling remains allowed
- switch off: Fable variants and aliases mapped to Fable are excluded
- Sonnet, Opus, Haiku, and Anthropic API-key accounts are unaffected
- re-enabling the switch removes the explicit override

## Tests

- `make test-unit`
- `pnpm run lint:check` with pnpm 9
- `pnpm run typecheck` with pnpm 9
- EditAccountModal tests: 52 passed
- locale compilation tests: 2 passed
- frontend critical tests: 168 passed