### PR TITLE
feat(openai): support ultrafast service tier

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -277,14 +277,16 @@ func TestOpenAIFastPolicySettingsFromDTO_NormalizesServiceTier(t *testing.T) {
 		in := &dto.OpenAIFastPolicySettings{
 			Rules: []dto.OpenAIFastPolicyRule{
 				{ServiceTier: "priority", Action: "filter", Scope: "all"},
+				{ServiceTier: "ULTRAFAST", Action: "pass", Scope: "oauth"},
 				{ServiceTier: "flex", Action: "block", Scope: "oauth"},
 				{ServiceTier: "all", Action: "pass", Scope: "apikey"},
 			},
 		}
 		out := openaiFastPolicySettingsFromDTO(in)
-		require.Len(t, out.Rules, 3)
+		require.Len(t, out.Rules, 4)
 		require.Equal(t, service.OpenAIFastTierPriority, out.Rules[0].ServiceTier)
-		require.Equal(t, service.OpenAIFastTierFlex, out.Rules[1].ServiceTier)
-		require.Equal(t, service.OpenAIFastTierAny, out.Rules[2].ServiceTier)
+		require.Equal(t, service.OpenAIFastTierUltraFast, out.Rules[1].ServiceTier)
+		require.Equal(t, service.OpenAIFastTierFlex, out.Rules[2].ServiceTier)
+		require.Equal(t, service.OpenAIFastTierAny, out.Rules[3].ServiceTier)
 	})
 }

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -120,12 +120,12 @@ func normalizeBillingServiceTier(serviceTier string) string {
 	return strings.ToLower(strings.TrimSpace(serviceTier))
 }
 
-func usePriorityServiceTierPricing(serviceTier string, pricing *ModelPricing) bool {
+func useFastServiceTierPricing(serviceTier string, pricing *ModelPricing) bool {
 	if pricing == nil {
 		return false
 	}
 	tier := normalizeBillingServiceTier(serviceTier)
-	if tier != "priority" && tier != "fast" {
+	if tier != OpenAIFastTierPriority && tier != "fast" && tier != OpenAIFastTierUltraFast {
 		return false
 	}
 	if pricing.FastMultiplier != nil {
@@ -137,7 +137,8 @@ func usePriorityServiceTierPricing(serviceTier string, pricing *ModelPricing) bo
 
 func serviceTierCostMultiplier(serviceTier string) float64 {
 	switch normalizeBillingServiceTier(serviceTier) {
-	case "priority", "fast":
+	case OpenAIFastTierPriority, "fast", OpenAIFastTierUltraFast:
+		// 渠道定价目前只有一个 FastMultiplier，ultrafast 复用该速度档倍率。
 		return 2.0
 	case "flex":
 		return 0.5
@@ -149,7 +150,7 @@ func serviceTierCostMultiplier(serviceTier string) float64 {
 func configuredServiceTierMultiplier(serviceTier string, pricing *ModelPricing) float64 {
 	if pricing != nil {
 		switch normalizeBillingServiceTier(serviceTier) {
-		case "priority", "fast":
+		case OpenAIFastTierPriority, "fast", OpenAIFastTierUltraFast:
 			if pricing.FastMultiplier != nil {
 				return *pricing.FastMultiplier
 			}
@@ -1368,7 +1369,7 @@ func (s *BillingService) computeTokenBreakdown(
 	cacheCreationMultiplier := 1.0
 	tierMultiplier := 1.0
 
-	if usePriorityServiceTierPricing(serviceTier, pricing) {
+	if useFastServiceTierPricing(serviceTier, pricing) {
 		if pricing.InputPricePerTokenPriority > 0 {
 			inputPrice = pricing.InputPricePerTokenPriority
 		}

--- a/backend/internal/service/channel_pricing_multipliers_test.go
+++ b/backend/internal/service/channel_pricing_multipliers_test.go
@@ -17,8 +17,10 @@ func TestConfiguredServiceTierMultiplier(t *testing.T) {
 	}{
 		{name: "gpt-5.5 fast", serviceTier: "fast", pricing: &ModelPricing{FastMultiplier: pricingMultiplier(2.5)}, want: 2.5},
 		{name: "priority alias", serviceTier: "priority", pricing: &ModelPricing{FastMultiplier: pricingMultiplier(2)}, want: 2},
+		{name: "ultrafast uses fast multiplier", serviceTier: "ultrafast", pricing: &ModelPricing{FastMultiplier: pricingMultiplier(3)}, want: 3},
 		{name: "flex configured", serviceTier: "flex", pricing: &ModelPricing{FlexMultiplier: pricingMultiplier(0.4)}, want: 0.4},
 		{name: "legacy fast default", serviceTier: "fast", pricing: &ModelPricing{}, want: 2},
+		{name: "ultrafast default", serviceTier: "ultrafast", pricing: &ModelPricing{}, want: 2},
 		{name: "legacy flex default", serviceTier: "flex", pricing: &ModelPricing{}, want: 0.5},
 	}
 

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -470,13 +470,18 @@ func newConfiguredCodexModelDescriptor(modelID string) configuredCodexModelDescr
 		descriptor.Description = "OpenAI GPT coding model routed through Sub2API."
 		descriptor.SupportsParallelToolCalls = true
 		if configuredCodexSupportsPriorityServiceTier(modelID) {
-			descriptor.ServiceTiers = []configuredCodexServiceTier{
-				{
-					ID:          "priority",
-					Name:        "Fast",
-					Description: "Priority processing for lower latency.",
-				},
-			}
+			descriptor.ServiceTiers = append(descriptor.ServiceTiers, configuredCodexServiceTier{
+				ID:          OpenAIFastTierPriority,
+				Name:        "Fast",
+				Description: "Priority processing for lower latency.",
+			})
+		}
+		if configuredCodexSupportsUltraFastServiceTier(modelID) {
+			descriptor.ServiceTiers = append(descriptor.ServiceTiers, configuredCodexServiceTier{
+				ID:          OpenAIFastTierUltraFast,
+				Name:        "Ultrafast",
+				Description: "Fastest processing for latency-sensitive workloads.",
+			})
 		}
 		if isOpenAICodexReasoningGPTModel(modelID) {
 			defaultReasoningLevel := "medium"
@@ -509,6 +514,10 @@ func configuredCodexSupportsPriorityServiceTier(modelID string) bool {
 		}
 	}
 	return false
+}
+
+func configuredCodexSupportsUltraFastServiceTier(modelID string) bool {
+	return normalizeKnownOpenAICodexModel(modelID) == "gpt-5.6-sol"
 }
 
 func configuredCodexGrokReasoningLevels(modelID string) []configuredCodexReasoningLevel {

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -427,8 +427,8 @@ func TestBuildCodexModelsManifestKeepsKnownReasoningChoices(t *testing.T) {
 	require.NotEqual(t, "none", firstLevel["effort"])
 }
 
-// Scenario: 支持 Fast 的 GPT 型号在目录中声明 priority service tier。
-func TestBuildCodexModelsManifestAdvertisesPriorityServiceTierForFastGPTModels(t *testing.T) {
+// Scenario: 支持速度档位的 GPT 型号在目录中声明可用的 service tiers。
+func TestBuildCodexModelsManifestAdvertisesServiceTiersForFastGPTModels(t *testing.T) {
 	t.Parallel()
 
 	body, err := BuildCodexModelsManifest([]string{
@@ -441,13 +441,21 @@ func TestBuildCodexModelsManifestAdvertisesPriorityServiceTierForFastGPTModels(t
 	require.Len(t, models, 3)
 
 	for _, model := range models {
-		require.Equal(t, []any{
+		want := []any{
 			map[string]any{
 				"id":          "priority",
 				"name":        "Fast",
 				"description": "Priority processing for lower latency.",
 			},
-		}, model["service_tiers"])
+		}
+		if model["slug"] == "gpt-5.6-sol" {
+			want = append(want, map[string]any{
+				"id":          "ultrafast",
+				"name":        "Ultrafast",
+				"description": "Fastest processing for latency-sensitive workloads.",
+			})
+		}
+		require.Equal(t, want, model["service_tiers"])
 		require.Nil(t, model["default_service_tier"])
 	}
 }

--- a/backend/internal/service/openai_fast_policy_test.go
+++ b/backend/internal/service/openai_fast_policy_test.go
@@ -100,6 +100,9 @@ func TestEvaluateOpenAIFastPolicy_DefaultPassesKnownTiers(t *testing.T) {
 	action, _ = svc.evaluateOpenAIFastPolicy(context.Background(), account, "gpt-5.5", OpenAIFastTierFlex)
 	require.Equal(t, BetaPolicyActionPass, action)
 
+	action, _ = svc.evaluateOpenAIFastPolicy(context.Background(), account, "gpt-5.6-sol", OpenAIFastTierUltraFast)
+	require.Equal(t, BetaPolicyActionPass, action)
+
 	// empty tier → pass
 	action, _ = svc.evaluateOpenAIFastPolicy(context.Background(), account, "gpt-5.5", "")
 	require.Equal(t, BetaPolicyActionPass, action)
@@ -176,7 +179,7 @@ func TestEvaluateOpenAIFastPolicy_UserScopedRuleOverridesGlobalRule(t *testing.T
 	require.Equal(t, BetaPolicyActionFilter, action)
 }
 
-func TestApplyOpenAIFastPolicyToBody_DefaultPassesPriorityAndFast(t *testing.T) {
+func TestApplyOpenAIFastPolicyToBody_DefaultPassesSpeedTiers(t *testing.T) {
 	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
@@ -189,6 +192,11 @@ func TestApplyOpenAIFastPolicyToBody_DefaultPassesPriorityAndFast(t *testing.T) 
 	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 	require.NoError(t, err)
 	require.Equal(t, "priority", gjson.GetBytes(updated, "service_tier").String())
+
+	body = []byte(`{"model":"gpt-5.6-sol","service_tier":"ultrafast"}`)
+	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.6-sol", body)
+	require.NoError(t, err)
+	require.Equal(t, string(body), string(updated))
 
 	body = []byte(`{"model":"gpt-4","service_tier":"priority"}`)
 	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-4", body)
@@ -259,7 +267,7 @@ func TestApplyOpenAIFastPolicyToBody_ForcePriorityRewritesKnownTier(t *testing.T
 	svc := newOpenAIGatewayServiceWithSettings(t, settings)
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	for _, tier := range []string{"flex", "auto", "default", "scale", "fast", "priority"} {
+	for _, tier := range []string{"ultrafast", "flex", "auto", "default", "scale", "fast", "priority"} {
 		body := []byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`)
 		updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 		require.NoError(t, err)
@@ -353,7 +361,7 @@ func TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule(t *testing.T
 	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	for _, tier := range []string{"auto", "default", "scale"} {
+	for _, tier := range []string{"ultrafast", "auto", "default", "scale"} {
 		body := []byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`)
 		updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 		require.NoError(t, err, "tier %q should pass without error", tier)
@@ -362,7 +370,7 @@ func TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule(t *testing.T
 	}
 
 	// evaluate 层也应判定为 pass（默认配置没有内置规则）。
-	for _, tier := range []string{"auto", "default", "scale"} {
+	for _, tier := range []string{"ultrafast", "auto", "default", "scale"} {
 		action, _ := svc.evaluateOpenAIFastPolicy(context.Background(), account, "gpt-5.5", tier)
 		require.Equal(t, BetaPolicyActionPass, action, "tier %q should evaluate to pass", tier)
 	}
@@ -382,7 +390,7 @@ func TestApplyOpenAIFastPolicyToBody_AllRuleStripsOfficialTiers(t *testing.T) {
 	svc := newOpenAIGatewayServiceWithSettings(t, settings)
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	for _, tier := range []string{"auto", "default", "scale", "priority", "flex"} {
+	for _, tier := range []string{"ultrafast", "auto", "default", "scale", "priority", "flex"} {
 		body := []byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`)
 		updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 		require.NoError(t, err)
@@ -460,7 +468,7 @@ func TestSetOpenAIFastPolicySettings_Validation(t *testing.T) {
 	// Non-positive and duplicate user IDs are rejected.
 	err = svc.SetOpenAIFastPolicySettings(context.Background(), &OpenAIFastPolicySettings{
 		Rules: []OpenAIFastPolicyRule{{
-			ServiceTier: OpenAIFastTierPriority,
+			ServiceTier: OpenAIFastTierUltraFast,
 			Action:      BetaPolicyActionPass,
 			Scope:       BetaPolicyScopeAll,
 			UserIDs:     []int64{0},
@@ -481,7 +489,7 @@ func TestSetOpenAIFastPolicySettings_Validation(t *testing.T) {
 	// Valid settings persisted
 	err = svc.SetOpenAIFastPolicySettings(context.Background(), &OpenAIFastPolicySettings{
 		Rules: []OpenAIFastPolicyRule{{
-			ServiceTier: OpenAIFastTierPriority,
+			ServiceTier: OpenAIFastTierUltraFast,
 			Action:      OpenAIFastPolicyActionForcePriority,
 			Scope:       BetaPolicyScopeAll,
 			UserIDs:     []int64{42, 43},
@@ -492,7 +500,7 @@ func TestSetOpenAIFastPolicySettings_Validation(t *testing.T) {
 	got, err := svc.GetOpenAIFastPolicySettings(context.Background())
 	require.NoError(t, err)
 	require.Len(t, got.Rules, 1)
-	require.Equal(t, OpenAIFastTierPriority, got.Rules[0].ServiceTier)
+	require.Equal(t, OpenAIFastTierUltraFast, got.Rules[0].ServiceTier)
 	require.Equal(t, OpenAIFastPolicyActionForcePriority, got.Rules[0].Action)
 	require.Equal(t, []int64{42, 43}, got.Rules[0].UserIDs)
 }

--- a/backend/internal/service/openai_fast_policy_ws_test.go
+++ b/backend/internal/service/openai_fast_policy_ws_test.go
@@ -112,7 +112,7 @@ func TestWSResponseCreate_ForcePriorityRewritesKnownTier(t *testing.T) {
 	svc := newOpenAIGatewayServiceWithSettings(t, settings)
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	for _, tier := range []string{"flex", "auto", "default", "scale", "fast", "priority"} {
+	for _, tier := range []string{"ultrafast", "flex", "auto", "default", "scale", "fast", "priority"} {
 		frame := []byte(`{"type":"response.create","model":"gpt-5.5","service_tier":"` + tier + `"}`)
 		updated, blocked, err := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "gpt-5.5", frame)
 		require.NoError(t, err)

--- a/backend/internal/service/openai_fast_service_tier_test.go
+++ b/backend/internal/service/openai_fast_service_tier_test.go
@@ -43,7 +43,7 @@ func TestValidateOpenAIServiceTierField(t *testing.T) {
 	})
 
 	t.Run("official tiers pass through", func(t *testing.T) {
-		for _, tier := range []string{"flex", "auto", "default", "scale"} {
+		for _, tier := range []string{"ultrafast", "flex", "auto", "default", "scale"} {
 			norm, err := ValidateOpenAIServiceTierField([]byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`))
 			require.NoError(t, err, "tier %q must be accepted", tier)
 			require.Equal(t, tier, norm)

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -100,6 +100,10 @@ func TestNormalizeResponsesRequestServiceTier(t *testing.T) {
 	normalizeResponsesRequestServiceTier(req)
 	require.Equal(t, "flex", req.ServiceTier)
 
+	req.ServiceTier = "ultrafast"
+	normalizeResponsesRequestServiceTier(req)
+	require.Equal(t, "ultrafast", req.ServiceTier)
+
 	// OpenAI 官方合法 tier 应被透传保留。
 	req.ServiceTier = "auto"
 	normalizeResponsesRequestServiceTier(req)
@@ -131,6 +135,11 @@ func TestNormalizeResponsesBodyServiceTier(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "flex", tier)
 	require.Equal(t, "flex", gjson.GetBytes(body, "service_tier").String())
+
+	body, tier, err = normalizeResponsesBodyServiceTier([]byte(`{"model":"gpt-5.6-sol","service_tier":"ultrafast"}`))
+	require.NoError(t, err)
+	require.Equal(t, "ultrafast", tier)
+	require.Equal(t, "ultrafast", gjson.GetBytes(body, "service_tier").String())
 
 	// OpenAI 官方 tier 直接保留在 body 中（透传上游）。
 	body, tier, err = normalizeResponsesBodyServiceTier([]byte(`{"model":"gpt-5.1","service_tier":"auto"}`))

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -1464,11 +1464,10 @@ func TestNormalizeOpenAIServiceTier(t *testing.T) {
 		require.Equal(t, "priority", *got)
 	})
 
-	t.Run("openai official tiers preserved", func(t *testing.T) {
-		// OpenAI 官方文档定义的合法 tier 值都应被透传保留，避免因白名单过窄
-		// 静默剥离客户端显式发送的合法字段。Codex 客户端只发 priority/flex，
-		// 所以扩大白名单对 Codex 流量零影响（见 codex-rs/core/src/client.rs）。
-		for _, tier := range []string{"priority", "flex", "auto", "default", "scale"} {
+	t.Run("openai and codex tiers preserved", func(t *testing.T) {
+		// OpenAI API 与 Codex 模型目录定义的合法 tier 值都应被透传保留，
+		// 避免因白名单过窄静默剥离客户端显式发送的合法字段。
+		for _, tier := range []string{"priority", "ultrafast", "flex", "auto", "default", "scale"} {
 			got := normalizeOpenAIServiceTier(tier)
 			require.NotNil(t, got, "tier %q should not be normalized to nil", tier)
 			require.Equal(t, tier, *got)
@@ -1483,6 +1482,7 @@ func TestNormalizeOpenAIServiceTier(t *testing.T) {
 
 func TestExtractOpenAIServiceTier(t *testing.T) {
 	require.Equal(t, "priority", *extractOpenAIServiceTier(map[string]any{"service_tier": "fast"}))
+	require.Equal(t, "ultrafast", *extractOpenAIServiceTier(map[string]any{"service_tier": "ultrafast"}))
 	require.Equal(t, "flex", *extractOpenAIServiceTier(map[string]any{"service_tier": "flex"}))
 	require.Equal(t, "auto", *extractOpenAIServiceTier(map[string]any{"service_tier": "auto"}))
 	require.Equal(t, "default", *extractOpenAIServiceTier(map[string]any{"service_tier": "default"}))
@@ -1493,6 +1493,7 @@ func TestExtractOpenAIServiceTier(t *testing.T) {
 
 func TestExtractOpenAIServiceTierFromBody(t *testing.T) {
 	require.Equal(t, "priority", *extractOpenAIServiceTierFromBody([]byte(`{"service_tier":"fast"}`)))
+	require.Equal(t, "ultrafast", *extractOpenAIServiceTierFromBody([]byte(`{"service_tier":"ultrafast"}`)))
 	require.Equal(t, "flex", *extractOpenAIServiceTierFromBody([]byte(`{"service_tier":"flex"}`)))
 	require.Equal(t, "auto", *extractOpenAIServiceTierFromBody([]byte(`{"service_tier":"auto"}`)))
 	require.Equal(t, "default", *extractOpenAIServiceTierFromBody([]byte(`{"service_tier":"default"}`)))
@@ -3144,6 +3145,11 @@ func TestGroupBillsOpenAIFastAtStandardRequiresOpenAIAccount(t *testing.T) {
 		apiKey,
 		&Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth},
 		"priority",
+	))
+	require.True(t, groupBillsOpenAIFastAtStandard(
+		apiKey,
+		&Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+		"ultrafast",
 	))
 	require.False(t, groupBillsOpenAIFastAtStandard(
 		apiKey,

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1435,12 +1435,12 @@ func normalizeOpenAIServiceTier(raw string) *string {
 	if value == "fast" {
 		value = "priority"
 	}
-	// 放过 OpenAI 官方文档定义的所有合法 tier 值：priority/flex/auto/default/scale。
-	// 对 Codex 客户端零影响（Codex 只发 priority 或 flex，见 codex-rs/core/src/client.rs），
-	// 但能让直连 OpenAI SDK 的用户透传 auto/default/scale 以便抓包/调试。
+	// 放过 OpenAI/Codex 定义的合法 tier 值：priority/ultrafast/flex/auto/default/scale。
+	// Codex 会从模型目录动态读取 service_tiers，并将选中的 id 原样发送。
+	// 直连 OpenAI SDK 的用户也可透传 auto/default/scale 以便抓包/调试。
 	// 真未知值仍返回 nil，由 normalizeResponsesBodyServiceTier 从 body 中删除。
 	switch value {
-	case "priority", "flex", "auto", "default", "scale":
+	case "priority", "ultrafast", "flex", "auto", "default", "scale":
 		return &value
 	default:
 		return nil
@@ -1457,7 +1457,7 @@ type ErrInvalidOpenAIServiceTier struct {
 }
 
 func (e *ErrInvalidOpenAIServiceTier) Error() string {
-	return fmt.Sprintf("invalid service_tier %q: must be one of auto, default, fast, flex, priority, scale", e.Value)
+	return fmt.Sprintf("invalid service_tier %q: must be one of auto, default, fast, flex, priority, scale, ultrafast", e.Value)
 }
 
 const invalidOpenAIServiceTierValueMaxLen = 64
@@ -1475,7 +1475,7 @@ func boundInvalidOpenAIServiceTierValue(raw string) string {
 //   - absent / null → valid, returns "" (field omitted keeps current behavior)
 //   - "fast" → normalized to "priority" (the two are equivalent; the canonical
 //     value is what reaches the OpenAI upstream)
-//   - "priority" / "flex" / "auto" / "default" / "scale" → valid, returned as-is
+//   - "priority" / "ultrafast" / "flex" / "auto" / "default" / "scale" → valid, returned as-is
 //   - an explicitly present non-string value, an empty string, or any other
 //     unknown value → *ErrInvalidOpenAIServiceTier (handler maps to HTTP 400),
 //     matching OpenAI's enum validation semantics

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -143,7 +143,7 @@ func groupBillsOpenAIFastAtStandard(apiKey *APIKey, account *Account, serviceTie
 		return false
 	}
 	switch normalizeBillingServiceTier(serviceTier) {
-	case "priority", "fast":
+	case OpenAIFastTierPriority, "fast", OpenAIFastTierUltraFast:
 		return true
 	default:
 		return false

--- a/backend/internal/service/openai_routing_hint.go
+++ b/backend/internal/service/openai_routing_hint.go
@@ -37,14 +37,13 @@ func setOpenAICodexRoutingHint(headers http.Header, account *Account, model stri
 
 	// Codex treats "default" as an explicit standard-routing sentinel, not as a
 	// service tier sent to the backend. Fast follows the gateway's existing
-	// canonicalization and therefore becomes "priority"; flex stays "flex".
+	// canonicalization and therefore becomes "priority"; ultrafast and flex
+	// keep their catalog ids.
 	canonicalTier := normalizedOpenAIServiceTierValue(serviceTier)
-	// This backport has no Codex model-catalog snapshot with which to validate
-	// arbitrary tier ids. Keep the hint to the two effective tiers Codex itself
-	// selects; default, missing, and other gateway-compatible API values remain
-	// model-only rather than expanding the ChatGPT routing protocol here.
+	// Keep the hint to effective tiers advertised by Codex model catalogs;
+	// default, missing, and other gateway-compatible API values remain model-only.
 	switch canonicalTier {
-	case OpenAIFastTierPriority, OpenAIFastTierFlex:
+	case OpenAIFastTierPriority, OpenAIFastTierUltraFast, OpenAIFastTierFlex:
 	default:
 		canonicalTier = ""
 	}

--- a/backend/internal/service/openai_routing_hint_test.go
+++ b/backend/internal/service/openai_routing_hint_test.go
@@ -23,6 +23,7 @@ func TestSetOpenAICodexRoutingHintCanonicalizesOfficialServiceTiers(t *testing.T
 	}{
 		{name: "fast alias", model: "gpt-5.6", serviceTier: " fast ", want: "model=gpt-5.6;tier=priority"},
 		{name: "priority", model: "gpt-5.6", serviceTier: "priority", want: "model=gpt-5.6;tier=priority"},
+		{name: "ultrafast", model: "gpt-5.6-sol", serviceTier: "ultrafast", want: "model=gpt-5.6-sol;tier=ultrafast"},
 		{name: "flex", model: "gpt-5.6", serviceTier: "flex", want: "model=gpt-5.6;tier=flex"},
 		{name: "explicit default sentinel", model: "gpt-5.6", serviceTier: "default", want: "model=gpt-5.6"},
 		{name: "omitted tier", model: "gpt-5.6", want: "model=gpt-5.6"},
@@ -89,6 +90,7 @@ func TestOpenAIOAuthHTTPBuildersSendRoutingHintFromFinalBody(t *testing.T) {
 		want string
 	}{
 		{name: "fast", body: []byte(`{"model":"gpt-5.6-codex","service_tier":"fast"}`), want: "model=gpt-5.6-codex;tier=priority"},
+		{name: "ultrafast", body: []byte(`{"model":"gpt-5.6-sol","service_tier":"ultrafast"}`), want: "model=gpt-5.6-sol;tier=ultrafast"},
 		{name: "flex", body: []byte(`{"model":"gpt-5.6-codex","service_tier":"flex"}`), want: "model=gpt-5.6-codex;tier=flex"},
 		{name: "default", body: []byte(`{"model":"gpt-5.6-codex","service_tier":"default"}`), want: "model=gpt-5.6-codex"},
 		{name: "omitted", body: []byte(`{"model":"gpt-5.6-codex"}`), want: "model=gpt-5.6-codex"},

--- a/backend/internal/service/service_tier_billing.go
+++ b/backend/internal/service/service_tier_billing.go
@@ -51,7 +51,7 @@ func serviceTierCostRank(tier string) (rank int, known bool) {
 		return 0, true
 	case "", "default", "standard", "auto", "scale":
 		return 1, true
-	case "priority", "fast":
+	case OpenAIFastTierPriority, "fast", OpenAIFastTierUltraFast:
 		return 2, true
 	default:
 		return 1, false

--- a/backend/internal/service/service_tier_billing_test.go
+++ b/backend/internal/service/service_tier_billing_test.go
@@ -17,6 +17,8 @@ func TestResolveBillingServiceTier(t *testing.T) {
 		{name: "openai priority served as default", requested: "priority", observed: "default", billing: "default", downgraded: true},
 		{name: "anthropic fast served as standard", requested: "fast", observed: "standard", billing: "standard", downgraded: true},
 		{name: "priority honoured", requested: "priority", observed: "priority", billing: "priority"},
+		{name: "ultrafast served as default", requested: "ultrafast", observed: "default", billing: "default", downgraded: true},
+		{name: "ultrafast honoured", requested: "ultrafast", observed: "ultrafast", billing: "ultrafast"},
 		{name: "no declaration keeps request", requested: "priority", observed: "", billing: "priority"},
 		{name: "no request no declaration", requested: "", observed: "", billing: ""},
 		{name: "response never raises the tier", requested: "", observed: "priority", billing: ""},

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -1016,7 +1016,7 @@ func (s *SettingService) SetOpenAIFastPolicySettings(ctx context.Context, settin
 		BetaPolicyScopeAll: true, BetaPolicyScopeOAuth: true, BetaPolicyScopeAPIKey: true, BetaPolicyScopeBedrock: true,
 	}
 	validTiers := map[string]bool{
-		OpenAIFastTierAny: true, OpenAIFastTierPriority: true, OpenAIFastTierFlex: true,
+		OpenAIFastTierAny: true, OpenAIFastTierPriority: true, OpenAIFastTierUltraFast: true, OpenAIFastTierFlex: true,
 	}
 
 	for i, rule := range settings.Rules {

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -675,18 +675,19 @@ func DefaultBetaPolicySettings() *BetaPolicySettings {
 // 本策略复用 BetaPolicyAction*/BetaPolicyScope* 常量语义，只是匹配键从
 // anthropic-beta header 换成 body 的 service_tier 字段。
 const (
-	OpenAIFastTierAny      = "all"      // 匹配任意已识别的 service_tier
-	OpenAIFastTierPriority = "priority" // 仅匹配 fast（priority）
-	OpenAIFastTierFlex     = "flex"     // 仅匹配 flex
+	OpenAIFastTierAny       = "all"       // 匹配任意已识别的 service_tier
+	OpenAIFastTierPriority  = "priority"  // 仅匹配 fast（priority）
+	OpenAIFastTierUltraFast = "ultrafast" // 仅匹配 ultrafast
+	OpenAIFastTierFlex      = "flex"      // 仅匹配 flex
 
 	// OpenAIFastPolicyActionForcePriority 会保留 service_tier 字段并强制写成
 	// priority，用于把 flex/auto/default/scale 等已识别 tier 收敛为 fast。
 	OpenAIFastPolicyActionForcePriority = "force_priority"
 )
 
-// OpenAIFastPolicyRule 单条 OpenAI fast/flex 策略规则
+// OpenAIFastPolicyRule 单条 OpenAI speed/flex 策略规则
 type OpenAIFastPolicyRule struct {
-	ServiceTier          string   `json:"service_tier"`                     // "priority" | "flex" | "auto" | "default" | "scale" | "all"
+	ServiceTier          string   `json:"service_tier"`                     // "priority" | "ultrafast" | "flex" | "auto" | "default" | "scale" | "all"
 	Action               string   `json:"action"`                           // "pass" | "filter" | "block" | "force_priority"
 	Scope                string   `json:"scope"`                            // "all" | "oauth" | "apikey" | "bedrock"
 	UserIDs              []int64  `json:"user_ids,omitempty"`               // 空=所有 Sub2API 用户；非空=仅指定 API Key 所属用户
@@ -703,7 +704,7 @@ type OpenAIFastPolicySettings struct {
 
 // DefaultOpenAIFastPolicySettings 返回默认的 OpenAI fast 策略配置。
 // 默认不配置任何规则，保留 OpenAI 上游 service_tier 语义；管理员如需
-// 限制 priority/flex，可以在 admin UI 中显式配置 filter 或 block 规则。
+// 限制 priority/ultrafast/flex，可以在 admin UI 中显式配置 filter 或 block 规则。
 func DefaultOpenAIFastPolicySettings() *OpenAIFastPolicySettings {
 	return &OpenAIFastPolicySettings{
 		Rules: []OpenAIFastPolicyRule{},

--- a/backend/internal/service/upstream_response_model.go
+++ b/backend/internal/service/upstream_response_model.go
@@ -139,8 +139,10 @@ func (o *upstreamResponseModelObserver) ServiceTier() string {
 // unknown values are ignored rather than guessed at.
 func normalizeObservedOpenAIServiceTier(raw string) string {
 	switch value := strings.ToLower(strings.TrimSpace(raw)); value {
-	case "priority", "fast":
+	case OpenAIFastTierPriority, "fast":
 		return OpenAIFastTierPriority
+	case OpenAIFastTierUltraFast:
+		return value
 	case "default", "flex", "scale":
 		return value
 	default:

--- a/backend/internal/service/upstream_response_model_test.go
+++ b/backend/internal/service/upstream_response_model_test.go
@@ -232,6 +232,12 @@ func TestUpstreamResponseModelObserverServiceTierUntypedPayloads(t *testing.T) {
 		require.Equal(t, "", auto.ServiceTier())
 	})
 
+	t.Run("non-stream body preserves ultrafast", func(t *testing.T) {
+		observer := &upstreamResponseModelObserver{}
+		observer.ObserveOpenAI([]byte(`{"id":"resp_3","object":"response","model":"gpt-5.6-sol","service_tier":"ultrafast"}`), "")
+		require.Equal(t, "ultrafast", observer.ServiceTier())
+	})
+
 	t.Run("model-free deltas never declare a tier", func(t *testing.T) {
 		observer := &upstreamResponseModelObserver{}
 		observer.ObserveOpenAI([]byte(`{"type":"response.output_text.delta","delta":"hi","service_tier":"default"}`), "response.output_text.delta")

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -1425,11 +1425,11 @@ export async function updateRectifierSettings(
 // ==================== OpenAI Fast Policy Settings ====================
 
 /**
- * OpenAI fast/flex policy rule interface.
+ * OpenAI speed/flex policy rule interface.
  * Matches backend dto.OpenAIFastPolicyRule.
  */
 export interface OpenAIFastPolicyRule {
-  service_tier: "all" | "priority" | "flex";
+  service_tier: "all" | "priority" | "ultrafast" | "flex";
   action: "pass" | "filter" | "block" | "force_priority";
   scope: "all" | "oauth" | "apikey" | "bedrock";
   user_ids?: number[];
@@ -1440,7 +1440,7 @@ export interface OpenAIFastPolicyRule {
 }
 
 /**
- * OpenAI fast/flex policy settings interface.
+ * OpenAI speed/flex policy settings interface.
  */
 export interface OpenAIFastPolicySettings {
   rules: OpenAIFastPolicyRule[];

--- a/frontend/src/i18n/__tests__/usageServiceTierLocales.spec.ts
+++ b/frontend/src/i18n/__tests__/usageServiceTierLocales.spec.ts
@@ -7,6 +7,7 @@ describe('usage service tier locale keys', () => {
   it('contains zh labels for service tier tooltip', () => {
     expect(zh.usage.serviceTier).toBe('服务档位')
     expect(zh.usage.serviceTierPriority).toBe('Fast')
+    expect(zh.usage.serviceTierUltraFast).toBe('Ultrafast')
     expect(zh.usage.serviceTierFlex).toBe('Flex')
     expect(zh.usage.serviceTierStandard).toBe('Standard')
   })
@@ -14,6 +15,7 @@ describe('usage service tier locale keys', () => {
   it('contains en labels for service tier tooltip', () => {
     expect(en.usage.serviceTier).toBe('Service tier')
     expect(en.usage.serviceTierPriority).toBe('Fast')
+    expect(en.usage.serviceTierUltraFast).toBe('Ultrafast')
     expect(en.usage.serviceTierFlex).toBe('Flex')
     expect(en.usage.serviceTierStandard).toBe('Standard')
   })

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -1080,8 +1080,8 @@ export default {
         commonPatterns: 'Common patterns'
       },
       openaiFastPolicy: {
-        title: 'OpenAI Fast/Flex Policy',
-        description: 'Intercept, filter, or pass OpenAI fast(priority) / flex requests based on the request body service_tier field. Applies to the OpenAI gateway only.',
+        title: 'OpenAI Fast/UltraFast/Flex Policy',
+        description: 'Intercept, filter, or pass OpenAI fast(priority), ultrafast, and flex requests based on the request body service_tier field. Applies to the OpenAI gateway only.',
         empty: 'No rules configured. Click the button below to add one.',
         ruleHeader: 'Rule #{index}',
         removeRule: 'Remove rule',
@@ -1090,6 +1090,7 @@ export default {
         serviceTier: 'service_tier match',
         tierAll: 'All tier values',
         tierPriority: 'priority (fast)',
+        tierUltraFast: 'ultrafast',
         tierFlex: 'flex',
         action: 'Action',
         actionPass: 'Pass (keep service_tier)',

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -398,6 +398,7 @@ export default {
     cacheWrite: 'Write',
     serviceTier: 'Service tier',
     serviceTierPriority: 'Fast',
+    serviceTierUltraFast: 'Ultrafast',
     serviceTierFlex: 'Flex',
     serviceTierStandard: 'Standard',
     rate: 'Rate',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -1074,8 +1074,8 @@ export default {
         commonPatterns: '常用模式'
       },
       openaiFastPolicy: {
-        title: 'OpenAI Fast/Flex 策略',
-        description: '基于请求体 service_tier 字段拦截/过滤/透传 OpenAI fast(priority) 与 flex 请求；仅作用于 OpenAI 网关。',
+        title: 'OpenAI Fast/UltraFast/Flex 策略',
+        description: '基于请求体 service_tier 字段拦截/过滤/透传 OpenAI fast(priority)、ultrafast 与 flex 请求；仅作用于 OpenAI 网关。',
         empty: '尚未配置任何规则。点击下方按钮新增。',
         ruleHeader: '规则 #{index}',
         removeRule: '删除规则',
@@ -1084,6 +1084,7 @@ export default {
         serviceTier: 'service_tier 匹配',
         tierAll: '全部 tier 值',
         tierPriority: 'priority（fast）',
+        tierUltraFast: 'ultrafast',
         tierFlex: 'flex',
         action: '处理方式',
         actionPass: '透传（保留 service_tier）',

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -403,6 +403,7 @@ export default {
     cacheWrite: '写入',
     serviceTier: '服务档位',
     serviceTierPriority: 'Fast',
+    serviceTierUltraFast: 'Ultrafast',
     serviceTierFlex: 'Flex',
     serviceTierStandard: 'Standard',
     rate: '倍率',

--- a/frontend/src/utils/__tests__/usageServiceTier.spec.ts
+++ b/frontend/src/utils/__tests__/usageServiceTier.spec.ts
@@ -11,6 +11,7 @@ describe('usageServiceTier utils', () => {
 
   it('preserves supported tiers', () => {
     expect(normalizeUsageServiceTier('priority')).toBe('priority')
+    expect(normalizeUsageServiceTier('ultrafast')).toBe('ultrafast')
     expect(normalizeUsageServiceTier('flex')).toBe('flex')
   })
 
@@ -27,11 +28,13 @@ describe('usageServiceTier utils', () => {
   it('maps tiers to translated labels', () => {
     const translate = (key: string) => ({
       'usage.serviceTierPriority': 'Fast',
+      'usage.serviceTierUltraFast': 'Ultrafast',
       'usage.serviceTierFlex': 'Flex',
       'usage.serviceTierStandard': 'Standard',
     })[key] ?? key
 
     expect(getUsageServiceTierLabel('fast', translate)).toBe('Fast')
+    expect(getUsageServiceTierLabel('ultrafast', translate)).toBe('Ultrafast')
     expect(getUsageServiceTierLabel('flex', translate)).toBe('Flex')
     expect(getUsageServiceTierLabel(undefined, translate)).toBe('Standard')
     expect(getUsageServiceTierLabel('custom-tier', translate)).toBe('custom-tier')

--- a/frontend/src/utils/usageServiceTier.ts
+++ b/frontend/src/utils/usageServiceTier.ts
@@ -19,6 +19,7 @@ export function getUsageServiceTierLabel(
 ): string {
   const tier = formatUsageServiceTier(serviceTier)
   if (tier === 'priority') return translate('usage.serviceTierPriority')
+  if (tier === 'ultrafast') return translate('usage.serviceTierUltraFast')
   if (tier === 'flex') return translate('usage.serviceTierFlex')
   if (tier === 'standard') return translate('usage.serviceTierStandard')
   return tier

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -1183,6 +1183,7 @@
                         rule.service_tier = $event as
                           | 'all'
                           | 'priority'
+                          | 'ultrafast'
                           | 'flex'
                       "
                       :options="openaiFastPolicyTierOptions"
@@ -12083,6 +12084,10 @@ const openaiFastPolicyTierOptions = computed(() => [
   {
     value: "priority",
     label: t("admin.settings.openaiFastPolicy.tierPriority"),
+  },
+  {
+    value: "ultrafast",
+    label: t("admin.settings.openaiFastPolicy.tierUltraFast"),
   },
   { value: "flex", label: t("admin.settings.openaiFastPolicy.tierFlex") },
 ]);


### PR DESCRIPTION
## Summary

- accept and preserve `service_tier=ultrafast` across Responses, Chat Completions, and WebSocket request paths
- advertise an `Ultrafast` catalog tier for `gpt-5.6-sol` and retain it in the Codex OAuth routing hint
- support tier-specific admin policy matching and usage display, while reusing the existing Fast multiplier and free-Fast billing behavior
- preserve observed `ultrafast` response tiers for billing resolution and usage records

## Compatibility basis

- Codex service-tier commands are catalog-driven and send the advertised tier `id` as the request value: https://github.com/openai/codex/pull/21745
- the current Codex request payload carries `service_tier` as a string selected from model metadata: https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/common.rs
- current Codex usage reporting recognizes `ultrafast` as a distinct speed value: https://github.com/openai/codex/blob/main/codex-rs/tui/src/status/thread_usage.rs

## Validation

- `GOTOOLCHAIN=auto go test ./internal/service -run ServiceTier/OpenAIFastPolicy/CodexModels/RoutingHint targeted cases -count=1`
- `GOTOOLCHAIN=auto go test ./internal/handler -run service-tier handler cases -count=1`
- `GOTOOLCHAIN=auto go test ./internal/handler/admin -run OpenAIFastPolicySettingsFromDTO -count=1`
- 3 targeted Vitest files: 10 tests passed
- `vue-tsc --noEmit`
- ESLint on modified frontend files