### PR TITLE
fix(antigravity): degrade orphaned tool_result to text instead of forging function name

### DIFF
--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -524,18 +524,28 @@ func buildParts(content json.RawMessage, toolIDToName map[string]string, allowDu
 			parts = append(parts, part)
 
 		case "tool_result":
-			// 获取函数名
+			// Get function name
 			funcName := block.Name
 			if funcName == "" {
 				if name, ok := toolIDToName[block.ToolUseID]; ok {
 					funcName = name
-				} else {
-					funcName = block.ToolUseID
 				}
 			}
 
-			// 解析 content
+			// Parse content
 			resultContent := parseToolResultContent(block.Content, block.IsError)
+
+			if funcName == "" {
+				// When client trims history in multi-turn sessions, the corresponding tool_use block is absent,
+				// causing key lookup failure in toolIDToName map.
+				// We must not fallback to using raw tool_use_id as function name when sending to Gemini,
+				// as upstream will reject the turn with MALFORMED_FUNCTION_CALL / empty reply.
+				// Degrade to plain text context: preserves semantics, stays structurally valid, and allows session to continue.
+				parts = append(parts, GeminiPart{
+					Text: fmt.Sprintf("[tool result %s]\n%s", block.ToolUseID, resultContent),
+				})
+				continue
+			}
 
 			parts = append(parts, GeminiPart{
 				FunctionResponse: &GeminiFunctionResponse{

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -621,3 +621,36 @@ func TestGeminiToolConfig_IncludeServerSideToolInvocations(t *testing.T) {
 		require.NotContains(t, raw, "includeServerSideToolInvocations")
 	})
 }
+
+func TestBuildParts_ToolResultWithUnmappedIDDegradesToText(t *testing.T) {
+	content := `[{"type":"tool_result","tool_use_id":"toolu_01ABCDEF","content":"file contents here"}]`
+	toolIDToName := make(map[string]string)
+
+	parts, _, err := buildParts(json.RawMessage(content), toolIDToName, true)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.Nil(t, parts[0].FunctionResponse,
+		"unmapped tool_result must not become FunctionResponse with a raw tool_use_id name")
+	require.True(t, strings.Contains(parts[0].Text, "toolu_01ABCDEF"),
+		"degraded text part must keep the tool_use_id, got %q", parts[0].Text)
+	require.True(t, strings.Contains(parts[0].Text, "file contents here"),
+		"degraded text part must keep the result content, got %q", parts[0].Text)
+}
+
+func TestBuildParts_ToolResultWithMappedIDKeepsFunctionResponse(t *testing.T) {
+	content := `[{"type":"tool_use","id":"toolu_9","name":"read_file","input":{}},{"type":"tool_result","tool_use_id":"toolu_9","content":"ok"}]`
+	toolIDToName := make(map[string]string)
+
+	parts, _, err := buildParts(json.RawMessage(content), toolIDToName, true)
+	require.NoError(t, err)
+
+	var funcResp *GeminiFunctionResponse
+	for _, part := range parts {
+		if part.FunctionResponse != nil {
+			funcResp = part.FunctionResponse
+		}
+	}
+	require.NotNil(t, funcResp, "mapped tool_result must stay a FunctionResponse")
+	require.Equal(t, "read_file", funcResp.Name)
+	require.Equal(t, "toolu_9", funcResp.ID)
+}

--- a/backend/internal/pkg/antigravity/response_transformer_test.go
+++ b/backend/internal/pkg/antigravity/response_transformer_test.go
@@ -107,3 +107,10 @@ func BenchmarkGenerateRandomID(b *testing.B) {
 		_ = generateRandomID()
 	}
 }
+
+func TestStreamingProcessor_MalformedFunctionCall(t *testing.T) {
+	proc := NewStreamingProcessor("gemini-2.5-flash")
+	out := proc.ProcessLine(`data: {"response":{"candidates":[{"finishReason":"MALFORMED_FUNCTION_CALL"}]}}`)
+	require.Contains(t, string(out), `"type":"error"`)
+	require.Contains(t, string(out), "upstream Gemini returned MALFORMED_FUNCTION_CALL")
+}

--- a/backend/internal/pkg/antigravity/stream_transformer.go
+++ b/backend/internal/pkg/antigravity/stream_transformer.go
@@ -138,6 +138,15 @@ func (p *StreamingProcessor) ProcessLine(line string) []byte {
 					log.Printf("[Antigravity] Malformed content: %s", string(b))
 				}
 			}
+			// Do not silently swallow: explicitly emit Anthropic error event
+			// so the client receives a retryable error instead of an "empty successful reply".
+			_, _ = result.Write(p.formatSSE("error", map[string]any{
+				"type": "error",
+				"error": map[string]any{
+					"type":    "api_error",
+					"message": "upstream Gemini returned MALFORMED_FUNCTION_CALL; the turn produced no valid tool call, please retry",
+				},
+			}))
 		}
 		if finishReason != "" {
 			_, _ = result.Write(p.emitFinish(finishReason))


### PR DESCRIPTION
## Problem

In multi-turn sessions, clients (e.g. Claude Code) trim older history. A trimmed turn may drop the original `tool_use` block while the following turn still carries its `tool_result`. When that happens, `toolIDToName` in `backend/internal/pkg/antigravity/request_transformer.go` cannot resolve the `tool_use_id` to a function name.

Before this patch the transformer fell back to using the raw `tool_use_id` string as `FunctionResponse.name`. Gemini rejects that with `MALFORMED_FUNCTION_CALL` (or an empty candidate). On top of that, `stream_transformer.go` only logged `MALFORMED_FUNCTION_CALL` and then closed the stream normally, so the client received a "successful" empty reply and the agent appeared to go silent mid-task.

## Root cause

1. `request_transformer.go` (tool_result branch): when the lookup in `toolIDToName` missed, the code set `funcName = block.ToolUseID`, forging an invalid function name.
2. `stream_transformer.go`: `MALFORMED_FUNCTION_CALL` was logged but no SSE `error` event was written, so the failure was swallowed and surfaced as an empty successful response.

## Fix

1. `request_transformer.go`: when `funcName` cannot be resolved, degrade the `tool_result` into a plain text part (`[tool result <id>]\n<content>`) instead of emitting a `FunctionResponse` with a forged name. Context semantics are preserved and the Gemini payload stays structurally valid, so the conversation can continue.
2. `stream_transformer.go`: when the upstream finish reason is `MALFORMED_FUNCTION_CALL`, explicitly emit an Anthropic-format SSE `error` event (`api_error`) so the client gets a retryable error rather than a silent empty reply.

## Tests

- `TestBuildParts_ToolResultWithUnmappedIDDegradesToText`: an unmapped `tool_result` becomes a text part that keeps both the id and the content, and no `FunctionResponse` is produced.
- `TestBuildParts_ToolResultWithMappedIDKeepsFunctionResponse`: a mapped `tool_result` still produces the normal `FunctionResponse` (regression guard).
- Streaming test in `response_transformer_test.go`: `MALFORMED_FUNCTION_CALL` now yields an explicit SSE error event.

`go test ./internal/pkg/antigravity/...` passes locally.

## How to reproduce

1. Run a multi-turn tool-using session through the Antigravity route (e.g. Claude Code pointed at this gateway).
2. Let the client trim history so a turn contains a `tool_result` whose `tool_use` is no longer present.
3. Before this patch: upstream returns `MALFORMED_FUNCTION_CALL` and the client sees an empty successful reply. After: the turn continues (degraded text context), and any remaining malformed-call error is surfaced as an SSE error event.
