### PR TITLE
feat: add OpenAI-compatible audio transcription gateway

### DIFF
--- a/backend/internal/handler/openai_transcriptions.go
+++ b/backend/internal/handler/openai_transcriptions.go
@@ -1,0 +1,234 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type openAITranscriptionRequest struct {
+	Model string
+}
+
+// Transcriptions handles OpenAI-compatible multipart audio transcription.
+// POST /v1/audio/transcriptions
+func (h *OpenAIGatewayHandler) Transcriptions(c *gin.Context) {
+	streamStarted := false
+	requestStart := time.Now()
+
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusUnauthorized, "authentication_error", "Invalid API key")
+		return
+	}
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
+		return
+	}
+	reqLog := requestLogger(c, "handler.openai_gateway.transcriptions",
+		zap.Int64("user_id", subject.UserID),
+		zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID),
+	)
+	if !h.ensureResponsesDependencies(c, reqLog) {
+		return
+	}
+
+	body, err := pkghttputil.ReadRequestBodyWithPrealloc(c.Request)
+	if err != nil {
+		if maxErr, ok := extractMaxBytesError(err); ok {
+			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
+			return
+		}
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body")
+		return
+	}
+	parsed, err := parseOpenAITranscriptionRequest(body, c.GetHeader("Content-Type"))
+	if err != nil {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	reqModel := parsed.Model
+	ensureCompositeTargetPlatform(c, apiKey, reqModel)
+	if !compositeTargetPlatformAllowed(c, apiKey, reqModel, service.PlatformOpenAI) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by this OpenAI-compatible endpoint for composite groups")
+		return
+	}
+	setOpsRequestContext(c, reqModel, false)
+	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
+	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
+	routingModel := channelMapping.MappedModel
+	if strings.TrimSpace(routingModel) == "" {
+		routingModel = reqModel
+	}
+
+	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+	userRelease, acquired := h.acquireResponsesUserSlot(c, subject.UserID, subject.Concurrency, false, &streamStarted, reqLog)
+	if !acquired {
+		return
+	}
+	if userRelease != nil {
+		defer userRelease()
+	}
+	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription, service.QuotaPlatform(c.Request.Context(), apiKey)); err != nil {
+		status, code, message, retryAfter := billingErrorDetails(err)
+		if retryAfter > 0 {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+		}
+		h.errorResponse(c, status, code, message)
+		return
+	}
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+
+	pricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	c.Request = c.Request.WithContext(pricingCtx)
+	failedAccountIDs := make(map[int64]struct{})
+	var lastFailoverErr *service.UpstreamFailoverError
+	maxAccountSwitches := h.maxAccountSwitches
+	if maxAccountSwitches <= 0 {
+		maxAccountSwitches = 3
+	}
+
+	for switchCount := 0; ; {
+		selection, _, selectErr := h.gatewayService.SelectAccountWithSchedulerForCapability(
+			c.Request.Context(), apiKey.GroupID, "", "", routingModel, failedAccountIDs,
+			service.OpenAIUpstreamTransportHTTPSSE, service.OpenAIEndpointCapabilityTranscriptions,
+			false, false, true,
+		)
+		if selectErr != nil || selection == nil || selection.Account == nil {
+			if len(failedAccountIDs) == 0 {
+				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, routingModel, service.PlatformOpenAI)
+				h.errorResponse(c, cls.Status, cls.ErrType, cls.Message)
+				return
+			}
+			if lastFailoverErr != nil {
+				h.handleFailoverExhausted(c, lastFailoverErr, false)
+			} else {
+				h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+			}
+			return
+		}
+		account := selection.Account
+		setOpsSelectedAccount(c, account.ID, account.Platform)
+		accountRelease, slotStatus := h.acquireResponsesAccountSlot(c, apiKey.GroupID, "", selection, false, &streamStarted, reqLog)
+		if slotStatus == openAISlotAcquireProfitVetoed {
+			failedAccountIDs[account.ID] = struct{}{}
+			continue
+		}
+		if slotStatus != openAISlotAcquireOK {
+			return
+		}
+
+		writerSizeBeforeForward := c.Writer.Size()
+		result, forwardErr := func() (*service.OpenAIForwardResult, error) {
+			defer accountRelease()
+			return h.gatewayService.ForwardTranscriptions(c.Request.Context(), c, account, body, c.GetHeader("Content-Type"), routingModel)
+		}()
+		if forwardErr != nil {
+			var failoverErr *service.UpstreamFailoverError
+			if errors.As(forwardErr, &failoverErr) {
+				if c.Writer.Size() != writerSizeBeforeForward {
+					h.handleFailoverExhausted(c, failoverErr, true)
+					return
+				}
+				h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, routingModel, false, result), false, nil, forwardErr)
+				failedAccountIDs[account.ID] = struct{}{}
+				lastFailoverErr = failoverErr
+				if switchCount >= maxAccountSwitches {
+					h.handleFailoverExhausted(c, failoverErr, false)
+					return
+				}
+				switchCount++
+				continue
+			}
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account, routingModel, false, nil, forwardErr)
+			if c.Writer.Size() == writerSizeBeforeForward {
+				h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+			}
+			return
+		}
+
+		result.Model = reqModel
+		result.BillingModel = routingModel
+		h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, routingModel, false, result), true, nil)
+		h.recordOpenAITranscriptionUsage(c, apiKey, &subject, account, subscription, body, result, channelMapping, reqModel, pricingAt)
+		return
+	}
+}
+
+func (h *OpenAIGatewayHandler) recordOpenAITranscriptionUsage(
+	c *gin.Context,
+	apiKey *service.APIKey,
+	subject *middleware2.AuthSubject,
+	account *service.Account,
+	subscription *service.UserSubscription,
+	body []byte,
+	result *service.OpenAIForwardResult,
+	channelMapping service.ChannelMappingResult,
+	requestModel string,
+	pricingAt time.Time,
+) {
+	if h == nil || c == nil || apiKey == nil || subject == nil || account == nil || result == nil {
+		return
+	}
+	userAgent := c.GetHeader("User-Agent")
+	clientIP := ip.GetClientIP(c)
+	inboundEndpoint := GetInboundEndpoint(c)
+	upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+	quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+	sessionID := service.ExtractClientSessionID(c)
+	h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
+		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
+			Result: result, APIKey: apiKey, User: apiKey.User, Account: account, Subscription: subscription,
+			InboundEndpoint: inboundEndpoint, UpstreamEndpoint: upstreamEndpoint, UserAgent: userAgent,
+			IPAddress: clientIP, RequestPayloadHash: service.HashUsageRequestPayload(body), APIKeyService: h.apiKeyService,
+			QuotaPlatform: quotaPlatform, SessionID: sessionID,
+			ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, requestModel, result.UpstreamModel), PricingAt: pricingAt,
+		}); err != nil {
+			logger.L().With(zap.String("component", "handler.openai_gateway.transcriptions"), zap.Int64("user_id", subject.UserID), zap.Int64("account_id", account.ID)).Error("openai_transcriptions.record_usage_failed", zap.Error(err))
+		}
+	})
+}
+
+// parseOpenAITranscriptionRequest validates the OpenAI multipart shape without
+// consuming the request body that must later be forwarded upstream intact.
+func parseOpenAITranscriptionRequest(body []byte, contentType string) (openAITranscriptionRequest, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil || !strings.EqualFold(mediaType, "multipart/form-data") || strings.TrimSpace(params["boundary"]) == "" {
+		return openAITranscriptionRequest{}, fmt.Errorf("Content-Type must be multipart/form-data")
+	}
+	form, err := multipart.NewReader(bytes.NewReader(body), params["boundary"]).ReadForm(32 << 20)
+	if err != nil {
+		return openAITranscriptionRequest{}, fmt.Errorf("invalid multipart form")
+	}
+	defer form.RemoveAll()
+	modelValues := form.Value["model"]
+	model := ""
+	if len(modelValues) > 0 {
+		model = strings.TrimSpace(modelValues[0])
+	}
+	if model == "" {
+		return openAITranscriptionRequest{}, fmt.Errorf("model is required")
+	}
+	if len(form.File["file"]) == 0 || strings.TrimSpace(form.File["file"][0].Filename) == "" {
+		return openAITranscriptionRequest{}, fmt.Errorf("file is required")
+	}
+	return openAITranscriptionRequest{Model: model}, nil
+}

--- a/backend/internal/handler/openai_transcriptions_test.go
+++ b/backend/internal/handler/openai_transcriptions_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"bytes"
+	"mime/multipart"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOpenAITranscriptionRequestRequiresModelAndAudioFile(t *testing.T) {
+	var valid bytes.Buffer
+	writer := multipart.NewWriter(&valid)
+	require.NoError(t, writer.WriteField("model", "fun-asr-nano"))
+	file, err := writer.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("RIFFaudio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	parsed, err := parseOpenAITranscriptionRequest(valid.Bytes(), writer.FormDataContentType())
+	require.NoError(t, err)
+	require.Equal(t, "fun-asr-nano", parsed.Model)
+
+	var missingFile bytes.Buffer
+	missingFileWriter := multipart.NewWriter(&missingFile)
+	require.NoError(t, missingFileWriter.WriteField("model", "fun-asr-nano"))
+	require.NoError(t, missingFileWriter.Close())
+	_, err = parseOpenAITranscriptionRequest(missingFile.Bytes(), missingFileWriter.FormDataContentType())
+	require.EqualError(t, err, "file is required")
+
+	var missingModel bytes.Buffer
+	missingModelWriter := multipart.NewWriter(&missingModel)
+	file, err = missingModelWriter.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("RIFFaudio"))
+	require.NoError(t, err)
+	require.NoError(t, missingModelWriter.Close())
+	_, err = parseOpenAITranscriptionRequest(missingModel.Bytes(), missingModelWriter.FormDataContentType())
+	require.EqualError(t, err, "model is required")
+}

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -250,6 +250,14 @@ func RegisterGatewayRoutes(
 			}
 			h.OpenAIGateway.Embeddings(c)
 		})
+		gateway.POST("/audio/transcriptions", func(c *gin.Context) {
+			if platform := getGroupPlatform(c); platform != service.PlatformOpenAI && platform != service.PlatformComposite {
+				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+				c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"type": "not_found_error", "message": "Audio transcription API is not supported for this platform"}})
+				return
+			}
+			h.OpenAIGateway.Transcriptions(c)
+		})
 		gateway.POST("/images/generations", imagesHandler)
 		gateway.POST("/images/edits", imagesHandler)
 		gateway.POST("/images/generations/async", h.AsyncImage.Submit)
@@ -399,6 +407,14 @@ func RegisterGatewayRoutes(
 			return
 		}
 		h.OpenAIGateway.Embeddings(c)
+	})
+	r.POST("/audio/transcriptions", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, func(c *gin.Context) {
+		if platform := getGroupPlatform(c); platform != service.PlatformOpenAI && platform != service.PlatformComposite {
+			service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"type": "not_found_error", "message": "Audio transcription API is not supported for this platform"}})
+			return
+		}
+		h.OpenAIGateway.Transcriptions(c)
 	})
 	r.POST("/images/generations", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, imagesHandler)
 	r.POST("/images/edits", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, imagesHandler)

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -1,7 +1,9 @@
 package routes
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -372,6 +374,31 @@ func TestGatewayRoutesCompositeOpenAIOnlyEndpointsRequireOpenAITarget(t *testing
 	w = httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestGatewayRoutesCompositeTranscriptionsRequireOpenAITarget(t *testing.T) {
+	router := newGatewayRoutesTestRouter(service.PlatformComposite)
+	buildRequest := func(model string) *http.Request {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		require.NoError(t, writer.WriteField("model", model))
+		file, err := writer.CreateFormFile("file", "sample.wav")
+		require.NoError(t, err)
+		_, err = file.Write([]byte("RIFFaudio"))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+		req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", bytes.NewReader(body.Bytes()))
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		return req
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, buildRequest("gemini-2.5-pro"))
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, buildRequest("fun-asr-nano"))
 	require.NotEqual(t, http.StatusNotFound, w.Code)
 }
 

--- a/backend/internal/server/routes/prompt_audit_route_coverage_test.go
+++ b/backend/internal/server/routes/prompt_audit_route_coverage_test.go
@@ -54,6 +54,7 @@ func TestEveryGatewayPOSTRouteIsClassifiedForPromptAuditCoverage(t *testing.T) {
 		"/messages/count_tokens":     "tokenization only; it does not execute a model request",
 		"/images/batches/:id/cancel": "control-plane cancellation with no user prompt",
 		"/stt":                       "speech transcription is not a text-generation prompt",
+		"/audio/transcriptions":      "speech transcription is not a text-generation prompt",
 		"/custom-voices":             "voice profile management has no model prompt",
 	}
 

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -91,8 +91,12 @@ const openAILongContextBillingEnabledKey = "openai_long_context_billing_enabled"
 const (
 	OpenAIEndpointCapabilityChatCompletions OpenAIEndpointCapability = "chat_completions"
 	OpenAIEndpointCapabilityEmbeddings      OpenAIEndpointCapability = "embeddings"
-	OpenAIEndpointCapabilityAlphaSearch     OpenAIEndpointCapability = "alpha_search"
-	OpenAIEndpointCapabilityLive            OpenAIEndpointCapability = "live"
+	// OpenAIEndpointCapabilityTranscriptions is the multipart
+	// /v1/audio/transcriptions endpoint. It is intentionally separate from
+	// chat and embeddings so audio-capable providers can be scheduled safely.
+	OpenAIEndpointCapabilityTranscriptions OpenAIEndpointCapability = "transcriptions"
+	OpenAIEndpointCapabilityAlphaSearch    OpenAIEndpointCapability = "alpha_search"
+	OpenAIEndpointCapabilityLive           OpenAIEndpointCapability = "live"
 	// OpenAIEndpointCapabilityGrokMediaGeneration keeps image/video generation
 	// away from Grok accounts that are explicitly disabled or whose billing
 	// entitlement probe was forbidden. Video status lookups intentionally do not
@@ -1821,7 +1825,7 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 		if a.Type != AccountTypeOAuth && a.Type != AccountTypeAPIKey {
 			return false
 		}
-	case OpenAIEndpointCapabilityEmbeddings:
+	case OpenAIEndpointCapabilityEmbeddings, OpenAIEndpointCapabilityTranscriptions:
 		if a.Type != AccountTypeAPIKey {
 			return false
 		}

--- a/backend/internal/service/openai_bulk_account_settings.go
+++ b/backend/internal/service/openai_bulk_account_settings.go
@@ -94,7 +94,7 @@ func normalizeBulkOpenAIEndpointCapabilities(raw any) (any, bool, error) {
 	selected := make(map[string]bool, 2)
 	for _, value := range values {
 		switch OpenAIEndpointCapability(value) {
-		case OpenAIEndpointCapabilityChatCompletions, OpenAIEndpointCapabilityEmbeddings:
+		case OpenAIEndpointCapabilityChatCompletions, OpenAIEndpointCapabilityEmbeddings, OpenAIEndpointCapabilityTranscriptions:
 			selected[value] = true
 		default:
 			return nil, false, invalidBulkOpenAIEndpointCapabilities()
@@ -105,19 +105,29 @@ func normalizeBulkOpenAIEndpointCapabilities(raw any) (any, bool, error) {
 	}
 
 	includeChat := selected[string(OpenAIEndpointCapabilityChatCompletions)]
-	if includeChat && selected[string(OpenAIEndpointCapabilityEmbeddings)] {
+	if includeChat && len(selected) == 2 && selected[string(OpenAIEndpointCapabilityEmbeddings)] {
 		return nil, true, nil
 	}
-	if includeChat {
+	if includeChat && len(selected) == 1 {
 		return []string{string(OpenAIEndpointCapabilityChatCompletions)}, true, nil
 	}
-	return []string{string(OpenAIEndpointCapabilityEmbeddings)}, false, nil
+	result := make([]string, 0, len(selected))
+	for _, capability := range []OpenAIEndpointCapability{
+		OpenAIEndpointCapabilityEmbeddings,
+		OpenAIEndpointCapabilityTranscriptions,
+		OpenAIEndpointCapabilityChatCompletions,
+	} {
+		if selected[string(capability)] {
+			result = append(result, string(capability))
+		}
+	}
+	return result, false, nil
 }
 
 func invalidBulkOpenAIEndpointCapabilities() error {
 	return infraerrors.BadRequest(
 		"OPENAI_ENDPOINT_CAPABILITIES_INVALID",
-		"openai_capabilities must contain chat_completions, embeddings, or both",
+		"openai_capabilities must contain chat_completions, embeddings, transcriptions, or a supported combination",
 	)
 }
 

--- a/backend/internal/service/openai_transcriptions.go
+++ b/backend/internal/service/openai_transcriptions.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ForwardTranscriptions forwards an OpenAI-compatible multipart transcription request.
+func (s *OpenAIGatewayService) ForwardTranscriptions(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	contentType string,
+	model string,
+) (*OpenAIForwardResult, error) {
+	if s == nil || account == nil {
+		return nil, fmt.Errorf("transcription service/account is required")
+	}
+	if account.Platform != PlatformOpenAI || account.Type != AccountTypeAPIKey {
+		return nil, fmt.Errorf("account is not an OpenAI API-key account")
+	}
+
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	upstreamModel := strings.TrimSpace(account.GetMappedModel(model))
+	if upstreamModel == "" {
+		upstreamModel = model
+	}
+	forwardBody, forwardContentType, err := rewriteOpenAIImagesModel(body, contentType, upstreamModel)
+	if err != nil {
+		return nil, fmt.Errorf("rewrite transcription model: %w", err)
+	}
+
+	baseURL := account.GetOpenAIFormatBaseURL()
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base_url: %w", err)
+	}
+	apiKey := strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
+	if apiKey == "" {
+		return nil, fmt.Errorf("account %d missing api_key", account.ID)
+	}
+
+	started := time.Now()
+	upstreamCtx, release := detachUpstreamContext(ctx)
+	defer release()
+	req, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, buildOpenAITranscriptionsURL(validatedURL), bytes.NewReader(forwardBody))
+	if err != nil {
+		return nil, fmt.Errorf("build upstream request: %w", err)
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", forwardContentType)
+	account.ApplyHeaderOverrides(req.Header)
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.doOpenAIUpstream(req, proxyURL, account)
+	if err != nil {
+		return nil, fmt.Errorf("upstream request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return nil, fmt.Errorf("read upstream response: %w", err)
+	}
+	writeOpenAITranscriptionsResponse(c, resp, responseBody)
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("upstream returned status %d", resp.StatusCode)
+	}
+	return &OpenAIForwardResult{RequestID: firstNonEmptyString(resp.Header.Get("x-request-id"), resp.Header.Get("request-id")), Model: model, UpstreamModel: upstreamModel, Duration: time.Since(started)}, nil
+}
+
+func buildOpenAITranscriptionsURL(base string) string {
+	return buildOpenAIEndpointURL(base, "/v1/audio/transcriptions")
+}
+
+func writeOpenAITranscriptionsResponse(c *gin.Context, resp *http.Response, body []byte) {
+	if c == nil || resp == nil || c.Writer.Written() {
+		return
+	}
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		c.Header("Content-Type", contentType)
+	} else {
+		c.Header("Content-Type", "application/json")
+	}
+	c.Writer.WriteHeader(resp.StatusCode)
+	_, _ = c.Writer.Write(body)
+}

--- a/backend/internal/service/openai_transcriptions.go
+++ b/backend/internal/service/openai_transcriptions.go
@@ -72,17 +72,32 @@ func (s *OpenAIGatewayService) ForwardTranscriptions(
 	}
 	resp, err := s.doOpenAIUpstream(req, proxyURL, account)
 	if err != nil {
-		return nil, fmt.Errorf("upstream request failed: %w", err)
+		return nil, &UpstreamFailoverError{StatusCode: http.StatusBadGateway, ResponseBody: []byte(sanitizeUpstreamErrorMessage(err.Error()))}
 	}
 	defer resp.Body.Close()
 	responseBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
 		return nil, fmt.Errorf("read upstream response: %w", err)
 	}
-	writeOpenAITranscriptionsResponse(c, resp, responseBody)
 	if resp.StatusCode >= http.StatusBadRequest {
+		upstreamMessage := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(responseBody)))
+		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMessage, responseBody) {
+			shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, responseBody, upstreamModel)
+			retryableOnSameAccount := !shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode)
+			if isOpenAIHTTPUpstreamAccessStateError(resp.StatusCode, upstreamMessage, responseBody) {
+				return nil, newOpenAIUpstreamFailoverError(resp.StatusCode, resp.Header, responseBody, upstreamMessage, retryableOnSameAccount)
+			}
+			return nil, &UpstreamFailoverError{
+				StatusCode:             resp.StatusCode,
+				ResponseBody:           responseBody,
+				ResponseHeaders:        resp.Header,
+				RetryableOnSameAccount: retryableOnSameAccount,
+			}
+		}
+		writeOpenAITranscriptionsResponse(c, resp, responseBody)
 		return nil, fmt.Errorf("upstream returned status %d", resp.StatusCode)
 	}
+	writeOpenAITranscriptionsResponse(c, resp, responseBody)
 	return &OpenAIForwardResult{RequestID: firstNonEmptyString(resp.Header.Get("x-request-id"), resp.Header.Get("request-id")), Model: model, UpstreamModel: upstreamModel, Duration: time.Since(started)}, nil
 }
 

--- a/backend/internal/service/openai_transcriptions_test.go
+++ b/backend/internal/service/openai_transcriptions_test.go
@@ -65,3 +65,49 @@ func TestForwardTranscriptions_APIKeyRewritesModelAndPreservesLanguage(t *testin
 	require.Equal(t, "zh", parsed.Value["language"][0])
 	require.Equal(t, "sample.wav", parsed.File["file"][0].Filename)
 }
+
+func TestForwardTranscriptions_RetryableUpstreamErrorDoesNotCommitResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "fun-asr-nano"))
+	part, err := writer.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("RIFFaudio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", bytes.NewReader(body.Bytes()))
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(`{"error":{"message":"try again"}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"api_key": "sk-test", "base_url": "https://asr.example",
+	}}
+
+	_, err = svc.ForwardTranscriptions(context.Background(), c, account, body.Bytes(), writer.FormDataContentType(), "fun-asr-nano")
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+	require.False(t, c.Writer.Written())
+}
+
+func TestAccountSupportsOpenAITranscriptionsCapability(t *testing.T) {
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"openai_capabilities": []any{"transcriptions"},
+	}}
+	require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityTranscriptions))
+	require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityEmbeddings))
+
+	configuredWithoutTranscriptions := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"openai_capabilities": []any{"chat_completions"},
+	}}
+	require.False(t, configuredWithoutTranscriptions.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityTranscriptions))
+
+}

--- a/backend/internal/service/openai_transcriptions_test.go
+++ b/backend/internal/service/openai_transcriptions_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildOpenAITranscriptionsURL(t *testing.T) {
+	require.Equal(t, "https://asr.example/v1/audio/transcriptions", buildOpenAITranscriptionsURL("https://asr.example"))
+	require.Equal(t, "https://asr.example/v1/audio/transcriptions", buildOpenAITranscriptionsURL("https://asr.example/v1"))
+}
+
+func multipartBoundary(t *testing.T, contentType string) string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(contentType)
+	require.NoError(t, err)
+	return params["boundary"]
+}
+
+func TestForwardTranscriptions_APIKeyRewritesModelAndPreservesLanguage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "fun-asr-nano"))
+	require.NoError(t, writer.WriteField("language", "zh"))
+	part, err := writer.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("RIFFaudio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", bytes.NewReader(body.Bytes()))
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(`{"text":"hello"}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"api_key": "sk-test", "base_url": "https://asr.example", "model_mapping": map[string]any{"fun-asr-nano": "FunAudioLLM/Fun-ASR-Nano-2512"},
+	}}
+
+	result, err := svc.ForwardTranscriptions(context.Background(), c, account, body.Bytes(), writer.FormDataContentType(), "fun-asr-nano")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "https://asr.example/v1/audio/transcriptions", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer sk-test", upstream.lastReq.Header.Get("Authorization"))
+	parsed, err := multipart.NewReader(bytes.NewReader(upstream.lastBody), multipartBoundary(t, upstream.lastReq.Header.Get("Content-Type"))).ReadForm(1024)
+	require.NoError(t, err)
+	require.Equal(t, "FunAudioLLM/Fun-ASR-Nano-2512", parsed.Value["model"][0])
+	require.Equal(t, "zh", parsed.Value["language"][0])
+	require.Equal(t, "sample.wav", parsed.File["file"][0].Filename)
+}


### PR DESCRIPTION
## Summary

Implements the OpenAI-compatible `POST /v1/audio/transcriptions` path requested in #3754.

- Preserves multipart `file`, `language`, and optional OpenAI transcription fields while mapping the upstream model.
- Adds an explicit `transcriptions` account capability, so explicitly configured non-audio accounts are never selected.
- Reuses gateway authentication, user/account concurrency, billing eligibility, scheduler reporting, usage recording, and typed upstream failover.
- Registers both `/v1/audio/transcriptions` and `/audio/transcriptions`; composite routing resolves the multipart `model` inside the handler.

This PR deliberately covers transcription only. TTS is a separate provider/API surface and is not bundled here.

## Validation

- `go test ./internal/service -run 'Test(ForwardTranscriptions|AccountSupportsOpenAITranscriptionsCapability|AdminServiceBulkUpdateAccounts)' -count=1`\n- `go test ./internal/server/routes -count=1`\n- `go test ./internal/handler -count=1`\n\nCloses #3754