### PR TITLE
fix(gateway): normalize GLM-5.3 thinking effort

### DIFF
--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -1388,6 +1388,9 @@ func NormalizeGLMOpenAIReasoningEffort(body []byte, mappedModel string) ([]byte,
 	}
 
 	mapped := normalizeGLMOpenAIReasoningEffort(raw)
+	if isGLM53Model(mappedModel) && mapped == "high" && normalizeEffortToken(raw) == "low" {
+		mapped = "low"
+	}
 	if mapped == "" || mapped == raw {
 		return body, false
 	}
@@ -1399,12 +1402,20 @@ func NormalizeGLMOpenAIReasoningEffort(body []byte, mappedModel string) ([]byte,
 	return modified, true
 }
 
-func normalizeGLMOpenAIReasoningEffort(raw string) string {
+func normalizeEffortToken(raw string) string {
 	value := strings.ToLower(strings.TrimSpace(raw))
+	return strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+}
+
+func isGLM53Model(model string) bool {
+	return strings.EqualFold(strings.TrimSpace(model), "glm-5.3")
+}
+
+func normalizeGLMOpenAIReasoningEffort(raw string) string {
+	value := normalizeEffortToken(raw)
 	if value == "" {
 		return ""
 	}
-	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
 
 	switch value {
 	case "low", "medium", "high":
@@ -1414,6 +1425,42 @@ func normalizeGLMOpenAIReasoningEffort(raw string) string {
 	default:
 		return ""
 	}
+}
+
+// NormalizeGLM53AnthropicThinking maps explicit client thinking effort onto the
+// GLM-5.3 Anthropic-compatible scale. Requests without an effort or thinking
+// preference are left unchanged so the upstream default remains in effect.
+func NormalizeGLM53AnthropicThinking(body []byte, mappedModel string) ([]byte, bool) {
+	if !isGLM53Model(mappedModel) {
+		return body, false
+	}
+
+	raw := gjson.GetBytes(body, "output_config.effort").String()
+	if strings.TrimSpace(raw) == "" {
+		raw = gjson.GetBytes(body, "thinking.type").String()
+	}
+
+	var effort string
+	switch normalizeEffortToken(raw) {
+	case "disabled", "off", "none", "minimal", "low":
+		effort = "low"
+	case "enabled", "adaptive", "medium", "high":
+		effort = "high"
+	case "xhigh", "max", "ultra":
+		effort = "max"
+	default:
+		return body, false
+	}
+
+	modified, err := sjson.SetBytes(body, "thinking.type", "enabled")
+	if err != nil {
+		return body, false
+	}
+	modified, err = sjson.SetBytes(modified, "output_config.effort", effort)
+	if err != nil {
+		return body, false
+	}
+	return modified, true
 }
 
 // =========================

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -1606,12 +1606,27 @@ func TestNormalizeGLMOpenAIReasoningEffort(t *testing.T) {
 			wantValue:   "high",
 		},
 		{
+			name:        "glm 5.2 low maps to high",
+			model:       "glm-5.2",
+			input:       `{"model":"glm-5.2","reasoning_effort":"low","messages":[]}`,
+			wantApplied: true,
+			wantPath:    "reasoning_effort",
+			wantValue:   "high",
+		},
+		{
 			name:        "nested high case-normalizes",
 			model:       "glm-5.2",
 			input:       `{"model":"glm-5.2","reasoning":{"effort":"HIGH"},"messages":[]}`,
 			wantApplied: true,
 			wantPath:    "reasoning.effort",
 			wantValue:   "high",
+		},
+		{
+			name:          "glm 5.3 native low unchanged",
+			model:         "glm-5.3",
+			input:         `{"model":"glm-5.3","reasoning_effort":"low","messages":[]}`,
+			wantApplied:   false,
+			wantUnchanged: true,
 		},
 		{
 			name:          "native max unchanged",

--- a/backend/internal/service/openai_gateway_messages_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native.go
@@ -57,6 +57,9 @@ func (s *OpenAIGatewayService) forwardAnthropicViaNativeAnthropicEndpoint(
 		}
 		body = rewritten
 	}
+	if normalized, changed := NormalizeGLM53AnthropicThinking(body, upstreamModel); changed {
+		body = normalized
+	}
 
 	// 记录客户端请求的推理强度：优先 Claude 协议的 output_config.effort；
 	// 缺失且 thinking 已启用时，按国产 passback-required 模型兜底为 high

--- a/backend/internal/service/openai_gateway_messages_anthropic_native_test.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // 国产供应商原生 Anthropic 直通路径（api_protocol=anthropic）的 reasoning_effort 记录。
@@ -33,6 +35,13 @@ func nativeAnthropicTestAccount() *Account {
 			},
 		},
 	}
+}
+
+func nativeAnthropicGLMTestAccount() *Account {
+	account := nativeAnthropicTestAccount()
+	account.Name = "zhipu-native"
+	account.Platform = PlatformZhipu
+	return account
 }
 
 func nativeAnthropicBufferedResponse() *http.Response {
@@ -136,4 +145,71 @@ func TestNativeAnthropicPassthroughNoEffortStaysNil(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Nil(t, result.ReasoningEffort)
+}
+
+func TestNativeAnthropicPassthroughNormalizesGLM53Thinking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name       string
+		stream     bool
+		preference string
+		wantEffort string
+	}{
+		{name: "disabled buffered", preference: `"thinking":{"type":"disabled"},`, wantEffort: "low"},
+		{name: "off buffered", preference: `"thinking":{"type":"off"},`, wantEffort: "low"},
+		{name: "none buffered", preference: `"thinking":{"type":"none"},`, wantEffort: "low"},
+		{name: "enabled buffered", preference: `"thinking":{"type":"enabled"},`, wantEffort: "high"},
+		{name: "enabled streaming", stream: true, preference: `"thinking":{"type":"enabled"},`, wantEffort: "high"},
+		{name: "adaptive buffered", preference: `"thinking":{"type":"adaptive"},`, wantEffort: "high"},
+		{name: "adaptive streaming", stream: true, preference: `"thinking":{"type":"adaptive"},`, wantEffort: "high"},
+		{name: "minimal buffered", preference: `"output_config":{"effort":"minimal"},`, wantEffort: "low"},
+		{name: "low buffered", preference: `"output_config":{"effort":"low"},`, wantEffort: "low"},
+		{name: "medium streaming", stream: true, preference: `"output_config":{"effort":"medium"},`, wantEffort: "high"},
+		{name: "high buffered", preference: `"output_config":{"effort":"high"},`, wantEffort: "high"},
+		{name: "xhigh buffered", preference: `"output_config":{"effort":"xhigh"},`, wantEffort: "max"},
+		{name: "max buffered", preference: `"output_config":{"effort":"max"},`, wantEffort: "max"},
+		{name: "ultra buffered", preference: `"output_config":{"effort":"ultra"},`, wantEffort: "max"},
+		{name: "output effort wins over thinking", preference: `"thinking":{"type":"adaptive"},"output_config":{"effort":"low"},`, wantEffort: "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(`{"model":"glm-5.3","max_tokens":32,"stream":%t,%s"messages":[{"role":"user","content":"hi"}]}`, tt.stream, tt.preference))
+			response := nativeAnthropicBufferedResponse()
+			if tt.stream {
+				response = nativeAnthropicStreamResponse()
+			}
+			upstream := &httpUpstreamRecorder{resp: response}
+			svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+
+			_, err := svc.ForwardAsAnthropic(context.Background(),
+				adaptiveProtocolTestContext("/v1/messages", body), nativeAnthropicGLMTestAccount(), body, "", "")
+			require.NoError(t, err)
+			require.Equal(t, "enabled", gjson.GetBytes(upstream.lastBody, "thinking.type").String())
+			require.Equal(t, tt.wantEffort, gjson.GetBytes(upstream.lastBody, "output_config.effort").String())
+		})
+	}
+}
+
+func TestNativeAnthropicPassthroughLeavesOtherThinkingUntouched(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "glm 5.3 unspecified", body: `{"model":"glm-5.3","max_tokens":32,"stream":false,"messages":[]}`},
+		{name: "glm 5.2 disabled", body: `{"model":"glm-5.2","max_tokens":32,"stream":false,"thinking":{"type":"disabled"},"messages":[]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			upstream := &httpUpstreamRecorder{resp: nativeAnthropicBufferedResponse()}
+			svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+			_, err := svc.ForwardAsAnthropic(context.Background(),
+				adaptiveProtocolTestContext("/v1/messages", body), nativeAnthropicGLMTestAccount(), body, "", "")
+			require.NoError(t, err)
+			require.JSONEq(t, tt.body, string(upstream.lastBody))
+		})
+	}
 }


### PR DESCRIPTION
## 问题
GLM-5.3 不再提供真正的无思考档位，仅支持 `low` / `high` / `max`。原生 Anthropic 直通路径会把客户端的 `thinking.type=disabled` 原样转发，导致上游仍按默认高强度思考，短输出请求可能只返回思考内容。

提交前已确认没有按 Issue 编号或特征关键词匹配的开放/关闭 PR。

## 根因
现有国产模型 thinking 归一化只覆盖 MiniMax；GLM 的 OpenAI 兼容通用逻辑还会把 `low` 提升为 `high`，未区分已原生支持 `low` 的 GLM-5.3。

## 改动
- 仅对 GLM-5.3 的原生 Anthropic 请求归一化显式思考意图：低档映射为 `low`，中高档映射为 `high`，超高档映射为 `max`
- `enabled` / `adaptive` 显式意图映射为 `high`，并保持 `output_config.effort` 优先级
- 客户端完全未指定时不注入，保留上游默认行为
- 保持 GLM-5.2 与其他模型行为不变
- OpenAI 兼容路径保留 GLM-5.3 原生 `low` 档位

## 验证
已验证：
- `go test ./...`
- `go test -tags=unit ./internal/service -run 'TestNormalizeGLMOpenAIReasoningEffort|TestNativeAnthropicPassthrough' -count=1`
- `golangci-lint v2.13.0 run --timeout=30m`
- `go vet ./...`
- `go build ./cmd/server`
- `git diff --check`

完整 unit 测试中唯一失败项是仓库现有的外部服务对照测试 `TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI`，当前环境无法解析外部服务域名；不涉及本次改动。其余服务测试与全部非 unit 测试通过。

Fixes #6501