### PR TITLE
fix(codex): complete model tool capability catalog

### DIFF
--- a/backend/internal/service/openai_codex_model_metadata.go
+++ b/backend/internal/service/openai_codex_model_metadata.go
@@ -1,6 +1,122 @@
 package service
 
-import "strings"
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+var codexToolCapabilityFields = [...]string{
+	"apply_patch_tool_type", "comp_hash", "tool_mode", "use_responses_lite",
+}
+
+// configuredCodexToolCapabilities 仅为已核实的 Codex 目录型号提供回退值。
+// 补丁格式、代码模式与压缩协议分别声明，不能把新型号的四个字段套给所有 GPT 模型。
+func configuredCodexToolCapabilities(modelID string) map[string]json.RawMessage {
+	capabilities := map[string]json.RawMessage{
+		"apply_patch_tool_type": json.RawMessage("null"),
+		"comp_hash":             json.RawMessage("null"),
+		"tool_mode":             json.RawMessage("null"),
+		"use_responses_lite":    json.RawMessage("false"),
+	}
+	if isOpenAIGPT56Model(modelID) {
+		capabilities["apply_patch_tool_type"] = json.RawMessage(`"freeform"`)
+		capabilities["comp_hash"] = json.RawMessage(`"3000"`)
+		capabilities["tool_mode"] = json.RawMessage(`"code_mode_only"`)
+		capabilities["use_responses_lite"] = json.RawMessage("true")
+		return capabilities
+	}
+	normalized := canonicalizeOpenAIModelAliasSpelling(modelID)
+	if normalized == "codex-auto-review" {
+		capabilities["apply_patch_tool_type"] = json.RawMessage(`"freeform"`)
+		capabilities["comp_hash"] = json.RawMessage(`"3000"`)
+		capabilities["tool_mode"] = json.RawMessage(`"code_mode_only"`)
+		capabilities["use_responses_lite"] = json.RawMessage("true")
+		return capabilities
+	}
+	for _, base := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.2"} {
+		suffix, hasSuffix := strings.CutPrefix(normalized, base+"-")
+		if normalized != base && !(hasSuffix && isKnownCodexModelSuffix(suffix)) {
+			continue
+		}
+		capabilities["apply_patch_tool_type"] = json.RawMessage(`"freeform"`)
+		if base != "gpt-5.2" {
+			capabilities["comp_hash"] = json.RawMessage(`"2911"`)
+		}
+		break
+	}
+	return capabilities
+}
+
+func isCodexToolCapabilityField(field string) bool {
+	for _, candidate := range codexToolCapabilityFields {
+		if field == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeCodexToolCapabilities 在上游信任边界只接收工具契约字段。
+// RawMessage 保留“未声明”和显式 null/false 的区别，避免回退逻辑重新开启上游禁用的能力。
+func normalizeCodexToolCapabilities(fields map[string]json.RawMessage) map[string]json.RawMessage {
+	var normalized map[string]json.RawMessage
+	for _, field := range codexToolCapabilityFields {
+		raw, exists := fields[field]
+		if !exists {
+			continue
+		}
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			continue
+		}
+		valid := value == nil
+		switch field {
+		case "apply_patch_tool_type":
+			valid = valid || value == "freeform" || value == "function"
+		case "comp_hash", "tool_mode":
+			_, isString := value.(string)
+			valid = valid || isString
+		case "use_responses_lite":
+			_, isBool := value.(bool)
+			valid = valid || isBool
+		}
+		if !valid {
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		if normalized == nil {
+			normalized = make(map[string]json.RawMessage)
+		}
+		normalized[field] = encoded
+	}
+	return normalized
+}
+
+func applyCodexToolCapabilities(descriptor *configuredCodexModelDescriptor, fields map[string]json.RawMessage) {
+	for field, raw := range normalizeCodexToolCapabilities(fields) {
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			continue
+		}
+		switch field {
+		case "apply_patch_tool_type":
+			descriptor.ApplyPatchToolType = nil
+			if patchType, ok := value.(string); ok {
+				descriptor.ApplyPatchToolType = &patchType
+			}
+		case "comp_hash":
+			descriptor.CompHash = value
+		case "tool_mode":
+			descriptor.ToolMode = value
+		case "use_responses_lite":
+			descriptor.UseResponsesLite, _ = value.(bool)
+		}
+	}
+}
 
 func groupCodexModelMetadata(
 	platform string,
@@ -25,11 +141,14 @@ func groupCodexModelMetadata(
 		if !resolved {
 			if codexExplicitModelTargetsConflict(accounts, modelID) {
 				return codexModelMetadataOverride{
+					UpstreamModelMetadata:   UpstreamModelMetadata{CodexToolCapabilities: configuredCodexToolCapabilities("")},
 					reasoningConflict:       true,
 					inputModalitiesConflict: true,
 				}, true
 			}
-			return codexModelMetadataOverride{}, false
+			return codexModelMetadataOverride{UpstreamModelMetadata: UpstreamModelMetadata{
+				CodexToolCapabilities: configuredCodexToolCapabilities(""),
+			}}, true
 		}
 	}
 	if !isConcreteRequestPlatform(platform) {
@@ -48,6 +167,7 @@ func groupCodexModelMetadata(
 	explicitTargetsConflict := explicitClaims && codexExplicitModelTargetsConflictForPlatform(accounts, platform, modelID)
 	publicAlias := upstreamModel != modelID
 	candidates := make([]UpstreamModelMetadata, 0)
+	missingMetadata := false
 	for i := range accounts {
 		account := &accounts[i]
 		if account.Platform != platform {
@@ -70,20 +190,23 @@ func groupCodexModelMetadata(
 		}
 		metadata, ok := account.GetUpstreamModelMetadata(lookupModel)
 		if !ok {
-			if explicitTargetsConflict {
-				return codexModelMetadataOverride{
-					reasoningConflict:       true,
-					inputModalitiesConflict: true,
-				}, true
-			}
-			return codexModelMetadataOverride{}, false
+			missingMetadata = true
 		}
+		// 工具回退依据真实路由目标；公开别名即使叫 GPT，也可能实际映射到未知模型。
+		metadata.ID = strings.TrimSpace(lookupModel)
 		candidates = append(candidates, metadata)
 	}
 	if len(candidates) == 0 {
 		return codexModelMetadataOverride{}, false
 	}
 	metadata := intersectUpstreamModelMetadata(modelID, candidates)
+	if missingMetadata {
+		// 保持现有推理/模态的缺失处理，但工具能力仍需包含所有路由账号的保守交集。
+		metadata = codexModelMetadataOverride{
+			UpstreamModelMetadata: UpstreamModelMetadata{ID: modelID, CodexToolCapabilities: metadata.CodexToolCapabilities},
+			reasoningConflict:     explicitTargetsConflict, inputModalitiesConflict: explicitTargetsConflict,
+		}
+	}
 	if publicAlias {
 		metadata.DisplayName = modelID
 		metadata.Description = configuredCodexCustomDescription
@@ -208,6 +331,30 @@ func intersectUpstreamModelMetadata(modelID string, candidates []UpstreamModelMe
 	if !contextKnown {
 		result.ContextWindow = 0
 	}
+	result.CodexToolCapabilities = configuredCodexToolCapabilities("")
+	toolCandidates := make([]map[string]json.RawMessage, 0, len(candidates))
+	for _, candidate := range candidates {
+		capabilities := configuredCodexToolCapabilities(candidate.ID)
+		for field, value := range normalizeCodexToolCapabilities(candidate.CodexToolCapabilities) {
+			capabilities[field] = value
+		}
+		toolCandidates = append(toolCandidates, capabilities)
+	}
+	for _, field := range codexToolCapabilityFields {
+		shared := toolCandidates[0][field]
+		for _, candidate := range toolCandidates[1:] {
+			if !bytes.Equal(shared, candidate[field]) {
+				shared = result.CodexToolCapabilities[field]
+				break
+			}
+		}
+		result.CodexToolCapabilities[field] = shared
+	}
+	if bytes.Equal(result.CodexToolCapabilities["apply_patch_tool_type"], json.RawMessage("null")) {
+		// 没有共同补丁协议时，继续声明代码模式或 Lite 路径会形成客户端无法执行的组合。
+		result.CodexToolCapabilities["tool_mode"] = json.RawMessage("null")
+		result.CodexToolCapabilities["use_responses_lite"] = json.RawMessage("false")
+	}
 	return result
 }
 
@@ -263,6 +410,7 @@ func applyUpstreamModelMetadataToCodexDescriptor(
 		descriptor.ContextWindow = metadata.ContextWindow
 		descriptor.MaxContextWindow = metadata.ContextWindow
 	}
+	applyCodexToolCapabilities(descriptor, metadata.CodexToolCapabilities)
 }
 
 func configuredCodexReasoningLevelDescription(level string) string {

--- a/backend/internal/service/openai_codex_model_metadata.go
+++ b/backend/internal/service/openai_codex_model_metadata.go
@@ -36,7 +36,7 @@ func configuredCodexToolCapabilities(modelID string) map[string]json.RawMessage 
 	}
 	for _, base := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.2"} {
 		suffix, hasSuffix := strings.CutPrefix(normalized, base+"-")
-		if normalized != base && !(hasSuffix && isKnownCodexModelSuffix(suffix)) {
+		if normalized != base && (!hasSuffix || !isKnownCodexModelSuffix(suffix)) {
 			continue
 		}
 		capabilities["apply_patch_tool_type"] = json.RawMessage(`"freeform"`)

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -469,6 +469,14 @@ func newConfiguredCodexModelDescriptor(modelID string) configuredCodexModelDescr
 		descriptor.DisplayName = openaiCodexDisplayName(modelID)
 		descriptor.Description = "OpenAI GPT coding model routed through Sub2API."
 		descriptor.SupportsParallelToolCalls = true
+		if isOpenAIGPT56Model(modelID) {
+			// GPT-5.6 依赖模型目录选择代码模式和专用补丁工具；缺省会静默降级为 shell 函数调用。
+			applyPatchToolType := "freeform"
+			descriptor.ApplyPatchToolType = &applyPatchToolType
+			descriptor.CompHash = "3000"
+			descriptor.UseResponsesLite = true
+			descriptor.ToolMode = "code_mode_only"
+		}
 		if configuredCodexSupportsPriorityServiceTier(modelID) {
 			descriptor.ServiceTiers = []configuredCodexServiceTier{
 				{

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -469,14 +469,6 @@ func newConfiguredCodexModelDescriptor(modelID string) configuredCodexModelDescr
 		descriptor.DisplayName = openaiCodexDisplayName(modelID)
 		descriptor.Description = "OpenAI GPT coding model routed through Sub2API."
 		descriptor.SupportsParallelToolCalls = true
-		if isOpenAIGPT56Model(modelID) {
-			// GPT-5.6 依赖模型目录选择代码模式和专用补丁工具；缺省会静默降级为 shell 函数调用。
-			applyPatchToolType := "freeform"
-			descriptor.ApplyPatchToolType = &applyPatchToolType
-			descriptor.CompHash = "3000"
-			descriptor.UseResponsesLite = true
-			descriptor.ToolMode = "code_mode_only"
-		}
 		if configuredCodexSupportsPriorityServiceTier(modelID) {
 			descriptor.ServiceTiers = []configuredCodexServiceTier{
 				{
@@ -506,6 +498,7 @@ func newConfiguredCodexModelDescriptor(modelID string) configuredCodexModelDescr
 		}
 	}
 
+	applyCodexToolCapabilities(&descriptor, configuredCodexToolCapabilities(modelID))
 	return descriptor
 }
 
@@ -1920,34 +1913,35 @@ func convertOpenAIModelListToCodexManifestForAccount(body []byte, account *Accou
 	if _, ok := envelope["models"]; ok {
 		return body
 	}
-	data, ok := envelope["data"]
+	_, ok := envelope["data"]
 	if !ok {
 		return body
 	}
-	var entries []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(data, &entries); err != nil {
-		return body
-	}
-	modelIDs := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		id := strings.TrimSpace(entry.ID)
-		if id == "" {
-			continue
-		}
-		modelIDs = append(modelIDs, id)
-	}
-	if len(modelIDs) == 0 {
+	modelIDs, upstreamMetadata, err := extractUpstreamModelCatalog(body, false)
+	if err != nil || len(modelIDs) == 0 {
 		return body
 	}
 	imageInputModels := make(map[string]bool, len(modelIDs))
+	metadataModels := make(map[string]string, len(modelIDs))
+	modelMetadata := make(map[string]codexModelMetadataOverride, len(modelIDs))
 	for _, modelID := range modelIDs {
 		if accountCodexModelSupportsImageInput(account, modelID) {
 			imageInputModels[modelID] = true
 		}
+		metadata := upstreamMetadata[modelID]
+		if account != nil {
+			mappedModel := account.GetMappedModel(modelID)
+			metadataModels[modelID] = mappedModel
+			if synced, ok := account.GetUpstreamModelMetadata(mappedModel); ok {
+				// 实时上游声明优先；只有缺失字段才使用当前账号快照。
+				metadata, _ = mergeUpstreamModelMetadata(metadata, synced)
+			}
+		}
+		if upstreamModelMetadataIsUseful(metadata) {
+			modelMetadata[modelID] = codexModelMetadataOverride{UpstreamModelMetadata: metadata}
+		}
 	}
-	converted, err := buildCodexModelsManifest(modelIDs, imageInputModels, nil, nil)
+	converted, err := buildCodexModelsManifest(modelIDs, imageInputModels, metadataModels, modelMetadata)
 	if err != nil {
 		return body
 	}
@@ -1972,9 +1966,12 @@ func (s *OpenAIGatewayService) CompleteAPIKeyCodexModelsManifestForClient(manife
 		}
 	}
 	var err error
-	body, err = applySyncedAPIKeyCodexModelMetadata(body, account, manifest.convertedFromOpenAIModelList)
-	if err != nil {
-		return err
+	// 普通列表在转换时已合并实时元数据和当前快照，不能再次用快照覆盖实时声明。
+	if !manifest.convertedFromOpenAIModelList || len(manifest.upstreamSourceBody) == 0 {
+		body, err = applySyncedAPIKeyCodexModelMetadata(body, account, manifest.convertedFromOpenAIModelList)
+		if err != nil {
+			return err
+		}
 	}
 	body, err = completeAPIKeyCodexModelsManifestMetadata(
 		body,
@@ -2019,12 +2016,13 @@ func applySyncedAPIKeyCodexModelMetadata(body []byte, account *Account, overwrit
 			continue
 		}
 		slug = strings.TrimSpace(slug)
-		metadata, ok := snapshot.Models[slug]
+		metadataModelID := account.GetMappedModel(slug)
+		metadata, ok := snapshot.Models[metadataModelID]
 		if !ok {
 			continue
 		}
 
-		descriptor := newConfiguredCodexModelDescriptor(slug)
+		descriptor := newConfiguredCodexModelDescriptor(metadataModelID)
 		applyUpstreamModelMetadataToCodexDescriptor(
 			&descriptor,
 			codexModelMetadataOverride{UpstreamModelMetadata: metadata},
@@ -2054,6 +2052,9 @@ func applySyncedAPIKeyCodexModelMetadata(body []byte, account *Account, overwrit
 		if metadata.ContextWindow > 0 {
 			fields = append(fields, "context_window", "max_context_window")
 		}
+		for field := range normalizeCodexToolCapabilities(metadata.CodexToolCapabilities) {
+			fields = append(fields, field)
+		}
 
 		modelChanged := false
 		for _, field := range fields {
@@ -2063,7 +2064,8 @@ func applySyncedAPIKeyCodexModelMetadata(body []byte, account *Account, overwrit
 			}
 			current, currentExists := model[field]
 			current = bytes.TrimSpace(current)
-			if !overwriteLocalDefaults && currentExists && len(current) > 0 && !bytes.Equal(current, []byte("null")) {
+			if !overwriteLocalDefaults && currentExists && len(current) > 0 &&
+				(isCodexToolCapabilityField(field) || !bytes.Equal(current, []byte("null"))) {
 				continue
 			}
 			if bytes.Equal(current, bytes.TrimSpace(value)) {
@@ -2148,7 +2150,16 @@ func completeAPIKeyCodexModelsManifestMetadata(body []byte, completeAll bool, ac
 			continue
 		}
 
-		descriptor := newConfiguredCodexModelDescriptor(slug)
+		metadataModelID := slug
+		if account != nil {
+			metadataModelID = account.GetMappedModel(slug)
+		}
+		descriptor := newConfiguredCodexModelDescriptor(metadataModelID)
+		descriptor.Slug = slug
+		if metadataModelID != slug {
+			descriptor.DisplayName = slug
+			descriptor.Description = configuredCodexCustomDescription
+		}
 		if accountCodexModelSupportsImageInput(account, slug) {
 			descriptor.InputModalities = []string{"text", "image"}
 		}
@@ -2218,7 +2229,7 @@ func mergeMissingCodexModelFields(current, defaults map[string]json.RawMessage) 
 	changed := false
 	for key, defaultValue := range defaults {
 		currentValue, exists := current[key]
-		if !exists || (bytes.Equal(bytes.TrimSpace(currentValue), []byte("null")) &&
+		if !exists || (!isCodexToolCapabilityField(key) && bytes.Equal(bytes.TrimSpace(currentValue), []byte("null")) &&
 			!bytes.Equal(bytes.TrimSpace(defaultValue), []byte("null"))) {
 			current[key] = defaultValue
 			changed = true

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -336,6 +336,11 @@ func TestNewConfiguredCodexModelDescriptorUsesProviderMetadataAndSafeFallback(t 
 	require.Equal(t, configuredCodexGPTReasoningLevels("gpt-5.6-sol"), gpt56.SupportedReasoningLevels)
 	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max", "ultra"}, effortsFromConfiguredCodexLevels(gpt56.SupportedReasoningLevels))
 	require.True(t, gpt56.SupportsParallelToolCalls)
+	require.NotNil(t, gpt56.ApplyPatchToolType)
+	require.Equal(t, "freeform", *gpt56.ApplyPatchToolType)
+	require.Equal(t, "3000", gpt56.CompHash)
+	require.True(t, gpt56.UseResponsesLite)
+	require.Equal(t, "code_mode_only", gpt56.ToolMode)
 	require.True(t, gpt56.SupportVerbosity)
 	require.Equal(t, []string{"text"}, gpt56.InputModalities)
 	require.Equal(t, int64(872_000), gpt56.MaxContextWindow)
@@ -1146,6 +1151,11 @@ func TestBuildGroupConfiguredCodexModelsManifestExpandsSelectedModelCoveredByWil
 	require.NoError(t, err)
 	require.True(t, configured)
 	require.Equal(t, []string{"gpt-5.6"}, codexManifestModelSlugs(t, manifest.Body))
+	models := decodeCodexManifestModels(t, manifest.Body)
+	require.Equal(t, "freeform", models[0]["apply_patch_tool_type"])
+	require.Equal(t, "3000", models[0]["comp_hash"])
+	require.Equal(t, true, models[0]["use_responses_lite"])
+	require.Equal(t, "code_mode_only", models[0]["tool_mode"])
 	require.NotContains(t, string(manifest.Body), "gpt-*")
 }
 

--- a/backend/internal/service/openai_codex_tool_capabilities_test.go
+++ b/backend/internal/service/openai_codex_tool_capabilities_test.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// 已核实的模型不能共享同一套代码模式和压缩协议；未知型号不能仅凭 GPT 前缀开启能力。
+func TestConfiguredCodexToolCapabilitiesByModel(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		model string
+		patch any
+		hash  any
+		mode  any
+		lite  bool
+	}{
+		{"gpt-5.6-sol", "freeform", "3000", "code_mode_only", true},
+		{"gpt-5.6-terra", "freeform", "3000", "code_mode_only", true},
+		{"gpt-5.6-luna", "freeform", "3000", "code_mode_only", true},
+		{"gpt-5.6", "freeform", "3000", "code_mode_only", true},
+		{"codex-auto-review", "freeform", "3000", "code_mode_only", true},
+		{"gpt-5.5", "freeform", "2911", nil, false},
+		{"gpt-5.4", "freeform", "2911", nil, false},
+		{"gpt-5.4-mini", "freeform", "2911", nil, false},
+		{"gpt-5.3-codex-spark", "freeform", "2911", nil, false},
+		{"gpt-5.2", "freeform", nil, nil, false},
+		{"openai/GPT_5.4_MINI", "freeform", "2911", nil, false},
+		{"gpt-5.5-2026-04-23", "freeform", "2911", nil, false},
+		{"gpt-5.4-high", "freeform", "2911", nil, false},
+		{"gpt-5.4-unknown", nil, nil, nil, false},
+		{"gpt-5.4-nano", nil, nil, nil, false},
+		{"gpt-5.5-pro", nil, nil, nil, false},
+		{"gpt-5.7", nil, nil, nil, false},
+		{"company-coder", nil, nil, nil, false},
+		{"claude-sonnet-4-6", nil, nil, nil, false},
+	} {
+		t.Run(tt.model, func(t *testing.T) {
+			body, err := BuildCodexModelsManifest([]string{tt.model})
+			require.NoError(t, err)
+			model := decodeCodexManifestModels(t, body)[0]
+			require.Equal(t, tt.patch, model["apply_patch_tool_type"])
+			require.Equal(t, tt.hash, model["comp_hash"])
+			require.Equal(t, tt.mode, model["tool_mode"])
+			require.Equal(t, tt.lite, model["use_responses_lite"])
+		})
+	}
+}
+
+// 经同步快照往返后仍保留显式 null/false，且不能把上游任意字段作为本地提示词保存。
+func TestSyncUpstreamModelCatalogPreservesCodexToolCapabilities(t *testing.T) {
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(`{"models":[{
+			"slug":"future-coder","reasoning":false,"input_modalities":["text"],"context_window":64000,
+			"apply_patch_tool_type":"function","comp_hash":"provider-v2","tool_mode":null,
+			"use_responses_lite":false,"model_messages":{"instructions_template":"do not copy"}
+		}]}`)),
+	}}
+	repo := &upstreamModelMetadataRepoStub{}
+	account := newCodexModelsAPIKeyTestAccount("https://provider.example/v1")
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, cfg: upstreamModelSyncTestConfig()}
+	catalog, err := svc.SyncUpstreamModelCatalog(context.Background(), account)
+	require.NoError(t, err)
+	require.Empty(t, catalog.Warnings)
+	require.Len(t, upstream.requests, 1)
+	require.NotNil(t, repo.updates)
+	metadata, ok := account.GetUpstreamModelMetadata("future-coder")
+	require.True(t, ok)
+	body, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"apply_patch_tool_type":"function"`)
+	require.Contains(t, string(body), `"tool_mode":null`)
+	require.Contains(t, string(body), `"use_responses_lite":false`)
+	require.NotContains(t, string(body), "instructions_template")
+
+	account.Credentials["model_mapping"] = map[string]any{"my-coder": "future-coder"}
+	manifest, err := buildCodexModelsManifestForAccounts(PlatformOpenAI, []string{"my-coder"}, []Account{*account}, nil, true)
+	require.NoError(t, err)
+	model := decodeCodexManifestModels(t, manifest)[0]
+	require.Equal(t, "my-coder", model["slug"])
+	require.Equal(t, "my-coder", model["display_name"])
+	require.Equal(t, "function", model["apply_patch_tool_type"])
+	require.Equal(t, "provider-v2", model["comp_hash"])
+	require.Nil(t, model["tool_mode"])
+	require.Equal(t, false, model["use_responses_lite"])
+}
+
+func codexToolCapabilityAccount(t *testing.T, id int64, alias, target, fields string) Account {
+	t.Helper()
+	account := Account{ID: id, Platform: PlatformOpenAI, Type: AccountTypeAPIKey,
+		Credentials: map[string]any{"model_mapping": map[string]any{alias: target}},
+	}
+	if fields != "" {
+		_, metadata, err := extractUpstreamModelCatalog([]byte(fmt.Sprintf(`{"models":[{"slug":%q,%s}]}`, target, fields)), false)
+		require.NoError(t, err)
+		account.SetUpstreamModelMetadataSnapshot(UpstreamModelMetadataSnapshot{Models: metadata})
+	}
+	return account
+}
+
+// 同名别名可能命中不同模型；能力必须与账号顺序无关，缺失和显式禁用都不能被型号默认值覆盖。
+func TestGroupCodexToolCapabilitiesIntersectMappedTargets(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		alias   string
+		targets []string
+		fields  []string
+		patch   any
+		hash    any
+		mode    any
+		lite    bool
+	}{
+		{"known alias", "my-coder", []string{"gpt-5.4"}, []string{""}, "freeform", "2911", nil, false},
+		{"mixed known models", "my-coder", []string{"gpt-5.6-sol", "gpt-5.5"}, []string{"", ""}, "freeform", nil, nil, false},
+		{"unknown mapped target", "gpt-5.6-sol", []string{"gpt-5.6-sol", "unknown-coder"}, []string{"", ""}, nil, nil, nil, false},
+		{"upstream overrides defaults", "my-coder", []string{"gpt-5.6-sol"}, []string{`"apply_patch_tool_type":"function","comp_hash":null,"tool_mode":null,"use_responses_lite":false`}, "function", nil, nil, false},
+		{"explicitly disabled", "gpt-5.6-sol", []string{"gpt-5.6-sol", "gpt-5.6-sol"}, []string{"", `"apply_patch_tool_type":null,"comp_hash":null,"tool_mode":null,"use_responses_lite":false`}, nil, nil, nil, false},
+		{"future model", "my-coder", []string{"future-a", "future-b"}, []string{`"apply_patch_tool_type":"freeform","comp_hash":"future-v1","tool_mode":"code_mode_only","use_responses_lite":true`, `"apply_patch_tool_type":"freeform","comp_hash":"future-v1","tool_mode":"code_mode_only","use_responses_lite":true`}, "freeform", "future-v1", "code_mode_only", true},
+		{"incompatible patch formats", "my-coder", []string{"future-a", "future-b"}, []string{`"apply_patch_tool_type":"freeform","tool_mode":"code_mode_only","use_responses_lite":true`, `"apply_patch_tool_type":"function","tool_mode":"code_mode_only","use_responses_lite":true`}, nil, nil, nil, false},
+		{"missing future metadata", "my-coder", []string{"future-a", "future-b"}, []string{`"apply_patch_tool_type":"freeform","tool_mode":"code_mode_only","use_responses_lite":true`, ""}, nil, nil, nil, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			accounts := make([]Account, len(tt.targets))
+			for i, target := range tt.targets {
+				accounts[i] = codexToolCapabilityAccount(t, int64(i+1), tt.alias, target, tt.fields[i])
+			}
+			for range 2 {
+				body, err := buildCodexModelsManifestForAccounts(PlatformOpenAI, []string{tt.alias}, accounts, nil, true)
+				require.NoError(t, err)
+				model := decodeCodexManifestModels(t, body)[0]
+				require.Equal(t, tt.patch, model["apply_patch_tool_type"])
+				require.Equal(t, tt.hash, model["comp_hash"])
+				require.Equal(t, tt.mode, model["tool_mode"])
+				require.Equal(t, tt.lite, model["use_responses_lite"])
+				accounts[0], accounts[len(accounts)-1] = accounts[len(accounts)-1], accounts[0]
+			}
+		})
+	}
+}
+
+// 原生目录及普通 /v1/models 转换都遵循：实时上游 > 已同步快照 > 已核实型号默认值。
+func TestCompleteAPIKeyCodexToolCapabilitiesPreserveUpstreamPrecedence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		body      string
+		converted bool
+		patch     any
+		hash      any
+		mode      any
+		lite      bool
+	}{
+		{"native explicit null", `{"models":[{"slug":"gpt-5.5","apply_patch_tool_type":null,"comp_hash":null,"tool_mode":null,"use_responses_lite":false}]}`, false, nil, nil, nil, false},
+		{"native synced fallback", `{"models":[{"slug":"gpt-5.5"}]}`, false, "function", "synced-v1", "code_mode_only", true},
+		{"converted synced fallback", `{"data":[{"id":"gpt-5.5"}]}`, true, "function", "synced-v1", "code_mode_only", true},
+		{"converted live fields", `{"data":[{"id":"gpt-5.5","apply_patch_tool_type":"freeform","comp_hash":"live-v2","tool_mode":null,"use_responses_lite":false}]}`, true, "freeform", "live-v2", nil, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			account := codexToolCapabilityAccount(t, 1, "gpt-5.5", "gpt-5.5", `"apply_patch_tool_type":"function","comp_hash":"synced-v1","tool_mode":"code_mode_only","use_responses_lite":true`)
+			account.Credentials["base_url"] = "https://provider.example/v1"
+			manifest := &CodexModelsManifest{Body: []byte(tt.body), upstreamSourceBody: []byte(tt.body), convertedFromOpenAIModelList: tt.converted}
+			svc := &OpenAIGatewayService{}
+			require.NoError(t, svc.CompleteAPIKeyCodexModelsManifestForClient(manifest, &account))
+			model := decodeCodexManifestModels(t, manifest.Body)[0]
+			require.Equal(t, tt.patch, model["apply_patch_tool_type"])
+			require.Equal(t, tt.hash, model["comp_hash"])
+			require.Equal(t, tt.mode, model["tool_mode"])
+			require.Equal(t, tt.lite, model["use_responses_lite"])
+			require.Equal(t, codexModelsManifestBodyETag(manifest.Body), manifest.ETag)
+		})
+	}
+}

--- a/backend/internal/service/upstream_models.go
+++ b/backend/internal/service/upstream_models.go
@@ -36,6 +36,8 @@ type UpstreamModelMetadata struct {
 	InputModalities          []string `json:"input_modalities,omitempty"`
 	ContextWindow            int64    `json:"context_window,omitempty"`
 	MaxOutputTokens          int64    `json:"max_output_tokens,omitempty"`
+	// 仅保存经过白名单校验的 Codex 工具字段；显式 null/false 必须在同步后仍可区分于缺失。
+	CodexToolCapabilities map[string]json.RawMessage `json:"codex_tool_capabilities,omitempty"`
 }
 
 type UpstreamModelMetadataSnapshot struct {
@@ -331,7 +333,8 @@ func upstreamModelMetadataIsUseful(metadata UpstreamModelMetadata) bool {
 		len(metadata.SupportedReasoningLevels) > 0 ||
 		len(metadata.InputModalities) > 0 ||
 		metadata.ContextWindow > 0 ||
-		metadata.MaxOutputTokens > 0
+		metadata.MaxOutputTokens > 0 ||
+		len(metadata.CodexToolCapabilities) > 0
 }
 
 func mergeUpstreamModelMetadata(primary, fallback UpstreamModelMetadata) (UpstreamModelMetadata, bool) {
@@ -372,6 +375,17 @@ func mergeUpstreamModelMetadata(primary, fallback UpstreamModelMetadata) (Upstre
 	}
 	if merged.MaxOutputTokens <= 0 && fallback.MaxOutputTokens > 0 {
 		merged.MaxOutputTokens = fallback.MaxOutputTokens
+		changed = true
+	}
+	merged.CodexToolCapabilities = normalizeCodexToolCapabilities(primary.CodexToolCapabilities)
+	for field, value := range normalizeCodexToolCapabilities(fallback.CodexToolCapabilities) {
+		if _, exists := merged.CodexToolCapabilities[field]; exists {
+			continue
+		}
+		if merged.CodexToolCapabilities == nil {
+			merged.CodexToolCapabilities = make(map[string]json.RawMessage)
+		}
+		merged.CodexToolCapabilities[field] = value
 		changed = true
 	}
 	return merged, changed
@@ -1128,6 +1142,10 @@ func extractUpstreamModelCatalog(body []byte, grok bool) ([]string, map[string]U
 		}
 		models = append(models, modelID)
 		entry := upstreamMetadataFromCapabilityEntry(modelID, capability)
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err == nil {
+			entry.CodexToolCapabilities = normalizeCodexToolCapabilities(fields)
+		}
 		if upstreamModelMetadataIsUseful(entry) {
 			metadata[modelID] = entry
 		}


### PR DESCRIPTION
## 问题

Sub2API 生成的 Codex 模型目录只为 GPT-5.6 补齐专用工具字段，GPT-5.2/5.3/5.4/5.5 因此会降级为普通函数或 shell 调用。此外，上游 `/models` 即使明确返回工具能力，账号同步快照也不会保存这些字段；公开别名和多账号分组随后仍会丢失能力。

## 修改

- 按当前 Codex bundled catalog 为 Sub2API 内置型号提供精确回退：
  - GPT-5.6 与 `codex-auto-review`：`freeform`、`comp_hash=3000`、Responses Lite、`code_mode_only`
  - GPT-5.5、GPT-5.4、GPT-5.4 Mini、GPT-5.3 Codex Spark：`freeform`、`comp_hash=2911`
  - GPT-5.2：`freeform`，不猜测缺失的压缩或代码模式
- 从上游目录白名单提取、持久化并回放 `apply_patch_tool_type`、`comp_hash`、`tool_mode`、`use_responses_lite`；不复制提示词或其他任意字段。
- 保留显式 `null`/`false`，能力优先级为：实时上游声明 > 当前账号同步快照 > 已核实型号回退。
- 公开别名按真实映射目标取能力；多个可路由账号只声明共同能力，协议不一致或元数据缺失时保守降级。
- 标准 `/v1/models` 列表和原生 Codex manifest 使用相同规则。

OpenAI 的 Apply Patch 文档说明该工具使用 Responses API 的专用 `apply_patch` 工具调用；本次回退值通过当前安装版 `codex debug models --bundled` 逐型号核对：https://developers.openai.com/api/docs/guides/tools-apply-patch

## 验证

- `go test ./internal/service -run 'CodexToolCapabilities|PreservesCodexToolCapabilities' -count=1`
- `go test ./internal/service -run 'CodexModels|ConfiguredCodex|UpstreamModelCatalog|UpstreamModelMetadata|CodexToolCapabilities' -count=1`
- `go test ./internal/handler -run 'CodexModels' -count=1`
- `go vet ./internal/service ./internal/handler`
- `go build ./...`
- `git diff --check`

完整 `go test ./internal/service -count=1` 在 Windows 上仍有未改动测试失败：内容审核缓存的 1 秒轮询条件未满足，以及 4 个插件包安装测试在临时文件 `rename` 时被占用。本次新增和相关回归均通过，Linux CI 结果以本 PR 最新提交为准。
