### PR TITLE
fix(openai): do not treat non-OpenAI OAuth as Codex or native CN Responses

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1302,7 +1302,15 @@ func (a *Account) IsOpenAIOAuthLike() bool {
 // UsesOpenAICodexProtocol preserves legacy OpenAI gateway OAuth routing for
 // accounts whose platform is implicit, while adding OpenAI SetupToken.
 func (a *Account) UsesOpenAICodexProtocol() bool {
-	return a != nil && (a.Type == AccountTypeOAuth || a.IsOpenAIOAuthLike())
+	if a == nil {
+		return false
+	}
+	// ChatGPT/Codex 协议只属于 OpenAI OAuth / setup-token。
+	// platform=kimi 且 Type=OAuth 的账号不能走 chatgpt.com。
+	if a.IsOpenAIOAuthLike() {
+		return true
+	}
+	return a.Type == AccountTypeOAuth && strings.TrimSpace(a.Platform) == ""
 }
 
 func (a *Account) IsOpenAIChatGPTSubscription() bool {
@@ -1426,7 +1434,7 @@ func (a *Account) SupportsNativeCNResponses() bool {
 // UsesNativeCNResponses 报告当前账号是否应按原生 Responses 协议转发
 // （显式 responses，或 adaptive 且平台具备原生端点）。
 func (a *Account) UsesNativeCNResponses() bool {
-	if a == nil || !a.SupportsNativeCNResponses() {
+	if a == nil || !a.SupportsNativeCNResponses() || a.Type == AccountTypeOAuth {
 		return false
 	}
 	switch a.GetAPIProtocol() {

--- a/backend/internal/service/cn_providers_test.go
+++ b/backend/internal/service/cn_providers_test.go
@@ -504,6 +504,28 @@ func TestSupportsNativeCNResponses(t *testing.T) {
 	require.False(t, (&Account{Platform: PlatformOpenAI}).SupportsNativeCNResponses())
 }
 
+func TestUsesNativeCNResponsesExcludesOAuth(t *testing.T) {
+	t.Parallel()
+	oauthAdaptive := &Account{
+		Platform: PlatformKimi,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"api_protocol": APIProtocolAdaptive,
+		},
+	}
+	apiKeyAdaptive := &Account{
+		Platform: PlatformKimi,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":      "sk-test",
+			"api_protocol": APIProtocolAdaptive,
+		},
+	}
+	require.True(t, oauthAdaptive.SupportsNativeCNResponses())
+	require.False(t, oauthAdaptive.UsesNativeCNResponses(), "kimi OAuth must not use native /v1/responses")
+	require.True(t, apiKeyAdaptive.UsesNativeCNResponses())
+}
+
 func TestAdaptiveProtocolBaseURLs(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_setup_token_compat_test.go
+++ b/backend/internal/service/openai_setup_token_compat_test.go
@@ -28,6 +28,8 @@ func TestIsOpenAIOAuthLike(t *testing.T) {
 		{name: "openai_api_key", account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}, want: false, codex: false},
 		{name: "anthropic_setup_token", account: &Account{Platform: PlatformAnthropic, Type: AccountTypeSetupToken}, want: false, codex: false},
 		{name: "grok_setup_token", account: &Account{Platform: PlatformGrok, Type: AccountTypeSetupToken}, want: false, codex: false},
+		{name: "kimi_oauth", account: &Account{Platform: PlatformKimi, Type: AccountTypeOAuth}, want: false, codex: false},
+		{name: "implicit_oauth", account: &Account{Type: AccountTypeOAuth}, want: false, codex: true},
 		{name: "nil", account: nil, want: false, codex: false},
 	}
 


### PR DESCRIPTION
## Summary
- `UsesOpenAICodexProtocol` is now OpenAI OAuth / setup-token only (legacy implicit-platform OAuth still counts).
- `UsesNativeCNResponses` is API-key only. `platform=kimi` + `type=oauth` no longer selects native `/v1/responses`.

Without this, a kimi OAuth account is classified as Codex (`Host: chatgpt.com`) **and** as native CN Responses.

## Test plan
- `go test ./internal/service/ -run TestIsOpenAIOAuthLike`
- `go test -tags=unit ./internal/service/ -run 'TestSupportsNativeCNResponses|TestUsesNativeCNResponsesExcludesOAuth'`