### PR TITLE
fix(billing): Anthropic 路径下 upstream 计费按实际发往上游的模型计价

### DIFF
--- a/backend/internal/service/gateway_record_usage_test.go
+++ b/backend/internal/service/gateway_record_usage_test.go
@@ -726,3 +726,68 @@ func TestGatewayServiceRecordUsage_FastSpeedHonouredKeepsPremium(t *testing.T) {
 	require.NoError(t, err)
 	require.InDelta(t, fastCost.TotalCost, usageRepo.lastLog.TotalCost, 1e-10)
 }
+
+// TestGatewayServiceRecordUsage_UpstreamBillingModelHonorsBillingModelSource 验证 Anthropic 路径下
+// billing_model_source 各取值对计费模型的选取，尤其是 upstream：应使用实际发往上游的模型
+// （result.UpstreamModel，来自账号模型映射）计价，而不是用户请求的模型。修复前 upstream 无分支，
+// 会退化为按请求模型计价，与 OpenAI 路径行为不一致（见 openai_gateway_record_usage_test.go 同名用例）。
+func TestGatewayServiceRecordUsage_UpstreamBillingModelHonorsBillingModelSource(t *testing.T) {
+	usageRepo := &openAIRecordUsageBestEffortLogRepoStub{}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50}
+	// 请求名与上游名价格不同（$3/$15 vs $5/$25），断言才能区分按谁计价。
+	const requestedModel = anthropicCheapFixtureModel // claude-sonnet-4
+	const upstreamModel = anthropicPriceyFixtureModel // claude-opus-4.8
+
+	requestedCost, err := svc.billingService.CalculateCost(requestedModel, tokens, 1.1)
+	require.NoError(t, err)
+	upstreamCost, err := svc.billingService.CalculateCost(upstreamModel, tokens, 1.1)
+	require.NoError(t, err)
+	require.NotEqual(t, requestedCost.TotalCost, upstreamCost.TotalCost, "fixture prices must differ")
+
+	tests := []struct {
+		name               string
+		billingModelSource string
+		wantCost           *CostBreakdown
+	}{
+		{
+			name:               "upstream bills by the model actually sent upstream",
+			billingModelSource: BillingModelSourceUpstream,
+			wantCost:           upstreamCost,
+		},
+		{
+			name:               "requested bills by the original requested model",
+			billingModelSource: BillingModelSourceRequested,
+			wantCost:           requestedCost,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.RecordUsage(context.Background(), &RecordUsageInput{
+				Result: &ForwardResult{
+					RequestID:     "gateway_upstream_billing_model_source",
+					Usage:         ClaudeUsage{InputTokens: 100, OutputTokens: 50},
+					Model:         requestedModel,
+					UpstreamModel: upstreamModel,
+					Duration:      time.Second,
+				},
+				APIKey:  &APIKey{ID: 501, Quota: 100},
+				User:    &User{ID: 601},
+				Account: &Account{ID: 701},
+				ChannelUsageFields: ChannelUsageFields{
+					ChannelID:          9,
+					OriginalModel:      requestedModel,
+					ChannelMappedModel: requestedModel,
+					BillingModelSource: tt.billingModelSource,
+				},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, usageRepo.lastLog)
+			require.InDelta(t, tt.wantCost.ActualCost, usageRepo.lastLog.ActualCost, 1e-12)
+			require.True(t, usageRepo.lastLog.ActualCost > 0, "cost must not be zero")
+		})
+	}
+}

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -759,6 +759,9 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	// 确定计费模型
 	concreteBillingModel := forwardResultBillingModel(result.Model, result.UpstreamModel)
 	billingModel := concreteBillingModel
+	if input.BillingModelSource == BillingModelSourceUpstream && result.UpstreamModel != "" {
+		billingModel = result.UpstreamModel
+	}
 	if input.BillingModelSource == BillingModelSourceChannelMapped && input.ChannelMappedModel != "" {
 		billingModel = input.ChannelMappedModel
 	}


### PR DESCRIPTION
Fixes #6515

## Problem

When a channel sets `billing_model_source = upstream` ("bill by final upstream model"), the Anthropic path (`/v1/messages`) bills by the **requested** model instead of the model actually **sent upstream**. The OpenAI path already bills correctly. The two paths disagree.

## Root cause

`GatewayService.recordUsageCore` (`backend/internal/service/gateway_usage_billing.go`) selects the billing model with only two `BillingModelSource` branches — `channel_mapped` and `requested`. There is no `upstream` branch, so selecting `upstream` falls through to `forwardResultBillingModel(result.Model, result.UpstreamModel)`, which prefers `result.Model`.

For Anthropic requests, `result.Model` is the client-requested name while the account-mapped name lives in `result.UpstreamModel` (set from `mappedModel` in `gateway_forward.go`). So `upstream` silently degrades to billing by the requested model.

The OpenAI path works because its default billing model, `result.BillingModel`, already holds the account-mapped model (`account.GetMappedModel` in `resolveOpenAIForwardMappedModels`). This PR adds the missing `upstream` branch on the Anthropic side so both paths agree.

## Fix

Add an `upstream` branch in `recordUsageCore` that bills by `result.UpstreamModel` when it is non-empty:

```go
if input.BillingModelSource == BillingModelSourceUpstream && result.UpstreamModel != "" {
    billingModel = result.UpstreamModel
}
```

The existing `channel_mapped` / `requested` branches, the composite override, and the pricing fallback are left untouched.

## Testing

Added `TestGatewayServiceRecordUsage_UpstreamBillingModelHonorsBillingModelSource`, a table-driven test mirroring the OpenAI-side `TestOpenAIGatewayServiceRecordUsage_ResponsesMappedBillingModelHonorsBillingModelSource`:

- `upstream` bills by the upstream model (`claude-opus-4.8`, $5/$25)
- `requested` bills by the requested model (`claude-sonnet-4`, $3/$15)

The two fixtures differ in price so the assertions distinguish which model is billed. Verified: `go test ./internal/service/`, `go vet`, and `golangci-lint` all pass.

Related: the scheduling-layer counterpart of this Anthropic/OpenAI `upstream` mismatch is tracked in #6492.
