### PR TITLE
新增批量账号连接测试与模型校验

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -1072,6 +1072,26 @@ type TestAccountRequest struct {
 	AudioDataURL string `json:"audio_data_url"`
 }
 
+type batchTestAccountRequest struct {
+	AccountIDs []int64 `json:"account_ids"`
+	ModelID    string  `json:"model_id"`
+}
+
+type batchTestAccountEvent struct {
+	Type               string `json:"type"`
+	AccountID          int64  `json:"account_id,omitempty"`
+	AccountName        string `json:"account_name,omitempty"`
+	Platform           string `json:"platform,omitempty"`
+	ModelID            string `json:"model_id,omitempty"`
+	UpstreamModel      string `json:"upstream_model,omitempty"`
+	Status             string `json:"status,omitempty"`
+	FirstByteLatencyMs int64  `json:"first_byte_latency_ms,omitempty"`
+	LatencyMs          int64  `json:"latency_ms,omitempty"`
+	Error              string `json:"error,omitempty"`
+	Completed          int    `json:"completed,omitempty"`
+	Total              int    `json:"total,omitempty"`
+}
+
 type SyncFromCRSRequest struct {
 	BaseURL            string   `json:"base_url" binding:"required"`
 	Username           string   `json:"username" binding:"required"`
@@ -1115,6 +1135,101 @@ func (h *AccountHandler) Test(c *gin.Context) {
 			_ = c.Error(err)
 		}
 	}
+}
+
+// BatchTest tests selected accounts in parallel and streams per-account results.
+// POST /api/v1/admin/accounts/batch-test
+func (h *AccountHandler) BatchTest(c *gin.Context) {
+	var req batchTestAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	accountIDs := normalizeInt64IDList(req.AccountIDs)
+	modelID := strings.TrimSpace(req.ModelID)
+	if len(accountIDs) == 0 {
+		response.BadRequest(c, "account_ids is required")
+		return
+	}
+	if modelID == "" {
+		response.BadRequest(c, "model_id is required")
+		return
+	}
+	if h.accountTestService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Account test service unavailable")
+		return
+	}
+
+	accounts, err := h.adminService.GetAccountsByIDs(c.Request.Context(), accountIDs)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	accountsByID := make(map[int64]*service.Account, len(accounts))
+	for _, account := range accounts {
+		if account != nil {
+			accountsByID[account.ID] = account
+		}
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Status(http.StatusOK)
+
+	var writeMu sync.Mutex
+	writeEvent := func(event batchTestAccountEvent) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		payload, _ := json.Marshal(event)
+		_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", payload)
+		c.Writer.Flush()
+	}
+	writeEvent(batchTestAccountEvent{Type: "batch_start", Total: len(accountIDs), ModelID: modelID})
+
+	var wg sync.WaitGroup
+	completed := 0
+	var completedMu sync.Mutex
+	for _, accountID := range accountIDs {
+		accountID := accountID
+		account := accountsByID[accountID]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name, platform := "", ""
+			if account != nil {
+				name, platform = account.Name, account.Platform
+			}
+			writeEvent(batchTestAccountEvent{Type: "account_started", AccountID: accountID, AccountName: name, Platform: platform, ModelID: modelID})
+
+			result := &service.AccountTestResult{Status: "failed", ErrorMessage: "account not found"}
+			if account != nil {
+				if tested, testErr := h.accountTestService.RunTestBackgroundDetailed(c.Request.Context(), accountID, modelID); testErr != nil {
+					result.ErrorMessage = testErr.Error()
+				} else {
+					result = tested
+					if result.Status == "success" && h.rateLimitService != nil {
+						if _, recoverErr := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), accountID); recoverErr != nil {
+							log.Printf("[WARN] Failed to recover account %d after batch test: %v", accountID, recoverErr)
+						}
+					}
+				}
+			}
+
+			completedMu.Lock()
+			completed++
+			current := completed
+			completedMu.Unlock()
+			writeEvent(batchTestAccountEvent{
+				Type: "account_result", AccountID: accountID, AccountName: name, Platform: platform, ModelID: modelID,
+				UpstreamModel: result.UpstreamModel,
+				Status:        result.Status, FirstByteLatencyMs: result.FirstByteLatencyMs, LatencyMs: result.LatencyMs,
+				Error: result.ErrorMessage, Completed: current, Total: len(accountIDs),
+			})
+		}()
+	}
+	wg.Wait()
+	writeEvent(batchTestAccountEvent{Type: "batch_complete", Completed: len(accountIDs), Total: len(accountIDs)})
 }
 
 // RecoverState handles unified recovery of recoverable account runtime state.

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -381,6 +381,7 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.POST("/:id/ollama-cloud-usage/refresh", h.Admin.Account.RefreshOllamaCloudUsage)
 		accounts.DELETE("/:id", h.Admin.Account.Delete)
 		accounts.POST("/:id/test", h.Admin.Account.Test)
+		accounts.POST("/batch-test", h.Admin.Account.BatchTest)
 		accounts.POST("/:id/recover-state", h.Admin.Account.RecoverState)
 		accounts.POST("/:id/refresh", h.Admin.Account.Refresh)
 		accounts.POST("/:id/apply-oauth-credentials", h.Admin.Account.ApplyOAuthCredentials)

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -50,12 +50,13 @@ const (
 
 // TestEvent represents a SSE event for account testing
 type TestEvent struct {
-	Type     string `json:"type"`
-	Text     string `json:"text,omitempty"`
-	Model    string `json:"model,omitempty"`
-	Status   string `json:"status,omitempty"`
-	Code     string `json:"code,omitempty"`
-	ImageURL string `json:"image_url,omitempty"`
+	Type          string `json:"type"`
+	Text          string `json:"text,omitempty"`
+	Model         string `json:"model,omitempty"`
+	UpstreamModel string `json:"upstream_model,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Code          string `json:"code,omitempty"`
+	ImageURL      string `json:"image_url,omitempty"`
 	// AudioURL / VideoURL are data: or https URLs for in-browser media players.
 	AudioURL string `json:"audio_url,omitempty"`
 	VideoURL string `json:"video_url,omitempty"`
@@ -70,6 +71,18 @@ type TestEvent struct {
 type AccountTestOptions struct {
 	ImageDataURL string
 	AudioDataURL string
+}
+
+// AccountTestResult is the background result used by batch account tests.
+type AccountTestResult struct {
+	Status             string
+	ResponseText       string
+	ErrorMessage       string
+	UpstreamModel      string
+	FirstByteLatencyMs int64
+	LatencyMs          int64
+	StartedAt          time.Time
+	FinishedAt         time.Time
 }
 
 func firstAccountTestOptions(opts []AccountTestOptions) AccountTestOptions {
@@ -2721,6 +2734,7 @@ func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, 
 	reader := bufio.NewReader(body)
 	seenJSON := false
 	seenFinish := false
+	upstreamModel := ""
 
 	for {
 		line, err := reader.ReadString('\n')
@@ -2728,6 +2742,7 @@ func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, 
 			if err == io.EOF {
 				if seenFinish {
 					s.sendEvent(c, TestEvent{Type: "status", Text: "已通过 /v1/chat/completions 验证"})
+					s.sendEvent(c, TestEvent{Type: "upstream_model", UpstreamModel: upstreamModel})
 					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 					return nil
 				}
@@ -2747,6 +2762,7 @@ func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, 
 		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
 		if jsonStr == "[DONE]" {
 			s.sendEvent(c, TestEvent{Type: "status", Text: "已通过 /v1/chat/completions 验证"})
+			s.sendEvent(c, TestEvent{Type: "upstream_model", UpstreamModel: upstreamModel})
 			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 			return nil
 		}
@@ -2756,6 +2772,9 @@ func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, 
 			return s.sendErrorAndEnd(c, "Invalid Chat Completions response from /v1/chat/completions: expected JSON data")
 		}
 		seenJSON = true
+		if model, ok := data["model"].(string); ok && strings.TrimSpace(model) != "" {
+			upstreamModel = strings.TrimSpace(model)
+		}
 
 		if errData, ok := data["error"].(map[string]any); ok {
 			errorMsg := "Chat Completions API (/v1/chat/completions) returned an error"
@@ -2795,12 +2814,16 @@ func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, 
 func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
 	seenCompleted := false
+	upstreamModel := ""
 
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
 				if seenCompleted {
+					if upstreamModel != "" {
+						s.sendEvent(c, TestEvent{Type: "upstream_model", UpstreamModel: upstreamModel})
+					}
 					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 					return nil
 				}
@@ -2817,6 +2840,9 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
 		if jsonStr == "[DONE]" {
 			if seenCompleted {
+				if upstreamModel != "" {
+					s.sendEvent(c, TestEvent{Type: "upstream_model", UpstreamModel: upstreamModel})
+				}
 				s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 				return nil
 			}
@@ -2829,6 +2855,11 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 		}
 
 		eventType, _ := data["type"].(string)
+		if responseData, ok := data["response"].(map[string]any); ok {
+			if model, ok := responseData["model"].(string); ok && strings.TrimSpace(model) != "" {
+				upstreamModel = strings.TrimSpace(model)
+			}
+		}
 
 		switch eventType {
 		case "response.output_text.delta":
@@ -2837,6 +2868,9 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 				s.sendEvent(c, TestEvent{Type: "content", Text: delta})
 			}
 		case "response.completed", "response.done":
+			if upstreamModel != "" {
+				s.sendEvent(c, TestEvent{Type: "upstream_model", UpstreamModel: upstreamModel})
+			}
 			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 			return nil
 		case "response.failed":
@@ -3111,17 +3145,36 @@ func (s *AccountTestService) sendErrorAndEnd(c *gin.Context, errorMsg string) er
 // RunTestBackground executes an account test in-memory (no real HTTP client),
 // capturing SSE output via httptest.NewRecorder, then parses the result.
 func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error) {
+	result, err := s.RunTestBackgroundDetailed(ctx, accountID, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return &ScheduledTestResult{
+		Status:       result.Status,
+		ResponseText: result.ResponseText,
+		ErrorMessage: result.ErrorMessage,
+		LatencyMs:    result.LatencyMs,
+		StartedAt:    result.StartedAt,
+		FinishedAt:   result.FinishedAt,
+	}, nil
+}
+
+// RunTestBackgroundDetailed executes an account test and captures first content
+// latency in addition to total latency for batch test reporting.
+func (s *AccountTestService) RunTestBackgroundDetailed(ctx context.Context, accountID int64, modelID string) (*AccountTestResult, error) {
 	startedAt := time.Now()
 
 	w := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(w)
 	ginCtx.Request = (&http.Request{}).WithContext(ctx)
+	timingWriter := &accountTestTimingWriter{ResponseWriter: ginCtx.Writer, startedAt: startedAt}
+	ginCtx.Writer = timingWriter
 
 	testErr := s.TestAccountConnection(ginCtx, accountID, modelID, "", AccountTestModeDefault)
 
 	finishedAt := time.Now()
-	body := w.Body.String()
-	responseText, errMsg := parseTestSSEOutput(body)
+	body := timingWriter.body.String()
+	responseText, errMsg, upstreamModel := parseTestSSEOutput(body)
 
 	status := "success"
 	if testErr != nil || errMsg != "" {
@@ -3131,18 +3184,63 @@ func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID in
 		}
 	}
 
-	return &ScheduledTestResult{
-		Status:       status,
-		ResponseText: responseText,
-		ErrorMessage: errMsg,
-		LatencyMs:    finishedAt.Sub(startedAt).Milliseconds(),
-		StartedAt:    startedAt,
-		FinishedAt:   finishedAt,
+	return &AccountTestResult{
+		Status:             status,
+		ResponseText:       responseText,
+		ErrorMessage:       errMsg,
+		UpstreamModel:      upstreamModel,
+		FirstByteLatencyMs: timingWriter.firstContentLatencyMs(),
+		LatencyMs:          finishedAt.Sub(startedAt).Milliseconds(),
+		StartedAt:          startedAt,
+		FinishedAt:         finishedAt,
 	}, nil
 }
 
+type accountTestTimingWriter struct {
+	gin.ResponseWriter
+	startedAt time.Time
+	body      bytes.Buffer
+	pending   string
+	firstAt   time.Time
+}
+
+func (w *accountTestTimingWriter) Write(data []byte) (int, error) {
+	w.record(data)
+	return w.body.Write(data)
+}
+
+func (w *accountTestTimingWriter) WriteString(data string) (int, error) {
+	return w.Write([]byte(data))
+}
+
+func (w *accountTestTimingWriter) record(data []byte) {
+	w.pending += string(data)
+	lines := strings.Split(w.pending, "\n")
+	w.pending = lines[len(lines)-1]
+	for _, line := range lines[:len(lines)-1] {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event TestEvent
+		if json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event) != nil {
+			continue
+		}
+		if w.firstAt.IsZero() && (event.Type == "content" || event.Type == "image" || event.Type == "audio" || event.Type == "video") {
+			w.firstAt = time.Now()
+		}
+	}
+}
+
+func (w *accountTestTimingWriter) firstContentLatencyMs() int64 {
+	if w.firstAt.IsZero() {
+		return 0
+	}
+	return w.firstAt.Sub(w.startedAt).Milliseconds()
+}
+
 // parseTestSSEOutput extracts response text and error message from captured SSE output.
-func parseTestSSEOutput(body string) (responseText, errMsg string) {
+func parseTestSSEOutput(body string) (responseText, errMsg, upstreamModel string) {
 	var texts []string
 	for _, line := range strings.Split(body, "\n") {
 		line = strings.TrimSpace(line)
@@ -3155,6 +3253,8 @@ func parseTestSSEOutput(body string) (responseText, errMsg string) {
 			continue
 		}
 		switch event.Type {
+		case "upstream_model":
+			upstreamModel = strings.TrimSpace(event.UpstreamModel)
 		case "content":
 			if event.Text != "" {
 				texts = append(texts, event.Text)

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -3,7 +3,8 @@
  * Handles AI platform account management for administrators
  */
 
-import { apiClient } from '../client'
+import { apiClient, buildApiUrl } from '../client'
+import { ADMIN_UI_REQUEST_HEADER } from '../adminUIRequest'
 import type {
   Account,
   CreateAccountRequest,
@@ -283,6 +284,55 @@ export async function testAccount(id: number): Promise<{
     latency_ms?: number
   }>(`/admin/accounts/${id}/test`)
   return data
+}
+
+export interface BatchTestAccountEvent {
+  type: 'batch_start' | 'account_started' | 'account_result' | 'batch_complete'
+  account_id?: number
+  account_name?: string
+  platform?: string
+  model_id?: string
+  upstream_model?: string
+  status?: string
+  first_byte_latency_ms?: number
+  latency_ms?: number
+  error?: string
+  completed?: number
+  total?: number
+}
+
+export async function batchTestAccounts(
+  accountIds: number[],
+  modelId: string,
+  onEvent: (event: BatchTestAccountEvent) => void
+): Promise<void> {
+  const response = await fetch(buildApiUrl('/admin/accounts/batch-test'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('auth_token')}`,
+      'Content-Type': 'application/json',
+      [ADMIN_UI_REQUEST_HEADER]: '1'
+    },
+    credentials: 'include',
+    body: JSON.stringify({ account_ids: accountIds, model_id: modelId })
+  })
+  if (!response.ok || !response.body) {
+    throw new Error(`Batch account test failed (${response.status})`)
+  }
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    buffer += decoder.decode(value || new Uint8Array(), { stream: !done })
+    for (const block of buffer.split('\n\n').slice(0, -1)) {
+      const line = block.split('\n').find(item => item.startsWith('data: '))
+      if (!line) continue
+      onEvent(JSON.parse(line.slice(6)) as BatchTestAccountEvent)
+    }
+    buffer = buffer.includes('\n\n') ? buffer.slice(buffer.lastIndexOf('\n\n') + 2) : buffer
+    if (done) break
+  }
 }
 
 /**
@@ -1057,6 +1107,7 @@ export const accountsAPI = {
   delete: deleteAccount,
   toggleStatus,
   testAccount,
+  batchTestAccounts,
   refreshCredentials,
   applyOAuthCredentials,
   getStats,

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -48,6 +48,7 @@
         <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
         <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
         <button @click="$emit('probe-upstream-billing')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.probeUpstreamBilling') }}</button>
+        <button @click="$emit('test-connection')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.testConnection') }}</button>
         <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
         <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
         <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
@@ -79,7 +80,8 @@ defineEmits([
   'toggle-schedulable',
   'reset-status',
   'refresh-token',
-  'probe-upstream-billing'
+  'probe-upstream-billing',
+  'test-connection'
 ])
 
 const { t } = useI18n()

--- a/frontend/src/components/admin/account/BatchAccountTestModal.vue
+++ b/frontend/src/components/admin/account/BatchAccountTestModal.vue
@@ -1,0 +1,244 @@
+<template>
+  <BaseDialog :show="show" :title="t('admin.accounts.batchTest.title')" width="extra-wide" @close="handleClose">
+    <div class="space-y-4">
+      <div class="flex flex-wrap items-end gap-3">
+        <label class="min-w-64 flex-1">
+          <span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200">{{ t('admin.accounts.batchTest.model') }}</span>
+          <select v-model="selectedModel" class="input w-full" :disabled="loadingModels || running || !modelOptions.length">
+            <option value="" disabled>{{ loadingModels ? t('admin.accounts.batchTest.loadingModels') : t('admin.accounts.batchTest.selectModel') }}</option>
+            <option v-for="option in modelOptions" :key="option.id" :value="option.id">
+              {{ option.id }} ({{ option.supported }}/{{ rows.length }})
+            </option>
+          </select>
+        </label>
+        <div class="text-sm text-gray-500 dark:text-gray-400">
+          {{ t('admin.accounts.batchTest.summary', { supported: supportedCount, skipped: skippedCount }) }}
+        </div>
+        <label class="w-36">
+          <span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200">{{ t('admin.accounts.batchTest.resultFilter') }}</span>
+          <select v-model="resultFilter" class="input w-full" :aria-label="t('admin.accounts.batchTest.resultFilter')">
+            <option value="all">{{ t('admin.accounts.batchTest.filter.all') }}</option>
+            <option value="success">{{ t('admin.accounts.batchTest.filter.success') }}</option>
+            <option value="failed">{{ t('admin.accounts.batchTest.filter.failed') }}</option>
+          </select>
+        </label>
+        <button class="btn btn-primary" data-testid="batch-test-start" :disabled="running || !selectedModel || supportedCount === 0" @click="startTest">
+          {{ running ? t('admin.accounts.batchTest.testing') : t('admin.accounts.batchTest.start') }}
+        </button>
+        <button v-if="snapshotAvailable" class="btn" data-testid="batch-test-view-snapshot" :disabled="running" @click="restoreSnapshot">
+          {{ t('admin.accounts.batchTest.viewSnapshot') }}
+        </button>
+      </div>
+
+      <div v-if="running || completedCount" class="text-sm text-gray-600 dark:text-gray-300">
+        {{ t('admin.accounts.batchTest.progress', { completed: completedCount, total: rows.length }) }}
+      </div>
+
+      <div class="max-h-[55vh] overflow-auto rounded-lg border border-gray-200 dark:border-dark-600">
+        <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-dark-600">
+          <thead class="bg-gray-50 dark:bg-dark-700">
+            <tr>
+              <th class="px-3 py-2 text-left">{{ t('admin.accounts.batchTest.account') }}</th>
+              <th class="px-3 py-2 text-left">{{ t('admin.accounts.batchTest.modelStatus') }}</th>
+              <th class="px-3 py-2 text-left">{{ t('admin.accounts.batchTest.result') }}</th>
+              <th class="px-3 py-2 text-right">{{ t('admin.accounts.batchTest.firstByte') }}</th>
+              <th class="px-3 py-2 text-right">{{ t('admin.accounts.batchTest.totalLatency') }}</th>
+              <th class="px-3 py-2 text-left">{{ t('admin.accounts.batchTest.error') }}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-dark-700">
+            <tr v-for="row in visibleRows" :key="row.id">
+              <td class="px-3 py-2">
+                <div class="font-medium text-gray-900 dark:text-gray-100">{{ row.name }}</div>
+                <div class="text-xs text-gray-500">{{ row.platform }} #{{ row.id }}</div>
+              </td>
+              <td class="px-3 py-2">
+                <span :class="row.supportedModels === null ? 'text-gray-500' : row.supportedModels.includes(selectedModel) ? 'text-green-600' : 'text-amber-600'">
+                  {{ modelSupportLabel(row) }}
+                </span>
+                <div class="mt-1">{{ row.requestedModel || selectedModel || '-' }}</div>
+                <div v-if="row.upstreamModel" :class="row.upstreamModel === (row.requestedModel || selectedModel) ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+                  ↳ {{ t('admin.accounts.batchTest.upstreamResponse') }}: {{ row.upstreamModel }}
+                  <span v-if="row.upstreamModel !== (row.requestedModel || selectedModel)">（{{ t('admin.accounts.batchTest.modelMismatch') }}）</span>
+                </div>
+              </td>
+              <td class="px-3 py-2">
+                <span :class="resultClass(row.status)">{{ resultLabel(row.status) }}</span>
+              </td>
+              <td class="px-3 py-2 text-right">{{ formatLatency(row.firstByteLatencyMs) }}</td>
+              <td class="px-3 py-2 text-right">{{ formatLatency(row.latencyMs) }}</td>
+              <td class="max-w-72 truncate px-3 py-2 text-red-600" :title="row.error">{{ row.error || '-' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import { adminAPI } from '@/api/admin'
+import type { Account } from '@/types'
+import type { BatchTestAccountEvent } from '@/api/admin/accounts'
+
+const props = defineProps<{ show: boolean; accountIds: number[]; accounts: Account[] }>()
+const emit = defineEmits<{ (event: 'close'): void }>()
+const { t } = useI18n()
+
+type Row = {
+  id: number
+  name: string
+  platform: string
+  supportedModels: string[] | null
+  status: 'checking' | 'ready' | 'skipped' | 'testing' | 'success' | 'failed'
+  firstByteLatencyMs: number
+  latencyMs: number
+  error: string
+  requestedModel: string
+  upstreamModel: string
+}
+
+const rows = ref<Row[]>([])
+const selectedModel = ref('')
+const loadingModels = ref(false)
+const running = ref(false)
+const completedCount = ref(0)
+const resultFilter = ref<'all' | 'success' | 'failed'>('all')
+const snapshotAvailable = ref(false)
+const SNAPSHOT_KEY = 'sub2api:batch-account-test-snapshot'
+let loadVersion = 0
+
+type Snapshot = { model: string; savedAt: string; rows: Row[] }
+const validStatuses = new Set<Row['status']>(['checking', 'ready', 'skipped', 'testing', 'success', 'failed'])
+const readSnapshot = (): Snapshot | null => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SNAPSHOT_KEY) || 'null') as Partial<Snapshot> | null
+    if (!parsed || typeof parsed.model !== 'string' || !Array.isArray(parsed.rows) || !parsed.rows.length) return null
+    if (!parsed.rows.every(row => row && typeof row.id === 'number' && typeof row.name === 'string' && typeof row.platform === 'string' && (row.supportedModels === null || Array.isArray(row.supportedModels)) && validStatuses.has(row.status))) return null
+    return parsed as Snapshot
+  } catch {
+    return null
+  }
+}
+
+const modelOptions = computed(() => {
+  const counts = new Map<string, number>()
+  for (const row of rows.value) {
+    for (const model of row.supportedModels || []) counts.set(model, (counts.get(model) || 0) + 1)
+  }
+  return [...counts.entries()].map(([id, supported]) => ({ id, supported })).sort((a, b) => a.id.localeCompare(b.id))
+})
+const supportedCount = computed(() => rows.value.filter(row => row.supportedModels?.includes(selectedModel.value)).length)
+const skippedCount = computed(() => rows.value.length - supportedCount.value)
+const visibleRows = computed(() => {
+  const filtered = resultFilter.value === 'all'
+    ? rows.value
+    : rows.value.filter(row => row.status === resultFilter.value)
+  return [...filtered].sort((a, b) => {
+    const rank = (status: Row['status']) => status === 'success' ? 0 : status === 'failed' ? 1 : 2
+    const rankDiff = rank(a.status) - rank(b.status)
+    if (rankDiff !== 0 || a.status !== 'success' || b.status !== 'success') return rankDiff
+    if (a.firstByteLatencyMs === 0) return b.firstByteLatencyMs === 0 ? 0 : 1
+    if (b.firstByteLatencyMs === 0) return -1
+    return a.firstByteLatencyMs - b.firstByteLatencyMs
+  })
+})
+
+const loadModels = async () => {
+  const version = ++loadVersion
+  loadingModels.value = true
+  selectedModel.value = ''
+  resultFilter.value = 'all'
+  completedCount.value = 0
+  const known = new Map(props.accounts.map(account => [account.id, account]))
+  rows.value = props.accountIds.map(id => {
+    const account = known.get(id)
+    return { id, name: account?.name || `Account ${id}`, platform: account?.platform || '-', supportedModels: null, status: 'checking', firstByteLatencyMs: 0, latencyMs: 0, error: '', requestedModel: '', upstreamModel: '' }
+  })
+  await Promise.all(rows.value.map(async row => {
+    try {
+      if (!known.has(row.id)) known.set(row.id, await adminAPI.accounts.getById(row.id))
+      const account = known.get(row.id)
+      if (account) { row.name = account.name; row.platform = account.platform }
+      row.supportedModels = (await adminAPI.accounts.getAvailableModels(row.id)).map(model => model.id)
+      row.status = 'ready'
+    } catch (error) {
+      row.status = 'skipped'
+      row.error = String(error)
+    }
+  }))
+  if (version !== loadVersion || !props.show) return
+  if (!selectedModel.value) selectedModel.value = modelOptions.value.find(option => option.id === 'gpt-5.6-sol')?.id || modelOptions.value[0]?.id || ''
+  loadingModels.value = false
+}
+
+const handleEvent = (event: BatchTestAccountEvent) => {
+  if (event.type === 'account_started' && event.account_id) {
+    const row = rows.value.find(item => item.id === event.account_id)
+    if (row) row.status = 'testing'
+  }
+  if (event.type !== 'account_result' || !event.account_id) return
+  const row = rows.value.find(item => item.id === event.account_id)
+  if (!row) return
+  row.status = event.status === 'success' ? 'success' : 'failed'
+  row.requestedModel = event.model_id || selectedModel.value
+  row.upstreamModel = event.upstream_model || ''
+  row.firstByteLatencyMs = event.first_byte_latency_ms || 0
+  row.latencyMs = event.latency_ms || 0
+  row.error = event.error || ''
+  completedCount.value = event.completed || completedCount.value + 1
+  persistSnapshot()
+}
+
+const startTest = async () => {
+  if (!selectedModel.value) return
+  const ids = rows.value.filter(row => row.supportedModels?.includes(selectedModel.value)).map(row => row.id)
+  rows.value.forEach(row => { if (!ids.includes(row.id)) row.status = 'skipped' })
+  completedCount.value = 0
+  running.value = true
+  try {
+    await adminAPI.accounts.batchTestAccounts(ids, selectedModel.value, handleEvent)
+  } catch (error) {
+    rows.value.filter(row => row.status === 'testing' || row.status === 'ready').forEach(row => { row.status = 'failed'; row.error = String(error) })
+  } finally {
+    running.value = false
+    persistSnapshot()
+  }
+}
+
+const persistSnapshot = () => {
+  if (running.value || !completedCount.value || !selectedModel.value) return
+  try {
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify({ model: selectedModel.value, savedAt: new Date().toISOString(), rows: rows.value }))
+    snapshotAvailable.value = true
+  } catch {
+    snapshotAvailable.value = false
+  }
+}
+
+const restoreSnapshot = () => {
+  const snapshot = readSnapshot()
+  if (!snapshot) { snapshotAvailable.value = false; return }
+  rows.value = snapshot.rows
+  selectedModel.value = snapshot.model
+  completedCount.value = rows.value.filter(row => row.status === 'success' || row.status === 'failed').length
+  resultFilter.value = 'all'
+  running.value = false
+}
+
+const handleClose = () => { if (!running.value) emit('close') }
+const modelSupportLabel = (row: Row) => row.supportedModels === null ? (row.status === 'skipped' ? t('admin.accounts.batchTest.status.skipped') : t('admin.accounts.batchTest.checking')) : row.supportedModels.includes(selectedModel.value) ? t('admin.accounts.batchTest.supported') : t('admin.accounts.batchTest.unsupported')
+const resultLabel = (status: Row['status']) => t(`admin.accounts.batchTest.status.${status}`)
+const resultClass = (status: Row['status']) => status === 'success' ? 'text-green-600 dark:text-green-400' : status === 'failed' ? 'text-red-600 dark:text-red-400' : 'text-gray-600 dark:text-gray-300'
+const formatLatency = (value: number) => value > 0 ? `${value} ms` : '-'
+
+watch(() => props.show, value => {
+  if (value) {
+    snapshotAvailable.value = !!readSnapshot()
+    void loadModels()
+  }
+})
+</script>

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -468,9 +468,47 @@ export default {
         resetStatus: 'Reset Status',
         refreshToken: 'Refresh Token',
         probeUpstreamBilling: 'Probe Upstream Rate',
+        testConnection: 'Batch Test Connection',
         resetStatusSuccess: 'Successfully reset {count} account(s) status',
         refreshTokenSuccess: 'Successfully refreshed {count} account(s) token',
         partialSuccess: 'Partially completed: {success} succeeded, {failed} failed'
+      },
+      batchTest: {
+        title: 'Batch Account Connection Test',
+        model: 'Test model',
+        loadingModels: 'Loading account models...',
+        selectModel: 'Select a model',
+        start: 'Start test',
+        testing: 'Testing...',
+        viewSnapshot: 'View last snapshot',
+        summary: '{supported} ready, {skipped} skipped',
+        progress: '{completed}/{total} completed',
+        resultFilter: 'Result filter',
+        filter: {
+          all: 'All',
+          success: 'Success',
+          failed: 'Failed'
+        },
+        account: 'Account',
+        modelStatus: 'Model support',
+        modelResult: 'Model result',
+        upstreamResponse: 'Upstream response',
+        modelMismatch: 'Model mismatch',
+        result: 'Result',
+        firstByte: 'First byte',
+        totalLatency: 'Total latency',
+        error: 'Error',
+        checking: 'Checking',
+        supported: 'Ready',
+        unsupported: 'Model unsupported',
+        status: {
+          checking: 'Checking',
+          ready: 'Ready',
+          skipped: 'Skipped',
+          testing: 'Testing',
+          success: 'Success',
+          failed: 'Failed'
+        }
       },
       bulkEdit: {
         title: 'Bulk Edit Accounts',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -555,9 +555,47 @@ export default {
         resetStatus: '批量重置状态',
         refreshToken: '批量刷新令牌',
         probeUpstreamBilling: '探测上游倍率',
+        testConnection: '批量测试连接',
         resetStatusSuccess: '已成功重置 {count} 个账号状态',
         refreshTokenSuccess: '已成功刷新 {count} 个账号令牌',
         partialSuccess: '操作部分完成：{success} 成功，{failed} 失败'
+      },
+      batchTest: {
+        title: '批量测试账号连接',
+        model: '测试模型',
+        loadingModels: '正在读取账号模型...',
+        selectModel: '请选择模型',
+        start: '开始测试',
+        testing: '测试中...',
+        viewSnapshot: '查看上次快照',
+        summary: '可测试 {supported} 个，跳过 {skipped} 个',
+        progress: '已完成 {completed}/{total}',
+        resultFilter: '结果筛选',
+        filter: {
+          all: '全部',
+          success: '成功',
+          failed: '失败'
+        },
+        account: '账号',
+        modelStatus: '模型支持',
+        modelResult: '模型结果',
+        upstreamResponse: '上游响应',
+        modelMismatch: '模型不一致',
+        result: '结果',
+        firstByte: '首字延迟',
+        totalLatency: '总耗时',
+        error: '错误',
+        checking: '检查中',
+        supported: '可测试',
+        unsupported: '不支持该模型',
+        status: {
+          checking: '检查中',
+          ready: '待测试',
+          skipped: '已跳过',
+          testing: '测试中',
+          success: '成功',
+          failed: '失败'
+        }
       },
       bulkEdit: {
         title: '批量编辑账号',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -184,6 +184,7 @@
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
           @probe-upstream-billing="handleBulkProbeUpstreamBilling"
+          @test-connection="openBatchTest"
           @edit-selected="openBulkEditSelected"
           @edit-filtered="openBulkEditFiltered"
           @clear="clearSelection"
@@ -454,6 +455,7 @@
     <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
     <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
+    <BatchAccountTestModal :show="showBatchTest" :account-ids="selIds" :accounts="accounts" @close="showBatchTest = false" />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
     <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
     <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @duplicate="handleDuplicateAccount" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @create-spark-shadow="handleCreateSparkShadow" />
@@ -511,6 +513,7 @@ import AccountActionMenu from '@/components/admin/account/AccountActionMenu.vue'
 import ImportDataModal from '@/components/admin/account/ImportDataModal.vue'
 import ReAuthAccountModal from '@/components/admin/account/ReAuthAccountModal.vue'
 import AccountTestModal from '@/components/admin/account/AccountTestModal.vue'
+import BatchAccountTestModal from '@/components/admin/account/BatchAccountTestModal.vue'
 import AccountStatsModal from '@/components/admin/account/AccountStatsModal.vue'
 import ScheduledTestsPanel from '@/components/admin/account/ScheduledTestsPanel.vue'
 import type { SelectOption } from '@/components/common/Select.vue'
@@ -594,6 +597,7 @@ const showDeleteDialog = ref(false)
 const showCreateShadowDialog = ref(false)
 const showReAuth = ref(false)
 const showTest = ref(false)
+const showBatchTest = ref(false)
 const showStats = ref(false)
 const showErrorPassthrough = ref(false)
 const showTLSFingerprintProfiles = ref(false)
@@ -2334,6 +2338,7 @@ const closeTestModal = () => { showTest.value = false; testingAcc.value = null }
 const closeStatsModal = () => { showStats.value = false; statsAcc.value = null }
 const closeReAuthModal = () => { showReAuth.value = false; reAuthAcc.value = null }
 const handleTest = (a: Account) => { testingAcc.value = a; showTest.value = true }
+const openBatchTest = () => { if (selIds.value.length > 0) showBatchTest.value = true }
 const handleViewStats = (a: Account) => { statsAcc.value = a; showStats.value = true }
 const handleSchedule = async (a: Account) => {
   scheduleAcc.value = a


### PR DESCRIPTION
您好作者，非常感谢您开源了这个项目，使得我在工作时真的很获收益。
在使用过程中我喜欢接入较多上游，然后我发现测试账号只有单个账号可以测试，因此我自己增加了批量测试账号。
本次改动包括：
- 支持一次选择多个账号进行连接测试
- 显示请求模型和上游实际响应模型
- 支持统一选择批量测试使用的模型，默认使用 gpt-5.6-sol
- 以流式方式返回每个账号的测试进度和结果
- 显示账号测试状态、首字延迟和总耗时
- 成功账号显示为绿色，失败账号显示为红色
- 支持按成功/失败筛选
- 成功账号优先显示，并按首字延迟从低到高排序
- 当上下游模型不一致时，显示红色提示
- 测试完成后自动保存最新测试快照，方便后续查看
这个功能主要是为了方便管理员快速筛选可用账号、比较账号响应速度，并及时发现模型映射或上游返回模型不一致的问题。