### PR TITLE
fix(openai): preserve reasoning effort in API-key passthrough

### DIFF
--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -59,6 +59,9 @@ func shouldPreserveOpenAIResponsesNoneReasoningEffort(account *Account) bool {
 	if account == nil {
 		return false
 	}
+	if account.IsOpenAIPassthroughEnabled() {
+		return true
+	}
 	if account.IsOpenAIOAuthLike() {
 		return true
 	}

--- a/backend/internal/service/openai_gateway_request_body_reasoning_test.go
+++ b/backend/internal/service/openai_gateway_request_body_reasoning_test.go
@@ -331,6 +331,23 @@ func TestFilterOpenAIResponsesNoneReasoningEffortForAccount(t *testing.T) {
 	}
 }
 
+func TestFilterOpenAIResponsesNoneReasoningEffortForAccount_APIKeyAutomaticPassthroughPreservesRequest(t *testing.T) {
+	body := []byte(`{"model":"qwen3.8-27b","input":"hi","max_output_tokens":20,"reasoning":{"effort":"none"},"presence_penalty":1.5}`)
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://compat.example/v1",
+		},
+		Extra: map[string]any{"openai_passthrough": true},
+	}
+
+	got, err := filterOpenAIResponsesNoneReasoningEffortForAccount(account, body)
+
+	require.NoError(t, err)
+	require.JSONEq(t, string(body), string(got))
+}
+
 // Lite 工具迁移到 input[].additional_tools 后，仍应按有工具请求处理。
 func TestNormalizeOpenAIParallelToolCallsWithoutTools_KeepsResponsesLiteAdditionalTools(t *testing.T) {
 	liteBody := []byte(`{"input":[{"type":"message","role":"user","content":"hi"},{"type":"additional_tools","tools":[{"type":"function","name":"spawn_agent"}]}],"parallel_tool_calls":false}`)


### PR DESCRIPTION
## 问题
OpenAI API-key 账号启用自动透传并使用第三方兼容端点时，`/v1/responses` 请求中的 `reasoning.effort: "none"` 会在发往上游前被删除，导致兼容上游无法关闭推理。

## 根因
兼容路径会把 `none` 当作模型目录占位值清理，但此前只豁免官方端点和 OAuth 账号，未把显式启用自动透传的 API-key 账号纳入原样透传语义。

## 改动
- 自动透传账号保留客户端提供的 `reasoning.effort: "none"`
- 非透传第三方兼容路径继续保持既有占位值清理行为
- 增加包含 `presence_penalty` 的原始复现请求回归测试

## 验证
已验证：
- `make -C backend test-unit`
- `make -C backend test-integration`
- `golangci-lint run --timeout=30m ./...`
- `make -C backend build`
- 前端 lint、typecheck、关键测试与生产构建
- `govulncheck ./...`
- 前端生产依赖审计例外校验
- `git diff --check`

Fixes #6521