### PR TITLE
fix(accounts): preserve custom upstream URL across protocol switches

### DIFF
--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -3038,7 +3038,7 @@ const editAdaptiveBaseUrls = ref<Record<CnNativeApiProtocol, string>>({
 // 回填窗口标志：syncFormFromAccount 会同步改写 editAccountMode / editApiProtocol，
 // 而 watcher（pre-flush）在同步代码执行完之后才触发——若不抑制，会把刚恢复的
 // 存储版 base_url（可能是用户自定义/中转地址）覆盖为官方预设并在下次保存时持久化。
-// nextTick 后解除，此后用户主动切换模式/协议仍正常联动重置。
+// nextTick 后解除，此后用户主动切换模式/协议仍正常联动处理。
 const syncingForm = ref(false)
 const cnAccountModeOptions = computed<Array<{ value: CnAccountMode; labelKey: 'payg' | 'coding' }>>(
   () => {
@@ -3073,23 +3073,38 @@ const editAdaptiveProtocolOptions = computed<Array<{ value: CnNativeApiProtocol;
 })
 watch(editApiProtocol, (protocol, previousProtocol) => {
   if (!isCNApiKeyAccount.value || syncingForm.value) return
+  const currentBaseUrl = editBaseUrl.value.trim()
+  const defaults = defaultCNAdaptiveBaseUrls(cnPresetPlatform.value, editAccountMode.value)
+
   if (protocol === 'adaptive') {
-    const defaults = defaultCNAdaptiveBaseUrls(cnPresetPlatform.value, editAccountMode.value)
     for (const item of editAdaptiveProtocolOptions.value) {
       if (!editAdaptiveBaseUrls.value[item.value]) editAdaptiveBaseUrls.value[item.value] = defaults[item.value]
     }
-    if (previousProtocol !== 'adaptive' && editBaseUrl.value.trim()) {
-      editAdaptiveBaseUrls.value[previousProtocol] = editBaseUrl.value.trim()
+    if (previousProtocol !== 'adaptive' && currentBaseUrl) {
+      // Keep the address the user was editing. The legacy single base_url field
+      // is the only source available for older accounts without api_base_urls.
+      editAdaptiveBaseUrls.value[previousProtocol] = currentBaseUrl
+      // base_url is the adaptive Chat Completions fallback. Replace only the
+      // generated default; an explicitly configured adaptive endpoint wins.
+      if (!editAdaptiveBaseUrls.value.chat_completions ||
+        editAdaptiveBaseUrls.value.chat_completions === defaults.chat_completions) {
+        editAdaptiveBaseUrls.value.chat_completions = currentBaseUrl
+      }
     }
-    editBaseUrl.value = editAdaptiveBaseUrls.value.chat_completions
+    editBaseUrl.value = currentBaseUrl || editAdaptiveBaseUrls.value.chat_completions
     return
   }
   if (previousProtocol === 'adaptive') {
-    editBaseUrl.value = editAdaptiveBaseUrls.value[protocol] ||
-      defaultCNBaseUrl(props.account!.platform, editAccountMode.value, protocol)
+    const configuredTargetUrl = editAdaptiveBaseUrls.value[protocol]?.trim()
+    const targetDefaultUrl = defaults[protocol as CnNativeApiProtocol]
+    editBaseUrl.value = configuredTargetUrl && configuredTargetUrl !== targetDefaultUrl
+      ? configuredTargetUrl
+      : currentBaseUrl || defaultCNBaseUrl(props.account!.platform, editAccountMode.value, protocol)
     return
   }
-  editBaseUrl.value = defaultCNBaseUrl(props.account!.platform, editAccountMode.value, protocol)
+  // Switching between fixed protocols must not silently replace a user relay
+  // with the provider default. Empty fields still receive the normal default.
+  editBaseUrl.value = currentBaseUrl || defaultCNBaseUrl(props.account!.platform, editAccountMode.value, protocol)
 })
 watch(editAccountMode, (mode, previousMode) => {
   if (!isCNApiKeyAccount.value || syncingForm.value) return

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -514,9 +514,8 @@ describe('EditAccountModal', () => {
       platform: 'zhipu',
       protocol: 'anthropic',
       baseUrl: 'https://relay.example.com/anthropic',
-      expectedBaseUrl: 'https://open.bigmodel.cn/api/paas/v4',
       expectedProtocolUrls: {
-        chat_completions: 'https://open.bigmodel.cn/api/paas/v4',
+        chat_completions: 'https://relay.example.com/anthropic',
         anthropic: 'https://relay.example.com/anthropic'
       }
     },
@@ -525,9 +524,8 @@ describe('EditAccountModal', () => {
       platform: 'deepseek',
       protocol: 'responses',
       baseUrl: 'https://relay.example.com/responses',
-      expectedBaseUrl: 'https://api.deepseek.com',
       expectedProtocolUrls: {
-        chat_completions: 'https://api.deepseek.com',
+        chat_completions: 'https://relay.example.com/responses',
         anthropic: 'https://api.deepseek.com/anthropic',
         responses: 'https://relay.example.com/responses'
       }
@@ -555,8 +553,38 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock).toHaveBeenCalledTimes(1)
     expect(updateAccountMock.mock.calls[0]?.[1]?.credentials).toMatchObject({
       api_protocol: 'adaptive',
-      base_url: testCase.expectedBaseUrl,
+      base_url: testCase.baseUrl,
       api_base_urls: testCase.expectedProtocolUrls
+    })
+  })
+
+  it.each([
+    ['zhipu', 'chat_completions', 'anthropic', 'https://relay.example.com/v1'],
+    ['deepseek', 'chat_completions', 'responses', 'https://relay.example.com/v1']
+  ])('preserves a custom relay when switching fixed protocols', async (platform, from, to, baseUrl) => {
+    const account = buildAccount()
+    account.platform = platform
+    account.credentials = {
+      api_key: 'sk-cn',
+      account_mode: 'payg',
+      api_protocol: from,
+      base_url: baseUrl
+    }
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const targetButton = wrapper
+      .findAll('button')
+      .find(button => button.text().includes(`admin.accounts.cnProviders.apiProtocol.${to === 'chat_completions' ? 'chatCompletions' : to}`))
+    expect(targetButton).toBeDefined()
+    await targetButton!.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials).toMatchObject({
+      api_protocol: to,
+      base_url: baseUrl
     })
   })
 


### PR DESCRIPTION
## Problem
For CN-provider API-key accounts, changing `api_protocol` in the edit modal can replace a user-entered custom `base_url` with the platform default URL. This is especially disruptive for relay endpoints: saving after a protocol switch silently changes the upstream target.

## Change
- Preserve the current non-empty upstream URL when switching between fixed protocols.
- When entering adaptive mode, carry the current URL into the legacy protocol slot and the adaptive Chat Completions fallback when that slot only contains the generated default.
- When leaving adaptive mode, prefer an explicitly configured non-default protocol endpoint; otherwise keep the current URL instead of silently falling back to the provider default.
- Keep existing preset selection behavior unchanged: an explicit preset click remains an intentional URL change.

## Tests
- Added regression coverage for fixed-to-fixed protocol switches.
- Updated adaptive-switch coverage for custom Anthropic and Responses relays.
- `pnpm test:run` (246 files, 1769 tests)
- `pnpm typecheck`
- `pnpm lint:check`
