### PR TITLE
fix(openai): normalize automation heartbeat bootstrap

### DIFF
--- a/backend/internal/handler/openai_automation_bootstrap_test.go
+++ b/backend/internal/handler/openai_automation_bootstrap_test.go
@@ -49,6 +49,20 @@ func TestNormalizeCodexAutomationBootstrapSupportedLastRunValues(t *testing.T) {
 	}
 }
 
+func TestNormalizeCodexAutomationBootstrapHeartbeat(t *testing.T) {
+	output := `<heartbeat><automation_id>wiki</automation_id></heartbeat>`
+	got, changed := normalizeCodexAutomationBootstrap(codexAutomationBootstrapBody(t, output, ""))
+	require.True(t, changed)
+	require.Equal(t, "message", gjson.GetBytes(got, "input.0.type").String())
+	require.Equal(t, "user", gjson.GetBytes(got, "input.0.role").String())
+	require.Equal(t, output, gjson.GetBytes(got, "input.0.content.0.text").String())
+	require.False(t, gjson.GetBytes(got, "input.0.call_id").Exists())
+
+	again, changedAgain := normalizeCodexAutomationBootstrap(got)
+	require.False(t, changedAgain)
+	require.Equal(t, got, again)
+}
+
 func TestNormalizeCodexAutomationBootstrapRejectsUnsafeShapes(t *testing.T) {
 	validOutput := codexAutomationBootstrap("wiki", "never", automationBootstrapPrompt)
 	tests := []struct {
@@ -74,10 +88,6 @@ func TestNormalizeCodexAutomationBootstrapRejectsUnsafeShapes(t *testing.T) {
 		{
 			name: "real call context",
 			body: []byte(`{"model":"gpt-5","input":[{"type":"function_call_output","namespace":"codex_app","name":"automation_update","output":` + mustJSON(t, validOutput) + `},{"type":"function_call","call_id":"call-1"}]}`),
-		},
-		{
-			name: "heartbeat output",
-			body: codexAutomationBootstrapBody(t, `<heartbeat><automation_id>wiki</automation_id></heartbeat>`, ""),
 		},
 		{
 			name: "mismatched memory id",
@@ -113,6 +123,31 @@ func TestNormalizeCodexAutomationBootstrapRejectsUnsafeShapes(t *testing.T) {
 			got, changed := normalizeCodexAutomationBootstrap(tt.body)
 			require.False(t, changed)
 			require.Equal(t, tt.body, got)
+		})
+	}
+}
+
+func TestNormalizeCodexAutomationBootstrapRejectsUnsafeHeartbeatShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{name: "arbitrary tool output", output: `<result><automation_id>wiki</automation_id></result>`},
+		{name: "root attribute", output: `<heartbeat status="ok"><automation_id>wiki</automation_id></heartbeat>`},
+		{name: "namespaced root", output: `<heartbeat xmlns="urn:codex"><automation_id>wiki</automation_id></heartbeat>`},
+		{name: "extra child", output: `<heartbeat><automation_id>wiki</automation_id><status>ok</status></heartbeat>`},
+		{name: "nested id content", output: `<heartbeat><automation_id><value>wiki</value></automation_id></heartbeat>`},
+		{name: "padded id", output: `<heartbeat><automation_id> wiki </automation_id></heartbeat>`},
+		{name: "unsafe id", output: `<heartbeat><automation_id>../wiki</automation_id></heartbeat>`},
+		{name: "comment", output: `<heartbeat><!-- ok --><automation_id>wiki</automation_id></heartbeat>`},
+		{name: "trailing content", output: `<heartbeat><automation_id>wiki</automation_id></heartbeat>extra`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := codexAutomationBootstrapBody(t, tt.output, "")
+			got, changed := normalizeCodexAutomationBootstrap(body)
+			require.False(t, changed)
+			require.Equal(t, body, got)
 		})
 	}
 }

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1756,7 +1756,7 @@ func isCodexAutomationCandidate(item map[string]any) bool {
 		return false
 	}
 	output, ok := item["output"].(string)
-	return ok && validCodexAutomationBootstrap(output)
+	return ok && (validCodexAutomationBootstrap(output) || validCodexAutomationHeartbeat(output))
 }
 
 func stringField(item map[string]any, key string) string {
@@ -1832,6 +1832,56 @@ func validCodexAutomationLastRun(value string) bool {
 	}
 	epochMillis, err := strconv.ParseInt(value[separator+2:len(value)-1], 10, 64)
 	return err == nil && runAt.UnixMilli() == epochMillis
+}
+
+func validCodexAutomationHeartbeat(value string) bool {
+	decoder := xml.NewDecoder(strings.NewReader(value))
+	var rootSeen, automationIDSeen bool
+	var automationID bytes.Buffer
+	depth := 0
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			id := automationID.String()
+			return rootSeen && automationIDSeen && depth == 0 &&
+				strings.TrimSpace(id) == id && validCodexAutomationID(id)
+		}
+		if err != nil {
+			return false
+		}
+		switch current := token.(type) {
+		case xml.StartElement:
+			depth++
+			if current.Name.Space != "" || len(current.Attr) != 0 || depth > 2 {
+				return false
+			}
+			if depth == 1 {
+				if rootSeen || current.Name.Local != "heartbeat" {
+					return false
+				}
+				rootSeen = true
+			} else if automationIDSeen || current.Name.Local != "automation_id" {
+				return false
+			}
+			automationIDSeen = depth == 2
+		case xml.EndElement:
+			if current.Name.Space != "" {
+				return false
+			}
+			depth--
+			if depth < 0 {
+				return false
+			}
+		case xml.CharData:
+			if depth == 2 {
+				_, _ = automationID.Write(current)
+			} else if len(bytes.TrimSpace(current)) != 0 {
+				return false
+			}
+		case xml.Comment, xml.ProcInst, xml.Directive:
+			return false
+		}
+	}
 }
 
 func validCodexDelegationEnvelope(value string) bool {


### PR DESCRIPTION
## 问题
Responses HTTP 收到新版 heartbeat XML 的孤立 automation_update function_call_output 时未规范化，随后因缺少 call_id 被拒绝。
## 根因
现有安全候选校验只接受旧版 Automation 文本 bootstrap，未识别严格的 heartbeat XML 形态。
## 改动
- 严格校验仅含 automation_id 的 heartbeat XML，并复用现有规范化路径转换为普通 user message
- 保留 namespace/name、call_id、previous_response_id、真实调用上下文和幂等性等现有安全门禁
- 增加真实 payload 与不安全 XML 形态回归测试
## 验证
- 已验证：make test-unit
- 已验证：make test-integration
- 已验证：make test-frontend
- 已验证：golangci-lint run --timeout=30m
- 已验证：govulncheck ./...（0 vulnerabilities）
Fixes #6547