### PR TITLE
feat(gateway): allow HTTP ingress to use OpenAI WS upstream behind a flag

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1245,6 +1245,10 @@ type GatewayOpenAIWSConfig struct {
 	APIKeyEnabled bool `mapstructure:"apikey_enabled"`
 	// ForceHTTP: 全局强制 HTTP（用于紧急回滚）
 	ForceHTTP bool `mapstructure:"force_http"`
+	// HTTPIngressWSUpstreamEnabled: 允许 HTTP 入站请求走 WS 上游（默认 false）。
+	// 用于绕开上游边缘对单个 HTTP 流约 900s 的时长上限；开启后 WS 各次尝试
+	// 均失败且尚未向客户端写出任何字节时，自动回落原 HTTP/SSE 路径。
+	HTTPIngressWSUpstreamEnabled bool `mapstructure:"http_ingress_ws_upstream_enabled"`
 	// AllowStoreRecovery: 允许在 WSv2 下按策略恢复 store=true（默认 false）
 	AllowStoreRecovery bool `mapstructure:"allow_store_recovery"`
 	// IngressPreviousResponseRecoveryEnabled: ingress 模式收到 previous_response_not_found 时，是否允许自动去掉 previous_response_id 重试一次（默认 true）
@@ -2385,6 +2389,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.oauth_enabled", true)
 	viper.SetDefault("gateway.openai_ws.apikey_enabled", true)
 	viper.SetDefault("gateway.openai_ws.force_http", false)
+	viper.SetDefault("gateway.openai_ws.http_ingress_ws_upstream_enabled", false)
 	viper.SetDefault("gateway.openai_ws.allow_store_recovery", false)
 	viper.SetDefault("gateway.openai_ws.ingress_previous_response_recovery_enabled", true)
 	viper.SetDefault("gateway.openai_ws.store_disabled_conn_mode", "strict")

--- a/backend/internal/config/openai_ws_http_ingress_test.go
+++ b/backend/internal/config/openai_ws_http_ingress_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOpenAIWSHTTPIngressWSUpstreamDefaultDisabled 确认新开关默认关闭：
+// 未显式开启时 HTTP 入站必须保持原有 HTTP/SSE 行为。
+func TestOpenAIWSHTTPIngressWSUpstreamDefaultDisabled(t *testing.T) {
+	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Gateway.OpenAIWS.HTTPIngressWSUpstreamEnabled {
+		t.Fatal("gateway.openai_ws.http_ingress_ws_upstream_enabled should default to false")
+	}
+}
+
+// TestOpenAIWSHTTPIngressWSUpstreamEnvOverride 确认环境变量可开启该开关。
+func TestOpenAIWSHTTPIngressWSUpstreamEnvOverride(t *testing.T) {
+	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	t.Setenv("GATEWAY_OPENAI_WS_HTTP_INGRESS_WS_UPSTREAM_ENABLED", "true")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if !cfg.Gateway.OpenAIWS.HTTPIngressWSUpstreamEnabled {
+		t.Fatal("env GATEWAY_OPENAI_WS_HTTP_INGRESS_WS_UPSTREAM_ENABLED=true should enable the flag")
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -106,7 +106,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	}
 	wsDecision := s.getOpenAIWSProtocolResolver().Resolve(account)
 	// 仅允许 WS 入站请求走 WS 上游，避免出现 HTTP -> WS 协议混用。
-	wsDecision = resolveOpenAIWSDecisionByClientTransport(wsDecision, GetOpenAIClientTransport(c))
+	// 例外：http_ingress_ws_upstream_enabled 开启时放行 HTTP 入站走 WS 上游，
+	// 用于绕开上游边缘对单个 HTTP 流约 900s 的时长上限（失败回落 HTTP，见下）。
+	if s.cfg == nil || !s.cfg.Gateway.OpenAIWS.HTTPIngressWSUpstreamEnabled {
+		wsDecision = resolveOpenAIWSDecisionByClientTransport(wsDecision, GetOpenAIClientTransport(c))
+	}
 	passthroughEnabled := account.IsOpenAIPassthroughEnabled()
 	compactPath := isOpenAIResponsesCompactPath(c)
 	if shouldFlattenOpenAIResponsesNamespaces(account, wsDecision.Transport, passthroughEnabled, compactPath) {
@@ -959,8 +963,21 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 			return wsResult, nil
 		}
-		s.writeOpenAIWSFallbackErrorResponse(c, account, wsErr)
-		return nil, wsErr
+		// http_ingress_ws_upstream_enabled 下的 HTTP 入站请求：WS 各次尝试均失败
+		// 且尚未向客户端写出任何字节时，回落原 HTTP/SSE 路径（不把 WS 错误抛给客户端）。
+		if s.cfg != nil && s.cfg.Gateway.OpenAIWS.HTTPIngressWSUpstreamEnabled &&
+			GetOpenAIClientTransport(c) == OpenAIClientTransportHTTP &&
+			c != nil && c.Writer != nil && !c.Writer.Written() {
+			logOpenAIWSModeInfo(
+				"http_ingress_ws_fallback_http account_id=%d attempts=%d cause=%s",
+				account.ID,
+				wsAttempts,
+				truncateOpenAIWSLogValue(wsErr.Error(), openAIWSLogValueMaxLen),
+			)
+		} else {
+			s.writeOpenAIWSFallbackErrorResponse(c, account, wsErr)
+			return nil, wsErr
+		}
 	}
 
 	reasoningEffort := extractOpenAIReasoningEffortFromBody(body, upstreamModel, billingModel, originalModel)

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -335,6 +335,12 @@ gateway:
     # 全局强制 OpenAI Responses 上游使用 HTTP/SSE，不使用 WebSocket（紧急回滚开关）。
     # 此开关不强制 HTTP/1.1；HTTP/2 由 gateway.openai_http2 单独控制。
     force_http: false
+    # 允许 HTTP 入站（POST /v1/responses）请求走 WebSocket 上游（默认 false）。
+    # 用途：部分边缘/CDN 对单个 HTTP 流有时长上限（实测约 900s 后 RST_STREAM），
+    # WS 通道不受该限制；开启后账号 WS mode 仍逐账号控制（off 的账号照旧走 HTTP）。
+    # WS 各次尝试均失败且尚未向客户端写出任何字节时，自动回落原 HTTP/SSE 路径。
+    # 环境变量：GATEWAY_OPENAI_WS_HTTP_INGRESS_WS_UPSTREAM_ENABLED=true
+    http_ingress_ws_upstream_enabled: false
     # 允许在 WSv2 下按策略恢复 store=true（默认 false）
     allow_store_recovery: false
     # ingress 模式收到 previous_response_not_found 时，自动去掉 previous_response_id 重试一次（默认 true）


### PR DESCRIPTION
## 背景 / Motivation

部分边缘/CDN 会对单个长时 HTTP 流强制设置约 **900 秒**的时长上限：即使流上持续有数据，也会在 ~900s 处收到 `RST_STREAM (INTERNAL_ERROR)`。对 `reasoning.effort` 较高的长任务（15 分钟以上）这是硬伤。

实测（同一账号、同一出口、同一 payload 对照）：

| 上游传输 | 结果 |
|---|---|
| HTTP/2（现状） | 3 次复现均在 901~902s 被上游 RST_STREAM 掐断 |
| WebSocket（responses_websockets_v2） | **2280s / 2336s 完整跑完**，`response.completed`/`response.incomplete(max_output_tokens)` 正常收尾 |

即 900s 墙是 HTTP 传输层策略，WS 通道不受影响。但当前代码在 `forwardOpenAIResponses` 里无条件把 HTTP 入站请求的 WS 决策降级为 HTTP（`client_protocol_http`），普通 POST 客户端永远吃不到 WS 上游。

## 方案 / Change

新增 `gateway.openai_ws.http_ingress_ws_upstream_enabled`（默认 **false**，env `GATEWAY_OPENAI_WS_HTTP_INGRESS_WS_UPSTREAM_ENABLED`）：

- **默认关闭时行为与现版本逐字节一致**（client-transport 闸门原样生效）
- 开启后：HTTP 入站的 `/v1/responses` 保留账号级 WS 路由决策，POST 流量可走 `responses_websockets_v2`（收 POST → WS 连上游 → SSE 回吐，客户端零改动）
- **账号级灰度不变**：账号 WS mode 为 off 的照旧走 HTTP，可逐账号放量/回退
- **失败回落**：开启状态下，WS 各次尝试均失败且尚未向客户端写出任何字节时，自动回落原 HTTP/SSE 路径（日志 `http_ingress_ws_fallback_http`），不把 WS 错误抛给客户端；已写出字节则维持原有错误语义

## 测试 / Tests

- 新增 `internal/config` 单测：默认值 false + env 覆盖生效
- 回归：开关关闭时 POST 走 HTTP 上游（与官方镜像行为一致）
- 功能：开关开启 + 账号 ctx_pool，POST → WS 上游 → SSE 完整回吐
- 回落：上游 WS 升级全部 404 时，重试耗尽后自动回落 HTTP 并正常完成，客户端无感
- 长跑：POST→WS 路径 1000s+ 持续流无本地超时；真实上游 2300s+ 跑通
- `go build ./...`、`go vet`、`go test ./internal/config/ ./internal/service/`（transport/resolver 相关）通过

## 兼容性 / Compatibility

- 默认关闭，零行为变化；不新增依赖；不改 DB schema
- 仅在显式开启时激活，且回落逻辑保证最坏情况退回现有 HTTP 行为
