### PR TITLE
feat(gateway): forward session routing header

### DIFF
--- a/backend/internal/service/openai_gateway_opencode_session_test.go
+++ b/backend/internal/service/openai_gateway_opencode_session_test.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIUpstreamRequestsScopeOpenCodeSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	builders := []struct {
+		name           string
+		forwardSession bool
+		build          func(*OpenAIGatewayService, *gin.Context, *Account, []byte) (*http.Request, error)
+	}{
+		{
+			name:           "normal responses",
+			forwardSession: true,
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "upstream-token", false, "", false)
+			},
+		},
+		{
+			name:           "passthrough responses",
+			forwardSession: true,
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "upstream-token")
+			},
+		},
+		{
+			name: "image generation",
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildOpenAIImagesRequest(c.Request.Context(), c, account, body, "application/json", "upstream-token", openAIImagesGenerationsEndpoint)
+			},
+		},
+		{
+			name: "image edit",
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildOpenAIImagesRequest(c.Request.Context(), c, account, body, "multipart/form-data", "upstream-token", openAIImagesEditsEndpoint)
+			},
+		},
+	}
+
+	for _, builder := range builders {
+		t.Run(builder.name, func(t *testing.T) {
+			for _, session := range []string{"opencode-session-123", ""} {
+				name := "present"
+				if session == "" {
+					name = "absent"
+				}
+				t.Run(name, func(t *testing.T) {
+					body := []byte(`{"model":"gpt-5","input":"hello"}`)
+					rec := httptest.NewRecorder()
+					c, _ := gin.CreateTestContext(rec)
+					c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+					c.Request.Header.Set("Authorization", "Bearer client-token")
+					if session != "" {
+						c.Request.Header.Set("X-OpenCode-Session", session)
+					}
+
+					svc := &OpenAIGatewayService{cfg: &config.Config{
+						Security: config.SecurityConfig{
+							URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+						},
+					}}
+					req, err := builder.build(svc, c, &Account{
+						Platform: PlatformOpenAI,
+						Type:     AccountTypeAPIKey,
+					}, body)
+					require.NoError(t, err)
+					_, hasSession := req.Header[http.CanonicalHeaderKey("X-OpenCode-Session")]
+					if session != "" && builder.forwardSession {
+						require.True(t, hasSession)
+						require.Equal(t, session, req.Header.Get("X-OpenCode-Session"))
+					} else {
+						require.False(t, hasSession)
+					}
+					require.Equal(t, "Bearer upstream-token", req.Header.Get("Authorization"))
+					require.NotContains(t, req.Header.Get("Authorization"), "client-token")
+				})
+			}
+		})
+	}
+}
+
+func TestOpenAIResponsesOpenCodeSessionPreservesHeaderOverridePrecedence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	builders := []struct {
+		name  string
+		build func(*OpenAIGatewayService, *gin.Context, *Account, []byte) (*http.Request, error)
+	}{
+		{
+			name: "normal responses",
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "upstream-token", false, "", false)
+			},
+		},
+		{
+			name: "passthrough responses",
+			build: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) (*http.Request, error) {
+				return svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "upstream-token")
+			},
+		},
+	}
+
+	for _, builder := range builders {
+		t.Run(builder.name, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5","input":"hello"}`)
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+			c.Request.Header.Set("X-OpenCode-Session", "client-session")
+
+			svc := &OpenAIGatewayService{cfg: &config.Config{
+				Security: config.SecurityConfig{
+					URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+				},
+			}}
+			req, err := builder.build(svc, c, &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					credKeyHeaderOverrideEnabled: true,
+					credKeyHeaderOverrides: map[string]any{
+						"x-opencode-session": "account-session",
+					},
+				},
+			}, body)
+			require.NoError(t, err)
+			require.Equal(t, "account-session", getHeaderRaw(req.Header, "x-opencode-session"))
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -991,6 +991,9 @@ func isOpenAIPassthroughAllowedRequestHeader(lowerKey string, allowTimeoutHeader
 	if lowerKey == "" {
 		return false
 	}
+	if lowerKey == "x-opencode-session" {
+		return true
+	}
 	if isOpenAIPassthroughTimeoutHeader(lowerKey) {
 		return allowTimeoutHeaders
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -83,6 +83,7 @@ var openaiAllowedHeaders = map[string]bool{
 	"x-codex-turn-state":      true,
 	"x-codex-turn-metadata":   true,
 	"x-codex-window-id":       true,
+	"x-opencode-session":      true,
 	responsesLiteHeaderKey:    true,
 }
 


### PR DESCRIPTION
## 背景
目标上游要求请求携带稳定的会话路由标识。当前网关已使用该标识参与会话粘性，但普通 Responses 与透传 Responses 的出站白名单会丢弃客户端提供的值。

## 根因
普通转发与透传转发分别使用独立的请求头白名单，两处均未放行所需的会话路由标识。

## 改动
- 普通 Responses 请求允许透传所需会话路由标识
- 透传 Responses 请求允许透传所需会话路由标识
- 保持未提供该标识时的现有行为
- 保持账号级 Header Override 的既有优先级，并避免客户端认证头泄漏到上游

## 验证
- 已验证：后端 unit 测试通过
- 已验证：后端 integration 测试通过
- 已验证：静态检查通过，0 issues
- 已验证：前端 lint、类型检查及 168 个关键测试通过
- 已验证：后端漏洞扫描未发现可调用漏洞
- 已验证：前端依赖审计例外校验通过
- 已验证：Linux 可执行的部署脚本检查通过

Fixes #6556