### PR TITLE
fix: adapt Anthropic reasoning fields to model capabilities

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic_reasoning_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_reasoning_test.go
@@ -1,0 +1,107 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesToAnthropic_ReasoningUsesModelCapabilities(t *testing.T) {
+	maxTokens := 20000
+	tests := []struct {
+		name             string
+		model            string
+		effort           string
+		wantOutputEffort string
+		wantThinkingType string
+		wantThinking     bool
+	}{
+		{
+			name:             "haiku 4.5 uses manual thinking",
+			model:            "claude-haiku-4-5-20251001",
+			effort:           "high",
+			wantThinkingType: "enabled",
+			wantThinking:     true,
+		},
+		{
+			name:             "sonnet 4.6 uses adaptive thinking",
+			model:            "claude-sonnet-4-6",
+			effort:           "high",
+			wantOutputEffort: "high",
+			wantThinkingType: "adaptive",
+			wantThinking:     true,
+		},
+		{
+			name:             "opus 4.5 clamps unsupported max to high",
+			model:            "claude-opus-4-5-20251101",
+			effort:           "xhigh",
+			wantOutputEffort: "high",
+			wantThinkingType: "adaptive",
+			wantThinking:     true,
+		},
+		{
+			name:   "unknown model omits optional reasoning fields",
+			model:  "claude-future-9",
+			effort: "high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := ResponsesToAnthropicRequest(&ResponsesRequest{
+				Model:           tt.model,
+				Input:           json.RawMessage("\"hello\""),
+				MaxOutputTokens: &maxTokens,
+				Reasoning:       &ResponsesReasoning{Effort: tt.effort},
+			})
+			require.NoError(t, err)
+
+			if tt.wantOutputEffort == "" {
+				require.Nil(t, out.OutputConfig)
+			} else {
+				require.NotNil(t, out.OutputConfig)
+				require.Equal(t, tt.wantOutputEffort, out.OutputConfig.Effort)
+			}
+
+			if !tt.wantThinking {
+				require.Nil(t, out.Thinking)
+				return
+			}
+			require.NotNil(t, out.Thinking)
+			require.Equal(t, tt.wantThinkingType, out.Thinking.Type)
+		})
+	}
+}
+
+func TestResponsesToAnthropic_ManualThinkingDisablesWhenMaxTokensTooSmall(t *testing.T) {
+	maxTokens := 1024
+	out, err := ResponsesToAnthropicRequest(&ResponsesRequest{
+		Model:           "claude-haiku-4-5-20251001",
+		Input:           json.RawMessage("\"hello\""),
+		MaxOutputTokens: &maxTokens,
+		Reasoning:       &ResponsesReasoning{Effort: "high"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, out.OutputConfig)
+	require.Nil(t, out.Thinking)
+}
+
+func TestResponsesToAnthropic_ReapplyUsesFinalMappedModel(t *testing.T) {
+	maxTokens := 20000
+	out, err := ResponsesToAnthropicRequest(&ResponsesRequest{
+		Model:           "claude-haiku-4-5-20251001",
+		Input:           json.RawMessage("\"hello\""),
+		MaxOutputTokens: &maxTokens,
+		Reasoning:       &ResponsesReasoning{Effort: "high"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, out.OutputConfig)
+	require.Equal(t, "enabled", out.Thinking.Type)
+
+	ReapplyResponsesReasoningToAnthropic(out, "claude-sonnet-4-6", "high")
+	require.NotNil(t, out.OutputConfig)
+	require.Equal(t, "high", out.OutputConfig.Effort)
+	require.NotNil(t, out.Thinking)
+	require.Equal(t, "adaptive", out.Thinking.Type)
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 )
 
 // ResponsesToAnthropicRequest converts a Responses API request into an
@@ -51,20 +53,144 @@ func ResponsesToAnthropicRequest(req *ResponsesRequest) (*AnthropicRequest, erro
 		out.ToolChoice = tc
 	}
 
-	// reasoning.effort → output_config.effort + thinking
-	if req.Reasoning != nil && req.Reasoning.Effort != "" {
-		effort := mapResponsesEffortToAnthropic(req.Reasoning.Effort)
-		out.OutputConfig = &AnthropicOutputConfig{Effort: effort}
-		// Enable thinking for non-low efforts
-		if effort != "low" {
-			out.Thinking = &AnthropicThinking{
-				Type:         "enabled",
-				BudgetTokens: defaultThinkingBudget(effort),
-			}
-		}
+	// reasoning.effort is optional upstream behavior. Only send the form
+	// supported by the selected Claude model; unknown models get no optional
+	// reasoning fields instead of a likely upstream 400.
+	if req.Reasoning != nil {
+		applyResponsesReasoningToAnthropic(out, req.Model, req.Reasoning.Effort)
 	}
 
 	return out, nil
+}
+
+func applyResponsesReasoningToAnthropic(out *AnthropicRequest, model, requestedEffort string) {
+	if out == nil || strings.TrimSpace(requestedEffort) == "" {
+		return
+	}
+
+	effort := mapResponsesEffortToAnthropic(strings.ToLower(strings.TrimSpace(requestedEffort)))
+	modelID := normalizeResponsesAnthropicModelID(model)
+
+	if levels := claude.EffortLevelsForModel(model); len(levels) > 0 {
+		selectedEffort, ok := selectSupportedAnthropicEffort(levels, effort)
+		if !ok {
+			return
+		}
+		out.OutputConfig = &AnthropicOutputConfig{Effort: selectedEffort}
+		out.Thinking = &AnthropicThinking{Type: "adaptive"}
+		return
+	}
+
+	// These model families use manual extended thinking and reject
+	// output_config.effort.
+	if isManualThinkingModel(modelID) {
+		if effort == "low" {
+			return
+		}
+		budget, ok := thinkingBudgetForMaxTokens(effort, out.MaxTokens)
+		if !ok {
+			return
+		}
+		out.Thinking = &AnthropicThinking{
+			Type:         "enabled",
+			BudgetTokens: budget,
+		}
+	}
+}
+
+// ReapplyResponsesReasoningToAnthropic recalculates optional reasoning fields
+// after a gateway has resolved the final upstream model.
+func ReapplyResponsesReasoningToAnthropic(out *AnthropicRequest, model, requestedEffort string) {
+	if out == nil {
+		return
+	}
+	out.OutputConfig = nil
+	out.Thinking = nil
+	applyResponsesReasoningToAnthropic(out, model, requestedEffort)
+}
+
+func selectSupportedAnthropicEffort(levels []string, requested string) (string, bool) {
+	requestedRank := anthropicEffortRank(requested)
+	if requestedRank < 0 {
+		return "", false
+	}
+
+	selected := ""
+	for _, level := range levels {
+		if rank := anthropicEffortRank(level); rank >= 0 && rank <= requestedRank {
+			selected = level
+		}
+	}
+	return selected, selected != ""
+}
+
+func anthropicEffortRank(effort string) int {
+	switch effort {
+	case "low":
+		return 0
+	case "medium":
+		return 1
+	case "high":
+		return 2
+	case "max":
+		return 3
+	default:
+		return -1
+	}
+}
+
+func thinkingBudgetForMaxTokens(effort string, maxTokens int) (int, bool) {
+	if maxTokens <= 1024 {
+		return 0, false
+	}
+
+	budget := defaultThinkingBudget(effort)
+	if budget >= maxTokens {
+		budget = maxTokens - 1
+	}
+	if budget < 1024 {
+		return 0, false
+	}
+	return budget, true
+}
+
+func isManualThinkingModel(modelID string) bool {
+	for _, family := range []string{
+		"claude-haiku-4-5",
+		"claude-sonnet-4-5",
+		"claude-3-7-sonnet",
+	} {
+		if modelID == family || strings.HasPrefix(modelID, family+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeResponsesAnthropicModelID(model string) string {
+	id := strings.ToLower(strings.TrimSpace(model))
+	id = strings.TrimPrefix(id, "models/")
+	if slash := strings.IndexByte(id, '/'); slash >= 0 {
+		id = strings.TrimPrefix(strings.TrimSpace(id[slash+1:]), "models/")
+	}
+	id = strings.TrimPrefix(id, "anthropic.")
+	id = strings.TrimSuffix(id, "-thinking")
+	if len(id) >= 9 {
+		suffix := id[len(id)-9:]
+		if suffix[0] == '-' {
+			digits := true
+			for _, r := range suffix[1:] {
+				if r < '0' || r > '9' {
+					digits = false
+					break
+				}
+			}
+			if digits {
+				id = id[:len(id)-9]
+			}
+		}
+	}
+	return id
 }
 
 // defaultThinkingBudget returns a sensible thinking budget based on effort level.

--- a/backend/internal/service/antigravity_gateway_compat.go
+++ b/backend/internal/service/antigravity_gateway_compat.go
@@ -207,8 +207,8 @@ func (s *AntigravityGatewayService) prepareAntigravityCompatCall(
 	account *Account,
 	request antigravityCompatRequest,
 ) (*antigravityCompatUpstreamCall, error) {
-	var claudeRequest antigravity.ClaudeRequest
-	if json.Unmarshal(request.claudeBody, &claudeRequest) != nil {
+	var anthropicRequest apicompat.AnthropicRequest
+	if json.Unmarshal(request.claudeBody, &anthropicRequest) != nil {
 		return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", "Invalid request body")
 	}
 
@@ -218,9 +218,25 @@ func (s *AntigravityGatewayService) prepareAntigravityCompatCall(
 		message := fmt.Sprintf("model %s not in whitelist", request.originalModel)
 		return nil, s.writeAntigravityCompatError(c, http.StatusForbidden, "permission_error", message)
 	}
-	thinkingEnabled := claudeRequest.Thinking != nil &&
-		(claudeRequest.Thinking.Type == "enabled" || claudeRequest.Thinking.Type == "adaptive")
+	if request.reasoningEffort != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			&anthropicRequest, mappedModel, *request.reasoningEffort,
+		)
+	}
+	thinkingEnabled := anthropicRequest.Thinking != nil &&
+		(anthropicRequest.Thinking.Type == "enabled" || anthropicRequest.Thinking.Type == "adaptive")
 	mappedModel = applyThinkingModelSuffix(mappedModel, thinkingEnabled)
+	if request.reasoningEffort != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			&anthropicRequest, mappedModel, *request.reasoningEffort,
+		)
+	}
+	request.claudeBody, _ = json.Marshal(&anthropicRequest)
+
+	var claudeRequest antigravity.ClaudeRequest
+	if json.Unmarshal(request.claudeBody, &claudeRequest) != nil {
+		return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", "Invalid request body")
+	}
 
 	if s.tokenProvider == nil {
 		return nil, s.writeAntigravityCompatError(c, http.StatusBadGateway, "api_error", "Antigravity token provider not configured")

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -76,6 +76,11 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		}
 	}
 	anthropicReq.Model = mappedModel
+	if responsesReq.Reasoning != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			anthropicReq, mappedModel, responsesReq.Reasoning.Effort,
+		)
+	}
 
 	logger.L().Debug("gateway forward_as_chat_completions: model mapping applied",
 		zap.Int64("account_id", account.ID),

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -89,6 +89,11 @@ func (s *GatewayService) ForwardAsResponses(
 	// 国产模型默认 effort 补充：需要 mappedModel 判定，推迟到 mapping 完成之后。
 	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, body, mappedModel)
 	anthropicReq.Model = mappedModel
+	if responsesReq.Reasoning != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			anthropicReq, mappedModel, responsesReq.Reasoning.Effort,
+		)
+	}
 
 	logger.L().Debug("gateway forward_as_responses: model mapping applied",
 		zap.Int64("account_id", account.ID),

--- a/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
@@ -72,6 +72,11 @@ func (s *OpenAIGatewayService) forwardChatCompletionsViaNativeAnthropic(
 	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	anthropicReq.Model = upstreamModel
+	if responsesReq.Reasoning != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			anthropicReq, upstreamModel, responsesReq.Reasoning.Effort,
+		)
+	}
 
 	// 4. Force upstream streaming（客户端原始终决定响应格式；
 	// 上游恒为流式，非流式由缓冲路径组装）。

--- a/backend/internal/service/openai_gateway_responses_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_responses_anthropic_native.go
@@ -74,6 +74,11 @@ func (s *OpenAIGatewayService) forwardResponsesViaNativeAnthropic(
 	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	anthropicReq.Model = upstreamModel
+	if responsesReq.Reasoning != nil {
+		apicompat.ReapplyResponsesReasoningToAnthropic(
+			anthropicReq, upstreamModel, responsesReq.Reasoning.Effort,
+		)
+	}
 
 	reasoningEffort := ExtractResponsesReasoningEffortFromBody(body, upstreamModel, billingModel, originalModel)
 	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, body, billingModel)


### PR DESCRIPTION
## Summary

- Adapt OpenAI Responses \easoning.effort\ to the selected Anthropic model capability.
- Use \	hinking.type=adaptive\ with \output_config.effort\ for models listed in the Claude effort catalog.
- Use bounded manual thinking for model families that do not accept \output_config.effort\, including Claude Haiku 4.5.
- Omit optional reasoning fields for unknown models instead of sending a likely-invalid request.
- Re-apply the reasoning mapping after account/model aliases are resolved, including native Anthropic and Antigravity compatibility paths.

## Problem

\ResponsesToAnthropicRequest\ previously emitted \output_config.effort\ for every model carrying \easoning.effort\. Anthropic rejects this for models such as Claude Haiku 4.5 with:

\This model does not support the effort parameter.\

The conversion also happened before gateway model mapping, so deciding from the client-facing model alone could select the wrong request shape.

## Validation

- \go test ./internal/pkg/apicompat -count=1\
- \go test ./internal/service -run 'Test(OpenAI|Responses|Anthropic|Antigravity)' -count=1\
- \go test -tags=unit ./...\

The change was also validated against a real Sub2API deployment using Claude Haiku 4.5.
