### PR TITLE
fix(frontend): allow collapsing sidebar groups while a child route is active

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -253,8 +253,11 @@ const isDark = ref(document.documentElement.classList.contains('dark'))
 
 const homePath = computed(() => (isAdmin.value ? '/admin/dashboard' : '/dashboard'))
 
-// Track which parent nav groups are expanded
-const expandedGroups = ref<Set<string>>(new Set())
+// Per-group expand/collapse overrides. A group with no entry follows the
+// automatic behavior (expanded while the active route is one of its children);
+// a chevron click records the user's choice, which wins over the automatic
+// state so an active group can still be collapsed manually.
+const groupExpandOverrides = ref<Map<string, boolean>>(new Map())
 
 // Site settings from appStore (cached, no flicker)
 const siteName = computed(() => appStore.siteName)
@@ -885,15 +888,13 @@ function isGroupActive(item: NavItem): boolean {
 }
 
 function isGroupExpanded(item: NavItem): boolean {
-  return expandedGroups.value.has(item.path) || isGroupActive(item)
+  const override = groupExpandOverrides.value.get(item.path)
+  if (override !== undefined) return override
+  return isGroupActive(item)
 }
 
 function toggleGroup(item: NavItem) {
-  if (expandedGroups.value.has(item.path)) {
-    expandedGroups.value.delete(item.path)
-  } else {
-    expandedGroups.value.add(item.path)
-  }
+  groupExpandOverrides.value.set(item.path, !isGroupExpanded(item))
 }
 
 /**
@@ -913,9 +914,7 @@ function handleGroupClick(item: NavItem) {
   if (route.path !== item.path) {
     router.push(item.path)
   }
-  if (!expandedGroups.value.has(item.path)) {
-    expandedGroups.value.add(item.path)
-  }
+  groupExpandOverrides.value.set(item.path, true)
 }
 
 // Initialize theme

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -42,6 +42,15 @@ describe('AppSidebar scroll position persistence', () => {
   })
 })
 
+describe('AppSidebar collapsible groups', () => {
+  it('lets the user collapse a group even while a child route is active', () => {
+    // The expand state must come from the user's override first, falling back
+    // to the active-route heuristic only when the user has not clicked yet.
+    expect(componentSource).toContain('const groupExpandOverrides = ref<Map<string, boolean>>(new Map())')
+    expect(componentSource).not.toContain('expandedGroups.value.has(item.path) || isGroupActive(item)')
+  })
+})
+
 describe('AppSidebar header styles', () => {
   it('does not clip the version badge dropdown', () => {
     const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n {2}\}/)


### PR DESCRIPTION
## Problem

Collapsible sidebar groups (e.g. 邀请返利 / Affiliate, order management, channel management) cannot be collapsed while the active route is one of their children:

```ts
function isGroupExpanded(item: NavItem): boolean {
  return expandedGroups.value.has(item.path) || isGroupActive(item)
}
```

Clicking the chevron toggles the internal `expandedGroups` set, but `isGroupActive(item)` keeps `isGroupExpanded` returning `true`, so nothing happens visually — the arrow stays rotated and the submenu stays open. The user's click produces no visible change, which reads as a bug.

This is especially noticeable for groups whose parent path redirects into a child (e.g. `/admin/affiliates` redirects to `/admin/affiliates/invites`): once you enter such a section you are always on a child page, so the group can never be closed.

## Solution

Replace the set with per-group expand/collapse overrides:

- No entry for a group → automatic behavior is preserved: expanded while the active route is one of its children (so context is not lost on initial load or navigation into the section).
- A chevron click records the user's choice, and that choice wins — an active group can now be collapsed and re-expanded at will. The parent item keeps its active styling when collapsed, so it is still clear where you are.

## Behavior after the change

| Scenario | Before | After |
|---|---|---|
| On a child page, click the chevron | no visible effect | collapses; parent stays highlighted |
| Page load / navigation into a child | auto-expanded | auto-expanded (unchanged) |
| Chevron toggling from any other page | works | works (unchanged) |

Verified with `vitest` (new source-assertion test added, following the existing spec style), `vue-tsc --noEmit`, and `eslint` on the touched files.