### PR TITLE
fix(gateway): keep account-pool internals out of gateway error responses

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -51,9 +51,10 @@ const (
 	maxProfitVetoAttempts = 10
 )
 
-// profitVetoExhaustedMessage 是利润否决次数耗尽时返回给客户端的文案。
+// profitVetoExhaustedReason 是利润否决次数耗尽时记录到 ops 错误日志的内部原因。
 // 语义上等同于「无可用账号」：候选账号都不满足分组的利润约束。
-const profitVetoExhaustedMessage = "No available accounts: all candidates rejected by group profit control"
+// 客户端只收到中性的 noAvailableAccountsClientMessage，不暴露利润控制的存在。
+const profitVetoExhaustedReason = "all candidates rejected by group profit control"
 
 func sameAccountRetryDelayFor(failoverErr *service.UpstreamFailoverError, retryCount int) time.Duration {
 	if failoverErr == nil {

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -342,11 +342,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Bool("model_not_found", cls.ModelNotFound),
 						zap.Error(err),
 					)
-					message := cls.Message
 					if !cls.ModelNotFound {
-						message = "No available accounts: " + err.Error()
+						recordNoAvailableAccountsErrorForOps(c, err)
 					}
-					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -396,7 +395,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage, streamStarted)
 					return
 				}
 				accountWaitCounted := false
@@ -449,7 +449,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				if fs.RecordProfitVeto(account.ID) == FailoverExhausted {
 					reqLog.Warn("gateway.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", fs.ProfitVetoCount()))
 					markOpsRoutingCapacityLimited(c)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", profitVetoExhaustedMessage, streamStarted)
+					recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage, streamStarted)
 					return
 				}
 				continue
@@ -673,11 +674,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Bool("model_not_found", cls.ModelNotFound),
 						zap.Error(err),
 					)
-					message := cls.Message
 					if !cls.ModelNotFound {
-						message = "No available accounts: " + err.Error()
+						recordNoAvailableAccountsErrorForOps(c, err)
 					}
-					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+					h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -737,7 +737,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage, streamStarted)
 					return
 				}
 				accountWaitCounted := false
@@ -790,7 +791,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				if fs.RecordProfitVeto(account.ID) == FailoverExhausted {
 					reqLog.Warn("gateway.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", fs.ProfitVetoCount()))
 					markOpsRoutingCapacityLimited(c)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", profitVetoExhaustedMessage, streamStarted)
+					recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage, streamStarted)
 					return
 				}
 				// 尝试被否决（从未转发），立即释放该账号的会话注册

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -179,11 +179,10 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
 				if !cls.ModelNotFound {
-					message = "No available accounts: " + err.Error()
+					recordNoAvailableAccountsErrorForOps(c, err)
 				}
-				h.chatCompletionsErrorResponse(c, cls.Status, cls.ErrType, message)
+				h.chatCompletionsErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -197,7 +196,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				if fs.LastFailoverErr != nil {
 					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
 				} else {
-					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Upstream service temporarily unavailable")
 				}
 				return
 			}
@@ -210,7 +209,8 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
@@ -237,7 +237,8 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			reqLog.Debug("gateway.cc.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
 			if fs.RecordProfitVeto(account.ID) == FailoverExhausted {
 				reqLog.Warn("gateway.cc.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", fs.ProfitVetoCount()))
-				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", profitVetoExhaustedMessage)
+				recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 				return
 			}
 			continue
@@ -405,5 +406,6 @@ func (h *GatewayHandler) handleCCFailoverExhausted(c *gin.Context, lastErr *serv
 		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage())
 		return
 	}
-	h.chatCompletionsErrorResponse(c, statusCode, "server_error", "All available accounts exhausted")
+	_, _, message := h.mapUpstreamError(statusCode)
+	h.chatCompletionsErrorResponse(c, statusCode, "server_error", message)
 }

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -181,11 +181,10 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
 				if !cls.ModelNotFound {
-					message = "No available accounts: " + err.Error()
+					recordNoAvailableAccountsErrorForOps(c, err)
 				}
-				h.responsesErrorResponse(c, cls.Status, cls.ErrType, message)
+				h.responsesErrorResponse(c, cls.Status, cls.ErrType, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(requestCtx)
@@ -199,7 +198,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				if fs.LastFailoverErr != nil {
 					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
 				} else {
-					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", "Upstream service temporarily unavailable")
 				}
 				return
 			}
@@ -212,7 +211,8 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
@@ -241,7 +241,8 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 			reqLog.Debug("gateway.responses.account_slot_profit_vetoed", zap.Int64("account_id", account.ID), zap.String("reason", reason))
 			if fs.RecordProfitVeto(account.ID) == FailoverExhausted {
 				reqLog.Warn("gateway.responses.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", fs.ProfitVetoCount()))
-				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", profitVetoExhaustedMessage)
+				recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 				return
 			}
 			continue
@@ -372,7 +373,8 @@ func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastEr
 	if lastErr != nil && lastErr.StatusCode > 0 {
 		statusCode = lastErr.StatusCode
 	}
-	status, code, message := statusCode, "server_error", "All available accounts exhausted"
+	_, _, exhaustedMessage := h.mapUpstreamError(statusCode)
+	status, code, message := statusCode, "server_error", exhaustedMessage
 	if lastErr != nil && lastErr.IsCredentialFailure() {
 		status, message = credentialFailoverClientResponse(lastErr)
 	} else if lastErr != nil && lastErr.IsOpenAICapacityShed() && strings.TrimSpace(lastErr.ClientMessage) != "" {
@@ -385,7 +387,7 @@ func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastEr
 		service.SetOpsUpstreamError(c, statusCode, service.OpenAISilentRefusalClientMessage(), "")
 		status, code, message = http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage()
 	} else if lastErr != nil && statusCode == http.StatusTooManyRequests {
-		status, code, message = http.StatusTooManyRequests, "rate_limit_error", "All available accounts are currently rate-limited. Please retry later."
+		status, code, message = http.StatusTooManyRequests, "rate_limit_error", exhaustedMessage
 	}
 	if streamStarted {
 		// A slot-wait heartbeat commits HTTP 200 before any upstream response.

--- a/backend/internal/handler/gateway_web_search.go
+++ b/backend/internal/handler/gateway_web_search.go
@@ -154,9 +154,11 @@ func (h *GatewayHandler) WebSearch(c *gin.Context) {
 		}
 		if selected == nil || selected.Account == nil {
 			if attempt == 0 {
+				markOpsRoutingCapacityLimited(c)
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
 				c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{
 					"type":    "scheduling_error",
-					"message": "No available accounts",
+					"message": noAvailableAccountsClientMessage,
 				}})
 				return
 			}
@@ -204,9 +206,11 @@ func (h *GatewayHandler) WebSearch(c *gin.Context) {
 		return
 	}
 	if account == nil {
+		markOpsRoutingCapacityLimited(c)
+		recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{
 			"type":    "scheduling_error",
-			"message": "No available accounts",
+			"message": noAvailableAccountsClientMessage,
 		}})
 		return
 	}

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -87,7 +87,8 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 			return
 		}
 		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-		googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
+		recordNoAvailableAccountsErrorForOps(c, err)
+		googleError(c, http.StatusServiceUnavailable, noAvailableAccountsClientMessage)
 		return
 	}
 
@@ -203,7 +204,8 @@ func (h *GatewayHandler) GeminiV1BetaGetModel(c *gin.Context) {
 			return
 		}
 		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-		googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
+		recordNoAvailableAccountsErrorForOps(c, err)
+		googleError(c, http.StatusServiceUnavailable, noAvailableAccountsClientMessage)
 		return
 	}
 
@@ -453,11 +455,10 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
 				if !cls.ModelNotFound {
-					message = "No available Gemini accounts: " + err.Error()
+					recordNoAvailableAccountsErrorForOps(c, err)
 				}
-				googleError(c, cls.Status, message)
+				googleError(c, cls.Status, cls.Message)
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -506,7 +507,8 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts")
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+				googleError(c, http.StatusServiceUnavailable, noAvailableAccountsClientMessage)
 				return
 			}
 			accountWaitCounted := false
@@ -559,7 +561,8 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			if fs.RecordProfitVeto(account.ID) == FailoverExhausted {
 				reqLog.Warn("gemini.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", fs.ProfitVetoCount()))
 				markOpsRoutingCapacityLimited(c)
-				googleError(c, http.StatusServiceUnavailable, profitVetoExhaustedMessage)
+				recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+				googleError(c, http.StatusServiceUnavailable, noAvailableAccountsClientMessage)
 				return
 			}
 			continue

--- a/backend/internal/handler/grok_audio.go
+++ b/backend/internal/handler/grok_audio.go
@@ -114,7 +114,9 @@ func (h *OpenAIGatewayHandler) GrokRealtime(c *gin.Context) {
 	}
 	if selection == nil || selection.Account == nil || release == nil || upstream == nil {
 		if !candidateSeen {
-			h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "No available Grok accounts")
+			markOpsRoutingCapacityLimited(c)
+			recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
+			h.errorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 		} else {
 			h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Grok realtime upstream unavailable")
 		}
@@ -241,7 +243,9 @@ func (h *OpenAIGatewayHandler) GrokVoice(c *gin.Context, endpoint string) {
 			if last != nil {
 				h.handleFailoverExhausted(c, last, false)
 			} else {
-				h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "No available Grok accounts")
+				markOpsRoutingCapacityLimited(c)
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
+				h.errorResponse(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage)
 			}
 			return
 		}

--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -70,7 +70,7 @@ func classifySelectionFailureError(err error, fallback noAccountErrorClassificat
 	return noAccountErrorClassification{
 		Status:  http.StatusTooManyRequests,
 		ErrType: "rate_limit_error",
-		Message: "All available accounts are currently rate-limited. Please retry later.",
+		Message: "Currently rate-limited, please retry later.",
 	}
 }
 

--- a/backend/internal/handler/no_account_response.go
+++ b/backend/internal/handler/no_account_response.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// noAvailableAccountsClientMessage is what end users see when the account pool
+// cannot serve a request right now (no schedulable account, no free concurrency
+// slot, profit control vetoed every candidate).
+//
+// It deliberately says nothing about accounts. The previous wording,
+// "No available accounts: <internal reason>", was forwarded verbatim by
+// downstream gateways into end-user terminals and disclosed how the service is
+// built (an account pool) together with scheduler internals (rate-limit
+// counters, profit control). The OpenAI gateway already answers these cases with
+// the neutral classifier fallback; this constant brings the other entrypoints in
+// line. The internal reason is still recorded for operators, see
+// recordNoAvailableAccountsReasonForOps.
+const noAvailableAccountsClientMessage = "Service temporarily unavailable, please retry later"
+
+// noAvailableAccountsOpsPrefix is the phrase the ops pipeline keys on: the
+// IgnoreNoAvailableAccounts filter (isOpsNoAvailableAccountMessage), the channel
+// monitor taxonomy ("account_pool_unavailable") and its SQL aggregation all
+// match "no available accounts" in the recorded text.
+const noAvailableAccountsOpsPrefix = "No available accounts"
+
+// noAvailableAccountsReasonNoSlot is recorded when the selected account has no
+// free concurrency slot and the group has no wait plan.
+const noAvailableAccountsReasonNoSlot = "account concurrency slots exhausted and no wait plan"
+
+// noAvailableAccountsReasonNoAccount is recorded when scheduling returned no
+// account at all for the request.
+const noAvailableAccountsReasonNoAccount = "no schedulable account for this request"
+const noAvailableAccountsReasonNoCompact = "no account supports /responses/compact"
+
+// noCompactAccountsClientMessage is the wire message for legacy /responses/compact
+// requests that no account can serve; it names the endpoint, not the pool.
+const noCompactAccountsClientMessage = "/responses/compact is not available for this request"
+
+// recordNoAvailableAccountsReasonForOps keeps the internal reason visible to the
+// ops error log without putting it on the wire. The reason lands in the entry's
+// upstream error message, which is exactly where handleFailoverExhausted already
+// stores the real upstream text while clients get a generic message.
+//
+// The upstream status is left unset: the request never reached upstream. Ops
+// attribution (phase "routing", business-limited) is decided by
+// markOpsRoutingCapacityLimited at the call site, which takes precedence over
+// the upstream-error context in classifyOpsErrorLog.
+func recordNoAvailableAccountsReasonForOps(c *gin.Context, reason string) {
+	msg := noAvailableAccountsOpsPrefix
+	if r := strings.TrimSpace(reason); r != "" {
+		msg += ": " + r
+	}
+	service.SetOpsUpstreamError(c, 0, msg, "")
+}
+
+// recordNoAvailableAccountsErrorForOps is the account-selection variant. Only
+// genuine no-available-account errors are recorded, mirroring
+// markOpsRoutingCapacityLimitedIfNoAvailable; any other selection failure keeps
+// its server-log trail (the call sites already log zap.Error) and is not
+// attributed to the account pool.
+func recordNoAvailableAccountsErrorForOps(c *gin.Context, err error) {
+	if !isOpsNoAvailableAccountError(err) {
+		return
+	}
+	recordNoAvailableAccountsReasonForOps(c, err.Error())
+}

--- a/backend/internal/handler/no_account_response_test.go
+++ b/backend/internal/handler/no_account_response_test.go
@@ -1,0 +1,100 @@
+//go:build unit
+
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func TestRecordNoAvailableAccountsReasonForOps_KeepsReasonOffTheWire(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+
+	v, ok := c.Get(service.OpsUpstreamErrorMessageKey)
+	require.True(t, ok)
+	require.Equal(t, "No available accounts: "+profitVetoExhaustedReason, v)
+
+	_, hasStatus := c.Get(service.OpsUpstreamStatusCodeKey)
+	require.False(t, hasStatus, "the request never reached upstream; no upstream status may be recorded")
+
+	// The wire message must not describe the pool or its scheduler.
+	require.NotContains(t, strings.ToLower(noAvailableAccountsClientMessage), "account")
+	require.NotContains(t, strings.ToLower(noAvailableAccountsClientMessage), "profit")
+	require.NotContains(t, strings.ToLower(noCompactAccountsClientMessage), "account")
+}
+
+func TestRecordNoAvailableAccountsErrorForOps_OnlyRecordsPoolErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("pool exhaustion is recorded with the scheduler's reason", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+
+		recordNoAvailableAccountsErrorForOps(c, errors.New("no available accounts supporting model: gpt-5 (total=3 eligible=0 model_rate_limited=3)"))
+
+		v, ok := c.Get(service.OpsUpstreamErrorMessageKey)
+		require.True(t, ok)
+		require.True(t, isOpsNoAvailableAccountMessage(v.(string)))
+		require.Contains(t, v.(string), "model_rate_limited=3")
+	})
+
+	t.Run("unrelated selection failure is not attributed to the pool", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+
+		recordNoAvailableAccountsErrorForOps(c, errors.New("redis: connection refused"))
+
+		_, ok := c.Get(service.OpsUpstreamErrorMessageKey)
+		require.False(t, ok)
+	})
+}
+
+func TestOpsFilterTextWithContext_ExposesRecordedReasonToSettingsFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	require.Equal(t, noAvailableAccountsClientMessage, opsFilterTextWithContext(c, noAvailableAccountsClientMessage))
+
+	recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+
+	text := opsFilterTextWithContext(c, noAvailableAccountsClientMessage)
+	require.True(t, strings.HasPrefix(text, noAvailableAccountsClientMessage))
+	// The IgnoreNoAvailableAccounts filter keys on this phrase; it must survive the neutral body.
+	require.Contains(t, strings.ToLower(text), opsErrNoAvailableAccounts)
+}
+
+func TestClassifyOpsErrorLog_NeutralBodyKeepsRoutingAttribution(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	markOpsRoutingCapacityLimited(c)
+	recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+
+	phase, isBusinessLimited, errorOwner, errorSource := classifyOpsErrorLog(
+		c,
+		"api_error",
+		noAvailableAccountsClientMessage,
+		"",
+		http.StatusServiceUnavailable,
+	)
+
+	// Same verdict as the former "No available accounts" body: the recorded
+	// upstream message must not flip the entry to an upstream/provider failure.
+	require.Equal(t, "routing", phase)
+	require.True(t, isBusinessLimited)
+	require.Equal(t, "platform", errorOwner)
+	require.Equal(t, "gateway", errorSource)
+}

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -109,7 +109,8 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 				h.errorResponse(c, infraerrors.Code(lastUpstreamErr), "upstream_error", infraerrors.Message(lastUpstreamErr))
 				return
 			}
-			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
+			recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
+			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", noAvailableAccountsClientMessage)
 			return
 		}
 		// 让 ops 错误日志携带实际选中的上游账号，便于定位失效账号（#4544）。

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -675,7 +675,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				if legacyCompact && errors.Is(err, service.ErrNoAvailableCompactAccounts) {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "compact_not_supported", "No available accounts support /responses/compact", streamStarted)
+					recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoCompact)
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "compact_not_supported", noCompactAccountsClientMessage, streamStarted)
 					return
 				}
 				cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel, requestPlatform)
@@ -2075,7 +2076,8 @@ func (h *OpenAIGatewayHandler) handleOpenAIProfitVetoExhausted(
 ) {
 	reqLog.Warn("openai.profit_veto_attempts_exhausted", zap.Int("profit_veto_count", vetoCount))
 	markOpsRoutingCapacityLimited(c)
-	h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", profitVetoExhaustedMessage, streamStarted)
+	recordNoAvailableAccountsReasonForOps(c, profitVetoExhaustedReason)
+	h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", noAvailableAccountsClientMessage, streamStarted)
 }
 
 func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
@@ -2112,7 +2114,8 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 	}
 	if selection == nil || selection.Account == nil {
 		markOpsRoutingCapacityLimited(c)
-		writeError(http.StatusServiceUnavailable, "api_error", "", "No available accounts")
+		recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
+		writeError(http.StatusServiceUnavailable, "api_error", "", noAvailableAccountsClientMessage)
 		return nil, openAISlotAcquireFailed
 	}
 
@@ -2142,7 +2145,8 @@ func (h *OpenAIGatewayHandler) acquireOpenAIAccountSlot(
 	}
 	if selection.WaitPlan == nil {
 		markOpsRoutingCapacityLimited(c)
-		writeError(http.StatusServiceUnavailable, "api_error", "", "No available accounts")
+		recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoSlot)
+		writeError(http.StatusServiceUnavailable, "api_error", "", noAvailableAccountsClientMessage)
 		return nil, openAISlotAcquireFailed
 	}
 

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -181,11 +181,10 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				if !cls.ModelNotFound {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				}
-				message := cls.Message
 				if !cls.ModelNotFound {
-					message = "No available compatible accounts"
+					recordNoAvailableAccountsErrorForOps(c, err)
 				}
-				h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+				h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -199,12 +198,9 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			cls := classifyNoAccountErrorFromGin(c, h.gatewayService, apiKey, clientRequestModel, routingModel, service.PlatformOpenAI)
 			if !cls.ModelNotFound {
 				markOpsRoutingCapacityLimited(c)
+				recordNoAvailableAccountsReasonForOps(c, noAvailableAccountsReasonNoAccount)
 			}
-			message := cls.Message
-			if !cls.ModelNotFound {
-				message = "No available compatible accounts"
-			}
-			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, message, streamStarted)
+			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 			return
 		}
 

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1139,7 +1139,7 @@ func OpsErrorLoggerMiddleware(ops *service.OpsService) gin.HandlerFunc {
 		}
 
 		// Skip logging if the error should be filtered based on settings
-		if shouldSkipOpsErrorLog(c.Request.Context(), ops, parsed.Message, string(body), c.Request.URL.Path) {
+		if shouldSkipOpsErrorLog(c.Request.Context(), ops, opsFilterTextWithContext(c, parsed.Message), string(body), c.Request.URL.Path) {
 			return
 		}
 
@@ -1425,7 +1425,7 @@ func logOpsStreamErrorValue(c *gin.Context, ops *service.OpsService, wireStatus 
 	}
 
 	// 复用与 status>=400 分支相同的设置过滤（context canceled / 无可用账号等）。
-	if shouldSkipOpsErrorLog(c.Request.Context(), ops, streamErr.Message, streamErr.Message, c.Request.URL.Path) {
+	if shouldSkipOpsErrorLog(c.Request.Context(), ops, opsFilterTextWithContext(c, streamErr.Message), streamErr.Message, c.Request.URL.Path) {
 		return
 	}
 
@@ -2412,6 +2412,26 @@ func truncateString(s string, max int) string {
 
 func strconvItoa(v int) string {
 	return strconv.Itoa(v)
+}
+
+// opsFilterTextWithContext widens the text inspected by shouldSkipOpsErrorLog with
+// the internal reason recorded in the request context (service.SetOpsUpstreamError).
+// Client-facing bodies are deliberately neutral for pool-exhaustion errors, so the
+// phrases the settings filter keys on ("no available accounts", ...) only exist in
+// the recorded reason.
+func opsFilterTextWithContext(c *gin.Context, text string) string {
+	if c == nil {
+		return text
+	}
+	v, ok := c.Get(service.OpsUpstreamErrorMessageKey)
+	if !ok {
+		return text
+	}
+	reason, ok := v.(string)
+	if !ok || strings.TrimSpace(reason) == "" {
+		return text
+	}
+	return text + "\n" + reason
 }
 
 // shouldSkipOpsErrorLog determines if an error should be skipped from logging based on settings.


### PR DESCRIPTION
Fixes #6548

> 本 PR 处理该 issue 中的信息泄露与文案不一致两点；issue 里提到的「状态码改 529」与「文案可配置」有意不纳入本 PR：状态码与 `error.type` 保持不变以把行为变化收敛到文案本身，两者可另行讨论。

## 背景

账号池无法服务请求时（无可调度账号 / 无空闲并发槽位 / 利润门否决了全部候选），网关会把 `"No available accounts: <内部原因>"` 直接写进对外响应，这条文案会被逐字透传到终端用户的客户端里（例如 Claude Code 终端）。

它泄露了两类不该出现在对外响应里的信息：

- **架构**：`accounts` 一词直接说明了后端是账号池；
- **调度内幕**：拼接的 `err.Error()` 带出限流计数（`model_rate_limited=3`）、`group profit control` 等运营细节。

同时它与 OpenAI 网关路径不一致——`openai_gateway_handler.go` 的选号失败分支早已只返回分类器的中性文案 `cls.Message`，本 PR 把其余入口对齐到这一行为。

## 改动

**对外响应**（覆盖 Anthropic Messages / Chat Completions / Responses / Gemini v1beta / Grok realtime / Codex models / Images / web_search 全部入口）：

- 选号失败：不再用内部错误覆盖 `cls.Message`，直接返回分类器给出的中性文案；
- 槽位不可用 / 利润否决耗尽 / 无候选账号：返回统一的中性文案 `noAvailableAccountsClientMessage`；
- `classifySelectionFailureError` 的 429 文案去掉 "All available accounts"；
- 故障转移耗尽时的 `"All available accounts exhausted"` / `"All available accounts are currently rate-limited..."`（Anthropic、Chat Completions、Responses 三条路径）改为复用 `mapUpstreamError` 的中性文案，状态码与 error type 不变。

状态码与 `error.type` **均保持不变**（503 / api_error 等），只改文案。

**运维侧不受影响**：新增 `recordNoAvailableAccountsReasonForOps` / `recordNoAvailableAccountsErrorForOps`（`no_account_response.go`），把内部原因以 `"No available accounts: <reason>"` 写入 ops 上下文的 upstream error message（不设 upstream status，因为请求未到达上游）。这复用了 `handleFailoverExhausted` 已有的"内部原文进 ops、客户端拿中性文案"模式，因此：

- `IgnoreNoAvailableAccounts` 过滤器继续生效（`shouldSkipOpsErrorLog` 的输入文本通过 `opsFilterTextWithContext` 并入上下文中记录的原因）；
- 渠道监控 v2 的 `account_pool_unavailable` 分类继续生效（Go 侧查询与 SQL 聚合都优先读取 `upstream_error_message`）；
- ops 归因不变：`markOpsRoutingCapacityLimited` 在 `classifyOpsErrorLog` 中优先于 upstream 上下文，phase 仍为 `routing`、business-limited 仍为 true（新增测试断言）。

`profitVetoExhaustedMessage` 重命名为 `profitVetoExhaustedReason`，语义改为"仅记录到 ops 的内部原因"。

## 行为差异说明

- 选号失败但错误**不是**无可用账号（如基础设施错误）时，客户端此前收到 `"No available accounts: <infra error>"`，现在收到中性文案；ops 归因由 `routing` 变为 `internal`（owner/source 仍为 platform/gateway，仍计入 SLA），更准确。
- web_search、Grok realtime 的无账号分支此前未标记 `markOpsRoutingCapacityLimited`，本 PR 补上，与其他入口一致。

## Rebase 说明（2026-09-08）

分支已 rebase 到最新 `main`。冲突仅一处：`openai_gateway_handler.go` 中 `writeError` 新增了 `code` 参数，按新签名解决。PR 标题从 no-available-account 放宽为 gateway error responses，因为本轮把 Chat Completions 与 Responses 故障转移耗尽路径的同类文案一并收敛。顺带覆盖了 main 新引入的一处同类文案：legacy `/responses/compact` 无可服务账号时的 `"No available accounts support /responses/compact"`，改为不提及账号池的 `noCompactAccountsClientMessage`，内部原因同样记入 ops。

## 测试与验证

- 新增 `no_account_response_test.go`（`//go:build unit`，4 个用例）：内部原因进 ops 上下文且不设 upstream status；非池类错误不被归因到账号池；过滤器输入文本包含记录的原因；中性文案下 ops 归因保持 `routing/platform/gateway`。
- 现有测试中对 `"No available accounts"` 的引用均为过滤器/分类器的**输入**文本，不受影响；`no_account_error_test` 对 429 文案的断言为 `Contains("rate-limited")`，新文案满足。
- 本地：`gofmt` / `go vet` / `go build ./...` 通过；`golangci-lint run`（v2.13，仓库 `.golangci.yml`）0 issues；`go test -tags=unit ./internal/handler/...` 全部通过。