### PR TITLE
fix(gateway): list Antigravity models on /v1/models fallback

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1136,6 +1136,10 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		writeGrokModelsList(c, xai.DefaultModelIDs())
 		return
 	}
+	if platform == service.PlatformAntigravity {
+		writeModelsList(c, platform, defaultModelIDsForPlatform(platform))
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",

--- a/backend/internal/handler/gateway_models_test.go
+++ b/backend/internal/handler/gateway_models_test.go
@@ -370,6 +370,31 @@ func TestGatewayModels_GeminiGroupFallsBackToGeminiModels(t *testing.T) {
 	require.NotContains(t, modelIDsForTest(got.Data), "claude-sonnet-4-6")
 }
 
+func TestGatewayModels_AntigravityGroupFallsBackToAntigravityModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	groupID := int64(21)
+	h := newGatewayModelsHandlerForTest(&gatewayModelsAccountRepoStub{})
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		Group: &service.Group{ID: groupID, Platform: service.PlatformAntigravity},
+	})
+
+	h.Models(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got gatewayModelsResponseForTest
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "list", got.Object)
+	ids := modelIDsForTest(got.Data)
+	require.Contains(t, ids, "gemini-3.6-flash")
+	require.Contains(t, ids, "gemini-2.5-flash")
+}
+
 func TestGatewayModels_Grok45AdvertisesReasoningEffortForGrokBuild(t *testing.T) {
 	assertGrokGatewayReasoningEfforts(t, 4409, "grok-4.5", []gatewayReasoningEffortOptionForTest{
 		{Value: "low", Label: "Low"},


### PR DESCRIPTION
## Problem

For an Antigravity group with no schedulable accounts, `GET /v1/models` advertises a **Claude-only** list — the entire Gemini family disappears.

The fallback chain in `GatewayHandler.Models` has branches for OpenAI, Gemini and Grok, but none for Antigravity, so it falls through to the final `claude.DefaultModels` return:

```go
if platform == service.PlatformOpenAI { ... }
if platform == service.PlatformGemini { ... }
if platform == service.PlatformGrok   { ... }
// no Antigravity branch
c.JSON(http.StatusOK, gin.H{"object": "list", "data": claude.DefaultModels})
```

`GetAvailableModels` returns nil when the group has no schedulable accounts, which is exactly when this fallback runs.

## Impact

Requests still route correctly — only **discovery** is broken. Downstream gateways that populate their model list from `/v1/models` (new-api and similar) silently end up with no Gemini models for Antigravity groups, and an operator has to enter them by hand.

Observed on a live deployment: the endpoint returned 11 Claude models and 0 Gemini for an Antigravity group, while `/antigravity/v1/models` returned 39 models including 29 Gemini for the same key.

## Fix

`defaultModelIDsForPlatform` already resolves Antigravity correctly (it returns `antigravity.DefaultModels()`), but it was only reachable through the custom-models-list branch. This adds the missing branch to the plain fallback so both paths agree.

```go
if platform == service.PlatformAntigravity {
    writeModelsList(c, platform, defaultModelIDsForPlatform(platform))
    return
}
```

One branch, no behavior change for any other platform.

## Test

`TestGatewayModels_AntigravityGroupFallsBackToAntigravityModels`, mirroring the existing `TestGatewayModels_GeminiGroupFallsBackToGeminiModels`.

Without the fix it fails with the exact production symptom:

```
[]string{"claude-fable-5-1", ..., "claude-haiku-4-5-20251001"} does not contain "gemini-3.6-flash"
```

Verified on this branch with Go 1.27 using the repo's own CI commands:

```
go build ./...          # ok
make test-unit          # ok — 106 packages, 0 failures
make test-integration   # ok
golangci-lint run       # 0 issues (v2.13, as pinned in CI)
```
