### PR TITLE
fix(gemini): apply custom list to native models endpoint

### DIFF
--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -52,6 +52,11 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 		return
 	}
 
+	if models, ok := customGeminiModelsList(apiKey.Group); ok {
+		c.JSON(http.StatusOK, models)
+		return
+	}
+
 	account, err := h.geminiCompatService.SelectAccountForAIStudioEndpoints(c.Request.Context(), apiKey.GroupID)
 	if err != nil {
 		// 没有 gemini 账户，检查是否有 antigravity 账户可用
@@ -76,6 +81,17 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 		return
 	}
 	writeUpstreamResponse(c, res)
+}
+
+func customGeminiModelsList(group *service.Group) (gemini.ModelsListResponse, bool) {
+	if group == nil || !group.CustomModelsListEnabled() {
+		return gemini.ModelsListResponse{}, false
+	}
+	models := make([]gemini.Model, 0, len(group.ModelsListConfig.Models))
+	for _, modelID := range group.ModelsListConfig.Models {
+		models = append(models, gemini.FallbackModel(modelID))
+	}
+	return gemini.ModelsListResponse{Models: models}, true
 }
 
 // GeminiV1BetaGetModel proxies:

--- a/backend/internal/handler/gemini_v1beta_handler_test.go
+++ b/backend/internal/handler/gemini_v1beta_handler_test.go
@@ -3,12 +3,80 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGeminiV1BetaListModels_CustomGroupListUsesNativeResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		Group: &service.Group{
+			Platform: service.PlatformGemini,
+			ModelsListConfig: service.GroupModelsListConfig{
+				Enabled: true,
+				Models:  []string{"gemini-2.5-pro", "models/gemini-custom"},
+			},
+		},
+	})
+
+	(&GatewayHandler{}).GeminiV1BetaListModels(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got gemini.ModelsListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, []gemini.Model{
+		gemini.FallbackModel("gemini-2.5-pro"),
+		gemini.FallbackModel("models/gemini-custom"),
+	}, got.Models)
+}
+
+func TestGeminiV1BetaListModels_ForcedAntigravityIgnoresCustomGroupList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/antigravity/v1beta/models", nil)
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		Group: &service.Group{
+			Platform: service.PlatformGemini,
+			ModelsListConfig: service.GroupModelsListConfig{
+				Enabled: true,
+				Models:  []string{"gemini-custom"},
+			},
+		},
+	})
+	c.Set(string(middleware.ContextKeyForcePlatform), service.PlatformAntigravity)
+
+	(&GatewayHandler{}).GeminiV1BetaListModels(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got antigravity.GeminiModelsListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, antigravity.FallbackGeminiModelsList(), got)
+}
+
+func TestCustomGeminiModelsList_DisabledKeepsExistingFlow(t *testing.T) {
+	group := &service.Group{
+		ModelsListConfig: service.GroupModelsListConfig{
+			Enabled: false,
+			Models:  []string{"gemini-2.5-pro"},
+		},
+	}
+
+	_, ok := customGeminiModelsList(group)
+	require.False(t, ok)
+}
 
 // TestGeminiV1BetaHandler_PlatformRoutingInvariant 文档化并验证 Handler 层的平台路由逻辑不变量
 // 该测试确保 gemini 和 antigravity 平台的路由逻辑符合预期

--- a/frontend/src/i18n/locales/en/admin/overview.ts
+++ b/frontend/src/i18n/locales/en/admin/overview.ts
@@ -1070,8 +1070,8 @@ export default {
         sumTooHigh: 'Min gross margin plus safety buffer must be less than 100%, otherwise every account would be excluded'
       },
       modelsList: {
-        title: 'Custom /v1/models Model List',
-        hint: 'Only changes the /v1/models response. Whitelist model calls and account routing are unchanged.',
+        title: 'Custom {endpoint} Model List',
+        hint: 'Only changes the {endpoint} response. Whitelist model calls and account routing are unchanged.',
         loading: 'Loading model list...',
         empty: 'No displayable models',
         selectedSummary: 'Selected {selected} / {total}',

--- a/frontend/src/i18n/locales/zh/admin/overview.ts
+++ b/frontend/src/i18n/locales/zh/admin/overview.ts
@@ -1067,8 +1067,8 @@ export default {
         sumTooHigh: '最低毛利率与安全缓冲之和必须小于 100%，否则将排除全部账号'
       },
       modelsList: {
-        title: '自定义 /v1/models 模型列表',
-        hint: '仅影响 /v1/models 展示结果，不影响白名单模型调用和账号调度。',
+        title: '自定义 {endpoint} 模型列表',
+        hint: '仅影响 {endpoint} 展示结果，不影响白名单模型调用和账号调度。',
         loading: '正在加载模型列表...',
         empty: '暂无可展示模型',
         selectedSummary: '已选 {selected} / {total}',

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -775,10 +775,10 @@
           <div class="mb-3 flex items-center justify-between gap-3">
             <div>
               <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {{ t("admin.groups.modelsList.title") }}
+                {{ t("admin.groups.modelsList.title", { endpoint: modelsListEndpoint(createForm.platform) }) }}
               </label>
               <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {{ t("admin.groups.modelsList.hint") }}
+                {{ t("admin.groups.modelsList.hint", { endpoint: modelsListEndpoint(createForm.platform) }) }}
               </p>
             </div>
             <button
@@ -2576,10 +2576,10 @@
           <div class="mb-3 flex items-center justify-between gap-3">
             <div>
               <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {{ t("admin.groups.modelsList.title") }}
+                {{ t("admin.groups.modelsList.title", { endpoint: modelsListEndpoint(editForm.platform) }) }}
               </label>
               <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {{ t("admin.groups.modelsList.hint") }}
+                {{ t("admin.groups.modelsList.hint", { endpoint: modelsListEndpoint(editForm.platform) }) }}
               </p>
             </div>
             <button
@@ -5167,6 +5167,8 @@ const createMessagesDispatchDefaults = createDefaultMessagesDispatchFormState();
 const editMessagesDispatchDefaults = createDefaultMessagesDispatchFormState();
 const createModelsListState = reactive(createInitialModelsListState());
 const editModelsListState = reactive(createInitialModelsListState());
+const modelsListEndpoint = (platform: string) =>
+  platform === "gemini" ? "/v1beta/models" : "/v1/models";
 const createModelsListLoading = ref(false);
 const editModelsListLoading = ref(false);
 type ReasoningEffortPolicyFieldsExpose = {

--- a/frontend/src/views/admin/__tests__/groupsModelsListLayout.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsModelsListLayout.spec.ts
@@ -23,4 +23,16 @@ describe("groups models list layout", () => {
       "btn btn-secondary shrink-0 whitespace-nowrap",
     );
   });
+
+  it("uses the Gemini-native models endpoint in Gemini group copy", () => {
+    expect(groupsViewSource).toContain(
+      'platform === "gemini" ? "/v1beta/models" : "/v1/models"',
+    );
+    expect(groupsViewSource).toContain(
+      "modelsListEndpoint(createForm.platform)",
+    );
+    expect(groupsViewSource).toContain(
+      "modelsListEndpoint(editForm.platform)",
+    );
+  });
 });


### PR DESCRIPTION
## 问题

Gemini 原生 `/v1beta/models` 接口未应用分组配置的自定义模型列表，管理界面也固定显示 `/v1/models`，导致配置含义与实际端点不一致。

## 根因

原生模型列表处理流程直接请求上游，没有优先读取分组的自定义模型列表配置；前端文案未根据分组平台切换模型列表端点。

## 改动

- 在 Gemini 原生模型列表接口中优先返回已启用的分组自定义模型列表。
- 保持模型调用白名单与账号调度行为不变。
- 管理界面根据平台显示 `/v1beta/models` 或 `/v1/models`。
- 补充后端行为测试和前端布局测试。

## 验证

已验证：

- 后端单元测试和集成测试通过。
- 后端静态检查通过，报告 0 个问题。
- 前端锁定依赖安装、代码规范检查、类型检查、关键测试、模型列表布局测试及构建通过。
- 已调用路径未发现已知漏洞，前端依赖审计例外校验通过。
- Linux 兼容的部署脚本测试通过。
- 差异格式检查通过。
- macOS 专用的容器生命周期测试未在 Linux 环境运行；该测试依赖特定系统命令，且与本次改动文件无关。

Fixes #6598