### PR TITLE
fix(usage): keep token and cost tooltips inside the viewport

### DIFF
--- a/frontend/src/components/admin/usage/UsageTable.vue
+++ b/frontend/src/components/admin/usage/UsageTable.vue
@@ -195,8 +195,10 @@
             <!-- Token Detail Tooltip -->
             <div
               class="group relative"
+              data-testid="usage-token-tooltip-trigger"
               @mouseenter="showTokenTooltip($event, row)"
               @mouseleave="hideTokenTooltip"
+              @click.stop="showTokenTooltip($event, row)"
             >
               <div class="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-gray-100 transition-colors group-hover:bg-blue-100 dark:bg-gray-700 dark:group-hover:bg-blue-900/50">
                 <Icon name="infoCircle" size="xs" class="text-gray-400 group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-400" />
@@ -217,8 +219,10 @@
               <!-- Cost Detail Tooltip -->
               <div
                 class="group relative"
+                data-testid="usage-cost-tooltip-trigger"
                 @mouseenter="showTooltip($event, row)"
                 @mouseleave="hideTooltip"
+                @click.stop="showTooltip($event, row)"
               >
                 <div class="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-gray-100 transition-colors group-hover:bg-blue-100 dark:bg-gray-700 dark:group-hover:bg-blue-900/50">
                   <Icon name="infoCircle" size="xs" class="text-gray-400 group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-400" />
@@ -295,13 +299,18 @@
   <Teleport to="body">
     <div
       v-if="tokenTooltipVisible"
-      class="fixed z-[9999] pointer-events-none -translate-y-1/2"
+      data-testid="usage-token-tooltip"
+      :data-placement="tokenTooltipPosition.placement"
+      class="fixed z-[9999] pointer-events-none"
       :style="{
-        left: tokenTooltipPosition.x + 'px',
-        top: tokenTooltipPosition.y + 'px'
+        left: tokenTooltipPosition.left + 'px',
+        top: tokenTooltipPosition.top + 'px'
       }"
     >
-      <div class="whitespace-nowrap rounded-lg border border-gray-700 bg-gray-900 px-3 py-2.5 text-xs text-white shadow-xl dark:border-gray-600 dark:bg-gray-800">
+      <div
+        ref="tokenTooltipEl"
+        class="w-max max-w-[min(20rem,calc(100vw-16px))] rounded-lg border border-gray-700 bg-gray-900 px-3 py-2.5 text-xs text-white shadow-xl dark:border-gray-600 dark:bg-gray-800"
+      >
         <div class="space-y-1.5">
           <div>
             <div class="text-xs font-semibold text-gray-300 mb-1">{{ t('usage.tokenDetails') }}</div>
@@ -370,7 +379,11 @@
             <span class="font-semibold text-blue-400">{{ ((tokenTooltipData?.input_tokens || 0) + (tokenTooltipData?.output_tokens || 0) + (tokenTooltipData?.cache_creation_tokens || 0) + (tokenTooltipData?.cache_read_tokens || 0)).toLocaleString() }}</span>
           </div>
         </div>
-        <div class="absolute right-full top-1/2 h-0 w-0 -translate-y-1/2 border-b-[6px] border-r-[6px] border-t-[6px] border-b-transparent border-r-gray-900 border-t-transparent dark:border-r-gray-800"></div>
+        <div
+          class="absolute h-0 w-0"
+          :class="tooltipArrowClass(tokenTooltipPosition.placement)"
+          :style="tooltipArrowStyle(tokenTooltipPosition)"
+        />
       </div>
     </div>
   </Teleport>
@@ -379,13 +392,18 @@
   <Teleport to="body">
     <div
       v-if="tooltipVisible"
-      class="fixed z-[9999] pointer-events-none -translate-y-1/2"
+      data-testid="usage-cost-tooltip"
+      :data-placement="tooltipPosition.placement"
+      class="fixed z-[9999] pointer-events-none"
       :style="{
-        left: tooltipPosition.x + 'px',
-        top: tooltipPosition.y + 'px'
+        left: tooltipPosition.left + 'px',
+        top: tooltipPosition.top + 'px'
       }"
     >
-      <div class="whitespace-nowrap rounded-lg border border-gray-700 bg-gray-900 px-3 py-2.5 text-xs text-white shadow-xl dark:border-gray-600 dark:bg-gray-800">
+      <div
+        ref="tooltipEl"
+        class="w-max max-w-[min(20rem,calc(100vw-16px))] rounded-lg border border-gray-700 bg-gray-900 px-3 py-2.5 text-xs text-white shadow-xl dark:border-gray-600 dark:bg-gray-800"
+      >
         <div class="space-y-1.5">
           <!-- Cost Breakdown -->
           <div class="mb-2 border-b border-gray-700 pb-1.5">
@@ -507,14 +525,18 @@
             </div>
           </template>
         </div>
-        <div class="absolute right-full top-1/2 h-0 w-0 -translate-y-1/2 border-b-[6px] border-r-[6px] border-t-[6px] border-b-transparent border-r-gray-900 border-t-transparent dark:border-r-gray-800"></div>
+        <div
+          class="absolute h-0 w-0"
+          :class="tooltipArrowClass(tooltipPosition.placement)"
+          :style="tooltipArrowStyle(tooltipPosition)"
+        />
       </div>
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { formatDateTime, formatReasoningEffort, reasoningEffortValuesEqual } from '@/utils/format'
@@ -565,6 +587,11 @@ import EmptyState from '@/components/common/EmptyState.vue'
 import IpGeoCell from '@/components/common/IpGeoCell.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { fetchBatch, getEntry } from '@/utils/ipGeoLookup'
+import {
+  getAnchoredTooltipPosition,
+  type AnchoredTooltipPlacement,
+  type AnchoredTooltipPosition,
+} from '@/utils/floatingPanel'
 import type { AdminUsageLog } from '@/types'
 import type { Column } from '@/components/common/types'
 
@@ -666,15 +693,72 @@ const copyRequestId = async (requestId: string) => {
   }
 }
 
+const ESTIMATED_TOOLTIP_SIZE = { width: 320, height: 320 }
+
+const emptyTooltipPosition = (): AnchoredTooltipPosition => ({
+  top: 0,
+  left: 0,
+  placement: 'right',
+  arrowOffset: 24,
+})
+
 // Tooltip state - cost
 const tooltipVisible = ref(false)
-const tooltipPosition = ref({ x: 0, y: 0 })
+const tooltipPosition = ref<AnchoredTooltipPosition>(emptyTooltipPosition())
 const tooltipData = ref<AdminUsageLog | null>(null)
+const tooltipEl = ref<HTMLElement | null>(null)
 
 // Tooltip state - token
 const tokenTooltipVisible = ref(false)
-const tokenTooltipPosition = ref({ x: 0, y: 0 })
+const tokenTooltipPosition = ref<AnchoredTooltipPosition>(emptyTooltipPosition())
 const tokenTooltipData = ref<AdminUsageLog | null>(null)
+const tokenTooltipEl = ref<HTMLElement | null>(null)
+
+const tooltipArrowClass = (placement: AnchoredTooltipPlacement): string => {
+  if (placement === 'right') {
+    return 'left-0 top-0 -translate-x-full -translate-y-1/2 border-y-[6px] border-r-[6px] border-y-transparent border-r-gray-900 dark:border-r-gray-800'
+  }
+  if (placement === 'left') {
+    return 'right-0 top-0 translate-x-full -translate-y-1/2 border-y-[6px] border-l-[6px] border-y-transparent border-l-gray-900 dark:border-l-gray-800'
+  }
+  if (placement === 'bottom') {
+    return 'left-0 top-0 -translate-x-1/2 -translate-y-full border-x-[6px] border-b-[6px] border-x-transparent border-b-gray-900 dark:border-b-gray-800'
+  }
+  return 'left-0 bottom-0 -translate-x-1/2 translate-y-full border-x-[6px] border-t-[6px] border-x-transparent border-t-gray-900 dark:border-t-gray-800'
+}
+
+const tooltipArrowStyle = (position: AnchoredTooltipPosition): Record<string, string> => {
+  if (position.placement === 'right' || position.placement === 'left') {
+    return { top: `${position.arrowOffset}px` }
+  }
+  return { left: `${position.arrowOffset}px` }
+}
+
+const placeUsageTooltip = (
+  trigger: HTMLElement,
+  size?: { width: number; height: number }
+): AnchoredTooltipPosition => {
+  const rect = trigger.getBoundingClientRect()
+  return getAnchoredTooltipPosition(rect, window.innerWidth, window.innerHeight, {
+    tooltipWidth: size?.width ?? ESTIMATED_TOOLTIP_SIZE.width,
+    tooltipHeight: size?.height ?? ESTIMATED_TOOLTIP_SIZE.height,
+  })
+}
+
+const refineUsageTooltipPosition = async (
+  trigger: HTMLElement,
+  getEl: () => HTMLElement | null,
+  assign: (position: AnchoredTooltipPosition) => void,
+  stillOpen: () => boolean
+) => {
+  await nextTick()
+  const el = getEl()
+  if (!el || !stillOpen()) return
+  const width = el.offsetWidth
+  const height = el.offsetHeight
+  if (width < 1 || height < 1) return
+  assign(placeUsageTooltip(trigger, { width, height }))
+}
 
 const getRequestTypeLabel = (row: AdminUsageLog): string => {
   const requestType = resolveUsageRequestType(row)
@@ -715,11 +799,17 @@ const formatDuration = (ms: number | null | undefined): string => {
 // Cost tooltip functions
 const showTooltip = (event: MouseEvent, row: AdminUsageLog) => {
   const target = event.currentTarget as HTMLElement
-  const rect = target.getBoundingClientRect()
+  tokenTooltipVisible.value = false
+  tokenTooltipData.value = null
   tooltipData.value = row
-  tooltipPosition.value.x = rect.right + 8
-  tooltipPosition.value.y = rect.top + rect.height / 2
+  tooltipPosition.value = placeUsageTooltip(target)
   tooltipVisible.value = true
+  void refineUsageTooltipPosition(
+    target,
+    () => tooltipEl.value,
+    (position) => { tooltipPosition.value = position },
+    () => tooltipVisible.value
+  )
 }
 
 const hideTooltip = () => {
@@ -730,11 +820,17 @@ const hideTooltip = () => {
 // Token tooltip functions
 const showTokenTooltip = (event: MouseEvent, row: AdminUsageLog) => {
   const target = event.currentTarget as HTMLElement
-  const rect = target.getBoundingClientRect()
+  tooltipVisible.value = false
+  tooltipData.value = null
   tokenTooltipData.value = row
-  tokenTooltipPosition.value.x = rect.right + 8
-  tokenTooltipPosition.value.y = rect.top + rect.height / 2
+  tokenTooltipPosition.value = placeUsageTooltip(target)
   tokenTooltipVisible.value = true
+  void refineUsageTooltipPosition(
+    target,
+    () => tokenTooltipEl.value,
+    (position) => { tokenTooltipPosition.value = position },
+    () => tokenTooltipVisible.value
+  )
 }
 
 const hideTokenTooltip = () => {

--- a/frontend/src/components/admin/usage/__tests__/UsageTable.spec.ts
+++ b/frontend/src/components/admin/usage/__tests__/UsageTable.spec.ts
@@ -21,6 +21,7 @@ import UsageTable from '../UsageTable.vue'
 const messages: Record<string, string> = {
   'admin.usage.userDeletedBadge': 'Deleted',
   'usage.costDetails': 'Cost Breakdown',
+  'usage.tokenDetails': 'Token Breakdown',
   'admin.usage.inputCost': 'Input Cost',
   'admin.usage.outputCost': 'Output Cost',
   'admin.usage.cacheCreationCost': 'Cache Creation Cost',
@@ -552,6 +553,103 @@ describe('admin UsageTable tooltip', () => {
     expect(text).toContain('Per-image price')
     expect(text).toContain('not recorded')
     expect(text).not.toContain('(2K)')
+  })
+
+  it('keeps cost and token tooltips inside a 390px mobile viewport', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 390 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 844 })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 358,
+      y: 420,
+      top: 420,
+      left: 358,
+      right: 374,
+      bottom: 436,
+      width: 16,
+      height: 16,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    const wrapper = mount(UsageTable, {
+      props: {
+        data: [{
+          ...baseImageRow,
+          billing_mode: 'token',
+          image_count: 0,
+          input_tokens: 348,
+          output_tokens: 196,
+          input_cost: 0.02,
+          output_cost: 0.11,
+          actual_cost: 0.137096,
+        }],
+        loading: false,
+        columns: [],
+      },
+      global: {
+        stubs: {
+          DataTable: DataTableStub,
+          EmptyState: true,
+          Icon: true,
+          Teleport: true,
+        },
+      },
+    })
+
+    await wrapper.get('[data-testid="usage-cost-tooltip-trigger"]').trigger('mouseenter')
+    await nextTick()
+
+    const costTooltip = wrapper.get('[data-testid="usage-cost-tooltip"]')
+    expect(costTooltip.attributes('data-placement')).toBe('left')
+    expect(parseFloat(costTooltip.element.style.left)).toBeGreaterThanOrEqual(8)
+    expect(parseFloat(costTooltip.element.style.left) + 320).toBeLessThanOrEqual(358)
+
+    await wrapper.get('[data-testid="usage-cost-tooltip-trigger"]').trigger('mouseleave')
+    await wrapper.get('[data-testid="usage-token-tooltip-trigger"]').trigger('click')
+    await nextTick()
+
+    const tokenTooltip = wrapper.get('[data-testid="usage-token-tooltip"]')
+    expect(tokenTooltip.attributes('data-placement')).toBe('left')
+    expect(parseFloat(tokenTooltip.element.style.left)).toBeGreaterThanOrEqual(8)
+    expect(wrapper.text()).toContain('Token Breakdown')
+  })
+
+  it('keeps the desktop tooltip on the right when the icon has room', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 800 })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 164,
+      y: 200,
+      top: 200,
+      left: 164,
+      right: 180,
+      bottom: 216,
+      width: 16,
+      height: 16,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    const wrapper = mount(UsageTable, {
+      props: {
+        data: [baseImageRow],
+        loading: false,
+        columns: [],
+      },
+      global: {
+        stubs: {
+          DataTable: DataTableStub,
+          EmptyState: true,
+          Icon: true,
+          Teleport: true,
+        },
+      },
+    })
+
+    await wrapper.get('[data-testid="usage-cost-tooltip-trigger"]').trigger('mouseenter')
+    await nextTick()
+
+    const costTooltip = wrapper.get('[data-testid="usage-cost-tooltip"]')
+    expect(costTooltip.attributes('data-placement')).toBe('right')
+    expect(parseFloat(costTooltip.element.style.left)).toBe(188)
   })
 })
 

--- a/frontend/src/utils/__tests__/floatingPanel.spec.ts
+++ b/frontend/src/utils/__tests__/floatingPanel.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getFloatingPanelPosition } from '@/utils/floatingPanel'
+import { getAnchoredTooltipPosition, getFloatingPanelPosition } from '@/utils/floatingPanel'
 
 describe('getFloatingPanelPosition', () => {
   it('移动端使用视口安全边距，不再从靠左按钮向屏幕外展开', () => {
@@ -39,5 +39,79 @@ describe('getFloatingPanelPosition', () => {
     expect(position.top).toBeNull()
     expect(position.bottom).toBe(108)
     expect(position.maxHeight).toBe(560)
+  })
+})
+
+describe('getAnchoredTooltipPosition', () => {
+  const tooltip = { tooltipWidth: 280, tooltipHeight: 220 }
+
+  it('keeps the default right-side placement when there is room', () => {
+    const position = getAnchoredTooltipPosition(
+      { top: 200, right: 180, bottom: 216, left: 164, width: 16, height: 16 },
+      1280,
+      800,
+      tooltip
+    )
+
+    expect(position.placement).toBe('right')
+    expect(position.left).toBe(188)
+    expect(position.top).toBe(98)
+    expect(position.left + 280).toBeLessThanOrEqual(1280 - 8)
+  })
+
+  it('flips to the left when the info icon sits on a mobile card edge', () => {
+    const position = getAnchoredTooltipPosition(
+      { top: 420, right: 374, bottom: 436, left: 358, width: 16, height: 16 },
+      390,
+      844,
+      tooltip
+    )
+
+    expect(position.placement).toBe('left')
+    expect(position.left).toBeGreaterThanOrEqual(8)
+    expect(position.left + 280).toBeLessThanOrEqual(358 - 8)
+    expect(position.top).toBeGreaterThanOrEqual(8)
+    expect(position.top + 220).toBeLessThanOrEqual(844 - 8)
+  })
+
+  it('opens below and stays inside a narrow viewport when neither side fits', () => {
+    const position = getAnchoredTooltipPosition(
+      { top: 200, right: 308, bottom: 216, left: 292, width: 16, height: 16 },
+      320,
+      700,
+      { tooltipWidth: 300, tooltipHeight: 180 }
+    )
+
+    expect(position.placement).toBe('bottom')
+    expect(position.left).toBeGreaterThanOrEqual(8)
+    expect(position.left + 300).toBeLessThanOrEqual(320 - 8)
+    expect(position.top).toBe(224)
+  })
+
+  it('opens above when the trigger is near the bottom of the screen', () => {
+    const position = getAnchoredTooltipPosition(
+      { top: 760, right: 200, bottom: 776, left: 40, width: 16, height: 16 },
+      390,
+      800,
+      { tooltipWidth: 360, tooltipHeight: 200 }
+    )
+
+    expect(position.placement).toBe('top')
+    expect(position.top + 200).toBeLessThanOrEqual(760 - 8)
+    expect(position.left).toBeGreaterThanOrEqual(8)
+    expect(position.left + 360).toBeLessThanOrEqual(390 - 8)
+  })
+
+  it('clamps a tall tooltip so it does not overflow the viewport vertically', () => {
+    const position = getAnchoredTooltipPosition(
+      { top: 20, right: 200, bottom: 36, left: 184, width: 16, height: 16 },
+      1280,
+      400,
+      { tooltipWidth: 240, tooltipHeight: 360 }
+    )
+
+    expect(position.top).toBe(8)
+    expect(position.top + 360).toBeLessThanOrEqual(400)
+    expect(position.arrowOffset).toBeGreaterThanOrEqual(12)
   })
 })

--- a/frontend/src/utils/floatingPanel.ts
+++ b/frontend/src/utils/floatingPanel.ts
@@ -54,3 +54,87 @@ export const getFloatingPanelPosition = (
     maxHeight
   }
 }
+
+export type AnchoredTooltipPlacement = 'right' | 'left' | 'bottom' | 'top'
+
+export interface AnchoredTooltipPosition {
+  top: number
+  left: number
+  placement: AnchoredTooltipPlacement
+  /** Distance from the start of the facing edge to the arrow center. */
+  arrowOffset: number
+}
+
+export interface AnchoredTooltipOptions {
+  tooltipWidth: number
+  tooltipHeight: number
+  gap?: number
+  viewportPadding?: number
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (max < min) return (min + max) / 2
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Place a compact tooltip next to its trigger and keep the whole box in view.
+ * Prefers the right side (current usage-table affordance), then left, then below/above.
+ */
+export const getAnchoredTooltipPosition = (
+  triggerRect: Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left' | 'width' | 'height'>,
+  viewportWidth: number,
+  viewportHeight: number,
+  options: AnchoredTooltipOptions
+): AnchoredTooltipPosition => {
+  const gap = options.gap ?? 8
+  const pad = options.viewportPadding ?? 8
+  const width = Math.max(0, options.tooltipWidth)
+  const height = Math.max(0, options.tooltipHeight)
+
+  const spaceRight = viewportWidth - triggerRect.right - gap - pad
+  const spaceLeft = triggerRect.left - gap - pad
+  const spaceBelow = viewportHeight - triggerRect.bottom - gap - pad
+  const spaceAbove = triggerRect.top - gap - pad
+
+  let placement: AnchoredTooltipPlacement
+  if (spaceRight >= width) {
+    placement = 'right'
+  } else if (spaceLeft >= width) {
+    placement = 'left'
+  } else if (spaceBelow >= height || spaceBelow >= spaceAbove) {
+    placement = 'bottom'
+  } else {
+    placement = 'top'
+  }
+
+  const triggerCenterX = triggerRect.left + triggerRect.width / 2
+  const triggerCenterY = triggerRect.top + triggerRect.height / 2
+
+  let left: number
+  let top: number
+  if (placement === 'right') {
+    left = triggerRect.right + gap
+    top = triggerCenterY - height / 2
+  } else if (placement === 'left') {
+    left = triggerRect.left - gap - width
+    top = triggerCenterY - height / 2
+  } else if (placement === 'bottom') {
+    left = triggerCenterX - width / 2
+    top = triggerRect.bottom + gap
+  } else {
+    left = triggerCenterX - width / 2
+    top = triggerRect.top - gap - height
+  }
+
+  const maxLeft = Math.max(pad, viewportWidth - width - pad)
+  const maxTop = Math.max(pad, viewportHeight - height - pad)
+  left = clamp(left, pad, maxLeft)
+  top = clamp(top, pad, maxTop)
+
+  const arrowOffset = placement === 'right' || placement === 'left'
+    ? clamp(triggerCenterY - top, 12, height - 12)
+    : clamp(triggerCenterX - left, 12, width - 12)
+
+  return { top, left, placement, arrowOffset }
+}


### PR DESCRIPTION
## Summary

On the usage records page (user and admin share `UsageTable.vue`), tapping the token / cost `(i)` icon always opens the breakdown popover to the **right** of the trigger. In the mobile card layout that icon sits on the right edge, so the popover is clipped by the viewport and the 费用明细 / Token 明细 cannot be read.

This keeps the existing desktop right-side placement when there is room, and otherwise flips or clamps the teleported popover so the full breakdown stays on screen.

## Changes

- Add `getAnchoredTooltipPosition()` in `frontend/src/utils/floatingPanel.ts`
  - Prefer right, then left, then bottom / top
  - Clamp into the viewport
  - Keep the arrow aligned with the trigger after clamping
- Wire both usage tooltips through that helper and re-measure after render
- Cap popover width at `min(20rem, 100vw - 16px)` so long cost rows wrap instead of overflowing
- Accept click as well as hover so mobile taps open the popover
- Unit tests for the positioner and for 390px / desktop `UsageTable` behavior

## Test plan

- [x] `pnpm exec vitest run src/utils/__tests__/floatingPanel.spec.ts src/components/admin/usage/__tests__/UsageTable.spec.ts`
- [ ] Mobile (~390px): 使用记录 card → tap TOKEN `(i)` → full Token 明细 visible
- [ ] Same card → tap 费用 `(i)` → full 费用明细 visible
- [ ] Desktop table: tooltips still open to the right of the icon when there is space
- [ ] Near the bottom of the viewport: popover flips above instead of overflowing

I have read the CLA Document and I hereby sign the CLA