### PR TITLE
fix: unblock ops dashboard and correct RMB plaza pricing

### DIFF
--- a/backend/internal/service/model_plaza_service.go
+++ b/backend/internal/service/model_plaza_service.go
@@ -207,6 +207,9 @@ func (s *ModelPlazaService) ListGroups(ctx context.Context) ([]PlazaGroup, error
 		for j := range pg.Models {
 			s.fillDisplayPricing(ctx, &pg.Models[j], g)
 			pg.Models[j].OfficialPricing = s.lookupOfficialPricing(ctx, pg.Models[j].Name, officialMemo)
+			if useChannelPricingAsOfficial(g) {
+				pg.Models[j].OfficialPricing = plazaOfficialPricingFromChannel(pg.Models[j].Pricing)
+			}
 		}
 		out = append(out, *pg)
 	}
@@ -218,6 +221,34 @@ func (s *ModelPlazaService) ListGroups(ctx context.Context) ([]PlazaGroup, error
 		return out[i].Name < out[j].Name
 	})
 	return out, nil
+}
+
+// useChannelPricingAsOfficial marks groups whose channel prices are entered in
+// RMB/M and therefore must be shown in the plaza's official-price column.
+func useChannelPricingAsOfficial(g *Group) bool {
+	if g == nil {
+		return false
+	}
+	name := strings.ToLower(strings.TrimSpace(g.Name))
+	return name == "deepseek-018" || name == "glm-018"
+}
+
+func plazaOfficialPricingFromChannel(p *ChannelModelPricing) *PlazaOfficialPricing {
+	if p == nil {
+		return nil
+	}
+	out := &PlazaOfficialPricing{
+		InputPrice:      p.InputPrice,
+		OutputPrice:     p.OutputPrice,
+		CacheWritePrice: p.CacheWritePrice,
+		CacheReadPrice:  p.CacheReadPrice,
+		Intervals:       p.Intervals,
+	}
+	if out.InputPrice == nil && out.OutputPrice == nil && out.CacheWritePrice == nil &&
+		out.CacheReadPrice == nil && len(out.Intervals) == 0 {
+		return nil
+	}
+	return out
 }
 
 // fillDisplayPricing 把模型的展示定价换成实收口径：

--- a/backend/internal/service/model_plaza_service_test.go
+++ b/backend/internal/service/model_plaza_service_test.go
@@ -35,6 +35,26 @@ func plazaPricedChannel(id int64, name string, groupIDs []int64, platform string
 	}
 }
 
+func TestUseChannelPricingAsOfficial(t *testing.T) {
+	require.True(t, useChannelPricingAsOfficial(&Group{Name: "deepseek-018"}))
+	require.True(t, useChannelPricingAsOfficial(&Group{Name: " GLM-018 "}))
+	require.False(t, useChannelPricingAsOfficial(&Group{Name: "claude-080"}))
+	require.False(t, useChannelPricingAsOfficial(nil))
+}
+
+func TestPlazaOfficialPricingFromChannel(t *testing.T) {
+	input := 1.5e-6
+	output := 4.5e-6
+	got := plazaOfficialPricingFromChannel(&ChannelModelPricing{
+		InputPrice:  &input,
+		OutputPrice: &output,
+	})
+	require.NotNil(t, got)
+	require.Equal(t, input, *got.InputPrice)
+	require.Equal(t, output, *got.OutputPrice)
+	require.Nil(t, plazaOfficialPricingFromChannel(&ChannelModelPricing{}))
+}
+
 func TestListPlazaGroups_GroupCentricAggregation(t *testing.T) {
 	// 两个渠道挂同一分组:模型并入同一 PlazaGroup;无模型的分组不返回。
 	channels := []Channel{

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -11,6 +11,7 @@ export type OpsQueryMode = 'auto' | 'raw' | 'preagg'
 
 export interface OpsRequestOptions {
   signal?: AbortSignal
+  timeout?: number
 }
 
 export type OpsUpstreamErrorEvent = {
@@ -973,7 +974,8 @@ export async function getDashboardOverview(
 ): Promise<OpsDashboardOverview> {
   const { data } = await apiClient.get<OpsDashboardOverview>('/admin/ops/dashboard/overview', {
     params,
-    signal: options.signal
+    signal: options.signal,
+    timeout: options.timeout
   })
   return data
 }
@@ -991,7 +993,8 @@ export async function getDashboardSnapshotV2(
 ): Promise<OpsDashboardSnapshotV2Response> {
   const { data } = await apiClient.get<OpsDashboardSnapshotV2Response>('/admin/ops/dashboard/snapshot-v2', {
     params,
-    signal: options.signal
+    signal: options.signal,
+    timeout: options.timeout
   })
   return data
 }

--- a/frontend/src/components/modelPlaza/PlazaGroupSection.vue
+++ b/frontend/src/components/modelPlaza/PlazaGroupSection.vue
@@ -59,6 +59,7 @@
         :platform="group.platform"
         :rate-multiplier="group.rate_multiplier"
         :user-rate-multiplier="group.user_rate_multiplier ?? null"
+        :currency-symbol="currencySymbol"
         :image-rate-independent="group.image_rate_independent"
         :image-rate-multiplier="group.image_rate_multiplier"
         :peak-window="peakWindow"
@@ -105,6 +106,11 @@ const peakNote = computed(() => {
     window: peakWindow.value,
     multiplier: props.group.peak_rate_multiplier
   })
+})
+
+const currencySymbol = computed(() => {
+  const name = props.group.name.trim().toLowerCase()
+  return name === 'deepseek-018' || name === 'glm-018' ? '¥' : '$'
 })
 
 /**

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -24,7 +24,7 @@
           <th colspan="3" class="pz-bg pt-2 text-center">
             <div class="pz-title border-b pb-2 font-semibold">
               {{ t('modelPlaza.table.paidPrice') }}
-              <span class="pz-unit ml-1 normal-case font-normal">{{ t('modelPlaza.table.unitPerMillion') }}</span>
+              <span class="pz-unit ml-1 normal-case font-normal">{{ unitPerMillion }}</span>
             </div>
           </th>
           <th
@@ -33,7 +33,7 @@
           >
             <div class="border-b border-gray-200 pb-2 text-gray-400 dark:border-dark-600 dark:text-dark-500">
               {{ t('modelPlaza.table.officialPrice') }}
-              <span class="ml-1 normal-case font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.unitPerMillion') }}</span>
+              <span class="ml-1 normal-case font-normal text-gray-400 dark:text-dark-500">{{ unitPerMillion }}</span>
             </div>
           </th>
           <th
@@ -301,6 +301,8 @@ const props = defineProps<{
   models: PlazaModel[]
   /** 分组平台;实付分区底色随平台着色,未知平台回退品牌青。 */
   platform?: string
+  /** Currency prefix used by this group's model-plaza prices. */
+  currencySymbol?: '$' | '¥'
   /** 分组默认倍率。 */
   rateMultiplier: number
   /** 用户专属倍率;与默认不同,实付价按此计算并划线展示原倍率。 */
@@ -323,6 +325,15 @@ const { t } = useI18n()
 const accentStyle = computed(() => ({ '--plaza-accent': platformAccentColor(props.platform ?? '') }))
 
 const PER_MILLION = 1_000_000
+const currencySymbol = computed(() => props.currencySymbol ?? '$')
+const unitPerMillion = computed(() =>
+  t('modelPlaza.table.unitPerMillion').replace(/^\$/, currencySymbol.value)
+)
+
+function formatPrice(value: number | null | undefined, scale: number, minFractionDigits = 0): string {
+  const formatted = formatScaled(value ?? null, scale, minFractionDigits)
+  return currencySymbol.value === '$' ? formatted : formatted.replace(/^\$/, currencySymbol.value)
+}
 
 /**
  * 展示顺序:
@@ -390,7 +401,7 @@ function periodRate(period: PlazaTimePricingPeriod): number {
 function paidPerMillion(value: number | null | undefined, period: PlazaTimePricingPeriod | null = null): string {
   if (value == null) return '-'
   const rate = period ? periodRate(period) : effectiveRate.value
-  return formatScaled(value * rate, PER_MILLION, MIN_DECIMALS)
+  return formatPrice(value * rate, PER_MILLION, MIN_DECIMALS)
 }
 
 /** 图片计费模型且分组开启生图独立倍率:实付倍率取独立倍率,与计费口径一致。 */
@@ -406,13 +417,13 @@ function requestRate(m: PlazaModel): number {
 /** 按次 / 按图片单价(乘该行生效倍率,不换算 1M)。 */
 function paidRequestPrice(m: PlazaModel, value: number | null | undefined): string {
   if (value == null) return '-'
-  return formatScaled(value * requestRate(m), 1, MIN_DECIMALS)
+  return formatPrice(value * requestRate(m), 1, MIN_DECIMALS)
 }
 
 /** 官方参考价不乘倍率。 */
 function official(value: number | null | undefined): string {
   if (value == null) return '-'
-  return formatScaled(value, PER_MILLION, MIN_DECIMALS)
+  return formatPrice(value, PER_MILLION, MIN_DECIMALS)
 }
 
 /** 非 token 计费的单位后缀:按图片 → “/ 张”,按次 → “/ 次”。 */

--- a/frontend/src/stores/__tests__/adminSettings.spec.ts
+++ b/frontend/src/stores/__tests__/adminSettings.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { getSettings, getPaymentConfig } = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getPaymentConfig: vi.fn()
+}))
+
+vi.mock('@/api', () => ({
+  adminAPI: {
+    settings: { getSettings },
+    payment: { getConfig: getPaymentConfig }
+  }
+}))
+
+import { useAdminSettingsStore } from '@/stores/adminSettings'
+
+describe('useAdminSettingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    localStorage.clear()
+    getSettings.mockResolvedValue({
+      ops_monitoring_enabled: true,
+      ops_realtime_monitoring_enabled: true,
+      ops_query_mode_default: 'auto',
+      custom_menu_items: []
+    })
+  })
+
+  it('does not block settings readiness on a slow payment config request', async () => {
+    let resolvePayment: ((value: { data: { enabled: boolean } }) => void) | undefined
+    getPaymentConfig.mockReturnValue(new Promise((resolve) => {
+      resolvePayment = resolve
+    }))
+
+    const store = useAdminSettingsStore()
+    await store.fetch()
+
+    expect(store.loaded).toBe(true)
+    expect(store.loading).toBe(false)
+    expect(store.opsMonitoringEnabled).toBe(true)
+    expect(store.paymentEnabled).toBe(false)
+
+    resolvePayment?.({ data: { enabled: true } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(store.paymentEnabled).toBe(true)
+  })
+})

--- a/frontend/src/stores/adminSettings.ts
+++ b/frontend/src/stores/adminSettings.ts
@@ -56,11 +56,11 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     if (loading.value) return
 
     loading.value = true
+    const paymentConfigPromise = adminAPI.payment.getConfig()
     try {
-      const [settings, paymentConfigResp] = await Promise.all([
-        adminAPI.settings.getSettings(),
-        adminAPI.payment.getConfig()
-      ])
+      // The ops dashboard only needs system settings. Payment configuration is
+      // optional for navigation and must not hold the whole admin shell open.
+      const settings = await adminAPI.settings.getSettings()
       opsMonitoringEnabled.value = settings.ops_monitoring_enabled ?? true
       writeCachedBool('ops_monitoring_enabled_cached', opsMonitoringEnabled.value)
 
@@ -72,9 +72,6 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
 
       customMenuItems.value = Array.isArray(settings.custom_menu_items) ? settings.custom_menu_items : []
 
-      paymentEnabled.value = paymentConfigResp.data?.enabled ?? false
-      writeCachedBool('payment_enabled_cached', paymentEnabled.value)
-
       loaded.value = true
     } catch (err) {
       // Keep cached/default value: do not "flip" the UI based on a transient fetch failure.
@@ -83,6 +80,18 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     } finally {
       loading.value = false
     }
+
+    // Finish the optional payment request independently. Keeping this promise
+    // handled prevents a slow or unavailable payment service from blocking the
+    // monitoring page or producing an unhandled rejection.
+    void paymentConfigPromise
+      .then((paymentConfigResp) => {
+        paymentEnabled.value = paymentConfigResp.data?.enabled ?? false
+        writeCachedBool('payment_enabled_cached', paymentEnabled.value)
+      })
+      .catch((err) => {
+        console.error('[adminSettings] Failed to fetch payment config:', err)
+      })
   }
 
   function setOpsMonitoringEnabledLocal(value: boolean) {

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -634,19 +634,17 @@ async function refreshCoreSnapshotWithCancel(fetchSeq: number, signal: AbortSign
   loadingTrend.value = true
   loadingErrorTrend.value = true
   try {
-    const data = await opsAPI.getDashboardSnapshotV2(buildApiParams(), { signal })
-    if (fetchSeq !== dashboardFetchSeq) return
-    overview.value = data.overview
-    throughputTrend.value = data.throughput_trend
-    errorTrend.value = data.error_trend
-  } catch (err: any) {
-    if (fetchSeq !== dashboardFetchSeq || isCanceledRequest(err)) return
-    // Fallback to legacy split endpoints when snapshot endpoint is unavailable.
+    // The combined snapshot can be slow on large production tables. Load the
+    // three bounded dashboard queries in parallel so the first paint is not
+    // held behind one long-running aggregate query.
     await Promise.all([
       refreshOverviewWithCancel(fetchSeq, signal),
       refreshThroughputTrendWithCancel(fetchSeq, signal),
       refreshErrorTrendWithCancel(fetchSeq, signal)
     ])
+  } catch (err: any) {
+    if (fetchSeq !== dashboardFetchSeq || isCanceledRequest(err)) return
+    console.error('[ops] failed to load core dashboard panels', err)
   } finally {
     if (fetchSeq === dashboardFetchSeq) {
       loadingTrend.value = false


### PR DESCRIPTION
## Summary\n- use configured channel pricing as the official-price source for deepseek-018 and glm-018\n- render those groups with the RMB symbol while preserving the per-million-token unit\n- load the ops dashboard through bounded parallel endpoints instead of the slow aggregate snapshot\n- keep optional payment configuration from blocking admin settings readiness\n\n## Verification\n- pnpm run build\n- pnpm run typecheck\n- pnpm run lint:check\n- pnpm exec vitest run src/stores/__tests__/adminSettings.spec.ts\n- backend unit tests require Go 1.27 in CI\n