### PR TITLE
fix(usage): preserve max reasoning effort for GPT-6 Astra

### DIFF
--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -2169,6 +2169,8 @@ func supportsOpenAIReasoningEffortMax(model string) bool {
 	normalized := strings.ToLower(lastOpenAIModelSegment(model))
 	normalized = strings.ReplaceAll(normalized, "_", "-")
 	switch {
+	case normalized == "gpt-6-astra" || strings.HasPrefix(normalized, "gpt-6-astra-"):
+		return true
 	case strings.HasPrefix(normalized, "deepseek-v4"):
 		return true
 	case strings.HasPrefix(normalized, "glm-"):

--- a/backend/internal/service/openai_gpt6_max_test.go
+++ b/backend/internal/service/openai_gpt6_max_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeOpenAIReasoningEffortForGPT6Astra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		raw   string
+		model string
+		want  string
+	}{
+		{name: "max", raw: "max", model: "gpt-6-astra", want: "max"},
+		{name: "provider and spelling", raw: " MAX ", model: " openai/GPT_6_ASTRA ", want: "max"},
+		{name: "version suffix", raw: "max", model: "gpt-6-astra-2026-09-03", want: "max"},
+		{name: "effort suffix", raw: "max", model: "gpt-6-astra-max", want: "max"},
+		{name: "xhigh stays distinct", raw: "x-high", model: "gpt-6-astra", want: "xhigh"},
+		{name: "similar name", raw: "max", model: "gpt-6-astral", want: "xhigh"},
+		{name: "other GPT-6 model", raw: "max", model: "gpt-6-other", want: "xhigh"},
+		{name: "legacy GPT model", raw: "max", model: "gpt-5.5", want: "xhigh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeOpenAIReasoningEffortForModel(tt.raw, tt.model))
+		})
+	}
+}
+
+func TestOpenAIGatewayServicePassthroughPreservesGPT6AstraMaxEffort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, model := range []string{"gpt-6-astra", "astra"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", model, stream), func(t *testing.T) {
+				responseBody := `{"model":"gpt-6-astra","usage":{"input_tokens":1,"output_tokens":2}}`
+				contentType := "application/json"
+				if stream {
+					responseBody = "data: {\"type\":\"response.completed\",\"response\":" + responseBody + "}\n\ndata: [DONE]\n\n"
+					contentType = "text/event-stream"
+				}
+				upstream := &httpUpstreamRecorder{
+					resp: &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{contentType}},
+						Body:       io.NopCloser(strings.NewReader(responseBody)),
+					},
+				}
+				cfg := &config.Config{}
+				cfg.Security.URLAllowlist.Enabled = false
+				svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+				account := &Account{
+					ID:          1,
+					Name:        "openai-apikey-passthrough",
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Concurrency: 1,
+					Credentials: map[string]any{
+						"api_key":  "sk-test",
+						"base_url": "https://example.com",
+						"model_mapping": map[string]any{
+							"astra": "gpt-6-astra",
+						},
+					},
+					Extra: map[string]any{"openai_passthrough": true},
+				}
+				body := []byte(fmt.Sprintf(`{"model":%q,"stream":%t,"reasoning":{"effort":"max"},"input":"hello"}`, model, stream))
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(string(body)))
+				SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+				result, err := svc.Forward(context.Background(), c, account, body)
+
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, http.StatusOK, rec.Code)
+				require.Equal(t, "gpt-6-astra", gjson.GetBytes(upstream.lastBody, "model").String())
+				require.Equal(t, "max", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+				require.NotNil(t, result.ReasoningEffort)
+				require.Equal(t, "max", *result.ReasoningEffort)
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- 使用 `gpt-6-astra` 请求 `reasoning.effort=max` 时，API Key 透传的请求体保留 `max`，但用量元数据被归一化成 `xhigh`，导致使用记录误显示 `Max → XHigh`。原因是 `supportsOpenAIReasoningEffortMax` 未识别 Astra。
- 将 `gpt-6-astra` 及以 `gpt-6-astra-` 分隔的后缀变体纳入独立 `max` 档位识别，复用现有的提供商前缀、大小写和下划线处理。普通 Astra 请求的记录由 `requested=max / effective=xhigh` 变为 `requested=max / effective=max`。
- 新增 8 个名称/档位边界用例，以及普通模型名、映射别名分别在流式和非流式 API Key 透传中的 4 个回归场景；同时断言上游请求体与用量结果中的 effort。

## Testing

- `git diff --cached --check`：通过。
- `gofmt -l backend/internal/service/openai_gateway_request_body.go backend/internal/service/openai_gpt6_max_test.go`：无输出，格式检查通过。
- 已完成完整差异与相关调用路径的代码审查。
- 按本次提交工作流，未在本地执行 Go 测试或构建；新增回归用例交由 PR CI 的 unit/integration 测试与 golangci-lint 检查。用例不会调用真实上游服务。

## Risks

- 仅新增 Astra 的 `max` 识别；其他模型既有的 `max → xhigh` 兼容行为、分组上限/映射规则保持现状。没有数据库迁移，历史记录不会回写。
- 本次未部署生产服务，修复需合入并更新运行版本后生效。
- 与尚未合并的 #6572 中 Astra `max` 识别部分重叠。本 PR 提供独立的记录修复和透传回归用例；若优先合入 #6572，可复用相关用例并关闭本 PR，避免重复维护。
