### PR TITLE
fix: preserve exclusive group authorization

### DIFF
--- a/backend/internal/repository/allowed_groups_contract_integration_test.go
+++ b/backend/internal/repository/allowed_groups_contract_integration_test.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/ent/apikey"
+	"github.com/Wei-Shaw/sub2api/ent/userallowedgroup"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +148,187 @@ func TestGroupRepository_DeleteCascade_PreservesApiKeyGroupID(t *testing.T) {
 	require.NotNil(t, keyAfter.GroupID)
 	require.Equal(t, targetGroup.ID, *keyAfter.GroupID)
 	require.Nil(t, keyAfter.Group)
+}
+
+func TestGroupUpdateExclusiveAuthorizesOnlyActiveUndeletedKeyOwners(t *testing.T) {
+	ctx := context.Background()
+	tx := testEntTx(t)
+	client := tx.Client()
+	groupRepo := newGroupRepositoryWithSQL(client, tx)
+	apiKeyRepo := newAPIKeyRepositoryWithSQL(client, tx)
+
+	createUser := func(email string) *dbent.User {
+		user, err := client.User.Create().
+			SetEmail(email).
+			SetPasswordHash("test-password-hash").
+			SetRole(service.RoleUser).
+			SetStatus(service.StatusActive).
+			Save(ctx)
+		require.NoError(t, err)
+		return user
+	}
+	createGroup := func(name string) *service.Group {
+		group, err := client.Group.Create().
+			SetName(name).
+			SetPlatform(service.PlatformAnthropic).
+			SetStatus(service.StatusActive).
+			SetSubscriptionType(service.SubscriptionTypeStandard).
+			Save(ctx)
+		require.NoError(t, err)
+		return groupEntityToService(group)
+	}
+	createKey := func(userID, groupID int64, name string) *service.APIKey {
+		key := &service.APIKey{
+			UserID:  userID,
+			GroupID: &groupID,
+			Key:     uniqueTestValue(t, "sk-"+name),
+			Name:    name,
+			Status:  service.StatusActive,
+		}
+		require.NoError(t, apiKeyRepo.Create(ctx, key))
+		return key
+	}
+	allowedCount := func(userID, groupID int64) int {
+		count, err := client.UserAllowedGroup.Query().
+			Where(userallowedgroup.UserIDEQ(userID), userallowedgroup.GroupIDEQ(groupID)).
+			Count(ctx)
+		require.NoError(t, err)
+		return count
+	}
+
+	group := createGroup(uniqueTestValue(t, "exclusive-transition"))
+	activeUser := createUser(uniqueTestValue(t, "exclusive-active") + "@example.com")
+	disabledUser := createUser(uniqueTestValue(t, "exclusive-disabled") + "@example.com")
+	deletedUser := createUser(uniqueTestValue(t, "exclusive-deleted") + "@example.com")
+
+	createKey(activeUser.ID, group.ID, "active")
+	disabledKey := createKey(disabledUser.ID, group.ID, "disabled")
+	deletedKey := createKey(deletedUser.ID, group.ID, "deleted")
+
+	_, err := client.APIKey.UpdateOneID(disabledKey.ID).SetStatus(service.StatusDisabled).Save(ctx)
+	require.NoError(t, err)
+	_, err = client.APIKey.UpdateOneID(deletedKey.ID).SetDeletedAt(time.Now().UTC()).Save(ctx)
+	require.NoError(t, err)
+
+	group.IsExclusive = true
+	require.NoError(t, groupRepo.Update(ctx, group))
+
+	require.Equal(t, 1, allowedCount(activeUser.ID, group.ID))
+	require.Equal(t, 0, allowedCount(disabledUser.ID, group.ID))
+	require.Equal(t, 0, allowedCount(deletedUser.ID, group.ID))
+
+	// Repeating the update must remain idempotent under the composite key.
+	require.NoError(t, groupRepo.Update(ctx, group))
+	require.Equal(t, 1, allowedCount(activeUser.ID, group.ID))
+}
+
+func TestUserAllowedGroupsUpdatePreservesExclusiveGroupUsedByActiveKey(t *testing.T) {
+	ctx := context.Background()
+	tx := testEntTx(t)
+	client := tx.Client()
+	userRepo := newUserRepositoryWithSQL(client, tx)
+	apiKeyRepo := newAPIKeyRepositoryWithSQL(client, tx)
+
+	user, err := client.User.Create().
+		SetEmail(uniqueTestValue(t, "allowed-groups-preserve") + "@example.com").
+		SetPasswordHash("test-password-hash").
+		SetRole(service.RoleUser).
+		SetStatus(service.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+	exclusiveGroup, err := client.Group.Create().
+		SetName(uniqueTestValue(t, "exclusive-preserve")).
+		SetPlatform(service.PlatformAnthropic).
+		SetStatus(service.StatusActive).
+		SetSubscriptionType(service.SubscriptionTypeStandard).
+		Save(ctx)
+	require.NoError(t, err)
+	otherGroup, err := client.Group.Create().
+		SetName(uniqueTestValue(t, "other-preserve")).
+		SetPlatform(service.PlatformAnthropic).
+		SetStatus(service.StatusActive).
+		SetSubscriptionType(service.SubscriptionTypeStandard).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Group.UpdateOneID(exclusiveGroup.ID).SetIsExclusive(true).Save(ctx)
+	require.NoError(t, err)
+	key := &service.APIKey{
+		UserID:  user.ID,
+		GroupID: &exclusiveGroup.ID,
+		Key:     uniqueTestValue(t, "sk-owner"),
+		Name:    "owner",
+		Status:  service.StatusActive,
+	}
+	require.NoError(t, apiKeyRepo.Create(ctx, key))
+	require.NoError(t, userRepo.AddGroupToAllowedGroups(ctx, user.ID, otherGroup.ID))
+
+	userIn := userEntityToService(user)
+	userIn.AllowedGroups = nil
+	require.NoError(t, userRepo.Update(ctx, userIn, service.UserUpdateFields{AllowedGroups: true}))
+
+	count, err := client.UserAllowedGroup.Query().
+		Where(userallowedgroup.UserIDEQ(user.ID), userallowedgroup.GroupIDEQ(exclusiveGroup.ID)).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	count, err = client.UserAllowedGroup.Query().
+		Where(userallowedgroup.UserIDEQ(user.ID), userallowedgroup.GroupIDEQ(otherGroup.ID)).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	keys, err := client.APIKey.Query().
+		Where(apikey.UserIDEQ(user.ID), apikey.GroupIDEQ(exclusiveGroup.ID), apikey.StatusEQ(service.StatusActive), apikey.DeletedAtIsNil()).
+		All(ctx)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+}
+
+func TestRemoveUserAllowedGroupPreservesExclusiveGroupUsedByActiveKey(t *testing.T) {
+	ctx := context.Background()
+	tx := testEntTx(t)
+	client := tx.Client()
+	userRepo := newUserRepositoryWithSQL(client, tx)
+	apiKeyRepo := newAPIKeyRepositoryWithSQL(client, tx)
+
+	user, err := client.User.Create().
+		SetEmail(uniqueTestValue(t, "remove-allowed-owner") + "@example.com").
+		SetPasswordHash("test-password-hash").
+		SetRole(service.RoleUser).
+		SetStatus(service.StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+	group, err := client.Group.Create().
+		SetName(uniqueTestValue(t, "remove-allowed-exclusive")).
+		SetPlatform(service.PlatformAnthropic).
+		SetStatus(service.StatusActive).
+		SetSubscriptionType(service.SubscriptionTypeStandard).
+		SetIsExclusive(true).
+		Save(ctx)
+	require.NoError(t, err)
+	key := &service.APIKey{
+		UserID:  user.ID,
+		GroupID: &group.ID,
+		Key:     uniqueTestValue(t, "sk-remove-allowed"),
+		Name:    "owner",
+		Status:  service.StatusActive,
+	}
+	require.NoError(t, apiKeyRepo.Create(ctx, key))
+	require.NoError(t, userRepo.RemoveGroupFromUserAllowedGroups(ctx, user.ID, group.ID))
+
+	count, err := client.UserAllowedGroup.Query().
+		Where(userallowedgroup.UserIDEQ(user.ID), userallowedgroup.GroupIDEQ(group.ID)).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	_, err = client.APIKey.UpdateOneID(key.ID).SetStatus(service.StatusDisabled).Save(ctx)
+	require.NoError(t, err)
+	require.NoError(t, userRepo.RemoveGroupFromUserAllowedGroups(ctx, user.ID, group.ID))
+	count, err = client.UserAllowedGroup.Query().
+		Where(userallowedgroup.UserIDEQ(user.ID), userallowedgroup.GroupIDEQ(group.ID)).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
 }

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/group"
 	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	"github.com/Wei-Shaw/sub2api/ent/user"
+	"github.com/Wei-Shaw/sub2api/ent/userallowedgroup"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
 
@@ -42,8 +43,75 @@ func (r *apiKeyRepository) activeQuery() *dbent.APIKeyQuery {
 	return r.client.APIKey.Query().Where(apikey.DeletedAtIsNil())
 }
 
+// ensureExclusiveGroupAuthorization serializes the group lookup with an API
+// key write and creates the owner authorization when the target is an
+// exclusive standard group.  Keeping this at the repository boundary closes
+// callers that do not pass through APIKeyService's permission check.
+func ensureExclusiveGroupAuthorization(ctx context.Context, client *dbent.Client, userID, groupID int64) error {
+	if client == nil || userID <= 0 || groupID <= 0 {
+		return nil
+	}
+	groupQuery := client.Group.Query().Where(group.IDEQ(groupID))
+	if client.Driver().Dialect() == dialect.Postgres {
+		groupQuery = groupQuery.ForUpdate()
+	}
+	target, err := groupQuery.Only(ctx)
+	if err != nil {
+		if dbent.IsNotFound(err) {
+			return service.ErrGroupNotFound
+		}
+		return err
+	}
+	if !target.IsExclusive || target.SubscriptionType == service.SubscriptionTypeSubscription {
+		return nil
+	}
+	if err := client.UserAllowedGroup.Create().
+		SetUserID(userID).
+		SetGroupID(groupID).
+		OnConflictColumns(userallowedgroup.FieldUserID, userallowedgroup.FieldGroupID).
+		DoNothing().
+		Exec(ctx); err != nil && !isSQLNoRowsError(err) {
+		return err
+	}
+	return nil
+}
+
+// beginAPIKeyWriteTx starts a transaction only when the caller has not
+// already supplied one.  Some repository instances are constructed with an
+// ent transaction client (notably integration tests), in which case Ent
+// returns ErrTxStarted and the injected client is reused.
+func beginAPIKeyWriteTx(ctx context.Context, client *dbent.Client) (context.Context, *dbent.Client, *dbent.Tx, error) {
+	if tx := dbent.TxFromContext(ctx); tx != nil {
+		return ctx, tx.Client(), nil, nil
+	}
+	tx, err := client.Tx(ctx)
+	if errors.Is(err, dbent.ErrTxStarted) {
+		return ctx, client, nil, nil
+	}
+	if err != nil {
+		return ctx, nil, nil, err
+	}
+	txCtx := dbent.NewTxContext(ctx, tx)
+	return txCtx, tx.Client(), tx, nil
+}
+
 func (r *apiKeyRepository) Create(ctx context.Context, key *service.APIKey) error {
-	builder := r.client.APIKey.Create().
+	if key == nil {
+		return errors.New("api key is nil")
+	}
+	txCtx, client, tx, err := beginAPIKeyWriteTx(ctx, r.client)
+	if err != nil {
+		return err
+	}
+	if tx != nil {
+		defer func() { _ = tx.Rollback() }()
+	}
+	if key.GroupID != nil {
+		if err := ensureExclusiveGroupAuthorization(txCtx, client, key.UserID, *key.GroupID); err != nil {
+			return err
+		}
+	}
+	builder := client.APIKey.Create().
 		SetUserID(key.UserID).
 		SetKey(key.Key).
 		SetName(key.Name).
@@ -64,14 +132,22 @@ func (r *apiKeyRepository) Create(ctx context.Context, key *service.APIKey) erro
 		builder.SetIPBlacklist(key.IPBlacklist)
 	}
 
-	created, err := builder.Save(ctx)
+	created, err := builder.Save(txCtx)
 	if err == nil {
 		key.ID = created.ID
 		key.LastUsedAt = created.LastUsedAt
 		key.CreatedAt = created.CreatedAt
 		key.UpdatedAt = created.UpdatedAt
 	}
-	return translatePersistenceError(err, nil, service.ErrAPIKeyExists)
+	if err != nil {
+		return translatePersistenceError(err, nil, service.ErrAPIKeyExists)
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *apiKeyRepository) GetByID(ctx context.Context, id int64) (*service.APIKey, error) {
@@ -242,6 +318,9 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 }
 
 func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey, fields service.APIKeyUpdateFields) error {
+	if key == nil {
+		return errors.New("api key is nil")
+	}
 	// 空掩码代表调用方不改任何列，直接返回，避免产生一次无意义的整行写。
 	if fields.IsEmpty() {
 		return nil
@@ -252,7 +331,22 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey, fiel
 	// 则会更新已删除的记录。
 	// 这里选择 Update().Where()，确保只有未软删除记录能被更新。
 	// 同时显式设置 updated_at，避免二次查询带来的并发可见性问题。
+	txCtx := ctx
 	client := clientFromContext(ctx, r.client)
+	var tx *dbent.Tx
+	if fields.GroupID && key.GroupID != nil {
+		var err error
+		txCtx, client, tx, err = beginAPIKeyWriteTx(ctx, r.client)
+		if err != nil {
+			return err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+		}
+		if err := ensureExclusiveGroupAuthorization(txCtx, client, key.UserID, *key.GroupID); err != nil {
+			return err
+		}
+	}
 	now := time.Now()
 	builder := client.APIKey.Update().
 		Where(apikey.IDEQ(key.ID), apikey.DeletedAtIsNil()).
@@ -329,7 +423,7 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey, fiel
 		}
 	}
 
-	affected, err := builder.Save(ctx)
+	affected, err := builder.Save(txCtx)
 	if err != nil {
 		return err
 	}
@@ -340,6 +434,11 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey, fiel
 
 	// 使用同一时间戳回填，避免并发删除导致二次查询失败。
 	key.UpdatedAt = now
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -717,12 +816,29 @@ func (r *apiKeyRepository) ClearGroupIDByGroupID(ctx context.Context, groupID in
 
 // UpdateGroupIDByUserAndGroup 将用户下绑定 oldGroupID 的所有 Key 迁移到 newGroupID
 func (r *apiKeyRepository) UpdateGroupIDByUserAndGroup(ctx context.Context, userID, oldGroupID, newGroupID int64) (int64, error) {
-	client := clientFromContext(ctx, r.client)
+	txCtx, client, tx, err := beginAPIKeyWriteTx(ctx, r.client)
+	if err != nil {
+		return 0, err
+	}
+	if tx != nil {
+		defer func() { _ = tx.Rollback() }()
+	}
+	if err := ensureExclusiveGroupAuthorization(txCtx, client, userID, newGroupID); err != nil {
+		return 0, err
+	}
 	n, err := client.APIKey.Update().
 		Where(apikey.UserIDEQ(userID), apikey.GroupIDEQ(oldGroupID), apikey.DeletedAtIsNil()).
 		SetGroupID(newGroupID).
-		Save(ctx)
-	return int64(n), err
+		Save(txCtx)
+	if err != nil {
+		return 0, err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return 0, err
+		}
+	}
+	return int64(n), nil
 }
 
 // CountByGroupID 获取分组的 API Key 数量

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/ent/apikey"
 	"github.com/Wei-Shaw/sub2api/ent/group"
+	"github.com/Wei-Shaw/sub2api/ent/userallowedgroup"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -244,11 +246,34 @@ func (r *groupRepository) GetByIDLite(ctx context.Context, id int64) (*service.G
 }
 
 func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) error {
+	if groupIn == nil {
+		return errors.New("group is nil")
+	}
+
+	// Group configuration and the authorization rows required by an exclusive
+	// group must commit together.  Reuse a caller-owned transaction when one is
+	// already present; otherwise own the transaction here.
+	txCtx := ctx
+	txClient := clientFromContext(ctx, r.client)
+	var ownedTx *dbent.Tx
+	if dbent.TxFromContext(ctx) == nil {
+		tx, txErr := r.client.Tx(ctx)
+		switch {
+		case txErr == nil:
+			ownedTx = tx
+			defer func() { _ = ownedTx.Rollback() }()
+			txClient = tx.Client()
+			txCtx = dbent.NewTxContext(ctx, tx)
+		case !errors.Is(txErr, dbent.ErrTxStarted):
+			return txErr
+		}
+	}
+
 	modelPricing, err := json.Marshal(groupIn.ModelPricing)
 	if err != nil {
 		return fmt.Errorf("marshal group model pricing: %w", err)
 	}
-	builder := r.client.Group.UpdateOneID(groupIn.ID).
+	builder := txClient.Group.UpdateOneID(groupIn.ID).
 		SetName(groupIn.Name).
 		SetDescription(groupIn.Description).
 		SetPlatform(groupIn.Platform).
@@ -396,13 +421,56 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 	// 处理 SupportedModelScopes（始终设置，空数组表示不限制）
 	builder = builder.SetSupportedModelScopes(groupIn.SupportedModelScopes)
 
-	updated, err := builder.Save(ctx)
+	updated, err := builder.Save(txCtx)
 	if err != nil {
 		return translatePersistenceError(err, service.ErrGroupNotFound, service.ErrGroupExists)
 	}
 	groupIn.UpdatedAt = updated.UpdatedAt
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
+
+	// An exclusive standard group can only be used by users explicitly listed
+	// in user_allowed_groups.  Repair/maintain that invariant for every
+	// non-deleted API key already bound to the group, including the transition
+	// from public to exclusive.  The insert is idempotent and lives in the same
+	// transaction as the group update.
+	if groupIn.IsExclusive && !groupIn.IsSubscriptionType() {
+		keys, keyErr := txClient.APIKey.Query().
+			Where(
+				apikey.GroupIDEQ(groupIn.ID),
+				apikey.StatusEQ(service.StatusActive),
+				apikey.DeletedAtIsNil(),
+			).
+			All(txCtx)
+		if keyErr != nil {
+			return keyErr
+		}
+		seenUsers := make(map[int64]struct{}, len(keys))
+		creates := make([]*dbent.UserAllowedGroupCreate, 0, len(keys))
+		for _, key := range keys {
+			if _, seen := seenUsers[key.UserID]; seen {
+				continue
+			}
+			seenUsers[key.UserID] = struct{}{}
+			creates = append(creates, txClient.UserAllowedGroup.Create().
+				SetUserID(key.UserID).
+				SetGroupID(groupIn.ID))
+		}
+		if len(creates) > 0 {
+			if err := txClient.UserAllowedGroup.CreateBulk(creates...).
+				OnConflictColumns(userallowedgroup.FieldUserID, userallowedgroup.FieldGroupID).
+				DoNothing().
+				Exec(txCtx); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := enqueueSchedulerOutbox(txCtx, txAwareSQLExecutor(txCtx, r.sql, txClient), service.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group update failed: group=%d err=%v", groupIn.ID, err)
+	}
+	if ownedTx != nil {
+		if err := ownedTx.Commit(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
 
+	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 )
 
@@ -1401,23 +1402,137 @@ func (r *userRepository) AddGroupToAllowedGroups(ctx context.Context, userID int
 }
 
 func (r *userRepository) RemoveGroupFromAllowedGroups(ctx context.Context, groupID int64) (int64, error) {
-	// 仅操作 user_allowed_groups 联接表，legacy users.allowed_groups 列已弃用。
-	affected, err := r.client.UserAllowedGroup.Delete().
-		Where(userallowedgroup.GroupIDEQ(groupID)).
-		Exec(ctx)
+	// The group row is the serialization point shared with API-key writes:
+	// deleting an authorization must not race a key being moved into an
+	// exclusive group.  Reuse a caller transaction when present, otherwise own
+	// one for the lookup and delete.
+	txCtx := ctx
+	client := clientFromContext(ctx, r.client)
+	var tx *dbent.Tx
+	if dbent.TxFromContext(ctx) == nil {
+		var err error
+		tx, err = r.client.Tx(ctx)
+		if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
+			return 0, err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+			client = tx.Client()
+			txCtx = dbent.NewTxContext(ctx, tx)
+		}
+	}
+
+	// Preserve permissions required by active, undeleted keys only for
+	// exclusive standard groups.  Public/subscription groups do not use this
+	// authorization gate and retain the historical replacement semantics.
+	groupQuery := client.Group.Query().Where(dbgroup.IDEQ(groupID))
+	if client.Driver().Dialect() == dialect.Postgres {
+		groupQuery = groupQuery.ForUpdate()
+	}
+	target, lookupErr := groupQuery.Only(txCtx)
+	protectedUsers := []int64(nil)
+	if lookupErr == nil && target.IsExclusive && target.SubscriptionType != service.SubscriptionTypeSubscription {
+		protectedKeyRows, keyErr := client.APIKey.Query().
+			Where(
+				apikey.GroupIDEQ(groupID),
+				apikey.StatusEQ(service.StatusActive),
+				apikey.DeletedAtIsNil(),
+			).
+			Select(apikey.FieldUserID).
+			All(txCtx)
+		if keyErr != nil {
+			lookupErr = keyErr
+		} else {
+			protectedUsers = make([]int64, 0, len(protectedKeyRows))
+			seen := make(map[int64]struct{}, len(protectedKeyRows))
+			for _, row := range protectedKeyRows {
+				if _, ok := seen[row.UserID]; ok {
+					continue
+				}
+				seen[row.UserID] = struct{}{}
+				protectedUsers = append(protectedUsers, row.UserID)
+			}
+		}
+	}
+	if lookupErr != nil && !dbent.IsNotFound(lookupErr) {
+		return 0, lookupErr
+	}
+
+	deleteQuery := client.UserAllowedGroup.Delete().Where(userallowedgroup.GroupIDEQ(groupID))
+	if len(protectedUsers) > 0 {
+		deleteQuery = deleteQuery.Where(userallowedgroup.UserIDNotIn(protectedUsers...))
+	}
+	affected, err := deleteQuery.Exec(txCtx)
 	if err != nil {
 		return 0, err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return 0, err
+		}
 	}
 	return int64(affected), nil
 }
 
 // RemoveGroupFromUserAllowedGroups 移除单个用户的指定分组权限
 func (r *userRepository) RemoveGroupFromUserAllowedGroups(ctx context.Context, userID int64, groupID int64) error {
+	// Keep the same invariant as bulk authorization replacement: an active,
+	// undeleted key owner must retain access to an exclusive standard group.
+	// ReplaceUserGroup calls this after moving keys, while other administrative
+	// paths may call it directly.
+	txCtx := ctx
 	client := clientFromContext(ctx, r.client)
+	var tx *dbent.Tx
+	if dbent.TxFromContext(ctx) == nil {
+		var err error
+		tx, err = r.client.Tx(ctx)
+		if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
+			return err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+			client = tx.Client()
+			txCtx = dbent.NewTxContext(ctx, tx)
+		}
+	}
+
+	groupQuery := client.Group.Query().Where(dbgroup.IDEQ(groupID))
+	if client.Driver().Dialect() == dialect.Postgres {
+		groupQuery = groupQuery.ForUpdate()
+	}
+	target, lookupErr := groupQuery.Only(txCtx)
+	if lookupErr != nil && !dbent.IsNotFound(lookupErr) {
+		return lookupErr
+	}
+	if lookupErr == nil && target.IsExclusive && target.SubscriptionType != service.SubscriptionTypeSubscription {
+		keyExists, err := client.APIKey.Query().
+			Where(
+				apikey.UserIDEQ(userID),
+				apikey.GroupIDEQ(groupID),
+				apikey.StatusEQ(service.StatusActive),
+				apikey.DeletedAtIsNil(),
+			).
+			Exist(txCtx)
+		if err != nil {
+			return err
+		}
+		if keyExists {
+			return nil
+		}
+	}
+
 	_, err := client.UserAllowedGroup.Delete().
 		Where(userallowedgroup.UserIDEQ(userID), userallowedgroup.GroupIDEQ(groupID)).
-		Exec(ctx)
-	return err
+		Exec(txCtx)
+	if err != nil {
+		return err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *userRepository) GetFirstAdmin(ctx context.Context) (*service.User, error) {
@@ -1471,7 +1586,7 @@ func (r *userRepository) loadAllowedGroups(ctx context.Context, userIDs []int64)
 // 仅操作 user_allowed_groups 联接表，legacy users.allowed_groups 列已弃用。
 func (r *userRepository) syncUserAllowedGroupsWithClient(ctx context.Context, client *dbent.Client, userID int64, groupIDs []int64) error {
 	if client == nil {
-		return nil
+		return errors.New("ent client is required to synchronize user allowed groups")
 	}
 
 	existingRows, err := client.UserAllowedGroup.Query().
@@ -1487,6 +1602,23 @@ func (r *userRepository) syncUserAllowedGroupsWithClient(ctx context.Context, cl
 			continue
 		}
 		desired[id] = struct{}{}
+	}
+
+	// Never remove an exclusive standard group while the user still owns a
+	// non-deleted API key bound to it.  AllowedGroups updates are replacement
+	// semantics, so preserving these rows here prevents a stale admin form (or
+	// a concurrent snapshot) from creating a key/group authorization gap.
+	boundKeys, err := client.APIKey.Query().
+		Where(apikey.UserIDEQ(userID), apikey.StatusEQ(service.StatusActive), apikey.DeletedAtIsNil(), apikey.GroupIDNotNil(),
+			apikey.HasGroupWith(dbgroup.IsExclusiveEQ(true), dbgroup.SubscriptionTypeNEQ(service.SubscriptionTypeSubscription))).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, key := range boundKeys {
+		if key.GroupID != nil {
+			desired[*key.GroupID] = struct{}{}
+		}
 	}
 
 	existing := make(map[int64]struct{}, len(existingRows))

--- a/backend/internal/service/admin_group.go
+++ b/backend/internal/service/admin_group.go
@@ -1209,19 +1209,15 @@ func (s *adminServiceImpl) AdminUpdateAPIKeyGroupID(ctx context.Context, keyID i
 
 		// 专属标准分组：使用事务保证「添加分组权限」与「更新 API Key」的原子性
 		if group.IsExclusive && !group.IsSubscriptionType() {
-			opCtx := ctx
-			var tx *dbent.Tx
 			if s.entClient == nil {
-				logger.LegacyPrintf("service.admin", "Warning: entClient is nil, skipping transaction protection for exclusive group binding")
-			} else {
-				var txErr error
-				tx, txErr = s.entClient.Tx(ctx)
-				if txErr != nil {
-					return nil, fmt.Errorf("begin transaction: %w", txErr)
-				}
-				defer func() { _ = tx.Rollback() }()
-				opCtx = dbent.NewTxContext(ctx, tx)
+				return nil, fmt.Errorf("entClient is nil, cannot atomically bind an exclusive group")
 			}
+			tx, txErr := s.entClient.Tx(ctx)
+			if txErr != nil {
+				return nil, fmt.Errorf("begin transaction: %w", txErr)
+			}
+			defer func() { _ = tx.Rollback() }()
+			opCtx := dbent.NewTxContext(ctx, tx)
 
 			if addErr := s.userRepo.AddGroupToAllowedGroups(opCtx, apiKey.UserID, gid); addErr != nil {
 				return nil, fmt.Errorf("add group to user allowed groups: %w", addErr)
@@ -1229,10 +1225,8 @@ func (s *adminServiceImpl) AdminUpdateAPIKeyGroupID(ctx context.Context, keyID i
 			if err := s.apiKeyRepo.Update(opCtx, apiKey, APIKeyUpdateFields{GroupID: true}); err != nil {
 				return nil, fmt.Errorf("update api key: %w", err)
 			}
-			if tx != nil {
-				if err := tx.Commit(); err != nil {
-					return nil, fmt.Errorf("commit transaction: %w", err)
-				}
+			if err := tx.Commit(); err != nil {
+				return nil, fmt.Errorf("commit transaction: %w", err)
 			}
 
 			result.AutoGrantedGroupAccess = true

--- a/backend/internal/service/admin_service_apikey_test.go
+++ b/backend/internal/service/admin_service_apikey_test.go
@@ -455,19 +455,13 @@ func TestAdminService_AdminUpdateAPIKeyGroupID_ExclusiveGroup_AddsAllowedGroup(t
 	cache := &authCacheInvalidatorStub{}
 	svc := &adminServiceImpl{apiKeyRepo: apiKeyRepo, groupRepo: groupRepo, userRepo: userRepo, authCacheInvalidator: cache}
 
-	got, err := svc.AdminUpdateAPIKeyGroupID(context.Background(), 1, int64Ptr(10))
-	require.NoError(t, err)
-	require.NotNil(t, got.APIKey.GroupID)
-	require.Equal(t, int64(10), *got.APIKey.GroupID)
-	// 验证 AddGroupToAllowedGroups 被调用，且参数正确
-	require.True(t, userRepo.addGroupCalled)
-	require.Equal(t, int64(42), userRepo.addedUserID)
-	require.Equal(t, int64(10), userRepo.addedGroupID)
-	// 验证 result 标记了自动授权
-	require.True(t, got.AutoGrantedGroupAccess)
-	require.NotNil(t, got.GrantedGroupID)
-	require.Equal(t, int64(10), *got.GrantedGroupID)
-	require.Equal(t, "Exclusive", got.GrantedGroupName)
+	_, err := svc.AdminUpdateAPIKeyGroupID(context.Background(), 1, int64Ptr(10))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "entClient is nil")
+	// An exclusive binding must never fall back to two non-atomic repository
+	// writes when the service has not been given a transaction-capable client.
+	require.False(t, userRepo.addGroupCalled)
+	require.Nil(t, apiKeyRepo.updated)
 }
 
 func TestAdminService_AdminUpdateAPIKeyGroupID_NonExclusiveGroup_NoAllowedGroupUpdate(t *testing.T) {
@@ -542,12 +536,12 @@ func TestAdminService_AdminUpdateAPIKeyGroupID_ExclusiveGroup_AllowedGroupAddFai
 	userRepo := &userRepoStubForGroupUpdate{addGroupErr: errors.New("db error")}
 	svc := &adminServiceImpl{apiKeyRepo: apiKeyRepo, groupRepo: groupRepo, userRepo: userRepo}
 
-	// 严格模式：AddGroupToAllowedGroups 失败时，整体操作报错
+	// Without a transaction client the operation must fail before attempting
+	// either side of the authorization/key update.
 	_, err := svc.AdminUpdateAPIKeyGroupID(context.Background(), 1, int64Ptr(10))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "add group to user allowed groups")
-	require.True(t, userRepo.addGroupCalled)
-	// apiKey 不应被更新
+	require.Contains(t, err.Error(), "entClient is nil")
+	require.False(t, userRepo.addGroupCalled)
 	require.Nil(t, apiKeyRepo.updated)
 }
 


### PR DESCRIPTION
## Summary
- atomically authorize API-key owners when binding keys to exclusive standard groups
- backfill owners when a group becomes exclusive
- prevent AllowedGroups replacement/removal from dropping authorization required by active keys
- keep ReplaceUserGroup atomic and invalidate authentication caches after changes

## Validation
- `go test ./internal/repository -run 'AllowedGroups|APIKey|Group|User' -count=1`
- `go test ./internal/service -run 'Admin.*APIKey|Group|AllowedGroups' -count=1`
- `go build ./cmd/server`
