### PR TITLE
fix: normalize and safely forward Responses Lite requests

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -83,7 +83,7 @@ var openaiAllowedHeaders = map[string]bool{
 	"x-codex-turn-state":      true,
 	"x-codex-turn-metadata":   true,
 	"x-codex-window-id":       true,
-	responsesLiteHeaderKey:    true,
+	responsesLiteHeaderKey:    false,
 }
 
 // OpenAI passthrough allowed headers whitelist.
@@ -102,7 +102,7 @@ var openaiPassthroughAllowedHeaders = map[string]bool{
 	"x-codex-turn-state":      true,
 	"x-codex-turn-metadata":   true,
 	"x-codex-window-id":       true,
-	responsesLiteHeaderKey:    true,
+	responsesLiteHeaderKey:    false,
 }
 
 // codex_cli_only 拒绝时记录的请求头白名单（仅用于诊断日志，不参与上游透传）

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -488,12 +488,20 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 	buildUpstreamRequest := func(requestBody []byte) (*http.Request, error) {
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 		defer releaseUpstreamCtx()
+		upstreamBody := requestBody
+		if account.Platform != PlatformGrok && isOpenAIResponsesLiteWebSocketPayload(payload) {
+			normalizedBody, _, normalizeErr := normalizeOpenAIResponsesLitePayloadForAccount(requestBody, account)
+			if normalizeErr != nil {
+				return nil, fmt.Errorf("normalize responses Lite upstream payload: %w", normalizeErr)
+			}
+			upstreamBody = normalizedBody
+		}
 		var upstreamReq *http.Request
 		var buildErr error
 		if account.Platform == PlatformGrok {
-			upstreamReq, buildErr = buildGrokResponsesRequest(upstreamCtx, c, account, requestBody, token, grokCacheIdentity, s.cfg, s.settingService)
+			upstreamReq, buildErr = buildGrokResponsesRequest(upstreamCtx, c, account, upstreamBody, token, grokCacheIdentity, s.cfg, s.settingService)
 		} else {
-			upstreamReq, buildErr = s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, requestBody, token)
+			upstreamReq, buildErr = s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, upstreamBody, token)
 		}
 		if buildErr != nil {
 			return nil, buildErr


### PR DESCRIPTION
## Problem
OpenAI Codex Responses Lite requests returned 400 unsupported_value because the gateway forwarded X-OpenAI-Internal-Codex-Responses-Lite: true on ordinary /v1/responses requests without guaranteeing reasoning.context = "all_turns" upstream.

## Fix
- Normalize the final body before the WebSocket-to-HTTP bridge adds the Lite header.
- Stop forwarding the internal Lite header on ordinary HTTP passthrough requests where the Lite payload contract cannot be guaranteed.
- Preserve the Lite normalization path for explicitly handled Responses Lite requests.

## Production validation
Reproduced on Sub2API v0.2.0-goforai-r2-alpha with upstream errors identifying param=reasoning.context, then deployed as sub2api:0.2.0-goforai-r4-lite-header-fix. The production health endpoint is healthy and the new container has no matching Lite errors after startup.

## Testing
- git diff --check passes.
- Production Docker build completed successfully.
- The local Windows workspace does not have the Go toolchain, so the Go test suite was not run locally.