### PR TITLE
fix(openai): enable Astra messages prompt caching

### DIFF
--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -494,6 +494,66 @@ func TestForwardAsAnthropic_AutoDerivesPromptCacheKeyWhenMessagesDispatchHasNoSe
 	require.Equal(t, generateSessionUUID(isolateOpenAISessionID(0, cacheKey)), upstream.lastReq.Header.Get("session_id"))
 }
 
+func TestForwardAsAnthropic_GPT6AstraPromptCacheIdentityStableAcrossAppendedTurns(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	for _, mappedModel := range []string{"gpt-6-astra", "gpt-6"} {
+		mappedModel := mappedModel
+		t.Run(mappedModel, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := &httpUpstreamRecorder{responses: []*http.Response{
+				openAICompatSSECompletedResponse("resp_gpt6_first", mappedModel),
+				openAICompatSSECompletedResponse("resp_gpt6_second", mappedModel),
+			}}
+			svc := &OpenAIGatewayService{
+				httpUpstream: upstream,
+				cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+			}
+			account := &Account{
+				ID:          6615,
+				Name:        "openai-apikey",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "sk-test",
+					"base_url": "https://api.openai.com/v1",
+				},
+			}
+
+			bodies := [][]byte{
+				[]byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"system":"You are helpful.","messages":[{"role":"user","content":"Inspect the repository"}],"stream":false}`),
+				[]byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"system":"You are helpful.","messages":[{"role":"user","content":"Inspect the repository"},{"role":"assistant","content":"Done."},{"role":"user","content":"Run the tests"}],"stream":false}`),
+			}
+			for _, body := range bodies {
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+				c.Request.Header.Set("Content-Type", "application/json")
+
+				result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", mappedModel)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+
+			require.Len(t, upstream.bodies, 2)
+			require.Len(t, upstream.requests, 2)
+			require.Equal(t, mappedModel, gjson.GetBytes(upstream.bodies[0], "model").String())
+			require.Equal(t, mappedModel, gjson.GetBytes(upstream.bodies[1], "model").String())
+			firstCacheKey := gjson.GetBytes(upstream.bodies[0], "prompt_cache_key").String()
+			secondCacheKey := gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").String()
+			require.NotEmpty(t, firstCacheKey)
+			require.Equal(t, firstCacheKey, secondCacheKey)
+			firstSessionID := upstream.requests[0].Header.Get("session_id")
+			secondSessionID := upstream.requests[1].Header.Get("session_id")
+			require.NotEmpty(t, firstSessionID)
+			require.Equal(t, firstSessionID, secondSessionID)
+		})
+	}
+}
+
 func TestForwardAsAnthropic_DoesNotAutoDerivePromptCacheKeyForNonCodexModel(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/service/openai_compat_prompt_cache_key.go
+++ b/backend/internal/service/openai_compat_prompt_cache_key.go
@@ -13,6 +13,12 @@ const compatPromptCacheKeyPrefix = "compat_cc_"
 
 func shouldAutoInjectPromptCacheKeyForCompat(model string) bool {
 	trimmed := strings.TrimSpace(strings.ToLower(model))
+	canonical := canonicalizeOpenAIModelAliasSpelling(trimmed)
+	// GPT-6 is the public alias for Astra. Keep this deliberately scoped to
+	// Astra so other GPT-6 families do not inherit Messages compatibility state.
+	if canonical == "gpt-6" || canonical == "gpt-6-astra" {
+		return true
+	}
 	// 仅对 Responses 兼容路径支持的 GPT-5 族开启自动注入，避免 normalizeCodexModel
 	// 的默认兜底把任意模型（如 gpt-4o、claude-*）误判为 gpt-5.4。
 	if !strings.Contains(trimmed, "gpt-5") && !strings.Contains(trimmed, "codex") {
@@ -21,7 +27,6 @@ func shouldAutoInjectPromptCacheKeyForCompat(model string) bool {
 	normalized := strings.TrimSpace(strings.ToLower(normalizeCodexModel(trimmed)))
 	return strings.HasPrefix(normalized, "gpt-5") || strings.Contains(normalized, "codex")
 }
-
 func deriveCompatPromptCacheKey(req *apicompat.ChatCompletionsRequest, mappedModel string) string {
 	if req == nil {
 		return ""

--- a/backend/internal/service/openai_compat_prompt_cache_key_test.go
+++ b/backend/internal/service/openai_compat_prompt_cache_key_test.go
@@ -26,6 +26,34 @@ func TestShouldAutoInjectPromptCacheKeyForCompat(t *testing.T) {
 	require.False(t, shouldAutoInjectPromptCacheKeyForCompat("gpt-4o"))
 }
 
+func TestShouldAutoInjectPromptCacheKeyForCompat_GPT6AstraForms(t *testing.T) {
+	for _, model := range []string{
+		"gpt-6",
+		"gpt-6-astra",
+		"openai/gpt-6",
+		"openai/gpt-6-astra",
+		"OPENAI/GPT-6_ASTRA",
+		"provider/gpt-6-astra",
+	} {
+		require.True(t, shouldAutoInjectPromptCacheKeyForCompat(model), model)
+	}
+
+	for _, model := range []string{
+		"gpt-6-terra",
+		"gpt-6.1",
+		"gpt-6-astra-preview",
+		"gpt-6-astra-unrelated-name",
+		"gpt-6-astra-2026-09-01",
+		"gpt-6-astra-2026-09-01-extra",
+		"gpt-6-astra-v",
+		"gpt-6-astra-v1.beta",
+		"claude-sonnet-4-5",
+		"gpt-4o",
+	} {
+		require.False(t, shouldAutoInjectPromptCacheKeyForCompat(model), model)
+	}
+}
+
 func TestDeriveCompatPromptCacheKey_StableAcrossLaterTurns(t *testing.T) {
 	base := &apicompat.ChatCompletionsRequest{
 		Model: "gpt-5.4",


### PR DESCRIPTION
## 问题
OpenAI 兼容的 `/v1/messages` 路径仅为 GPT-5/Codex 模型启用稳定缓存身份，导致 `gpt-6-astra` 与 `gpt-6` 映射在转换到 Responses 时没有自动生成 `prompt_cache_key` 和 `session_id`。

## 根因
缓存身份开关在模型归一化前使用 GPT-5/Codex 家族预筛选，因此 Astra 的精确模型名与公开别名未进入已有的 Messages 缓存链路。

## 改动
- 将精确的 `gpt-6-astra` 和 `gpt-6` 别名纳入已有 Messages→Responses 缓存身份逻辑。
- 支持平台前缀、大小写和下划线规范化，同时拒绝其他 GPT-6 家族和未知后缀。
- 补充真实转发回归测试，验证追加对话轮次后 `prompt_cache_key` 与 `session_id` 保持稳定。

## 验证
已验证：
- 后端 unit 全量测试通过。
- 后端 integration 全量测试通过。
- 后端代码质量检查报告 0 个问题。
- 后端漏洞调用扫描未发现已调用漏洞。
- 后端构建通过。
- 前端规范检查、类型检查与关键测试通过（13 个文件，168 个测试）。
- 前后端完整构建通过。
- Linux 兼容的部署与入口代理脚本检查通过；macOS 专用容器脚本仅完成语法检查。
- 差异格式检查通过。
- 独立代码审查通过。

重复检查：开放的 #6572 涵盖 Astra 模型目录、归一化、能力和计价，但未修改 Messages 缓存身份开关，本改动与其互补。

Fixes #6615