### PR TITLE
feat(openai): allow none as reasoning mapping source

### DIFF
--- a/backend/internal/service/openai_reasoning_effort_policy.go
+++ b/backend/internal/service/openai_reasoning_effort_policy.go
@@ -23,6 +23,13 @@ const (
 
 var openAIReasoningEffortValues = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
 
+func normalizeReasoningEffortMappingSource(raw string) string {
+	if strings.EqualFold(strings.TrimSpace(raw), "none") {
+		return "none"
+	}
+	return NormalizeMaxReasoningEffort(raw)
+}
+
 type openAIReasoningEffortPolicyContextKey struct{}
 type requestedReasoningEffortContextKey struct{}
 
@@ -220,7 +227,7 @@ func selectReasoningEffortMapping(mappings []ReasoningEffortMapping, from, reque
 	}
 	candidates := make([]candidate, 0, len(mappings))
 	for i, mapping := range mappings {
-		if NormalizeMaxReasoningEffort(mapping.From) != from {
+		if normalizeReasoningEffortMappingSource(mapping.From) != from {
 			continue
 		}
 		model := strings.TrimSpace(mapping.Model)
@@ -283,7 +290,7 @@ func NormalizeReasoningEffortMappings(platform string, raw []ReasoningEffortMapp
 	normalized := make([]ReasoningEffortMapping, 0, len(raw))
 	seen := make(map[string]struct{}, len(raw))
 	for i, mapping := range raw {
-		from := NormalizeMaxReasoningEffort(mapping.From)
+		from := normalizeReasoningEffortMappingSource(mapping.From)
 		to := NormalizeMaxReasoningEffort(mapping.To)
 		if from == "" || to == "" {
 			return nil, fmt.Errorf("reasoning effort mapping %d contains an empty or unknown value", i+1)
@@ -291,8 +298,15 @@ func NormalizeReasoningEffortMappings(platform string, raw []ReasoningEffortMapp
 		if len(from) > maxReasoningEffortValueLen || len(to) > maxReasoningEffortValueLen {
 			return nil, fmt.Errorf("reasoning effort mapping %d values cannot exceed %d characters", i+1, maxReasoningEffortValueLen)
 		}
-		if _, err := normalizeMaxReasoningEffortForPlatform(platform, from); err != nil {
-			return nil, fmt.Errorf("reasoning effort mapping %d source: %w", i+1, err)
+		if from != "none" {
+			if _, err := normalizeMaxReasoningEffortForPlatform(platform, from); err != nil {
+				return nil, fmt.Errorf("reasoning effort mapping %d source: %w", i+1, err)
+			}
+		} else if len(reasoningEffortValuesForPlatform(platform)) == 0 {
+			return nil, fmt.Errorf(
+				"reasoning effort mapping %d source: reasoning effort policy is only supported for platforms %q and %q",
+				i+1, PlatformOpenAI, PlatformComposite,
+			)
 		}
 		if _, err := normalizeMaxReasoningEffortForPlatform(platform, to); err != nil {
 			return nil, fmt.Errorf("reasoning effort mapping %d target: %w", i+1, err)
@@ -383,7 +397,7 @@ func ApplyOpenAIReasoningEffortPolicyFromContext(ctx context.Context, body []byt
 
 func mapReasoningEffort(raw string, mappings []ReasoningEffortMapping, requestModel string) (string, bool) {
 	value := strings.TrimSpace(raw)
-	canonical := NormalizeMaxReasoningEffort(value)
+	canonical := normalizeReasoningEffortMappingSource(value)
 	if canonical == "" {
 		return value, false
 	}

--- a/backend/internal/service/openai_reasoning_effort_policy_test.go
+++ b/backend/internal/service/openai_reasoning_effort_policy_test.go
@@ -152,10 +152,18 @@ func TestNormalizeReasoningEffortMappings(t *testing.T) {
 			require.ErrorContains(t, err, "only supported for platforms \"openai\" and \"composite\"")
 		}
 
-		_, err := NormalizeReasoningEffortMappings(PlatformOpenAI, []ReasoningEffortMapping{{From: "none", To: "low"}})
+		_, err := NormalizeReasoningEffortMappings(PlatformOpenAI, []ReasoningEffortMapping{{From: "ultra", To: "high"}})
 		require.ErrorContains(t, err, "empty or unknown")
+	})
 
-		_, err = NormalizeReasoningEffortMappings(PlatformOpenAI, []ReasoningEffortMapping{{From: "ultra", To: "high"}})
+	t.Run("allows none only as a source for OpenAI routes", func(t *testing.T) {
+		for _, platform := range []string{PlatformOpenAI, PlatformComposite} {
+			got, err := NormalizeReasoningEffortMappings(platform, []ReasoningEffortMapping{{From: " NONE ", To: "low"}})
+			require.NoError(t, err)
+			require.Equal(t, []ReasoningEffortMapping{{From: "none", To: "low"}}, got)
+		}
+
+		_, err := NormalizeReasoningEffortMappings(PlatformOpenAI, []ReasoningEffortMapping{{From: "low", To: "none"}})
 		require.ErrorContains(t, err, "empty or unknown")
 	})
 }
@@ -252,6 +260,15 @@ func TestApplyOpenAIReasoningEffortPolicy(t *testing.T) {
 		{name: "caps both shapes", body: `{"reasoning":{"effort":"high"},"reasoning_effort":"xhigh"}`, max: "low", path: "reasoning.effort", want: "low", changed: true},
 		{name: "maps before cap", body: `{"reasoning":{"effort":"MAX"}}`, max: "medium", mappings: []ReasoningEffortMapping{{From: "max", To: "xhigh"}}, path: "reasoning.effort", want: "medium", changed: true},
 		{name: "does not chain mappings", body: `{"reasoning_effort":"max"}`, mappings: []ReasoningEffortMapping{{From: "max", To: "xhigh"}, {From: "xhigh", To: "low"}}, path: "reasoning_effort", want: "xhigh", changed: true},
+		{name: "maps nested none", body: `{"reasoning":{"effort":"none"}}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low"}}, path: "reasoning.effort", want: "low", changed: true},
+		{name: "maps flat none", body: `{"reasoning_effort":"none"}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low"}}, path: "reasoning_effort", want: "low", changed: true},
+		{name: "none mapping runs before cap", body: `{"reasoning_effort":"none"}`, max: "low", mappings: []ReasoningEffortMapping{{From: "none", To: "high"}}, path: "reasoning_effort", want: "low", changed: true},
+		{name: "keeps none byte for byte without mappings", body: `{ "reasoning_effort": " none " }`, max: "low", path: "reasoning_effort", want: " none ", changed: false},
+		{name: "keeps none byte for byte when scope does not match", body: `{ "model":"o3", "reasoning_effort":"none" }`, mappings: []ReasoningEffortMapping{{From: "none", To: "low", MatchType: domain.ReasoningEffortMatchExact, Model: "gpt-5"}}, path: "reasoning_effort", want: "none", changed: false},
+		{name: "exact scope maps none", body: `{"model":"gpt-5","reasoning_effort":"none"}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low", MatchType: domain.ReasoningEffortMatchExact, Model: "gpt-5"}}, path: "reasoning_effort", want: "low", changed: true},
+		{name: "prefix scope maps none", body: `{"model":"gpt-5-mini","reasoning_effort":"none"}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low", MatchType: domain.ReasoningEffortMatchPrefix, Model: "gpt-5"}}, path: "reasoning_effort", want: "low", changed: true},
+		{name: "suffix scope maps none", body: `{"model":"gpt-5-mini","reasoning_effort":"none"}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low", MatchType: domain.ReasoningEffortMatchSuffix, Model: "mini"}}, path: "reasoning_effort", want: "low", changed: true},
+		{name: "global scope maps none", body: `{"model":"o3","reasoning_effort":"none"}`, mappings: []ReasoningEffortMapping{{From: "none", To: "low"}}, path: "reasoning_effort", want: "low", changed: true},
 		{name: "keeps unknown without mapping", body: `{"reasoning_effort":"future"}`, max: "low", path: "reasoning_effort", want: "future", changed: false},
 		{name: "keeps non string value", body: `{"reasoning_effort":{"level":"high"}}`, max: "low", path: "reasoning_effort.level", want: "high", changed: false},
 		{
@@ -398,6 +415,9 @@ func TestApplyOpenAIReasoningEffortPolicy(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.changed, changed)
+			if !tt.changed {
+				require.Equal(t, tt.body, string(got))
+			}
 			if tt.path != "" {
 				require.Equal(t, tt.want, gjson.GetBytes(got, tt.path).String())
 			}

--- a/frontend/src/components/admin/group/ReasoningEffortPolicyFields.vue
+++ b/frontend/src/components/admin/group/ReasoningEffortPolicyFields.vue
@@ -136,7 +136,7 @@
               <Select
                 :id="`${idPrefix}-${pair.id}-from`"
                 :model-value="pair.from"
-                :options="reasoningEffortOptions"
+                :options="reasoningEffortSourceOptions"
                 :placeholder="t('admin.groups.form.reasoningEffortFromPlaceholder')"
                 :error="showValidation && !!pairErrors(pair.id).from"
                 :aria-label="t('admin.groups.form.reasoningEffortFrom')"
@@ -217,6 +217,7 @@ import {
   createReasoningEffortMappingRow,
   normalizeReasoningEffortMatchType,
   reasoningEffortOptionsForPlatform,
+  reasoningEffortSourceOptionsForPlatform,
   reasoningEffortOverLimitDeny,
   reasoningEffortOverLimitDowngrade,
   validateReasoningEffortMappings,
@@ -242,6 +243,9 @@ const { t } = useI18n();
 const showValidation = ref(false);
 const reasoningEffortOptions = computed(() =>
   reasoningEffortOptionsForPlatform(props.platform),
+);
+const reasoningEffortSourceOptions = computed(() =>
+  reasoningEffortSourceOptionsForPlatform(props.platform),
 );
 const matchTypeOptions = computed(() => [
   {

--- a/frontend/src/components/admin/group/__tests__/ReasoningEffortPolicyFields.spec.ts
+++ b/frontend/src/components/admin/group/__tests__/ReasoningEffortPolicyFields.spec.ts
@@ -13,6 +13,48 @@ vi.mock("vue-i18n", async () => {
 });
 
 describe("ReasoningEffortPolicyFields", () => {
+  it("offers none only in the mapping source selector", () => {
+    const mapping = createReasoningEffortMappingRow({
+      from: "none",
+      to: "low",
+    });
+    const wrapper = mount(ReasoningEffortPolicyFields, {
+      props: {
+        idPrefix: "edit-group-reasoning",
+        platform: "openai",
+        maxEffort: "",
+        overLimit: "downgrade",
+        mappings: [mapping],
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          Select: {
+            props: ["id", "options"],
+            template:
+              '<div :id="id"><span v-for="option in options" :key="option.value" :data-value="option.value" /></div>',
+          },
+        },
+      },
+    });
+
+    const optionValues = (id: string) =>
+      wrapper
+        .get(`#${id}`)
+        .findAll("[data-value]")
+        .map((option) => option.attributes("data-value"));
+
+    expect(optionValues("edit-group-reasoning-max-effort")).not.toContain(
+      "none",
+    );
+    expect(
+      optionValues(`edit-group-reasoning-${mapping.pairs[0].id}-from`),
+    ).toContain("none");
+    expect(
+      optionValues(`edit-group-reasoning-${mapping.pairs[0].id}-to`),
+    ).not.toContain("none");
+  });
+
   it("renders model scope fields for each mapping", () => {
     const mapping = createReasoningEffortMappingRow({
       from: "max",

--- a/frontend/src/views/admin/__tests__/groupsReasoningEffort.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsReasoningEffort.spec.ts
@@ -4,11 +4,13 @@ import {
   createReasoningEffortMappingPair,
   createReasoningEffortMappingRow,
   normalizeReasoningEffortForPlatform,
+  normalizeReasoningEffortSourceForPlatform,
   normalizeReasoningEffortMatchType,
   normalizeReasoningEffortOverLimit,
   reasoningEffortMappingsToAPI,
   reasoningEffortMappingsToRows,
   reasoningEffortOptionsForPlatform,
+  reasoningEffortSourceOptionsForPlatform,
   reasoningEffortOverLimitDeny,
   reasoningEffortOverLimitDowngrade,
   supportsReasoningEffortPolicyPlatform,
@@ -31,6 +33,11 @@ describe("groupsReasoningEffort", () => {
           (option) => option.value,
         ),
       ).toEqual(expected);
+      expect(
+        reasoningEffortSourceOptionsForPlatform(platform).map(
+          (option) => option.value,
+        ),
+      ).toEqual(["none", ...expected]);
       expect(supportsReasoningEffortPolicyPlatform(platform)).toBe(true);
     }
     for (const platform of [
@@ -40,6 +47,7 @@ describe("groupsReasoningEffort", () => {
       "grok",
     ] as const) {
       expect(reasoningEffortOptionsForPlatform(platform)).toEqual([]);
+      expect(reasoningEffortSourceOptionsForPlatform(platform)).toEqual([]);
       expect(supportsReasoningEffortPolicyPlatform(platform)).toBe(false);
     }
   });
@@ -57,6 +65,27 @@ describe("groupsReasoningEffort", () => {
     expect(reasoningEffortMappingsToAPI(rows)).toEqual([
       { from: "max", to: "xhigh" },
     ]);
+  });
+
+  it("hydrates and validates none only as a mapping source", () => {
+    const rows = reasoningEffortMappingsToRows(
+      [{ from: " NONE ", to: "low" }],
+      "openai",
+    );
+    expect(reasoningEffortMappingsToAPI(rows)).toEqual([
+      { from: "none", to: "low" },
+    ]);
+    expect(validateReasoningEffortMappings(rows, "openai")).toEqual({});
+    expect(normalizeReasoningEffortSourceForPlatform("composite", " NONE ")).toBe("none");
+
+    const invalidTarget = createReasoningEffortMappingRow({
+      from: "low",
+      to: "none",
+    });
+    expect(validateReasoningEffortMappings([invalidTarget], "openai")).toEqual({
+      [invalidTarget.pairs[0].id]: { to: "unsupportedTo" },
+    });
+    expect(normalizeReasoningEffortForPlatform("openai", "none")).toBe("");
   });
 
   it("hydrates model scoped mappings", () => {

--- a/frontend/src/views/admin/groupsReasoningEffort.ts
+++ b/frontend/src/views/admin/groupsReasoningEffort.ts
@@ -12,6 +12,10 @@ const openAIReasoningEffortValues = [
   "xhigh",
   "max",
 ] as const;
+const openAIReasoningEffortSourceValues = [
+  "none",
+  ...openAIReasoningEffortValues,
+] as const;
 
 const reasoningEffortMatchTypes: readonly ReasoningEffortMatchType[] = [
   "exact",
@@ -42,6 +46,15 @@ export function reasoningEffortOptionsForPlatform(platform: GroupPlatform) {
   }));
 }
 
+export function reasoningEffortSourceOptionsForPlatform(
+  platform: GroupPlatform,
+) {
+  return (supportsReasoningEffortPolicyPlatform(platform)
+    ? openAIReasoningEffortSourceValues
+    : []
+  ).map((value) => ({ value, label: value }));
+}
+
 export function normalizeReasoningEffortForPlatform(
   platform: GroupPlatform,
   value: string | null | undefined,
@@ -52,6 +65,17 @@ export function normalizeReasoningEffortForPlatform(
   )
     ? normalized
     : "";
+}
+
+export function normalizeReasoningEffortSourceForPlatform(
+  platform: GroupPlatform,
+  value: string | null | undefined,
+): string {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return supportsReasoningEffortPolicyPlatform(platform) &&
+    normalized === "none"
+    ? "none"
+    : normalizeReasoningEffortForPlatform(platform, value);
 }
 
 export function normalizeReasoningEffortMatchType(
@@ -154,7 +178,10 @@ export function reasoningEffortMappingsToRows(
   const indexByScope = new Map<string, number>();
 
   (mappings ?? []).forEach((mapping) => {
-    const from = normalizeReasoningEffortForPlatform(platform, mapping.from);
+    const from = normalizeReasoningEffortSourceForPlatform(
+      platform,
+      mapping.from,
+    );
     const to = normalizeReasoningEffortForPlatform(platform, mapping.to);
     if (!from || !to) return;
 
@@ -225,7 +252,7 @@ export function validateReasoningEffortMappings(
       const to = pair.to.trim();
       if (!from) {
         errors[pair.id] = { ...errors[pair.id], from: "fromRequired" };
-      } else if (!normalizeReasoningEffortForPlatform(platform, from)) {
+      } else if (!normalizeReasoningEffortSourceForPlatform(platform, from)) {
         errors[pair.id] = { ...errors[pair.id], from: "unsupportedFrom" };
       } else {
         const key = `${scope}\0${from.toLowerCase()}`;


### PR DESCRIPTION
## 背景
部分旧模型缓存、第三方客户端或手工模板会为不支持 `none` 的模型发送 `reasoning.effort: none`。现有分组推理强度映射无法将该值按模型转换为受支持档位。

## 改动
- 允许 `none` 仅作为 OpenAI/Composite 分组推理强度映射的来源值。
- 保持 `none` 不能作为映射目标或最大推理强度。
- 复用现有 exact、prefix、suffix 与全局模型范围，先执行显式映射，再应用推理强度上限。
- 同时覆盖 `reasoning.effort` 与 `reasoning_effort`；无匹配映射时保持原值不变。
- 管理端仅在映射来源选择器中提供 `none`，并兼容读取已有来源为 `none` 的规则。

## 验证
已验证：
- 后端针对性回归测试通过。
- 后端 unit 全量测试通过。
- 后端 integration 全量测试通过。
- 后端代码质量检查报告 0 个问题。
- 后端漏洞调用扫描未发现已调用漏洞。
- 后端构建通过。
- 前端新增回归测试通过（2 个文件，21 个测试）。
- 前端规范检查、类型检查与关键测试通过（13 个文件，168 个测试）。
- 前端生产构建通过。
- 前端依赖审计例外校验通过。
- Linux 兼容的部署与入口代理脚本检查通过；macOS 专用容器脚本仅完成语法检查。
- 差异格式检查通过。
- 独立代码审查通过。

重复检查：未发现按模型将 `none` 映射为其他推理强度的开放或已合并实现。#6622 / #6572 处理模型清单能力声明，本改动为旧缓存和第三方客户端请求提供分组级兼容兜底。

Fixes #6624
