### PR TITLE
feat(openai): replay encrypted reasoning for Chat Completions clients on the Codex path

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -11,12 +11,35 @@ type chatMessageContent struct {
 	Parts []ChatContentPart
 }
 
+// ChatToResponsesOptions carries optional hooks for
+// ChatCompletionsToResponsesWithOptions. All fields are optional; a nil
+// *ChatToResponsesOptions behaves exactly like ChatCompletionsToResponses.
+type ChatToResponsesOptions struct {
+	// ReasoningByToolCallID returns the encrypted reasoning payloads that the
+	// upstream emitted immediately before the function_call with this call_id
+	// in an earlier turn. Chat Completions has no field for carrying Responses
+	// reasoning items, so a Chat client replaying tool history cannot return
+	// them on its own; the gateway caches them under the call_id when the
+	// tool call is streamed to the client and restores them here. Each entry
+	// becomes a `reasoning` input item (with encrypted_content) placed right
+	// before the corresponding function_call item, which is the shape the
+	// Responses API expects for stateless multi-turn reasoning. Return nil on
+	// a miss. A nil hook keeps the original behavior.
+	ReasoningByToolCallID func(callID string) []string
+}
+
 // ChatCompletionsToResponses converts a Chat Completions request into a
 // Responses API request. The upstream always streams, so Stream is forced to
 // true. store is always false and reasoning.encrypted_content is always
 // included so that the response translator has full context.
 func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest, error) {
-	input, err := convertChatMessagesToResponsesInput(req.Messages)
+	return ChatCompletionsToResponsesWithOptions(req, nil)
+}
+
+// ChatCompletionsToResponsesWithOptions is ChatCompletionsToResponses with
+// optional hooks (see ChatToResponsesOptions).
+func ChatCompletionsToResponsesWithOptions(req *ChatCompletionsRequest, opts *ChatToResponsesOptions) (*ResponsesRequest, error) {
+	input, err := convertChatMessagesToResponsesInput(req.Messages, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -99,10 +122,10 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 
 // convertChatMessagesToResponsesInput converts the Chat Completions messages
 // array into a Responses API input items array.
-func convertChatMessagesToResponsesInput(msgs []ChatMessage) ([]ResponsesInputItem, error) {
+func convertChatMessagesToResponsesInput(msgs []ChatMessage, opts *ChatToResponsesOptions) ([]ResponsesInputItem, error) {
 	var out []ResponsesInputItem
 	for _, m := range msgs {
-		items, err := chatMessageToResponsesItems(m)
+		items, err := chatMessageToResponsesItems(m, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -113,14 +136,14 @@ func convertChatMessagesToResponsesInput(msgs []ChatMessage) ([]ResponsesInputIt
 
 // chatMessageToResponsesItems converts a single ChatMessage into one or more
 // ResponsesInputItem values.
-func chatMessageToResponsesItems(m ChatMessage) ([]ResponsesInputItem, error) {
+func chatMessageToResponsesItems(m ChatMessage, opts *ChatToResponsesOptions) ([]ResponsesInputItem, error) {
 	switch m.Role {
 	case "system":
 		return chatSystemToResponses(m)
 	case "user":
 		return chatUserToResponses(m)
 	case "assistant":
-		return chatAssistantToResponses(m)
+		return chatAssistantToResponses(m, opts)
 	case "tool":
 		return chatToolToResponses(m)
 	case "function":
@@ -161,11 +184,20 @@ func chatUserToResponses(m ChatMessage) ([]ResponsesInputItem, error) {
 // text content and tool_calls, the text is emitted as an assistant message
 // first, then each tool_call becomes a function_call item. If the content is
 // empty/nil and there are tool_calls, only function_call items are emitted.
-func chatAssistantToResponses(m ChatMessage) ([]ResponsesInputItem, error) {
+//
+// When opts.ReasoningByToolCallID restores encrypted reasoning for any of the
+// tool_calls, the matching `reasoning` items are emitted right before their
+// function_call and the plaintext reasoning_content is no longer echoed as a
+// <thinking> block: the restored items carry the real reasoning state, and
+// replaying the summary as assistant output_text would only present the model
+// with its own reasoning summary as if it were spoken output.
+func chatAssistantToResponses(m ChatMessage, opts *ChatToResponsesOptions) ([]ResponsesInputItem, error) {
 	var items []ResponsesInputItem
 	content := ""
 
-	if m.ReasoningContent != "" {
+	replay := lookupChatToolCallReasoning(m.ToolCalls, opts)
+
+	if m.ReasoningContent != "" && len(replay) == 0 {
 		content = "<thinking>" + m.ReasoningContent + "</thinking>"
 	}
 
@@ -192,8 +224,16 @@ func chatAssistantToResponses(m ChatMessage) ([]ResponsesInputItem, error) {
 		items = append(items, ResponsesInputItem{Role: "assistant", Content: partsJSON})
 	}
 
-	// Emit one function_call item per tool_call.
+	// Emit one function_call item per tool_call, preceded by any restored
+	// reasoning items bound to that call.
 	for _, tc := range m.ToolCalls {
+		for _, encrypted := range replay[tc.ID] {
+			items = append(items, ResponsesInputItem{
+				Type:             "reasoning",
+				EncryptedContent: encrypted,
+				Summary:          json.RawMessage("[]"),
+			})
+		}
 		args := tc.Function.Arguments
 		if args == "" {
 			args = "{}"
@@ -207,6 +247,37 @@ func chatAssistantToResponses(m ChatMessage) ([]ResponsesInputItem, error) {
 	}
 
 	return items, nil
+}
+
+// lookupChatToolCallReasoning resolves the restored encrypted reasoning for
+// each tool_call id via opts.ReasoningByToolCallID. It returns an empty map
+// when the hook is absent or nothing is restored.
+func lookupChatToolCallReasoning(toolCalls []ChatToolCall, opts *ChatToResponsesOptions) map[string][]string {
+	if opts == nil || opts.ReasoningByToolCallID == nil || len(toolCalls) == 0 {
+		return nil
+	}
+	var replay map[string][]string
+	for _, tc := range toolCalls {
+		id := strings.TrimSpace(tc.ID)
+		if id == "" {
+			continue
+		}
+		var restored []string
+		for _, encrypted := range opts.ReasoningByToolCallID(id) {
+			if strings.TrimSpace(encrypted) == "" {
+				continue
+			}
+			restored = append(restored, encrypted)
+		}
+		if len(restored) == 0 {
+			continue
+		}
+		if replay == nil {
+			replay = make(map[string][]string)
+		}
+		replay[tc.ID] = restored
+	}
+	return replay
 }
 
 // parseAssistantContent returns assistant content as plain text.

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses_reasoning_replay_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses_reasoning_replay_test.go
@@ -1,0 +1,160 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func replayTestRequest() *ChatCompletionsRequest {
+	return &ChatCompletionsRequest{
+		Model: "gpt-5.6",
+		Messages: []ChatMessage{
+			{Role: "user", Content: json.RawMessage(`"list files"`)},
+			{
+				Role:             "assistant",
+				ReasoningContent: "I should list the directory first",
+				ToolCalls: []ChatToolCall{
+					{ID: "call_a", Type: "function", Function: ChatFunctionCall{Name: "ls", Arguments: `{"path":"."}`}},
+					{ID: "call_b", Type: "function", Function: ChatFunctionCall{Name: "cat", Arguments: `{"path":"README"}`}},
+				},
+			},
+			{Role: "tool", ToolCallID: "call_a", Content: json.RawMessage(`"a.txt"`)},
+			{Role: "tool", ToolCallID: "call_b", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+}
+
+func decodeReplayInput(t *testing.T, req *ResponsesRequest) []map[string]any {
+	t.Helper()
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal(req.Input, &items))
+	return items
+}
+
+// A cache hit inserts the encrypted reasoning items directly before the tool
+// call they produced and stops echoing the plaintext summary as <thinking>.
+func TestChatCompletionsToResponses_ReasoningReplayInsertsItemsBeforeToolCall(t *testing.T) {
+	lookups := []string{}
+	out, err := ChatCompletionsToResponsesWithOptions(replayTestRequest(), &ChatToResponsesOptions{
+		ReasoningByToolCallID: func(callID string) []string {
+			lookups = append(lookups, callID)
+			switch callID {
+			case "call_a":
+				return []string{"enc-1", "enc-2"}
+			case "call_b":
+				return []string{"enc-3"}
+			}
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"call_a", "call_b"}, lookups)
+
+	items := decodeReplayInput(t, out)
+	types := make([]string, 0, len(items))
+	for _, item := range items {
+		typ, _ := item["type"].(string)
+		if typ == "" {
+			role, _ := item["role"].(string)
+			typ = "message:" + role
+		}
+		types = append(types, typ)
+	}
+	assert.Equal(t, []string{
+		"message:user",
+		"reasoning", "reasoning", "function_call",
+		"reasoning", "function_call",
+		"function_call_output", "function_call_output",
+	}, types)
+
+	assert.Equal(t, "enc-1", items[1]["encrypted_content"])
+	assert.Equal(t, []any{}, items[1]["summary"], "replayed reasoning must carry an explicit empty summary")
+	_, hasID := items[1]["id"]
+	assert.False(t, hasID, "replayed reasoning must not carry an rs_ id (store=false upstream 404s on it)")
+	assert.Equal(t, "enc-2", items[2]["encrypted_content"])
+	assert.Equal(t, "call_a", items[3]["call_id"])
+	assert.Equal(t, "enc-3", items[4]["encrypted_content"])
+	assert.Equal(t, "call_b", items[5]["call_id"])
+
+	raw := string(out.Input)
+	assert.NotContains(t, raw, "<thinking>", "plaintext reasoning summary must not be echoed once real reasoning is restored")
+}
+
+// A partial hit still restores what is cached; the assistant text (if any)
+// is kept, and only the <thinking> echo is dropped.
+func TestChatCompletionsToResponses_ReasoningReplayPartialHitKeepsAssistantText(t *testing.T) {
+	req := replayTestRequest()
+	req.Messages[1].Content = json.RawMessage(`"Let me look."`)
+	out, err := ChatCompletionsToResponsesWithOptions(req, &ChatToResponsesOptions{
+		ReasoningByToolCallID: func(callID string) []string {
+			if callID == "call_b" {
+				return []string{"enc-b"}
+			}
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	items := decodeReplayInput(t, out)
+
+	require.Equal(t, "assistant", items[1]["role"])
+	var parts []ResponsesContentPart
+	partsRaw, _ := json.Marshal(items[1]["content"])
+	require.NoError(t, json.Unmarshal(partsRaw, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "Let me look.", parts[0].Text)
+
+	assert.Equal(t, "function_call", items[2]["type"])
+	assert.Equal(t, "call_a", items[2]["call_id"])
+	assert.Equal(t, "reasoning", items[3]["type"])
+	assert.Equal(t, "enc-b", items[3]["encrypted_content"])
+	assert.Equal(t, "function_call", items[4]["type"])
+	assert.Equal(t, "call_b", items[4]["call_id"])
+}
+
+// A miss (or no hook) keeps the pre-existing behavior byte for byte: the
+// reasoning_content is echoed as <thinking> and no reasoning item appears.
+func TestChatCompletionsToResponses_ReasoningReplayMissKeepsLegacyShape(t *testing.T) {
+	legacy, err := ChatCompletionsToResponses(replayTestRequest())
+	require.NoError(t, err)
+
+	missed, err := ChatCompletionsToResponsesWithOptions(replayTestRequest(), &ChatToResponsesOptions{
+		ReasoningByToolCallID: func(string) []string { return nil },
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(legacy.Input), string(missed.Input))
+
+	blank, err := ChatCompletionsToResponsesWithOptions(replayTestRequest(), &ChatToResponsesOptions{
+		ReasoningByToolCallID: func(string) []string { return []string{"", "  "} },
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(legacy.Input), string(blank.Input), "blank payloads must count as a miss")
+
+	items := decodeReplayInput(t, legacy)
+	partsRaw, _ := json.Marshal(items[1]["content"])
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(partsRaw, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "<thinking>I should list the directory first</thinking>", parts[0].Text)
+	for _, item := range items {
+		assert.NotEqual(t, "reasoning", item["type"])
+	}
+}
+
+// Tool calls without an id are never looked up.
+func TestChatCompletionsToResponses_ReasoningReplaySkipsBlankToolCallIDs(t *testing.T) {
+	req := replayTestRequest()
+	req.Messages[1].ToolCalls[0].ID = " "
+	called := 0
+	_, err := ChatCompletionsToResponsesWithOptions(req, &ChatToResponsesOptions{
+		ReasoningByToolCallID: func(callID string) []string {
+			called++
+			assert.Equal(t, "call_b", callID)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, called)
+}

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -269,6 +269,9 @@ type ResponsesInputItem struct {
 
 	// type=reasoning (multi-turn replay of encrypted reasoning)
 	EncryptedContent string `json:"encrypted_content,omitempty"`
+	// Summary is required by the Responses API on replayed reasoning items;
+	// an empty array satisfies upstreams that reject a missing field.
+	Summary json.RawMessage `json:"summary,omitempty"`
 
 	// type=function_call
 	CallID    string `json:"call_id,omitempty"`

--- a/backend/internal/service/openai_chat_reasoning_replay.go
+++ b/backend/internal/service/openai_chat_reasoning_replay.go
@@ -1,0 +1,415 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// Chat Completions → Responses reasoning replay.
+//
+// Reasoning models keep their working state in Responses `reasoning` items.
+// Under store=false the API returns them with encrypted_content and expects
+// the caller to replay every reasoning item that preceded a function_call
+// when it sends the function_call_output back. Codex clients do this
+// natively. Chat Completions clients cannot: the protocol has no field for
+// a reasoning item, so an assistant message with tool_calls comes back as
+// text plus tool_calls and the reasoning that produced them is lost. The
+// model then continues each tool round from scratch, which noticeably
+// degrades multi-step agent quality even though every request succeeds.
+//
+// This file closes the gap on the gateway side:
+//
+//   - Response direction (chatReasoningReplayRecorder): while the Responses
+//     stream is translated to Chat chunks, completed `reasoning` items are
+//     held until the next completed function_call / custom_tool_call and
+//     then stored under that call_id, together with the account that
+//     produced them (encrypted_content is bound to the upstream account).
+//   - Request direction (chatReasoningReplayLookup): when the next Chat
+//     request replays the assistant tool_calls, the converter asks for the
+//     cached items by call_id and inserts them as `reasoning` input items
+//     right before the matching function_call. Items produced by another
+//     account are skipped so the upstream never sees foreign ciphertext.
+//
+// The cache is best-effort: a miss leaves the request exactly as before.
+
+const (
+	// chatReasoningReplayKeyPrefix namespaces call_id keys inside the shared
+	// reasoning cache (repository key becomes "reasoning_content:cc_tool_call:<call_id>").
+	chatReasoningReplayKeyPrefix = "cc_tool_call:"
+	chatReasoningReplayCacheTTL  = responsesReasoningCacheTTL
+	chatReasoningReplayCacheOpTO = 2 * time.Second
+	// chatReasoningReplayMaxItemsPerCall bounds the number of reasoning items
+	// bound to one tool call; Codex emits one, occasionally two.
+	chatReasoningReplayMaxItemsPerCall = 8
+)
+
+// chatReasoningReplayRecord is the JSON document stored per call_id.
+//
+// A Responses turn emits one reasoning item and then possibly several
+// parallel function calls. The reasoning is bound to the first call of that
+// batch (Items non-empty); every later call in the same batch gets a marker
+// record with CoveredBy pointing at that first call and no Items, so a
+// lookup can tell "already replayed via a sibling" apart from a real miss.
+type chatReasoningReplayRecord struct {
+	AccountID  int64    `json:"account_id"`
+	ResponseID string   `json:"response_id,omitempty"`
+	Items      []string `json:"encrypted_items,omitempty"`
+	CoveredBy  string   `json:"covered_by,omitempty"`
+	CreatedAt  int64    `json:"created_at"`
+}
+
+// chatReasoningReplayStats summarizes one request's lookup phase for logging.
+type chatReasoningReplayStats struct {
+	Lookups          int
+	Hits             int
+	Misses           int
+	CoveredBySibling int // call ids whose reasoning was replayed via the first call of their batch
+	AccountMismatch  int
+	Injected         int
+}
+
+type chatReasoningReplayDisabledContextKey struct{}
+
+// withChatReasoningReplayDisabled marks a retry that must not inject cached
+// reasoning (used after the upstream rejected the injected ciphertext).
+func withChatReasoningReplayDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, chatReasoningReplayDisabledContextKey{}, true)
+}
+
+func chatReasoningReplayDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	disabled, _ := ctx.Value(chatReasoningReplayDisabledContextKey{}).(bool)
+	return disabled
+}
+
+const chatReasoningReplayRecorderGinKey = "openai.chat_reasoning_replay.recorder"
+
+func setChatReasoningReplayRecorder(c *gin.Context, rec *chatReasoningReplayRecorder) {
+	if c == nil {
+		return
+	}
+	if rec == nil {
+		c.Set(chatReasoningReplayRecorderGinKey, nil)
+		return
+	}
+	c.Set(chatReasoningReplayRecorderGinKey, rec)
+}
+
+func chatReasoningReplayRecorderFromContext(c *gin.Context) *chatReasoningReplayRecorder {
+	if c == nil {
+		return nil
+	}
+	v, ok := c.Get(chatReasoningReplayRecorderGinKey)
+	if !ok || v == nil {
+		return nil
+	}
+	rec, _ := v.(*chatReasoningReplayRecorder)
+	return rec
+}
+
+// chatReasoningReplayEnabled reports whether the replay bridge applies to
+// this request: only the Codex OAuth protocol returns encrypted reasoning we
+// can replay, and a cache must be available.
+func (s *OpenAIGatewayService) chatReasoningReplayEnabled(ctx context.Context, account *Account) bool {
+	if s == nil || s.cache == nil || account == nil {
+		return false
+	}
+	if !account.UsesOpenAICodexProtocol() {
+		return false
+	}
+	return !chatReasoningReplayDisabled(ctx)
+}
+
+// chatReasoningReplayLookup returns the converter hook plus the stats it
+// fills in. accountID scopes the hit: records written by another account are
+// reported as AccountMismatch and not injected.
+func (s *OpenAIGatewayService) chatReasoningReplayLookup(accountID int64, log *zap.Logger) (func(callID string) []string, *chatReasoningReplayStats) {
+	stats := &chatReasoningReplayStats{}
+	if s == nil || s.cache == nil {
+		return nil, stats
+	}
+	if log == nil {
+		log = logger.L()
+	}
+	hook := func(callID string) []string {
+		stats.Lookups++
+		record, ok := s.loadChatReasoningReplayRecord(callID)
+		if !ok {
+			stats.Misses++
+			log.Debug("openai chat_completions: reasoning replay miss",
+				zap.String("call_id", callID),
+			)
+			return nil
+		}
+		if len(record.Items) == 0 {
+			// Sibling of a parallel batch: the reasoning item is injected in
+			// front of record.CoveredBy, which precedes this call in the input.
+			stats.CoveredBySibling++
+			log.Debug("openai chat_completions: reasoning replay covered by sibling call",
+				zap.String("call_id", callID),
+				zap.String("covered_by", record.CoveredBy),
+			)
+			return nil
+		}
+		if record.AccountID != accountID {
+			stats.AccountMismatch++
+			log.Info("openai chat_completions: reasoning replay skipped, cached by another account",
+				zap.String("call_id", callID),
+				zap.Int64("cached_account_id", record.AccountID),
+				zap.Int64("account_id", accountID),
+			)
+			return nil
+		}
+		stats.Hits++
+		stats.Injected += len(record.Items)
+		log.Debug("openai chat_completions: reasoning replay hit",
+			zap.String("call_id", callID),
+			zap.Int("items", len(record.Items)),
+			zap.Int("encrypted_bytes", chatReasoningReplayBytes(record.Items)),
+			zap.String("cached_response_id", record.ResponseID),
+			zap.Int64("cached_age_seconds", time.Now().Unix()-record.CreatedAt),
+		)
+		return record.Items
+	}
+	return hook, stats
+}
+
+func (s *OpenAIGatewayService) loadChatReasoningReplayRecord(callID string) (*chatReasoningReplayRecord, bool) {
+	callID = strings.TrimSpace(callID)
+	if callID == "" || s == nil || s.cache == nil {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), chatReasoningReplayCacheOpTO)
+	defer cancel()
+	raw, err := s.cache.GetReasoningContent(ctx, chatReasoningReplayKeyPrefix+callID)
+	if err != nil {
+		if err != ErrReasoningContentNotFound {
+			logger.L().Warn("openai chat_completions: reasoning replay cache read failed",
+				zap.Error(err),
+				zap.String("call_id", callID),
+			)
+		}
+		return nil, false
+	}
+	var record chatReasoningReplayRecord
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		logger.L().Warn("openai chat_completions: reasoning replay cache record malformed",
+			zap.Error(err),
+			zap.String("call_id", callID),
+		)
+		return nil, false
+	}
+	if len(record.Items) == 0 && strings.TrimSpace(record.CoveredBy) == "" {
+		return nil, false
+	}
+	return &record, true
+}
+
+func (s *OpenAIGatewayService) storeChatReasoningReplayRecord(callID string, record *chatReasoningReplayRecord) error {
+	if s == nil || s.cache == nil || record == nil || (len(record.Items) == 0 && record.CoveredBy == "") {
+		return nil
+	}
+	callID = strings.TrimSpace(callID)
+	if callID == "" {
+		return nil
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), chatReasoningReplayCacheOpTO)
+	defer cancel()
+	return s.cache.SetReasoningContent(ctx, chatReasoningReplayKeyPrefix+callID, string(raw), chatReasoningReplayCacheTTL)
+}
+
+func chatReasoningReplayBytes(items []string) int {
+	n := 0
+	for _, item := range items {
+		n += len(item)
+	}
+	return n
+}
+
+// chatReasoningReplayRecorder binds completed reasoning items to the next
+// completed tool call in one upstream Responses stream and persists them.
+type chatReasoningReplayRecorder struct {
+	svc        *OpenAIGatewayService
+	log        *zap.Logger
+	accountID  int64
+	responseID string
+
+	pending     []string // encrypted reasoning items not yet bound to a call
+	lastBoundID string   // first call of the current parallel batch (owner of the reasoning record)
+
+	reasoningSeen     int // reasoning items with encrypted_content
+	reasoningNoCipher int // reasoning items without encrypted_content (nothing to replay)
+	toolCallsSeen     int
+	bound             int // tool calls that got reasoning attached
+	covered           int // sibling calls marked as covered by the batch owner
+	stored            int // records written to cache
+	storeFailures     int
+	finished          bool
+}
+
+func newChatReasoningReplayRecorder(svc *OpenAIGatewayService, accountID int64, log *zap.Logger) *chatReasoningReplayRecorder {
+	if log == nil {
+		log = logger.L()
+	}
+	return &chatReasoningReplayRecorder{svc: svc, log: log, accountID: accountID}
+}
+
+// Observe inspects one Responses stream event.
+func (r *chatReasoningReplayRecorder) Observe(event *apicompat.ResponsesStreamEvent) {
+	if r == nil || event == nil {
+		return
+	}
+	switch strings.TrimSpace(event.Type) {
+	case "response.created":
+		if event.Response != nil && event.Response.ID != "" {
+			r.responseID = event.Response.ID
+		}
+	case "response.output_item.done":
+		r.observeItem(event.Item)
+	}
+}
+
+// ObserveOutput inspects a terminal (buffered) Responses output list.
+func (r *chatReasoningReplayRecorder) ObserveOutput(responseID string, output []apicompat.ResponsesOutput) {
+	if r == nil {
+		return
+	}
+	if responseID != "" {
+		r.responseID = responseID
+	}
+	for i := range output {
+		r.observeItem(&output[i])
+	}
+}
+
+func (r *chatReasoningReplayRecorder) observeItem(item *apicompat.ResponsesOutput) {
+	if item == nil {
+		return
+	}
+	switch item.Type {
+	case "reasoning":
+		encrypted := strings.TrimSpace(item.EncryptedContent)
+		if encrypted == "" {
+			r.reasoningNoCipher++
+			return
+		}
+		r.reasoningSeen++
+		if len(r.pending) < chatReasoningReplayMaxItemsPerCall {
+			r.pending = append(r.pending, encrypted)
+		}
+	case "function_call", "custom_tool_call":
+		r.toolCallsSeen++
+		callID := strings.TrimSpace(item.CallID)
+		if callID == "" {
+			return
+		}
+		if len(r.pending) == 0 {
+			if r.lastBoundID == "" || r.lastBoundID == callID {
+				return
+			}
+			// Parallel sibling: no reasoning of its own, covered by the batch owner.
+			marker := &chatReasoningReplayRecord{
+				AccountID:  r.accountID,
+				ResponseID: r.responseID,
+				CoveredBy:  r.lastBoundID,
+				CreatedAt:  time.Now().Unix(),
+			}
+			r.covered++
+			if err := r.svc.storeChatReasoningReplayRecord(callID, marker); err != nil {
+				r.storeFailures++
+				r.log.Warn("openai chat_completions: reasoning replay sibling marker write failed",
+					zap.Error(err),
+					zap.String("call_id", callID),
+					zap.String("covered_by", r.lastBoundID),
+				)
+				return
+			}
+			r.stored++
+			return
+		}
+		record := &chatReasoningReplayRecord{
+			AccountID:  r.accountID,
+			ResponseID: r.responseID,
+			Items:      r.pending,
+			CreatedAt:  time.Now().Unix(),
+		}
+		r.pending = nil
+		r.lastBoundID = callID
+		r.bound++
+		if err := r.svc.storeChatReasoningReplayRecord(callID, record); err != nil {
+			r.storeFailures++
+			r.log.Warn("openai chat_completions: reasoning replay cache write failed",
+				zap.Error(err),
+				zap.String("call_id", callID),
+			)
+			return
+		}
+		r.stored++
+		r.log.Debug("openai chat_completions: reasoning replay cached",
+			zap.String("call_id", callID),
+			zap.Int64("account_id", r.accountID),
+			zap.Int("items", len(record.Items)),
+			zap.Int("encrypted_bytes", chatReasoningReplayBytes(record.Items)),
+			zap.String("response_id", r.responseID),
+		)
+	}
+}
+
+// Finish logs a per-response summary. Reasoning left in pending belongs to a
+// final assistant message (no following tool call); it has no call_id to
+// hang on and is not replayable through Chat Completions today.
+func (r *chatReasoningReplayRecorder) Finish() {
+	if r == nil || r.finished {
+		return
+	}
+	r.finished = true
+	if r.reasoningSeen == 0 && r.reasoningNoCipher == 0 && r.toolCallsSeen == 0 {
+		return
+	}
+	fields := []zap.Field{
+		zap.String("response_id", r.responseID),
+		zap.Int64("account_id", r.accountID),
+		zap.Int("reasoning_items", r.reasoningSeen),
+		zap.Int("reasoning_items_without_cipher", r.reasoningNoCipher),
+		zap.Int("tool_calls", r.toolCallsSeen),
+		zap.Int("tool_calls_bound", r.bound),
+		zap.Int("tool_calls_covered_by_sibling", r.covered),
+		zap.Int("records_stored", r.stored),
+		zap.Int("store_failures", r.storeFailures),
+		zap.Int("unbound_reasoning_items", len(r.pending)),
+	}
+	if r.storeFailures > 0 {
+		r.log.Warn("openai chat_completions: reasoning replay recorded with cache failures", fields...)
+		return
+	}
+	r.log.Debug("openai chat_completions: reasoning replay recorded", fields...)
+}
+
+// isOpenAIInvalidEncryptedContentError reports whether an upstream 400 body
+// rejects replayed reasoning ciphertext. It matches the documented error code
+// and the verify/decrypt message variants the ChatGPT backend emits.
+func isOpenAIInvalidEncryptedContentError(respBody []byte, upstreamMsg string) bool {
+	if strings.EqualFold(strings.TrimSpace(extractUpstreamErrorCode(respBody)), "invalid_encrypted_content") {
+		return true
+	}
+	lower := strings.ToLower(upstreamMsg)
+	if !strings.Contains(lower, "encrypted content") {
+		return false
+	}
+	return strings.Contains(lower, "could not be verified") ||
+		strings.Contains(lower, "could not be decrypted") ||
+		strings.Contains(lower, "invalid_encrypted_content")
+}

--- a/backend/internal/service/openai_chat_reasoning_replay_forward_test.go
+++ b/backend/internal/service/openai_chat_reasoning_replay_forward_test.go
@@ -1,0 +1,228 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func replayForwardTestAccount() *Account {
+	return &Account{
+		ID:          9,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+}
+
+func replayForwardTestContext(t *testing.T, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	return c, rec
+}
+
+// A Codex Responses stream: reasoning (with encrypted_content) followed by a
+// function call, then the terminal event.
+func replayCodexToolCallStream() string {
+	return strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_turn1","model":"gpt-5.6","status":"in_progress"}}`,
+		``,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_1","summary":[]}}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"look at the tree"}`,
+		``,
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"look at the tree"}],"encrypted_content":"ENC_TURN1"}}`,
+		``,
+		`data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_1","call_id":"call_ls_1","name":"ls","arguments":""}}`,
+		``,
+		`data: {"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"path\":\".\"}"}`,
+		``,
+		`data: {"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc_1","call_id":"call_ls_1","name":"ls","arguments":"{\"path\":\".\"}","status":"completed"}}`,
+		``,
+		`data: {"type":"response.completed","response":{"id":"resp_turn1","model":"gpt-5.6","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}`,
+		``,
+	}, "\n")
+}
+
+func replayStreamResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_replay"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func replayInputItems(t *testing.T, upstreamBody []byte) []map[string]any {
+	t.Helper()
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(gjson.GetBytes(upstreamBody, "input").Raw), &items), string(upstreamBody))
+	return items
+}
+
+// Turn 1: the streamed tool call is delivered to the client unchanged and the
+// reasoning ciphertext is cached under the tool call id.
+// Turn 2: the client replays the tool call history; the upstream body now
+// carries the reasoning item right before the function_call and the
+// plaintext <thinking> echo is gone.
+func TestForwardAsChatCompletions_ReasoningReplayAcrossToolTurns(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream, cache: cache}
+	account := replayForwardTestAccount()
+
+	// --- turn 1 ---
+	turn1 := []byte(`{"model":"gpt-5.6","stream":true,"reasoning_effort":"high","tools":[{"type":"function","function":{"name":"ls","parameters":{"type":"object"}}}],"messages":[{"role":"user","content":"list files"}]}`)
+	c1, rec1 := replayForwardTestContext(t, turn1)
+	upstream.responses = []*http.Response{replayStreamResponse(replayCodexToolCallStream())}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c1, account, turn1, "", "gpt-5.6")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	clientStream := rec1.Body.String()
+	assert.Contains(t, clientStream, `"reasoning_content":"look at the tree"`)
+	assert.Contains(t, clientStream, `"id":"call_ls_1"`)
+	assert.NotContains(t, clientStream, "ENC_TURN1", "ciphertext must never leak to the chat client")
+
+	stored := cache.snapshotSets()
+	raw, ok := stored[chatReasoningReplayKeyPrefix+"call_ls_1"]
+	require.True(t, ok, "turn 1 must cache reasoning under the tool call id, got %v", stored)
+	var record chatReasoningReplayRecord
+	require.NoError(t, json.Unmarshal([]byte(raw), &record))
+	assert.Equal(t, account.ID, record.AccountID)
+	assert.Equal(t, "resp_turn1", record.ResponseID)
+	assert.Equal(t, []string{"ENC_TURN1"}, record.Items)
+
+	// --- turn 2 ---
+	cache.getResp = stored
+	turn2 := []byte(`{"model":"gpt-5.6","stream":true,"reasoning_effort":"high","tools":[{"type":"function","function":{"name":"ls","parameters":{"type":"object"}}}],"messages":[
+		{"role":"user","content":"list files"},
+		{"role":"assistant","content":null,"reasoning_content":"look at the tree","tool_calls":[{"id":"call_ls_1","type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]},
+		{"role":"tool","tool_call_id":"call_ls_1","content":"a.txt\nb.txt"}
+	]}`)
+	c2, _ := replayForwardTestContext(t, turn2)
+	upstream.responses = []*http.Response{replayStreamResponse(strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_turn2","model":"gpt-5.6","status":"in_progress"}}`,
+		``,
+		`data: {"type":"response.output_text.delta","output_index":0,"delta":"two files"}`,
+		``,
+		`data: {"type":"response.completed","response":{"id":"resp_turn2","model":"gpt-5.6","status":"completed","output":[],"usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}`,
+		``,
+	}, "\n"))}
+
+	result, err = svc.ForwardAsChatCompletions(context.Background(), c2, account, turn2, "", "gpt-5.6")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	items := replayInputItems(t, upstream.lastBody)
+	types := make([]string, 0, len(items))
+	for _, item := range items {
+		typ, _ := item["type"].(string)
+		if typ == "" {
+			typ, _ = item["role"].(string)
+		}
+		types = append(types, typ)
+	}
+	require.Equal(t, []string{"user", "reasoning", "function_call", "function_call_output"}, types, string(upstream.lastBody))
+	assert.Equal(t, "ENC_TURN1", items[1]["encrypted_content"])
+	assert.Equal(t, []any{}, items[1]["summary"])
+	_, hasID := items[1]["id"]
+	assert.False(t, hasID, "codex transform must not attach an rs_ id to the replayed item")
+	// The codex transform normalizes call ids for the upstream (call_ -> fc_);
+	// the replayed reasoning item still sits directly before that call.
+	assert.Contains(t, []any{"call_ls_1", "fc_ls_1"}, items[2]["call_id"])
+	assert.NotContains(t, gjson.GetBytes(upstream.lastBody, "input").String(), "thinking")
+	assert.Contains(t, gjson.GetBytes(upstream.lastBody, "include").Raw, "reasoning.encrypted_content")
+}
+
+// A miss keeps the previous request shape: the plaintext reasoning_content is
+// echoed as <thinking> and no reasoning item is inserted.
+func TestForwardAsChatCompletions_ReasoningReplayMissKeepsLegacyBody(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop before response parsing"}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream, cache: cache}
+
+	body := []byte(`{"model":"gpt-5.6","stream":true,"messages":[
+		{"role":"user","content":"list files"},
+		{"role":"assistant","content":null,"reasoning_content":"look at the tree","tool_calls":[{"id":"call_unknown","type":"function","function":{"name":"ls","arguments":"{}"}}]},
+		{"role":"tool","tool_call_id":"call_unknown","content":"a.txt"}
+	]}`)
+	c, _ := replayForwardTestContext(t, body)
+	_, err := svc.ForwardAsChatCompletions(context.Background(), c, replayForwardTestAccount(), body, "", "gpt-5.6")
+	require.Error(t, err)
+	require.Len(t, upstream.bodies, 1)
+
+	items := replayInputItems(t, upstream.lastBody)
+	for _, item := range items {
+		assert.NotEqual(t, "reasoning", item["type"])
+	}
+	assert.Equal(t, "<thinking>look at the tree</thinking>", gjson.GetBytes(upstream.lastBody, "input.1.content.0.text").String())
+}
+
+// When the upstream rejects the injected ciphertext (typically after the
+// sticky account changed), the request is retried once without replay and
+// the client still gets the answer.
+func TestForwardAsChatCompletions_ReasoningReplayRetriesWithoutReplayOnRejectedCipher(t *testing.T) {
+	record, _ := json.Marshal(chatReasoningReplayRecord{AccountID: 9, Items: []string{"ENC_STALE"}, CreatedAt: 1})
+	cache := &reasoningRecordingCache{getResp: map[string]string{chatReasoningReplayKeyPrefix + "call_ls_1": string(record)}}
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_reject"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","code":"invalid_encrypted_content","message":"The encrypted content could not be verified"}}`)),
+		},
+		replayStreamResponse(strings.Join([]string{
+			`data: {"type":"response.created","response":{"id":"resp_retry","model":"gpt-5.6","status":"in_progress"}}`,
+			``,
+			`data: {"type":"response.output_text.delta","output_index":0,"delta":"ok"}`,
+			``,
+			`data: {"type":"response.completed","response":{"id":"resp_retry","model":"gpt-5.6","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+			``,
+		}, "\n")),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream, cache: cache}
+
+	body := []byte(`{"model":"gpt-5.6","stream":true,"messages":[
+		{"role":"user","content":"list files"},
+		{"role":"assistant","content":null,"tool_calls":[{"id":"call_ls_1","type":"function","function":{"name":"ls","arguments":"{}"}}]},
+		{"role":"tool","tool_call_id":"call_ls_1","content":"a.txt"}
+	]}`)
+	c, rec := replayForwardTestContext(t, body)
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, replayForwardTestAccount(), body, "", "gpt-5.6")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2, "exactly one retry")
+
+	assert.Contains(t, string(upstream.bodies[0]), "ENC_STALE", "first attempt injects the cached reasoning")
+	assert.NotContains(t, string(upstream.bodies[1]), "ENC_STALE", "retry must not inject again")
+	for _, item := range replayInputItems(t, upstream.bodies[1]) {
+		assert.NotEqual(t, "reasoning", item["type"])
+	}
+	assert.Contains(t, rec.Body.String(), `"content":"ok"`)
+}

--- a/backend/internal/service/openai_chat_reasoning_replay_test.go
+++ b/backend/internal/service/openai_chat_reasoning_replay_test.go
@@ -1,0 +1,212 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func replayRecordFromCache(t *testing.T, cache *reasoningRecordingCache, callID string) chatReasoningReplayRecord {
+	t.Helper()
+	raw, ok := cache.snapshotSets()[chatReasoningReplayKeyPrefix+callID]
+	require.True(t, ok, "expected cache record for %s", callID)
+	var record chatReasoningReplayRecord
+	require.NoError(t, json.Unmarshal([]byte(raw), &record))
+	return record
+}
+
+// Each reasoning item is bound to the next completed tool call in stream
+// order; reasoning after the last tool call (final message) is not stored.
+func TestChatReasoningReplayRecorder_BindsReasoningToNextToolCall(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	svc := &OpenAIGatewayService{cache: cache}
+	rec := newChatReasoningReplayRecorder(svc, 7, nil)
+
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.created", Response: &apicompat.ResponsesResponse{ID: "resp_1"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.added", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_1"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_1", EncryptedContent: "enc-1"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_2", EncryptedContent: "enc-2"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "function_call", CallID: "call_a", Name: "ls"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_3", EncryptedContent: "enc-3"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "custom_tool_call", CallID: "call_b", Name: "apply_patch"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_4", EncryptedContent: "enc-4"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "message", Role: "assistant"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.completed"})
+	rec.Finish()
+
+	a := replayRecordFromCache(t, cache, "call_a")
+	assert.Equal(t, int64(7), a.AccountID)
+	assert.Equal(t, "resp_1", a.ResponseID)
+	assert.Equal(t, []string{"enc-1", "enc-2"}, a.Items)
+	assert.NotZero(t, a.CreatedAt)
+
+	b := replayRecordFromCache(t, cache, "call_b")
+	assert.Equal(t, []string{"enc-3"}, b.Items)
+
+	assert.Len(t, cache.snapshotSets(), 2, "reasoning after the final tool call has no call_id and must not be stored")
+	assert.Equal(t, 4, rec.reasoningSeen)
+	assert.Equal(t, 2, rec.toolCallsSeen)
+	assert.Equal(t, 2, rec.bound)
+	assert.Equal(t, 2, rec.stored)
+	assert.Len(t, rec.pending, 1)
+}
+
+// A parallel batch (one reasoning item, several function calls) binds the
+// reasoning to the first call and marks the rest as covered by it, so the
+// next lookup does not report them as misses.
+func TestChatReasoningReplayRecorder_ParallelBatchMarksSiblings(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	svc := &OpenAIGatewayService{cache: cache}
+	rec := newChatReasoningReplayRecorder(svc, 7, nil)
+	rec.ObserveOutput("resp_par", []apicompat.ResponsesOutput{
+		{Type: "reasoning", EncryptedContent: "enc-batch"},
+		{Type: "function_call", CallID: "call_1"},
+		{Type: "function_call", CallID: "call_2"},
+		{Type: "function_call", CallID: "call_3"},
+		{Type: "reasoning", EncryptedContent: "enc-second"},
+		{Type: "function_call", CallID: "call_4"},
+		{Type: "function_call", CallID: "call_5"},
+	})
+	rec.Finish()
+
+	owner := replayRecordFromCache(t, cache, "call_1")
+	assert.Equal(t, []string{"enc-batch"}, owner.Items)
+	assert.Empty(t, owner.CoveredBy)
+	for _, sibling := range []string{"call_2", "call_3"} {
+		marker := replayRecordFromCache(t, cache, sibling)
+		assert.Empty(t, marker.Items)
+		assert.Equal(t, "call_1", marker.CoveredBy)
+		assert.Equal(t, int64(7), marker.AccountID)
+	}
+	second := replayRecordFromCache(t, cache, "call_4")
+	assert.Equal(t, []string{"enc-second"}, second.Items)
+	assert.Equal(t, "call_4", replayRecordFromCache(t, cache, "call_5").CoveredBy)
+	assert.Equal(t, 2, rec.bound)
+	assert.Equal(t, 3, rec.covered)
+	assert.Equal(t, 5, rec.stored)
+
+	cache.getResp = cache.snapshotSets()
+	hook, stats := svc.chatReasoningReplayLookup(7, nil)
+	assert.Equal(t, []string{"enc-batch"}, hook("call_1"))
+	assert.Nil(t, hook("call_2"))
+	assert.Nil(t, hook("call_3"))
+	assert.Equal(t, []string{"enc-second"}, hook("call_4"))
+	assert.Nil(t, hook("call_5"))
+	assert.Equal(t, 2, stats.Hits)
+	assert.Equal(t, 3, stats.CoveredBySibling)
+	assert.Equal(t, 0, stats.Misses)
+	assert.Equal(t, 2, stats.Injected)
+}
+
+// Reasoning items without encrypted_content carry nothing replayable, and a
+// tool call with no preceding reasoning writes nothing.
+func TestChatReasoningReplayRecorder_IgnoresItemsWithoutCipher(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	rec := newChatReasoningReplayRecorder(&OpenAIGatewayService{cache: cache}, 1, nil)
+
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", ID: "rs_1"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "function_call", CallID: "call_a"}})
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "function_call", CallID: "call_b"}})
+	rec.Finish()
+
+	assert.Empty(t, cache.snapshotSets(), "no bound owner means no sibling markers either")
+	assert.Equal(t, 1, rec.reasoningNoCipher)
+	assert.Equal(t, 0, rec.bound)
+	assert.Equal(t, 0, rec.covered)
+}
+
+// The buffered (stream=false) path feeds the terminal output list.
+func TestChatReasoningReplayRecorder_ObserveOutput(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	rec := newChatReasoningReplayRecorder(&OpenAIGatewayService{cache: cache}, 3, nil)
+	rec.ObserveOutput("resp_buffered", []apicompat.ResponsesOutput{
+		{Type: "reasoning", ID: "rs_1", EncryptedContent: "enc-1"},
+		{Type: "function_call", CallID: "call_x", Name: "ls"},
+	})
+	rec.Finish()
+
+	record := replayRecordFromCache(t, cache, "call_x")
+	assert.Equal(t, "resp_buffered", record.ResponseID)
+	assert.Equal(t, []string{"enc-1"}, record.Items)
+}
+
+// A nil recorder is safe to drive (replay disabled for the request).
+func TestChatReasoningReplayRecorder_NilSafe(t *testing.T) {
+	var rec *chatReasoningReplayRecorder
+	rec.Observe(&apicompat.ResponsesStreamEvent{Type: "response.output_item.done", Item: &apicompat.ResponsesOutput{Type: "reasoning", EncryptedContent: "x"}})
+	rec.ObserveOutput("r", nil)
+	rec.Finish()
+}
+
+// Lookup returns cached items only for the same account and counts outcomes.
+func TestChatReasoningReplayLookup_AccountScopedHitsAndMisses(t *testing.T) {
+	sameAccount, _ := json.Marshal(chatReasoningReplayRecord{AccountID: 7, ResponseID: "resp_1", Items: []string{"enc-1", "enc-2"}, CreatedAt: 1})
+	otherAccount, _ := json.Marshal(chatReasoningReplayRecord{AccountID: 8, Items: []string{"enc-foreign"}, CreatedAt: 1})
+	cache := &reasoningRecordingCache{getResp: map[string]string{
+		chatReasoningReplayKeyPrefix + "call_same":      string(sameAccount),
+		chatReasoningReplayKeyPrefix + "call_other":     string(otherAccount),
+		chatReasoningReplayKeyPrefix + "call_malformed": "{not json",
+		chatReasoningReplayKeyPrefix + "call_empty":     `{"account_id":7,"encrypted_items":[]}`,
+	}}
+	svc := &OpenAIGatewayService{cache: cache}
+
+	hook, stats := svc.chatReasoningReplayLookup(7, nil)
+	require.NotNil(t, hook)
+
+	assert.Equal(t, []string{"enc-1", "enc-2"}, hook("call_same"))
+	assert.Nil(t, hook("call_other"), "ciphertext from another account must never be injected")
+	assert.Nil(t, hook("call_missing"))
+	assert.Nil(t, hook("call_malformed"))
+	assert.Nil(t, hook("call_empty"))
+	assert.Nil(t, hook("  "))
+
+	assert.Equal(t, 6, stats.Lookups)
+	assert.Equal(t, 1, stats.Hits)
+	assert.Equal(t, 1, stats.AccountMismatch)
+	assert.Equal(t, 4, stats.Misses)
+	assert.Equal(t, 2, stats.Injected)
+}
+
+// Round trip: what the recorder stores is what the lookup returns.
+func TestChatReasoningReplay_RecorderLookupRoundTrip(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	svc := &OpenAIGatewayService{cache: cache}
+	rec := newChatReasoningReplayRecorder(svc, 5, nil)
+	rec.ObserveOutput("resp_rt", []apicompat.ResponsesOutput{
+		{Type: "reasoning", EncryptedContent: "enc-rt"},
+		{Type: "function_call", CallID: "call_rt"},
+	})
+	cache.getResp = cache.snapshotSets()
+
+	hook, stats := svc.chatReasoningReplayLookup(5, nil)
+	assert.Equal(t, []string{"enc-rt"}, hook("call_rt"))
+	assert.Equal(t, 1, stats.Hits)
+}
+
+func TestChatReasoningReplayEnabled(t *testing.T) {
+	cache := &reasoningRecordingCache{}
+	svc := &OpenAIGatewayService{cache: cache}
+	codex := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	require.True(t, codex.UsesOpenAICodexProtocol(), "test fixture must be a codex oauth account")
+
+	assert.True(t, svc.chatReasoningReplayEnabled(context.Background(), codex))
+	assert.False(t, svc.chatReasoningReplayEnabled(withChatReasoningReplayDisabled(context.Background()), codex), "retry after upstream rejection must not inject again")
+	assert.False(t, (&OpenAIGatewayService{}).chatReasoningReplayEnabled(context.Background(), codex), "no cache, no replay")
+	assert.False(t, svc.chatReasoningReplayEnabled(context.Background(), nil))
+
+	apiKey := &Account{ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	assert.False(t, svc.chatReasoningReplayEnabled(context.Background(), apiKey), "third-party API key upstreams do not return replayable codex ciphertext")
+}
+
+func TestIsOpenAIInvalidEncryptedContentError(t *testing.T) {
+	assert.True(t, isOpenAIInvalidEncryptedContentError([]byte(`{"error":{"code":"invalid_encrypted_content","message":"x"}}`), "x"))
+	assert.True(t, isOpenAIInvalidEncryptedContentError(nil, "The encrypted content CAIS... could not be Verified. Reason: Encrypted content could not be decrypted or parsed."))
+	assert.False(t, isOpenAIInvalidEncryptedContentError([]byte(`{"error":{"code":"invalid_request_error","message":"Instructions are required"}}`), "Instructions are required"))
+	assert.False(t, isOpenAIInvalidEncryptedContentError(nil, "encrypted content is fine"))
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -165,6 +165,15 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 	originalModel := chatReq.Model
 	clientStream := chatReq.Stream
 
+	replayEnabled := s.chatReasoningReplayEnabled(ctx, account)
+	var replayStats *chatReasoningReplayStats
+	replayLog := logger.FromContext(ctx).With(zap.Int64("account_id", account.ID))
+	if replayEnabled {
+		setChatReasoningReplayRecorder(c, newChatReasoningReplayRecorder(s, account.ID, replayLog))
+	} else {
+		setChatReasoningReplayRecorder(c, nil)
+	}
+
 	// 2. Resolve model mapping early so compat prompt_cache_key injection can
 	// derive a stable seed from the final upstream model family.
 	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
@@ -230,9 +239,28 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 	} else {
 		// Normal path: convert Chat Completions → Responses.
 		// ChatCompletionsToResponses always sets Stream=true (upstream always streams).
-		responsesReq, err = apicompat.ChatCompletionsToResponses(&chatReq)
+		// On the Codex OAuth path the converter also restores cached encrypted
+		// reasoning items in front of replayed tool calls (see
+		// openai_chat_reasoning_replay.go); a miss leaves the body unchanged.
+		var convertOpts *apicompat.ChatToResponsesOptions
+		if replayEnabled {
+			hook, stats := s.chatReasoningReplayLookup(account.ID, replayLog)
+			replayStats = stats
+			convertOpts = &apicompat.ChatToResponsesOptions{ReasoningByToolCallID: hook}
+		}
+		responsesReq, err = apicompat.ChatCompletionsToResponsesWithOptions(&chatReq, convertOpts)
 		if err != nil {
 			return nil, fmt.Errorf("convert chat completions to responses: %w", err)
+		}
+		if replayStats != nil && replayStats.Lookups > 0 {
+			replayLog.Debug("openai chat_completions: reasoning replay lookup",
+				zap.Int("tool_call_lookups", replayStats.Lookups),
+				zap.Int("hits", replayStats.Hits),
+				zap.Int("misses", replayStats.Misses),
+				zap.Int("covered_by_sibling", replayStats.CoveredBySibling),
+				zap.Int("account_mismatch", replayStats.AccountMismatch),
+				zap.Int("reasoning_items_injected", replayStats.Injected),
+			)
 		}
 		responsesReq.Model = upstreamModel
 		normalizeResponsesRequestServiceTier(responsesReq)
@@ -360,6 +388,18 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 	// 8. Handle error response with failover
 	if resp.StatusCode >= 400 {
 		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
+		if replayStats != nil && replayStats.Injected > 0 &&
+			resp.StatusCode == http.StatusBadRequest &&
+			isOpenAIInvalidEncryptedContentError(respBody, upstreamMsg) {
+			// The injected reasoning was rejected (typically the sticky account
+			// changed since it was cached). Retry once without replay so the
+			// client still gets an answer; the request then behaves like before.
+			replayLog.Warn("openai chat_completions: upstream rejected replayed reasoning, retrying without replay",
+				zap.Int("reasoning_items_injected", replayStats.Injected),
+				zap.String("upstream_message", upstreamMsg),
+			)
+			return s.ForwardAsChatCompletions(withChatReasoningReplayDisabled(ctx), c, account, body, promptCacheKey, defaultMappedModel)
+		}
 		if !agentIdentityTaskRecoveryWasTried(ctx) && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, respBody) {
 			expectedTaskID := account.GetCredential("task_id")
 			if err := s.recoverAgentIdentityTask(ctx, account, expectedTaskID); err != nil {
@@ -563,6 +603,11 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 	// accumulated delta events so the client receives the full content.
 	acc.SupplementResponseOutput(finalResponse)
 
+	if replayRecorder := chatReasoningReplayRecorderFromContext(c); replayRecorder != nil {
+		replayRecorder.ObserveOutput(finalResponse.ID, finalResponse.Output)
+		replayRecorder.Finish()
+	}
+
 	chatResp := apicompat.ResponsesToChatCompletions(finalResponse, originalModel)
 
 	if s.responseHeaderFilter != nil {
@@ -681,6 +726,8 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 	}
 
 	scanner := s.newUpstreamSSEScanner(resp.Body)
+	replayRecorder := chatReasoningReplayRecorderFromContext(c)
+	defer replayRecorder.Finish()
 
 	streamInterval := time.Duration(0)
 	if s.cfg != nil && s.cfg.Gateway.StreamDataIntervalTimeout > 0 {
@@ -739,6 +786,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 		observer.ObserveOpenAI([]byte(payload), event.Type)
 		refusalDetector.ObservePayload([]byte(payload))
 		s.parseSSEUsageBytesWithType([]byte(payload), event.Type, &usage)
+		replayRecorder.Observe(&event)
 
 		isTerminalEvent := isOpenAICompatResponsesTerminalEvent(event.Type)
 		if isTerminalEvent {


### PR DESCRIPTION
## Summary

Chat Completions clients that reach Codex through `/v1/chat/completions` lose the Responses `reasoning` items between tool turns. Chat Completions has no field for them, so when such a client replays `assistant.tool_calls` the gateway forwards the `function_call` items without the reasoning that produced them. Under `store=false` the upstream expects those items (with `encrypted_content`) to be replayed in front of the `function_call` (the same contract #3588 preserves for native Codex clients); without them the model restarts every tool round from scratch. Every request still returns 200, so the only symptoms are degraded multi-step agent quality and a lower prompt-cache hit rate.

The bridge also echoed the plaintext `reasoning_content` back to the upstream as a `<thinking>` block inside assistant `output_text`, so the model saw its own reasoning summary as spoken output.

This PR closes the gap on the gateway side, mirroring the existing Responses→Chat reasoning cache (#5729) and the Anthropic `thinking.signature` round-trip:

- **Response direction** (`chatReasoningReplayRecorder`): while the Responses stream is translated to Chat chunks, completed `reasoning` items are bound to the next completed `function_call` / `custom_tool_call` and stored in the shared reasoning cache under the tool `call_id`, tagged with the account that produced them. Later calls of the same parallel batch get a marker record pointing at the batch owner. The buffered (`stream=false`) path is covered too.
- **Request direction** (`apicompat.ChatCompletionsToResponsesWithOptions`): on the Codex OAuth path the converter looks up `tool_calls[].id` and inserts the cached items as `reasoning` input items (with `encrypted_content` and an explicit empty `summary`) right before the matching `function_call`. When real reasoning is restored the `<thinking>` echo is dropped. Records written by another account are never injected (ciphertext is account-bound).
- **Recovery**: if the upstream still rejects the ciphertext (`invalid_encrypted_content`), the request is retried once without replay.

A cache miss leaves the request byte-for-byte as before. Only `account.UsesOpenAICodexProtocol()` accounts are affected; the other six callers of `ChatCompletionsToResponses` keep the nil-options path. No config, schema or API changes; the cache reuses `GatewayCache.Set/GetReasoningContent` with a `cc_tool_call:` key prefix and the existing 7-day TTL.

## Production data

Deployed on our gateway (upstream v0.1.183 + this patch) with a Chat Completions agent client (WorkBuddy) driving Codex `gpt-5.6` on a chatgpt.com OAuth account:

| | before | after |
|---|---|---|
| tool-continuation requests: fresh input tokens | ~10k avg | 250–1300 |
| tool-continuation requests: cache hit | 84.6% | 95.6–99.2% |
| avg latency (tool-heavy task) | 23.2 s | 7.0 s |
| avg TTFT | 3.7 s | 1.0 s |
| `invalid_encrypted_content` retries / account-mismatch skips | – | 0 in ~100 requests, context up to 125k tokens |

Each encrypted reasoning item is ~2.2 KB (max 3.8 KB seen); Redis growth was negligible.

## Logging

Per-request summaries are `Debug` (`reasoning replay recorded` / `reasoning replay lookup` with hit/miss/covered/injected counts). `Info` only when a cached record from another account is skipped, `Warn` on cache read/write failures and on the rejected-ciphertext retry.

## Tests

- `apicompat`: hit inserts items before the call and drops `<thinking>`; partial hit keeps assistant text; miss/blank keeps the legacy shape; blank ids skipped.
- `service`: recorder binding (stream + buffered, parallel batches with sibling markers), account-scoped lookup, round trip, enable gating, error matcher.
- `service` end-to-end through `ForwardAsChatCompletions` with a fake Codex stream: two-turn replay, miss, rejected-cipher retry.
- `go test ./internal/pkg/apicompat/`, `go test -tags unit ./internal/service/`, `go vet`, golangci-lint v2.13 (CI config): clean.

Closes #6632
