### PR TITLE
fix(gemini): 瞬时 429 重试成功后不应残留账号限流状态

### DIFF
--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -163,9 +163,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 				}
 				break
 			}
-			if resp.StatusCode == http.StatusTooManyRequests {
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-			}
+			// 429 不在重试循环内持久化账号限流，理由同 Forward：留到最终结果确定后再写。
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
 				if upstreamReqID == "" {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -16,6 +16,7 @@ import (
 	mathrand "math/rand"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,10 +35,12 @@ import (
 const geminiStickySessionTTL = time.Hour
 
 const (
-	geminiMaxRetries     = 5
-	geminiRetryBaseDelay = 1 * time.Second
-	geminiRetryMaxDelay  = 16 * time.Second
+	geminiMaxRetries    = 5
+	geminiRetryMaxDelay = 16 * time.Second
 )
+
+// geminiRetryBaseDelay 是重试退避的基准间隔；变量而非常量，便于测试压缩等待时间。
+var geminiRetryBaseDelay = 1 * time.Second
 
 // Gemini tool calling now requires `thoughtSignature` in parts that include `functionCall`.
 // Many clients don't send it; we inject a known dummy signature to satisfy the validator.
@@ -893,10 +896,9 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				}
 				break
 			}
-			if resp.StatusCode == 429 {
-				// Mark as rate-limited early so concurrent requests avoid this account.
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-			}
+			// 429 不在此处持久化账号限流：重试仍可能成功，提前写入会让一个瞬时 429
+			// 在客户端已经拿到 200 之后仍把账号停调度（service_account 甚至到 PST 午夜）。
+			// 账号状态统一由循环结束后的错误策略分支处理，只有最终一次仍失败才写。
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
 				if upstreamReqID == "" {
@@ -1388,9 +1390,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				}
 				break
 			}
-			if resp.StatusCode == 429 {
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-			}
+			// 429 不在重试循环内持久化账号限流，理由同 Forward：留到最终结果确定后再写。
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
 				if upstreamReqID == "" {
@@ -3050,7 +3050,23 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 	projectID := strings.TrimSpace(account.GetCredential("project_id"))
 	isCodeAssist := account.IsGeminiCodeAssist()
 
+	// Vertex service_account 是按量计费项目，没有 AI Studio 那套「日配额」语义，
+	// 所以绝不能落到 PST 午夜兜底：一次瞬时的 per-minute / MODEL_CAPACITY_EXHAUSTED
+	// 429 会把账号停调度到第二天。单独分支处理。
+	if account.IsVertexServiceAccount() {
+		s.applyGeminiServiceAccountRateLimit(ctx, account, headers, body)
+		return
+	}
+
 	resetAt := ParseGeminiRateLimitResetTime(body)
+	if resetAt == nil {
+		// 响应体没给出重置时间时，上游显式的 Retry-After 仍优先于本地启发式兜底。
+		if delay, ok := parseGeminiRetryAfterHeader(headers); ok {
+			ts := time.Now().Add(delay).Unix()
+			resetAt = &ts
+			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d rate limited by Retry-After, cooldown=%v", account.ID, delay)
+		}
+	}
 	if resetAt == nil {
 		// 根据账号类型使用不同的默认重置时间
 		var ra time.Time
@@ -3088,6 +3104,108 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 		account.ID, resetTime, oauthType, tierID)
 }
 
+// geminiMaxRetryDelay 限制上游显式重试提示（RetryInfo.retryDelay / Retry-After）的最大值。
+// 上游偶尔会给出异常大的值，直接采信会把账号长时间停调度。
+const geminiMaxRetryDelay = 15 * time.Minute
+
+// geminiServiceAccountFallbackCooldown 是 service_account 429 无任何可解析重试提示时的
+// 兜底冷却，仅在 rate_limit_429_cooldown_settings 不可用时使用。
+const geminiServiceAccountFallbackCooldown = 5 * time.Second
+
+// applyGeminiServiceAccountRateLimit 处理 Vertex service_account 的 429。
+// 优先级：RetryInfo.retryDelay → Retry-After → 可配置的秒级短冷却
+// （rate_limit_429_cooldown_settings，默认 5s）。永远不使用 PST 午夜兜底。
+func (s *GeminiMessagesCompatService) applyGeminiServiceAccountRateLimit(ctx context.Context, account *Account, headers http.Header, body []byte) {
+	delay, ok := parseGeminiRetryInfoDelay(body)
+	source := "retry_info"
+	if !ok {
+		if delay, ok = parseGeminiRetryAfterHeader(headers); ok {
+			source = "retry_after"
+		}
+	}
+	if !ok {
+		// 没有任何显式提示：复用管理端的 429 兜底冷却配置。关闭时保持既有语义——
+		// 不写账号状态，由调度层自行消化。
+		delay = geminiServiceAccountFallbackCooldown
+		if s.rateLimitService != nil {
+			cooldown, enabled := s.rateLimitService.Fallback429Cooldown(ctx, account)
+			if !enabled {
+				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Vertex service_account, project=%s) fallback cooldown disabled, not marking", account.ID, account.VertexProjectID())
+				return
+			}
+			delay = cooldown
+		}
+		source = "short_cooldown"
+	}
+
+	resetAt := time.Now().Add(delay)
+	_ = s.accountRepo.SetRateLimited(ctx, account.ID, resetAt)
+	logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Vertex service_account, project=%s) rate limited, source=%s cooldown=%v", account.ID, account.VertexProjectID(), source, delay)
+}
+
+// parseGeminiRetryInfoDelay 解析 error.details[] 中的 google.rpc.RetryInfo.retryDelay
+// （protojson Duration，例如 "39s" / "1.5s"）。小数秒向上取整到秒，并按
+// geminiMaxRetryDelay 截断。返回 false 表示上游没有给出可用的重试提示。
+func parseGeminiRetryInfoDelay(body []byte) (time.Duration, bool) {
+	var (
+		delay time.Duration
+		found bool
+	)
+	gjson.GetBytes(body, "error.details").ForEach(func(_, detail gjson.Result) bool {
+		// gjson 中 "@" 是 modifier 前缀，访问字面量 key 需要转义。
+		if !strings.HasSuffix(detail.Get(`\@type`).String(), "google.rpc.RetryInfo") {
+			return true
+		}
+		raw := strings.TrimSpace(detail.Get("retryDelay").String())
+		if raw == "" {
+			return true
+		}
+		dur, err := time.ParseDuration(raw)
+		if err != nil || dur <= 0 {
+			return true
+		}
+		delay = clampGeminiRetryDelay(dur)
+		found = true
+		return false
+	})
+	return delay, found
+}
+
+// parseGeminiRetryAfterHeader 解析 HTTP Retry-After（秒数或 HTTP-date 两种形式）。
+func parseGeminiRetryAfterHeader(headers http.Header) (time.Duration, bool) {
+	if headers == nil {
+		return 0, false
+	}
+	raw := strings.TrimSpace(headers.Get("Retry-After"))
+	if raw == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseFloat(raw, 64); err == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+		return clampGeminiRetryDelay(time.Duration(math.Ceil(seconds)) * time.Second), true
+	}
+	if at, err := http.ParseTime(raw); err == nil {
+		if d := time.Until(at); d > 0 {
+			return clampGeminiRetryDelay(d), true
+		}
+	}
+	return 0, false
+}
+
+// clampGeminiRetryDelay 把上游提示的重试延迟向上取整到秒，并限制在 (0, geminiMaxRetryDelay]。
+func clampGeminiRetryDelay(d time.Duration) time.Duration {
+	rounded := time.Duration(math.Ceil(d.Seconds())) * time.Second
+	if rounded < time.Second {
+		rounded = time.Second
+	}
+	if rounded > geminiMaxRetryDelay {
+		return geminiMaxRetryDelay
+	}
+	return rounded
+}
+
 // ParseGeminiRateLimitResetTime 解析 Gemini 格式的 429 响应，返回重置时间的 Unix 时间戳
 func ParseGeminiRateLimitResetTime(body []byte) *int64 {
 	// 第一阶段：gjson 结构化提取
@@ -3116,6 +3234,12 @@ func ParseGeminiRateLimitResetTime(body []byte) *int64 {
 	})
 	if found != nil {
 		return found
+	}
+
+	// google.rpc.RetryInfo.retryDelay：Vertex / Gemini 对瞬时 429 给出的显式重试延迟。
+	if delay, ok := parseGeminiRetryInfoDelay(body); ok {
+		ts := time.Now().Add(delay).Unix()
+		return &ts
 	}
 
 	// 第二阶段：regex 回退匹配 "Please retry in Xs"

--- a/backend/internal/service/gemini_transient_429_test.go
+++ b/backend/internal/service/gemini_transient_429_test.go
@@ -1,0 +1,471 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// 生产复现：Gemini service_account (account_id=6) 上游第一次返回 429，Sub2API 立刻
+// 把账号 SetRateLimited 到次日 PST 午夜，随后 retry 1/5 成功、客户端拿到 200，但
+// rate_limit_reset_at 仍留在账号上，账号被停止调度到第二天。
+//
+// 两条不变量：
+//  1. 重试期间不写账号级限流；任意一次重试成功则不得留下 rate_limit 状态。
+//  2. 只有最终一次仍是 429 才写，且只写一次。
+//
+// Claude-compatible / Gemini native / Chat Completions 三条转发路径都要成立。
+// ---------------------------------------------------------------------------
+
+// geminiSequenceUpstreamStub 按顺序返回预置响应，用于驱动真实的重试循环。
+type geminiSequenceUpstreamStub struct {
+	statuses []int
+	bodies   []string
+	headers  []http.Header
+	calls    int
+}
+
+func (s *geminiSequenceUpstreamStub) Do(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	if s.calls >= len(s.statuses) {
+		return nil, fmt.Errorf("unexpected upstream call #%d (only %d responses staged)", s.calls+1, len(s.statuses))
+	}
+	idx := s.calls
+	s.calls++
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if idx < len(s.headers) && s.headers[idx] != nil {
+		header = s.headers[idx].Clone()
+		header.Set("Content-Type", "application/json")
+	}
+	return &http.Response{
+		StatusCode: s.statuses[idx],
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(s.bodies[idx])),
+	}, nil
+}
+
+func (s *geminiSequenceUpstreamStub) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return s.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+// geminiTransient429Body 是生产上观测到的 Vertex 瞬时 429：RESOURCE_EXHAUSTED，
+// 没有 quotaResetDelay，也没有 "per day" 字样。
+const geminiTransient429Body = `{"error":{"code":429,"message":"Resource exhausted, please try again later.","status":"RESOURCE_EXHAUSTED"}}`
+
+const geminiNativeSuccessBody = `{"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}`
+
+// shrinkGeminiRetryBackoff 把指数退避压到毫秒级，避免单测真的睡 1+2+4+8 秒。
+func shrinkGeminiRetryBackoff(t *testing.T) {
+	t.Helper()
+	original := geminiRetryBaseDelay
+	geminiRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { geminiRetryBaseDelay = original })
+}
+
+func geminiVertexServiceAccount(id int64) *Account {
+	return &Account{
+		ID:       id,
+		Platform: PlatformGemini,
+		Type:     AccountTypeServiceAccount,
+		Credentials: map[string]any{
+			"service_account_json": map[string]any{
+				"type":         "service_account",
+				"project_id":   "proj",
+				"private_key":  "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n",
+				"client_email": "svc@proj.iam.gserviceaccount.com",
+			},
+		},
+	}
+}
+
+func newGeminiTransient429Service(stub *geminiSequenceUpstreamStub) (*GeminiMessagesCompatService, *rateLimit429AccountRepoStub) {
+	repo := &rateLimit429AccountRepoStub{}
+	return &GeminiMessagesCompatService{
+		httpUpstream:     stub,
+		cfg:              &config.Config{},
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+		tokenProvider:    NewGeminiTokenProvider(repo, &fakeGeminiTokenCache{token: "ya29.test-token"}, nil),
+	}, repo
+}
+
+func newGeminiTransient429Context(t *testing.T, path string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader("{}"))
+	return c, rec
+}
+
+// ---------------------------------------------------------------------------
+// 1. 第一次 429、第二次 200：三条路径都必须成功返回且 SetRateLimited 调用次数为 0。
+// ---------------------------------------------------------------------------
+
+func TestGeminiServiceAccount_Transient429ThenSuccessLeavesNoRateLimit(t *testing.T) {
+	shrinkGeminiRetryBackoff(t)
+
+	tests := []struct {
+		name    string
+		path    string
+		forward func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account) (*ForwardResult, error)
+	}{
+		{
+			name: "claude_compatible",
+			path: "/v1/messages",
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account) (*ForwardResult, error) {
+				body := []byte(`{"model":"gemini-2.5-pro","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+				return svc.Forward(context.Background(), c, account, body)
+			},
+		},
+		{
+			name: "gemini_native",
+			path: "/v1beta/models/gemini-2.5-pro:generateContent",
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account) (*ForwardResult, error) {
+				body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+				return svc.ForwardNative(context.Background(), c, account, "gemini-2.5-pro", "generateContent", false, body)
+			},
+		},
+		{
+			name: "chat_completions",
+			path: "/v1/chat/completions",
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account) (*ForwardResult, error) {
+				body := []byte(`{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hello"}]}`)
+				return svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &geminiSequenceUpstreamStub{
+				statuses: []int{http.StatusTooManyRequests, http.StatusOK},
+				bodies:   []string{geminiTransient429Body, geminiNativeSuccessBody},
+			}
+			svc, repo := newGeminiTransient429Service(stub)
+			c, rec := newGeminiTransient429Context(t, tt.path)
+
+			result, err := tt.forward(svc, c, geminiVertexServiceAccount(6))
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, stub.calls, "应该重试一次后成功")
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Zero(t, repo.rateLimitCalls,
+				"重试成功后账号不得留下任何 rate_limit 状态（生产缺陷：429 后重试成功，账号仍被冷却到 PST 午夜）")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. 连续 5 次 429：最终失败，且 SetRateLimited 只调用一次（而不是每次重试一次）。
+// ---------------------------------------------------------------------------
+
+func TestGeminiServiceAccount_AllAttempts429MarksRateLimitOnce(t *testing.T) {
+	shrinkGeminiRetryBackoff(t)
+
+	stub := &geminiSequenceUpstreamStub{
+		statuses: []int{
+			http.StatusTooManyRequests, http.StatusTooManyRequests, http.StatusTooManyRequests,
+			http.StatusTooManyRequests, http.StatusTooManyRequests,
+		},
+		bodies: []string{
+			geminiTransient429Body, geminiTransient429Body, geminiTransient429Body,
+			geminiTransient429Body, geminiTransient429Body,
+		},
+	}
+	svc, repo := newGeminiTransient429Service(stub)
+	c, _ := newGeminiTransient429Context(t, "/v1/messages")
+
+	body := []byte(`{"model":"gemini-2.5-pro","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+	before := time.Now()
+	_, err := svc.Forward(context.Background(), c, geminiVertexServiceAccount(6), body)
+
+	require.Error(t, err, "5 次都 429 应向上返回 failover 错误")
+	require.Equal(t, geminiMaxRetries, stub.calls)
+	require.Equal(t, 1, repo.rateLimitCalls, "只有最终结果确定后写一次账号限流")
+	require.Equal(t, int64(6), repo.lastRateLimitID)
+	// service_account 用短冷却，不是 PST 午夜。
+	require.WithinDuration(t, before.Add(geminiServiceAccountFallbackCooldown), repo.lastRateLimitReset, 5*time.Second)
+}
+
+// ---------------------------------------------------------------------------
+// 3~5. RetryInfo.retryDelay 解析：整数秒、小数秒向上取整、异常长值截断。
+// ---------------------------------------------------------------------------
+
+func geminiRetryInfoBody(retryDelay string) []byte {
+	return []byte(`{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED","details":[` +
+		`{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED"},` +
+		`{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"` + retryDelay + `"}]}}`)
+}
+
+func TestParseGeminiRetryInfoDelay(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryDelay string
+		wantFound  bool
+		want       time.Duration
+	}{
+		{name: "integer_seconds", retryDelay: "39s", wantFound: true, want: 39 * time.Second},
+		{name: "fractional_seconds_round_up", retryDelay: "1.5s", wantFound: true, want: 2 * time.Second},
+		{name: "sub_second_rounds_up_to_one", retryDelay: "0.2s", wantFound: true, want: time.Second},
+		{name: "absurdly_long_is_capped", retryDelay: "86400s", wantFound: true, want: geminiMaxRetryDelay},
+		{name: "just_over_cap_is_capped", retryDelay: "16m", wantFound: true, want: geminiMaxRetryDelay},
+		{name: "zero_is_ignored", retryDelay: "0s", wantFound: false},
+		{name: "unparsable_is_ignored", retryDelay: "soon", wantFound: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseGeminiRetryInfoDelay(geminiRetryInfoBody(tt.retryDelay))
+			require.Equal(t, tt.wantFound, ok)
+			if tt.wantFound {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseGeminiRetryInfoDelay_IgnoresOtherDetailTypes(t *testing.T) {
+	body := []byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","retryDelay":"39s"}]}}`)
+	_, ok := parseGeminiRetryInfoDelay(body)
+	require.False(t, ok, "retryDelay 只在 google.rpc.RetryInfo 里有意义")
+}
+
+func TestParseGeminiRateLimitResetTime_UsesRetryInfo(t *testing.T) {
+	now := time.Now().Unix()
+	got := ParseGeminiRateLimitResetTime(geminiRetryInfoBody("39s"))
+	require.NotNil(t, got)
+	require.InDelta(t, now+39, *got, 2)
+}
+
+func TestHandleGeminiUpstreamError_ServiceAccountUsesRetryInfoDelay(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+		http.StatusTooManyRequests, http.Header{}, geminiRetryInfoBody("39s"))
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.WithinDuration(t, before.Add(39*time.Second), repo.lastRateLimitReset, 3*time.Second)
+}
+
+func TestHandleGeminiUpstreamError_ServiceAccountCapsAbsurdRetryInfoDelay(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+		http.StatusTooManyRequests, http.Header{}, geminiRetryInfoBody("86400s"))
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.WithinDuration(t, before.Add(geminiMaxRetryDelay), repo.lastRateLimitReset, 3*time.Second)
+}
+
+// ---------------------------------------------------------------------------
+// 6. service_account 无任何可解析 reset 信息 → 短冷却，绝不是 PST 午夜。
+// ---------------------------------------------------------------------------
+
+func TestHandleGeminiUpstreamError_ServiceAccountFallsBackToShortCooldown(t *testing.T) {
+	// MODEL_CAPACITY_EXHAUSTED 对按量计费的 Vertex 项目是瞬时容量问题，不是日配额。
+	capacityExhausted := []byte(`{"error":{"code":429,"message":"No capacity available for model gemini-3.1-pro-preview on the server","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED"}]}}`)
+	// 中转/上游偶尔会带 "per day" 文案；service_account 依然不能套用 AI Studio 的日配额语义。
+	dailyQuotaWording := []byte(`{"error":{"code":429,"message":"Quota exceeded for quota metric 'Generate requests per day'","status":"RESOURCE_EXHAUSTED"}}`)
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "plain_resource_exhausted", body: []byte(geminiTransient429Body)},
+		{name: "model_capacity_exhausted", body: capacityExhausted},
+		{name: "daily_quota_wording", body: dailyQuotaWording},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rateLimit429AccountRepoStub{}
+			svc := &GeminiMessagesCompatService{
+				accountRepo:      repo,
+				rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+			}
+
+			before := time.Now()
+			svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+				http.StatusTooManyRequests, http.Header{}, tt.body)
+
+			require.Equal(t, 1, repo.rateLimitCalls)
+			require.WithinDuration(t, before.Add(geminiServiceAccountFallbackCooldown), repo.lastRateLimitReset, 5*time.Second)
+			require.True(t, repo.lastRateLimitReset.Before(geminiDailyResetTime(before)),
+				"Vertex 按量账号不得冷却到 PST 午夜")
+		})
+	}
+}
+
+func TestHandleGeminiUpstreamError_ServiceAccountShortCooldownReadsSettings(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimit429CooldownSettings{Enabled: true, CooldownSeconds: 12})
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = string(data)
+
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rlSvc.SetSettingService(NewSettingService(settingRepo, &config.Config{}))
+	svc := &GeminiMessagesCompatService{accountRepo: repo, rateLimitService: rlSvc}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+		http.StatusTooManyRequests, http.Header{}, []byte(geminiTransient429Body))
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.WithinDuration(t, before.Add(12*time.Second), repo.lastRateLimitReset, 3*time.Second)
+}
+
+func TestHandleGeminiUpstreamError_ServiceAccountShortCooldownDisabledSkipsWrite(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimit429CooldownSettings{Enabled: false, CooldownSeconds: 12})
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = string(data)
+
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rlSvc.SetSettingService(NewSettingService(settingRepo, &config.Config{}))
+	svc := &GeminiMessagesCompatService{accountRepo: repo, rateLimitService: rlSvc}
+
+	svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+		http.StatusTooManyRequests, http.Header{}, []byte(geminiTransient429Body))
+
+	require.Zero(t, repo.rateLimitCalls, "管理端关闭 429 兜底冷却时保持既有语义：不标记账号")
+}
+
+// ---------------------------------------------------------------------------
+// Retry-After：上游显式给出的时间优先于本地启发式兜底。
+// ---------------------------------------------------------------------------
+
+func TestParseGeminiRetryAfterHeader(t *testing.T) {
+	httpDate := time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)
+
+	tests := []struct {
+		name      string
+		value     string
+		wantFound bool
+		want      time.Duration
+		delta     time.Duration
+	}{
+		{name: "seconds", value: "39", wantFound: true, want: 39 * time.Second},
+		{name: "fractional_seconds_round_up", value: "1.5", wantFound: true, want: 2 * time.Second},
+		{name: "absurdly_long_is_capped", value: "86400", wantFound: true, want: geminiMaxRetryDelay},
+		{name: "http_date", value: httpDate, wantFound: true, want: 90 * time.Second, delta: 2 * time.Second},
+		{name: "past_http_date_ignored", value: time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)},
+		{name: "zero_ignored", value: "0"},
+		{name: "garbage_ignored", value: "later"},
+		{name: "empty_ignored", value: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := http.Header{}
+			if tt.value != "" {
+				headers.Set("Retry-After", tt.value)
+			}
+			got, ok := parseGeminiRetryAfterHeader(headers)
+			require.Equal(t, tt.wantFound, ok)
+			if !tt.wantFound {
+				return
+			}
+			if tt.delta > 0 {
+				require.InDelta(t, tt.want.Seconds(), got.Seconds(), tt.delta.Seconds())
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHandleGeminiUpstreamError_ServiceAccountHonorsRetryAfterHeader(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	headers := http.Header{"Retry-After": []string{"42"}}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), geminiVertexServiceAccount(6),
+		http.StatusTooManyRequests, headers, []byte(geminiTransient429Body))
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.WithinDuration(t, before.Add(42*time.Second), repo.lastRateLimitReset, 3*time.Second)
+}
+
+func TestHandleGeminiUpstreamError_APIKeyHonorsRetryAfterInsteadOfPSTMidnight(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{ID: 7, Platform: PlatformGemini, Type: AccountTypeAPIKey}
+	headers := http.Header{"Retry-After": []string{"30"}}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account,
+		http.StatusTooManyRequests, headers, []byte(geminiTransient429Body))
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.WithinDuration(t, before.Add(30*time.Second), repo.lastRateLimitReset, 3*time.Second)
+}
+
+// ---------------------------------------------------------------------------
+// 7. API Key 的日配额 / PST 午夜语义不回归。
+// ---------------------------------------------------------------------------
+
+func TestHandleGeminiUpstreamError_APIKeyDailyQuotaStillResetsAtPSTMidnight(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "explicit_daily_quota_message",
+			body: []byte(`{"error":{"code":429,"message":"Quota exceeded for quota metric 'Generate requests per day'","status":"RESOURCE_EXHAUSTED"}}`),
+		},
+		{
+			name: "no_parsable_reset_info",
+			body: []byte(geminiTransient429Body),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rateLimit429AccountRepoStub{}
+			svc := &GeminiMessagesCompatService{
+				accountRepo:      repo,
+				rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+			}
+			account := &Account{ID: 7, Platform: PlatformGemini, Type: AccountTypeAPIKey}
+
+			now := time.Now()
+			svc.handleGeminiUpstreamError(context.Background(), account,
+				http.StatusTooManyRequests, http.Header{}, tt.body)
+
+			require.Equal(t, 1, repo.rateLimitCalls)
+			require.WithinDuration(t, geminiDailyResetTime(now), repo.lastRateLimitReset, 2*time.Second)
+		})
+	}
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1285,6 +1285,14 @@ func (s *RateLimitService) apply429FallbackRateLimit(ctx context.Context, accoun
 	}
 }
 
+// Fallback429Cooldown exposes the configurable 429 fallback cooldown
+// (rate_limit_429_cooldown_settings) to gateway services that persist the
+// account rate-limit themselves. The bool reports whether the operator has the
+// fallback enabled; false means "do not mark the account".
+func (s *RateLimitService) Fallback429Cooldown(ctx context.Context, account *Account) (time.Duration, bool) {
+	return s.get429FallbackCooldown(ctx, account)
+}
+
 func (s *RateLimitService) get429FallbackCooldown(ctx context.Context, account *Account) (time.Duration, bool) {
 	if s.settingService != nil {
 		settings, err := s.settingService.GetRateLimit429CooldownSettings(ctx)


### PR DESCRIPTION
## 症状

生产环境可稳定复现：Gemini `service_account` 账号（`account_id=6`）在一次瞬时 429 之后，即使内部重试成功、客户端已经拿到 HTTP 200，账号仍被持久化冷却到次日 PST 午夜，从而停止调度一整天。

单次请求的时间线：

| 时间 | 事件 |
|---|---|
| 19:53:01 | 请求开始 |
| 19:53:05 | 上游第一次返回 429 |
| 19:53:05 | Sub2API 立即把账号 `SetRateLimited` 到次日 PST 午夜，同时执行 retry 1/5 |
| 19:53:07 | 重试成功，客户端收到 HTTP 200 |
| 之后 | `rate_limit_reset_at` 没有被清除，账号被停止调度到第二天 |

## 根因一：在重试循环内提前写入限流状态

三条 Gemini 转发路径的重试循环，在收到**第一次** 429 时就调用 `handleGeminiUpstreamError(...)` 持久化账号限流，然后才继续重试：

- `Forward`（Claude-compatible）—— `gemini_messages_compat_service.go`
- `ForwardNative`（Gemini native）—— `gemini_messages_compat_service.go`
- `forwardClaudeBodyAsChatCompletions`（Chat Completions）—— `gemini_chat_completions_compat_service.go`

原注释写的是 "Mark as rate-limited early so concurrent requests avoid this account"，但代价是：重试预算还没用完就先把账号判了死刑，而后续重试成功之后没有任何地方回收这个状态。

**修复**：删掉三处循环内的提前写入。账号状态改为在重试全部结束、最终结果确定之后，由循环外已有的错误策略分支（`ErrorPolicyNone` / `ErrorPolicyMatched`）统一写入——这条路径本来就存在，最终一次仍为 429 时行为与之前完全一致。

这里刻意选择"延迟写入"而不是"成功后无条件 `ClearRateLimit`"：后者会误清除并发请求刚刚写入的真实限流状态，延迟写入没有这个竞态。

## 根因二：`service_account` 被当成 API Key / AI Studio 处理

`handleGeminiUpstreamError(...)` 在解析不出 reset 时间时，只区分 Code Assist / Google One（按 tier 冷却）和"其他"（冷却到 PST 午夜）。Vertex `service_account` 落进了后者。

但 Vertex 是按量计费项目，根本没有 AI Studio 那套"日配额"语义，PST 午夜兜底对它永远是错的——一次 per-minute 限流或 `MODEL_CAPACITY_EXHAUSTED` 就会让账号消失一天。

**修复**：`service_account` 单独分支，按以下优先级解析冷却时间：

1. `error.details[]` 中的 `google.rpc.RetryInfo.retryDelay`（`"39s"` / `"1.5s"`）
2. HTTP `Retry-After`（秒数或 HTTP-date）
3. 复用管理端已有的 `rate_limit_429_cooldown_settings` 短冷却（默认 5s）；该配置被关闭时保持既有语义，不写账号状态

`MODEL_CAPACITY_EXHAUSTED` 因此被当作瞬时容量问题处理，不再冷却到午夜。

## 其他改动

- `RetryInfo.retryDelay` 的解析放进了共享的 `ParseGeminiRateLimitResetTime`，因此 `RateLimitService.handle429` 和 Antigravity 网关也一并受益。小数秒向上取整（`1.5s` → `2s`）。
- 所有上游给出的重试延迟（`RetryInfo` / `Retry-After`）统一按 **15 分钟**封顶，避免上游返回异常大的值时把账号长时间停调度。
- 响应体解析不出 reset 时间时，非 service_account 账号也会先看 `Retry-After` 再走本地兜底——上游明确给出的时间优先于启发式。
- `RateLimitService.Fallback429Cooldown` 是 `get429FallbackCooldown` 的导出封装，供自己持久化账号状态的网关服务复用同一份配置。
- `geminiRetryBaseDelay` 由 const 改为 var，仅为让重试循环的回归测试能把指数退避压到毫秒级（否则单测要真睡 1+2+4+8 秒）。这不是新引入的写法：同包的 `internal/service/openai_ws_forwarder.go:57` `openAIWSIngressPreflightPingIdle` 已经是同一约定——包级 var 存放时间参数，测试保存/覆盖/defer 恢复（见 `openai_ws_forwarder_ingress_session_test.go:1785`）。本 PR 沿用它。

**未改变的行为**：API Key / AI Studio 明确日配额耗尽的 429 仍然冷却到 PST 午夜；池模式账号仍然不写账号级限流；Code Assist / Google One 仍走 tier 冷却。

## 与 #5443 的关系

#5443 已经实现了 `RetryInfo` 解析和 service_account 的 1 分钟兜底，方向一致。但它没有解决本 PR 的核心问题——**第一次 429 就写入限流、随后重试成功仍被封**。只要提前写入还在，无论兜底时长改成多少，一次瞬时 429 都会在请求成功之后留下限流状态。本 PR 同时修掉了这两点，并把兜底改为复用管理端已有的 `rate_limit_429_cooldown_settings` 而不是新引入一个硬编码时长。

## 回归测试

新增 `backend/internal/service/gemini_transient_429_test.go`，表驱动，全部在修复前失败：

| 测试 | 钉住的缺陷 |
|---|---|
| `TestGeminiServiceAccount_Transient429ThenSuccessLeavesNoRateLimit` | 第一次 429、第二次 200 → 请求成功且 `SetRateLimited` 调用次数为 **0**。三条路径各一个子用例（修复前三个全部报 `was 1`） |
| `TestGeminiServiceAccount_AllAttempts429MarksRateLimitOnce` | 连续 5 次 429 → 最终失败，`SetRateLimited` 只调用 **1** 次，且冷却是短冷却而非 PST 午夜（修复前为 5 次） |
| `TestParseGeminiRetryInfoDelay` | `39s` 原样、`1.5s` → `2s`、`0.2s` → `1s`、`86400s` / `16m` → 截断到 15m、`0s` 与非法值忽略 |
| `TestParseGeminiRetryInfoDelay_IgnoresOtherDetailTypes` | `retryDelay` 只在 `google.rpc.RetryInfo` 里有意义，不误读其他 detail |
| `TestHandleGeminiUpstreamError_ServiceAccountFallsBackToShortCooldown` | service_account 无 RetryInfo（含 `MODEL_CAPACITY_EXHAUSTED`、含 "per day" 文案）→ 短冷却，断言早于 PST 午夜 |
| `TestHandleGeminiUpstreamError_ServiceAccountShortCooldownReadsSettings` / `...DisabledSkipsWrite` | 短冷却读取 `rate_limit_429_cooldown_settings`，关闭时不写账号 |
| `TestParseGeminiRetryAfterHeader` + `...HonorsRetryAfterHeader` | 秒数 / 小数 / HTTP-date / 过期时间 / 非法值，以及在 handler 中被采信 |
| `TestHandleGeminiUpstreamError_APIKeyDailyQuotaStillResetsAtPSTMidnight` | API Key 日配额语义不回归 |

现有的 `TestHandleGeminiUpstreamError_PoolMode429` 与 `TestHandleGeminiUpstreamError_GoogleOneCapacityExhaustedUsesTierCooldown` 保持通过。

## 验证

在本地按 `.github/workflows/backend-ci.yml` 的四个 job 逐条跑过，全绿：

| CI job | 本地执行 | 结果 |
|---|---|---|
| `test` | `make test-unit`（`go test -tags=unit ./...`） | 通过 |
| `test` | `make test-integration`（`go test -tags=integration ./...`） | 通过 |
| `golangci-lint` | `golangci-lint run --timeout=30m`（v2.13.0，与 CI 同版本） | 0 issues |
| `shell` | `deploy/` 下的 6 个脚本检查（macOS，与 CI 的 `macos-15` 同平台） | 全部通过 |
| `frontend` | `pnpm lint:check` + `pnpm typecheck` + critical vitest（13 files / 168 tests） | 通过 |

另外：`go vet ./...`、`go vet -tags unit ./...` 通过；`gofmt -l internal/` 只剩 4 个本 PR 之前就未格式化的文件，不含本 PR 改动的文件。Go 1.27.0，与 CI 的 `go-version-file` 一致。

未运行 `-tags=e2e`（`scripts/e2e-test.sh` 需要外部服务）。

> 本仓库的 CI 对首次贡献者的 fork PR 需要 maintainer 手动批准才会跑，所以本 PR 上的 `CI` / `Security Scan` 目前停在 `action_required`。
>
> 不过这两个 workflow 都带 `push:` 触发，所以它们**已经在我的 fork 上针对同一个 commit（`8ad29cbb9`）真实跑过，全绿**，无需批准即可查看：
>
> - CI（`shell` / `test` / `frontend` / `golangci-lint` 四个 job 全部 success）：https://github.com/Imccccc/sub2api/actions/runs/33963458691
> - Security Scan（`backend-security` / `frontend-security` 均 success）：https://github.com/Imccccc/sub2api/actions/runs/33963458706

