### PR TITLE
feat(grok): 为官方 Responses 客户端增加自动透传

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2691,6 +2691,10 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 	// Handle Grok accounts
 	if account.Platform == service.PlatformGrok {
 		defaultModels := xai.DefaultModels()
+		if account.IsGrokPassthroughEnabled() {
+			response.Success(c, defaultModels)
+			return
+		}
 
 		hasExplicitMapping := false
 		switch rawMapping := account.Credentials["model_mapping"].(type) {

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -220,6 +220,43 @@ func TestAccountHandlerGetAvailableModels_OpenAIOAuthPassthroughFallsBackToDefau
 	require.NotEqual(t, "gpt-5", resp.Data[0].ID)
 }
 
+func TestAccountHandlerGetAvailableModels_GrokPassthroughFallsBackToDefaults(t *testing.T) {
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       47,
+			Name:     "grok-passthrough",
+			Platform: service.PlatformGrok,
+			Type:     service.AccountTypeOAuth,
+			Status:   service.StatusActive,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"stale-grok": "stale-grok",
+				},
+			},
+			Extra: map[string]any{
+				"grok_passthrough": true,
+			},
+		},
+	}
+	router := setupAvailableModelsRouter(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/47/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data)
+	require.NotEqual(t, "stale-grok", resp.Data[0].ID)
+}
+
 func TestAccountHandlerGetAvailableModels_OpenAIAPIKeyDefaultsToConcreteGPT56Sol(t *testing.T) {
 	svc := &availableModelsAdminService{
 		stubAdminService: newStubAdminService(),

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1136,6 +1136,12 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		return
 	}
 
+	if platform == service.PlatformGrok {
+		if wrote := writeGrokPassthroughModelsIfEnabled(c, h.gatewayService, groupID, apiKey); wrote {
+			return
+		}
+	}
+
 	// Get available models from account configurations for the selected group platform.
 	availableModels := h.gatewayService.GetAvailableModels(c.Request.Context(), groupID, platform)
 	if apiKey != nil && apiKey.Group != nil && apiKey.Group.CustomModelsListEnabled() {
@@ -1361,6 +1367,42 @@ func writeGrokModelsList(c *gin.Context, modelIDs []string) {
 		"object": "list",
 		"data":   models,
 	})
+}
+
+func writeGrokPassthroughModelsIfEnabled(c *gin.Context, gatewayService *service.GatewayService, groupID *int64, apiKey *service.APIKey) bool {
+	if gatewayService == nil {
+		return false
+	}
+	resolution := gatewayService.ResolveGrokPassthroughModels(c.Request.Context(), groupID)
+	if !resolution.Enabled {
+		return false
+	}
+
+	raw := resolution.RawData
+	fallbackIDs := resolution.FallbackIDs
+	if apiKey != nil && apiKey.Group != nil && apiKey.Group.CustomModelsListEnabled() {
+		selected := apiKey.Group.ModelsListConfig.Models
+		if len(raw) > 0 {
+			raw = service.FilterGrokPassthroughCatalog(raw, selected)
+		}
+		if len(fallbackIDs) > 0 {
+			fallbackIDs = filterModelsByCustomList(fallbackIDs, xai.DefaultModelIDs(), selected)
+		} else if len(raw) == 0 {
+			fallbackIDs = filterModelsByCustomList(xai.DefaultModelIDs(), xai.DefaultModelIDs(), selected)
+		}
+	}
+	if len(raw) > 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"object": "list",
+			"data":   raw,
+		})
+		return true
+	}
+	if len(fallbackIDs) == 0 {
+		fallbackIDs = xai.DefaultModelIDs()
+	}
+	writeGrokModelsList(c, fallbackIDs)
+	return true
 }
 
 func grokModelSupportsConfigurableReasoning(modelID string) bool {

--- a/backend/internal/pkg/xai/cli_identity.go
+++ b/backend/internal/pkg/xai/cli_identity.go
@@ -29,6 +29,11 @@ const (
 
 	// CLIClientMode is used by billing / quota probes on the CLI surface.
 	CLIClientMode = "cli"
+
+	// CLIAuthenticateResponse is required by cli-chat-proxy auth middleware.
+	CLIAuthenticateResponse = "authenticate-response"
+
+	officialShellUserAgentPrefix = "grok-shell/"
 )
 
 // ResolveCLIVersion returns a supported CLI client version.
@@ -60,6 +65,60 @@ func CLIUserAgent(version string) string {
 		version = CLIClientVersion
 	}
 	return "xai-grok-workspace/" + version
+}
+
+// OfficialShellUserAgentVersion returns the grok-shell/ version from a User-Agent.
+func OfficialShellUserAgentVersion(userAgent string) string {
+	ua := strings.TrimSpace(userAgent)
+	if !strings.HasPrefix(strings.ToLower(ua), officialShellUserAgentPrefix) {
+		return ""
+	}
+	rest := ua[len(officialShellUserAgentPrefix):]
+	if i := strings.IndexAny(rest, " \t"); i >= 0 {
+		rest = rest[:i]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// HasSupportedOfficialIdentity reports whether headers already identify a
+// supported official grok-shell / grok CLI client.
+func HasSupportedOfficialIdentity(h http.Header) bool {
+	if h == nil {
+		return false
+	}
+	version := strings.TrimSpace(firstHeaderValue(h, "x-grok-client-version"))
+	if version == "" {
+		version = OfficialShellUserAgentVersion(h.Get("User-Agent"))
+	}
+	if !IsSupportedCLIVersion(version) {
+		return false
+	}
+	identifier := strings.TrimSpace(firstHeaderValue(h, "x-grok-client-identifier"))
+	ua := strings.ToLower(strings.TrimSpace(h.Get("User-Agent")))
+	return identifier == CLIClientIdentifier || strings.HasPrefix(ua, officialShellUserAgentPrefix)
+}
+
+// EnsureCLIProxyAuthHeaders fills cli-chat-proxy auth headers when missing.
+func EnsureCLIProxyAuthHeaders(h http.Header) {
+	if h == nil {
+		return
+	}
+	if strings.TrimSpace(h.Get("X-XAI-Token-Auth")) == "" {
+		h.Set("X-XAI-Token-Auth", CLITokenAuth)
+	}
+	if strings.TrimSpace(firstHeaderValue(h, "x-authenticateresponse")) == "" {
+		h.Set("x-authenticateresponse", CLIAuthenticateResponse)
+	}
+}
+
+func firstHeaderValue(h http.Header, key string) string {
+	if h == nil {
+		return ""
+	}
+	if v := strings.TrimSpace(h.Get(key)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(h.Get(http.CanonicalHeaderKey(key)))
 }
 
 // ApplyCLIProxyHeaders stamps the fixed Grok CLI identity when the request

--- a/backend/internal/pkg/xai/cli_identity.go
+++ b/backend/internal/pkg/xai/cli_identity.go
@@ -115,10 +115,7 @@ func firstHeaderValue(h http.Header, key string) string {
 	if h == nil {
 		return ""
 	}
-	if v := strings.TrimSpace(h.Get(key)); v != "" {
-		return v
-	}
-	return strings.TrimSpace(h.Get(http.CanonicalHeaderKey(key)))
+	return strings.TrimSpace(h.Get(key))
 }
 
 // ApplyCLIProxyHeaders stamps the fixed Grok CLI identity when the request

--- a/backend/internal/pkg/xai/cli_identity_test.go
+++ b/backend/internal/pkg/xai/cli_identity_test.go
@@ -51,6 +51,22 @@ func TestApplyCLIProxyHeaders(t *testing.T) {
 	require.Equal(t, CLIUserAgent(CLIClientVersion), req.Header.Get("User-Agent"))
 }
 
+func TestHasSupportedOfficialIdentity(t *testing.T) {
+	t.Run("grok-shell user agent", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("User-Agent", "grok-shell/1.0.5")
+		h.Set("x-grok-client-version", "1.0.5")
+		h.Set("x-grok-client-identifier", CLIClientIdentifier)
+		require.True(t, HasSupportedOfficialIdentity(h))
+	})
+
+	t.Run("legacy curl is not official", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("User-Agent", "curl/8.5.0")
+		require.False(t, HasSupportedOfficialIdentity(h))
+	})
+}
+
 func TestApplyCLIProxyHeadersLeavesAPIHostUnchanged(t *testing.T) {
 	t.Setenv(CLIVersionEnv, "0.2.95")
 

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -467,10 +467,15 @@ func applyGrokCLIProxyHeaders(req *http.Request) {
 	if !isSupportedGrokCLIVersion(version) {
 		version = grokCLIStableVersion
 	}
+	if xai.HasSupportedOfficialIdentity(req.Header) {
+		xai.EnsureCLIProxyAuthHeaders(req.Header)
+		return
+	}
 	req.Header.Set("X-XAI-Token-Auth", xai.CLITokenAuth)
 	req.Header.Set("x-grok-client-version", version)
 	req.Header.Set("x-grok-client-identifier", xai.CLIClientIdentifier)
 	req.Header.Set("User-Agent", xai.CLIUserAgent(version))
+	xai.EnsureCLIProxyAuthHeaders(req.Header)
 }
 
 func isSupportedGrokCLIVersion(version string) bool {

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -529,6 +529,22 @@ func TestApplyGrokCLIProxyHeaders(t *testing.T) {
 		})
 	}
 
+	t.Run("preserves supported official grok-shell identity", func(t *testing.T) {
+		t.Setenv("XAI_GROK_CLI_VERSION", "")
+		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", "grok-shell/1.0.5")
+		req.Header.Set("x-grok-client-version", "1.0.5")
+		req.Header.Set("x-grok-client-identifier", xai.CLIClientIdentifier)
+
+		applyGrokCLIProxyHeaders(req)
+
+		require.Equal(t, "grok-shell/1.0.5", req.Header.Get("User-Agent"))
+		require.Equal(t, "1.0.5", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, xai.CLITokenAuth, req.Header.Get("X-XAI-Token-Auth"))
+		require.Equal(t, xai.CLIAuthenticateResponse, req.Header.Get("x-authenticateresponse"))
+	})
+
 	t.Run("leaves direct xAI API requests unchanged", func(t *testing.T) {
 		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.95")
 		req, err := http.NewRequest(http.MethodPost, "https://api.x.ai/v1/responses", nil)

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -840,7 +840,7 @@ func (a *Account) IsModelSupported(requestedModel string) bool {
 	// 该短路必须在 model_mapping 判定之前：账号从"白名单模式"切换到透传后，
 	// credentials 里常残留旧的非空 model_mapping，若不在此放行，透传账号会被
 	// model_mapping 白名单错误排除出候选集，导致 no available accounts / 404（issue #4936）。
-	if a.IsOpenAIPassthroughEnabled() {
+	if a.IsOpenAIPassthroughEnabled() || a.IsGrokPassthroughEnabled() {
 		return true
 	}
 	mapping := a.GetModelMapping()
@@ -2040,6 +2040,18 @@ func (a *Account) IsOpenAIPassthroughEnabled() bool {
 		return enabled
 	}
 	return false
+}
+
+// IsGrokPassthroughEnabled 返回 Grok 账号是否启用「自动透传（仅替换认证）」。
+//
+// 字段：accounts.extra.grok_passthrough。
+// 仅 Grok 平台生效；缺省或非 bool 按 false（关闭）处理。
+func (a *Account) IsGrokPassthroughEnabled() bool {
+	if a == nil || !a.IsGrok() || a.Extra == nil {
+		return false
+	}
+	enabled, ok := a.Extra["grok_passthrough"].(bool)
+	return ok && enabled
 }
 
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。

--- a/backend/internal/service/account_grok_passthrough_test.go
+++ b/backend/internal/service/account_grok_passthrough_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount_IsGrokPassthroughEnabled(t *testing.T) {
+	t.Run("新字段开启", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeOAuth,
+			Extra: map[string]any{
+				"grok_passthrough": true,
+			},
+		}
+		require.True(t, account.IsGrokPassthroughEnabled())
+	})
+
+	t.Run("非Grok账号始终关闭", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra: map[string]any{
+				"grok_passthrough": true,
+			},
+		}
+		require.False(t, account.IsGrokPassthroughEnabled())
+	})
+
+	t.Run("空额外配置默认关闭", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeAPIKey,
+		}
+		require.False(t, account.IsGrokPassthroughEnabled())
+	})
+
+	t.Run("非 bool 默认关闭", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeOAuth,
+			Extra: map[string]any{
+				"grok_passthrough": "true",
+			},
+		}
+		require.False(t, account.IsGrokPassthroughEnabled())
+	})
+
+	t.Run("显式 false 关闭", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeAPIKey,
+			Extra: map[string]any{
+				"grok_passthrough": false,
+			},
+		}
+		require.False(t, account.IsGrokPassthroughEnabled())
+	})
+}
+
+func TestIsModelSupported_GrokPassthroughIgnoresLeftoverMapping(t *testing.T) {
+	account := &Account{
+		Platform: PlatformGrok,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"grok_passthrough": true},
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"grok-4.5": "grok-4.5"},
+		},
+	}
+
+	require.True(t, account.IsModelSupported("grok-4.6-new"), "透传应放行不在残留白名单中的新模型")
+	require.True(t, account.IsModelSupported("grok-imagine-image"), "透传调度不因 mapping 排除模型")
+}
+
+func TestResolveOpenAIAccountUpstreamModelForRequest_GrokPassthroughKeepsRequestModel(t *testing.T) {
+	account := &Account{
+		Platform: PlatformGrok,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{"grok_passthrough": true},
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"grok-4.6": "grok-4.5"},
+		},
+	}
+
+	require.Equal(t, "grok-4.6", resolveOpenAIAccountUpstreamModelForRequest(account, "grok-4.6", false))
+	billing, upstream := resolveOpenAIForwardMappedModels(account, "grok-4.6", false)
+	require.Equal(t, "grok-4.6", billing)
+	require.Equal(t, "grok-4.6", upstream)
+	require.Equal(t, "grok-4.6", canonicalOpenAIAccountSchedulingModel(account, "grok-4.6"))
+}

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2624,6 +2624,9 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
 		return true
 	}
+	if account.IsGrokPassthroughEnabled() {
+		return true
+	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
 		if account.Type == AccountTypeServiceAccount {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1419,7 +1419,8 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 		// Passthrough routing accepts models independently of model_mapping. A stale
 		// mapping on any eligible passthrough account therefore cannot define the
 		// public whitelist; return nil so the handler uses its default model set.
-		if platform == PlatformOpenAI && acc.IsOpenAIPassthroughEnabled() {
+		if (platform == PlatformOpenAI && acc.IsOpenAIPassthroughEnabled()) ||
+			(platform == PlatformGrok && acc.IsGrokPassthroughEnabled()) {
 			if s.modelsListCache != nil {
 				s.modelsListCache.Set(cacheKey, []string(nil), s.modelsListCacheTTL)
 				modelsListCacheStoreTotal.Add(1)

--- a/backend/internal/service/grok_passthrough_models.go
+++ b/backend/internal/service/grok_passthrough_models.go
@@ -1,0 +1,201 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/tidwall/gjson"
+)
+
+const grokPassthroughModelsCacheTTL = 5 * time.Minute
+
+type GrokPassthroughModelsResolution struct {
+	RawData     []any
+	FallbackIDs []string
+	Enabled     bool
+}
+
+func grokPassthroughModelsCacheKey(groupID *int64) string {
+	return "grok-pt-catalog|" + modelsListCacheKey(groupID, PlatformGrok)
+}
+
+// ResolveGrokPassthroughModels returns the live upstream /models catalog for a
+// Grok passthrough group. Enabled is false when the group has no passthrough
+// account. RawData is the upstream data[] when the fetch succeeds; otherwise
+// FallbackIDs holds observed IDs (or empty so the handler can use defaults).
+func (s *GatewayService) ResolveGrokPassthroughModels(ctx context.Context, groupID *int64) GrokPassthroughModelsResolution {
+	if s == nil {
+		return GrokPassthroughModelsResolution{}
+	}
+	accounts, err := s.listGrokPassthroughCatalogAccounts(ctx, groupID)
+	if err != nil {
+		return GrokPassthroughModelsResolution{}
+	}
+	account := firstGrokPassthroughAccount(accounts)
+	if account == nil {
+		return GrokPassthroughModelsResolution{}
+	}
+
+	cacheKey := grokPassthroughModelsCacheKey(groupID)
+	if s.modelsListCache != nil {
+		if cached, found := s.modelsListCache.Get(cacheKey); found {
+			if resolution, ok := cached.(GrokPassthroughModelsResolution); ok {
+				return resolution
+			}
+		}
+	}
+
+	resolution := GrokPassthroughModelsResolution{Enabled: true}
+	if raw := s.fetchGrokUpstreamModelsCatalog(ctx, account); len(raw) > 0 {
+		resolution.RawData = raw
+	} else if snap := parseGrokObservedModels(account.Extra); snap != nil {
+		resolution.FallbackIDs = append([]string(nil), snap.Models...)
+	}
+
+	if s.modelsListCache != nil {
+		s.modelsListCache.Set(cacheKey, resolution, grokPassthroughModelsCacheTTL)
+	}
+	return resolution
+}
+
+func FilterGrokPassthroughCatalog(items []any, allowedIDs []string) []any {
+	if len(items) == 0 || len(allowedIDs) == 0 {
+		return items
+	}
+	allow := make(map[string]struct{}, len(allowedIDs))
+	for _, id := range allowedIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		allow[id] = struct{}{}
+	}
+	if len(allow) == 0 {
+		return items
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		id := grokPassthroughCatalogModelID(item)
+		if id == "" {
+			continue
+		}
+		if _, ok := allow[id]; ok {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func (s *GatewayService) listGrokPassthroughCatalogAccounts(ctx context.Context, groupID *int64) ([]Account, error) {
+	if s.accountRepo == nil {
+		return nil, nil
+	}
+	if groupID != nil {
+		return s.accountRepo.ListSchedulableByGroupID(ctx, *groupID)
+	}
+	return s.accountRepo.ListSchedulable(ctx)
+}
+
+func firstGrokPassthroughAccount(accounts []Account) *Account {
+	for i := range accounts {
+		if accounts[i].IsGrokPassthroughEnabled() {
+			return &accounts[i]
+		}
+	}
+	return nil
+}
+
+func (s *GatewayService) fetchGrokUpstreamModelsCatalog(ctx context.Context, account *Account) []any {
+	if s == nil || s.httpUpstream == nil || account == nil {
+		return nil
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, grokObservedModelsTimeout)
+	defer cancel()
+
+	token, _, err := s.GetAccessToken(fetchCtx, account)
+	if err != nil || strings.TrimSpace(token) == "" {
+		return nil
+	}
+	baseURL := strings.TrimSpace(account.GetGrokBaseURL())
+	if s.settingService != nil {
+		baseURL = strings.TrimSpace(s.settingService.ResolveGrokBaseURL(fetchCtx, account))
+	}
+	if baseURL == "" {
+		baseURL = xai.DefaultCLIBaseURL
+	}
+	validator, err := grokBaseURLValidator(account, s.cfg)
+	if err != nil {
+		return nil
+	}
+	validatedBaseURL, err := validator(baseURL)
+	if err != nil {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, buildOpenAIModelsURL(validatedBaseURL), nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", defaultGrokUpstreamUserAgent())
+	if account.IsGrokOAuth() {
+		applyGrokCLIHeaders(req.Header)
+		if isGrokCLIProxyTarget(req.URL.String()) {
+			xai.EnsureCLIProxyAuthHeaders(req.Header)
+		}
+	}
+	account.ApplyHeaderOverrides(req.Header)
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil || resp.StatusCode >= 400 {
+		return nil
+	}
+	return parseGrokUpstreamModelsCatalog(body)
+}
+
+func parseGrokUpstreamModelsCatalog(body []byte) []any {
+	data := gjson.GetBytes(body, "data")
+	if !data.IsArray() {
+		parsed := gjson.ParseBytes(body)
+		if parsed.IsArray() {
+			data = parsed
+		}
+	}
+	if !data.IsArray() || len(data.Array()) == 0 {
+		return nil
+	}
+	var items []any
+	if err := json.Unmarshal([]byte(data.Raw), &items); err != nil {
+		return nil
+	}
+	return items
+}
+
+func grokPassthroughCatalogModelID(item any) string {
+	obj, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"id", "model", "model_id", "modelId"} {
+		if id, ok := obj[key].(string); ok {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}

--- a/backend/internal/service/grok_passthrough_models_test.go
+++ b/backend/internal/service/grok_passthrough_models_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGrokUpstreamModelsCatalogPreservesEffortMetadata(t *testing.T) {
+	body := []byte(`{
+		"object":"list",
+		"data":[
+			{
+				"id":"grok-4.20",
+				"object":"model",
+				"context_window":256000,
+				"supportsReasoningEffort":true,
+				"reasoningEfforts":[{"value":"xhigh","label":"xHigh"}]
+			}
+		]
+	}`)
+	items := parseGrokUpstreamModelsCatalog(body)
+	require.Len(t, items, 1)
+	item, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "grok-4.20", item["id"])
+	require.Equal(t, true, item["supportsReasoningEffort"])
+	require.EqualValues(t, 256000, item["context_window"])
+}
+
+func TestResolveGrokPassthroughModelsUsesUpstreamCatalog(t *testing.T) {
+	groupID := int64(88)
+	account := Account{
+		ID:       1,
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+		Extra:    map[string]any{"grok_passthrough": true},
+		Credentials: map[string]any{
+			"api_key":  "xai-test-key",
+			"base_url": xai.DefaultBaseURL,
+		},
+	}
+	repo := &modelsListAccountRepoStub{byGroup: map[int64][]Account{groupID: {account}}}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(`{"object":"list","data":[{"id":"grok-4.20","reasoningEfforts":[{"value":"max"}]}]}`)),
+	}}
+	svc := &GatewayService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+	}
+
+	resolution := svc.ResolveGrokPassthroughModels(context.Background(), &groupID)
+	require.True(t, resolution.Enabled)
+	require.Len(t, resolution.RawData, 1)
+	item := resolution.RawData[0].(map[string]any)
+	require.Equal(t, "grok-4.20", item["id"])
+	require.Contains(t, upstream.lastReq.URL.String(), "/models")
+	require.Equal(t, "Bearer xai-test-key", upstream.lastReq.Header.Get("Authorization"))
+}
+
+func TestResolveGrokPassthroughModelsFallsBackToObservedIDs(t *testing.T) {
+	groupID := int64(89)
+	account := Account{
+		ID:       2,
+		Platform: PlatformGrok,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"grok_passthrough": true,
+			grokObservedModelsExtraKey: map[string]any{
+				"models":     []any{"grok-observed"},
+				"fetched_at": "2026-01-01T00:00:00Z",
+			},
+		},
+		Credentials: map[string]any{
+			"access_token": "oauth-token",
+			"base_url":     xai.DefaultCLIBaseURL,
+		},
+	}
+	repo := &modelsListAccountRepoStub{byGroup: map[int64][]Account{groupID: {account}}}
+	svc := &GatewayService{
+		accountRepo:  repo,
+		httpUpstream: &httpUpstreamRecorder{resp: &http.Response{StatusCode: http.StatusBadGateway, Body: io.NopCloser(strings.NewReader(`nope`))}},
+	}
+
+	resolution := svc.ResolveGrokPassthroughModels(context.Background(), &groupID)
+	require.True(t, resolution.Enabled)
+	require.Empty(t, resolution.RawData)
+	require.Equal(t, []string{"grok-observed"}, resolution.FallbackIDs)
+}
+
+func TestResolveGrokPassthroughModelsDisabledWithoutFlag(t *testing.T) {
+	groupID := int64(90)
+	repo := &modelsListAccountRepoStub{byGroup: map[int64][]Account{groupID: {{
+		ID:       3,
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+	}}}}
+	svc := &GatewayService{accountRepo: repo}
+
+	resolution := svc.ResolveGrokPassthroughModels(context.Background(), &groupID)
+	require.False(t, resolution.Enabled)
+}
+
+func TestGetAvailableModels_GrokPassthroughUsesDefaultFallback(t *testing.T) {
+	groupID := int64(91)
+	repo := &modelsListAccountRepoStub{byGroup: map[int64][]Account{groupID: {{
+		ID:       4,
+		Platform: PlatformGrok,
+		Extra:    map[string]any{"grok_passthrough": true},
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"stale-model": "stale-model"},
+		},
+	}}}}
+	svc := &GatewayService{accountRepo: repo}
+
+	require.Nil(t, svc.GetAvailableModels(context.Background(), &groupID, PlatformGrok))
+}
+
+func TestFilterGrokPassthroughCatalog(t *testing.T) {
+	items := []any{
+		map[string]any{"id": "keep"},
+		map[string]any{"id": "drop"},
+	}
+	filtered := FilterGrokPassthroughCatalog(items, []string{"keep"})
+	require.Len(t, filtered, 1)
+	require.Equal(t, "keep", grokPassthroughCatalogModelID(filtered[0]))
+}

--- a/backend/internal/service/grok_passthrough_models_test.go
+++ b/backend/internal/service/grok_passthrough_models_test.go
@@ -49,7 +49,7 @@ func TestResolveGrokPassthroughModelsUsesUpstreamCatalog(t *testing.T) {
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body: io.NopCloser(strings.NewReader(`{"object":"list","data":[{"id":"grok-4.20","reasoningEfforts":[{"value":"max"}]}]}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"object":"list","data":[{"id":"grok-4.20","reasoningEfforts":[{"value":"max"}]}]}`)),
 	}}
 	svc := &GatewayService{
 		accountRepo:  repo,
@@ -59,7 +59,8 @@ func TestResolveGrokPassthroughModelsUsesUpstreamCatalog(t *testing.T) {
 	resolution := svc.ResolveGrokPassthroughModels(context.Background(), &groupID)
 	require.True(t, resolution.Enabled)
 	require.Len(t, resolution.RawData, 1)
-	item := resolution.RawData[0].(map[string]any)
+	item, ok := resolution.RawData[0].(map[string]any)
+	require.True(t, ok)
 	require.Equal(t, "grok-4.20", item["id"])
 	require.Contains(t, upstream.lastReq.URL.String(), "/models")
 	require.Equal(t, "Bearer xai-test-key", upstream.lastReq.Header.Get("Authorization"))

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -432,6 +432,9 @@ func canonicalOpenAIAccountSchedulingModel(account *Account, requestedModel stri
 	if account.IsOpenAI() {
 		return resolveOpenAIAccountUpstreamModelForRequest(account, model, false)
 	}
+	if account.IsGrokPassthroughEnabled() {
+		return model
+	}
 	if mapped := strings.TrimSpace(account.GetMappedModel(model)); mapped != "" {
 		return mapped
 	}

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -43,6 +43,9 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 	if account.Type != AccountTypeOAuth && account.Type != AccountTypeAPIKey {
 		return nil, fmt.Errorf("grok account type %s is not supported by Responses forwarding", account.Type)
 	}
+	if account.IsGrokPassthroughEnabled() {
+		return s.forwardGrokPassthrough(ctx, c, account, body, originalModel, reqStream, startTime)
+	}
 
 	upstreamModel := account.GetMappedModel(originalModel)
 	if strings.TrimSpace(upstreamModel) == "" {

--- a/backend/internal/service/openai_gateway_grok_passthrough.go
+++ b/backend/internal/service/openai_gateway_grok_passthrough.go
@@ -1,0 +1,301 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/sjson"
+)
+
+var grokPassthroughForwardHeaders = []string{
+	"x-grok-req-id",
+	"x-grok-session-id",
+	"x-grok-agent-id",
+	"x-grok-turn-idx",
+	"x-grok-client-mode",
+	"x-grok-client-surface",
+	"x-grok-doom-loop-check",
+	"x-grok-model-override",
+	"x-compactions-remaining",
+	"x-compaction-at",
+}
+
+func (s *OpenAIGatewayService) forwardGrokPassthrough(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	originalModel string,
+	reqStream bool,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	upstreamModel := strings.TrimSpace(originalModel)
+	if isGrokImageGenerationModel(upstreamModel) {
+		return nil, fmt.Errorf("model %s is an image model and is not available on the Responses endpoint; use /v1/images/generations instead", upstreamModel)
+	}
+
+	cacheIdentity := resolveGrokCacheIdentity(c, body, "", upstreamModel)
+	forwardBody, err := applyGrokPassthroughCacheIdentity(body, cacheIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("apply grok prompt cache identity: %w", err)
+	}
+
+	token, _, err := s.getRequestCredential(ctx, c, account)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	defer releaseUpstreamCtx()
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	upstreamStart := time.Now()
+	var resp *http.Response
+	for attempt := 0; ; attempt++ {
+		upstreamReq, buildErr := buildGrokPassthroughRequest(upstreamCtx, c, account, forwardBody, token, cacheIdentity, s.cfg, s.settingService)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		resp, err = s.doOpenAIUpstream(upstreamReq, proxyURL, account)
+		SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+		if err != nil {
+			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+		}
+
+		if attempt > 0 || (resp.StatusCode != http.StatusBadRequest && resp.StatusCode != http.StatusUnprocessableEntity) {
+			break
+		}
+		respBody := s.readUpstreamErrorBody(resp)
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		invalidEncryptedContent := isGrokInvalidEncryptedContentResponse(resp.StatusCode, respBody)
+		if !invalidEncryptedContent && !isGrokCompactionReplayDecodeError(resp.StatusCode, respBody) {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			break
+		}
+
+		var retryBody []byte
+		var changed bool
+		var trimErr error
+		if invalidEncryptedContent {
+			retryBody, changed, trimErr = trimGrokInvalidEncryptedContentRetryBody(forwardBody)
+		} else {
+			retryBody, changed, trimErr = sanitizeGrokCompactionReplayBody(forwardBody)
+		}
+		if trimErr != nil {
+			return nil, fmt.Errorf("prepare Grok replay decode retry: %w", trimErr)
+		}
+		if !changed {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			break
+		}
+
+		forwardBody = retryBody
+		slog.Info("grok_replay_decode_retry", "account_id", account.ID, "cache_identity_present", cacheIdentity != "", "passthrough", true)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		respBody := s.readUpstreamErrorBody(resp)
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		upstreamMsg := sanitizeUpstreamErrorMessage(extractUpstreamErrorMessage(respBody))
+		if upstreamMsg == "" {
+			upstreamMsg = fmt.Sprintf("xAI upstream returned status %d", resp.StatusCode)
+		}
+		kind := "http_error"
+		if s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody) {
+			kind = "failover"
+		}
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			ProxyID:            opsUpstreamProxyID(account),
+			ProxyName:          opsUpstreamProxyName(account),
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+			Kind:               kind,
+			Message:            upstreamMsg,
+		})
+		errCtx := withGrokTeamRateLimitModel(ctx, upstreamModel)
+		s.handleGrokAccountUpstreamError(errCtx, account, resp.StatusCode, resp.Header, respBody)
+		if shouldMarkGrokTeamModelRateLimit(resp.StatusCode, respBody) {
+			markGrokTeamModelRateLimit(account, upstreamModel, resolveGrokTeamRateLimitUntil(time.Now().Add(grokTeamRateLimitDefaultTTL), time.Now()))
+		}
+		if s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody) {
+			retryable, retryDelay, retryDeadline, retryMax := grokSameAccountRetryMetadata(account, resp.StatusCode, respBody)
+			return nil, &UpstreamFailoverError{
+				StatusCode:               resp.StatusCode,
+				ResponseBody:             respBody,
+				ResponseHeaders:          resp.Header.Clone(),
+				RetryableOnSameAccount:   retryable,
+				RequestScopedTransient:   retryable && resp.StatusCode == http.StatusTooManyRequests,
+				SameAccountRetryDelay:    retryDelay,
+				SameAccountRetryDeadline: retryDeadline,
+				SameAccountRetryMax:      retryMax,
+			}
+		}
+		return s.handleErrorResponse(ctx, resp, c, account, forwardBody, upstreamModel)
+	}
+
+	stateCtx := withGrokTeamRateLimitModel(ctx, upstreamModel)
+	s.updateGrokUsageFromResponse(stateCtx, account, resp.Header, resp.StatusCode)
+
+	var usage *OpenAIUsage
+	var firstTokenMs *int
+	responseID := ""
+	searchCount := 0
+	imageCount := 0
+	var imageOutputSizes []string
+	if reqStream {
+		maxLineSize := defaultMaxLineSize
+		if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+			maxLineSize = s.cfg.Gateway.MaxLineSize
+		}
+		resp.Body = newGrokResponsesBillingPingFilterBody(resp.Body, account, maxLineSize)
+		streamResult, streamErr := s.handleStreamingResponse(ctx, resp, c, account, startTime, originalModel, upstreamModel)
+		if streamErr != nil {
+			return nil, streamErr
+		}
+		usage = streamResult.usage
+		firstTokenMs = streamResult.firstTokenMs
+		responseID = strings.TrimSpace(streamResult.responseID)
+		searchCount = streamResult.searchCount
+		imageCount = streamResult.imageCount
+		imageOutputSizes = streamResult.imageOutputSizes
+	} else {
+		nonStreamResult, nonStreamErr := s.handleNonStreamingResponse(ctx, resp, c, account, originalModel, upstreamModel)
+		if nonStreamErr != nil {
+			return nil, nonStreamErr
+		}
+		usage = nonStreamResult.usage
+		responseID = strings.TrimSpace(nonStreamResult.responseID)
+		searchCount = nonStreamResult.searchCount
+		imageCount = nonStreamResult.imageCount
+		imageOutputSizes = nonStreamResult.imageOutputSizes
+	}
+
+	if usage == nil {
+		usage = &OpenAIUsage{}
+	}
+	reasoningEffort := extractOpenAIReasoningEffortFromBody(forwardBody, originalModel)
+	result := &OpenAIForwardResult{
+		RequestID:       firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+		UpstreamHeaders: resp.Header,
+		ResponseID:      responseID,
+		Usage:           *usage,
+		Model:           originalModel,
+		UpstreamModel:   upstreamModel,
+		ReasoningEffort: reasoningEffort,
+		Stream:          reqStream,
+		OpenAIWSMode:    false,
+		ResponseHeaders: resp.Header.Clone(),
+		Duration:        time.Since(startTime),
+		FirstTokenMs:    firstTokenMs,
+	}
+	if searchCount > 0 {
+		result.SearchCount = searchCount
+	}
+	if imageCount > 0 {
+		result.ImageCount = imageCount
+		result.ImageOutputSizes = imageOutputSizes
+	}
+	return result, nil
+}
+
+func applyGrokPassthroughCacheIdentity(body []byte, identity string) ([]byte, error) {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return body, nil
+	}
+	return sjson.SetBytes(body, "prompt_cache_key", identity)
+}
+
+func buildGrokPassthroughRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, cacheIdentity string, cfg *config.Config, settings ...*SettingService) (*http.Request, error) {
+	targetURL, err := buildGrokResponsesURL(account, cfg, settings...)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileGrok))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if c != nil {
+		if v := strings.TrimSpace(c.GetHeader("OpenAI-Beta")); v != "" {
+			req.Header.Set("OpenAI-Beta", v)
+		}
+	}
+
+	officialIdentity := grokInboundHasSupportedOfficialIdentity(c)
+	if officialIdentity {
+		copyGrokOfficialIdentityHeaders(req.Header, c.Request.Header)
+	} else if account.IsGrokOAuth() {
+		applyGrokCLIHeaders(req.Header)
+	}
+	if isGrokCLIProxyTarget(targetURL) {
+		xai.EnsureCLIProxyAuthHeaders(req.Header)
+	}
+	copyGrokPassthroughForwardHeaders(req.Header, c)
+	applyGrokCacheHeaders(req.Header, cacheIdentity)
+	account.ApplyHeaderOverrides(req.Header)
+	return req, nil
+}
+
+func grokInboundHasSupportedOfficialIdentity(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	return xai.HasSupportedOfficialIdentity(c.Request.Header)
+}
+
+func copyGrokOfficialIdentityHeaders(dst, src http.Header) {
+	if dst == nil || src == nil {
+		return
+	}
+	if ua := strings.TrimSpace(src.Get("User-Agent")); ua != "" {
+		dst.Set("User-Agent", ua)
+	}
+	if version := strings.TrimSpace(firstNonEmpty(src.Get("x-grok-client-version"), src.Get("X-Grok-Client-Version"))); version != "" {
+		dst.Set("X-Grok-Client-Version", version)
+		dst.Set("x-grok-client-version", version)
+	}
+	if identifier := strings.TrimSpace(src.Get("x-grok-client-identifier")); identifier != "" {
+		dst.Set("x-grok-client-identifier", identifier)
+	}
+	if mode := strings.TrimSpace(firstNonEmpty(src.Get("x-grok-client-mode"), src.Get("X-Grok-Client-Mode"))); mode != "" {
+		dst.Set("X-Grok-Client-Mode", mode)
+		dst.Set("x-grok-client-mode", mode)
+	}
+}
+
+func copyGrokPassthroughForwardHeaders(dst http.Header, c *gin.Context) {
+	if dst == nil || c == nil {
+		return
+	}
+	for _, key := range grokPassthroughForwardHeaders {
+		value := strings.TrimSpace(c.GetHeader(key))
+		if value == "" {
+			continue
+		}
+		dst.Set(key, value)
+	}
+}

--- a/backend/internal/service/openai_gateway_grok_passthrough_test.go
+++ b/backend/internal/service/openai_gateway_grok_passthrough_test.go
@@ -1,0 +1,132 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func grokPassthroughTestAccount(id int64, extra map[string]any) *Account {
+	account := healthyGrokOAuthGatewayTestAccount(id, "access-token")
+	account.Extra = extra
+	account.Credentials["model_mapping"] = map[string]any{"grok-4.5": "grok-4.5"}
+	return account
+}
+
+func TestForwardGrokPassthroughKeepsClientBodyAndReplacesAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"model":"grok-4.6-new","input":[{"type":"message","role":"user","content":"hi"}],"reasoning":{"effort":"none"},"prompt_cache_key":"session-abc","stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer inbound-key")
+	c.Request.Header.Set("User-Agent", "grok-shell/1.0.5")
+	c.Request.Header.Set("x-grok-client-version", "1.0.5")
+	c.Request.Header.Set("x-grok-client-identifier", "grok-shell")
+	c.Request.Header.Set("x-grok-req-id", "req-passthrough")
+	c.Request.Header.Set("x-grok-session-id", "sess-passthrough")
+	c.Set("api_key", &APIKey{ID: 7701})
+
+	account := grokPassthroughTestAccount(77, map[string]any{"grok_passthrough": true})
+	upstreamBody := strings.Join([]string{
+		"event: ping",
+		`data: {"type":"ping"}`,
+		"",
+		`data: {"type":"response.output_text.delta","sequence_number":0,"delta":"ok"}`,
+		"",
+		`data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_pt","usage":{"input_tokens":2,"output_tokens":1}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		httpUpstream:      upstream,
+		grokTokenProvider: NewGrokTokenProvider(nil, nil),
+	}
+
+	result, err := svc.forwardGrokResponses(context.Background(), c, account, body, "grok-4.6-new", true, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, xai.DefaultCLIBaseURL+"/responses", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer access-token", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "grok-shell/1.0.5", upstream.lastReq.Header.Get("User-Agent"))
+	require.Equal(t, "1.0.5", upstream.lastReq.Header.Get("x-grok-client-version"))
+	require.NotEqual(t, xai.CLIClientVersion, upstream.lastReq.Header.Get("x-grok-client-version"))
+	require.Equal(t, xai.CLITokenAuth, upstream.lastReq.Header.Get("X-XAI-Token-Auth"))
+	require.Equal(t, xai.CLIAuthenticateResponse, upstream.lastReq.Header.Get("x-authenticateresponse"))
+	require.Equal(t, "req-passthrough", upstream.lastReq.Header.Get("x-grok-req-id"))
+	require.Equal(t, "sess-passthrough", upstream.lastReq.Header.Get("x-grok-session-id"))
+	require.Equal(t, "grok-4.6-new", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "none", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
+	require.NotEqual(t, "session-abc", gjson.GetBytes(upstream.lastBody, "prompt_cache_key").String())
+	require.NotEmpty(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").String())
+	require.Equal(t, "resp_pt", result.ResponseID)
+	require.NotContains(t, recorder.Body.String(), "event: ping")
+	require.Contains(t, recorder.Body.String(), ": ping")
+}
+
+func TestForwardGrokPassthroughOffUsesCompatRewrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"model":"grok","input":"hi","stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("api_key", &APIKey{ID: 7702})
+
+	account := grokPassthroughTestAccount(78, nil)
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_compat","usage":{"input_tokens":1,"output_tokens":1}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		httpUpstream:      upstream,
+		grokTokenProvider: NewGrokTokenProvider(nil, nil),
+	}
+
+	_, err := svc.forwardGrokResponses(context.Background(), c, account, body, "grok", true, time.Now())
+	require.NoError(t, err)
+	require.NotEqual(t, "grok", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, xai.CLIUserAgent(xai.ResolveCLIVersion()), upstream.lastReq.Header.Get("User-Agent"))
+}
+
+func TestFilterOpenAIResponsesNoneReasoningEffortPreservesGrokPassthrough(t *testing.T) {
+	account := &Account{
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+		Extra:    map[string]any{"grok_passthrough": true},
+	}
+	got, err := filterOpenAIResponsesNoneReasoningEffortForAccount(account, []byte(`{"reasoning":{"effort":"none"}}`))
+	require.NoError(t, err)
+	require.Equal(t, "none", gjson.GetBytes(got, "reasoning.effort").String())
+}
+
+func TestApplyGrokPassthroughCacheIdentityKeepsClientKeyWhenUnresolved(t *testing.T) {
+	body := []byte(`{"model":"grok-4.6","prompt_cache_key":"session-keep"}`)
+	got, err := applyGrokPassthroughCacheIdentity(body, "")
+	require.NoError(t, err)
+	require.Equal(t, "session-keep", gjson.GetBytes(got, "prompt_cache_key").String())
+}

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -59,7 +59,7 @@ func shouldPreserveOpenAIResponsesNoneReasoningEffort(account *Account) bool {
 	if account == nil {
 		return false
 	}
-	if account.IsOpenAIPassthroughEnabled() {
+	if account.IsOpenAIPassthroughEnabled() || account.IsGrokPassthroughEnabled() {
 		return true
 	}
 	if account.IsOpenAIOAuthLike() {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -820,6 +820,9 @@ func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedMode
 		}
 		return upstreamModel
 	}
+	if account != nil && account.IsGrokPassthroughEnabled() {
+		return strings.TrimSpace(requestedModel)
+	}
 
 	// Compact mappings are keyed by the client-visible model. Prefer an exact
 	// compact rule before ordinary account mapping; otherwise a normal alias can
@@ -856,7 +859,7 @@ func ResolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedMode
 // accounting, while upstreamModel is the model the scheduler has admitted.
 func resolveOpenAIForwardMappedModels(account *Account, requestedModel string, requireCompact bool) (billingModel, upstreamModel string) {
 	requestedModel = strings.TrimSpace(requestedModel)
-	if account != nil && account.IsOpenAIPassthroughEnabled() {
+	if account != nil && (account.IsOpenAIPassthroughEnabled() || account.IsGrokPassthroughEnabled()) {
 		billingModel = requestedModel
 	} else if account != nil {
 		billingModel = strings.TrimSpace(account.GetMappedModel(requestedModel))

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -31,9 +31,9 @@
         </p>
       </div>
 
-      <!-- OpenAI passthrough -->
+      <!-- OpenAI / Grok passthrough -->
       <div
-        v-if="allOpenAIPassthroughCapable"
+        v-if="allPassthroughCapable"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
         <div class="mb-3 flex items-center justify-between">
@@ -1563,6 +1563,19 @@ const allOpenAIPassthroughCapable = computed(() => {
   )
 })
 
+const allGrokPassthroughCapable = computed(() => {
+  return (
+    targetSelectedPlatforms.value.length === 1 &&
+    targetSelectedPlatforms.value[0] === 'grok' &&
+    targetSelectedTypes.value.length > 0 &&
+    targetSelectedTypes.value.every(t => t === 'oauth' || t === 'apikey')
+  )
+})
+
+const allPassthroughCapable = computed(
+  () => allOpenAIPassthroughCapable.value || allGrokPassthroughCapable.value
+)
+
 const allOpenAIOAuth = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
@@ -1749,7 +1762,7 @@ const upstreamBillingAutoProbeOptions = computed(() => [
 ])
 const isOpenAIModelRestrictionDisabled = computed(
   () =>
-    allOpenAIPassthroughCapable.value &&
+    allPassthroughCapable.value &&
     enableOpenAIPassthrough.value &&
     openaiPassthroughEnabled.value
 )
@@ -1975,11 +1988,15 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     }
   }
 
-  if (enableOpenAIPassthrough.value) {
+  if (enableOpenAIPassthrough.value && allPassthroughCapable.value) {
     const extra = ensureExtra()
-    extra.openai_passthrough = openaiPassthroughEnabled.value
-    if (!openaiPassthroughEnabled.value) {
-      extra.openai_oauth_passthrough = false
+    if (allGrokPassthroughCapable.value) {
+      extra.grok_passthrough = openaiPassthroughEnabled.value
+    } else {
+      extra.openai_passthrough = openaiPassthroughEnabled.value
+      if (!openaiPassthroughEnabled.value) {
+        extra.openai_oauth_passthrough = false
+      }
     }
   }
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2967,9 +2967,9 @@
         </p>
       </div>
 
-      <!-- OpenAI 自动透传开关（OAuth/API Key） -->
+      <!-- OpenAI / Grok 自动透传开关（OAuth/API Key） -->
       <div
-        v-if="form.platform === 'openai'"
+        v-if="form.platform === 'openai' || form.platform === 'grok'"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
         <div class="flex items-center justify-between">
@@ -4471,7 +4471,7 @@ const openAIWSModeConcurrencyHintKey = computed(() =>
 )
 
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  form.platform === 'openai' && openaiPassthroughEnabled.value
+  (form.platform === 'openai' || form.platform === 'grok') && openaiPassthroughEnabled.value
 )
 
 const mixedChannelWarningMessageText = computed(() => {
@@ -5222,6 +5222,19 @@ const handleClose = () => {
   emit('close')
 }
 
+const buildGrokExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
+  if (form.platform !== 'grok') {
+    return base
+  }
+  const extra: Record<string, unknown> = { ...(base || {}) }
+  if (openaiPassthroughEnabled.value) {
+    extra.grok_passthrough = true
+  } else {
+    delete extra.grok_passthrough
+  }
+  return Object.keys(extra).length > 0 ? extra : undefined
+}
+
 const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
   if (form.platform !== 'openai') {
     return base
@@ -5662,7 +5675,7 @@ const handleSubmit = async () => {
   }
 
   form.credentials = credentials
-  const extra = buildAnthropicExtra(buildOpenAIExtra())
+  const extra = buildGrokExtra(buildAnthropicExtra(buildOpenAIExtra()))
 
   await doCreateAccount({
     ...form,
@@ -5776,13 +5789,18 @@ const createAccountAndFinish = async (
     if (!credentials.base_url) {
       credentials.base_url = apiKeyBaseUrl.value.trim() || 'https://api.x.ai/v1'
     }
-    const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
-    if (modelMapping) {
-      credentials.model_mapping = modelMapping
+    if (!isOpenAIModelRestrictionDisabled.value) {
+      const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
+      if (modelMapping) {
+        credentials.model_mapping = modelMapping
+      } else {
+        delete credentials.model_mapping
+      }
     } else {
       delete credentials.model_mapping
     }
   }
+  finalExtra = buildGrokExtra(finalExtra)
   await doCreateAccount({
     name: form.name,
     notes: form.notes,
@@ -5839,12 +5857,14 @@ const handleGrokValidateRT = async (refreshTokenInput: string) => {
 
         const credentials = grokOAuth.buildCredentials(tokenInfo)
         applyGrokOAuthUpstreamConfig(credentials)
-        const extra = grokOAuth.buildExtraInfo(tokenInfo)
+        const extra = buildGrokExtra(grokOAuth.buildExtraInfo(tokenInfo) as Record<string, unknown> | undefined)
         const accountName = refreshTokens.length > 1 ? `${form.name || tokenInfo.email || 'Grok OAuth Account'} #${i + 1}` : (form.name || tokenInfo.email || 'Grok OAuth Account')
 
-        const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
-        if (modelMapping) {
-          credentials.model_mapping = modelMapping
+        if (!isOpenAIModelRestrictionDisabled.value) {
+          const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
+          if (modelMapping) {
+            credentials.model_mapping = modelMapping
+          }
         }
         if (!applyTempUnschedConfig(credentials)) {
           return

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1623,9 +1623,9 @@
         </p>
       </div>
 
-      <!-- OpenAI 自动透传开关（OAuth/API Key） -->
+      <!-- OpenAI / Grok 自动透传开关（OAuth/API Key） -->
       <div
-        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
+        v-if="(account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')) || (account?.platform === 'grok' && (account?.type === 'oauth' || account?.type === 'apikey'))"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
         <div class="flex items-center justify-between">
@@ -3511,7 +3511,7 @@ const normalizeOpenAIResponsesMode = (mode: unknown): OpenAIResponsesMode => {
   return 'auto'
 }
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  props.account?.platform === 'openai' && openaiPassthroughEnabled.value
+  (props.account?.platform === 'openai' || props.account?.platform === 'grok') && openaiPassthroughEnabled.value
 )
 const openAIResponsesStatusKey = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
@@ -3773,6 +3773,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
+  if (newAccount.platform === 'grok' && (newAccount.type === 'oauth' || newAccount.type === 'apikey')) {
+    openaiPassthroughEnabled.value = extra?.grok_passthrough === true
+  }
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openaiFlattenNamespacesEnabled.value =
@@ -4697,7 +4700,7 @@ const handleSubmit = async () => {
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
       const newBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
-      const shouldApplyModelMapping = !(props.account.platform === 'openai' && openaiPassthroughEnabled.value)
+      const shouldApplyModelMapping = !((props.account.platform === 'openai' || props.account.platform === 'grok') && openaiPassthroughEnabled.value)
 
       // Always update credentials for apikey type to handle model mapping changes
       const newCredentials: Record<string, unknown> = {
@@ -4964,7 +4967,7 @@ const handleSubmit = async () => {
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
       if (props.account.platform === 'openai') {
         applyOpenAIModelMappingCredentials(newCredentials)
-      } else {
+      } else if (!openaiPassthroughEnabled.value) {
         const modelMapping = buildModelRestrictionMapping()
         if (modelMapping) {
           newCredentials.model_mapping = modelMapping
@@ -5179,6 +5182,17 @@ const handleSubmit = async () => {
         delete newExtra.web_search_emulation
       } else {
         newExtra.web_search_emulation = webSearchEmulationMode.value
+      }
+      updatePayload.extra = newExtra
+    }
+
+    if (props.account.platform === 'grok' && (props.account.type === 'oauth' || props.account.type === 'apikey')) {
+      const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
+      const newExtra: Record<string, unknown> = { ...currentExtra }
+      if (openaiPassthroughEnabled.value) {
+        newExtra.grok_passthrough = true
+      } else {
+        delete newExtra.grok_passthrough
       }
       updatePayload.extra = newExtra
     }

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -991,4 +991,62 @@ describe('BulkEditAccountModal', () => {
       }
     })
   })
+
+  it('Grok 账号批量编辑可开启自动透传', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['grok'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-passthrough-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-passthrough-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        grok_passthrough: true
+      }
+    })
+  })
+
+  it('Grok 账号批量编辑可关闭自动透传', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['grok'],
+      selectedTypes: ['apikey']
+    })
+
+    await wrapper.get('#bulk-edit-openai-passthrough-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        grok_passthrough: false
+      }
+    })
+  })
+
+  it('开启 Grok 自动透传时不再同时提交模型限制', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['grok'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-passthrough-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-passthrough-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-model-restriction-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        grok_passthrough: true
+      }
+    })
+    expect(wrapper.text()).toContain('admin.accounts.openai.modelRestrictionDisabledByPassthrough')
+  })
 })


### PR DESCRIPTION
## 摘要

参照 Codex 现有的「自动透传（仅替换认证）」机制，为 Grok OAuth / API Key 账号新增 `extra.grok_passthrough` 开关，使其获得同等能力。

**背景**：Codex 账号已支持透传模式，可跳过兼容改写、仅替换认证头。Grok 场景存在相同诉求——官方 `grok-shell` / xAI SDK 发出的请求本身已是 xAI Responses 方言，现有兼容改写逻辑会破坏请求体，并将 CLI 身份强制锁定为 `xai-grok-workspace/0.2.120`。本 PR 复用 Codex 透传路径，为 Grok 补齐该能力。

---

## 变更详情

### POST /v1/responses — 薄透传模式

开启开关后，请求经过最小化处理：

| 行为 | 说明 |
|------|------|
| ✅ 保留客户端 body | 可解析身份时对 `prompt_cache_key` 做 hash；解析失败不删除客户端原有 key |
| ✅ 仅替换认证 | 不改写其他字段 |
| ✅ 补齐缺失头 | 上游为 `cli-chat-proxy` 时自动补 `X-XAI-Token-Auth` / `x-authenticateresponse` |
| ✅ 保留官方身份 | 保留 `grok-shell` User-Agent |
| ✅ 透传白名单头 | 转发 `x-grok-*` 系列请求头 |
| ✅ SSE 兼容 | `event: ping` 改写为注释行 |
| ✅ 基础设施不变 | 继续走计费 / 并发限制 / 审计 / 故障转移 |

**跳过**：`mapping`、`patchGrokResponsesBody*`、Free 搜索注入、compact 模拟。

> WebSocket 及其他入口仍走兼容路径，不受影响。

### GET /v1/models — 透传分组实时目录

- 返回上游实时模型列表，字段包含 `id`、`context_window`、`supportsReasoningEffort`、`reasoningEfforts`
- 拉取失败时：先回落 observed ID，再回落默认集
- 管理端开启开关后：禁用白名单与映射
- 批量编辑使用独立的 `allGrokPassthroughCapable`，与 OpenAI 专用控件解耦

---

## 单元测试

| 测试文件 | 覆盖场景 |
|----------|----------|
| `account_grok_passthrough_test.go` | `IsGrokPassthroughEnabled` 按平台门控；缺省/非 bool 为关；透传账号 `IsModelSupported` 忽略残留 mapping；调度保持请求模型名 |
| `openai_gateway_grok_passthrough_test.go` | 透传不改写 body；替换认证；保留 `grok-shell/1.0.x` 身份；缺则补 `X-XAI-Token-Auth`；转发 `x-grok-*` 头；SSE `event: ping` 改注释；关闭时走兼容改写；`effort=none` 保留；cache identity 解析失败不删 `prompt_cache_key` |
| `grok_passthrough_models_test.go` | 透传分组返回上游 `data[]`（含 `reasoningEfforts`）；拉取失败回落；未开开关不启用；`GetAvailableModels` 不把残留 mapping 当白名单 |
| `cli_identity_test.go` / `http_upstream_test.go` | 识别官方身份；官方 `grok-shell` 头不被传输层覆盖 |
| `account_handler_available_models_test.go` | 管理端单账号模型列表在透传时回落默认集 |
| `BulkEditAccountModal.spec.ts` | 批量开启/关闭写入 `grok_passthrough`；开启时不提交模型限制 |
