### PR TITLE
fix(openai): preserve max reasoning effort for GPT-6 Astra

### DIFF
--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -2169,7 +2169,7 @@ func normalizeOpenAIReasoningEffortForModel(raw, model string) string {
 // supportsOpenAIReasoningEffortMax reports model families whose upstream scale
 // has a distinct max level. Other models keep the legacy max -> xhigh behavior.
 func supportsOpenAIReasoningEffortMax(model string) bool {
-	if isOpenAIGPT56Model(model) {
+	if isOpenAIGPT56Model(model) || isOpenAIGPT6AstraModel(model) {
 		return true
 	}
 

--- a/backend/internal/service/openai_gpt56_max_test.go
+++ b/backend/internal/service/openai_gpt56_max_test.go
@@ -24,6 +24,8 @@ func TestNormalizeOpenAIReasoningEffortForGPT56(t *testing.T) {
 		{name: "Sol 保留 max", raw: "max", model: "gpt-5.6-sol", want: "max"},
 		{name: "Terra 保留 max", raw: "max", model: "openai/gpt-5.6-terra", want: "max"},
 		{name: "Luna 后缀保留 max", raw: "max", model: "gpt-5.6-luna-2026-07-09", want: "max"},
+		{name: "GPT-6 Astra 保留 max", raw: "max", model: "gpt-6-astra", want: "max"},
+		{name: "GPT-6 Astra 后缀保留 max", raw: "max", model: "gpt-6-astra-2026-08-01", want: "max"},
 		{name: "DeepSeek V4 保留 max", raw: "max", model: "deepseek-v4-pro", want: "max"},
 		{name: "旧 GPT 模型沿用 xhigh", raw: "max", model: "gpt-5.5", want: "xhigh"},
 	}


### PR DESCRIPTION
## Summary

GPT-6 Astra traffic currently shows `Max -> XHigh` on the usage page (#6608): the model catalog advertises a `max` reasoning level to Codex clients, but the request-side rewrite silently downgrades every `effort: max` request to `xhigh` before forwarding upstream.

## Root cause

Two code paths disagree about Astra's capabilities:

- `configuredCodexGPTReasoningLevels` (openai_codex_models_service.go) uses `isOpenAIGPT6AstraModel` to advertise `max` in the client-facing catalog, so Codex lets users select Max.
- `supportsOpenAIReasoningEffortMax` (openai_gateway_request_body.go) only whitelists `gpt-5.6-*`, `deepseek-v4*`, `glm-*`, `kimi-*`/`moonshot-*` and `k3` — Astra is missing, so `normalizeOpenAIReasoningEffortForModel` falls back to the legacy `max -> xhigh` downgrade.

Upstream itself accepts `effort: max` for `gpt-6-astra` and executes normally (verified with a live request: HTTP 200, tokens billed as usual, no error event), so the downgrade is purely a gateway-side rewrite.

## Fix

Add `isOpenAIGPT6AstraModel` to `supportsOpenAIReasoningEffortMax` so the request-side effort handling agrees with the advertised catalog levels. Dated/provider-prefixed Astra variants are covered by the same helper.

## Tests

- Extended `TestNormalizeOpenAIReasoningEffortForGPT56` with bare (`gpt-6-astra`) and dated (`gpt-6-astra-2026-08-01`) variants asserting `max` is preserved.
- Full `internal/service` suite passes (`go test ./internal/service/...`).

Fixes #6608