### PR TITLE
fix(openai): preserve cyber failures and block response lineages

### DIFF
--- a/backend/internal/handler/openai_gateway_cyber_test.go
+++ b/backend/internal/handler/openai_gateway_cyber_test.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/testutil"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -176,6 +179,39 @@ func TestRejectIfCyberSessionBlocked_FailOpen(t *testing.T) {
 	h2 := &OpenAIGatewayHandler{gatewayService: nil}
 	key := &service.APIKey{ID: 1}
 	require.False(t, h2.rejectIfCyberSessionBlocked(c, key, []byte(`{}`), "gpt-5", cyberBlockFormatResponses), "nil gateway service → pass")
+}
+
+func TestRejectIfCyberSessionBlockedUsesPreviousResponseLineageBeforeAccountSelection(t *testing.T) {
+	gatewayCache := testutil.NewRedisGatewayCache(t)
+	lineageStore, ok := gatewayCache.(service.CyberSessionLineageStore)
+	require.True(t, ok)
+	blockStore, ok := gatewayCache.(service.CyberSessionBlockStore)
+	require.True(t, ok)
+
+	settingRepo := &contentModerationHandlerSettingRepo{values: map[string]string{
+		service.SettingKeyCyberSessionBlockEnabled:    "true",
+		service.SettingKeyCyberSessionBlockTTLSeconds: "60",
+	}}
+	gatewayService := service.NewOpenAIGatewayService(
+		nil, nil, nil, nil, nil, nil, gatewayCache, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, service.NewSettingService(settingRepo, nil), nil,
+	)
+	groupID := int64(7)
+	const apiKeyID = int64(11)
+	const root = "blocked-lineage-root"
+	require.NoError(t, lineageStore.BindCyberSessionRoot(context.Background(), groupID, apiKeyID, "resp_1", root, time.Minute))
+	require.NoError(t, blockStore.SetCyberSessionBlocked(context.Background(), "", []string{root}, time.Minute))
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"previous_response_id":"resp_1","input":"continue"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(string(body)))
+	h := &OpenAIGatewayHandler{gatewayService: gatewayService}
+	apiKey := &service.APIKey{ID: apiKeyID, GroupID: &groupID}
+
+	require.True(t, h.rejectIfCyberSessionBlocked(c, apiKey, body, "gpt-5.6-sol", cyberBlockFormatResponses))
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), `"code":"session_blocked_by_cyber_policy"`)
 }
 
 func TestBuildCyberSessionBlockWritePlanCombinesExplicitAndTranscriptKeys(t *testing.T) {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2388,7 +2388,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 
 	// The first response.create frame is available here, so explicit IDs are
 	// checked directly and body-derived sessions use the coarse scope gate.
-	if cyberBlockKey := findBlockedCyberSessionKey(c.Request.Context(), h.gatewayService, apiKey.ID, c, firstMessage); cyberBlockKey != "" {
+	if cyberBlockKey := findBlockedCyberSessionKey(c.Request.Context(), h.gatewayService, derefGroupID(apiKey.GroupID), apiKey.ID, c, firstMessage); cyberBlockKey != "" {
 		writeCyberSessionBlockedWSError(c.Request.Context(), wsConn)
 		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, "session blocked by cyber-security policy")
 		h.enqueueCyberSessionBlockedOpsEntry(c, apiKey, reqModel, cyberBlockKey)
@@ -2747,7 +2747,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				// the connection-level cyber session gate here as well. Native ingress
 				// visits this hook first and gets the same side-effect-free close error;
 				// its original BeforeTurn guard remains as defense in depth.
-				if cyberBlockedThisConn {
+				if cyberBlockedThisConn && service.CyberSessionBlockStillActive(c) {
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, cyberSessionBlockedClientMsg, nil)
 				}
 				if turn == 1 {
@@ -2755,6 +2755,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				if !gjson.ValidBytes(payload) {
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", errors.New("invalid json"))
+				}
+				if cyberBlockKey := findBlockedCyberSessionKey(c.Request.Context(), h.gatewayService, derefGroupID(apiKey.GroupID), apiKey.ID, c, payload); cyberBlockKey != "" {
+					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, cyberSessionBlockedClientMsg, nil)
 				}
 				model := strings.TrimSpace(originalModel)
 				if model == "" {
@@ -2788,7 +2791,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			},
 			BeforeTurn: func(turn int) error {
 				// turn==1 的会话屏蔽已由握手层检查覆盖；连接内 flag 只拦截后续 turn。
-				if cyberBlockedThisConn {
+				if cyberBlockedThisConn && service.CyberSessionBlockStillActive(c) {
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, cyberSessionBlockedClientMsg, nil)
 				}
 				// 长连接跨峰谷/倍率刷新防护：每个 turn 按当前时刻重装门并复核
@@ -3924,7 +3927,7 @@ func (h *OpenAIGatewayHandler) rejectIfCyberSessionBlocked(c *gin.Context, apiKe
 	if enabled, _ := h.gatewayService.CyberSessionBlockRuntime(c.Request.Context()); !enabled {
 		return false
 	}
-	key := findBlockedCyberSessionKey(c.Request.Context(), h.gatewayService, apiKey.ID, c, body)
+	key := findBlockedCyberSessionKey(c.Request.Context(), h.gatewayService, derefGroupID(apiKey.GroupID), apiKey.ID, c, body)
 	if key == "" {
 		return false
 	}
@@ -3961,15 +3964,14 @@ type cyberSessionBlockWritePlan struct {
 }
 
 func buildCyberSessionBlockWritePlan(apiKeyID int64, c *gin.Context, body []byte) cyberSessionBlockWritePlan {
-	plan := cyberSessionBlockWritePlan{}
+	identityScope, identityKeys := service.CyberSessionIdentityBlockWritePlan(c)
+	plan := cyberSessionBlockWritePlan{scopeKey: identityScope, keys: identityKeys}
 	if key := service.CyberSessionExplicitBlockKey(apiKeyID, c, body); key != "" {
-		plan.keys = append(plan.keys, key)
+		plan.keys = appendCyberSessionBlockPlanKey(plan.keys, key)
 	}
 	transcriptKeys := service.CyberSessionTranscriptBlockKeys(apiKeyID, body)
 	for _, key := range transcriptKeys {
-		if len(plan.keys) == 0 || key != plan.keys[0] {
-			plan.keys = append(plan.keys, key)
-		}
+		plan.keys = appendCyberSessionBlockPlanKey(plan.keys, key)
 	}
 	if len(transcriptKeys) > 0 {
 		plan.scopeKey = cyberSessionScopeKey(apiKeyID, c)
@@ -3977,7 +3979,19 @@ func buildCyberSessionBlockWritePlan(apiKeyID int64, c *gin.Context, body []byte
 	return plan
 }
 
-func findBlockedCyberSessionKey(ctx context.Context, gatewayService *service.OpenAIGatewayService, apiKeyID int64, c *gin.Context, body []byte) string {
+func appendCyberSessionBlockPlanKey(keys []string, key string) []string {
+	if key == "" {
+		return keys
+	}
+	for _, existing := range keys {
+		if existing == key {
+			return keys
+		}
+	}
+	return append(keys, key)
+}
+
+func findBlockedCyberSessionKey(ctx context.Context, gatewayService *service.OpenAIGatewayService, groupID, apiKeyID int64, c *gin.Context, body []byte) string {
 	if gatewayService == nil {
 		return ""
 	}
@@ -3986,6 +4000,8 @@ func findBlockedCyberSessionKey(ctx context.Context, gatewayService *service.Ope
 		clientIP = strings.TrimSpace(ip.GetClientIP(c))
 		userAgent = c.GetHeader("User-Agent")
 	}
+	identity := gatewayService.PrepareCyberSessionIdentity(ctx, groupID, apiKeyID, c, body, clientIP, userAgent)
+	service.BindCyberSessionIdentity(c, identity)
 	return gatewayService.FindCyberSessionBlockedForRequest(ctx, apiKeyID, c, body, clientIP, userAgent)
 }
 
@@ -4121,7 +4137,7 @@ func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey 
 		ClientIP:        clientIPStr,
 		CreatedAt:       time.Now(),
 	}
-	if gwSvc != nil && apiKey != nil {
+	if gwSvc != nil && apiKey != nil && !service.RetryCyberSessionBlock(c) {
 		plan := buildCyberSessionBlockWritePlan(apiKey.ID, c, cyberBlockBody)
 		if len(plan.keys) > 0 {
 			blockCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)

--- a/backend/internal/repository/gateway_cache.go
+++ b/backend/internal/repository/gateway_cache.go
@@ -225,6 +225,8 @@ func (c *gatewayCache) ReleaseGrokVideoBilled(ctx context.Context, key string) e
 
 // Compile-time assertion: gatewayCache must implement CyberSessionBlockStore.
 var _ service.CyberSessionBlockStore = (*gatewayCache)(nil)
+var _ service.CyberSessionLineageStore = (*gatewayCache)(nil)
+var _ service.CyberSessionLineageRefresher = (*gatewayCache)(nil)
 var _ service.LiveCallStore = (*gatewayCache)(nil)
 
 const reasoningContentPrefix = "reasoning_content:"
@@ -272,8 +274,116 @@ func (c *gatewayCache) GetReasoningContent(ctx context.Context, itemID string) (
 const (
 	cyberSessionBlockPrefix         = "cyber_session_block:"
 	cyberSessionScopePrefix         = "cyber_session_scope:"
+	cyberSessionLineagePrefix       = "cyber_session_lineage:"
 	cyberSessionRedisCommandMaxKeys = 128
 )
+
+func cyberSessionLineageKey(groupID, apiKeyID int64, responseID string) string {
+	raw := fmt.Sprintf("v1|group=%d|api_key=%d|response=%s", groupID, apiKeyID, strings.TrimSpace(responseID))
+	sum := sha256.Sum256([]byte(raw))
+	return cyberSessionLineagePrefix + hex.EncodeToString(sum[:])
+}
+
+func cyberSessionLineageMembersKey(groupID, apiKeyID int64, root string) string {
+	return cyberSessionLineageKey(groupID, apiKeyID, root) + ":members"
+}
+
+var bindCyberLineage = redis.NewScript(`
+local ttl = tonumber(ARGV[2])
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  ttl = math.max(ttl, redis.call('PTTL', KEYS[1]))
+end
+redis.call('SET', KEYS[1], ARGV[1], 'PX', ttl)
+redis.call('SADD', KEYS[2], KEYS[1])
+if redis.call('PTTL', KEYS[2]) < ttl then
+  redis.call('PEXPIRE', KEYS[2], ttl)
+end
+return 1
+`)
+
+func (c *gatewayCache) BindCyberSessionRoot(ctx context.Context, groupID, apiKeyID int64, responseID, root string, ttl time.Duration) error {
+	if c == nil || c.rdb == nil {
+		return errors.New("gateway cache unavailable")
+	}
+	responseID = strings.TrimSpace(responseID)
+	root = strings.TrimSpace(root)
+	if groupID <= 0 || apiKeyID <= 0 || responseID == "" || root == "" {
+		return errors.New("invalid cyber session lineage binding")
+	}
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	key := cyberSessionLineageKey(groupID, apiKeyID, responseID)
+	members := cyberSessionLineageMembersKey(groupID, apiKeyID, root)
+	return bindCyberLineage.Run(ctx, c.rdb, []string{key, members}, root, max(int64(1), ttl.Milliseconds())).Err()
+}
+
+const refreshCyberLineageAlias = `
+local current = redis.call('GET', KEYS[1])
+if not current or current == ARGV[1] then
+  local remaining = redis.call('PTTL', KEYS[1])
+  local ttl = math.max(remaining, tonumber(ARGV[2]))
+  redis.call('SET', KEYS[1], ARGV[1], 'PX', ttl)
+end
+return 1
+`
+
+func (c *gatewayCache) RefreshCyberSessionLineage(ctx context.Context, groupID, apiKeyID int64, root string, ttl time.Duration) error {
+	if c == nil || c.rdb == nil {
+		return errors.New("gateway cache unavailable")
+	}
+	if ttl <= 0 {
+		return nil
+	}
+	members := cyberSessionLineageMembersKey(groupID, apiKeyID, root)
+	var cursor uint64
+	for {
+		keys, next, err := c.rdb.SScan(ctx, members, cursor, "", cyberSessionRedisCommandMaxKeys).Result()
+		if err != nil {
+			return err
+		}
+		// SSCAN's count is a hint; explicitly bound each pipeline as well.
+		for start := 0; start < len(keys); start += cyberSessionRedisCommandMaxKeys {
+			pipe := c.rdb.Pipeline()
+			for _, key := range keys[start:min(start+cyberSessionRedisCommandMaxKeys, len(keys))] {
+				pipe.Eval(ctx, refreshCyberLineageAlias, []string{key}, root, max(int64(1), ttl.Milliseconds()))
+			}
+			if _, err := pipe.Exec(ctx); err != nil {
+				return err
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return c.rdb.Eval(ctx, `
+if redis.call('PTTL', KEYS[1]) < tonumber(ARGV[1]) then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+return 1`, []string{members}, max(int64(1), ttl.Milliseconds())).Err()
+		}
+	}
+}
+
+func (c *gatewayCache) GetCyberSessionRoot(ctx context.Context, groupID, apiKeyID int64, responseID string) (string, bool, error) {
+	if c == nil || c.rdb == nil {
+		return "", false, errors.New("gateway cache unavailable")
+	}
+	responseID = strings.TrimSpace(responseID)
+	if groupID <= 0 || apiKeyID <= 0 || responseID == "" {
+		return "", false, errors.New("invalid cyber session lineage lookup")
+	}
+	root, err := c.rdb.Get(ctx, cyberSessionLineageKey(groupID, apiKeyID, responseID)).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", false, nil
+	}
+	return root, true, nil
+}
 
 // SetCyberSessionBlocked writes exact blocks in bounded transactions. The
 // coarse scope is activated only after all exact blocks have been stored.
@@ -288,7 +398,7 @@ func (c *gatewayCache) SetCyberSessionBlocked(ctx context.Context, scopeKey stri
 		}
 		pipe := c.rdb.TxPipeline()
 		for _, key := range exactKeys {
-			pipe.Set(ctx, cyberSessionBlockPrefix+key, "1", ttl)
+			pipe.SetNX(ctx, cyberSessionBlockPrefix+key, "1", ttl)
 		}
 		_, err := pipe.Exec(ctx)
 		exactKeys = exactKeys[:0]

--- a/backend/internal/repository/gateway_cache_cyber_deadline_test.go
+++ b/backend/internal/repository/gateway_cache_cyber_deadline_test.go
@@ -1,0 +1,146 @@
+package repository
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+type reviewSettings struct {
+	service.SettingRepository
+	ttl string
+}
+
+func (s *reviewSettings) GetValue(_ context.Context, key string) (string, error) {
+	if key == service.SettingKeyCyberSessionBlockEnabled {
+		return "true", nil
+	}
+	if key == service.SettingKeyCyberSessionBlockTTLSeconds {
+		if s.ttl != "" {
+			return s.ttl, nil
+		}
+		return "60", nil
+	}
+	return "", service.ErrSettingNotFound
+}
+
+func TestReviewCyberConfiguredTTLAndLookup(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	defer func() { _ = client.Close() }()
+	cache := NewGatewayCache(client)
+	settings := service.NewSettingService(&reviewSettings{ttl: "120"}, nil)
+	svc := service.NewOpenAIGatewayService(nil, nil, nil, nil, nil, nil, cache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, settings, nil)
+	enabled, ttl := svc.CyberSessionBlockRuntime(context.Background())
+	require.True(t, enabled)
+	require.Equal(t, 120*time.Second, ttl)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	c.Request.Header.Set("session_id", "explicit-ttl")
+	body := []byte(`{"input":"trigger"}`)
+	service.BindCyberSessionIdentity(c, svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, body, "ip", "ua"))
+	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "blocked"})
+	key := service.CyberSessionExplicitBlockKey(11, c, body)
+	require.InDelta(t, float64(120*time.Second), float64(server.TTL(cyberSessionBlockPrefix+key)), float64(time.Second))
+	server.FastForward(100 * time.Second)
+	require.NotEmpty(t, svc.FindCyberSessionBlockedForRequest(context.Background(), 11, c, body, "ip", "ua"))
+	require.InDelta(t, float64(20*time.Second), float64(server.TTL(cyberSessionBlockPrefix+key)), float64(time.Second), "blocked request lookup must not reset the block TTL")
+	server.FastForward(21 * time.Second)
+	require.Empty(t, svc.FindCyberSessionBlockedForRequest(context.Background(), 11, c, body, "ip", "ua"))
+}
+
+func TestReviewCyberFallbackExtendsFirstHitDeadline(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	defer func() { _ = client.Close() }()
+	cache := NewGatewayCache(client)
+	svc := service.NewOpenAIGatewayService(nil, nil, nil, nil, nil, nil, cache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.NewSettingService(&reviewSettings{ttl: "120"}, nil), nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	body := []byte(`{"input":"trigger"}`)
+	service.BindCyberSessionIdentity(c, svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, body, "ip", "ua"))
+	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "blocked"})
+	scope, keys := service.CyberSessionIdentityBlockWritePlan(c)
+	server.FastForward(20 * time.Second)
+	svc.MarkCyberSessionBlocked(context.Background(), scope, keys)
+	require.InDelta(t, float64(100*time.Second), float64(server.TTL(cyberSessionBlockPrefix+keys[0])), float64(time.Second), "post-forward fallback must preserve first-hit deadline")
+}
+func TestReviewCyberLineageExpiresBeforeBlock(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	defer func() { _ = client.Close() }()
+	cache := NewGatewayCache(client)
+	svc := service.NewOpenAIGatewayService(nil, nil, nil, nil, nil, nil, cache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.NewSettingService(&reviewSettings{}, nil), nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	identity := svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, []byte(`{"input":"trigger"}`), "ip", "ua")
+	service.BindCyberSessionIdentity(c, identity)
+	service.ObserveCyberSessionResponseID(c, "resp_1")
+	server.FastForward(30 * time.Second)
+	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "blocked", UpstreamStatus: 200})
+	_, keys := service.CyberSessionIdentityBlockWritePlan(c)
+	server.FastForward(31 * time.Second)
+	blockStore, ok := cache.(service.CyberSessionBlockStore)
+	require.True(t, ok)
+	matched, err := blockStore.FindCyberSessionBlocked(context.Background(), keys)
+	require.NoError(t, err)
+	require.NotEmpty(t, matched, "the cyber block still has 29 seconds remaining")
+	next, _ := gin.CreateTestContext(httptest.NewRecorder())
+	next.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	body := []byte(`{"previous_response_id":"resp_1","input":"continue"}`)
+	service.BindCyberSessionIdentity(next, svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, next, body, "ip", "ua"))
+	require.NotEmpty(t, svc.FindCyberSessionBlockedForRequest(context.Background(), 11, next, body, "ip", "ua"), "continuation must remain blocked for the full cooldown TTL")
+}
+
+func TestCyberLineageRefreshPreservesEarlierTurnsAndTenantIsolation(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	defer func() { _ = client.Close() }()
+	store, ok := NewGatewayCache(client).(*gatewayCache)
+	require.True(t, ok)
+	ctx := context.Background()
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 11, "resp_1", "root", time.Minute))
+	server.FastForward(40 * time.Second)
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 11, "resp_2", "root", time.Minute))
+	server.FastForward(30 * time.Second)
+	// The root is still active through resp_2. Restore the earlier alias for
+	// the block's full TTL without touching a different API key's mapping.
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 12, "resp_1", "other", time.Minute))
+	require.NoError(t, store.RefreshCyberSessionLineage(ctx, 7, 11, "root", time.Minute))
+	root, found, err := store.GetCyberSessionRoot(ctx, 7, 11, "resp_1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "root", root)
+	root, found, err = store.GetCyberSessionRoot(ctx, 7, 12, "resp_1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "other", root)
+	server.FastForward(61 * time.Second)
+	_, found, err = store.GetCyberSessionRoot(ctx, 7, 11, "resp_1")
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestCyberLineageShorterSettingDoesNotShortenActiveAliases(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	defer func() { _ = client.Close() }()
+	store, ok := NewGatewayCache(client).(*gatewayCache)
+	require.True(t, ok)
+	ctx := context.Background()
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 11, "resp_1", "root", 120*time.Second))
+	server.FastForward(20 * time.Second)
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 11, "resp_1", "root", 10*time.Second))
+	require.NoError(t, store.RefreshCyberSessionLineage(ctx, 7, 11, "root", 10*time.Second))
+	server.FastForward(11 * time.Second)
+	_, found, err := store.GetCyberSessionRoot(ctx, 7, 11, "resp_1")
+	require.NoError(t, err)
+	require.True(t, found, "a shorter new setting must not remove an alias of an existing longer block")
+}

--- a/backend/internal/repository/gateway_cache_cyber_test.go
+++ b/backend/internal/repository/gateway_cache_cyber_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +13,40 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGatewayCacheCyberSessionLineageRoundTripAndIsolation(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	store, ok := NewGatewayCache(client).(service.CyberSessionLineageStore)
+	require.True(t, ok)
+
+	ctx := context.Background()
+	require.NoError(t, store.BindCyberSessionRoot(ctx, 7, 11, "resp_1", "root-a", time.Minute))
+	root, found, err := store.GetCyberSessionRoot(ctx, 7, 11, "resp_1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "root-a", root)
+
+	_, found, err = store.GetCyberSessionRoot(ctx, 7, 12, "resp_1")
+	require.NoError(t, err)
+	require.False(t, found)
+	_, found, err = store.GetCyberSessionRoot(ctx, 8, 11, "resp_1")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	keys := server.Keys()
+	for _, key := range keys {
+		require.NotContains(t, key, "resp_1")
+		require.NotContains(t, key, "root-a")
+		require.True(t, strings.HasPrefix(key, cyberSessionLineagePrefix))
+	}
+
+	server.FastForward(time.Minute + time.Second)
+	_, found, err = store.GetCyberSessionRoot(ctx, 7, 11, "resp_1")
+	require.NoError(t, err)
+	require.False(t, found)
+}
 
 type cyberRedisCommandHook struct {
 	mu            sync.Mutex

--- a/backend/internal/service/openai_cpa_legacy_cyber_test.go
+++ b/backend/internal/service/openai_cpa_legacy_cyber_test.go
@@ -1,0 +1,300 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const cpaLegacyCyberEvent = `{"type":"error","code":"cyber_policy","message":"blocked by CPA","sequence_number":0}`
+
+type cyberBlockCheckingWriter struct {
+	gin.ResponseWriter
+	t       *testing.T
+	store   *comboCacheAndStore
+	root    string
+	seen    strings.Builder
+	checked bool
+}
+
+func (w *cyberBlockCheckingWriter) Write(body []byte) (int, error) {
+	_, _ = w.seen.Write(body)
+	if !w.checked && strings.Contains(w.seen.String(), `"code":"cyber_policy"`) {
+		w.checked = true
+		require.True(w.t, w.store.store.blocked[w.root], "cyber block must exist before the failure bytes reach the client")
+		w.store.events = append(w.store.events, "downstream_write")
+	}
+	return w.ResponseWriter.Write(body)
+}
+
+func (w *cyberBlockCheckingWriter) WriteString(body string) (int, error) {
+	return w.Write([]byte(body))
+}
+
+func openAITestSSEData(t *testing.T, event string) string {
+	t.Helper()
+	for _, line := range strings.Split(event, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			return strings.TrimPrefix(line, "data: ")
+		}
+	}
+	t.Fatalf("SSE event has no data line: %q", event)
+	return ""
+}
+
+func TestCPALegacyCyberErrorFieldsReachEveryConsumer(t *testing.T) {
+	hit, code, message := detectOpenAICyberPolicy([]byte(cpaLegacyCyberEvent))
+	require.True(t, hit)
+	require.Equal(t, "cyber_policy", code)
+	require.Equal(t, "blocked by CPA", message)
+
+	httpSSE := buildOpenAIResponseFailedSSE("resp_cpa", "gpt-5.6-sol", []byte(cpaLegacyCyberEvent), "")
+	httpPayload := openAITestSSEData(t, httpSSE)
+	require.Equal(t, "response.failed", gjson.Get(httpPayload, "type").String())
+	require.Equal(t, "resp_cpa", gjson.Get(httpPayload, "response.id").String())
+	require.Equal(t, "gpt-5.6-sol", gjson.Get(httpPayload, "response.model").String())
+	require.Equal(t, "response", gjson.Get(httpPayload, "response.object").String())
+	require.Equal(t, "failed", gjson.Get(httpPayload, "response.status").String())
+	require.Equal(t, "[]", gjson.Get(httpPayload, "response.output").Raw)
+	require.Equal(t, "cyber_policy", gjson.Get(httpPayload, "response.error.code").String())
+	require.Equal(t, "blocked by CPA", gjson.Get(httpPayload, "response.error.message").String())
+
+	wsEvent := buildOpenAIWSHTTPBridgeFailedEvent("resp_cpa", "gpt-5.6-sol", []byte(cpaLegacyCyberEvent), "")
+	require.Equal(t, "cyber_policy", gjson.GetBytes(wsEvent, "response.error.code").String())
+	require.Equal(t, "blocked by CPA", gjson.GetBytes(wsEvent, "response.error.message").String())
+
+	require.Equal(t, "cyber_policy", openAIStreamFailedEventErrorCode([]byte(cpaLegacyCyberEvent)))
+	require.Equal(t, http.StatusBadRequest, openAIStreamFailedEventSemanticStatus([]byte(cpaLegacyCyberEvent), "blocked by CPA"))
+	require.False(t, openAIStreamErrorEventShouldFailover([]byte(cpaLegacyCyberEvent), "please retry after policy review"))
+
+	wsCode, wsType, wsMessage := parseOpenAIWSErrorEventFields([]byte(cpaLegacyCyberEvent))
+	require.Equal(t, "cyber_policy", wsCode)
+	require.Empty(t, wsType)
+	require.Equal(t, "blocked by CPA", wsMessage)
+}
+
+func TestCPALegacyCapacityCodeIsRewrittenOnlyForClientDelivery(t *testing.T) {
+	payload := []byte(`{"type":"error","code":"server_is_overloaded","message":"Our servers are currently overloaded"}`)
+
+	updated, changed := sanitizeOpenAICapacityShedErrorCodeForClient(payload)
+
+	require.True(t, changed)
+	require.Equal(t, openAICapacityShedRetryableClientCode, gjson.GetBytes(updated, "code").String())
+	require.Equal(t, "Our servers are currently overloaded", gjson.GetBytes(updated, "message").String())
+}
+
+func TestCPALegacyCyberBareErrorEOFPreservesCodeAndSkipsAccountMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stream := "event: response.created\n" +
+		`data: {"type":"response.created","response":{"id":"resp_cpa","status":"in_progress"}}` + "\n\n" +
+		"event: error\n" +
+		"data: " + cpaLegacyCyberEvent + "\n\n"
+
+	tests := []struct {
+		name string
+		run  func(*OpenAIGatewayService, *gin.Context, *http.Response, *Account) error
+	}{
+		{
+			name: "native SSE",
+			run: func(svc *OpenAIGatewayService, c *gin.Context, resp *http.Response, account *Account) error {
+				_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, account, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+				return err
+			},
+		},
+		{
+			name: "passthrough SSE",
+			run: func(svc *OpenAIGatewayService, c *gin.Context, resp *http.Response, account *Account) error {
+				_, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, account, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &openAIAuthPolicyAccountRepo{}
+			combo := &comboCacheAndStore{}
+			svc := enabledCyberSessionTestService(combo)
+			svc.cfg = &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+			svc.rateLimitService = &RateLimitService{accountRepo: repo}
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			requestBody := []byte(`{"input":"trigger"}`)
+			BindCyberSessionIdentity(c, svc.PrepareCyberSessionIdentity(c.Request.Context(), 7, 11, c, requestBody, "203.0.113.1", "client/1.0"))
+			writer := &cyberBlockCheckingWriter{ResponseWriter: c.Writer, t: t, store: combo, root: getCyberSessionIdentity(c).lineageRoot}
+			c.Writer = writer
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(stream)),
+			}
+
+			err := tt.run(svc, c, resp, &Account{ID: 991, Platform: PlatformOpenAI, Type: AccountTypeOAuth})
+			require.True(t, writer.checked, "must observe a real downstream failure write")
+
+			require.Error(t, err)
+			var failoverErr *UpstreamFailoverError
+			require.False(t, errors.As(err, &failoverErr))
+			require.Zero(t, repo.setErrorCalls)
+			require.Zero(t, repo.tempCalls)
+			require.NotNil(t, GetOpsCyberPolicy(c))
+			require.Equal(t, 1, strings.Count(recorder.Body.String(), `"type":"response.failed"`))
+			require.Contains(t, recorder.Body.String(), `"id":"resp_cpa"`)
+			require.Contains(t, recorder.Body.String(), `"code":"cyber_policy"`)
+			require.Contains(t, recorder.Body.String(), `"message":"blocked by CPA"`)
+			require.Equal(t, []string{"lineage_bind", "lineage_bind", "block_set", "downstream_write"}, combo.events)
+		})
+	}
+}
+
+func TestCPALegacyCyberWSHTTPBridgeEOFPreservesCodeAndSkipsAccountMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_cpa_ws\",\"status\":\"in_progress\"}}\n\n" +
+		"event: error\ndata: " + cpaLegacyCyberEvent + "\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}}
+	repo := &openAIAuthPolicyAccountRepo{}
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	svc.cfg = &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+	svc.httpUpstream = upstream
+	svc.rateLimitService = &RateLimitService{accountRepo: repo}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	request := []byte(`{"type":"response.create","model":"gpt-5.6-sol","input":"hi"}`)
+	BindCyberSessionIdentity(c, svc.PrepareCyberSessionIdentity(c.Request.Context(), 7, 11, c, request, "203.0.113.1", "client/1.0"))
+	var writes [][]byte
+
+	result, err := svc.proxyOpenAIWSHTTPBridgeTurn(
+		context.Background(), c,
+		&Account{ID: 992, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 1},
+		"sk-test", request, len(request), "gpt-5.6-sol", "", "", "", "", 1,
+		func(message []byte) error {
+			writes = append(writes, append([]byte(nil), message...))
+			if gjson.GetBytes(message, "response.error.code").String() == "cyber_policy" {
+				combo.events = append(combo.events, "downstream_write")
+			}
+			return nil
+		},
+	)
+
+	require.EqualError(t, err, "blocked by CPA")
+	require.NotNil(t, result)
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.tempCalls)
+	require.NotNil(t, GetOpsCyberPolicy(c))
+	require.Len(t, writes, 2)
+	require.Equal(t, "response.failed", gjson.GetBytes(writes[1], "type").String())
+	require.Equal(t, "resp_cpa_ws", gjson.GetBytes(writes[1], "response.id").String())
+	require.Equal(t, "cyber_policy", gjson.GetBytes(writes[1], "response.error.code").String())
+	require.Equal(t, "blocked by CPA", gjson.GetBytes(writes[1], "response.error.message").String())
+	require.Equal(t, []string{"lineage_bind", "lineage_bind", "block_set", "downstream_write"}, combo.events)
+}
+
+func TestCPALegacyCyberBareErrorWithoutCreatedBindsSyntheticResponseID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stream := "event: error\ndata: " + cpaLegacyCyberEvent + "\n\n"
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	svc.cfg = &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	requestBody := []byte(`{"input":"trigger"}`)
+	identity := svc.PrepareCyberSessionIdentity(c.Request.Context(), 7, 11, c, requestBody, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(c, identity)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 993, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+
+	require.Error(t, err)
+	_, failedPayload, ok := extractOpenAISSETerminalEvent(recorder.Body.String())
+	require.True(t, ok)
+	responseID := gjson.GetBytes(failedPayload, "response.id").String()
+	require.NotEmpty(t, responseID)
+	require.Equal(t, identity.lineageRoot, combo.lineages[fakeCyberLineageKey(7, 11, responseID)])
+	require.True(t, combo.store.blocked[identity.lineageRoot])
+}
+
+func TestPreviousResponseLineageBlocksContinuationAfterCPALegacyCyber(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	svc.cfg = &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+	account := &Account{ID: 994, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	firstBody := []byte(`{"input":"first turn"}`)
+	firstRecorder := httptest.NewRecorder()
+	firstCtx, _ := gin.CreateTestContext(firstRecorder)
+	firstCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	firstIdentity := svc.PrepareCyberSessionIdentity(firstCtx.Request.Context(), 7, 11, firstCtx, firstBody, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(firstCtx, firstIdentity)
+	firstStream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		``,
+	}, "\n")
+	firstResp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(firstStream))}
+	_, err := svc.handleStreamingResponse(firstCtx.Request.Context(), firstResp, firstCtx, account, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+	require.NoError(t, err)
+	require.Equal(t, firstIdentity.lineageRoot, combo.lineages[fakeCyberLineageKey(7, 11, "resp_1")])
+	require.False(t, combo.store.blocked[firstIdentity.lineageRoot])
+
+	secondBody := []byte(`{"previous_response_id":"resp_1","input":"trigger"}`)
+	secondRecorder := httptest.NewRecorder()
+	secondCtx, _ := gin.CreateTestContext(secondRecorder)
+	secondCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	secondIdentity := svc.PrepareCyberSessionIdentity(secondCtx.Request.Context(), 7, 11, secondCtx, secondBody, "203.0.113.1", "client/1.0")
+	require.Equal(t, firstIdentity.lineageRoot, secondIdentity.lineageRoot)
+	BindCyberSessionIdentity(secondCtx, secondIdentity)
+	secondStream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_2","status":"in_progress"}}`,
+		``,
+		`event: error`,
+		`data: ` + cpaLegacyCyberEvent,
+		``,
+	}, "\n")
+	secondResp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(secondStream))}
+	_, err = svc.handleStreamingResponse(secondCtx.Request.Context(), secondResp, secondCtx, account, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+	require.Error(t, err)
+	require.Equal(t, firstIdentity.lineageRoot, combo.lineages[fakeCyberLineageKey(7, 11, "resp_2")])
+	require.True(t, combo.store.blocked[firstIdentity.lineageRoot])
+
+	for _, previousResponseID := range []string{"resp_1", "resp_2"} {
+		t.Run(previousResponseID, func(t *testing.T) {
+			body := []byte(`{"previous_response_id":"` + previousResponseID + `","input":"continue"}`)
+			c, _ := newCyberBlockTestCtx(nil, string(body))
+			identity := svc.PrepareCyberSessionIdentity(c.Request.Context(), 7, 11, c, body, "203.0.113.1", "client/1.0")
+			BindCyberSessionIdentity(c, identity)
+			require.Equal(t, firstIdentity.lineageRoot, svc.FindCyberSessionBlockedForRequest(c.Request.Context(), 11, c, body, "203.0.113.1", "client/1.0"))
+		})
+	}
+
+	newCtx, newBody := newCyberBlockTestCtx(nil, `{"input":"new independent turn"}`)
+	newIdentity := svc.PrepareCyberSessionIdentity(newCtx.Request.Context(), 7, 11, newCtx, newBody, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(newCtx, newIdentity)
+	require.Empty(t, svc.FindCyberSessionBlockedForRequest(newCtx.Request.Context(), 11, newCtx, newBody, "203.0.113.1", "client/1.0"))
+}

--- a/backend/internal/service/openai_cyber_policy.go
+++ b/backend/internal/service/openai_cyber_policy.go
@@ -2,16 +2,22 @@ package service
 
 import (
 	"errors"
+	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tidwall/gjson"
 )
 
 // opsCyberPolicyKey 在 gin context 中携带 cyber_policy 命中标记。
 // 由 gateway 服务层在检测到上游 error.code=="cyber_policy" 时设置，
 // handler 在 Forward 返回后读取以触发风控记录、邮件与 tokens=0 用量行。
 const opsCyberPolicyKey = "ops_cyber_policy"
+
+// Serialize mark replacement, never mutation: readers may retain a snapshot
+// while an authoritative terminal event supplies the final usage.
+var opsCyberPolicyMu sync.Mutex
 
 // errOpenAICyberPolicyForwarded 表示 cyber_policy 已按当前端点格式透传给客户端
 // （error 已写出/下发）。compat 路径 ForwardAsChatCompletions / ForwardAsAnthropic 出口
@@ -21,6 +27,7 @@ var errOpenAICyberPolicyForwarded = errors.New("openai cyber_policy forwarded to
 
 // CyberPolicyMark 记录一次 cyber_policy 硬阻断的上游证据。
 type CyberPolicyMark struct {
+	hitAt          time.Time
 	Code           string // 固定 "cyber_policy"
 	Message        string // 上游 error.message
 	Body           string // 上游 response.failed / 400 原始 body（已截断；未脱敏，ops_error 落库由 sanitizeErrorBodyForStorage、风控日志由 redactContentModerationSecrets 统一脱敏）
@@ -29,19 +36,30 @@ type CyberPolicyMark struct {
 	UpstreamOutTok int    // 上游已报 output tokens（如有）
 }
 
-// MarkOpsCyberPolicy 记录 cyber 标记；首个写入生效，后续忽略（同一 turn 只记一次）。
+// MarkOpsCyberPolicy preserves the first hit and its deadline, while later
+// terminal events can supply additional usage through immutable snapshots.
 // WS 多轮场景由 handler 在每个 turn 结束后调用 ClearOpsCyberPolicy 重置。
 func MarkOpsCyberPolicy(c *gin.Context, mark CyberPolicyMark) {
 	if c == nil {
 		return
 	}
-	if GetOpsCyberPolicy(c) != nil {
+	opsCyberPolicyMu.Lock()
+	if previous := GetOpsCyberPolicy(c); previous != nil {
+		updated := *previous
+		updated.UpstreamInTok = max(updated.UpstreamInTok, mark.UpstreamInTok)
+		updated.UpstreamOutTok = max(updated.UpstreamOutTok, mark.UpstreamOutTok)
+		c.Set(opsCyberPolicyKey, &updated)
+		opsCyberPolicyMu.Unlock()
+		activateCyberSessionIdentity(c)
 		return
 	}
 	mark.Code = "cyber_policy"
+	mark.hitAt = time.Now()
 	mark.Message = strings.TrimSpace(mark.Message)
 	mark.Body = strings.TrimSpace(mark.Body)
 	c.Set(opsCyberPolicyKey, &mark)
+	opsCyberPolicyMu.Unlock()
+	activateCyberSessionIdentity(c)
 }
 
 // GetOpsCyberPolicy 返回 cyber 标记，未命中（或已被 Clear）返回 nil。
@@ -67,24 +85,51 @@ func ClearOpsCyberPolicy(c *gin.Context) {
 	if c == nil {
 		return
 	}
+	opsCyberPolicyMu.Lock()
 	c.Set(opsCyberPolicyKey, (*CyberPolicyMark)(nil))
+	opsCyberPolicyMu.Unlock()
+}
+
+func openAICyberPolicyErrorBody(payload []byte) gin.H {
+	fields := extractOpenAIResponsesErrorFields(payload, 0)
+	errType := fields.Type
+	if errType == "" {
+		errType = "invalid_request_error"
+	}
+	message := sanitizeUpstreamErrorMessage(fields.Message)
+	if message == "" {
+		message = "Request blocked by upstream cyber-security policy"
+	}
+	return gin.H{"code": "cyber_policy", "type": errType, "message": message}
+}
+
+func buildOpenAICyberPolicyErrorEvent(payload []byte) []byte {
+	body, _ := marshalOpenAIUpstreamJSON(gin.H{"type": "error", "status": http.StatusBadRequest, "error": openAICyberPolicyErrorBody(payload)})
+	return body
+}
+
+func writeOpenAICyberPolicyHTTPError(c *gin.Context, payload []byte, status int, usage *OpenAIUsage) bool {
+	if !markOpenAICyberPolicyEvent(c, payload, status, usage) {
+		return false
+	}
+	errBody := openAICyberPolicyErrorBody(payload)
+	message, _ := errBody["message"].(string)
+	if openAICompactClientWantsStream(c) && StopOpenAICompactSSEKeepaliveCommitted(c) {
+		writeOpenAICompactSSEFailureMessage(c, http.StatusBadRequest, "cyber_policy", message)
+	} else {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errBody})
+	}
+	return true
 }
 
 // detectOpenAICyberPolicy 精确识别 cyber_policy（对齐 codex api_bridge.rs:145 /
 // sse/responses.rs:529）。命中返回 (true, "cyber_policy", message)。
 func detectOpenAICyberPolicy(payload []byte) (bool, string, string) {
-	code := gjson.GetBytes(payload, "error.code").String()
-	if code == "" {
-		code = gjson.GetBytes(payload, "response.error.code").String()
-	}
-	if !strings.EqualFold(strings.TrimSpace(code), "cyber_policy") {
+	fields := extractOpenAIResponsesErrorFields(payload, 0)
+	if !strings.EqualFold(strings.TrimSpace(fields.Code), "cyber_policy") {
 		return false, "", ""
 	}
-	msg := gjson.GetBytes(payload, "error.message").String()
-	if msg == "" {
-		msg = gjson.GetBytes(payload, "response.error.message").String()
-	}
-	return true, "cyber_policy", strings.TrimSpace(msg)
+	return true, "cyber_policy", strings.TrimSpace(fields.Message)
 }
 
 func markOpenAICyberPolicyEvent(c *gin.Context, payload []byte, upstreamStatus int, usage *OpenAIUsage) bool {
@@ -102,6 +147,7 @@ func markOpenAICyberPolicyEvent(c *gin.Context, payload []byte, upstreamStatus i
 		mark.UpstreamInTok = usage.InputTokens
 		mark.UpstreamOutTok = usage.OutputTokens
 	}
+	ObserveCyberSessionResponseID(c, extractOpenAIResponseIDFromJSONBytes(payload))
 	MarkOpsCyberPolicy(c, mark)
 	return true
 }

--- a/backend/internal/service/openai_cyber_review_regression_test.go
+++ b/backend/internal/service/openai_cyber_review_regression_test.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestCyberPolicyUsageSnapshotsAreImmutable(t *testing.T) {
+	c, _ := newCyberBlockTestCtx(nil, `{}`)
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "first"})
+	first := GetOpsCyberPolicy(c)
+	var workers sync.WaitGroup
+	for i := 1; i <= 32; i++ {
+		workers.Add(1)
+		go func(tokens int) {
+			defer workers.Done()
+			MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "later", UpstreamInTok: tokens})
+		}(i)
+	}
+	workers.Wait()
+	require.Zero(t, first.UpstreamInTok, "published snapshots must not be mutated by later events")
+	require.Equal(t, 32, GetOpsCyberPolicy(c).UpstreamInTok)
+	require.Equal(t, "first", GetOpsCyberPolicy(c).Message)
+}
+
+func TestCyberPolicyBeatsGenericWSRetryHints(t *testing.T) {
+	require.False(t, isOpenAIWSRateLimitError("cyber_policy", "rate_limit_error", "rate limit exceeded"))
+	_, retry := classifyOpenAIWSErrorEventFromRaw("cyber_policy", "server_error", "upgrade required")
+	require.False(t, retry)
+}
+
+func TestCyberSessionSettingsRefreshAffectsNewHits(t *testing.T) {
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"input":"test"}`)
+	identity := svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, body, "", "")
+	BindCyberSessionIdentity(c, identity)
+	svc.settingService.refreshCachedSettings(&SystemSettings{CyberSessionBlockEnabled: true, CyberSessionBlockTTLSeconds: 120})
+	enabled, ttl := svc.CyberSessionBlockRuntime(context.Background())
+	require.True(t, enabled)
+	require.Equal(t, 120*time.Second, ttl)
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "blocked"})
+	require.InDelta(t, 120, time.Until(identity.blockedUntil).Seconds(), 1)
+}
+
+func TestCyberSessionDeadlineExpiresWithoutBeingRestarted(t *testing.T) {
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	svc.settingService.settingRepo = &fakeSettingRepo{vals: map[string]string{
+		SettingKeyCyberSessionBlockEnabled: "true", SettingKeyCyberSessionBlockTTLSeconds: "1",
+	}}
+	c, body := newCyberBlockTestCtx(nil, `{"input":"test"}`)
+	identity := svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, body, "", "")
+	BindCyberSessionIdentity(c, identity)
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "blocked"})
+	require.True(t, CyberSessionBlockStillActive(c))
+	deadline := identity.blockedUntil
+	RetryCyberSessionBlock(c)
+	require.Equal(t, deadline, identity.blockedUntil)
+	time.Sleep(time.Until(deadline) + 10*time.Millisecond)
+	require.False(t, CyberSessionBlockStillActive(c), "WS connection flags must expire with the configured block")
+	before := len(combo.events)
+	RetryCyberSessionBlock(c)
+	require.Len(t, combo.events, before, "late handler cleanup must not re-create an expired block")
+}
+
+type reviewCyber429Dialer struct{}
+
+func (*reviewCyber429Dialer) Dial(context.Context, string, http.Header, string) (openAIWSClientConn, int, http.Header, error) {
+	return nil, 429, http.Header{}, &openAIWSHandshakeError{Body: []byte(openAIWSHandshakeCyberBody), Err: errors.New("handshake rejected")}
+}
+func TestReviewCyber429HandshakeMustNotFailover(t *testing.T) {
+	control, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), newStagedPassthroughConn())
+	svc.openaiWSPassthroughDialer = &reviewCyber429Dialer{}
+	observed := make(chan error, 1)
+	server, _ := startPassthroughLifecycleServerWithHooks(t, control, svc, passthroughLifecycleAccount(), func(c *gin.Context) *OpenAIWSIngressHooks {
+		return &OpenAIWSIngressHooks{AfterTurn: func(_ int, _ *OpenAIForwardResult, err error) { observed <- err }}
+	})
+	defer server.Close()
+	client := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = client.CloseNow() }()
+	select {
+	case err := <-observed:
+		var failover *UpstreamFailoverError
+		require.False(t, errors.As(err, &failover), "cyber must beat a wrapper's HTTP 429")
+	case <-time.After(3 * time.Second):
+		t.Fatal("missing AfterTurn")
+	}
+}
+
+func TestReviewCyberBufferedSSE(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	body := []byte("event: error\ndata: " + cpaLegacyCyberEvent + "\n\n")
+	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"text/event-stream"}}}
+	_, err := svc.handleSSEToJSON(resp, c, &Account{ID: 1, Platform: PlatformOpenAI}, body, "gpt-5.6-sol", "gpt-5.6-sol")
+	t.Logf("err=%v mark=%+v status=%d body=%s", err, GetOpsCyberPolicy(c), c.Writer.Status(), recorder.Body.String())
+	require.NotNil(t, GetOpsCyberPolicy(c), "buffered cyber must activate the session block")
+	require.Equal(t, 400, recorder.Code)
+	require.Equal(t, "cyber_policy", gjson.Get(recorder.Body.String(), "error.code").String())
+}
+
+func TestCyberPolicyBufferedResponsesShapes(t *testing.T) {
+	for _, passthrough := range []bool{false, true} {
+		for _, payload := range []string{openAIWSHandshakeCyberBody, cpaLegacyCyberEvent, `{"type":"response.failed","response":{"id":"resp_json","error":{"code":"cyber_policy","message":"blocked"},"usage":{"input_tokens":9,"output_tokens":2}}}`} {
+			for _, stream := range []bool{false, true} {
+				t.Run(fmt.Sprintf("passthrough=%v/sse=%v/%s", passthrough, stream, payload), func(t *testing.T) {
+					combo := &comboCacheAndStore{}
+					svc := enabledCyberSessionTestService(combo)
+					svc.cfg = &config.Config{}
+					recorder := httptest.NewRecorder()
+					c, _ := gin.CreateTestContext(recorder)
+					c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+					identity := svc.PrepareCyberSessionIdentity(context.Background(), 7, 11, c, []byte(`{"input":"trigger"}`), "", "")
+					BindCyberSessionIdentity(c, identity)
+					contentType, body := "application/json", payload
+					if stream {
+						contentType = "text/event-stream"
+						body = "event: error\ndata: " + payload + "\n\n"
+					}
+					resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {contentType}}, Body: io.NopCloser(strings.NewReader(body))}
+					account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+					if passthrough {
+						_, _ = svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, account, "gpt-5.6-sol", "gpt-5.6-sol")
+					} else {
+						_, _ = svc.handleNonStreamingResponse(context.Background(), resp, c, account, "gpt-5.6-sol", "gpt-5.6-sol")
+					}
+					require.Equal(t, 400, recorder.Code)
+					require.Equal(t, "cyber_policy", gjson.Get(recorder.Body.String(), "error.code").String())
+					require.True(t, combo.store.blocked[identity.lineageRoot])
+				})
+			}
+		}
+	}
+}
+
+func TestReviewCyberBridgeHTTPError(t *testing.T) {
+	c, _ := newCyberBlockTestCtx(nil, `{}`)
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: 400, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(openAIWSHandshakeCyberBody)),
+	}}}
+	request := []byte(`{"type":"response.create","model":"gpt-5.6-sol","input":"hi"}`)
+	var frames [][]byte
+	_, _ = svc.proxyOpenAIWSHTTPBridgeTurn(context.Background(), c, &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 1}, "sk-test", request, len(request), "gpt-5.6-sol", "", "", "", "", 1, func(b []byte) error { frames = append(frames, b); return nil })
+	require.Len(t, frames, 1)
+	t.Logf("mark=%+v frame=%s", GetOpsCyberPolicy(c), frames[0])
+	require.Equal(t, "cyber_policy", gjson.GetBytes(frames[0], "error.code").String())
+}
+
+func TestReviewCyberPairUsage(t *testing.T) {
+	c, _ := newCyberBlockTestCtx(nil, `{}`)
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	body := "event: error\ndata: " + cpaLegacyCyberEvent + "\n\n" +
+		`event: response.failed` + "\n" + `data: {"type":"response.failed","response":{"id":"resp_final","status":"failed","error":{"code":"cyber_policy","message":"blocked"},"usage":{"input_tokens":9,"output_tokens":2}}}` + "\n\n"
+	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(body))}
+	result, _ := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, time.Now(), "gpt-5.6-sol", "gpt-5.6-sol")
+	t.Logf("result usage=%+v mark=%+v", result.usage, GetOpsCyberPolicy(c))
+	require.Equal(t, 9, GetOpsCyberPolicy(c).UpstreamInTok)
+}
+
+func TestReviewCyberPassthroughSuccessfulLineage(t *testing.T) {
+	control, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.created","response":{"id":"resp_success"}}`)
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_success","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}}`)
+	combo := &comboCacheAndStore{}
+	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream)
+	svc.cache = combo
+	svc.settingService = enabledCyberSessionTestService(combo).settingService
+	observed := make(chan int, 1)
+	server, _ := startPassthroughLifecycleServerWithHooks(t, control, svc, passthroughLifecycleAccount(), func(c *gin.Context) *OpenAIWSIngressHooks {
+		BindCyberSessionIdentity(c, svc.PrepareCyberSessionIdentity(control, 7, 11, c, []byte(`{"input":"hello"}`), "", ""))
+		return &OpenAIWSIngressHooks{AfterTurn: func(_ int, _ *OpenAIForwardResult, _ error) { observed <- combo.lineageSets }}
+	})
+	defer server.Close()
+	client := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = client.CloseNow() }()
+	for i := 0; i < 2; i++ {
+		_, err := readPassthroughLifecycleFrame(t, client, 3*time.Second)
+		require.NoError(t, err)
+	}
+	select {
+	case writes := <-observed:
+		require.Greater(t, writes, 0, "successful Responses IDs must be bound before next turn")
+	case <-time.After(3 * time.Second):
+		t.Fatal("missing AfterTurn")
+	}
+}

--- a/backend/internal/service/openai_cyber_session_block.go
+++ b/backend/internal/service/openai_cyber_session_block.go
@@ -6,10 +6,12 @@ import (
 	"encoding/hex"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 // CyberSessionBlockStore 是 cyber 会话屏蔽表的存取接口。
@@ -21,7 +23,48 @@ type CyberSessionBlockStore interface {
 	FindCyberSessionBlocked(ctx context.Context, keys []string) (string, error)
 }
 
+// CyberSessionLineageStore maps downstream Responses IDs to opaque,
+// API-key-isolated cyber session roots. It is optional so existing GatewayCache
+// implementations and test doubles keep working without the lineage extension.
+type CyberSessionLineageStore interface {
+	BindCyberSessionRoot(ctx context.Context, groupID, apiKeyID int64, responseID, root string, ttl time.Duration) error
+	GetCyberSessionRoot(ctx context.Context, groupID, apiKeyID int64, responseID string) (root string, found bool, err error)
+}
+
+// The Redis implementation renews all response aliases of an active root at
+// a cyber hit, including earlier turns, so aliases cannot expire before blocks.
+type CyberSessionLineageRefresher interface {
+	RefreshCyberSessionLineage(ctx context.Context, groupID, apiKeyID int64, root string, ttl time.Duration) error
+}
+
 const cyberSessionTranscriptLookupOverflowBlockKey = "transcript_lookup_limit_exceeded"
+const cyberSessionIdentityContextKey = "openai_cyber_session_identity"
+const cyberSessionStoreTimeout = 500 * time.Millisecond
+const maxCyberSessionObservedResponseIDs = 8
+
+// CyberSessionIdentity is the request-local exact identity used for both
+// pre-routing block lookups and response-ID lineage binding. Mutable turn state
+// is guarded independently; Redis operations must never run while mu is held.
+type CyberSessionIdentity struct {
+	mu sync.Mutex
+
+	gateway     *OpenAIGatewayService
+	groupID     int64
+	apiKeyID    int64
+	explicitKey string
+	lineageRoot string
+	scopeKey    string
+	ttl         time.Duration
+
+	transcriptBlockKeys      []string
+	transcriptLookupKeys     []string
+	transcriptLookupOverflow bool
+	observedResponseIDs      map[string]struct{}
+	activating               bool
+	activated                bool
+	activationDone           chan struct{}
+	blockedUntil             time.Time
+}
 
 // CyberSessionExplicitBlockKey returns an inexpensive exact key when the
 // client supplies a stable session signal.
@@ -86,6 +129,17 @@ func (s *OpenAIGatewayService) cyberSessionBlockStore() CyberSessionBlockStore {
 	return store
 }
 
+func (s *OpenAIGatewayService) cyberSessionLineageStore() CyberSessionLineageStore {
+	if s == nil || s.cache == nil {
+		return nil
+	}
+	store, ok := s.cache.(CyberSessionLineageStore)
+	if !ok {
+		return nil
+	}
+	return store
+}
+
 // CyberSessionBlockRuntime 返回 (开关, TTL)。开关默认关。
 // 委托给 SettingService.GetCyberSessionBlockRuntime，进程内缓存避免热路径 DB 往返。
 func (s *OpenAIGatewayService) CyberSessionBlockRuntime(ctx context.Context) (bool, time.Duration) {
@@ -114,6 +168,273 @@ func (s *OpenAIGatewayService) MarkCyberSessionBlocked(ctx context.Context, scop
 	}
 }
 
+// PrepareCyberSessionIdentity resolves the strongest available request
+// identity. The disabled path returns before parsing the request or touching
+// the optional lineage store.
+func (s *OpenAIGatewayService) PrepareCyberSessionIdentity(
+	ctx context.Context,
+	groupID, apiKeyID int64,
+	c *gin.Context,
+	body []byte,
+	clientIP, userAgent string,
+) *CyberSessionIdentity {
+	enabled, ttl := s.CyberSessionBlockRuntime(ctx)
+	if !enabled || apiKeyID <= 0 {
+		return nil
+	}
+
+	transcript := deriveOpenAICyberTranscriptBlockKeys(apiKeyID, body)
+	transcriptBlockKeys := make([]string, 0, 2)
+	if len(transcript.lookupKeys) > 0 {
+		transcriptBlockKeys = append(transcriptBlockKeys, transcript.lookupKeys[len(transcript.lookupKeys)-1])
+		if transcript.preLatestUserKey != "" && transcript.preLatestUserKey != transcriptBlockKeys[0] {
+			transcriptBlockKeys = append(transcriptBlockKeys, transcript.preLatestUserKey)
+		}
+	}
+	identity := &CyberSessionIdentity{
+		gateway:                  s,
+		groupID:                  groupID,
+		apiKeyID:                 apiKeyID,
+		explicitKey:              CyberSessionExplicitBlockKey(apiKeyID, c, body),
+		scopeKey:                 CyberSessionScopeKey(apiKeyID, clientIP, userAgent),
+		ttl:                      ttl,
+		transcriptBlockKeys:      transcriptBlockKeys,
+		transcriptLookupKeys:     transcript.lookupKeys,
+		observedResponseIDs:      make(map[string]struct{}),
+		transcriptLookupOverflow: transcript.lookupKeysTruncated,
+	}
+	if identity.explicitKey != "" {
+		identity.lineageRoot = identity.explicitKey
+		return identity
+	}
+
+	previousResponseID := strings.TrimSpace(openAIRequestPayloadView(body).Get("previous_response_id").String())
+	if previousResponseID == "" {
+		identity.lineageRoot = hashCyberSessionBlockKey(apiKeyID, "response-lineage-root:"+uuid.NewString())
+		return identity
+	}
+	identity.observedResponseIDs[previousResponseID] = struct{}{}
+
+	store := s.cyberSessionLineageStore()
+	if store != nil && groupID > 0 {
+		storeCtx, cancel := context.WithTimeout(ctx, cyberSessionStoreTimeout)
+		defer cancel()
+		root, found, err := store.GetCyberSessionRoot(storeCtx, groupID, apiKeyID, previousResponseID)
+		if err != nil {
+			logger.LegacyPrintf("service.openai_gateway", "cyber session lineage read failed: err=%v", err)
+		} else if found && strings.TrimSpace(root) != "" {
+			identity.lineageRoot = strings.TrimSpace(root)
+			if err := store.BindCyberSessionRoot(storeCtx, groupID, apiKeyID, previousResponseID, identity.lineageRoot, ttl); err != nil {
+				logger.LegacyPrintf("service.openai_gateway", "cyber session lineage refresh failed: err=%v", err)
+			}
+			return identity
+		}
+	}
+
+	identity.lineageRoot = hashCyberSessionBlockKey(apiKeyID, "response-lineage:"+previousResponseID)
+	return identity
+}
+
+// BindCyberSessionIdentity installs the prepared identity on the request.
+func BindCyberSessionIdentity(c *gin.Context, identity *CyberSessionIdentity) {
+	if c == nil {
+		return
+	}
+	c.Set(cyberSessionIdentityContextKey, identity)
+}
+
+func getCyberSessionIdentity(c *gin.Context) *CyberSessionIdentity {
+	if c == nil {
+		return nil
+	}
+	value, ok := c.Get(cyberSessionIdentityContextKey)
+	if !ok {
+		return nil
+	}
+	identity, _ := value.(*CyberSessionIdentity)
+	return identity
+}
+
+func cyberSessionRequestContext(c *gin.Context) context.Context {
+	if c != nil && c.Request != nil {
+		return c.Request.Context()
+	}
+	return context.Background()
+}
+
+// ObserveCyberSessionResponseID persists a response-to-root binding before the
+// corresponding response event is made visible. Duplicate observations within
+// a turn do not repeat Redis writes.
+func ObserveCyberSessionResponseID(c *gin.Context, responseID string) {
+	identity := getCyberSessionIdentity(c)
+	responseID = strings.TrimSpace(responseID)
+	if identity == nil || responseID == "" {
+		return
+	}
+
+	identity.mu.Lock()
+	if _, exists := identity.observedResponseIDs[responseID]; exists {
+		identity.mu.Unlock()
+		return
+	}
+	if len(identity.observedResponseIDs) >= maxCyberSessionObservedResponseIDs {
+		identity.mu.Unlock()
+		return
+	}
+	identity.observedResponseIDs[responseID] = struct{}{}
+	gateway, groupID, apiKeyID := identity.gateway, identity.groupID, identity.apiKeyID
+	root, ttl := identity.lineageRoot, identity.ttl
+	identity.mu.Unlock()
+
+	if gateway == nil || groupID <= 0 || apiKeyID <= 0 || root == "" {
+		return
+	}
+	store := gateway.cyberSessionLineageStore()
+	if store == nil {
+		return
+	}
+	storeCtx, cancel := context.WithTimeout(cyberSessionRequestContext(c), cyberSessionStoreTimeout)
+	defer cancel()
+	if err := store.BindCyberSessionRoot(storeCtx, groupID, apiKeyID, responseID, root, ttl); err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "cyber session lineage bind failed: err=%v", err)
+		return
+	}
+}
+
+// CyberSessionIdentityBlockWritePlan exposes the exact request-local keys for
+// the handler's post-forward idempotent fallback write.
+func CyberSessionIdentityBlockWritePlan(c *gin.Context) (scopeKey string, keys []string) {
+	identity := getCyberSessionIdentity(c)
+	if identity == nil {
+		return "", nil
+	}
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	keys = appendCyberSessionUniqueKey(keys, identity.lineageRoot)
+	keys = appendCyberSessionUniqueKey(keys, identity.explicitKey)
+	for _, key := range identity.transcriptBlockKeys {
+		keys = appendCyberSessionUniqueKey(keys, key)
+	}
+	if len(identity.transcriptBlockKeys) > 0 {
+		scopeKey = identity.scopeKey
+	}
+	return scopeKey, keys
+}
+
+func appendCyberSessionUniqueKey(keys []string, key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return keys
+	}
+	for _, existing := range keys {
+		if existing == key {
+			return keys
+		}
+	}
+	return append(keys, key)
+}
+
+func activateCyberSessionIdentity(c *gin.Context) {
+	identity := getCyberSessionIdentity(c)
+	if identity == nil {
+		return
+	}
+	enabled, configuredTTL := identity.gateway.CyberSessionBlockRuntime(cyberSessionRequestContext(c))
+	if !enabled {
+		return
+	}
+
+	identity.mu.Lock()
+	if identity.activated {
+		identity.mu.Unlock()
+		return
+	}
+	if identity.activating {
+		done := identity.activationDone
+		identity.mu.Unlock()
+		<-done
+		return
+	}
+	identity.activating = true
+	identity.activationDone = make(chan struct{})
+	gateway, groupID, apiKeyID := identity.gateway, identity.groupID, identity.apiKeyID
+	if identity.blockedUntil.IsZero() {
+		identity.ttl = configuredTTL
+		hitAt := time.Now()
+		if mark := GetOpsCyberPolicy(c); mark != nil && !mark.hitAt.IsZero() {
+			hitAt = mark.hitAt
+		}
+		identity.blockedUntil = hitAt.Add(configuredTTL)
+	}
+	root, deadline := identity.lineageRoot, identity.blockedUntil
+	ttl := time.Until(deadline)
+	responseIDs := make([]string, 0, len(identity.observedResponseIDs))
+	for responseID := range identity.observedResponseIDs {
+		responseIDs = append(responseIDs, responseID)
+	}
+	identity.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(cyberSessionRequestContext(c)), cyberSessionStoreTimeout)
+	defer cancel()
+	if ttl > 0 && gateway != nil && groupID > 0 && apiKeyID > 0 && root != "" {
+		if store := gateway.cyberSessionLineageStore(); store != nil {
+			for _, responseID := range responseIDs {
+				if err := store.BindCyberSessionRoot(ctx, groupID, apiKeyID, responseID, root, ttl); err != nil {
+					logger.LegacyPrintf("service.openai_gateway", "cyber session lineage activation bind failed: err=%v", err)
+				}
+			}
+		}
+		if refresher, ok := gateway.cache.(CyberSessionLineageRefresher); ok {
+			if err := refresher.RefreshCyberSessionLineage(ctx, groupID, apiKeyID, root, ttl); err != nil {
+				logger.LegacyPrintf("service.openai_gateway", "cyber session lineage refresh failed: err=%v", err)
+			}
+		}
+	}
+	scopeKey, keys := CyberSessionIdentityBlockWritePlan(c)
+	ttl = time.Until(deadline)
+	succeeded := ttl <= 0
+	if ttl > 0 && gateway != nil {
+		if store := gateway.cyberSessionBlockStore(); store != nil {
+			if err := store.SetCyberSessionBlocked(ctx, scopeKey, keys, ttl); err != nil {
+				logger.LegacyPrintf("service.openai_gateway", "cyber session block write failed: err=%v", err)
+			} else {
+				succeeded = true
+			}
+		}
+	}
+
+	identity.mu.Lock()
+	identity.activated = succeeded
+	identity.activating = false
+	close(identity.activationDone)
+	identity.mu.Unlock()
+}
+
+// RetryCyberSessionBlock reuses the first hit's deadline. Returning true means
+// an identity owns this turn; the handler must not start a fresh TTL itself.
+func RetryCyberSessionBlock(c *gin.Context) bool {
+	if getCyberSessionIdentity(c) == nil {
+		return false
+	}
+	activateCyberSessionIdentity(c)
+	return true
+}
+
+// CyberSessionBlockStillActive bounds the WS connection's defensive flag by
+// the same configured deadline as the distributed session block.
+func CyberSessionBlockStillActive(c *gin.Context) bool {
+	identity := getCyberSessionIdentity(c)
+	if identity == nil {
+		return false
+	}
+	if enabled, _ := identity.gateway.CyberSessionBlockRuntime(cyberSessionRequestContext(c)); !enabled {
+		return false
+	}
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	return time.Now().Before(identity.blockedUntil)
+}
+
 // FindCyberSessionBlockedForRequest applies explicit-first lookup followed by
 // scope-gated transcript matching. All failures remain fail-open.
 func (s *OpenAIGatewayService) FindCyberSessionBlockedForRequest(ctx context.Context, apiKeyID int64, c *gin.Context, body []byte, clientIP, userAgent string) string {
@@ -124,6 +445,9 @@ func (s *OpenAIGatewayService) FindCyberSessionBlockedForRequest(ctx context.Con
 	store := s.cyberSessionBlockStore()
 	if store == nil {
 		return ""
+	}
+	if identity := getCyberSessionIdentity(c); identity != nil && identity.gateway == s && identity.apiKeyID == apiKeyID {
+		return s.findBoundCyberSessionBlocked(ctx, store, identity)
 	}
 	if explicitKey := CyberSessionExplicitBlockKey(apiKeyID, c, body); explicitKey != "" {
 		key, err := store.FindCyberSessionBlocked(ctx, []string{explicitKey})
@@ -155,6 +479,49 @@ func (s *OpenAIGatewayService) FindCyberSessionBlockedForRequest(ctx context.Con
 		return ""
 	}
 	key, err := store.FindCyberSessionBlocked(ctx, keys)
+	if err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "cyber session block batch read failed: err=%v", err)
+		return ""
+	}
+	return key
+}
+
+func (s *OpenAIGatewayService) findBoundCyberSessionBlocked(ctx context.Context, store CyberSessionBlockStore, identity *CyberSessionIdentity) string {
+	if identity.explicitKey != "" {
+		key, err := store.FindCyberSessionBlocked(ctx, []string{identity.explicitKey})
+		if err != nil {
+			logger.LegacyPrintf("service.openai_gateway", "cyber explicit session read failed: err=%v", err)
+			return ""
+		}
+		if key != "" {
+			return key
+		}
+	}
+	if identity.lineageRoot != "" && identity.lineageRoot != identity.explicitKey {
+		key, err := store.FindCyberSessionBlocked(ctx, []string{identity.lineageRoot})
+		if err != nil {
+			logger.LegacyPrintf("service.openai_gateway", "cyber session lineage block read failed: err=%v", err)
+			return ""
+		}
+		if key != "" {
+			return key
+		}
+	}
+	active, err := store.IsCyberSessionScopeActive(ctx, identity.scopeKey)
+	if err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "cyber session scope read failed: err=%v", err)
+		return ""
+	}
+	if !active {
+		return ""
+	}
+	if identity.transcriptLookupOverflow {
+		return cyberSessionTranscriptLookupOverflowBlockKey
+	}
+	if len(identity.transcriptLookupKeys) == 0 {
+		return ""
+	}
+	key, err := store.FindCyberSessionBlocked(ctx, identity.transcriptLookupKeys)
 	if err != nil {
 		logger.LegacyPrintf("service.openai_gateway", "cyber session block batch read failed: err=%v", err)
 		return ""

--- a/backend/internal/service/openai_cyber_session_block_test.go
+++ b/backend/internal/service/openai_cyber_session_block_test.go
@@ -103,6 +103,7 @@ type fakeCyberBlockStore struct {
 	blocked   map[string]bool
 	scopes    map[string]bool
 	findCalls int
+	findKeys  [][]string
 }
 
 var _ CyberSessionBlockStore = (*fakeCyberBlockStore)(nil)
@@ -129,6 +130,7 @@ func (f *fakeCyberBlockStore) IsCyberSessionScopeActive(_ context.Context, scope
 
 func (f *fakeCyberBlockStore) FindCyberSessionBlocked(_ context.Context, keys []string) (string, error) {
 	f.findCalls++
+	f.findKeys = append(f.findKeys, append([]string(nil), keys...))
 	for _, key := range keys {
 		if f.blocked[key] {
 			return key, nil
@@ -157,8 +159,14 @@ func (r *fakeSettingRepo) Get(_ context.Context, _ string) (*Setting, error) {
 func (r *fakeSettingRepo) Set(_ context.Context, _, _ string) error {
 	panic("fakeSettingRepo.Set not implemented")
 }
-func (r *fakeSettingRepo) GetMultiple(_ context.Context, _ []string) (map[string]string, error) {
-	panic("fakeSettingRepo.GetMultiple not implemented")
+func (r *fakeSettingRepo) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+	values := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := r.vals[key]; ok {
+			values[key] = value
+		}
+	}
+	return values, nil
 }
 func (r *fakeSettingRepo) SetMultiple(_ context.Context, _ map[string]string) error {
 	panic("fakeSettingRepo.SetMultiple not implemented")
@@ -176,11 +184,17 @@ var _ SettingRepository = (*fakeSettingRepo)(nil)
 // CyberSessionBlockStore (delegates to fakeCyberBlockStore) so it can be
 // injected as s.cache and successfully type-asserted to CyberSessionBlockStore.
 type comboCacheAndStore struct {
-	store fakeCyberBlockStore
+	store       fakeCyberBlockStore
+	lineages    map[string]string
+	lineageGets int
+	lineageSets int
+	lineageErr  error
+	events      []string
 }
 
 var _ GatewayCache = (*comboCacheAndStore)(nil)
 var _ CyberSessionBlockStore = (*comboCacheAndStore)(nil)
+var _ CyberSessionLineageStore = (*comboCacheAndStore)(nil)
 
 func (c *comboCacheAndStore) GetSessionAccountID(_ context.Context, _ int64, _ string) (int64, error) {
 	return 0, errors.New("stub")
@@ -217,6 +231,7 @@ func (c *comboCacheAndStore) GetReasoningContent(_ context.Context, _ string) (s
 }
 
 func (c *comboCacheAndStore) SetCyberSessionBlocked(ctx context.Context, scopeKey string, keys []string, ttl time.Duration) error {
+	c.events = append(c.events, "block_set")
 	return c.store.SetCyberSessionBlocked(ctx, scopeKey, keys, ttl)
 }
 func (c *comboCacheAndStore) IsCyberSessionScopeActive(ctx context.Context, scopeKey string) (bool, error) {
@@ -224,6 +239,32 @@ func (c *comboCacheAndStore) IsCyberSessionScopeActive(ctx context.Context, scop
 }
 func (c *comboCacheAndStore) FindCyberSessionBlocked(ctx context.Context, keys []string) (string, error) {
 	return c.store.FindCyberSessionBlocked(ctx, keys)
+}
+
+func fakeCyberLineageKey(groupID, apiKeyID int64, responseID string) string {
+	return strconv.FormatInt(groupID, 10) + ":" + strconv.FormatInt(apiKeyID, 10) + ":" + strings.TrimSpace(responseID)
+}
+
+func (c *comboCacheAndStore) BindCyberSessionRoot(_ context.Context, groupID, apiKeyID int64, responseID, root string, _ time.Duration) error {
+	c.lineageSets++
+	c.events = append(c.events, "lineage_bind")
+	if c.lineageErr != nil {
+		return c.lineageErr
+	}
+	if c.lineages == nil {
+		c.lineages = map[string]string{}
+	}
+	c.lineages[fakeCyberLineageKey(groupID, apiKeyID, responseID)] = root
+	return nil
+}
+
+func (c *comboCacheAndStore) GetCyberSessionRoot(_ context.Context, groupID, apiKeyID int64, responseID string) (string, bool, error) {
+	c.lineageGets++
+	if c.lineageErr != nil {
+		return "", false, c.lineageErr
+	}
+	root, ok := c.lineages[fakeCyberLineageKey(groupID, apiKeyID, responseID)]
+	return root, ok, nil
 }
 
 // --- tests ---
@@ -329,4 +370,202 @@ func TestCyberSessionScopeKeyNormalizesUserAgentVersion(t *testing.T) {
 	require.Equal(t, base, CyberSessionScopeKey(7, "203.0.113.10", "Codex CLI 1.2.4"))
 	require.NotEqual(t, base, CyberSessionScopeKey(8, "203.0.113.10", "Codex CLI 1.2.3"))
 	require.NotEqual(t, base, CyberSessionScopeKey(7, "203.0.113.11", "Codex CLI 1.2.3"))
+}
+
+func enabledCyberSessionTestService(cache GatewayCache) *OpenAIGatewayService {
+	return &OpenAIGatewayService{
+		cache: cache,
+		settingService: &SettingService{settingRepo: &fakeSettingRepo{vals: map[string]string{
+			SettingKeyCyberSessionBlockEnabled:    "true",
+			SettingKeyCyberSessionBlockTTLSeconds: "60",
+		}}},
+	}
+}
+
+func TestPrepareCyberSessionIdentityResolvesExplicitAndPreviousResponseLineage(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{lineages: map[string]string{
+		fakeCyberLineageKey(7, 11, "resp_known"): "known-root",
+	}}
+	svc := enabledCyberSessionTestService(combo)
+
+	explicitCtx, explicitBody := newCyberBlockTestCtx(map[string]string{"session_id": "sess-1"}, `{}`)
+	explicit := svc.PrepareCyberSessionIdentity(ctx, 7, 11, explicitCtx, explicitBody, "203.0.113.1", "client/1.0")
+	require.NotNil(t, explicit)
+	require.Equal(t, CyberSessionExplicitBlockKey(11, explicitCtx, explicitBody), explicit.lineageRoot)
+	require.Equal(t, explicit.explicitKey, explicit.lineageRoot)
+	require.Zero(t, combo.lineageGets)
+
+	previousCtx, previousBody := newCyberBlockTestCtx(nil, `{"previous_response_id":"resp_known","input":"continue"}`)
+	previous := svc.PrepareCyberSessionIdentity(ctx, 7, 11, previousCtx, previousBody, "203.0.113.1", "client/1.0")
+	require.NotNil(t, previous)
+	require.Equal(t, "known-root", previous.lineageRoot)
+	require.Equal(t, 1, combo.lineageGets)
+	require.Equal(t, 1, combo.lineageSets, "a resolved lineage refreshes its TTL")
+
+	missingCtx, missingBody := newCyberBlockTestCtx(nil, `{"previous_response_id":"resp_missing","input":"continue"}`)
+	missing := svc.PrepareCyberSessionIdentity(ctx, 7, 11, missingCtx, missingBody, "203.0.113.1", "client/1.0")
+	require.NotNil(t, missing)
+	require.NotEmpty(t, missing.lineageRoot)
+	missingAgain := svc.PrepareCyberSessionIdentity(ctx, 7, 11, missingCtx, missingBody, "203.0.113.1", "client/1.0")
+	require.Equal(t, missing.lineageRoot, missingAgain.lineageRoot)
+	differentAPIKey := svc.PrepareCyberSessionIdentity(ctx, 7, 12, missingCtx, missingBody, "203.0.113.1", "client/1.0")
+	require.NotEqual(t, missing.lineageRoot, differentAPIKey.lineageRoot)
+}
+
+func TestPrepareCyberSessionIdentityAllocatesNewRootAndSkipsStoreWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"input":"new turn"}`)
+	first := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	second := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	require.NotEmpty(t, first.lineageRoot)
+	require.NotEqual(t, first.lineageRoot, second.lineageRoot)
+	require.Zero(t, combo.lineageGets)
+	require.Zero(t, combo.lineageSets)
+
+	disabled := &OpenAIGatewayService{
+		cache: combo,
+		settingService: &SettingService{settingRepo: &fakeSettingRepo{vals: map[string]string{
+			SettingKeyCyberSessionBlockEnabled: "false",
+		}}},
+	}
+	require.Nil(t, disabled.PrepareCyberSessionIdentity(ctx, 7, 11, c, []byte(`{"previous_response_id":"resp_known"}`), "203.0.113.1", "client/1.0"))
+	require.Zero(t, combo.lineageGets)
+	require.Zero(t, combo.lineageSets)
+}
+
+func TestFindCyberSessionBlockedForBoundIdentityUsesExplicitThenLineageThenTranscript(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(map[string]string{"session_id": "sess-order"}, `{"messages":[{"role":"user","content":"setup"},{"role":"assistant","content":"ready"},{"role":"user","content":"continue"}]}`)
+	identity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	require.NotNil(t, identity)
+	BindCyberSessionIdentity(c, identity)
+
+	transcriptKey := CyberSessionTranscriptBlockKeys(11, body)[0]
+	combo.store.blocked = map[string]bool{transcriptKey: true}
+	combo.store.scopes = map[string]bool{identity.scopeKey: true}
+
+	require.Equal(t, transcriptKey, svc.FindCyberSessionBlockedForRequest(ctx, 11, c, body, "203.0.113.1", "client/1.0"))
+	require.Len(t, combo.store.findKeys, 2)
+	require.Equal(t, []string{identity.explicitKey}, combo.store.findKeys[0])
+	require.Equal(t, identity.transcriptLookupKeys, combo.store.findKeys[1])
+
+	combo.store.findKeys = nil
+	combo.store.blocked[identity.lineageRoot] = true
+	require.Equal(t, identity.lineageRoot, svc.FindCyberSessionBlockedForRequest(ctx, 11, c, body, "203.0.113.1", "client/1.0"))
+	require.Len(t, combo.store.findKeys, 1, "explicit roots are checked only once")
+}
+
+func TestCyberSessionIdentityNeverBlocksOnlyByIPAndUserAgent(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c1, body := newCyberBlockTestCtx(nil, `{"input":"first independent request"}`)
+	c2, _ := newCyberBlockTestCtx(nil, string(body))
+	first := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c1, body, "203.0.113.1", "client/1.0")
+	second := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c2, body, "203.0.113.1", "client/1.0")
+	require.NotEqual(t, first.lineageRoot, second.lineageRoot)
+	combo.store.blocked = map[string]bool{first.lineageRoot: true}
+	combo.store.scopes = map[string]bool{first.scopeKey: true}
+	BindCyberSessionIdentity(c2, second)
+
+	require.Empty(t, svc.FindCyberSessionBlockedForRequest(ctx, 11, c2, body, "203.0.113.1", "client/1.0"))
+}
+
+func TestFindCyberSessionBlockedForMappedPreviousResponseUsesLineageRoot(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{
+		lineages: map[string]string{fakeCyberLineageKey(7, 11, "resp_known"): "known-root"},
+		store:    fakeCyberBlockStore{blocked: map[string]bool{"known-root": true}},
+	}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"previous_response_id":"resp_known","input":"continue"}`)
+	identity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(c, identity)
+
+	require.Equal(t, "known-root", svc.FindCyberSessionBlockedForRequest(ctx, 11, c, body, "203.0.113.1", "client/1.0"))
+	require.Equal(t, [][]string{{"known-root"}}, combo.store.findKeys)
+}
+
+func TestCyberSessionLineageReadFailureKeepsTranscriptFallback(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{lineageErr: errors.New("redis unavailable")}
+	svc := enabledCyberSessionTestService(combo)
+	body := []byte(`{"previous_response_id":"resp_unknown","messages":[{"role":"user","content":"setup"},{"role":"assistant","content":"ready"},{"role":"user","content":"continue"}]}`)
+	c, _ := newCyberBlockTestCtx(nil, string(body))
+	identity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	require.NotNil(t, identity)
+	require.NotEmpty(t, identity.lineageRoot)
+	BindCyberSessionIdentity(c, identity)
+	transcriptKey := CyberSessionTranscriptBlockKeys(11, body)[0]
+	combo.store.blocked = map[string]bool{transcriptKey: true}
+	combo.store.scopes = map[string]bool{identity.scopeKey: true}
+
+	require.Equal(t, transcriptKey, svc.FindCyberSessionBlockedForRequest(ctx, 11, c, body, "203.0.113.1", "client/1.0"))
+}
+
+func TestCyberSessionIdentityBindsResponsesAndBlocksBeforeClientWrite(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"input":"first turn"}`)
+	identity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(c, identity)
+
+	ObserveCyberSessionResponseID(c, "resp_1")
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "blocked", UpstreamStatus: 200})
+	combo.events = append(combo.events, "downstream_write")
+
+	require.Equal(t, []string{"lineage_bind", "lineage_bind", "block_set", "downstream_write"}, combo.events)
+	require.True(t, combo.store.blocked[identity.lineageRoot])
+	require.Equal(t, identity.lineageRoot, combo.lineages[fakeCyberLineageKey(7, 11, "resp_1")])
+	require.True(t, identity.activated)
+
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "duplicate", UpstreamStatus: 200})
+	require.Equal(t, []string{"lineage_bind", "lineage_bind", "block_set", "downstream_write"}, combo.events)
+
+	nextCtx, nextBody := newCyberBlockTestCtx(nil, `{"previous_response_id":"resp_1","input":"continue"}`)
+	next := svc.PrepareCyberSessionIdentity(ctx, 7, 11, nextCtx, nextBody, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(nextCtx, next)
+	require.Equal(t, identity.lineageRoot, svc.FindCyberSessionBlockedForRequest(ctx, 11, nextCtx, nextBody, "203.0.113.1", "client/1.0"))
+
+	newCtx, newBody := newCyberBlockTestCtx(nil, `{"input":"genuinely new session"}`)
+	newIdentity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, newCtx, newBody, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(newCtx, newIdentity)
+	require.Empty(t, svc.FindCyberSessionBlockedForRequest(ctx, 11, newCtx, newBody, "203.0.113.1", "client/1.0"))
+}
+
+func TestCyberSessionIdentityObservesResponseAfterActivation(t *testing.T) {
+	ctx := context.Background()
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"input":"blocked before response id"}`)
+	identity := svc.PrepareCyberSessionIdentity(ctx, 7, 11, c, body, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(c, identity)
+	MarkOpsCyberPolicy(c, CyberPolicyMark{Message: "blocked", UpstreamStatus: 200})
+
+	ObserveCyberSessionResponseID(c, "resp_late")
+
+	require.Equal(t, identity.lineageRoot, combo.lineages[fakeCyberLineageKey(7, 11, "resp_late")])
+	require.True(t, combo.store.blocked[identity.lineageRoot])
+}
+
+func TestCyberSessionIdentityBoundsObservedResponseLineageWrites(t *testing.T) {
+	combo := &comboCacheAndStore{}
+	svc := enabledCyberSessionTestService(combo)
+	c, body := newCyberBlockTestCtx(nil, `{"input":"bounded response ids"}`)
+	identity := svc.PrepareCyberSessionIdentity(c.Request.Context(), 7, 11, c, body, "203.0.113.1", "client/1.0")
+	BindCyberSessionIdentity(c, identity)
+
+	for i := 0; i < 20; i++ {
+		ObserveCyberSessionResponseID(c, "resp_"+strconv.Itoa(i))
+	}
+
+	require.Equal(t, 8, combo.lineageSets)
 }

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -88,9 +88,10 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	upstreamMsg string,
 	upstreamModel string,
 ) *UpstreamFailoverError {
+	cyberPolicy := markOpenAICyberPolicyEvent(c, respBody, resp.StatusCode, nil)
 	shouldFailover := s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody)
 	tempUnscheduled := false
-	if c != nil && account != nil && account.Platform != PlatformGrok && !shouldFailover && !IsResponseCommitted(c) && s.rateLimitService != nil {
+	if !cyberPolicy && c != nil && account != nil && account.Platform != PlatformGrok && !shouldFailover && !IsResponseCommitted(c) && s.rateLimitService != nil {
 		tempUnscheduled = s.rateLimitService.CheckErrorPolicy(ctx, account, resp.StatusCode, respBody, upstreamModel) == ErrorPolicyTempUnscheduled
 		shouldFailover = tempUnscheduled
 	}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -936,6 +936,7 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	// 故下方跳过 handleOpenAIAccountUpstreamError（避免自定义 temp-unschedulable 规则误冷却）。
 	cyberHit, cyberCode, cyberMsg := detectOpenAICyberPolicy(body)
 	if cyberHit {
+		ObserveCyberSessionResponseID(c, extractOpenAIResponseIDFromJSONBytes(body))
 		MarkOpsCyberPolicy(c, CyberPolicyMark{
 			Code:           cyberCode,
 			Message:        cyberMsg,
@@ -1284,11 +1285,7 @@ func openAIStreamDataStartsTTFT(data, eventType string, forceOutput bool, mode s
 // openAIStreamFailedEventErrorCode 提取流内 failed 事件的错误码（小写），
 // 兼容 response.failed 的嵌套形态与裸 error 形态。
 func openAIStreamFailedEventErrorCode(payload []byte) string {
-	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String()))
-	if code == "" {
-		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
-	}
-	return code
+	return strings.ToLower(strings.TrimSpace(extractOpenAIResponsesErrorFields(payload, 0).Code))
 }
 
 // isOpenAIUpstreamCapacityShedEvent 判断流内 failed 事件是否为上游容量降载信号。
@@ -1363,19 +1360,31 @@ func sanitizeOpenAICapacityShedErrorCodeForClient(payload []byte) ([]byte, bool)
 		updated = next
 		changed = true
 	}
+	if topLevelCode := gjson.GetBytes(updated, "code"); topLevelCode.Exists() {
+		code := strings.ToLower(strings.TrimSpace(topLevelCode.String()))
+		if code == "server_is_overloaded" || code == "slow_down" {
+			next, err := sjson.SetBytes(updated, "code", openAICapacityShedRetryableClientCode)
+			if err != nil {
+				return payload, false
+			}
+			updated = next
+			changed = true
+		}
+	}
 	return updated, changed
 }
 
 func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
+	fields := extractOpenAIResponsesErrorFields(payload, http.StatusOK)
+	if strings.EqualFold(strings.TrimSpace(fields.Code), "cyber_policy") {
+		return fields.SemanticStatus
+	}
 	if isOpenAIContextWindowError(message, payload) {
 		return http.StatusBadRequest
 	}
 
-	code := openAIStreamFailedEventErrorCode(payload)
-	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String()))
-	if errType == "" {
-		errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.type").String()))
-	}
+	code := strings.ToLower(strings.TrimSpace(fields.Code))
+	errType := strings.ToLower(strings.TrimSpace(fields.Type))
 	combined := strings.TrimSpace(errType + " " + code + " " + strings.ToLower(strings.TrimSpace(message)))
 	for _, path := range []string{"response.error.status_code", "error.status_code", "status_code"} {
 		if status := int(gjson.GetBytes(payload, path).Int()); status == http.StatusUnauthorized ||
@@ -1950,6 +1959,8 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		if clientDisconnected || !writePendingLines() {
 			return
 		}
+		responseID = ensureOpenAIResponseID(responseID)
+		ObserveCyberSessionResponseID(c, responseID)
 		if _, err := fmt.Fprint(w, buildOpenAIResponseFailedSSE(responseID, originalModel, bareErrorPayload, failedMessage)); err != nil {
 			clientDisconnected = true
 			return
@@ -2126,6 +2137,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			if responseID == "" {
 				responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
 			}
+			ObserveCyberSessionResponseID(c, responseID)
 			imageCounter.AddSSEData(dataBytes)
 			if sanitizedData, sanitized := sanitizeOpenAIResponseFailedEventForClient(
 				dataBytes,
@@ -2297,6 +2309,9 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 		// 兜底：尝试从 SSE 文本中解析 usage
 		usage = s.parseSSEUsageFromBody(string(body))
 	}
+	if !bodyHasSSEFraming(body) && writeOpenAICyberPolicyHTTPError(c, body, resp.StatusCode, usage) {
+		return nil, errOpenAICyberPolicyForwarded
+	}
 	logOpenAISuccessMissingUsage(ctx, c, account, resp, usage, "json", false)
 
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
@@ -2317,13 +2332,15 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	if err != nil {
 		return nil, fmt.Errorf("restore OpenAI Responses client tools: %w", err)
 	}
+	responseID := extractOpenAIResponseIDFromJSONBytes(body)
+	ObserveCyberSessionResponseID(c, responseID)
 	if !writeOpenAICompactSSEBridge(c, resp.StatusCode, body) {
 		c.Data(resp.StatusCode, contentType, body)
 	}
 	return &openaiNonStreamingResultPassthrough{
 		OpenAIUsage:      usage,
 		usage:            usage,
-		responseID:       extractOpenAIResponseIDFromJSONBytes(body),
+		responseID:       responseID,
 		imageCount:       countOpenAIResponseImageOutputsFromJSONBytes(body),
 		imageOutputSizes: collectOpenAIResponseImageOutputSizesFromJSONBytes(body),
 	}, nil
@@ -2337,6 +2354,9 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 	bodyText := string(body)
 	terminalType, terminalPayload, terminalOK := extractOpenAISSETerminalEvent(bodyText)
 	if terminalOK && (terminalType == "response.failed" || terminalType == "error") {
+		if writeOpenAICyberPolicyHTTPError(c, terminalPayload, resp.StatusCode, s.parseSSEUsageFromBody(bodyText)) {
+			return nil, errOpenAICyberPolicyForwarded
+		}
 		msg := extractOpenAISSEErrorMessage(terminalPayload)
 		if msg == "" {
 			msg = "Upstream compact response failed"
@@ -2395,6 +2415,8 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			contentType = "text/event-stream"
 		}
 	}
+	responseID := extractOpenAIResponseIDFromJSONBytes(body)
+	ObserveCyberSessionResponseID(c, responseID)
 	if !writeOpenAICompactSSEBridge(c, resp.StatusCode, body) {
 		c.Data(resp.StatusCode, contentType, body)
 	}
@@ -2402,7 +2424,7 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 	return &openaiNonStreamingResultPassthrough{
 		OpenAIUsage:      usage,
 		usage:            usage,
-		responseID:       extractOpenAIResponseIDFromJSONBytes(body),
+		responseID:       responseID,
 		imageCount:       countOpenAIImageOutputsFromSSEBody(bodyText),
 		imageOutputSizes: collectOpenAIImageOutputSizesFromSSEBody(bodyText),
 	}, nil

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -378,6 +378,8 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		}
 		if codexFailureTerminal && sawBareError && !sawResponseFailed && !clientDisconnected {
 			applyAttemptResponseHeaders()
+			responseID = ensureOpenAIResponseID(responseID)
+			ObserveCyberSessionResponseID(c, responseID)
 			if _, err := writePendingString(buildOpenAIResponseFailedSSE(responseID, originalModel, bareErrorPayload, failedMessage)); err != nil {
 				handlePendingWriteError(err)
 			} else {
@@ -508,6 +510,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			if responseID == "" {
 				responseID = extractOpenAIResponseIDFromJSONBytes(dataBytes)
 			}
+			ObserveCyberSessionResponseID(c, responseID)
 			forceFlushFailedEvent := false
 			if !capacityFailoverSuppressedLogged && account != nil && account.Platform == PlatformOpenAI &&
 				(eventType == "error" || eventType == "response.failed") &&
@@ -1603,6 +1606,9 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	}
 
 	usageValue, usageOK := extractOpenAIUsageFromJSONBytes(body)
+	if !bodyLooksLikeSSE && writeOpenAICyberPolicyHTTPError(c, body, resp.StatusCode, &usageValue) {
+		return nil, errOpenAICyberPolicyForwarded
+	}
 	if !usageOK {
 		if bodyLooksLikeSSE {
 			return s.handleSSEToJSON(resp, c, account, body, originalModel, mappedModel)
@@ -1641,6 +1647,8 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 		}
 	}
 
+	responseID := extractOpenAIResponseIDFromJSONBytes(body)
+	ObserveCyberSessionResponseID(c, responseID)
 	if !writeOpenAICompactSSEBridge(c, resp.StatusCode, body) {
 		c.Data(resp.StatusCode, contentType, body)
 	}
@@ -1648,7 +1656,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	return &openaiNonStreamingResult{
 		OpenAIUsage:      usage,
 		usage:            usage,
-		responseID:       extractOpenAIResponseIDFromJSONBytes(body),
+		responseID:       responseID,
 		imageCount:       countOpenAIResponseImageOutputsFromJSONBytes(body),
 		imageOutputSizes: collectOpenAIResponseImageOutputSizesFromJSONBytes(body),
 		searchCount:      countGrokNativeSearchCallsFromJSONBytes(body),
@@ -1680,6 +1688,9 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 	bodyText := string(body)
 	terminalType, terminalPayload, terminalOK := extractOpenAISSETerminalEvent(bodyText)
 	if terminalOK && (terminalType == "response.failed" || terminalType == "error") {
+		if writeOpenAICyberPolicyHTTPError(c, terminalPayload, resp.StatusCode, s.parseSSEUsageFromBody(bodyText)) {
+			return nil, errOpenAICyberPolicyForwarded
+		}
 		msg := extractOpenAISSEErrorMessage(terminalPayload)
 		if msg == "" {
 			msg = "Upstream compact response failed"
@@ -1748,6 +1759,8 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			contentType = "text/event-stream"
 		}
 	}
+	responseID := extractOpenAIResponseIDFromJSONBytes(body)
+	ObserveCyberSessionResponseID(c, responseID)
 	if !writeOpenAICompactSSEBridge(c, resp.StatusCode, body) {
 		c.Data(resp.StatusCode, contentType, body)
 	}
@@ -1755,7 +1768,7 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 	return &openaiNonStreamingResult{
 		OpenAIUsage:      usage,
 		usage:            usage,
-		responseID:       extractOpenAIResponseIDFromJSONBytes(body),
+		responseID:       responseID,
 		imageCount:       countOpenAIImageOutputsFromSSEBody(bodyText),
 		imageOutputSizes: collectOpenAIImageOutputSizesFromSSEBody(bodyText),
 		searchCount:      countGrokNativeSearchCallsFromSSEBody(bodyText),
@@ -1782,31 +1795,21 @@ func extractOpenAISSEErrorMessage(payload []byte) string {
 	if len(payload) == 0 {
 		return ""
 	}
-	for _, path := range []string{"response.error.message", "error.message", "message"} {
-		if msg := strings.TrimSpace(gjson.GetBytes(payload, path).String()); msg != "" {
-			return sanitizeUpstreamErrorMessage(msg)
-		}
+	if message := extractOpenAIResponsesErrorFields(payload, 0).Message; message != "" {
+		return sanitizeUpstreamErrorMessage(message)
 	}
 	return sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(payload)))
 }
 
 func buildOpenAIResponseFailedSSE(responseID, model string, source []byte, fallbackMessage string) string {
-	responseID = strings.TrimSpace(responseID)
-	if responseID == "" {
-		responseID = "resp_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	}
-	errorType := strings.TrimSpace(gjson.GetBytes(source, "error.type").String())
-	if errorType == "" {
-		errorType = strings.TrimSpace(gjson.GetBytes(source, "response.error.type").String())
-	}
-	code := strings.TrimSpace(gjson.GetBytes(source, "error.code").String())
-	if code == "" {
-		code = strings.TrimSpace(gjson.GetBytes(source, "response.error.code").String())
-	}
+	responseID = ensureOpenAIResponseID(responseID)
+	fields := extractOpenAIResponsesErrorFields(source, http.StatusOK)
+	errorType := fields.Type
+	code := fields.Code
 	if code == "" {
 		code = "upstream_error"
 	}
-	message := extractOpenAISSEErrorMessage(source)
+	message := sanitizeUpstreamErrorMessage(fields.Message)
 	if message == "" {
 		message = strings.TrimSpace(fallbackMessage)
 	}
@@ -1836,6 +1839,14 @@ func buildOpenAIResponseFailedSSE(responseID, model string, source []byte, fallb
 		payload = []byte(`{"type":"response.failed","response":{"status":"failed","output":[],"error":{"code":"upstream_error","message":"Upstream response failed"}}}`)
 	}
 	return "event: response.failed\ndata: " + string(payload) + "\n\n"
+}
+
+func ensureOpenAIResponseID(responseID string) string {
+	responseID = strings.TrimSpace(responseID)
+	if responseID != "" {
+		return responseID
+	}
+	return "resp_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 }
 
 func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string, clientOutputStarted bool) ([]byte, bool) {

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -491,6 +491,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	// 当前请求恒透传（需求1）；标记供 handler 事后写风控/邮件。400 cyber 不可 failover
 	// （shouldFailoverUpstreamError(400)=false），故走到此处即可安全早返回。
 	if hit, code, cyberMsg := detectOpenAICyberPolicy(body); hit {
+		ObserveCyberSessionResponseID(c, extractOpenAIResponseIDFromJSONBytes(body))
 		MarkOpsCyberPolicy(c, CyberPolicyMark{
 			Code:           code,
 			Message:        cyberMsg,
@@ -743,6 +744,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	// 安全策略拦截，不冷却账号，故标记后直接以兼容格式回写错误并返回，跳过下方
 	// handleOpenAIAccountUpstreamError（避免自定义 temp-unschedulable 规则误冷却）。
 	if hit, code, cyberMsg := detectOpenAICyberPolicy(body); hit {
+		ObserveCyberSessionResponseID(c, extractOpenAIResponseIDFromJSONBytes(body))
 		MarkOpsCyberPolicy(c, CyberPolicyMark{
 			Code:           code,
 			Message:        cyberMsg,

--- a/backend/internal/service/openai_response_error_fields.go
+++ b/backend/internal/service/openai_response_error_fields.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+type openAIResponsesErrorFields struct {
+	Code            string
+	Type            string
+	Message         string
+	TransportStatus int
+	SemanticStatus  int
+}
+
+func firstOpenAIResponsesErrorString(payload []byte, paths ...string) string {
+	for _, path := range paths {
+		if value := strings.TrimSpace(gjson.GetBytes(payload, path).String()); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func extractOpenAIResponsesErrorFields(payload []byte, transportStatus int) openAIResponsesErrorFields {
+	fields := openAIResponsesErrorFields{
+		Code: firstOpenAIResponsesErrorString(payload,
+			"error.code", "response.error.code", "code"),
+		Type: firstOpenAIResponsesErrorString(payload,
+			"error.type", "response.error.type"),
+		Message: firstOpenAIResponsesErrorString(payload,
+			"response.error.message", "error.message", "message"),
+		TransportStatus: transportStatus,
+		SemanticStatus:  http.StatusBadGateway,
+	}
+
+	for _, path := range []string{
+		"response.error.status_code", "error.status_code", "status_code",
+		"response.error.status", "error.status", "status",
+	} {
+		if status := int(gjson.GetBytes(payload, path).Int()); status >= 400 && status <= 599 {
+			fields.SemanticStatus = status
+			break
+		}
+	}
+
+	code := strings.ToLower(strings.TrimSpace(fields.Code))
+	errType := strings.ToLower(strings.TrimSpace(fields.Type))
+	switch {
+	case code == "cyber_policy":
+		fields.SemanticStatus = http.StatusBadRequest
+	case strings.Contains(code, "rate_limit"):
+		fields.SemanticStatus = http.StatusTooManyRequests
+	case strings.Contains(errType, "invalid_request"):
+		fields.SemanticStatus = http.StatusBadRequest
+	}
+
+	return fields
+}

--- a/backend/internal/service/openai_response_error_fields_test.go
+++ b/backend/internal/service/openai_response_error_fields_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractOpenAIResponsesErrorFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		payload         string
+		transportStatus int
+		wantCode        string
+		wantType        string
+		wantMessage     string
+		wantSemantic    int
+	}{
+		{
+			name:            "nested error",
+			payload:         `{"error":{"type":"invalid_request","code":"cyber_policy","message":"nested"}}`,
+			transportStatus: http.StatusBadRequest,
+			wantCode:        "cyber_policy",
+			wantType:        "invalid_request",
+			wantMessage:     "nested",
+			wantSemantic:    http.StatusBadRequest,
+		},
+		{
+			name:            "response failed",
+			payload:         `{"type":"response.failed","response":{"error":{"type":"invalid_request","code":"cyber_policy","message":"wrapped"}}}`,
+			transportStatus: http.StatusOK,
+			wantCode:        "cyber_policy",
+			wantType:        "invalid_request",
+			wantMessage:     "wrapped",
+			wantSemantic:    http.StatusBadRequest,
+		},
+		{
+			name:            "CPA legacy top level",
+			payload:         `{"type":"error","code":"Cyber_Policy","message":"legacy","sequence_number":0}`,
+			transportStatus: http.StatusOK,
+			wantCode:        "Cyber_Policy",
+			wantMessage:     "legacy",
+			wantSemantic:    http.StatusBadRequest,
+		},
+		{
+			name:            "top level event type is not semantic type",
+			payload:         `{"type":"error","code":"provider_error","message":"failed"}`,
+			transportStatus: http.StatusOK,
+			wantCode:        "provider_error",
+			wantMessage:     "failed",
+			wantSemantic:    http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractOpenAIResponsesErrorFields([]byte(tt.payload), tt.transportStatus)
+			require.Equal(t, tt.wantCode, got.Code)
+			require.Equal(t, tt.wantType, got.Type)
+			require.Equal(t, tt.wantMessage, got.Message)
+			require.Equal(t, tt.transportStatus, got.TransportStatus)
+			require.Equal(t, tt.wantSemantic, got.SemanticStatus)
+		})
+	}
+}

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -859,7 +859,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		lease, acquireErr := pool.Acquire(acquireCtx, req)
 		acquireCancel()
 		var dialErr *openAIWSDialError
-		if acquireErr != nil && s.isAgentIdentityAccount(ctx, account) && errors.As(acquireErr, &dialErr) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
+		if errors.As(acquireErr, &dialErr) && dialErr != nil {
+			markOpenAICyberPolicyEvent(c, dialErr.ResponseBody, dialErr.StatusCode, nil)
+		}
+		if acquireErr != nil && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
 			agentTaskRecoveryTried = true
 			if recoveryErr := s.recoverAgentIdentityTask(ctx, account, account.GetCredential("task_id")); recoveryErr != nil {
 				return nil, fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
@@ -893,8 +896,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				wsPath,
 				account.ProxyID != nil && account.Proxy != nil,
 			)
-			var dialErr *openAIWSDialError
-			if errors.As(acquireErr, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
+			if dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
 				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()), canonicalModel)
 				return nil, s.newOpenAIWSRateLimitFailoverError(account, dialErr.ResponseHeaders, nil, acquireErr.Error())
 			}
@@ -938,6 +940,12 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			truncateOpenAIWSLogValue(preferred, openAIWSIDValueMaxLen),
 		)
 		return lease, nil
+	}
+	finishHandshakeFailure := func(turn int, turnErr error) error {
+		if hooks != nil && hooks.AfterTurn != nil {
+			hooks.AfterTurn(turn, nil, turnErr)
+		}
+		return turnErr
 	}
 
 	var rejectedFieldRetryState *openAIResponsesRejectedFieldRetryState
@@ -1625,7 +1633,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if sessionLease == nil {
 			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
 			if acquireErr != nil {
-				return fmt.Errorf("acquire upstream websocket: %w", acquireErr)
+				return finishHandshakeFailure(turn, fmt.Errorf("acquire upstream websocket: %w", acquireErr))
 			}
 			sessionLease = acquiredLease
 			sessionConnID = strings.TrimSpace(sessionLease.ConnID())
@@ -1733,7 +1741,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 				acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
 				if acquireErr != nil {
-					return fmt.Errorf("acquire upstream websocket after preflight ping fail: %w", acquireErr)
+					return finishHandshakeFailure(turn, fmt.Errorf("acquire upstream websocket after preflight ping fail: %w", acquireErr))
 				}
 				sessionLease = acquiredLease
 				sessionConnID = strings.TrimSpace(sessionLease.ConnID())

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -860,7 +860,12 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		acquireCancel()
 		var dialErr *openAIWSDialError
 		if errors.As(acquireErr, &dialErr) && dialErr != nil {
-			markOpenAICyberPolicyEvent(c, dialErr.ResponseBody, dialErr.StatusCode, nil)
+			if markOpenAICyberPolicyEvent(c, dialErr.ResponseBody, dialErr.StatusCode, nil) {
+				writeCtx, cancelWrite := context.WithTimeout(ctx, s.openAIWSWriteTimeout())
+				_ = clientConn.Write(writeCtx, coderws.MessageText, buildOpenAICyberPolicyErrorEvent(dialErr.ResponseBody))
+				cancelWrite()
+				return nil, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "request blocked by cyber-security policy", errOpenAICyberPolicyForwarded)
+			}
 		}
 		if acquireErr != nil && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
 			agentTaskRecoveryTried = true
@@ -1018,6 +1023,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 
 			eventType, eventResponseID, _ := parseOpenAIWSEventEnvelope(upstreamMessage)
+			ObserveCyberSessionResponseID(c, eventResponseID)
 			responseModelObserver.ObserveOpenAI(upstreamMessage, eventType)
 			if responseID == "" && eventResponseID != "" {
 				responseID = eventResponseID

--- a/backend/internal/service/openai_ws_forwarder_logutil.go
+++ b/backend/internal/service/openai_ws_forwarder_logutil.go
@@ -218,8 +218,8 @@ func parseOpenAIWSErrorEventFields(message []byte) (code string, errType string,
 	if len(message) == 0 {
 		return "", "", ""
 	}
-	values := gjson.GetManyBytes(message, "error.code", "error.type", "error.message")
-	return strings.TrimSpace(values[0].String()), strings.TrimSpace(values[1].String()), strings.TrimSpace(values[2].String())
+	fields := extractOpenAIResponsesErrorFields(message, 0)
+	return fields.Code, fields.Type, fields.Message
 }
 
 func summarizeOpenAIWSErrorEventFieldsFromRaw(codeRaw, errTypeRaw, errMessageRaw string) (code string, errType string, errMessage string) {

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -230,27 +230,10 @@ func markOpenAIWSClientVisibleFailure(c *gin.Context, eventType string, payload 
 	if eventType != "error" && eventType != "response.failed" {
 		return
 	}
-	prefix := "error"
-	if eventType == "response.failed" {
-		prefix = "response.error"
-	}
-	code := strings.TrimSpace(gjson.GetBytes(payload, prefix+".code").String())
-	errType := strings.TrimSpace(gjson.GetBytes(payload, prefix+".type").String())
-	message := strings.TrimSpace(gjson.GetBytes(payload, prefix+".message").String())
-	if eventType == "response.failed" && code == "" && errType == "" && message == "" {
-		prefix = "error"
-		code = strings.TrimSpace(gjson.GetBytes(payload, prefix+".code").String())
-		errType = strings.TrimSpace(gjson.GetBytes(payload, prefix+".type").String())
-		message = strings.TrimSpace(gjson.GetBytes(payload, prefix+".message").String())
-	}
-	status := int(gjson.GetBytes(payload, prefix+".status_code").Int())
-	if status == 0 {
-		status = int(gjson.GetBytes(payload, prefix+".status").Int())
-	}
-	if status == 0 && eventType == "error" {
-		status = int(gjson.GetBytes(payload, "status").Int())
-	}
-	if status == 0 {
+	fields := extractOpenAIResponsesErrorFields(payload, 0)
+	code, errType, message := fields.Code, fields.Type, fields.Message
+	status := fields.SemanticStatus
+	if status == http.StatusBadGateway {
 		status = openAIWSErrorHTTPStatusFromRaw(code, errType)
 	}
 	if errType == "" {
@@ -269,6 +252,10 @@ func openAIWSPayloadTransientStatus(payload []byte) int {
 	if len(payload) == 0 {
 		return 0
 	}
+	fields := extractOpenAIResponsesErrorFields(payload, 0)
+	if strings.EqualFold(strings.TrimSpace(fields.Code), "cyber_policy") {
+		return 0
+	}
 	status := int(gjson.GetBytes(payload, "response.error.status_code").Int())
 	if status == 0 {
 		status = int(gjson.GetBytes(payload, "response.error.status").Int())
@@ -279,20 +266,20 @@ func openAIWSPayloadTransientStatus(payload []byte) int {
 	if status == 0 {
 		status = int(gjson.GetBytes(payload, "error.status").Int())
 	}
+	if status == 0 {
+		status = int(gjson.GetBytes(payload, "status_code").Int())
+	}
+	if status == 0 {
+		status = int(gjson.GetBytes(payload, "status").Int())
+	}
 	if shouldCooldownOpenAITransientUpstreamError(status, payload) {
 		return status
 	}
 	if status != 0 {
 		return 0
 	}
-	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String()))
-	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String()))
-	if code == "" {
-		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
-	}
-	if errType == "" {
-		errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.type").String()))
-	}
+	code := strings.ToLower(strings.TrimSpace(fields.Code))
+	errType := strings.ToLower(strings.TrimSpace(fields.Type))
 	switch {
 	case code == "server_is_overloaded", code == "slow_down":
 		return http.StatusServiceUnavailable
@@ -669,6 +656,9 @@ func classifyOpenAIWSAcquireError(err error) string {
 
 func isOpenAIWSRateLimitError(codeRaw, errTypeRaw, msgRaw string) bool {
 	code := strings.ToLower(strings.TrimSpace(codeRaw))
+	if code == "cyber_policy" {
+		return false
+	}
 	errType := strings.ToLower(strings.TrimSpace(errTypeRaw))
 	msg := strings.ToLower(strings.TrimSpace(msgRaw))
 
@@ -732,6 +722,8 @@ func classifyOpenAIWSErrorEventFromRaw(codeRaw, errTypeRaw, msgRaw string) (stri
 	msg := strings.ToLower(strings.TrimSpace(msgRaw))
 
 	switch code {
+	case "cyber_policy":
+		return "cyber_policy", false
 	case "upgrade_required":
 		return "upgrade_required", true
 	case "websocket_not_supported", "websocket_unsupported":
@@ -783,6 +775,8 @@ func openAIWSErrorHTTPStatusFromRaw(codeRaw, errTypeRaw string) int {
 	code := strings.ToLower(strings.TrimSpace(codeRaw))
 	errType := strings.ToLower(strings.TrimSpace(errTypeRaw))
 	switch {
+	case code == "cyber_policy":
+		return http.StatusBadRequest
 	case strings.Contains(errType, "invalid_request"),
 		strings.Contains(code, "invalid_request"),
 		strings.Contains(code, "bad_request"),

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -212,8 +212,11 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		}(),
 	})
 	if err != nil {
-		var agentDialErr *openAIWSDialError
-		if s.isAgentIdentityAccount(ctx, account) && errors.As(err, &agentDialErr) && isAgentIdentityTaskInvalidWSDialError(agentDialErr) && agentTaskRecoveryTried != nil && !*agentTaskRecoveryTried {
+		var dialErr *openAIWSDialError
+		if errors.As(err, &dialErr) && dialErr != nil {
+			markOpenAICyberPolicyEvent(c, dialErr.ResponseBody, dialErr.StatusCode, nil)
+		}
+		if s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && agentTaskRecoveryTried != nil && !*agentTaskRecoveryTried {
 			*agentTaskRecoveryTried = true
 			if recoveryErr := s.recoverAgentIdentityTask(ctx, account, account.GetCredential("task_id")); recoveryErr != nil {
 				return nil, fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
@@ -243,8 +246,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 			wsPath,
 			account.ProxyID != nil && account.Proxy != nil,
 		)
-		var dialErr *openAIWSDialError
-		if errors.As(err, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
+		if dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
 			s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()), mappedModel)
 		}
 		return nil, wrapOpenAIWSFallback(classifyOpenAIWSAcquireError(err), err)

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -214,7 +214,9 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	if err != nil {
 		var dialErr *openAIWSDialError
 		if errors.As(err, &dialErr) && dialErr != nil {
-			markOpenAICyberPolicyEvent(c, dialErr.ResponseBody, dialErr.StatusCode, nil)
+			if writeOpenAICyberPolicyHTTPError(c, dialErr.ResponseBody, dialErr.StatusCode, nil) {
+				return nil, errOpenAICyberPolicyForwarded
+			}
 		}
 		if s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && agentTaskRecoveryTried != nil && !*agentTaskRecoveryTried {
 			*agentTaskRecoveryTried = true
@@ -534,6 +536,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		if eventType == "" {
 			continue
 		}
+		ObserveCyberSessionResponseID(c, eventResponseID)
 		responseModelObserver.ObserveOpenAI(message, eventType)
 		eventCount++
 		if firstEventType == "" {
@@ -650,6 +653,9 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 				emitStreamMessage(message, true)
 			}
 			if !reqStream {
+				if writeOpenAICyberPolicyHTTPError(c, message, http.StatusOK, usage) {
+					return nil, errOpenAICyberPolicyForwarded
+				}
 				c.JSON(statusCode, gin.H{
 					"error": gin.H{
 						"type":    "upstream_error",
@@ -728,6 +734,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		if responseID == "" {
 			responseID = strings.TrimSpace(gjson.GetBytes(finalResponse, "id").String())
 		}
+		ObserveCyberSessionResponseID(c, responseID)
 
 		c.Data(http.StatusOK, "application/json", finalResponse)
 	} else {

--- a/backend/internal/service/openai_ws_handshake_cyber_test.go
+++ b/backend/internal/service/openai_ws_handshake_cyber_test.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const openAIWSHandshakeCyberBody = `{"error":{"type":"invalid_request_error","code":"cyber_policy","message":"blocked by cyber policy"}}`
+
+type openAIWSHandshakeCyberDialer struct{}
+
+func (d *openAIWSHandshakeCyberDialer) Dial(context.Context, string, http.Header, string) (openAIWSClientConn, int, http.Header, error) {
+	body := []byte(openAIWSHandshakeCyberBody)
+	return nil, http.StatusBadRequest, http.Header{"X-Request-Id": []string{"req_handshake_cyber"}}, &openAIWSHandshakeError{
+		Body: body,
+		Err:  errors.New("websocket handshake rejected"),
+	}
+}
+
+type openAIWSHandshakeCyberObservation struct {
+	mark    *CyberPolicyMark
+	turnErr error
+}
+
+func TestOpenAIWSIngressCtxPoolHandshakeCyberMarkVisibleToAfterTurn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+
+	cfg := passthroughLifecycleConfig()
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModeCtxPool
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(&openAIWSHandshakeCyberDialer{})
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := passthroughLifecycleAccount()
+	account.ID = 902
+	account.Extra["openai_apikey_responses_websockets_v2_mode"] = OpenAIWSIngressModeCtxPool
+
+	observed := make(chan openAIWSHandshakeCyberObservation, 1)
+	server, serverErr := startPassthroughLifecycleServerWithHooks(t, controlCtx, svc, account, func(c *gin.Context) *OpenAIWSIngressHooks {
+		return &OpenAIWSIngressHooks{AfterTurn: func(_ int, _ *OpenAIForwardResult, turnErr error) {
+			observed <- openAIWSHandshakeCyberObservation{mark: GetOpsCyberPolicy(c), turnErr: turnErr}
+		}}
+	})
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	select {
+	case got := <-observed:
+		require.Error(t, got.turnErr)
+		requireOpenAIWSHandshakeCyberMark(t, got.mark)
+	case <-time.After(3 * time.Second):
+		t.Fatal("ctx_pool handshake failure did not reach AfterTurn")
+	}
+	select {
+	case err := <-serverErr:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("ctx_pool handshake failure did not exit")
+	}
+}
+
+func TestForwardOpenAIWSV2HandshakeBodyMarksCyberPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Request-Id", "req_http_ws_cyber")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(openAIWSHandshakeCyberBody))
+	}))
+	defer server.Close()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "unit-test-agent/1.0")
+	cfg := newOpenAIWSV2TestConfig()
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+	}
+	account := &Account{
+		ID: 903, Name: "http-ws-handshake-cyber", Platform: PlatformOpenAI,
+		Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test", "base_url": server.URL},
+		Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.5","stream":false,"input":"hello"}`))
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	requireOpenAIWSHandshakeCyberMark(t, GetOpsCyberPolicy(c))
+}
+
+func TestOpenAIWSV2PassthroughHandshakeCyberMarkVisibleToAfterTurn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+
+	cfg := passthroughLifecycleConfig()
+	svc := newPassthroughLifecycleService(cfg, newStagedPassthroughConn())
+	svc.openaiWSPassthroughDialer = &openAIWSHandshakeCyberDialer{}
+	account := passthroughLifecycleAccount()
+	account.ID = 904
+
+	observed := make(chan openAIWSHandshakeCyberObservation, 1)
+	server, serverErr := startPassthroughLifecycleServerWithHooks(t, controlCtx, svc, account, func(c *gin.Context) *OpenAIWSIngressHooks {
+		return &OpenAIWSIngressHooks{AfterTurn: func(_ int, _ *OpenAIForwardResult, turnErr error) {
+			observed <- openAIWSHandshakeCyberObservation{mark: GetOpsCyberPolicy(c), turnErr: turnErr}
+		}}
+	})
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	select {
+	case got := <-observed:
+		require.Error(t, got.turnErr)
+		requireOpenAIWSHandshakeCyberMark(t, got.mark)
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough handshake failure did not reach AfterTurn")
+	}
+	select {
+	case err := <-serverErr:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough handshake failure did not exit")
+	}
+}
+
+func TestFailoverOpenAIUpstreamHTTPErrorCyberBypassesCustomPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	repo := &tempUnschedulableOpenAIAccountRepo{}
+	svc := &OpenAIGatewayService{
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{
+		ID: 905, Platform: PlatformOpenAI, Type: AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{map[string]any{
+				"error_code":       float64(http.StatusBadRequest),
+				"keywords":         []any{"blocked by cyber policy"},
+				"duration_minutes": float64(1),
+			}},
+		},
+	}
+	resp := &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}
+
+	got := svc.failoverOpenAIUpstreamHTTPError(
+		context.Background(), c, account, resp, []byte(openAIWSHandshakeCyberBody),
+		"blocked by cyber policy", "gpt-5.5",
+	)
+
+	require.Nil(t, got, "cyber policy rejection must not fail over even when a custom rule matches")
+	require.Zero(t, repo.modelRateLimitAccountID, "cyber policy rejection must skip custom temp-unscheduled state")
+	require.Empty(t, repo.modelRateLimitKey)
+	requireOpenAIWSHandshakeCyberMark(t, GetOpsCyberPolicy(c))
+}
+
+func requireOpenAIWSHandshakeCyberMark(t *testing.T, mark *CyberPolicyMark) {
+	t.Helper()
+	require.NotNil(t, mark)
+	require.Equal(t, "cyber_policy", mark.Code)
+	require.Equal(t, "blocked by cyber policy", mark.Message)
+	require.Contains(t, mark.Body, `"code":"cyber_policy"`)
+	require.Equal(t, http.StatusBadRequest, mark.UpstreamStatus)
+	require.Zero(t, mark.UpstreamInTok)
+	require.Zero(t, mark.UpstreamOutTok)
+}

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -369,18 +369,13 @@ func buildOpenAIWSHTTPBridgeErrorEvent(statusCode int, message string) []byte {
 }
 
 func buildOpenAIWSHTTPBridgeFailedEvent(responseID, model string, source []byte, fallbackMessage string) []byte {
-	errorType := strings.TrimSpace(gjson.GetBytes(source, "error.type").String())
-	if errorType == "" {
-		errorType = strings.TrimSpace(gjson.GetBytes(source, "response.error.type").String())
-	}
-	code := strings.TrimSpace(gjson.GetBytes(source, "error.code").String())
-	if code == "" {
-		code = strings.TrimSpace(gjson.GetBytes(source, "response.error.code").String())
-	}
+	fields := extractOpenAIResponsesErrorFields(source, http.StatusOK)
+	errorType := fields.Type
+	code := fields.Code
 	if code == "" {
 		code = "upstream_error"
 	}
-	message := extractOpenAISSEErrorMessage(source)
+	message := sanitizeUpstreamErrorMessage(fields.Message)
 	if message == "" {
 		message = strings.TrimSpace(fallbackMessage)
 	}
@@ -563,7 +558,12 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, openAIWSHTTPBridgeErrorBodyLimitBytes))
 		_ = resp.Body.Close()
-		markOpenAICyberPolicyEvent(c, respBody, resp.StatusCode, nil)
+		if markOpenAICyberPolicyEvent(c, respBody, resp.StatusCode, nil) {
+			if err := writeClientMessage(buildOpenAICyberPolicyErrorEvent(respBody)); err != nil {
+				return nil, err
+			}
+			return nil, errOpenAICyberPolicyForwarded
+		}
 		if resp.StatusCode == http.StatusBadRequest &&
 			extractUpstreamErrorCode(respBody) == openAIWSFallbackReasonInvalidEncryptedContent {
 			s.markOpenAIWSInvalidEncryptedContentLineageFromPayload(
@@ -708,6 +708,8 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 		if clientDisconnected {
 			return nil
 		}
+		responseID = ensureOpenAIResponseID(responseID)
+		ObserveCyberSessionResponseID(c, responseID)
 		clientMessage := buildOpenAIWSHTTPBridgeFailedEvent(responseID, originalModel, bareErrorPayload, bareErrorMessage)
 		if rewritten, changed := sanitizeOpenAICapacityShedErrorCodeForClient(clientMessage); changed {
 			clientMessage = rewritten
@@ -760,6 +762,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 		if responseID == "" && eventResponseID != "" {
 			responseID = eventResponseID
 		}
+		ObserveCyberSessionResponseID(c, eventResponseID)
 		if eventType != "" {
 			eventCount++
 			if firstEventType == "" {

--- a/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
+++ b/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
@@ -197,9 +197,9 @@ func TestProxyResponsesWebSocketFromClient_MarksCyberPolicyBeforeEarlyReturn(t *
 		wantOutput    int
 	}{
 		{
-			name:          "error_before_rate_limit_failover",
+			name:          "cyber_error_bypasses_rate_limit_failover",
 			upstreamEvent: []byte(`{"type":"error","error":{"type":"rate_limit_error","code":"cyber_policy","message":"rate limit exceeded by cyber policy"},"usage":{"input_tokens":5,"output_tokens":1}}`),
-			wantFailover:  true,
+			wantClientMsg: true,
 			wantInput:     5,
 			wantOutput:    1,
 		},
@@ -285,7 +285,7 @@ func TestProxyResponsesWebSocketFromClient_MarksCyberPolicyBeforeEarlyReturn(t *
 				_, message, readErr := clientConn.Read(readCtx)
 				cancelRead()
 				require.NoError(t, readErr)
-				require.Equal(t, "response.failed", gjson.GetBytes(message, "type").String())
+				require.Equal(t, gjson.GetBytes(tt.upstreamEvent, "type").String(), gjson.GetBytes(message, "type").String())
 			}
 
 			select {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -870,6 +870,12 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	var upstreamConn openAIWSClientConn
 	statusCode := 0
 	var handshakeHeaders http.Header
+	finishHandshakeFailure := func(turnErr error) error {
+		if hooks != nil && hooks.AfterTurn != nil {
+			hooks.AfterTurn(1, nil, turnErr)
+		}
+		return turnErr
+	}
 	for {
 		headers, err = s.refreshOpenAIAgentIdentityHeaders(ctx, account, headers)
 		if err != nil {
@@ -886,11 +892,12 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		if errors.As(err, &handshakeErr) && handshakeErr != nil {
 			responseBody = handshakeErr.Body
 		}
+		markOpenAICyberPolicyEvent(c, responseBody, statusCode, nil)
 		dialErr := &openAIWSDialError{StatusCode: statusCode, ResponseHeaders: cloneHeader(handshakeHeaders), ResponseBody: responseBody, Err: err}
 		if s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
 			agentTaskRecoveryTried = true
 			if recoveryErr := s.recoverAgentIdentityTask(ctx, account, account.GetCredential("task_id")); recoveryErr != nil {
-				return fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
+				return finishHandshakeFailure(fmt.Errorf("agent identity task recovery failed: %w", recoveryErr))
 			}
 			continue
 		}
@@ -903,9 +910,9 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		s.handleOpenAIWSDialTransientFailure(ctx, account, capturedSessionModel, dialErr)
 		if statusCode == http.StatusTooManyRequests {
 			s.persistOpenAIWSRateLimitSignal(ctx, account, handshakeHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()), capturedSessionModel)
-			return s.newOpenAIWSRateLimitFailoverError(account, handshakeHeaders, nil, err.Error())
+			return finishHandshakeFailure(s.newOpenAIWSRateLimitFailoverError(account, handshakeHeaders, nil, err.Error()))
 		}
-		return s.mapOpenAIWSPassthroughDialError(err, statusCode, handshakeHeaders)
+		return finishHandshakeFailure(s.mapOpenAIWSPassthroughDialError(err, statusCode, handshakeHeaders))
 	}
 	defer func() {
 		_ = upstreamConn.Close()

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -892,7 +892,12 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		if errors.As(err, &handshakeErr) && handshakeErr != nil {
 			responseBody = handshakeErr.Body
 		}
-		markOpenAICyberPolicyEvent(c, responseBody, statusCode, nil)
+		if markOpenAICyberPolicyEvent(c, responseBody, statusCode, nil) {
+			writeCtx, cancelWrite := context.WithTimeout(ctx, s.openAIWSWriteTimeout())
+			_ = clientConn.Write(writeCtx, coderws.MessageText, buildOpenAICyberPolicyErrorEvent(responseBody))
+			cancelWrite()
+			return finishHandshakeFailure(NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "request blocked by cyber-security policy", errOpenAICyberPolicyForwarded))
+		}
 		dialErr := &openAIWSDialError{StatusCode: statusCode, ResponseHeaders: cloneHeader(handshakeHeaders), ResponseBody: responseBody, Err: err}
 		if s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
 			agentTaskRecoveryTried = true
@@ -1280,7 +1285,8 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				if msgType != coderws.MessageText {
 					return nil
 				}
-				eventType, _, _ := parseOpenAIWSEventEnvelope(payload)
+				eventType, responseID, _ := parseOpenAIWSEventEnvelope(payload)
+				ObserveCyberSessionResponseID(c, responseID)
 				if eventType == "response.created" {
 					failureAccountSideEffectsApplied = false
 				}

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -229,8 +229,8 @@ func TestPassthroughLifecycle_CyberTerminalEventsMarkBeforeAfterTurn(t *testing.
 			},
 			wantBody:    `"type":"error"`,
 			wantMessage: "blocked by error event",
-			wantInput:   5,
-			wantOutput:  1,
+			wantInput:   9,
+			wantOutput:  2,
 		},
 		{
 			name: "response_failed",

--- a/backend/internal/service/setting_gateway_runtime.go
+++ b/backend/internal/service/setting_gateway_runtime.go
@@ -167,6 +167,8 @@ func (s *SettingService) GetCyberSessionBlockRuntime(ctx context.Context) (bool,
 		}
 	}
 	result, _, _ := s.cyberSessionBlockRuntimeSF.Do("cyber_session_block_runtime", func() (any, error) {
+		s.cyberSessionBlockRuntimeMu.Lock()
+		defer s.cyberSessionBlockRuntimeMu.Unlock()
 		if cached, ok := s.cyberSessionBlockRuntimeCache.Load().(*cachedCyberSessionBlockRuntime); ok && cached != nil {
 			if time.Now().UnixNano() < cached.expiresAt {
 				return cached, nil

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -135,6 +135,7 @@ type SettingService struct {
 
 	cyberSessionBlockRuntimeCache atomic.Value // *cachedCyberSessionBlockRuntime
 	cyberSessionBlockRuntimeSF    singleflight.Group
+	cyberSessionBlockRuntimeMu    sync.Mutex
 
 	// panelRateLimitCache 面板 API 限流配置进程内缓存（*cachedPanelRateLimitSettings）。
 	// 面板每个认证请求都会读取，禁止在热路径上直接访问 DB。

--- a/backend/internal/service/setting_update.go
+++ b/backend/internal/service/setting_update.go
@@ -687,6 +687,18 @@ func (s *SettingService) refreshCachedSettings(settings *SystemSettings) {
 	if settings == nil {
 		return
 	}
+	// Serialize with a cold runtime read so a pre-save DB snapshot cannot
+	// overwrite the value that the administrator just saved.
+	s.cyberSessionBlockRuntimeMu.Lock()
+	cyberTTL := time.Hour
+	if settings.CyberSessionBlockTTLSeconds > 0 {
+		cyberTTL = time.Duration(settings.CyberSessionBlockTTLSeconds) * time.Second
+	}
+	s.cyberSessionBlockRuntimeCache.Store(&cachedCyberSessionBlockRuntime{
+		enabled: settings.CyberSessionBlockEnabled, ttl: cyberTTL,
+		expiresAt: time.Now().Add(cyberSessionBlockRuntimeCacheTTL).UnixNano(),
+	})
+	s.cyberSessionBlockRuntimeMu.Unlock()
 
 	// 先使 inflight singleflight 失效，再刷新缓存，缩小旧值覆盖新值的竞态窗口
 	versionBoundsSF.Forget("version_bounds")


### PR DESCRIPTION
Responses cyber-policy failures can lose their structured error code or bypass session blocking in several HTTP and WebSocket paths. For example, a compatible upstream's `{"type":"error","code":"cyber_policy","message":"blocked"}` SSE frame was synthesized as `upstream_error`; buffered Responses errors could instead return an unmarked 502.

This PR preserves cyber classification across those paths and blocks subsequent requests in the same session for the administrator-configured duration.

## Error handling

- Inspect non-2xx WebSocket handshake bodies and finish rejected ingress turns through `AfterTurn`.
- Give explicit `cyber_policy` precedence over custom temporary-unschedulable rules, HTTP 429 wrappers, and generic retry hints.
- Normalize nested HTTP errors, nested `response.failed`, and legacy top-level error fields. Preserve the code/message in synthetic SSE failures, buffered JSON/SSE Responses, WS HTTP bridge errors, and HTTP-to-WS errors.
- Keep actual upstream transport status separate from cyber's semantic status 400. Cyber failures do not trigger account failover or cooldown.
- Preserve the first cyber evidence while allowing subsequent terminal frames to supply final usage via immutable mark snapshots, without recording or billing twice.

## Session identity and expiration

- Keep explicit session headers and `prompt_cache_key` as the strongest identity signals. Add Redis mappings from `(group, downstream API-key ID, response ID)` to an opaque session root for `previous_response_id` continuations.
- Bind response IDs before downstream delivery, including successful WS v2 passthrough responses and locally synthesized response IDs.
- On the first cyber hit, freeze `blocked_until = hit_at + configured TTL`. Activate the block synchronously before failure delivery; post-forward cleanup retries failed storage attempts using the same deadline.
- Do not reset block expiry on duplicate events, cleanup writes, or locally rejected continuation requests. The connection-level WS guard also respects the deadline.
- Keep response aliases of an active lineage available through the block window. A shorter new configuration must not shorten aliases needed by an existing block. Alias refreshes use bounded Redis batches and request timeouts.
- Refresh the local runtime settings cache after an admin save; other instances retain the existing 60-second settings-cache refresh interval. Existing block deadlines are not retroactively rewritten by a TTL change.
- Retain scope-gated transcript matching as a fallback. IP and User-Agent scope alone never constitute a block key; lineage keys remain group/API-key isolated and hashed.
- Keep storage failures fail-open and the feature opt-in: `cyber_session_block_enabled=false`, default `cyber_session_block_ttl_seconds=3600`.

A matching HTTP continuation is rejected before account selection with 403 and `session_blocked_by_cyber_policy`. After the configured block expires, requests are eligible again.

## Validation

- Regression tests reproduce the legacy-code loss, buffered cyber omission, handshake 429 failover, missing successful passthrough lineage, paired-event usage loss, premature alias expiration, and cleanup extending the first-hit deadline.
- A 12-case matrix exercises the three error shapes across JSON/SSE and native/passthrough buffered Responses.
- Tests inspect actual downstream writer calls for pre-delivery blocking, and exercise configurable TTL, expiry, earlier response aliases, tenant isolation, shorter-setting changes, and immutable concurrent usage snapshots.
- Go 1.27 build and full backend unit suite passed on the PR branch.
- Full integration suite passed with Docker CLI present, `CI=true` (no repository-suite skip), and `SUB2API_TEST_POSTGRES_IMAGE=postgres:16-alpine`.
- Focused race tests passed for service, handler, and repository packages; golangci-lint v2.13.0 reported zero issues.
