### PR TITLE
fix(onboarding): remove button text shadows

### DIFF
--- a/frontend/src/styles/onboarding.css
+++ b/frontend/src/styles/onboarding.css
@@ -187,6 +187,7 @@
   padding: 8px 16px !important;
   font-size: 13px !important;
   font-weight: 500 !important;
+  text-shadow: none !important;
   border-radius: 6px !important;
   cursor: pointer !important;
   transition: all 0.2s !important;


### PR DESCRIPTION
Driver.js adds a white 1px text shadow to popover buttons. With the onboarding theme's white primary-button text and dark secondary button, this makes the labels appear doubled or blurry.

Clear the shadow in the existing tour-button rule. This is a one-line CSS change scoped to onboarding.

Fixes #312.

Validation:
- Browser comparison using Driver.js 1.4.0 CSS and the complete project onboarding stylesheet in light and dark themes: reproduced the shadow before the fix and confirmed it is gone afterward; button dimensions and colors are unchanged.
- Frontend type checking, production build and full ESLint passed.
- All 13 critical frontend test files passed (168 tests).
- `git diff --check` passed.
