### PR TITLE
fix(grok): sanitize unsupported Chat Completions parameters

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -157,6 +157,10 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		if err != nil {
 			return nil, fmt.Errorf("normalize Grok chat reasoning effort: %w", err)
 		}
+		upstreamBody, err = sanitizeGrokChatCompletionsBody(upstreamBody)
+		if err != nil {
+			return nil, fmt.Errorf("sanitize Grok chat compatibility fields: %w", err)
+		}
 	}
 	upstreamBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamBody)
 

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -481,7 +481,7 @@ func grokChatNullOrEmptyArray(raw json.RawMessage) bool {
 // sanitizeGrokChatCompletionsBody removes Chat Completions controls that xAI's
 // native Grok endpoint rejects even though they are accepted by many OpenAI
 // compatible clients. In particular, tool_choice without a non-empty tools
-// array is invalid upstream, and Grok 4.x rejects the stop parameter.
+// array is invalid upstream, and Grok 4.x rejects stop/penalty parameters.
 func sanitizeGrokChatCompletionsBody(body []byte) ([]byte, error) {
 	out := body
 	tools := gjson.GetBytes(out, "tools")
@@ -498,11 +498,14 @@ func sanitizeGrokChatCompletionsBody(body []byte) ([]byte, error) {
 			}
 		}
 	}
-	if gjson.GetBytes(out, "stop").Exists() {
+	for _, field := range []string{"stop", "presence_penalty", "presencePenalty", "frequency_penalty", "frequencyPenalty"} {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
 		var err error
-		out, err = sjson.DeleteBytes(out, "stop")
+		out, err = sjson.DeleteBytes(out, field)
 		if err != nil {
-			return nil, fmt.Errorf("remove unsupported Grok chat stop: %w", err)
+			return nil, fmt.Errorf("remove unsupported Grok chat %s: %w", field, err)
 		}
 	}
 	return out, nil

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const (
@@ -475,6 +476,36 @@ func grokChatNullOrEmptyArray(raw json.RawMessage) bool {
 	}
 	var values []json.RawMessage
 	return json.Unmarshal(raw, &values) == nil && len(values) == 0
+}
+
+// sanitizeGrokChatCompletionsBody removes Chat Completions controls that xAI's
+// native Grok endpoint rejects even though they are accepted by many OpenAI
+// compatible clients. In particular, tool_choice without a non-empty tools
+// array is invalid upstream, and Grok 4.x rejects the stop parameter.
+func sanitizeGrokChatCompletionsBody(body []byte) ([]byte, error) {
+	out := body
+	tools := gjson.GetBytes(out, "tools")
+	hasTools := tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+	if !hasTools {
+		for _, field := range []string{"tools", "tool_choice", "parallel_tool_calls"} {
+			if !gjson.GetBytes(out, field).Exists() {
+				continue
+			}
+			var err error
+			out, err = sjson.DeleteBytes(out, field)
+			if err != nil {
+				return nil, fmt.Errorf("remove orphan Grok chat %s: %w", field, err)
+			}
+		}
+	}
+	if gjson.GetBytes(out, "stop").Exists() {
+		var err error
+		out, err = sjson.DeleteBytes(out, "stop")
+		if err != nil {
+			return nil, fmt.Errorf("remove unsupported Grok chat stop: %w", err)
+		}
+	}
+	return out, nil
 }
 
 func grokChatResponsesCacheIntentBody(body []byte) ([]byte, error) {

--- a/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
@@ -33,7 +33,7 @@ func TestSanitizeGrokChatCompletionsBody(t *testing.T) {
 	}{
 		{
 			name: "orphan tool choice and stop are removed",
-			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"tool_choice":"auto","parallel_tool_calls":true,"stop":["END"]}`,
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"tool_choice":"auto","parallel_tool_calls":true,"stop":["END"],"presencePenalty":0.1,"frequency_penalty":0.2}`,
 		},
 		{
 			name:              "real tools keep tool controls but stop is removed",

--- a/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
@@ -20,6 +20,46 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestSanitizeGrokChatCompletionsBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		body              string
+		wantTools         bool
+		wantToolChoice    bool
+		wantParallelTools bool
+		wantStop          bool
+	}{
+		{
+			name: "orphan tool choice and stop are removed",
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"tool_choice":"auto","parallel_tool_calls":true,"stop":["END"]}`,
+		},
+		{
+			name:              "real tools keep tool controls but stop is removed",
+			body:              `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],"tool_choice":"auto","parallel_tool_calls":true,"stop":"END"}`,
+			wantTools:         true,
+			wantToolChoice:    true,
+			wantParallelTools: true,
+		},
+		{
+			name: "empty tools are treated as tool free",
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"tools":[],"tool_choice":"none"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patched, err := sanitizeGrokChatCompletionsBody([]byte(tt.body))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantTools, gjson.GetBytes(patched, "tools").Exists())
+			require.Equal(t, tt.wantToolChoice, gjson.GetBytes(patched, "tool_choice").Exists())
+			require.Equal(t, tt.wantParallelTools, gjson.GetBytes(patched, "parallel_tool_calls").Exists())
+			require.Equal(t, tt.wantStop, gjson.GetBytes(patched, "stop").Exists())
+		})
+	}
+}
+
 func TestGrokChatResponsesBridgeEligibility(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Sanitize OpenAI-compatible Grok Chat Completions requests before upstream forwarding.
- Remove orphaned tool_choice and parallel_tool_calls when no non-empty tools array is present.
- Remove Grok-unsupported stop, presencePenalty, presence_penalty, frequencyPenalty, and frequency_penalty fields.
- Preserve tool controls when real tools are supplied.

## Validation

- Targeted Grok compatibility tests pass.
- Production blue-green verification passed for non-streaming Chat Completions and SSE.
- SSE returned HTTP 200 and completed with [DONE].

This fixes the upstream HTTP 400 errors seen by domestic relay users when clients sent unsupported or orphaned Grok parameters.