### PR TITLE
fix(frontend): improve color contrast readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ CLAUDE.md
 scripts
 !backend/scripts/
 !backend/scripts/resolve-version.sh
+!frontend/scripts/
+!frontend/scripts/**
 .code-review-state
 #openspec/
 code-reviews/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "contrast:check": "node scripts/check-color-contrast.mjs"
   },
   "dependencies": {
     "@airwallex/components-sdk": "^1.30.2",

--- a/frontend/scripts/check-color-contrast.mjs
+++ b/frontend/scripts/check-color-contrast.mjs
@@ -1,0 +1,167 @@
+const colors = {
+  white: '#ffffff',
+  gray50: '#f9fafb',
+  gray100: '#f3f4f6',
+  gray500: '#6b7280',
+  gray600: '#4b5563',
+  gray700: '#374151',
+  gray800: '#1f2937',
+  gray950: '#030712',
+  dark100: '#f1f5f9',
+  dark200: '#e2e8f0',
+  dark300: '#cbd5e1',
+  dark400: '#94a3b8',
+  dark800: '#1e293b',
+  dark900: '#0f172a',
+  dark950: '#020617',
+  primary50: '#f0fdfa',
+  primary100: '#ccfbf1',
+  primary400: '#2dd4bf',
+  primary300: '#5eead4',
+  primary700: '#0f766e',
+  primary800: '#115e59',
+  primary900: '#134e4a',
+  emerald100: '#d1fae5',
+  emerald400: '#34d399',
+  emerald300: '#6ee7b7',
+  emerald700: '#047857',
+  emerald800: '#065f46',
+  emerald900: '#064e3b',
+  amber100: '#fef3c7',
+  amber400: '#fbbf24',
+  amber300: '#fcd34d',
+  amber700: '#b45309',
+  amber800: '#92400e',
+  amber900: '#78350f',
+  red100: '#fee2e2',
+  red400: '#f87171',
+  red300: '#fca5a5',
+  red600: '#dc2626',
+  red700: '#b91c1c',
+  red800: '#991b1b',
+  red900: '#7f1d1d',
+  stripe: '#635bff',
+  stripeHover: '#5851ea',
+  airwallexLight: '#14171a',
+  airwallexLightHover: '#20252a',
+  airwallexDark: '#7af0c4',
+  airwallexDarkHover: '#62d9ad',
+  alipay: '#00aeef',
+  alipayHover: '#009dd6',
+  alipayActive: '#008cbe',
+  wxpay: '#2bb741',
+  wxpayHover: '#24a038',
+  wxpayActive: '#1d8a2f'
+}
+
+function parseHex(hex) {
+  const normalized = hex.replace('#', '')
+  const value = normalized.length === 3
+    ? normalized.split('').map((part) => `${part}${part}`).join('')
+    : normalized
+
+  if (!/^[0-9a-f]{6}$/i.test(value)) {
+    throw new Error(`Invalid hex color: ${hex}`)
+  }
+
+  return [0, 2, 4].map((offset) => Number.parseInt(value.slice(offset, offset + 2), 16) / 255)
+}
+
+function relativeLuminance(hex) {
+  const [red, green, blue] = parseHex(hex).map((channel) => (
+    channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4
+  ))
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(foreground)
+  const backgroundLuminance = relativeLuminance(background)
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance)
+  const darker = Math.min(foregroundLuminance, backgroundLuminance)
+
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function blend(foreground, background, opacity) {
+  const foregroundChannels = parseHex(foreground)
+  const backgroundChannels = parseHex(background)
+  const channels = foregroundChannels.map((channel, index) => (
+    Math.round((channel * opacity + backgroundChannels[index] * (1 - opacity)) * 255)
+  ))
+
+  return `#${channels.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`
+}
+
+const checks = [
+  ['body.light', 'gray800', 'gray50'],
+  ['body.dark', 'dark100', 'dark950'],
+  ['input.text.light', 'gray800', 'white'],
+  ['input.text.dark', 'dark100', 'dark800'],
+  ['input.placeholder.light', 'gray500', 'white'],
+  ['input.placeholder.dark', 'dark300', 'dark800'],
+  ['button.primary.start', 'white', 'primary700'],
+  ['button.primary.end', 'white', 'primary800'],
+  ['button.primary.hover-end', 'white', 'primary900'],
+  ['button.danger.start', 'white', 'red600'],
+  ['button.danger.end', 'white', 'red700'],
+  ['button.success.start', 'white', 'emerald700'],
+  ['button.success.end', 'white', 'emerald800'],
+  ['button.warning.start', 'white', 'amber700'],
+  ['button.warning.end', 'white', 'amber800'],
+  ['button.stripe', 'white', 'stripe'],
+  ['button.stripe.hover', 'white', 'stripeHover'],
+  ['button.airwallex.light', 'white', 'airwallexLight'],
+  ['button.airwallex.light-hover', 'white', 'airwallexLightHover'],
+  ['button.airwallex.dark', 'gray950', 'airwallexDark'],
+  ['button.airwallex.dark-hover', 'gray950', 'airwallexDarkHover'],
+  ['button.alipay', 'gray950', 'alipay'],
+  ['button.alipay.hover', 'gray950', 'alipayHover'],
+  ['button.alipay.active', 'gray950', 'alipayActive'],
+  ['button.wxpay', 'gray950', 'wxpay'],
+  ['button.wxpay.hover', 'gray950', 'wxpayHover'],
+  ['button.wxpay.active', 'gray950', 'wxpayActive'],
+  ['text.sidebar-section.light', 'gray500', 'white'],
+  ['text.sidebar-section.dark', 'dark400', 'dark900'],
+  ['text.error.light', 'red700', 'white'],
+  ['text.code.light', 'primary800', 'gray100'],
+  ['text.code.dark', 'primary300', 'dark800'],
+  ['badge.primary.light', 'primary700', 'primary100'],
+  ['badge.success.light', 'emerald700', 'emerald100'],
+  ['badge.warning.light', 'amber700', 'amber100'],
+  ['badge.danger.light', 'red700', 'red100'],
+  ['stat-icon.primary.dark', 'primary300', blend(colors.primary900, colors.dark800, 0.3)],
+  ['stat-icon.success.dark', 'emerald300', blend(colors.emerald900, colors.dark800, 0.3)],
+  ['stat-icon.warning.dark', 'amber300', blend(colors.amber900, colors.dark800, 0.3)],
+  ['stat-icon.danger.dark', 'red300', blend(colors.red900, colors.dark800, 0.3)],
+  ['badge.primary.dark', 'primary400', blend(colors.primary900, colors.dark800, 0.3)],
+  ['badge.success.dark', 'emerald400', blend(colors.emerald900, colors.dark800, 0.3)],
+  ['badge.warning.dark', 'amber400', blend(colors.amber900, colors.dark800, 0.3)],
+  ['badge.danger.dark', 'red400', blend(colors.red900, colors.dark800, 0.3)]
+]
+
+const minimumRatio = 4.5
+const failures = []
+
+for (const [name, foregroundToken, backgroundToken] of checks) {
+  const foreground = colors[foregroundToken] ?? foregroundToken
+  const background = colors[backgroundToken] ?? backgroundToken
+  const ratio = contrastRatio(foreground, background)
+  const passes = ratio >= minimumRatio
+
+  console.log(`${passes ? 'PASS' : 'FAIL'} ${ratio.toFixed(2).padStart(5)}:1 ${name} (${foreground} on ${background})`)
+
+  if (!passes) {
+    failures.push({ name, ratio })
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} contrast check(s) failed. Target for normal text: ${minimumRatio}:1.`)
+  process.exitCode = 1
+} else {
+  console.log(`\nAll ${checks.length} contrast checks passed at ${minimumRatio}:1 or higher.`)
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -80,10 +80,10 @@
   }
 
   .btn-primary {
-    @apply bg-gradient-to-r from-primary-500 to-primary-600;
-    @apply text-white shadow-md shadow-primary-500/25;
-    @apply hover:from-primary-600 hover:to-primary-700 hover:shadow-lg hover:shadow-primary-500/30;
-    @apply dark:shadow-primary-500/20;
+    @apply bg-gradient-to-r from-primary-700 to-primary-800;
+    @apply text-white shadow-md shadow-primary-700/25;
+    @apply hover:from-primary-800 hover:to-primary-900 hover:shadow-lg hover:shadow-primary-700/30;
+    @apply dark:shadow-primary-700/20;
   }
 
   .btn-secondary {
@@ -100,23 +100,23 @@
   }
 
   .btn-danger {
-    @apply bg-gradient-to-r from-red-500 to-red-600;
-    @apply text-white shadow-md shadow-red-500/25;
-    @apply hover:from-red-600 hover:to-red-700 hover:shadow-lg hover:shadow-red-500/30;
+    @apply bg-gradient-to-r from-red-600 to-red-700;
+    @apply text-white shadow-md shadow-red-600/25;
+    @apply hover:from-red-700 hover:to-red-800 hover:shadow-lg hover:shadow-red-600/30;
   }
 
   .btn-success {
-    @apply bg-gradient-to-r from-emerald-500 to-emerald-600;
-    @apply text-white shadow-md shadow-emerald-500/25;
-    @apply hover:from-emerald-600 hover:to-emerald-700 hover:shadow-lg hover:shadow-emerald-500/30;
-    @apply dark:shadow-emerald-500/20;
+    @apply bg-gradient-to-r from-emerald-700 to-emerald-800;
+    @apply text-white shadow-md shadow-emerald-700/25;
+    @apply hover:from-emerald-800 hover:to-emerald-900 hover:shadow-lg hover:shadow-emerald-700/30;
+    @apply dark:shadow-emerald-700/20;
   }
 
   .btn-warning {
-    @apply bg-gradient-to-r from-amber-500 to-amber-600;
-    @apply text-white shadow-md shadow-amber-500/25;
-    @apply hover:from-amber-600 hover:to-amber-700 hover:shadow-lg hover:shadow-amber-500/30;
-    @apply dark:shadow-amber-500/20;
+    @apply bg-gradient-to-r from-amber-700 to-amber-800;
+    @apply text-white shadow-md shadow-amber-700/25;
+    @apply hover:from-amber-800 hover:to-amber-900 hover:shadow-lg hover:shadow-amber-700/30;
+    @apply dark:shadow-amber-700/20;
   }
 
   .btn-stripe {
@@ -134,14 +134,14 @@
   }
 
   .btn-alipay {
-    @apply bg-[#00AEEF] text-white shadow-md shadow-[#00AEEF]/25;
+    @apply bg-[#00AEEF] text-gray-950 shadow-md shadow-[#00AEEF]/25;
     @apply hover:bg-[#009dd6] hover:shadow-lg hover:shadow-[#00AEEF]/30;
     @apply active:bg-[#008cbe];
     @apply dark:shadow-[#00AEEF]/20;
   }
 
   .btn-wxpay {
-    @apply bg-[#2BB741] text-white shadow-md shadow-[#2BB741]/25;
+    @apply bg-[#2BB741] text-gray-950 shadow-md shadow-[#2BB741]/25;
     @apply hover:bg-[#24a038] hover:shadow-lg hover:shadow-[#2BB741]/30;
     @apply active:bg-[#1d8a2f];
     @apply dark:shadow-[#2BB741]/20;
@@ -169,7 +169,7 @@
     @apply bg-white dark:bg-dark-800;
     @apply border border-gray-200 dark:border-dark-600;
     @apply text-gray-900 dark:text-gray-100;
-    @apply placeholder:text-gray-400 dark:placeholder:text-dark-400;
+    @apply placeholder:text-gray-500 dark:placeholder:text-dark-300;
     @apply transition-all duration-200;
     @apply focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30;
     @apply disabled:cursor-not-allowed disabled:bg-gray-100 dark:disabled:bg-dark-900;
@@ -196,7 +196,7 @@
   }
 
   .input-error-text {
-    @apply mt-1 text-xs text-red-500;
+    @apply mt-1 text-xs text-red-700 dark:text-red-300;
   }
 
   /* Hide number input spinner buttons for cleaner UI */
@@ -272,19 +272,19 @@
   }
 
   .stat-icon-primary {
-    @apply bg-primary-100 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400;
+    @apply bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300;
   }
 
   .stat-icon-success {
-    @apply bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400;
+    @apply bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300;
   }
 
   .stat-icon-warning {
-    @apply bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400;
+    @apply bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300;
   }
 
   .stat-icon-danger {
-    @apply bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400;
+    @apply bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300;
   }
 
   .stat-value {
@@ -292,7 +292,7 @@
   }
 
   .stat-label {
-    @apply text-sm text-gray-500 dark:text-dark-400;
+    @apply text-sm text-gray-600 dark:text-dark-300;
   }
 
   .stat-trend {
@@ -300,11 +300,11 @@
   }
 
   .stat-trend-up {
-    @apply text-emerald-600 dark:text-emerald-400;
+    @apply text-emerald-700 dark:text-emerald-300;
   }
 
   .stat-trend-down {
-    @apply text-red-600 dark:text-red-400;
+    @apply text-red-700 dark:text-red-300;
   }
 
   /* ============ 表格样式 ============ */
@@ -318,14 +318,14 @@
 
   .table th {
     @apply px-4 py-3 text-left font-medium;
-    @apply text-gray-600 dark:text-dark-300;
+    @apply text-gray-700 dark:text-dark-200;
     @apply bg-gray-50 dark:bg-dark-800/50;
     @apply border-b border-gray-200 dark:border-dark-700;
   }
 
   .table td {
     @apply px-4 py-3;
-    @apply text-gray-700 dark:text-gray-300;
+    @apply text-gray-800 dark:text-dark-200;
     @apply border-b border-gray-100 dark:border-dark-800;
   }
 
@@ -573,7 +573,7 @@
 
   .sidebar-link-active {
     @apply bg-primary-50 dark:bg-primary-900/20;
-    @apply text-primary-600 dark:text-primary-400;
+    @apply text-primary-800 dark:text-primary-300;
     @apply hover:bg-primary-100 dark:hover:bg-primary-900/30;
   }
 
@@ -584,7 +584,7 @@
   .sidebar-section-title {
     @apply mb-2 px-3;
     @apply text-xs font-semibold uppercase tracking-wider;
-    @apply text-gray-400 dark:text-dark-500;
+    @apply text-gray-500 dark:text-dark-400;
   }
 
   /* ============ 页面头部 ============ */
@@ -597,7 +597,7 @@
   }
 
   .page-description {
-    @apply mt-1 text-sm text-gray-500 dark:text-dark-400;
+    @apply mt-1 text-sm text-gray-600 dark:text-dark-300;
   }
 
   /* ============ 空状态 ============ */
@@ -616,7 +616,7 @@
   }
 
   .empty-state-description {
-    @apply max-w-sm text-sm text-gray-500 dark:text-dark-400;
+    @apply max-w-sm text-sm text-gray-600 dark:text-dark-300;
   }
 
   /* ============ 加载状态 ============ */
@@ -689,7 +689,7 @@
     @apply font-mono text-sm;
     @apply bg-gray-100 dark:bg-dark-800;
     @apply rounded px-1.5 py-0.5;
-    @apply text-primary-600 dark:text-primary-400;
+    @apply text-primary-800 dark:text-primary-300;
   }
 
   .code-block {


### PR DESCRIPTION
## Summary

- improve light and dark theme contrast for buttons, placeholders, error text, statistic icons, tables, sidebar items, and supporting text
- add a repeatable `contrast:check` script for the audited semantic color combinations
- ensure all 44 audited combinations meet the WCAG AA 4.5:1 contrast threshold

## Validation

- `pnpm run contrast:check` — 44/44 checks passed
- ESLint passed
- Vue TypeScript typecheck passed
- full frontend test suite passed — 254 files, 1857 tests
- Vite production build passed

The production build reports only the existing chunk-size/dynamic-import warnings.