### PR TITLE
fix(antigravity): refresh default user agent version

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -34,7 +34,7 @@ const (
 	AntigravityUserAgentVersionEnv = "ANTIGRAVITY_USER_AGENT_VERSION"
 
 	// DefaultUserAgentVersion 是未通过环境变量或后台设置覆盖时使用的默认版本号。
-	DefaultUserAgentVersion = "1.23.2"
+	DefaultUserAgentVersion = "2.9.1"
 
 	// 固定的 redirect_uri（用户需手动复制 code）
 	RedirectURI = "http://localhost:8085/callback"

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -693,7 +693,7 @@ func TestConstants_值正确(t *testing.T) {
 	if RedirectURI != "http://localhost:8085/callback" {
 		t.Errorf("RedirectURI 不匹配: got %s", RedirectURI)
 	}
-	if GetUserAgent() != "antigravity/1.23.2 windows/amd64" {
+	if GetUserAgent() != "antigravity/2.9.1 windows/amd64" {
 		t.Errorf("UserAgent 不匹配: got %s", GetUserAgent())
 	}
 	if SessionTTL != 30*time.Minute {


### PR DESCRIPTION
## Summary

The built-in default Antigravity User-Agent version had drifted behind current real client builds. The Antigravity service fingerprints clients by the version embedded in the User-Agent header, so requests going out with the stale default `1.23.2` fail OAuth / probe flows.

## Changes

- `DefaultUserAgentVersion`: `1.23.2` → `2.9.1` (current client build)
- Update the constant test assertion in `oauth_test.go`

The default remains overridable via the `ANTIGRAVITY_USER_AGENT_VERSION` env var and the admin setting, so operators pinning a specific version are unaffected.

## Notes

- This change has been running in production deployments since Aug 21 with no regressions.
