### PR TITLE
fix(monitors): send explicit user role in Gemini monitor probes

### DIFF
--- a/backend/internal/service/channel_monitor_checker.go
+++ b/backend/internal/service/channel_monitor_checker.go
@@ -198,7 +198,7 @@ var providerAdapters = map[string]providerAdapter{
 		buildBody: func(_, prompt string) ([]byte, error) {
 			return json.Marshal(map[string]any{
 				"contents": []map[string]any{
-					{"parts": []map[string]any{{"text": prompt}}},
+					{"role": "user", "parts": []map[string]any{{"text": prompt}}},
 				},
 				"generationConfig": map[string]any{"maxOutputTokens": monitorChallengeMaxTokens},
 			})

--- a/backend/internal/service/channel_monitor_checker_body_test.go
+++ b/backend/internal/service/channel_monitor_checker_body_test.go
@@ -498,3 +498,26 @@ func TestValidateChallenge_AnthropicTextAfterThinking(t *testing.T) {
 		t.Fatalf("validateChallenge(%q, %q) = false, want true", respText, "2")
 	}
 }
+
+func TestGeminiMonitorBodyIncludesExplicitUserRole(t *testing.T) {
+	adapter := providerAdapters[MonitorProviderGemini]
+	body, err := adapter.buildBody("gemini-3.6-flash", "Reply with only 7.")
+	if err != nil {
+		t.Fatalf("buildBody() error = %v", err)
+	}
+
+	var payload struct {
+		Contents []struct {
+			Role string `json:"role"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(payload.Contents) != 1 {
+		t.Fatalf("contents length = %d, want 1", len(payload.Contents))
+	}
+	if payload.Contents[0].Role != "user" {
+		t.Fatalf("contents[0].role = %q, want user", payload.Contents[0].Role)
+	}
+}


### PR DESCRIPTION
## Summary

The Antigravity native Gemini route (`generateContent`) expects each `contents` entry to carry an explicit `"user"` role. The built-in Gemini monitor probe body omitted it, so probes were rejected with `400 INVALID_ARGUMENT` and Gemini channel monitors reported false failures.

## Changes

- Add `"role": "user"` to the Gemini provider adapter probe body in `channel_monitor_checker.go`
- Add a regression test (`channel_monitor_checker_body_test.go`) that parses the generated request body and asserts the explicit role

## Notes

- Reproduced in production: the same probe request returns `200` with only the `role: user` addition; model resolution is unaffected.
- No configuration or schema change.
