### PR TITLE
fix(antigravity): always set toolConfig for reasoning models without tools

### DIFF
--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -148,21 +148,20 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 	}
 
 	// 针对 Gemini Reasoning 模型（如 gemini-3.1-pro-high等）过滤强制空 ToolConfig
-	isReasoning := IsGeminiReasoningModel(targetModel)
-	if !isReasoning || len(tools) > 0 {
-		// 总是设置 toolConfig，与官方客户端一致
-		innerRequest.ToolConfig = &GeminiToolConfig{
-			FunctionCallingConfig: &GeminiFunctionCallingConfig{
-				Mode: "VALIDATED",
-			},
-		}
-		// 内置工具（googleSearch）与函数调用混用时，上游要求显式开启
-		// includeServerSideToolInvocations，否则返回 400（issue #5709）。
-		// 与 raw 透传路的 enableMixedGeminiToolInvocations 注入保持同一语义。
-		if hasMixedToolInvocations(tools) {
-			enabled := true
-			innerRequest.ToolConfig.IncludeServerSideToolInvocations = &enabled
-		}
+	// toolConfig must always be present: upstream rejects requests without it,
+	// including reasoning models called without any tools.
+	// 总是设置 toolConfig，与官方客户端一致
+	innerRequest.ToolConfig = &GeminiToolConfig{
+		FunctionCallingConfig: &GeminiFunctionCallingConfig{
+			Mode: "VALIDATED",
+		},
+	}
+	// 内置工具（googleSearch）与函数调用混用时，上游要求显式开启
+	// includeServerSideToolInvocations，否则返回 400（issue #5709）。
+	// 与 raw 透传路的 enableMixedGeminiToolInvocations 注入保持同一语义。
+	if hasMixedToolInvocations(tools) {
+		enabled := true
+		innerRequest.ToolConfig.IncludeServerSideToolInvocations = &enabled
 	}
 
 	if systemInstruction != nil {

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -621,3 +621,38 @@ func TestGeminiToolConfig_IncludeServerSideToolInvocations(t *testing.T) {
 		require.NotContains(t, raw, "includeServerSideToolInvocations")
 	})
 }
+
+// TestToolConfigAlwaysPresent ensures toolConfig is always emitted, including for
+// reasoning models without any tools: upstream rejects requests that omit it.
+func TestToolConfigAlwaysPresent(t *testing.T) {
+	cases := []struct {
+		name  string
+		model string
+		tools []ClaudeTool
+	}{
+		{name: "reasoning model without tools", model: "gemini-3.1-pro-high"},
+		{name: "reasoning model with tools", model: "gemini-3.1-pro-high", tools: []ClaudeTool{{
+			Name:        "web_search",
+			Description: "Search the web",
+			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		}}},
+		{name: "non-reasoning model without tools", model: "gemini-3.1-pro"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claudeReq := &ClaudeRequest{
+				Model:    tc.model,
+				Messages: []ClaudeMessage{{Role: "user", Content: json.RawMessage(`"Hello"`)}},
+				Tools:    tc.tools,
+			}
+			body, err := TransformClaudeToGeminiWithOptions(claudeReq, "project-1", tc.model, DefaultTransformOptions())
+			require.NoError(t, err)
+
+			var req V1InternalRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.NotNil(t, req.Request.ToolConfig, "toolConfig must be present")
+			require.NotNil(t, req.Request.ToolConfig.FunctionCallingConfig)
+			require.Equal(t, "VALIDATED", req.Request.ToolConfig.FunctionCallingConfig.Mode)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Antigravity 通道：reasoning 类模型（`IsReasoning: true`，如 `gemini-3.1-pro-high`）在请求**不带 `tools`** 时，`request_transformer.go` 会跳过 `toolConfig`，上游随即返回：

```
400 Request contains an invalid argument.
```

原守卫 `if !isReasoning || len(tools) > 0 { ToolConfig = … }` 与其注释「总是设置 toolConfig，与官方客户端一致」相矛盾：`isReasoning && len(tools)==0` 时整段被跳过。本 PR 去掉该守卫，`toolConfig` 恒定设置；分支内原有逻辑（含 `hasMixedToolInvocations` 处理）保持不变。附单元测试覆盖「reasoning 无工具 / reasoning 有工具 / 非 reasoning 无工具」三种情况。

Fixes #6664（其中的第一个缺陷）。

## 复现（修复前）

同一网关、同一批账号、间隔 ≥2s，仅改变是否携带 `tools`：

- `gemini-3.1-pro-high` 不带 tools ×10 → `400,400,400,400,400,400,400,400,400,200`
- 同请求带一个空工具 ×10 → `400,200,200,200,200,200,200,200,200,200`
- 对照 `gemini-3.1-pro` / `gemini-3.8-flash`（非 reasoning，不带 tools）各 3/3 → 200

## 验证（修复后）

- `go test ./internal/pkg/antigravity/` 通过（含新增 `TestToolConfigAlwaysPresent`）
- 生产环境部署后：`gemini-3.1-pro-high` 不带 tools 连续 10 个不同提示 10/10 → 200；`gemini-3.8-flash`、`gemini-3.1-pro` 回归正常

## 影响面

仅「reasoning 模型 + 不带任何工具」的请求受影响；以工具调用为主的用法天然带 tools，行为不变。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3CGXXhrhUHLzSKQvPac61
