### PR TITLE
[codex] Fix stale official Astra input modalities

### DIFF
--- a/backend/internal/service/openai_codex_astra_image_test.go
+++ b/backend/internal/service/openai_codex_astra_image_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCodexModelsManifestForGroupCorrectsOfficialAstraStaleModalities(t *testing.T) {
+	t.Parallel()
+
+	const groupID int64 = 780
+	account := Account{
+		ID:          1,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-test"},
+	}
+	account.SetUpstreamModelMetadataSnapshot(UpstreamModelMetadataSnapshot{
+		Models: map[string]UpstreamModelMetadata{
+			"gpt-6-astra": {ID: "gpt-6-astra", InputModalities: []string{"text"}},
+		},
+	})
+
+	svc := &GatewayService{accountRepo: codexModelsVisibilityAccountRepo{
+		byGroup: map[int64][]Account{groupID: {account}},
+	}}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformOpenAI},
+		"",
+		[]string{"gpt-6-astra"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, []any{"text", "image"}, models[0]["input_modalities"])
+}
+
+func TestBuildCodexModelsManifestForGroupPreservesCompatibleAstraTextOnlyMetadata(t *testing.T) {
+	t.Parallel()
+
+	const groupID int64 = 781
+	account := Account{
+		ID:          2,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://relay.example.test/v1"},
+	}
+	account.SetUpstreamModelMetadataSnapshot(UpstreamModelMetadataSnapshot{
+		Models: map[string]UpstreamModelMetadata{
+			"gpt-6-astra": {ID: "gpt-6-astra", InputModalities: []string{"text"}},
+		},
+	})
+
+	svc := &GatewayService{accountRepo: codexModelsVisibilityAccountRepo{
+		byGroup: map[int64][]Account{groupID: {account}},
+	}}
+
+	body, err := svc.BuildCodexModelsManifestForGroup(
+		context.Background(),
+		&Group{ID: groupID, Platform: PlatformOpenAI},
+		"",
+		[]string{"gpt-6-astra"},
+	)
+	require.NoError(t, err)
+	models := decodeCodexManifestModels(t, body)
+	require.Len(t, models, 1)
+	require.Equal(t, []any{"text"}, models[0]["input_modalities"])
+}

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -888,12 +888,14 @@ func buildCodexModelsManifest(
 		seen[modelID] = struct{}{}
 		descriptor := newConfiguredCodexModelDescriptor(metadataModelID)
 		descriptor.Slug = modelID
-		if imageInputModels[modelID] {
-			descriptor.InputModalities = []string{"text", "image"}
-		}
 		descriptor.SupportsSearchTool = searchToolModels[modelID]
 		if metadata, ok := modelMetadata[modelID]; ok {
 			applyUpstreamModelMetadataToCodexDescriptor(&descriptor, metadata)
+		}
+		if imageInputModels[modelID] {
+			// Apply the capability-derived modality after upstream metadata so
+			// a stale official Astra snapshot cannot downgrade the catalog.
+			descriptor.InputModalities = []string{"text", "image"}
 		}
 		if metadataModelID != modelID {
 			descriptor.DisplayName = modelID
@@ -1186,6 +1188,13 @@ func accountCodexModelSupportsImageInput(account *Account, upstreamModel string)
 	case PlatformOpenAI:
 		if metadata, ok := account.GetUpstreamModelMetadata(upstreamModel); ok {
 			if modalities := normalizeCodexInputModalities(metadata.InputModalities); len(modalities) > 0 {
+				// Official GPT-6 Astra metadata briefly shipped with a stale
+				// text-only modality list. Keep explicit provider metadata
+				// authoritative for compatible hosts, but repair that stale
+				// official snapshot at the capability boundary.
+				if isOpenAIGPT6AstraModel(upstreamModel) && isOfficialOpenAICodexAccount(account) {
+					return true
+				}
 				return stringSliceContains(modalities, "image")
 			}
 		}
@@ -1210,6 +1219,16 @@ func accountCodexModelSupportsImageInput(account *Account, upstreamModel string)
 	default:
 		return false
 	}
+}
+
+func isOfficialOpenAICodexAccount(account *Account) bool {
+	if account == nil || account.Platform != PlatformOpenAI {
+		return false
+	}
+	if account.IsOpenAIOAuth() {
+		return true
+	}
+	return account.IsOpenAIApiKey() && isOfficialOpenAIModelsBaseURL(account.GetOpenAIBaseURL())
 }
 
 func isGrokCodexImageInputModel(model string) bool {


### PR DESCRIPTION
## Summary

- Use the official `v0.2.1` behavior as the baseline.
- Repair stale official GPT-6 Astra `input_modalities` metadata at the Codex catalog capability boundary.
- Preserve explicit text-only metadata from OpenAI-compatible providers.
- Add regression coverage for both cases.

## Root Cause

The group Codex manifest builder derived Astra image support correctly for official OpenAI accounts, but applied upstream model metadata afterward. A stale official snapshot containing `input_modalities: ["text"]` therefore downgraded the generated catalog back to text-only.

## Validation

- `go test ./internal/service -run 'TestBuildCodexModelsManifestForGroup(CorrectsOfficialAstraStaleModalities|PreservesCompatibleAstraTextOnlyMetadata)$' -count=1`
- `go test ./internal/service -run 'Test(Astra|BuildCodexModelsManifestForGroup|CompleteAPIKeyCodexModelsManifest)' -count=1`
- `git diff --check`

The full `internal/service` package run still has unrelated existing failures in content-moderation runtime snapshot and plugin package tests; the focused Astra/Codex coverage passes.
