### PR TITLE
feat(groups): add bulk editing to group management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 FRONTEND_CRITICAL_VITEST := \
 	src/api/__tests__/client.spec.ts \
 	src/api/__tests__/tokenRefresh.spec.ts \
+	src/api/__tests__/admin.groups.bulkUpdate.spec.ts \
+	src/components/admin/group/__tests__/BulkEditGroupModal.spec.ts \
+	src/views/admin/__tests__/GroupsView.columnSettings.spec.ts \
 	src/api/__tests__/channelMonitorV2.spec.ts \
 	src/views/auth/__tests__/LinuxDoCallbackView.spec.ts \
 	src/views/auth/__tests__/WechatCallbackView.spec.ts \

--- a/frontend/src/api/__tests__/admin.groups.bulkUpdate.spec.ts
+++ b/frontend/src/api/__tests__/admin.groups.bulkUpdate.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { bulkUpdate } from '../admin/groups'
+
+const { put } = vi.hoisted(() => ({ put: vi.fn() }))
+vi.mock('../client', () => ({ apiClient: { put } }))
+
+describe('admin group bulk updates', () => {
+  beforeEach(() => {
+    put.mockReset()
+  })
+
+  it('deduplicates IDs, sends sparse updates, and preserves partial failures', async () => {
+    const failure = { status: 403, message: 'Permission denied' }
+    put.mockImplementation((url: string) => url === '/admin/groups/2'
+      ? Promise.reject(failure) : Promise.resolve({ data: {} }))
+    const updates = { rate_multiplier: 0.5, is_exclusive: false, daily_limit_usd: null, weekly_limit_usd: 0 }
+    const result = await bulkUpdate([1, 2, 1, 3], updates)
+
+    expect(put.mock.calls).toEqual([
+      ['/admin/groups/1', updates], ['/admin/groups/2', updates], ['/admin/groups/3', updates]
+    ])
+    expect(result).toEqual({ succeededIds: [1, 3], failures: [{ id: 2, error: failure }] })
+  })
+
+  it('limits in-flight requests to five and continues after failures', async () => {
+    const settle: Array<() => void> = []
+    let inFlight = 0
+    let peak = 0
+    put.mockImplementation(() => new Promise((resolve, reject) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      const index = settle.length
+      settle.push(() => {
+        inFlight--
+        if (index === 0) reject(new Error('network error'))
+        else resolve({ data: {} })
+      })
+    }))
+    const pending = bulkUpdate([1, 2, 3, 4, 5, 6, 7], { status: 'inactive' })
+    expect(put).toHaveBeenCalledTimes(5)
+    settle.slice(0, 4).forEach((finish) => finish())
+    await flushPromises()
+    expect(put).toHaveBeenCalledTimes(5)
+    settle[4]()
+    await flushPromises()
+    expect(put).toHaveBeenCalledTimes(7)
+    settle.slice(5).forEach((finish) => finish())
+    const result = await pending
+    expect(peak).toBe(5)
+    expect(result.succeededIds).toEqual([2, 3, 4, 5, 6, 7])
+    expect(result.failures.map(({ id }) => id)).toEqual([1])
+  })
+
+  it('does not send requests for an empty selection', async () => {
+    expect(await bulkUpdate([], { rpm_limit: 0 })).toEqual({ succeededIds: [], failures: [] })
+    expect(put).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/admin/groups.ts
+++ b/frontend/src/api/admin/groups.ts
@@ -220,6 +220,32 @@ export async function update(id: number, updates: UpdateGroupRequest): Promise<A
   return data
 }
 
+export interface BulkUpdateGroupsResult {
+  succeededIds: number[]
+  failures: Array<{ id: number; error: unknown }>
+}
+
+/** Keep existing per-group validation and cache invalidation, with bounded concurrency. */
+export async function bulkUpdate(
+  ids: number[],
+  updates: UpdateGroupRequest
+): Promise<BulkUpdateGroupsResult> {
+  const uniqueIds = [...new Set(ids)]
+  const result: BulkUpdateGroupsResult = { succeededIds: [], failures: [] }
+  for (let offset = 0; offset < uniqueIds.length; offset += 5) {
+    const batch = uniqueIds.slice(offset, offset + 5)
+    const responses = await Promise.allSettled(batch.map((id) => update(id, updates)))
+    responses.forEach((response, index) => {
+      if (response.status === 'fulfilled') {
+        result.succeededIds.push(batch[index])
+      } else {
+        result.failures.push({ id: batch[index], error: response.reason })
+      }
+    })
+  }
+  return result
+}
+
 /**
  * Delete group
  * @param id - Group ID
@@ -481,6 +507,7 @@ export const groupsAPI = {
   create,
   duplicate,
   update,
+  bulkUpdate,
   delete: deleteGroup,
   toggleStatus,
   getStats,

--- a/frontend/src/components/admin/group/BulkEditGroupModal.vue
+++ b/frontend/src/components/admin/group/BulkEditGroupModal.vue
@@ -1,0 +1,296 @@
+<template>
+  <BaseDialog
+    :show="show"
+    :title="t('admin.groups.bulkEdit.title')"
+    width="normal"
+    :close-on-escape="!submitting"
+    :show-close-button="!submitting"
+    @close="close"
+  >
+    <form id="bulk-edit-groups-form" class="space-y-5" @submit.prevent="submit">
+      <div class="space-y-1 text-sm">
+        <p class="font-medium text-gray-900 dark:text-white">
+          {{ t('admin.groups.bulkEdit.selectedCount', { count: pendingGroups.length }) }}
+        </p>
+        <p class="text-gray-500 dark:text-gray-400">{{ t('admin.groups.bulkEdit.hint') }}</p>
+      </div>
+
+      <fieldset :disabled="submitting" class="space-y-5">
+        <div class="space-y-2">
+          <label class="flex items-center gap-2 text-sm font-medium">
+            <input v-model="enabled.rate_multiplier" type="checkbox" class="checkbox" data-test="enable-rate" />
+            {{ t('admin.groups.form.rateMultiplierLabel') }}
+          </label>
+          <div v-if="enabled.rate_multiplier">
+            <input
+              v-model="rateMultiplier"
+              type="number"
+              min="0"
+              step="any"
+              required
+              class="input"
+              :aria-label="t('admin.groups.form.rateMultiplierLabel')"
+              data-test="rate-input"
+            />
+            <p class="input-hint">{{ t('admin.groups.form.rateMultiplierHint') }}</p>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <label class="flex items-center gap-2 text-sm font-medium">
+            <input v-model="enabled.status" type="checkbox" class="checkbox" data-test="enable-status" />
+            {{ t('admin.groups.form.statusLabel') }}
+          </label>
+          <Select
+            v-if="enabled.status"
+            v-model="status"
+            :options="statusOptions"
+            :disabled="submitting"
+            :aria-label="t('admin.groups.form.statusLabel')"
+            data-test="status-input"
+          />
+        </div>
+
+        <div class="space-y-2">
+          <label class="flex items-center gap-2 text-sm font-medium">
+            <input v-model="enabled.is_exclusive" type="checkbox" class="checkbox" data-test="enable-exclusive" />
+            {{ t('admin.groups.form.exclusiveLabel') }}
+          </label>
+          <Select
+            v-if="enabled.is_exclusive"
+            v-model="isExclusive"
+            :options="exclusiveOptions"
+            :disabled="submitting"
+            :aria-label="t('admin.groups.form.exclusiveLabel')"
+            data-test="exclusive-input"
+          />
+        </div>
+
+        <div class="space-y-2">
+          <label class="flex items-center gap-2 text-sm font-medium">
+            <input v-model="enabled.description" type="checkbox" class="checkbox" data-test="enable-description" />
+            {{ t('admin.groups.form.descriptionLabel') }}
+          </label>
+          <div v-if="enabled.description">
+            <textarea
+              v-model="description"
+              rows="3"
+              class="input"
+              :aria-label="t('admin.groups.form.descriptionLabel')"
+              data-test="description-input"
+            />
+            <p class="input-hint">{{ t('admin.groups.bulkEdit.descriptionHint') }}</p>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <label class="flex items-center gap-2 text-sm font-medium">
+            <input v-model="enabled.rpm_limit" type="checkbox" class="checkbox" data-test="enable-rpm" />
+            {{ t('admin.groups.form.rpmLimit') }}
+          </label>
+          <div v-if="enabled.rpm_limit">
+            <input
+              v-model="rpmLimit"
+              type="number"
+              min="0"
+              step="1"
+              required
+              class="input"
+              :aria-label="t('admin.groups.form.rpmLimit')"
+              data-test="rpm-input"
+            />
+            <p class="input-hint">{{ t('admin.groups.form.rpmLimitHint') }}</p>
+          </div>
+        </div>
+
+        <div class="space-y-4 border-t border-gray-200 pt-4 dark:border-dark-700">
+          <p v-if="!allSubscriptions" class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('admin.groups.bulkEdit.subscriptionOnly') }}
+          </p>
+          <div v-for="field in limitFields" :key="field.key" class="space-y-2">
+            <label class="flex items-center gap-2 text-sm font-medium" :class="{ 'opacity-50': !allSubscriptions }">
+              <input
+                v-model="enabled[field.key]"
+                type="checkbox"
+                class="checkbox"
+                :disabled="!allSubscriptions"
+                :data-test="`enable-${field.key}`"
+              />
+              {{ t(field.label) }}
+            </label>
+            <div v-if="enabled[field.key]" class="space-y-2">
+              <label class="flex items-center gap-2 text-sm">
+                <input v-model="unlimited[field.key]" type="checkbox" class="checkbox" :data-test="`unlimited-${field.key}`" />
+                {{ t('admin.groups.subscription.noLimit') }}
+              </label>
+              <input
+                v-if="!unlimited[field.key]"
+                v-model="limits[field.key]"
+                type="number"
+                min="0"
+                step="any"
+                required
+                class="input"
+                :aria-label="t(field.label)"
+                :data-test="`${field.key}-input`"
+              />
+              <p class="input-hint">{{ t('admin.groups.bulkEdit.limitHint') }}</p>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <p v-if="validationError" role="alert" class="text-sm text-red-600 dark:text-red-400">
+        {{ validationError }}
+      </p>
+      <div v-if="failures.length" role="alert" class="space-y-2 text-sm text-red-600 dark:text-red-400">
+        <p>{{ t('admin.groups.bulkEdit.failureHint') }}</p>
+        <ul class="max-h-40 space-y-1 overflow-y-auto">
+          <li v-for="failure in failures" :key="failure.id" class="break-words">
+            #{{ failure.id }} {{ failure.name }}: {{ failure.message }}
+          </li>
+        </ul>
+      </div>
+    </form>
+
+    <template #footer>
+      <button type="button" class="btn btn-secondary" :disabled="submitting" @click="close">
+        {{ t('common.cancel') }}
+      </button>
+      <button
+        type="submit"
+        form="bulk-edit-groups-form"
+        class="btn btn-primary"
+        :disabled="!canSubmit"
+        data-test="submit"
+      >
+        {{ submitting ? t('common.saving') : t('admin.groups.bulkEdit.apply', { count: pendingGroups.length }) }}
+      </button>
+    </template>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { adminAPI } from '@/api/admin'
+import { useAppStore } from '@/stores/app'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import Select from '@/components/common/Select.vue'
+import type { AdminGroup, UpdateGroupRequest } from '@/types'
+
+type SelectedGroup = Pick<AdminGroup, 'id' | 'name' | 'subscription_type'>
+type LimitField = 'daily_limit_usd' | 'weekly_limit_usd' | 'monthly_limit_usd'
+type EditableField = LimitField | 'rate_multiplier' | 'status' | 'is_exclusive' | 'description' | 'rpm_limit'
+
+const props = defineProps<{ show: boolean; selectedGroups: SelectedGroup[] }>()
+const emit = defineEmits<{ close: []; updated: [succeededIds: number[]] }>()
+const { t } = useI18n()
+const appStore = useAppStore()
+const submitting = ref(false)
+const pendingGroups = ref<SelectedGroup[]>([])
+const failures = ref<Array<{ id: number; name: string; message: string }>>([])
+const enabled = reactive<Record<EditableField, boolean>>({
+  rate_multiplier: false, status: false, is_exclusive: false, description: false,
+  rpm_limit: false, daily_limit_usd: false, weekly_limit_usd: false, monthly_limit_usd: false
+})
+const rateMultiplier = ref<string | number>('')
+const rpmLimit = ref<string | number>('')
+const status = ref<'active' | 'inactive'>('active')
+const isExclusive = ref(false)
+const description = ref('')
+const limits = reactive<Record<LimitField, string | number>>({ daily_limit_usd: '', weekly_limit_usd: '', monthly_limit_usd: '' })
+const unlimited = reactive<Record<LimitField, boolean>>({ daily_limit_usd: false, weekly_limit_usd: false, monthly_limit_usd: false })
+const limitFields: Array<{ key: LimitField; label: string }> = [
+  { key: 'daily_limit_usd', label: 'admin.groups.subscription.dailyLimit' },
+  { key: 'weekly_limit_usd', label: 'admin.groups.subscription.weeklyLimit' },
+  { key: 'monthly_limit_usd', label: 'admin.groups.subscription.monthlyLimit' }
+]
+const allSubscriptions = computed(() => pendingGroups.value.length > 0
+  && pendingGroups.value.every((group) => group.subscription_type === 'subscription'))
+const statusOptions = computed(() => [
+  { value: 'active', label: t('common.active') },
+  { value: 'inactive', label: t('common.inactive') }
+])
+const exclusiveOptions = computed(() => [
+  { value: true, label: t('admin.groups.exclusiveObj.yes') },
+  { value: false, label: t('admin.groups.exclusiveObj.no') }
+])
+
+const parseNumber = (value: string | number) => String(value).trim() === '' ? NaN : Number(value)
+const validationError = computed(() => {
+  const rate = parseNumber(rateMultiplier.value)
+  if (enabled.rate_multiplier && (!Number.isFinite(rate) || rate <= 0)) return t('admin.groups.bulkEdit.invalidRate')
+  const rpm = parseNumber(rpmLimit.value)
+  if (enabled.rpm_limit && (!Number.isSafeInteger(rpm) || rpm < 0)) return t('admin.groups.bulkEdit.invalidRPM')
+  for (const { key } of limitFields) {
+    if (!enabled[key]) continue
+    if (!allSubscriptions.value) return t('admin.groups.bulkEdit.subscriptionOnly')
+    const value = parseNumber(limits[key])
+    if (!unlimited[key] && (!Number.isFinite(value) || value < 0)) return t('admin.groups.bulkEdit.invalidLimit')
+  }
+  return ''
+})
+const canSubmit = computed(() => pendingGroups.value.length > 0 && Object.values(enabled).some(Boolean)
+  && !validationError.value && !submitting.value)
+
+watch(() => props.show, (show) => {
+  if (!show) return
+  pendingGroups.value = props.selectedGroups.map(({ id, name, subscription_type }) => ({ id, name, subscription_type }))
+  failures.value = []
+  for (const field of Object.keys(enabled) as EditableField[]) enabled[field] = false
+  for (const { key } of limitFields) {
+    limits[key] = ''
+    unlimited[key] = false
+  }
+  rateMultiplier.value = ''
+  rpmLimit.value = ''
+  status.value = 'active'
+  isExclusive.value = false
+  description.value = ''
+}, { immediate: true })
+
+const close = () => {
+  if (!submitting.value) emit('close')
+}
+const errorMessage = (error: unknown): string => {
+  const message = (error as { message?: unknown } | null)?.message
+  return typeof message === 'string' && message ? message : t('admin.groups.failedToUpdate')
+}
+
+const submit = async () => {
+  if (!canSubmit.value) return
+  const updates: UpdateGroupRequest = {}
+  if (enabled.rate_multiplier) updates.rate_multiplier = Number(rateMultiplier.value)
+  if (enabled.status) updates.status = status.value
+  if (enabled.is_exclusive) updates.is_exclusive = isExclusive.value
+  if (enabled.description) updates.description = description.value
+  if (enabled.rpm_limit) updates.rpm_limit = Number(rpmLimit.value)
+  for (const { key } of limitFields) {
+    if (enabled[key]) updates[key] = unlimited[key] ? null : Number(limits[key])
+  }
+
+  submitting.value = true
+  try {
+    const result = await adminAPI.groups.bulkUpdate(pendingGroups.value.map((group) => group.id), updates)
+    failures.value = result.failures.map(({ id, error }) => ({
+      id, name: pendingGroups.value.find((group) => group.id === id)?.name ?? '', message: errorMessage(error)
+    }))
+    const failedIds = new Set(result.failures.map(({ id }) => id))
+    pendingGroups.value = pendingGroups.value.filter((group) => failedIds.has(group.id))
+    if (result.succeededIds.length) emit('updated', result.succeededIds)
+    if (result.failures.length) {
+      appStore.showError(t('admin.groups.bulkEdit.partialFailure', {
+        success: result.succeededIds.length, failed: result.failures.length
+      }))
+    } else {
+      appStore.showSuccess(t('admin.groups.bulkEdit.success', { count: result.succeededIds.length }))
+      emit('close')
+    }
+  } catch (error) {
+    appStore.showError(errorMessage(error))
+  } finally {
+    submitting.value = false
+  }
+}
+</script>

--- a/frontend/src/components/admin/group/__tests__/BulkEditGroupModal.spec.ts
+++ b/frontend/src/components/admin/group/__tests__/BulkEditGroupModal.spec.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import BulkEditGroupModal from '../BulkEditGroupModal.vue'
+import type { AdminGroup } from '@/types'
+
+const { bulkUpdate, showSuccess, showError } = vi.hoisted(() => ({
+  bulkUpdate: vi.fn(), showSuccess: vi.fn(), showError: vi.fn()
+}))
+vi.mock('@/api/admin', () => ({ adminAPI: { groups: { bulkUpdate } } }))
+vi.mock('@/stores/app', () => ({ useAppStore: () => ({ showSuccess, showError }) }))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string, params?: Record<string, unknown>) => `${key} ${JSON.stringify(params ?? {})}` })
+}))
+
+type SelectedGroup = Pick<AdminGroup, 'id' | 'name' | 'subscription_type'>
+const selectedGroups: SelectedGroup[] = [
+  { id: 1, name: 'First', subscription_type: 'subscription' },
+  { id: 2, name: 'Second', subscription_type: 'subscription' }
+]
+const mountModal = (groups = selectedGroups) => mount(BulkEditGroupModal, {
+  props: { show: true, selectedGroups: groups },
+  global: {
+    stubs: {
+      BaseDialog: {
+        name: 'BaseDialog',
+        props: ['show', 'closeOnEscape', 'showCloseButton'],
+        emits: ['close'],
+        template: '<div v-if="show"><slot /><slot name="footer" /></div>'
+      },
+      Select: {
+        props: ['modelValue', 'options', 'disabled'],
+        emits: ['update:modelValue'],
+        template: `<select :disabled="disabled" :value="String(modelValue)" @change="$emit('update:modelValue', options.find(option => String(option.value) === $event.target.value).value)">
+          <option v-for="option in options" :key="String(option.value)" :value="String(option.value)">{{ option.label }}</option>
+        </select>`
+      }
+    }
+  }
+})
+
+describe('BulkEditGroupModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    bulkUpdate.mockResolvedValue({ succeededIds: [1, 2], failures: [] })
+  })
+
+  it('requires a field choice and updates only the selected rate multiplier', async () => {
+    const wrapper = mountModal()
+    expect(wrapper.get('[data-test="submit"]').attributes('disabled')).toBeDefined()
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).not.toHaveBeenCalled()
+    await wrapper.get('[data-test="enable-rate"]').setValue(true)
+    await wrapper.get('[data-test="rate-input"]').setValue('0.25')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(bulkUpdate).toHaveBeenCalledWith([1, 2], { rate_multiplier: 0.25 })
+    expect(wrapper.emitted('updated')).toEqual([[[1, 2]]])
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it.each(['', '0', '-0.1', 'not-a-number'])('rejects invalid multipliers: %s', async (value) => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-rate"]').setValue(true)
+    await wrapper.get('[data-test="rate-input"]').setValue(value)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).not.toHaveBeenCalled()
+  })
+
+  it('preserves explicit false, empty descriptions, and zero RPM', async () => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-exclusive"]').setValue(true)
+    await wrapper.get('[data-test="exclusive-input"]').setValue('false')
+    await wrapper.get('[data-test="enable-description"]').setValue(true)
+    await wrapper.get('[data-test="enable-rpm"]').setValue(true)
+    await wrapper.get('[data-test="rpm-input"]').setValue('0')
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).toHaveBeenCalledWith([1, 2], { is_exclusive: false, description: '', rpm_limit: 0 })
+  })
+
+  it.each(['', '-1', '1.5', '9007199254740992'])('rejects invalid RPM: %s', async (value) => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-rpm"]').setValue(true)
+    await wrapper.get('[data-test="rpm-input"]').setValue(value)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).not.toHaveBeenCalled()
+  })
+
+  it('distinguishes zero quota from unlimited while preserving unchecked limits', async () => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-daily_limit_usd"]').setValue(true)
+    await wrapper.get('[data-test="daily_limit_usd-input"]').setValue('0')
+    await wrapper.get('[data-test="enable-weekly_limit_usd"]').setValue(true)
+    await wrapper.get('[data-test="unlimited-weekly_limit_usd"]').setValue(true)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).toHaveBeenCalledWith([1, 2], { daily_limit_usd: 0, weekly_limit_usd: null })
+  })
+
+  it.each(['', '-10'])('requires a valid subscription quota or explicit unlimited: %s', async (value) => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-monthly_limit_usd"]').setValue(true)
+    await wrapper.get('[data-test="monthly_limit_usd-input"]').setValue(value)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).not.toHaveBeenCalled()
+  })
+
+  it('disables subscription quotas for a mixed selection while allowing common fields', async () => {
+    const wrapper = mountModal([
+      selectedGroups[0], { id: 2, name: 'Standard', subscription_type: 'standard' }
+    ])
+    expect(wrapper.get('[data-test="enable-daily_limit_usd"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('admin.groups.bulkEdit.subscriptionOnly')
+    await wrapper.get('[data-test="enable-status"]').setValue(true)
+    await wrapper.get('[data-test="status-input"]').setValue('inactive')
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).toHaveBeenCalledWith([1, 2], { status: 'inactive' })
+  })
+
+  it('discards a value when its field is unchecked again', async () => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-rate"]').setValue(true)
+    await wrapper.get('[data-test="rate-input"]').setValue('0.5')
+    await wrapper.get('[data-test="enable-rate"]').setValue(false)
+    await wrapper.get('[data-test="enable-status"]').setValue(true)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).toHaveBeenCalledWith([1, 2], { status: 'active' })
+  })
+
+  it('shows backend errors and retries only the failed groups from the original selection', async () => {
+    bulkUpdate.mockResolvedValueOnce({
+      succeededIds: [1], failures: [{ id: 2, error: { message: 'Permission denied' } }]
+    }).mockResolvedValueOnce({ succeededIds: [2], failures: [] })
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-rate"]').setValue(true)
+    await wrapper.get('[data-test="rate-input"]').setValue('2')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.text()).toContain('#2 Second: Permission denied')
+    expect(wrapper.emitted('updated')).toEqual([[[1]]])
+    expect(wrapper.emitted('close')).toBeUndefined()
+    expect(showSuccess).not.toHaveBeenCalled()
+    await wrapper.setProps({ selectedGroups: [{ id: 3, name: 'New group', subscription_type: 'standard' }] })
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(bulkUpdate).toHaveBeenLastCalledWith([2], { rate_multiplier: 2 })
+    expect(wrapper.emitted('updated')).toEqual([[[1]], [[2]]])
+  })
+
+  it('blocks duplicate submissions and closing while requests are in flight', async () => {
+    let finish!: (result: { succeededIds: number[]; failures: [] }) => void
+    bulkUpdate.mockReturnValue(new Promise((resolve) => { finish = resolve }))
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-status"]').setValue(true)
+    await wrapper.get('form').trigger('submit')
+    await wrapper.get('form').trigger('submit')
+    wrapper.findComponent({ name: 'BaseDialog' }).vm.$emit('close')
+    expect(bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('close')).toBeUndefined()
+    expect(wrapper.get('fieldset').attributes('disabled')).toBeDefined()
+    finish({ succeededIds: [1, 2], failures: [] })
+    await flushPromises()
+  })
+
+  it('resets field choices when reopened for another selection', async () => {
+    const wrapper = mountModal()
+    await wrapper.get('[data-test="enable-rate"]').setValue(true)
+    await wrapper.get('[data-test="rate-input"]').setValue('2')
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true, selectedGroups: [{ id: 3, name: 'Third', subscription_type: 'standard' }] })
+    expect(wrapper.find('[data-test="rate-input"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="submit"]').attributes('disabled')).toBeDefined()
+    await wrapper.get('[data-test="enable-status"]').setValue(true)
+    await wrapper.get('form').trigger('submit')
+    expect(bulkUpdate).toHaveBeenCalledWith([3], { status: 'active' })
+  })
+})

--- a/frontend/src/i18n/locales/en/admin/overview.ts
+++ b/frontend/src/i18n/locales/en/admin/overview.ts
@@ -777,6 +777,23 @@ export default {
 
     // Groups
     groups: {
+      bulkEdit: {
+        title: 'Bulk Edit',
+        selectedCount: '{count} groups selected',
+        selectGroup: 'Select group {name}',
+        clearSelection: 'Clear selection',
+        hint: 'Check the fields to update. Unchecked fields keep their current values.',
+        descriptionHint: 'Leave empty to clear the description on the selected groups.',
+        subscriptionOnly: 'Subscription limits can only be edited when all selected groups are subscription groups.',
+        limitHint: '0 blocks usage. Select Unlimited to remove this limit.',
+        invalidRate: 'The rate multiplier must be a valid number greater than 0.',
+        invalidRPM: 'RPM must be an integer greater than or equal to 0.',
+        invalidLimit: 'Enter a valid limit greater than or equal to 0, or select Unlimited.',
+        apply: 'Apply to {count} groups',
+        success: 'Updated {count} groups',
+        partialFailure: 'Updated {success} groups; {failed} failed',
+        failureHint: 'These groups could not be updated. Adjust the settings and retry. Only failed groups will be retried.'
+      },
       title: 'Group Management',
       description: 'Manage API key groups and rate multipliers',
       searchGroups: 'Search groups...',

--- a/frontend/src/i18n/locales/zh/admin/overview.ts
+++ b/frontend/src/i18n/locales/zh/admin/overview.ts
@@ -774,6 +774,23 @@ export default {
 
     // Groups Management
     groups: {
+      bulkEdit: {
+        title: '批量编辑',
+        selectedCount: '已选择 {count} 个分组',
+        selectGroup: '选择分组 {name}',
+        clearSelection: '取消选择',
+        hint: '勾选需要修改的字段，未勾选的字段保持原值。',
+        descriptionHint: '留空将清空所选分组的描述。',
+        subscriptionOnly: '仅当所选分组全部为订阅分组时，才能批量修改订阅额度。',
+        limitHint: '0 表示不允许产生用量；勾选“无限制”可解除此项限额。',
+        invalidRate: '费率倍数必须是大于 0 的有效数字。',
+        invalidRPM: 'RPM 必须是大于或等于 0 的整数。',
+        invalidLimit: '请输入大于或等于 0 的有效额度，或勾选“无限制”。',
+        apply: '应用到 {count} 个分组',
+        success: '已更新 {count} 个分组',
+        partialFailure: '已更新 {success} 个分组，{failed} 个失败',
+        failureHint: '以下分组更新失败，可修改设置后重试。再次提交只会更新失败的分组。'
+      },
       title: '分组管理',
       description: '管理 API 密钥分组和费率配置',
       searchGroups: '搜索分组...',

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -26,21 +26,21 @@
               :options="platformFilterOptions"
               :placeholder="t('admin.groups.allPlatforms')"
               class="w-44"
-              @change="loadGroups"
+              @change="handleFilterChange"
             />
             <Select
               v-model="filters.status"
               :options="statusOptions"
               :placeholder="t('admin.groups.allStatus')"
               class="w-40"
-              @change="loadGroups"
+              @change="handleFilterChange"
             />
             <Select
               v-model="filters.is_exclusive"
               :options="exclusiveOptions"
               :placeholder="t('admin.groups.allGroups')"
               class="w-44"
-              @change="loadGroups"
+              @change="handleFilterChange"
             />
           </div>
 
@@ -110,6 +110,22 @@
             </button>
           </div>
         </div>
+        <div v-if="selectedIds.length" class="mt-3 flex flex-wrap items-center gap-3 text-sm">
+          <span class="text-gray-600 dark:text-gray-300">
+            {{ t("admin.groups.bulkEdit.selectedCount", { count: selectedIds.length }) }}
+          </span>
+          <button
+            class="btn btn-primary btn-sm"
+            :disabled="loading"
+            data-test="bulk-edit-groups"
+            @click="showBulkEditModal = true"
+          >
+            {{ t("admin.groups.bulkEdit.title") }}
+          </button>
+          <button class="btn btn-secondary btn-sm" @click="selectedIds = []">
+            {{ t("admin.groups.bulkEdit.clearSelection") }}
+          </button>
+        </div>
       </template>
 
       <template #table>
@@ -117,6 +133,11 @@
           :columns="columns"
           :data="groups"
           :loading="loading"
+          selectable
+          row-key="id"
+          :selected-keys="selectedIds"
+          :selection-label="(group: AdminGroup) => t('admin.groups.bulkEdit.selectGroup', { name: group.name })"
+          @update:selected-keys="handleSelectionChange"
           :server-side-sort="true"
           default-sort-key="sort_order"
           default-sort-order="asc"
@@ -4554,6 +4575,13 @@
       @success="loadGroups"
     />
 
+    <BulkEditGroupModal
+      :show="showBulkEditModal"
+      :selected-groups="selectedGroups"
+      @close="showBulkEditModal = false"
+      @updated="handleBulkUpdated"
+    />
+
     <!-- Group RPM Overrides Modal -->
     <GroupRPMOverridesModal
       :show="showRPMOverridesModal"
@@ -4598,6 +4626,7 @@ import PlatformIcon from "@/components/common/PlatformIcon.vue";
 import Icon from "@/components/icons/Icon.vue";
 import GroupRateMultipliersModal from "@/components/admin/group/GroupRateMultipliersModal.vue";
 import GroupRPMOverridesModal from "@/components/admin/group/GroupRPMOverridesModal.vue";
+import BulkEditGroupModal from "@/components/admin/group/BulkEditGroupModal.vue";
 import GroupCapacityBadge from "@/components/common/GroupCapacityBadge.vue";
 import ReasoningEffortPolicyFields from "@/components/admin/group/ReasoningEffortPolicyFields.vue";
 import CodexManifestAccountsField from "@/components/admin/group/CodexManifestAccountsField.vue";
@@ -5078,6 +5107,21 @@ const copyAccountsGroupOptionsForEdit = computed(() => {
 });
 
 const groups = ref<AdminGroup[]>([]);
+const selectedIds = ref<number[]>([]);
+const showBulkEditModal = ref(false);
+const selectedGroups = computed(() => groups.value.filter((group) => selectedIds.value.includes(group.id)));
+
+const handleSelectionChange = (ids: Array<string | number>) => {
+  const visibleIds = new Set(groups.value.map((group) => group.id));
+  selectedIds.value = [...new Set(ids.map(Number))].filter((id) => visibleIds.has(id));
+};
+
+const handleBulkUpdated = (succeededIds: number[]) => {
+  const succeeded = new Set(succeededIds);
+  selectedIds.value = selectedIds.value.filter((id) => !succeeded.has(id));
+  loadGroups();
+};
+
 const loading = ref(false);
 type GroupUsageSummary = {
   today_cost: number;
@@ -5889,6 +5933,7 @@ const loadGroups = async () => {
     );
     if (signal.aborted) return;
     groups.value = response.items;
+    handleSelectionChange(selectedIds.value);
     pagination.total = response.total;
     pagination.pages = response.pages;
     if (hasVisibleUsageSummaryConsumer.value) {
@@ -6000,7 +6045,14 @@ const loadCapacitySummary = async () => {
 };
 
 let searchTimeout: ReturnType<typeof setTimeout>;
+const handleFilterChange = () => {
+  selectedIds.value = [];
+  pagination.page = 1;
+  loadGroups();
+};
+
 const handleSearch = () => {
+  selectedIds.value = [];
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
     pagination.page = 1;
@@ -6009,17 +6061,20 @@ const handleSearch = () => {
 };
 
 const handlePageChange = (page: number) => {
+  selectedIds.value = [];
   pagination.page = page;
   loadGroups();
 };
 
 const handlePageSizeChange = (pageSize: number) => {
+  selectedIds.value = [];
   pagination.page_size = pageSize;
   pagination.page = 1;
   loadGroups();
 };
 
 const handleSort = (key: string, order: 'asc' | 'desc') => {
+  selectedIds.value = [];
   sortState.sort_by = key;
   sortState.sort_order = order;
   pagination.page = 1;

--- a/frontend/src/views/admin/__tests__/GroupsView.columnSettings.spec.ts
+++ b/frontend/src/views/admin/__tests__/GroupsView.columnSettings.spec.ts
@@ -148,8 +148,9 @@ const TablePageLayoutStub = {
 }
 
 const DataTableStub = {
-  props: ['columns', 'data'],
-  emits: ['sort'],
+  name: 'DataTable',
+  props: { columns: Array, data: Array, selectedKeys: Array, selectable: Boolean },
+  emits: ['sort', 'update:selectedKeys'],
   template: `
     <div>
       <div data-test="columns">{{ columns.map((col) => col.key).join(',') }}</div>
@@ -162,6 +163,7 @@ const DataTableStub = {
 }
 
 const SelectStub = {
+  name: 'Select',
   props: ['modelValue', 'options', 'placeholder'],
   emits: ['update:modelValue', 'change'],
   template: `
@@ -203,6 +205,7 @@ const mountView = async () => {
         GroupCapacityBadge: true,
         GroupRateMultipliersModal: true,
         GroupRPMOverridesModal: true,
+        BulkEditGroupModal: true,
         VueDraggable: { template: '<div><slot /></div>' },
       },
     },
@@ -279,6 +282,67 @@ describe('admin GroupsView column settings', () => {
     ])
     expect(localStorage.getItem('group-hidden-columns')).toBe(JSON.stringify(['id']))
     expect(localStorage.getItem('group-column-settings-version')).toBe('2')
+  })
+
+  it('opens bulk editing with only the selected visible groups', async () => {
+    const wrapper = await mountView()
+    const table = wrapper.findComponent({ name: 'DataTable' })
+    expect(table.props('selectable')).toBe(true)
+    table.vm.$emit('update:selectedKeys', [1, 99])
+    await flushPromises()
+    await wrapper.get('[data-test="bulk-edit-groups"]').trigger('click')
+    const modal = wrapper.findComponent({ name: 'BulkEditGroupModal' })
+    expect(modal.props('show')).toBe(true)
+    expect(modal.props('selectedGroups').map((group: AdminGroup) => group.id)).toEqual([1])
+    wrapper.unmount()
+  })
+
+  it.each(['filter', 'page', 'page size', 'sort', 'search'])('clears the selection on %s changes', async (change) => {
+    const wrapper = await mountView()
+    const table = wrapper.findComponent({ name: 'DataTable' })
+    table.vm.$emit('update:selectedKeys', [1])
+    await flushPromises()
+    if (change === 'filter') {
+      wrapper.findComponent({ name: 'Select' }).vm.$emit('change')
+    } else if (change === 'page') {
+      wrapper.findComponent({ name: 'Pagination' }).vm.$emit('update:page', 2)
+    } else if (change === 'page size') {
+      wrapper.findComponent({ name: 'Pagination' }).vm.$emit('update:pageSize', 50)
+    } else if (change === 'sort') {
+      table.vm.$emit('sort', 'name', 'asc')
+    } else {
+      await wrapper.get('input[type="text"]').setValue('different group')
+    }
+    await flushPromises()
+    expect(table.props('selectedKeys')).toEqual([])
+    expect(wrapper.find('[data-test="bulk-edit-groups"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('deselects successful groups and refreshes while retaining failed groups', async () => {
+    listGroups.mockResolvedValue({ items: [createGroup(), createGroup({ id: 2, name: 'Second' })], total: 2, pages: 1 })
+    const wrapper = await mountView()
+    const table = wrapper.findComponent({ name: 'DataTable' })
+    table.vm.$emit('update:selectedKeys', [1, 2])
+    await flushPromises()
+    await wrapper.get('[data-test="bulk-edit-groups"]').trigger('click')
+    wrapper.findComponent({ name: 'BulkEditGroupModal' }).vm.$emit('updated', [1])
+    await flushPromises()
+    expect(listGroups).toHaveBeenCalledTimes(2)
+    expect(table.props('selectedKeys')).toEqual([2])
+    wrapper.unmount()
+  })
+
+  it('drops groups that disappear from the page after a refresh', async () => {
+    const wrapper = await mountView()
+    const table = wrapper.findComponent({ name: 'DataTable' })
+    table.vm.$emit('update:selectedKeys', [1])
+    await flushPromises()
+    listGroups.mockResolvedValue({ items: [], total: 0, pages: 0 })
+    await wrapper.get('button[title="common.refresh"]').trigger('click')
+    await flushPromises()
+    expect(table.props('selectedKeys')).toEqual([])
+    wrapper.unmount()
   })
 
   it('applies saved hidden columns on mount and ignores unknown keys', async () => {


### PR DESCRIPTION
Group Management currently requires opening and saving each group separately when applying the same settings. This adds row selection and a bulk editor for the current page, with an explicit choice of which fields to change.

- Edit rate multiplier, status, exclusive/public visibility, description, and RPM limit together. Unchecked fields are omitted from each request, and an empty selected description clears the description.
- Edit daily, weekly, and monthly limits when every selected group is a subscription group. The explicit Unlimited option sends `null`; an entered `0` remains zero quota. Mixed selections can still edit the common fields.
- Reuse the existing authenticated group update endpoint with at most five requests in flight. Show per-group failures and retry only failed groups, keeping successful updates out of subsequent attempts.
- Clear selection on search, filter, pagination, and sort changes. Include Chinese and English labels and register regression coverage in `frontend-critical`.

Validation:

- `pnpm exec vitest run` with the Makefile's critical test list: 16 files, 204 tests passed.
- Focused group API, bulk editor, selection, duplicate, and composite-platform tests: 5 files, 42 tests passed (overlaps with the critical suite).
- `pnpm run lint:check` and `pnpm run build` passed; the build includes `vue-tsc -b`.
- Chrome checks at 1440 x 1000 and 390 x 844 against mocked API responses: sparse payloads, zero versus unlimited quota, partial failure and retry, untouched unselected groups, mixed-selection restrictions, no horizontal overflow, and no page errors.
- `git diff --check` passed.

No backend endpoint, schema, credential, or deployment changes. Browser validation used synthetic local data; it did not change production groups.
