### PR TITLE
perf(admin): send only changed settings fields and slim the PUT response

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -474,6 +474,11 @@ func loginAgreementDocumentsToService(items []dto.LoginAgreementDocument) []serv
 	return result
 }
 
+// systemSettingsResponseData 把 dto.SystemSettings 展平为响应 map，并附加
+// auth_source_default_* 与 force_email_on_third_party_signup 等只读派生键。
+// 注意：PUT 路径会再用 filterSystemSettingsResponseForPut 裁剪（见
+// setting_handler_response_filter.go）；若此处新增派生自请求字段的只读键，
+// 需同步登记到 putResponseCompanions，否则部分载荷保存后客户端拿不到它。
 func systemSettingsResponseData(settings dto.SystemSettings, authSourceDefaults *service.AuthSourceDefaultSettings) map[string]any {
 	data := make(map[string]any)
 	raw, err := json.Marshal(settings)

--- a/backend/internal/handler/admin/setting_handler_auth_source_defaults_test.go
+++ b/backend/internal/handler/admin/setting_handler_auth_source_defaults_test.go
@@ -201,9 +201,12 @@ func TestSettingHandler_UpdateSettings_PreservesOmittedAuthSourceDefaults(t *tes
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.True(t, ok)
+	// PUT 响应只回传发送的字段（见 setting_handler_response_filter.go）：
+	// email_balance 这次发送了 → 回传终值；未发送的 concurrency /
+	// force_email_on_third_party_signup 不再出现在响应里。
 	require.Equal(t, 12.75, data["auth_source_default_email_balance"])
-	require.Equal(t, float64(8), data["auth_source_default_email_concurrency"])
-	require.Equal(t, true, data["force_email_on_third_party_signup"])
+	require.NotContains(t, data, "auth_source_default_email_concurrency")
+	require.NotContains(t, data, "force_email_on_third_party_signup")
 }
 
 func TestSettingHandler_UpdateSettings_PersistsPaymentVisibleMethodsAndAdvancedScheduler(t *testing.T) {

--- a/backend/internal/handler/admin/setting_handler_response_filter.go
+++ b/backend/internal/handler/admin/setting_handler_response_filter.go
@@ -1,0 +1,112 @@
+package admin
+
+import "encoding/json"
+
+// PUT /settings 的响应瘦身：保存只需要回传「这次发过来的字段 + 其只读伴生键」，
+// 而不是整份 800KB 的设置文档（GET 才负责整份）。客户端（SettingsView）的合并
+// 逻辑已按「键存在才写」设计，因此少回传键是安全的。
+//
+// 契约：
+//   - 发送过的键 → 回传持久化后的终值（含后端 clamp/归一化的结果）；
+//   - 未知/多余的发送键 → 自然落空（响应 map 里没有就不回传）；
+//   - always 键 → 无论是否发送都回传（保存路径会 fail-closed 重推导它们，
+//     客户端需要拿到重推导后的值）；
+//   - 伴生键 → 只读派生键（*_configured / *_effective_* 等），跟随触发它的
+//     可写字段一起回传。
+//
+// 维护提醒：如果给响应新增了派生自请求字段的只读键（例如新的 *_configured），
+// 必须同步登记到 putResponseCompanions，否则部分载荷保存后客户端拿不到它。
+
+// putResponseAlwaysKeys 每次保存 handler 都会重推导的安全键，即使未发送也回传。
+var putResponseAlwaysKeys = []string{
+	"api_key_acl_trust_forwarded_ip",
+	"forwarded_client_ip_headers",
+}
+
+// putResponseCompanions 发送键 → 需要一并回传的只读伴生响应键。
+var putResponseCompanions = map[string][]string{
+	// 密钥字段：GET 永不回传明文，客户端靠 *_configured 判断已配置状态。
+	// 发送密钥（含发送空串清除）后必须回传新的 *_configured。
+	"smtp_password":                    {"smtp_password_configured"},
+	"turnstile_secret_key":             {"turnstile_secret_key_configured"},
+	"tencent_captcha_app_secret_key":   {"tencent_captcha_app_secret_key_configured"},
+	"tencent_captcha_cloud_secret_id":  {"tencent_captcha_cloud_secret_id_configured"},
+	"tencent_captcha_cloud_secret_key": {"tencent_captcha_cloud_secret_key_configured"},
+	"aliyun_captcha_access_key_secret": {"aliyun_captcha_access_key_secret_configured"},
+	"linuxdo_connect_client_secret":    {"linuxdo_connect_client_secret_configured"},
+	"dingtalk_connect_client_secret":   {"dingtalk_connect_client_secret_configured"},
+	"wechat_connect_app_secret":        {"wechat_connect_app_secret_configured"},
+	"wechat_connect_open_app_secret":   {"wechat_connect_open_app_secret_configured"},
+	"wechat_connect_mp_app_secret":     {"wechat_connect_mp_app_secret_configured"},
+	"wechat_connect_mobile_app_secret": {"wechat_connect_mobile_app_secret_configured"},
+	"oidc_connect_client_secret":       {"oidc_connect_client_secret_configured"},
+	"github_oauth_client_secret":       {"github_oauth_client_secret_configured"},
+	"google_oauth_client_secret":       {"google_oauth_client_secret_configured"},
+
+	// passkey_configured 由部署配置派生，开启 passkey_enabled 时有 gate 校验，
+	// 客户端需要看到校验后的状态。
+	"passkey_enabled": {"passkey_configured"},
+
+	// codex 版本自动同步会改写 openai_codex_client_version，终值经 *_synced 体现。
+	"openai_codex_client_version":            {"openai_codex_client_version_synced"},
+	"openai_codex_version_auto_sync_enabled": {"openai_codex_client_version_synced"},
+}
+
+// 调度器 14 个可写请求键共享同一组 12 个 effective 只读派生键，
+// 单列出来避免上面 map 里重复 14 遍。
+var openAIAdvancedSchedulerEffectiveKeys = []string{
+	"openai_advanced_scheduler_effective_lb_top_k",
+	"openai_advanced_scheduler_effective_weight_priority",
+	"openai_advanced_scheduler_effective_weight_load",
+	"openai_advanced_scheduler_effective_weight_queue",
+	"openai_advanced_scheduler_effective_weight_error_rate",
+	"openai_advanced_scheduler_effective_weight_ttft",
+	"openai_advanced_scheduler_effective_weight_reset",
+	"openai_advanced_scheduler_effective_weight_quota_headroom",
+	"openai_advanced_scheduler_effective_weight_upstream_cost",
+	"openai_advanced_scheduler_effective_weight_previous_response",
+	"openai_advanced_scheduler_effective_weight_session_sticky",
+}
+
+func init() {
+	for _, key := range []string{
+		"openai_advanced_scheduler_enabled",
+		"openai_advanced_scheduler_sticky_weighted_enabled",
+		"openai_advanced_scheduler_subscription_priority_enabled",
+		"openai_advanced_scheduler_lb_top_k",
+		"openai_advanced_scheduler_weight_priority",
+		"openai_advanced_scheduler_weight_load",
+		"openai_advanced_scheduler_weight_queue",
+		"openai_advanced_scheduler_weight_error_rate",
+		"openai_advanced_scheduler_weight_ttft",
+		"openai_advanced_scheduler_weight_reset",
+		"openai_advanced_scheduler_weight_quota_headroom",
+		"openai_advanced_scheduler_weight_upstream_cost",
+		"openai_advanced_scheduler_weight_previous_response",
+		"openai_advanced_scheduler_weight_session_sticky",
+	} {
+		putResponseCompanions[key] = append(
+			putResponseCompanions[key], openAIAdvancedSchedulerEffectiveKeys...)
+	}
+}
+
+// filterSystemSettingsResponseForPut 把完整的设置响应裁剪成部分载荷保存所需的最小子集：
+// always 键 ∪ 发送键 ∪ 发送键的伴生键。data 里不存在但客户端发送的键自然被忽略。
+func filterSystemSettingsResponseForPut(data map[string]any, sentFields map[string]json.RawMessage) map[string]any {
+	filtered := make(map[string]any, len(sentFields)+len(putResponseAlwaysKeys)+4)
+	copyIfPresent := func(key string) {
+		if v, ok := data[key]; ok {
+			filtered[key] = v
+		}
+	}
+	for _, key := range putResponseAlwaysKeys {
+		copyIfPresent(key)
+	}
+	for key := range sentFields {
+		copyIfPresent(key)
+		for _, companion := range putResponseCompanions[key] {
+			copyIfPresent(companion)
+		}
+	}
+	return filtered
+}

--- a/backend/internal/handler/admin/setting_handler_response_filter_test.go
+++ b/backend/internal/handler/admin/setting_handler_response_filter_test.go
@@ -1,0 +1,94 @@
+//go:build unit
+
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/stretchr/testify/require"
+)
+
+// PUT /settings 的响应只回传本次发送的字段及其只读伴生键（整份文档由 GET 负责），
+// 避免每次保存都在链路上搬运 ~800KB。以下测试钉住这个契约。
+
+func decodeUpdateSettingsData(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var resp response.Response
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.True(t, ok, "response data must be an object")
+	return data
+}
+
+func TestUpdateSettingsSlimResponseIncludesSentAndCompanionKeys(t *testing.T) {
+	h, repo := newStepUpSwitchTestHandler(t, map[string]string{
+		service.SettingKeySiteName:                      "Example Gateway",
+		service.SettingKeySMTPPassword:                  "stored-smtp-secret",
+		service.SettingKeyAuthSourceDefaultEmailBalance: "9.5",
+	})
+
+	rec := doUpdateSettings(t, h, map[string]any{
+		"registration_enabled": true,
+		"smtp_password":        "new-smtp-secret",
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "new-smtp-secret", repo.values[service.SettingKeySMTPPassword])
+
+	data := decodeUpdateSettingsData(t, rec)
+
+	// 发送的字段：回传终值。
+	require.Equal(t, true, data["registration_enabled"])
+	// 密钥的只读伴生键：必须一并回传，且不回传明文。
+	require.Equal(t, true, data["smtp_password_configured"])
+	require.NotContains(t, data, "smtp_password")
+	// always 键：未发送也回传（保存路径 fail-closed 重推导）。
+	require.Contains(t, data, "api_key_acl_trust_forwarded_ip")
+	require.Contains(t, data, "forwarded_client_ip_headers")
+}
+
+func TestUpdateSettingsSlimResponseOmitsUnsentKeys(t *testing.T) {
+	h, _ := newStepUpSwitchTestHandler(t, map[string]string{
+		service.SettingKeySiteName:     "Example Gateway",
+		service.SettingKeySMTPPassword: "stored-smtp-secret",
+	})
+
+	rec := doUpdateSettings(t, h, map[string]any{"registration_enabled": true}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	data := decodeUpdateSettingsData(t, rec)
+
+	// 未发送的键不回传——这是瘦身的核心契约，客户端按「键存在才写」合并。
+	require.NotContains(t, data, "site_name")
+	require.NotContains(t, data, "smtp_password_configured")
+	require.NotContains(t, data, "auth_source_default_email_balance")
+}
+
+func TestUpdateSettingsSlimResponseIncludesSchedulerEffectiveCompanions(t *testing.T) {
+	h, _ := newStepUpSwitchTestHandler(t, map[string]string{})
+
+	rec := doUpdateSettings(t, h, map[string]any{
+		"openai_advanced_scheduler_enabled": true,
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	data := decodeUpdateSettingsData(t, rec)
+	require.Equal(t, true, data["openai_advanced_scheduler_enabled"])
+	for _, key := range openAIAdvancedSchedulerEffectiveKeys {
+		require.Contains(t, data, key,
+			"scheduler effective keys must accompany any scheduler request field")
+	}
+}
+
+func TestFilterSystemSettingsResponseForPutUnknownSentKeyIsIgnored(t *testing.T) {
+	filtered := filterSystemSettingsResponseForPut(
+		map[string]any{"site_name": "Example Gateway"},
+		map[string]json.RawMessage{"not_a_real_setting": json.RawMessage(`"x"`)},
+	)
+	require.Empty(t, filtered, "sent keys absent from the response data are dropped, not invented")
+}

--- a/backend/internal/handler/admin/setting_handler_update.go
+++ b/backend/internal/handler/admin/setting_handler_update.go
@@ -2398,7 +2398,10 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 	} else {
 		payload.DefaultPlatformQuotas = platformQuotas
 	}
-	response.Success(c, systemSettingsResponseData(payload, updatedAuthSourceDefaults))
+	// PUT 响应只回传本次发送的字段及其只读伴生键（见 setting_handler_response_filter.go），
+	// 客户端按「键存在才写」合并；整份文档由 GET 负责。
+	response.Success(c, filterSystemSettingsResponseForPut(
+		systemSettingsResponseData(payload, updatedAuthSourceDefaults), sentFields))
 }
 
 // hasPaymentFields returns true if any payment-related field was explicitly provided.

--- a/frontend/src/api/__tests__/settings.diff.spec.ts
+++ b/frontend/src/api/__tests__/settings.diff.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  diffSettingsPayload,
+  fingerprintSettingsPayload,
+  stableStringify,
+} from "@/api/admin/settings";
+import type { UpdateSettingsRequest } from "@/api/admin/settings";
+
+// 设置页「只发变更字段」依赖这三个纯函数；这里钉住它们的关键语义。
+
+describe("stableStringify", () => {
+  it("对 key 顺序不敏感", () => {
+    expect(stableStringify({ b: 1, a: [1, { y: null, x: "s" }] })).toBe(
+      stableStringify({ a: [1, { x: "s", y: null }], b: 1 }),
+    );
+  });
+
+  it("把 undefined 属性与键不存在归一为同一种缺失", () => {
+    // 密钥留空（undefined）= 未变更 = 不发送，必须与键不存在等价。
+    expect(stableStringify({ a: undefined, b: 1 })).toBe(
+      stableStringify({ b: 1 }),
+    );
+    expect(stableStringify(undefined)).toBe("null");
+  });
+
+  it("区分真正会改变行为的值", () => {
+    expect(stableStringify(false)).not.toBe(stableStringify(undefined));
+    expect(stableStringify("")).not.toBe(stableStringify(null));
+    expect(stableStringify(0)).not.toBe(stableStringify(null));
+  });
+});
+
+describe("diffSettingsPayload", () => {
+  it("只保留相对基线变化过的键", () => {
+    const baseline = fingerprintSettingsPayload({
+      site_name: "A",
+      registration_enabled: true,
+      default_platform_quotas: { anthropic: { daily: 1 } },
+    } as unknown as UpdateSettingsRequest);
+
+    const diff = diffSettingsPayload(
+      {
+        site_name: "B",
+        registration_enabled: true,
+        default_platform_quotas: { anthropic: { daily: 2 } },
+      } as unknown as UpdateSettingsRequest,
+      baseline,
+    );
+
+    expect(diff).toEqual({
+      site_name: "B",
+      default_platform_quotas: { anthropic: { daily: 2 } },
+    });
+  });
+
+  it("嵌套对象内部相同（仅 key 顺序不同）不产生 diff", () => {
+    const baseline = fingerprintSettingsPayload({
+      default_platform_quotas: { anthropic: { daily: 1 }, openai: { weekly: 2 } },
+    } as unknown as UpdateSettingsRequest);
+
+    const diff = diffSettingsPayload(
+      {
+        default_platform_quotas: { openai: { weekly: 2 }, anthropic: { daily: 1 } },
+      } as unknown as UpdateSettingsRequest,
+      baseline,
+    );
+
+    expect(diff).toEqual({});
+  });
+
+  it("基线为 null（首次加载前）时原样返回全量 payload", () => {
+    const payload = { site_name: "A" } as unknown as UpdateSettingsRequest;
+    expect(diffSettingsPayload(payload, null)).toBe(payload);
+  });
+
+  it("密钥留空（undefined）与基线一致，不进入 diff", () => {
+    const baseline = fingerprintSettingsPayload({
+      smtp_password: undefined,
+      site_name: "A",
+    } as unknown as UpdateSettingsRequest);
+
+    const diff = diffSettingsPayload(
+      { smtp_password: undefined, site_name: "A" } as unknown as UpdateSettingsRequest,
+      baseline,
+    );
+
+    expect(diff).toEqual({});
+  });
+});

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -308,6 +308,109 @@ export function appendAuthSourceDefaultsToUpdateRequest(
   return payload;
 }
 
+/**
+ * 按键合并部分响应里的 auth_source_default_* 到现有 state。
+ * PUT 响应已瘦身为只含本次发送的字段（见后端 setting_handler_response_filter.go），
+ * 不能再用 buildAuthSourceDefaultsState 整体重算——它会用默认值覆盖未发送的 source。
+ */
+export function mergeAuthSourceDefaultsFromResponse(
+  current: AuthSourceDefaultsState,
+  response: Partial<SystemSettings>,
+): AuthSourceDefaultsState {
+  const raw = response as Record<string, unknown>;
+  const merged = {} as AuthSourceDefaultsState;
+
+  for (const source of AUTH_SOURCE_TYPES) {
+    const prev = current[source];
+    const next = { ...prev };
+    const has = (field: string) =>
+      `auth_source_default_${source}_${field}` in raw;
+
+    if (has("balance")) next.balance = Number(raw[`auth_source_default_${source}_balance`]);
+    if (has("concurrency"))
+      next.concurrency = Math.max(
+        1,
+        Number(raw[`auth_source_default_${source}_concurrency`]),
+      );
+    if (has("subscriptions"))
+      next.subscriptions = normalizeDefaultSubscriptionSettings(
+        raw[`auth_source_default_${source}_subscriptions`] as DefaultSubscriptionSetting[],
+      );
+    if (has("grant_on_signup"))
+      next.grant_on_signup = raw[`auth_source_default_${source}_grant_on_signup`] === true;
+    if (has("grant_on_first_bind"))
+      next.grant_on_first_bind =
+        raw[`auth_source_default_${source}_grant_on_first_bind`] === true;
+    if (has("platform_quotas"))
+      next.platform_quotas = normalizePlatformQuotasMap(
+        raw[`auth_source_default_${source}_platform_quotas`] as DefaultPlatformQuotasMap,
+      );
+
+    merged[source] = next;
+  }
+
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
+// 保存 diff：设置页保存时只发送相对基线变化过的字段，而不是整份 ~800KB 文档。
+// 基线 = 上次加载/保存后由 buildSettingsPayload() 生成的指纹；未变的键不发送。
+// ---------------------------------------------------------------------------
+
+/**
+ * 递归排序 key 的稳定序列化：同一数据结构不同 key 顺序得到相同字符串。
+ * undefined 属性与「键不存在」归一为同一种缺失（密钥留空=未变更=不发送）。
+ */
+export function stableStringify(value: unknown): string {
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const key of Object.keys(record).sort()) {
+    const item = record[key];
+    if (item === undefined) continue;
+    parts.push(`${JSON.stringify(key)}:${stableStringify(item)}`);
+  }
+  return `{${parts.join(",")}}`;
+}
+
+/** payload 的逐键指纹，用作保存 diff 的基线。 */
+export function fingerprintSettingsPayload(
+  payload: UpdateSettingsRequest,
+): Record<string, string> {
+  const source = payload as Record<string, unknown>;
+  const result: Record<string, string> = {};
+  for (const key of Object.keys(source)) {
+    result[key] = stableStringify(source[key]);
+  }
+  return result;
+}
+
+/**
+ * 只保留相对基线变化过的键。基线为 null（首次加载前）时原样返回全量 payload。
+ * 注意：外部写入（如 codex 版本自动同步）会让基线过期，但 diff 只含用户改的键，
+ * 外部变更不会被覆盖——这比整包重写更安全。
+ */
+export function diffSettingsPayload(
+  current: UpdateSettingsRequest,
+  baseline: Record<string, string> | null,
+): UpdateSettingsRequest {
+  if (!baseline) return current;
+  const source = current as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    if (baseline[key] !== stableStringify(source[key])) {
+      result[key] = source[key];
+    }
+  }
+  return result as UpdateSettingsRequest;
+}
+
 export function getPaymentVisibleMethodSourceOptions(
   method: PaymentVisibleMethod,
 ): PaymentVisibleMethodSourceOption[] {
@@ -1051,13 +1154,13 @@ export async function getSettings(): Promise<SystemSettings> {
 
 /**
  * Update system settings
- * @param settings - Partial settings to update
- * @returns Updated settings
+ * @param settings - Partial settings to update（后端 PUT 支持 omitted 字段保持现值）
+ * @returns 本次发送字段的终值及其只读伴生键（PUT 响应已瘦身，不再是整份文档）
  */
 export async function updateSettings(
   settings: UpdateSettingsRequest,
-): Promise<SystemSettings> {
-  const { data } = await apiClient.put<SystemSettings>(
+): Promise<Partial<SystemSettings>> {
+  const { data } = await apiClient.put<Partial<SystemSettings>>(
     "/admin/settings",
     settings,
   );

--- a/frontend/src/stores/adminSettings.ts
+++ b/frontend/src/stores/adminSettings.ts
@@ -109,6 +109,11 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     loaded.value = true
   }
 
+  function setCustomMenuItemsLocal(value: CustomMenuItem[]) {
+    customMenuItems.value = Array.isArray(value) ? value : []
+    loaded.value = true
+  }
+
   // Keep UI consistent if we learn that ops is disabled via feature-gated 404s.
   // (event is dispatched from the axios interceptor)
   let eventHandlerCleanup: (() => void) | null = null
@@ -145,6 +150,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     setOpsMonitoringEnabledLocal,
     setOpsRealtimeMonitoringEnabledLocal,
     setPaymentEnabledLocal,
-    setOpsQueryModeDefaultLocal
+    setOpsQueryModeDefaultLocal,
+    setCustomMenuItemsLocal
   }
 })

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -8769,6 +8769,9 @@ import { adminAPI } from "@/api";
 import {
   appendAuthSourceDefaultsToUpdateRequest,
   buildAuthSourceDefaultsState,
+  diffSettingsPayload,
+  fingerprintSettingsPayload,
+  mergeAuthSourceDefaultsFromResponse,
   normalizeAccountSchedulingThresholdsMap,
   normalizePlatformQuotasMap,
   sanitizeAccountSchedulingThresholdsMap,
@@ -8794,6 +8797,7 @@ import type {
 } from "@/api/admin/settings";
 import type {
   AdminGroup,
+  CustomMenuItem,
   LoginAgreementDocument,
   NotifyEmailEntry,
   Proxy,
@@ -9044,6 +9048,13 @@ const openaiFastPolicyForm = reactive({
 // 标记 openai_fast_policy_settings 是否已成功从后端加载，
 // 避免后端 GET 出错或字段缺失时，保存把默认规则覆盖成空数组。
 const openaiFastPolicyLoaded = ref(false);
+
+// 保存 diff 的基线：上次加载/保存后 buildSettingsPayload() 的逐键指纹。
+// 保存时只发送相对基线变化过的字段（后端 PUT 支持省略=保持现值），
+// 避免每次保存在链路上搬运 ~800KB 的整份文档。
+// 注意：外部写入（如 codex 版本自动同步）会让基线过期，但 diff 只含
+// 用户改的键，外部变更不会被覆盖——比整包重写更安全。
+const settingsBaseline = ref<Record<string, string> | null>(null);
 
 const tablePageSizeMin = 5;
 const tablePageSizeMax = 1000;
@@ -10925,6 +10936,9 @@ async function loadSettings() {
 
     // Load web search emulation config separately
     await loadWebSearchConfig();
+
+    // 表单已归一化完毕，记录保存 diff 的基线
+    settingsBaseline.value = fingerprintSettingsPayload(buildSettingsPayload());
   } catch (error: unknown) {
     loadFailed.value = true;
     appStore.showError(
@@ -11139,401 +11153,58 @@ async function saveSettings() {
     if (!isValidHttpUrl(form.frontend_url)) form.frontend_url = "";
     if (!isValidHttpUrl(form.doc_url)) form.doc_url = "";
     syncWeChatConnectMode();
-    const wechatStoredMode = deriveWeChatConnectStoredMode(
-      form.wechat_connect_open_enabled,
-      form.wechat_connect_mp_enabled,
-      form.wechat_connect_mobile_enabled,
-      form.wechat_connect_mode,
-    );
-    const claudeOAuthSystemPromptBlocksJSON =
-      serializeClaudeOAuthSystemPromptBlocksToJSON(
-        claudeOAuthSystemPromptBlocks.value,
+    const payload = buildSettingsPayload();
+    // diff 必须在 step-up 之外先算好：step-up 验证重试时重发的是同一份部分 payload。
+    const diff = diffSettingsPayload(payload, settingsBaseline.value);
+
+    let updated: Partial<SystemSettings> = {};
+    if (Object.keys(diff).length > 0) {
+      updated = await settingsStepUp.run(() =>
+        adminAPI.settings.updateSettings(diff),
       );
-    form.claude_oauth_system_prompt_blocks =
-      claudeOAuthSystemPromptBlocksJSON;
-
-    const payload: UpdateSettingsRequest = {
-      registration_enabled: form.registration_enabled,
-      email_verify_enabled: form.email_verify_enabled,
-      registration_email_suffix_whitelist:
-        registrationEmailSuffixWhitelistTags.value.map((suffix) =>
-          suffix.startsWith("*.") ? suffix : `@${suffix}`,
-        ),
-      registration_email_domain_quota_enabled:
-        form.registration_email_domain_quota_enabled,
-      promo_code_enabled: form.promo_code_enabled,
-      invitation_code_enabled: form.invitation_code_enabled,
-      password_reset_enabled: form.password_reset_enabled,
-      totp_enabled: form.totp_enabled,
-      passkey_enabled: form.passkey_enabled,
-      session_binding_enabled: form.session_binding_enabled,
-      step_up_enabled: form.step_up_enabled,
-      // 清空数字框时 v-model.number 会得到空串，后端 int 字段解析空串会 400 拒绝整次保存；
-      // 空/非法值回退默认 180（与后端 parseAuditLogRetentionDays("") 语义一致，0 仍表示永久保留）。
-      audit_log_retention_days: Number.isFinite(form.audit_log_retention_days)
-        ? form.audit_log_retention_days
-        : 180,
-      login_agreement_enabled: form.login_agreement_enabled,
-      login_agreement_mode: form.login_agreement_mode,
-      login_agreement_updated_at: form.login_agreement_updated_at,
-      login_agreement_documents: form.login_agreement_documents,
-      default_balance: form.default_balance,
-      affiliate_rebate_rate: Math.min(
-        100,
-        Math.max(0, Number(form.affiliate_rebate_rate) || 0),
-      ),
-      affiliate_rebate_freeze_hours: Math.max(0, Math.min(720, Number(form.affiliate_rebate_freeze_hours) || 0)),
-      affiliate_rebate_duration_days: Math.max(0, Math.min(3650, Math.floor(Number(form.affiliate_rebate_duration_days) || 0))),
-      affiliate_rebate_per_invitee_cap: Math.max(0, Number(form.affiliate_rebate_per_invitee_cap) || 0),
-      affiliate_admin_recharge_enabled: form.affiliate_admin_recharge_enabled,
-      default_concurrency: form.default_concurrency,
-      default_subscriptions: normalizedDefaultSubscriptions,
-      force_email_on_third_party_signup: form.force_email_on_third_party_signup,
-      default_user_rpm_limit: form.default_user_rpm_limit,
-      site_name: form.site_name,
-      site_logo: form.site_logo,
-      site_subtitle: form.site_subtitle,
-      api_base_url: form.api_base_url,
-      contact_info: form.contact_info,
-      doc_url: form.doc_url,
-      home_content: form.home_content,
-      compact_home_enabled: form.compact_home_enabled,
-      backend_mode_enabled: form.backend_mode_enabled,
-      hide_ccs_import_button: form.hide_ccs_import_button,
-      table_default_page_size: form.table_default_page_size,
-      table_page_size_options: form.table_page_size_options,
-      custom_menu_items: form.custom_menu_items,
-      custom_endpoints: form.custom_endpoints,
-      frontend_url: form.frontend_url,
-      smtp_host: form.smtp_host,
-      smtp_port: form.smtp_port,
-      smtp_username: form.smtp_username,
-      smtp_password: form.smtp_password || undefined,
-      smtp_from_email: form.smtp_from_email,
-      smtp_from_name: form.smtp_from_name,
-      smtp_use_tls: form.smtp_use_tls,
-      turnstile_enabled: form.turnstile_enabled,
-      turnstile_site_key: form.turnstile_site_key,
-      turnstile_secret_key: form.turnstile_secret_key || undefined,
-      tencent_captcha_enabled: form.tencent_captcha_enabled,
-      tencent_captcha_app_id: form.tencent_captcha_app_id,
-      tencent_captcha_app_secret_key:
-        form.tencent_captcha_app_secret_key || undefined,
-      tencent_captcha_cloud_secret_id:
-        form.tencent_captcha_cloud_secret_id || undefined,
-      tencent_captcha_cloud_secret_key:
-        form.tencent_captcha_cloud_secret_key || undefined,
-      tencent_captcha_region: form.tencent_captcha_region,
-      aliyun_captcha_enabled: form.aliyun_captcha_enabled,
-      aliyun_captcha_access_key_id: form.aliyun_captcha_access_key_id,
-      aliyun_captcha_access_key_secret:
-        form.aliyun_captcha_access_key_secret || undefined,
-      aliyun_captcha_scene_id: form.aliyun_captcha_scene_id,
-      aliyun_captcha_prefix: form.aliyun_captcha_prefix,
-      aliyun_captcha_region: form.aliyun_captcha_region,
-      api_key_acl_trust_forwarded_ip: form.api_key_acl_trust_forwarded_ip,
-      forwarded_client_ip_headers: form.forwarded_client_ip_headers,
-      linuxdo_connect_enabled: form.linuxdo_connect_enabled,
-      linuxdo_connect_client_id: form.linuxdo_connect_client_id,
-      linuxdo_connect_client_secret:
-        form.linuxdo_connect_client_secret || undefined,
-      linuxdo_connect_redirect_url: form.linuxdo_connect_redirect_url,
-      dingtalk_connect_enabled: form.dingtalk_connect_enabled,
-      dingtalk_connect_client_id: form.dingtalk_connect_client_id,
-      dingtalk_connect_client_secret:
-        form.dingtalk_connect_client_secret || undefined,
-      dingtalk_connect_redirect_url: form.dingtalk_connect_redirect_url,
-      dingtalk_connect_corp_restriction_policy:
-        form.dingtalk_connect_corp_restriction_policy,
-      dingtalk_connect_internal_corp_id: form.dingtalk_connect_internal_corp_id,
-      dingtalk_connect_bypass_registration: form.dingtalk_connect_bypass_registration,
-      dingtalk_connect_sync_corp_email: form.dingtalk_connect_sync_corp_email,
-      dingtalk_connect_sync_display_name: form.dingtalk_connect_sync_display_name,
-      dingtalk_connect_sync_dept: form.dingtalk_connect_sync_dept,
-      dingtalk_connect_sync_corp_email_attr_key: form.dingtalk_connect_sync_corp_email_attr_key,
-      dingtalk_connect_sync_display_name_attr_key: form.dingtalk_connect_sync_display_name_attr_key,
-      dingtalk_connect_sync_dept_attr_key: form.dingtalk_connect_sync_dept_attr_key,
-      dingtalk_connect_sync_corp_email_attr_name: form.dingtalk_connect_sync_corp_email_attr_name,
-      dingtalk_connect_sync_display_name_attr_name: form.dingtalk_connect_sync_display_name_attr_name,
-      dingtalk_connect_sync_dept_attr_name: form.dingtalk_connect_sync_dept_attr_name,
-      wechat_connect_enabled: form.wechat_connect_enabled,
-      wechat_connect_app_id:
-        form.wechat_connect_open_app_id ||
-        form.wechat_connect_mp_app_id ||
-        form.wechat_connect_mobile_app_id ||
-        form.wechat_connect_app_id,
-      wechat_connect_app_secret: form.wechat_connect_app_secret || undefined,
-      wechat_connect_open_app_id: form.wechat_connect_open_app_id,
-      wechat_connect_open_app_secret:
-        form.wechat_connect_open_app_secret || undefined,
-      wechat_connect_mp_app_id: form.wechat_connect_mp_app_id,
-      wechat_connect_mp_app_secret:
-        form.wechat_connect_mp_app_secret || undefined,
-      wechat_connect_mobile_app_id: form.wechat_connect_mobile_app_id,
-      wechat_connect_mobile_app_secret:
-        form.wechat_connect_mobile_app_secret || undefined,
-      wechat_connect_open_enabled: form.wechat_connect_open_enabled,
-      wechat_connect_mp_enabled: form.wechat_connect_mp_enabled,
-      wechat_connect_mobile_enabled: form.wechat_connect_mobile_enabled,
-      wechat_connect_mode: wechatStoredMode,
-      wechat_connect_scopes:
-        defaultWeChatConnectScopesForMode(wechatStoredMode),
-      wechat_connect_redirect_url: form.wechat_connect_redirect_url,
-      wechat_connect_frontend_redirect_url:
-        form.wechat_connect_frontend_redirect_url,
-      oidc_connect_enabled: form.oidc_connect_enabled,
-      oidc_connect_provider_name: form.oidc_connect_provider_name,
-      oidc_connect_client_id: form.oidc_connect_client_id,
-      oidc_connect_client_secret: form.oidc_connect_client_secret || undefined,
-      oidc_connect_issuer_url: form.oidc_connect_issuer_url,
-      oidc_connect_discovery_url: form.oidc_connect_discovery_url,
-      oidc_connect_authorize_url: form.oidc_connect_authorize_url,
-      oidc_connect_token_url: form.oidc_connect_token_url,
-      oidc_connect_userinfo_url: form.oidc_connect_userinfo_url,
-      oidc_connect_jwks_url: form.oidc_connect_jwks_url,
-      oidc_connect_scopes: form.oidc_connect_scopes,
-      oidc_connect_redirect_url: form.oidc_connect_redirect_url,
-      oidc_connect_frontend_redirect_url:
-        form.oidc_connect_frontend_redirect_url,
-      oidc_connect_token_auth_method: form.oidc_connect_token_auth_method,
-      oidc_connect_use_pkce: form.oidc_connect_use_pkce,
-      oidc_connect_validate_id_token: form.oidc_connect_validate_id_token,
-      oidc_connect_allowed_signing_algs: form.oidc_connect_allowed_signing_algs,
-      oidc_connect_clock_skew_seconds: form.oidc_connect_clock_skew_seconds,
-      oidc_connect_require_email_verified:
-        form.oidc_connect_require_email_verified,
-      oidc_connect_userinfo_email_path: form.oidc_connect_userinfo_email_path,
-      oidc_connect_userinfo_id_path: form.oidc_connect_userinfo_id_path,
-      oidc_connect_userinfo_username_path:
-        form.oidc_connect_userinfo_username_path,
-      github_oauth_enabled: form.github_oauth_enabled,
-      github_oauth_client_id: form.github_oauth_client_id,
-      github_oauth_client_secret:
-        form.github_oauth_client_secret || undefined,
-      github_oauth_redirect_url: form.github_oauth_redirect_url,
-      github_oauth_frontend_redirect_url:
-        form.github_oauth_frontend_redirect_url,
-      google_oauth_enabled: form.google_oauth_enabled,
-      google_oauth_client_id: form.google_oauth_client_id,
-      google_oauth_client_secret:
-        form.google_oauth_client_secret || undefined,
-      google_oauth_redirect_url: form.google_oauth_redirect_url,
-      google_oauth_frontend_redirect_url:
-        form.google_oauth_frontend_redirect_url,
-      enable_model_fallback: form.enable_model_fallback,
-      fallback_model_anthropic: form.fallback_model_anthropic,
-      fallback_model_openai: form.fallback_model_openai,
-      fallback_model_gemini: form.fallback_model_gemini,
-      fallback_model_antigravity: form.fallback_model_antigravity,
-      grok_default_text_model:
-        form.grok_default_text_model.trim() || "grok-4.5",
-      grok_cross_client_model_map_enabled:
-        form.grok_cross_client_model_map_enabled,
-      grok_default_base_url_mode: form.grok_default_base_url_mode,
-      enable_identity_patch: form.enable_identity_patch,
-      identity_patch_prompt: form.identity_patch_prompt,
-      min_claude_code_version: form.min_claude_code_version,
-      max_claude_code_version: form.max_claude_code_version,
-      allow_ungrouped_key_scheduling: form.allow_ungrouped_key_scheduling,
-      openai_ttft_mode:
-        form.openai_ttft_mode === "visible" ? "visible" : "semantic",
-      enable_fingerprint_unification: form.enable_fingerprint_unification,
-      enable_metadata_passthrough: form.enable_metadata_passthrough,
-      enable_cch_signing: form.enable_cch_signing,
-      enable_claude_oauth_system_prompt_injection:
-        form.enable_claude_oauth_system_prompt_injection,
-      claude_oauth_system_prompt: form.claude_oauth_system_prompt?.trim()
-        ? form.claude_oauth_system_prompt
-        : "",
-      claude_oauth_system_prompt_blocks: claudeOAuthSystemPromptBlocksJSON,
-      enable_anthropic_cache_ttl_1h_injection:
-        form.enable_anthropic_cache_ttl_1h_injection,
-      rewrite_message_cache_control: form.rewrite_message_cache_control,
-      enable_client_dateline_normalization:
-        form.enable_client_dateline_normalization,
-      antigravity_user_agent_version:
-        form.antigravity_user_agent_version?.trim() || "",
-      openai_codex_user_agent:
-        form.openai_codex_user_agent?.trim() || "",
-      openai_codex_client_version:
-        form.openai_codex_client_version?.trim() || "",
-      openai_codex_version_auto_sync_enabled:
-        form.openai_codex_version_auto_sync_enabled,
-      min_codex_version: form.min_codex_version?.trim() || "",
-      max_codex_version: form.max_codex_version?.trim() || "",
-      codex_cli_only_allow_app_server_clients:
-        form.codex_cli_only_allow_app_server_clients,
-      codex_cli_only_engine_fingerprint_signals: serializeFingerprintRowsToJSON(
-        codexFingerprintRows.value,
-      ),
-      codex_cli_only_blacklist: serializeCodexRowsToJSON(
-        codexBlacklistRows.value,
-      ),
-      codex_cli_only_whitelist: serializeCodexRowsToJSON(
-        codexWhitelistRows.value,
-      ),
-      // Payment configuration
-      payment_enabled: form.payment_enabled,
-      risk_control_enabled: form.risk_control_enabled,
-      cyber_session_block_enabled: form.cyber_session_block_enabled,
-      cyber_session_block_ttl_seconds:
-        Number(form.cyber_session_block_ttl_seconds) || 3600,
-      payment_min_amount: Number(form.payment_min_amount) || 0,
-      payment_max_amount: Number(form.payment_max_amount) || 0,
-      payment_daily_limit: Number(form.payment_daily_limit) || 0,
-      payment_max_pending_orders: Number(form.payment_max_pending_orders) || 0,
-      payment_order_timeout_minutes:
-        Number(form.payment_order_timeout_minutes) || 0,
-      payment_balance_disabled: form.payment_balance_disabled,
-      payment_balance_recharge_multiplier:
-        Number(form.payment_balance_recharge_multiplier) || 1,
-      payment_subscription_usd_to_cny_rate:
-        Number(form.payment_subscription_usd_to_cny_rate) || 0,
-      payment_recharge_fee_rate: Number(form.payment_recharge_fee_rate) || 0,
-      payment_enabled_types: form.payment_enabled_types,
-      payment_load_balance_strategy: form.payment_load_balance_strategy,
-      payment_product_name_prefix: form.payment_product_name_prefix,
-      payment_product_name_suffix: form.payment_product_name_suffix,
-      payment_help_image_url: form.payment_help_image_url,
-      payment_help_text: form.payment_help_text,
-      payment_cancel_rate_limit_enabled: form.payment_cancel_rate_limit_enabled,
-      payment_cancel_rate_limit_max:
-        Number(form.payment_cancel_rate_limit_max) || 10,
-      payment_cancel_rate_limit_window:
-        Number(form.payment_cancel_rate_limit_window) || 1,
-      payment_cancel_rate_limit_unit: form.payment_cancel_rate_limit_unit,
-      payment_cancel_rate_limit_window_mode:
-        form.payment_cancel_rate_limit_window_mode,
-      payment_alipay_force_qrcode: form.payment_alipay_force_qrcode,
-      payment_alipay_mobile_precreate_deep_link:
-        form.payment_alipay_mobile_precreate_deep_link,
-      openai_low_upstream_rate_priority_enabled:
-        form.openai_low_upstream_rate_priority_enabled,
-      openai_oauth_scheduling_rate_multiplier:
-        form.openai_oauth_scheduling_rate_multiplier,
-      openai_advanced_scheduler_enabled: form.openai_advanced_scheduler_enabled,
-      openai_advanced_scheduler_sticky_weighted_enabled:
-        form.openai_advanced_scheduler_sticky_weighted_enabled,
-      openai_advanced_scheduler_subscription_priority_enabled:
-        form.openai_advanced_scheduler_subscription_priority_enabled,
-      openai_advanced_scheduler_lb_top_k:
-        form.openai_advanced_scheduler_lb_top_k.trim(),
-      openai_advanced_scheduler_weight_priority:
-        form.openai_advanced_scheduler_weight_priority.trim(),
-      openai_advanced_scheduler_weight_load:
-        form.openai_advanced_scheduler_weight_load.trim(),
-      openai_advanced_scheduler_weight_queue:
-        form.openai_advanced_scheduler_weight_queue.trim(),
-      openai_advanced_scheduler_weight_error_rate:
-        form.openai_advanced_scheduler_weight_error_rate.trim(),
-      openai_advanced_scheduler_weight_ttft:
-        form.openai_advanced_scheduler_weight_ttft.trim(),
-      openai_advanced_scheduler_weight_reset:
-        form.openai_advanced_scheduler_weight_reset.trim(),
-      openai_advanced_scheduler_weight_quota_headroom:
-        form.openai_advanced_scheduler_weight_quota_headroom.trim(),
-      openai_advanced_scheduler_weight_upstream_cost:
-        form.openai_advanced_scheduler_weight_upstream_cost.trim(),
-      openai_advanced_scheduler_weight_previous_response:
-        form.openai_advanced_scheduler_weight_previous_response.trim(),
-      openai_advanced_scheduler_weight_session_sticky:
-        form.openai_advanced_scheduler_weight_session_sticky.trim(),
-      // 余额、订阅到期与账号限额通知
-      balance_low_notify_enabled: form.balance_low_notify_enabled,
-      balance_low_notify_threshold:
-        Number(form.balance_low_notify_threshold) || 0,
-      balance_low_notify_recharge_url: (form.balance_low_notify_recharge_url =
-        form.balance_low_notify_recharge_url || currentOrigin),
-      subscription_expiry_notify_enabled:
-        form.subscription_expiry_notify_enabled,
-      account_quota_notify_enabled: form.account_quota_notify_enabled,
-      account_quota_notify_emails: (
-        form.account_quota_notify_emails || []
-      ).filter((e) => e.email.trim() !== ""),
-      // Channel Monitor feature switch
-      channel_monitor_enabled: form.channel_monitor_enabled,
-      channel_monitor_mode: form.channel_monitor_mode === 'v1' ? 'v1' : 'v2',
-      channel_monitor_default_interval_seconds:
-        Number(form.channel_monitor_default_interval_seconds) || 60,
-      channel_monitor_hide_throughput: Boolean(form.channel_monitor_hide_throughput),
-      channel_monitor_show_quota: Boolean(form.channel_monitor_show_quota),
-      // Available Channels feature switch
-      available_channels_enabled: form.available_channels_enabled,
-      // Model Plaza feature switches + description
-      model_plaza_enabled: form.model_plaza_enabled,
-      model_plaza_require_auth: form.model_plaza_require_auth,
-      model_plaza_description: form.model_plaza_description,
-      plugin_management_enabled: form.plugin_management_enabled,
-      // Affiliate (邀请返利) feature switch
-      affiliate_enabled: form.affiliate_enabled,
-      allow_user_view_error_requests: form.allow_user_view_error_requests,
-    };
-
-    // 仅当 openai_fast_policy_settings 已成功从后端加载时才回写，
-    // 否则省略整个字段，让后端保留既有规则（含默认值）。
-    if (openaiFastPolicyLoaded.value) {
-      payload.openai_fast_policy_settings = {
-        rules: openaiFastPolicyForm.rules.map((rule) => {
-          const whitelist = (rule.model_whitelist || [])
-            .map((p) => p.trim())
-            .filter((p) => p !== "");
-          const hasWhitelist = whitelist.length > 0;
-          return {
-            service_tier: rule.service_tier,
-            action: rule.action,
-            scope: rule.scope,
-            user_ids:
-              rule.user_ids && rule.user_ids.length > 0
-                ? [...rule.user_ids]
-                : undefined,
-            error_message:
-              rule.action === "block" ? rule.error_message : undefined,
-            model_whitelist: hasWhitelist ? whitelist : undefined,
-            fallback_action: hasWhitelist
-              ? rule.fallback_action || "pass"
-              : undefined,
-            fallback_error_message:
-              hasWhitelist && rule.fallback_action === "block"
-                ? rule.fallback_error_message
-                : undefined,
-          };
-        }),
-      };
     }
 
-    payload.default_platform_quotas = sanitizePlatformQuotasMap(form.default_platform_quotas);
-    payload.account_scheduling_thresholds = sanitizeAccountSchedulingThresholdsMap(
-      form.account_scheduling_thresholds,
-    );
-    appendAuthSourceDefaultsToUpdateRequest(payload, authSourceDefaults);
-
-    const updated = await settingsStepUp.run(() =>
-      adminAPI.settings.updateSettings(payload),
-    );
+    // PUT 响应是部分载荷（只含发送字段的终值 + 只读伴生键，见后端
+    // setting_handler_response_filter.go），逐块加存在性守卫，
+    // 避免未发送字段被 undefined / 默认值清掉。
     for (const [key, value] of Object.entries(updated)) {
       if (key === "openai_fast_policy_settings") continue;
       if (value !== null && value !== undefined) {
         (form as Record<string, unknown>)[key] = value;
       }
     }
-    Object.assign(authSourceDefaults, buildAuthSourceDefaultsState(updated));
-    form.default_platform_quotas = normalizePlatformQuotasMap(updated.default_platform_quotas);
-    form.account_scheduling_thresholds = normalizeAccountSchedulingThresholdsMap(
-      updated.account_scheduling_thresholds,
+    Object.assign(
+      authSourceDefaults,
+      mergeAuthSourceDefaultsFromResponse(authSourceDefaults, updated),
     );
-    registrationEmailSuffixWhitelistTags.value =
-      normalizeRegistrationEmailSuffixDomains(
-        updated.registration_email_suffix_whitelist,
+    if (updated.default_platform_quotas !== undefined) {
+      form.default_platform_quotas = normalizePlatformQuotasMap(
+        updated.default_platform_quotas,
       );
-    form.forwarded_client_ip_headers = normalizeForwardedClientIpHeaders(
-      updated.forwarded_client_ip_headers,
-    );
+    }
+    if (updated.account_scheduling_thresholds !== undefined) {
+      form.account_scheduling_thresholds =
+        normalizeAccountSchedulingThresholdsMap(
+          updated.account_scheduling_thresholds,
+        );
+    }
+    if (updated.registration_email_suffix_whitelist !== undefined) {
+      registrationEmailSuffixWhitelistTags.value =
+        normalizeRegistrationEmailSuffixDomains(
+          updated.registration_email_suffix_whitelist,
+        );
+    }
+    if (updated.forwarded_client_ip_headers !== undefined) {
+      form.forwarded_client_ip_headers = normalizeForwardedClientIpHeaders(
+        updated.forwarded_client_ip_headers,
+      );
+    }
     forwardedClientIpHeaderDraft.value = "";
-    tablePageSizeOptionsInput.value = formatTablePageSizeOptions(
-      Array.isArray(updated.table_page_size_options)
-        ? updated.table_page_size_options
-        : [10, 20, 50, 100],
-    );
+    if (Array.isArray(updated.table_page_size_options)) {
+      tablePageSizeOptionsInput.value = formatTablePageSizeOptions(
+        updated.table_page_size_options,
+      );
+    }
     registrationEmailSuffixWhitelistDraft.value = "";
     form.smtp_password = "";
     smtpPasswordManuallyEdited.value = false;
@@ -11547,22 +11218,30 @@ async function saveSettings() {
     form.wechat_connect_open_app_secret = "";
     form.wechat_connect_mp_app_secret = "";
     form.wechat_connect_mobile_app_secret = "";
-    const updatedWechatCapabilities = resolveWeChatConnectModeCapabilities(
-      updated.wechat_connect_open_enabled,
-      updated.wechat_connect_mp_enabled,
-      updated.wechat_connect_mobile_enabled,
-      updated.wechat_connect_mode,
-    );
-    form.wechat_connect_open_enabled = updatedWechatCapabilities.openEnabled;
-    form.wechat_connect_mp_enabled = updatedWechatCapabilities.mpEnabled;
-    form.wechat_connect_mobile_enabled =
-      updatedWechatCapabilities.mobileEnabled;
-    form.wechat_connect_mode = deriveWeChatConnectStoredMode(
-      updatedWechatCapabilities.openEnabled,
-      updatedWechatCapabilities.mpEnabled,
-      updatedWechatCapabilities.mobileEnabled,
-      updated.wechat_connect_mode,
-    );
+    if (
+      updated.wechat_connect_open_enabled !== undefined ||
+      updated.wechat_connect_mp_enabled !== undefined ||
+      updated.wechat_connect_mobile_enabled !== undefined ||
+      updated.wechat_connect_mode !== undefined
+    ) {
+      const updatedWechatCapabilities = resolveWeChatConnectModeCapabilities(
+        updated.wechat_connect_open_enabled ?? form.wechat_connect_open_enabled,
+        updated.wechat_connect_mp_enabled ?? form.wechat_connect_mp_enabled,
+        updated.wechat_connect_mobile_enabled ??
+          form.wechat_connect_mobile_enabled,
+        updated.wechat_connect_mode ?? form.wechat_connect_mode,
+      );
+      form.wechat_connect_open_enabled = updatedWechatCapabilities.openEnabled;
+      form.wechat_connect_mp_enabled = updatedWechatCapabilities.mpEnabled;
+      form.wechat_connect_mobile_enabled =
+        updatedWechatCapabilities.mobileEnabled;
+      form.wechat_connect_mode = deriveWeChatConnectStoredMode(
+        updatedWechatCapabilities.openEnabled,
+        updatedWechatCapabilities.mpEnabled,
+        updatedWechatCapabilities.mobileEnabled,
+        updated.wechat_connect_mode ?? form.wechat_connect_mode,
+      );
+    }
     form.wechat_connect_scopes = defaultWeChatConnectScopesForMode(
       form.wechat_connect_mode,
     );
@@ -11582,11 +11261,49 @@ async function saveSettings() {
         }));
       openaiFastPolicyLoaded.value = true;
     }
+
+    // 保存成功后从 post-merge 表单重建基线（响应不含未发送字段，不能拿它建基线）。
+    settingsBaseline.value = fingerprintSettingsPayload(buildSettingsPayload());
+
     // Save web search emulation config separately (errors handled internally)
     const wsOk = await saveWebSearchConfig();
-    // Refresh cached settings so sidebar/header update immediately
-    await appStore.fetchPublicSettings(true);
-    await adminSettingsStore.fetch(true);
+
+    // 保存后不再整包重拉设置（adminSettings GET 821KB / 公开设置 417KB）：
+    // adminSettingsStore 只消费少数键，直接本地打补丁；公开设置仅当本次
+    // 保存涉及公开字段（PUBLIC_SETTINGS_KEYS）时才强刷，最坏情况是公开 UI
+    // 短暂显示旧值——只影响时效性不影响正确性。
+    const savedKeys = diff as Record<string, unknown>;
+    if (savedKeys.ops_monitoring_enabled !== undefined) {
+      adminSettingsStore.setOpsMonitoringEnabledLocal(
+        Boolean(savedKeys.ops_monitoring_enabled),
+      );
+    }
+    if (savedKeys.ops_realtime_monitoring_enabled !== undefined) {
+      adminSettingsStore.setOpsRealtimeMonitoringEnabledLocal(
+        Boolean(savedKeys.ops_realtime_monitoring_enabled),
+      );
+    }
+    if (savedKeys.ops_query_mode_default !== undefined) {
+      adminSettingsStore.setOpsQueryModeDefaultLocal(
+        String(savedKeys.ops_query_mode_default || "auto"),
+      );
+    }
+    if (savedKeys.custom_menu_items !== undefined) {
+      adminSettingsStore.setCustomMenuItemsLocal(
+        Array.isArray(savedKeys.custom_menu_items)
+          ? (savedKeys.custom_menu_items as CustomMenuItem[])
+          : [],
+      );
+    }
+    if (savedKeys.payment_enabled !== undefined) {
+      adminSettingsStore.setPaymentEnabledLocal(
+        Boolean(savedKeys.payment_enabled),
+      );
+    }
+    if (PUBLIC_SETTINGS_KEYS.some((key) => key in savedKeys)) {
+      // Refresh cached settings so sidebar/header update immediately
+      await appStore.fetchPublicSettings(true);
+    }
     if (wsOk) {
       appStore.showSuccess(t("admin.settings.settingsSaved"));
     }
@@ -11616,6 +11333,455 @@ async function saveSettings() {
   } finally {
     saving.value = false;
   }
+}
+
+// 与后端 service/setting_public.go 的 PublicSettingsInjectionPayload 对齐：
+// 这些 PUT 字段会体现在公开设置（/api/v1/settings/public，前端 store 缓存）里，
+// 保存涉及任一字段时才强刷公开设置，其余保存不再整包重拉。
+// 注意 oauth_* 公开键对应的请求键是 *_connect_* 命名。
+const PUBLIC_SETTINGS_KEYS = [
+  "registration_enabled",
+  "email_verify_enabled",
+  "registration_email_suffix_whitelist",
+  "registration_email_domain_quota_enabled",
+  "promo_code_enabled",
+  "password_reset_enabled",
+  "invitation_code_enabled",
+  "totp_enabled",
+  "passkey_enabled",
+  "login_agreement_enabled",
+  "login_agreement_mode",
+  "login_agreement_updated_at",
+  "login_agreement_documents",
+  "turnstile_enabled",
+  "turnstile_site_key",
+  "tencent_captcha_enabled",
+  "tencent_captcha_app_id",
+  "tencent_captcha_region",
+  "aliyun_captcha_enabled",
+  "aliyun_captcha_scene_id",
+  "aliyun_captcha_prefix",
+  "aliyun_captcha_region",
+  "site_name",
+  "site_logo",
+  "site_subtitle",
+  "api_base_url",
+  "contact_info",
+  "doc_url",
+  "home_content",
+  "compact_home_enabled",
+  "hide_ccs_import_button",
+  "purchase_subscription_enabled",
+  "purchase_subscription_url",
+  "table_default_page_size",
+  "table_page_size_options",
+  "custom_menu_items",
+  "custom_endpoints",
+  "linuxdo_connect_enabled",
+  "dingtalk_connect_enabled",
+  "wechat_connect_enabled",
+  "wechat_connect_open_enabled",
+  "wechat_connect_mp_enabled",
+  "wechat_connect_mobile_enabled",
+  "oidc_connect_enabled",
+  "oidc_connect_provider_name",
+  "github_oauth_enabled",
+  "google_oauth_enabled",
+  "backend_mode_enabled",
+  "payment_enabled",
+  "balance_low_notify_enabled",
+  "balance_low_notify_threshold",
+  "balance_low_notify_recharge_url",
+  "account_quota_notify_enabled",
+  "channel_monitor_enabled",
+  "channel_monitor_mode",
+  "channel_monitor_default_interval_seconds",
+  "channel_monitor_hide_throughput",
+  "channel_monitor_show_quota",
+  "available_channels_enabled",
+  "model_plaza_enabled",
+  "model_plaza_require_auth",
+  "model_plaza_description",
+  "plugin_management_enabled",
+  "affiliate_enabled",
+  "risk_control_enabled",
+  "allow_user_view_error_requests",
+];
+
+// 从当前表单状态构建完整设置 payload。saveSettings 保存前与保存后（重建
+// diff 基线）都会调用，因此必须幂等：派生值重算、不引入随机性。
+function buildSettingsPayload(): UpdateSettingsRequest {
+  const normalizedDefaultSubscriptions = normalizeDefaultSubscriptionSettings(
+    form.default_subscriptions,
+  );
+  const wechatStoredMode = deriveWeChatConnectStoredMode(
+    form.wechat_connect_open_enabled,
+    form.wechat_connect_mp_enabled,
+    form.wechat_connect_mobile_enabled,
+    form.wechat_connect_mode,
+  );
+  const claudeOAuthSystemPromptBlocksJSON =
+    serializeClaudeOAuthSystemPromptBlocksToJSON(
+      claudeOAuthSystemPromptBlocks.value,
+    );
+  form.claude_oauth_system_prompt_blocks =
+    claudeOAuthSystemPromptBlocksJSON;
+
+  const payload: UpdateSettingsRequest = {
+    registration_enabled: form.registration_enabled,
+    email_verify_enabled: form.email_verify_enabled,
+    registration_email_suffix_whitelist:
+      registrationEmailSuffixWhitelistTags.value.map((suffix) =>
+        suffix.startsWith("*.") ? suffix : `@${suffix}`,
+      ),
+    registration_email_domain_quota_enabled:
+      form.registration_email_domain_quota_enabled,
+    promo_code_enabled: form.promo_code_enabled,
+    invitation_code_enabled: form.invitation_code_enabled,
+    password_reset_enabled: form.password_reset_enabled,
+    totp_enabled: form.totp_enabled,
+    passkey_enabled: form.passkey_enabled,
+    session_binding_enabled: form.session_binding_enabled,
+    step_up_enabled: form.step_up_enabled,
+    // 清空数字框时 v-model.number 会得到空串，后端 int 字段解析空串会 400 拒绝整次保存；
+    // 空/非法值回退默认 180（与后端 parseAuditLogRetentionDays("") 语义一致，0 仍表示永久保留）。
+    audit_log_retention_days: Number.isFinite(form.audit_log_retention_days)
+      ? form.audit_log_retention_days
+      : 180,
+    login_agreement_enabled: form.login_agreement_enabled,
+    login_agreement_mode: form.login_agreement_mode,
+    login_agreement_updated_at: form.login_agreement_updated_at,
+    login_agreement_documents: form.login_agreement_documents,
+    default_balance: form.default_balance,
+    affiliate_rebate_rate: Math.min(
+      100,
+      Math.max(0, Number(form.affiliate_rebate_rate) || 0),
+    ),
+    affiliate_rebate_freeze_hours: Math.max(0, Math.min(720, Number(form.affiliate_rebate_freeze_hours) || 0)),
+    affiliate_rebate_duration_days: Math.max(0, Math.min(3650, Math.floor(Number(form.affiliate_rebate_duration_days) || 0))),
+    affiliate_rebate_per_invitee_cap: Math.max(0, Number(form.affiliate_rebate_per_invitee_cap) || 0),
+    affiliate_admin_recharge_enabled: form.affiliate_admin_recharge_enabled,
+    default_concurrency: form.default_concurrency,
+    default_subscriptions: normalizedDefaultSubscriptions,
+    force_email_on_third_party_signup: form.force_email_on_third_party_signup,
+    default_user_rpm_limit: form.default_user_rpm_limit,
+    site_name: form.site_name,
+    site_logo: form.site_logo,
+    site_subtitle: form.site_subtitle,
+    api_base_url: form.api_base_url,
+    contact_info: form.contact_info,
+    doc_url: form.doc_url,
+    home_content: form.home_content,
+    compact_home_enabled: form.compact_home_enabled,
+    backend_mode_enabled: form.backend_mode_enabled,
+    hide_ccs_import_button: form.hide_ccs_import_button,
+    table_default_page_size: form.table_default_page_size,
+    table_page_size_options: form.table_page_size_options,
+    custom_menu_items: form.custom_menu_items,
+    custom_endpoints: form.custom_endpoints,
+    frontend_url: form.frontend_url,
+    smtp_host: form.smtp_host,
+    smtp_port: form.smtp_port,
+    smtp_username: form.smtp_username,
+    smtp_password: form.smtp_password || undefined,
+    smtp_from_email: form.smtp_from_email,
+    smtp_from_name: form.smtp_from_name,
+    smtp_use_tls: form.smtp_use_tls,
+    turnstile_enabled: form.turnstile_enabled,
+    turnstile_site_key: form.turnstile_site_key,
+    turnstile_secret_key: form.turnstile_secret_key || undefined,
+    tencent_captcha_enabled: form.tencent_captcha_enabled,
+    tencent_captcha_app_id: form.tencent_captcha_app_id,
+    tencent_captcha_app_secret_key:
+      form.tencent_captcha_app_secret_key || undefined,
+    tencent_captcha_cloud_secret_id:
+      form.tencent_captcha_cloud_secret_id || undefined,
+    tencent_captcha_cloud_secret_key:
+      form.tencent_captcha_cloud_secret_key || undefined,
+    tencent_captcha_region: form.tencent_captcha_region,
+    aliyun_captcha_enabled: form.aliyun_captcha_enabled,
+    aliyun_captcha_access_key_id: form.aliyun_captcha_access_key_id,
+    aliyun_captcha_access_key_secret:
+      form.aliyun_captcha_access_key_secret || undefined,
+    aliyun_captcha_scene_id: form.aliyun_captcha_scene_id,
+    aliyun_captcha_prefix: form.aliyun_captcha_prefix,
+    aliyun_captcha_region: form.aliyun_captcha_region,
+    api_key_acl_trust_forwarded_ip: form.api_key_acl_trust_forwarded_ip,
+    forwarded_client_ip_headers: form.forwarded_client_ip_headers,
+    linuxdo_connect_enabled: form.linuxdo_connect_enabled,
+    linuxdo_connect_client_id: form.linuxdo_connect_client_id,
+    linuxdo_connect_client_secret:
+      form.linuxdo_connect_client_secret || undefined,
+    linuxdo_connect_redirect_url: form.linuxdo_connect_redirect_url,
+    dingtalk_connect_enabled: form.dingtalk_connect_enabled,
+    dingtalk_connect_client_id: form.dingtalk_connect_client_id,
+    dingtalk_connect_client_secret:
+      form.dingtalk_connect_client_secret || undefined,
+    dingtalk_connect_redirect_url: form.dingtalk_connect_redirect_url,
+    dingtalk_connect_corp_restriction_policy:
+      form.dingtalk_connect_corp_restriction_policy,
+    dingtalk_connect_internal_corp_id: form.dingtalk_connect_internal_corp_id,
+    dingtalk_connect_bypass_registration: form.dingtalk_connect_bypass_registration,
+    dingtalk_connect_sync_corp_email: form.dingtalk_connect_sync_corp_email,
+    dingtalk_connect_sync_display_name: form.dingtalk_connect_sync_display_name,
+    dingtalk_connect_sync_dept: form.dingtalk_connect_sync_dept,
+    dingtalk_connect_sync_corp_email_attr_key: form.dingtalk_connect_sync_corp_email_attr_key,
+    dingtalk_connect_sync_display_name_attr_key: form.dingtalk_connect_sync_display_name_attr_key,
+    dingtalk_connect_sync_dept_attr_key: form.dingtalk_connect_sync_dept_attr_key,
+    dingtalk_connect_sync_corp_email_attr_name: form.dingtalk_connect_sync_corp_email_attr_name,
+    dingtalk_connect_sync_display_name_attr_name: form.dingtalk_connect_sync_display_name_attr_name,
+    dingtalk_connect_sync_dept_attr_name: form.dingtalk_connect_sync_dept_attr_name,
+    wechat_connect_enabled: form.wechat_connect_enabled,
+    wechat_connect_app_id:
+      form.wechat_connect_open_app_id ||
+      form.wechat_connect_mp_app_id ||
+      form.wechat_connect_mobile_app_id ||
+      form.wechat_connect_app_id,
+    wechat_connect_app_secret: form.wechat_connect_app_secret || undefined,
+    wechat_connect_open_app_id: form.wechat_connect_open_app_id,
+    wechat_connect_open_app_secret:
+      form.wechat_connect_open_app_secret || undefined,
+    wechat_connect_mp_app_id: form.wechat_connect_mp_app_id,
+    wechat_connect_mp_app_secret:
+      form.wechat_connect_mp_app_secret || undefined,
+    wechat_connect_mobile_app_id: form.wechat_connect_mobile_app_id,
+    wechat_connect_mobile_app_secret:
+      form.wechat_connect_mobile_app_secret || undefined,
+    wechat_connect_open_enabled: form.wechat_connect_open_enabled,
+    wechat_connect_mp_enabled: form.wechat_connect_mp_enabled,
+    wechat_connect_mobile_enabled: form.wechat_connect_mobile_enabled,
+    wechat_connect_mode: wechatStoredMode,
+    wechat_connect_scopes:
+      defaultWeChatConnectScopesForMode(wechatStoredMode),
+    wechat_connect_redirect_url: form.wechat_connect_redirect_url,
+    wechat_connect_frontend_redirect_url:
+      form.wechat_connect_frontend_redirect_url,
+    oidc_connect_enabled: form.oidc_connect_enabled,
+    oidc_connect_provider_name: form.oidc_connect_provider_name,
+    oidc_connect_client_id: form.oidc_connect_client_id,
+    oidc_connect_client_secret: form.oidc_connect_client_secret || undefined,
+    oidc_connect_issuer_url: form.oidc_connect_issuer_url,
+    oidc_connect_discovery_url: form.oidc_connect_discovery_url,
+    oidc_connect_authorize_url: form.oidc_connect_authorize_url,
+    oidc_connect_token_url: form.oidc_connect_token_url,
+    oidc_connect_userinfo_url: form.oidc_connect_userinfo_url,
+    oidc_connect_jwks_url: form.oidc_connect_jwks_url,
+    oidc_connect_scopes: form.oidc_connect_scopes,
+    oidc_connect_redirect_url: form.oidc_connect_redirect_url,
+    oidc_connect_frontend_redirect_url:
+      form.oidc_connect_frontend_redirect_url,
+    oidc_connect_token_auth_method: form.oidc_connect_token_auth_method,
+    oidc_connect_use_pkce: form.oidc_connect_use_pkce,
+    oidc_connect_validate_id_token: form.oidc_connect_validate_id_token,
+    oidc_connect_allowed_signing_algs: form.oidc_connect_allowed_signing_algs,
+    oidc_connect_clock_skew_seconds: form.oidc_connect_clock_skew_seconds,
+    oidc_connect_require_email_verified:
+      form.oidc_connect_require_email_verified,
+    oidc_connect_userinfo_email_path: form.oidc_connect_userinfo_email_path,
+    oidc_connect_userinfo_id_path: form.oidc_connect_userinfo_id_path,
+    oidc_connect_userinfo_username_path:
+      form.oidc_connect_userinfo_username_path,
+    github_oauth_enabled: form.github_oauth_enabled,
+    github_oauth_client_id: form.github_oauth_client_id,
+    github_oauth_client_secret:
+      form.github_oauth_client_secret || undefined,
+    github_oauth_redirect_url: form.github_oauth_redirect_url,
+    github_oauth_frontend_redirect_url:
+      form.github_oauth_frontend_redirect_url,
+    google_oauth_enabled: form.google_oauth_enabled,
+    google_oauth_client_id: form.google_oauth_client_id,
+    google_oauth_client_secret:
+      form.google_oauth_client_secret || undefined,
+    google_oauth_redirect_url: form.google_oauth_redirect_url,
+    google_oauth_frontend_redirect_url:
+      form.google_oauth_frontend_redirect_url,
+    enable_model_fallback: form.enable_model_fallback,
+    fallback_model_anthropic: form.fallback_model_anthropic,
+    fallback_model_openai: form.fallback_model_openai,
+    fallback_model_gemini: form.fallback_model_gemini,
+    fallback_model_antigravity: form.fallback_model_antigravity,
+    grok_default_text_model:
+      form.grok_default_text_model.trim() || "grok-4.5",
+    grok_cross_client_model_map_enabled:
+      form.grok_cross_client_model_map_enabled,
+    grok_default_base_url_mode: form.grok_default_base_url_mode,
+    enable_identity_patch: form.enable_identity_patch,
+    identity_patch_prompt: form.identity_patch_prompt,
+    min_claude_code_version: form.min_claude_code_version,
+    max_claude_code_version: form.max_claude_code_version,
+    allow_ungrouped_key_scheduling: form.allow_ungrouped_key_scheduling,
+    openai_ttft_mode:
+      form.openai_ttft_mode === "visible" ? "visible" : "semantic",
+    enable_fingerprint_unification: form.enable_fingerprint_unification,
+    enable_metadata_passthrough: form.enable_metadata_passthrough,
+    enable_cch_signing: form.enable_cch_signing,
+    enable_claude_oauth_system_prompt_injection:
+      form.enable_claude_oauth_system_prompt_injection,
+    claude_oauth_system_prompt: form.claude_oauth_system_prompt?.trim()
+      ? form.claude_oauth_system_prompt
+      : "",
+    claude_oauth_system_prompt_blocks: claudeOAuthSystemPromptBlocksJSON,
+    enable_anthropic_cache_ttl_1h_injection:
+      form.enable_anthropic_cache_ttl_1h_injection,
+    rewrite_message_cache_control: form.rewrite_message_cache_control,
+    enable_client_dateline_normalization:
+      form.enable_client_dateline_normalization,
+    antigravity_user_agent_version:
+      form.antigravity_user_agent_version?.trim() || "",
+    openai_codex_user_agent:
+      form.openai_codex_user_agent?.trim() || "",
+    openai_codex_client_version:
+      form.openai_codex_client_version?.trim() || "",
+    openai_codex_version_auto_sync_enabled:
+      form.openai_codex_version_auto_sync_enabled,
+    min_codex_version: form.min_codex_version?.trim() || "",
+    max_codex_version: form.max_codex_version?.trim() || "",
+    codex_cli_only_allow_app_server_clients:
+      form.codex_cli_only_allow_app_server_clients,
+    codex_cli_only_engine_fingerprint_signals: serializeFingerprintRowsToJSON(
+      codexFingerprintRows.value,
+    ),
+    codex_cli_only_blacklist: serializeCodexRowsToJSON(
+      codexBlacklistRows.value,
+    ),
+    codex_cli_only_whitelist: serializeCodexRowsToJSON(
+      codexWhitelistRows.value,
+    ),
+    // Payment configuration
+    payment_enabled: form.payment_enabled,
+    risk_control_enabled: form.risk_control_enabled,
+    cyber_session_block_enabled: form.cyber_session_block_enabled,
+    cyber_session_block_ttl_seconds:
+      Number(form.cyber_session_block_ttl_seconds) || 3600,
+    payment_min_amount: Number(form.payment_min_amount) || 0,
+    payment_max_amount: Number(form.payment_max_amount) || 0,
+    payment_daily_limit: Number(form.payment_daily_limit) || 0,
+    payment_max_pending_orders: Number(form.payment_max_pending_orders) || 0,
+    payment_order_timeout_minutes:
+      Number(form.payment_order_timeout_minutes) || 0,
+    payment_balance_disabled: form.payment_balance_disabled,
+    payment_balance_recharge_multiplier:
+      Number(form.payment_balance_recharge_multiplier) || 1,
+    payment_subscription_usd_to_cny_rate:
+      Number(form.payment_subscription_usd_to_cny_rate) || 0,
+    payment_recharge_fee_rate: Number(form.payment_recharge_fee_rate) || 0,
+    payment_enabled_types: form.payment_enabled_types,
+    payment_load_balance_strategy: form.payment_load_balance_strategy,
+    payment_product_name_prefix: form.payment_product_name_prefix,
+    payment_product_name_suffix: form.payment_product_name_suffix,
+    payment_help_image_url: form.payment_help_image_url,
+    payment_help_text: form.payment_help_text,
+    payment_cancel_rate_limit_enabled: form.payment_cancel_rate_limit_enabled,
+    payment_cancel_rate_limit_max:
+      Number(form.payment_cancel_rate_limit_max) || 10,
+    payment_cancel_rate_limit_window:
+      Number(form.payment_cancel_rate_limit_window) || 1,
+    payment_cancel_rate_limit_unit: form.payment_cancel_rate_limit_unit,
+    payment_cancel_rate_limit_window_mode:
+      form.payment_cancel_rate_limit_window_mode,
+    payment_alipay_force_qrcode: form.payment_alipay_force_qrcode,
+    payment_alipay_mobile_precreate_deep_link:
+      form.payment_alipay_mobile_precreate_deep_link,
+    openai_low_upstream_rate_priority_enabled:
+      form.openai_low_upstream_rate_priority_enabled,
+    openai_oauth_scheduling_rate_multiplier:
+      form.openai_oauth_scheduling_rate_multiplier,
+    openai_advanced_scheduler_enabled: form.openai_advanced_scheduler_enabled,
+    openai_advanced_scheduler_sticky_weighted_enabled:
+      form.openai_advanced_scheduler_sticky_weighted_enabled,
+    openai_advanced_scheduler_subscription_priority_enabled:
+      form.openai_advanced_scheduler_subscription_priority_enabled,
+    openai_advanced_scheduler_lb_top_k:
+      form.openai_advanced_scheduler_lb_top_k.trim(),
+    openai_advanced_scheduler_weight_priority:
+      form.openai_advanced_scheduler_weight_priority.trim(),
+    openai_advanced_scheduler_weight_load:
+      form.openai_advanced_scheduler_weight_load.trim(),
+    openai_advanced_scheduler_weight_queue:
+      form.openai_advanced_scheduler_weight_queue.trim(),
+    openai_advanced_scheduler_weight_error_rate:
+      form.openai_advanced_scheduler_weight_error_rate.trim(),
+    openai_advanced_scheduler_weight_ttft:
+      form.openai_advanced_scheduler_weight_ttft.trim(),
+    openai_advanced_scheduler_weight_reset:
+      form.openai_advanced_scheduler_weight_reset.trim(),
+    openai_advanced_scheduler_weight_quota_headroom:
+      form.openai_advanced_scheduler_weight_quota_headroom.trim(),
+    openai_advanced_scheduler_weight_upstream_cost:
+      form.openai_advanced_scheduler_weight_upstream_cost.trim(),
+    openai_advanced_scheduler_weight_previous_response:
+      form.openai_advanced_scheduler_weight_previous_response.trim(),
+    openai_advanced_scheduler_weight_session_sticky:
+      form.openai_advanced_scheduler_weight_session_sticky.trim(),
+    // 余额、订阅到期与账号限额通知
+    balance_low_notify_enabled: form.balance_low_notify_enabled,
+    balance_low_notify_threshold:
+      Number(form.balance_low_notify_threshold) || 0,
+    balance_low_notify_recharge_url: (form.balance_low_notify_recharge_url =
+      form.balance_low_notify_recharge_url || currentOrigin),
+    subscription_expiry_notify_enabled:
+      form.subscription_expiry_notify_enabled,
+    account_quota_notify_enabled: form.account_quota_notify_enabled,
+    account_quota_notify_emails: (
+      form.account_quota_notify_emails || []
+    ).filter((e) => e.email.trim() !== ""),
+    // Channel Monitor feature switch
+    channel_monitor_enabled: form.channel_monitor_enabled,
+    channel_monitor_mode: form.channel_monitor_mode === 'v1' ? 'v1' : 'v2',
+    channel_monitor_default_interval_seconds:
+      Number(form.channel_monitor_default_interval_seconds) || 60,
+    channel_monitor_hide_throughput: Boolean(form.channel_monitor_hide_throughput),
+    channel_monitor_show_quota: Boolean(form.channel_monitor_show_quota),
+    // Available Channels feature switch
+    available_channels_enabled: form.available_channels_enabled,
+    // Model Plaza feature switches + description
+    model_plaza_enabled: form.model_plaza_enabled,
+    model_plaza_require_auth: form.model_plaza_require_auth,
+    model_plaza_description: form.model_plaza_description,
+    plugin_management_enabled: form.plugin_management_enabled,
+    // Affiliate (邀请返利) feature switch
+    affiliate_enabled: form.affiliate_enabled,
+    allow_user_view_error_requests: form.allow_user_view_error_requests,
+  };
+
+  // 仅当 openai_fast_policy_settings 已成功从后端加载时才回写，
+  // 否则省略整个字段，让后端保留既有规则（含默认值）。
+  if (openaiFastPolicyLoaded.value) {
+    payload.openai_fast_policy_settings = {
+      rules: openaiFastPolicyForm.rules.map((rule) => {
+        const whitelist = (rule.model_whitelist || [])
+          .map((p) => p.trim())
+          .filter((p) => p !== "");
+        const hasWhitelist = whitelist.length > 0;
+        return {
+          service_tier: rule.service_tier,
+          action: rule.action,
+          scope: rule.scope,
+          user_ids:
+            rule.user_ids && rule.user_ids.length > 0
+              ? [...rule.user_ids]
+              : undefined,
+          error_message:
+            rule.action === "block" ? rule.error_message : undefined,
+          model_whitelist: hasWhitelist ? whitelist : undefined,
+          fallback_action: hasWhitelist
+            ? rule.fallback_action || "pass"
+            : undefined,
+          fallback_error_message:
+            hasWhitelist && rule.fallback_action === "block"
+              ? rule.fallback_error_message
+              : undefined,
+        };
+      }),
+    };
+  }
+
+  payload.default_platform_quotas = sanitizePlatformQuotasMap(form.default_platform_quotas);
+  payload.account_scheduling_thresholds = sanitizeAccountSchedulingThresholdsMap(
+    form.account_scheduling_thresholds,
+  );
+  appendAuthSourceDefaultsToUpdateRequest(payload, authSourceDefaults);
+  return payload;
 }
 
 async function testSmtpConnection() {

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -132,6 +132,12 @@ vi.mock("@/stores", () => ({
 vi.mock("@/stores/adminSettings", () => ({
   useAdminSettingsStore: () => ({
     fetch: adminSettingsFetch,
+    // 保存后不再整包重拉，改为本地打补丁（见 saveSettings 尾部）
+    setOpsMonitoringEnabledLocal: vi.fn(),
+    setOpsRealtimeMonitoringEnabledLocal: vi.fn(),
+    setOpsQueryModeDefaultLocal: vi.fn(),
+    setCustomMenuItemsLocal: vi.fn(),
+    setPaymentEnabledLocal: vi.fn(),
   }),
 }));
 
@@ -604,6 +610,44 @@ async function openUsersTab(wrapper: ReturnType<typeof mountView>) {
   await flushPromises();
 }
 
+async function openFeaturesTab(wrapper: ReturnType<typeof mountView>) {
+  const featuresTabButton = wrapper
+    .findAll("button")
+    .find((node) => node.text().includes("admin.settings.tabs.features"));
+
+  expect(featuresTabButton).toBeDefined();
+  await featuresTabButton?.trigger("click");
+  await flushPromises();
+}
+
+// 定位没有 data-testid 的 Toggle：按所在行（div.flex）里渲染出的 label key 找。
+// i18n mock 未翻译的 key 会原样输出，因此可用 key 文本匹配。
+function findToggleByLabelText(
+  wrapper: ReturnType<typeof mountView>,
+  labelKey: string,
+) {
+  const toggle = wrapper
+    .findAll('input[type="checkbox"]')
+    .find(
+      (node) =>
+        node.element.closest("div.flex")?.textContent?.includes(labelKey),
+    );
+  expect(toggle, `toggle for ${labelKey} should exist`).toBeDefined();
+  return toggle!;
+}
+
+// 同上，按 placeholder key 定位文本输入框。
+function findInputByPlaceholder(
+  wrapper: ReturnType<typeof mountView>,
+  placeholderKey: string,
+) {
+  const input = wrapper.findAll("input").find((node) =>
+    node.attributes("placeholder")?.includes(placeholderKey),
+  );
+  expect(input, `input with placeholder ${placeholderKey} should exist`).toBeDefined();
+  return input!;
+}
+
 describe("admin SettingsView email domain quota copy", () => {
   it("documents the email domain quota and empty-whitelist behavior in both locales", () => {
     expect(zhCommon.auth.emailDomainRegistrationLimit).toContain("主流邮箱");
@@ -807,6 +851,12 @@ describe("admin SettingsView payment visible method controls", () => {
   });
 
   it("人机验证切换到腾讯天御并保存四项配置", async () => {
+    // 基线让 Turnstile 处于启用状态：切换到腾讯时 turnstile_enabled 才会
+    // 出现在 diff 里（部分 PUT 语义：未变化的键不发送）。
+    getSettings.mockResolvedValueOnce({
+      ...baseSettingsResponse,
+      turnstile_enabled: true,
+    });
     const wrapper = mountView();
     await flushPromises();
     await openSecurityTab(wrapper);
@@ -842,12 +892,10 @@ describe("admin SettingsView payment visible method controls", () => {
       expect.objectContaining({
         turnstile_enabled: false,
         tencent_captcha_enabled: true,
-        aliyun_captcha_enabled: false,
         tencent_captcha_app_id: "123456789",
         tencent_captcha_app_secret_key: "app-secret-value",
         tencent_captcha_cloud_secret_id: "cloud-secret-id-value",
         tencent_captcha_cloud_secret_key: "cloud-secret-key-value",
-        tencent_captcha_region: "cn",
       }),
     );
   });
@@ -882,6 +930,11 @@ describe("admin SettingsView payment visible method controls", () => {
   });
 
   it("人机验证切换到阿里云并保存配置", async () => {
+    // 基线启用 Turnstile，切换阿里云后 turnstile_enabled 变化才会进入 diff。
+    getSettings.mockResolvedValueOnce({
+      ...baseSettingsResponse,
+      turnstile_enabled: true,
+    });
     const wrapper = mountView();
     await flushPromises();
     await openSecurityTab(wrapper);
@@ -910,13 +963,11 @@ describe("admin SettingsView payment visible method controls", () => {
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         turnstile_enabled: false,
-        tencent_captcha_enabled: false,
         aliyun_captcha_enabled: true,
         aliyun_captcha_prefix: "prefix-1",
         aliyun_captcha_scene_id: "scene-1",
         aliyun_captcha_access_key_id: "ak-id",
         aliyun_captcha_access_key_secret: "ak-secret-value",
-        aliyun_captcha_region: "cn",
       }),
     );
   });
@@ -943,13 +994,16 @@ describe("admin SettingsView payment visible method controls", () => {
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
+    // 部分 PUT 语义：只有真正变化的 tencent 开关进入 payload；
+    // 本来就是 false 的 turnstile/aliyun 开关不随包发送（省略 = 保留当前值）。
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
-        turnstile_enabled: false,
         tencent_captcha_enabled: false,
-        aliyun_captcha_enabled: false,
       }),
     );
+    const payload = updateSettings.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("turnstile_enabled");
+    expect(payload).not.toHaveProperty("aliyun_captcha_enabled");
   });
 
   it("disables passkey sign-in when the RP configuration is unavailable", async () => {
@@ -1063,6 +1117,8 @@ describe("admin SettingsView payment visible method controls", () => {
     const wrapper = mountView();
 
     await flushPromises();
+    // 部分 PUT 语义下需要有变更才会发送 PUT；借首页紧凑开关触发一次保存。
+    await wrapper.get('[data-testid="compact-home-toggle"]').setValue(true);
     await openPaymentTab(wrapper);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
@@ -1085,26 +1141,31 @@ describe("admin SettingsView payment visible method controls", () => {
     const wrapper = mountView();
 
     await flushPromises();
+    await openFeaturesTab(wrapper);
+    await findToggleByLabelText(
+      wrapper,
+      "admin.settings.features.affiliate.adminRechargeRebate",
+    ).setValue(false);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
     expect(updateSettings).toHaveBeenCalledTimes(1);
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
-        affiliate_admin_recharge_enabled: true,
+        affiliate_admin_recharge_enabled: false,
       }),
     );
   });
 
   it("submits Anthropic cache TTL injection gateway setting", async () => {
-    getSettings.mockResolvedValueOnce({
-      ...baseSettingsResponse,
-      enable_anthropic_cache_ttl_1h_injection: true,
-    });
-
     const wrapper = mountView();
 
     await flushPromises();
+    await openGatewayTab(wrapper);
+    await findToggleByLabelText(
+      wrapper,
+      "admin.settings.gatewayForwarding.anthropicCacheTTL1hInjection",
+    ).setValue(true);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
@@ -1117,14 +1178,14 @@ describe("admin SettingsView payment visible method controls", () => {
   });
 
   it("submits message cache_control rewrite gateway setting", async () => {
-    getSettings.mockResolvedValueOnce({
-      ...baseSettingsResponse,
-      rewrite_message_cache_control: true,
-    });
-
     const wrapper = mountView();
 
     await flushPromises();
+    await openGatewayTab(wrapper);
+    await findToggleByLabelText(
+      wrapper,
+      "admin.settings.gatewayForwarding.rewriteMessageCacheControl",
+    ).setValue(true);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
@@ -1147,13 +1208,27 @@ describe("admin SettingsView payment visible method controls", () => {
     const wrapper = mountView();
 
     await flushPromises();
+    await openGatewayTab(wrapper);
+
+    // 展开第一个系统块并修改文本，让 blocks JSON 相对基线发生变化
+    // （部分 PUT 语义：未变化的 blocks 不会随包发送；加载的块默认展开）。
+    const blockTextarea = wrapper.findAll("textarea").find(
+      (node) => (node.element as HTMLTextAreaElement).value === "custom block",
+    );
+    expect(blockTextarea).toBeDefined();
+    await blockTextarea!.setValue("edited block text");
+
+    await findToggleByLabelText(
+      wrapper,
+      "admin.settings.gatewayForwarding.claudeOAuthSystemPromptInjection",
+    ).setValue(true);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
     expect(updateSettings).toHaveBeenCalledTimes(1);
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
-        enable_claude_oauth_system_prompt_injection: false,
+        enable_claude_oauth_system_prompt_injection: true,
       }),
     );
     const payload = updateSettings.mock.calls[0][0] as {
@@ -1163,7 +1238,7 @@ describe("admin SettingsView payment visible method controls", () => {
       {
         enabled: true,
         type: "text",
-        text: "custom block",
+        text: "edited block text",
         cache_control: {
           type: "ephemeral",
           ttl: "5m",
@@ -1173,14 +1248,14 @@ describe("admin SettingsView payment visible method controls", () => {
   });
 
   it("submits Antigravity user agent version gateway setting", async () => {
-    getSettings.mockResolvedValueOnce({
-      ...baseSettingsResponse,
-      antigravity_user_agent_version: "1.23.2",
-    });
-
     const wrapper = mountView();
 
     await flushPromises();
+    await openGatewayTab(wrapper);
+    await findInputByPlaceholder(
+      wrapper,
+      "admin.settings.gatewayForwarding.antigravityUserAgentVersionPlaceholder",
+    ).setValue("1.23.2");
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
@@ -1723,17 +1798,14 @@ describe("admin SettingsView wechat connect controls", () => {
     await flushPromises();
 
     expect(updateSettings).toHaveBeenCalledTimes(1);
+    // 部分 PUT 语义：只断言相对基线变化过的键（enabled/mp_enabled/回调地址
+    // 与基线一致，不随包发送；省略 = 保留当前值）。
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
-        wechat_connect_enabled: true,
         wechat_connect_app_id: "wx-app-id-updated",
         wechat_connect_open_enabled: true,
-        wechat_connect_mp_enabled: true,
         wechat_connect_mp_app_id: "wx-app-id-updated",
         wechat_connect_mp_app_secret: "new-secret",
-        wechat_connect_redirect_url:
-          "https://admin.example.com/api/v1/auth/oauth/wechat/callback",
-        wechat_connect_frontend_redirect_url: "/auth/wechat/callback",
       }),
     );
     expect(
@@ -1780,14 +1852,19 @@ describe("admin SettingsView wechat connect controls", () => {
     getSettings.mockResolvedValueOnce({
       ...baseSettingsResponse,
       oidc_connect_enabled: true,
-      oidc_connect_use_pkce: false,
-      oidc_connect_validate_id_token: false,
+      oidc_connect_use_pkce: true,
+      oidc_connect_validate_id_token: true,
     });
 
     const wrapper = mountView();
 
     await flushPromises();
     await openSecurityTab(wrapper);
+    // 用户显式关闭 PKCE：保存时应如实提交 false，而不是被强制回 true；
+    // 未改动的 validate_id_token 不随包发送（省略 = 保留当前值）。
+    await wrapper
+      .get('[data-testid="oidc-connect-use-pkce"]')
+      .setValue(false);
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
@@ -1795,9 +1872,150 @@ describe("admin SettingsView wechat connect controls", () => {
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         oidc_connect_use_pkce: false,
-        oidc_connect_validate_id_token: false,
       }),
     );
+    const payload = updateSettings.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("oidc_connect_validate_id_token");
+  });
+
+  it("零变更保存不发 PUT、仍保存 web-search 配置并提示成功", async () => {
+    const wrapper = mountView();
+
+    await flushPromises();
+    updateSettings.mockClear();
+    updateWebSearchEmulationConfig.mockClear();
+    showSuccess.mockClear();
+
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(updateWebSearchEmulationConfig).toHaveBeenCalledTimes(1);
+    expect(showSuccess).toHaveBeenCalled();
+  });
+
+  it("只改 site_name 时 payload 恰好只包含该键", async () => {
+    const wrapper = mountView();
+
+    await flushPromises();
+    await findInputByPlaceholder(
+      wrapper,
+      "admin.settings.site.siteNamePlaceholder",
+    ).setValue("RickToken Gateway");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+    const payload = updateSettings.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toEqual({ site_name: "RickToken Gateway" });
+    expect(payload).not.toHaveProperty("site_logo");
+  });
+
+  it("瘦身响应（只回传发送字段）不会清空未发送的表单状态", async () => {
+    // 模拟后端 PUT 响应瘦身：只回传发送字段 + 只读伴生键。
+    updateSettings.mockResolvedValueOnce({
+      site_name: "Slim Response Site",
+    });
+
+    const wrapper = mountView();
+
+    await flushPromises();
+    await findInputByPlaceholder(
+      wrapper,
+      "admin.settings.site.siteNamePlaceholder",
+    ).setValue("Slim Response Site");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+
+    // WeChat 开关与公众号 AppID：未发送 → 保持加载值，不被 undefined 清掉
+    expect(
+      (
+        wrapper.get('[data-testid="wechat-connect-enabled"]')
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+    expect(
+      (
+        wrapper.get('[data-testid="wechat-connect-mp-app-id"]')
+          .element as HTMLInputElement
+      ).value,
+    ).toBe("wx-app-id-123");
+    // 平台配额（嵌套对象）：未发送 → 保持加载值（openai 周限额 12.5）
+    const openaiQuotaRow = wrapper.findAll("tr").find(
+      (tr) =>
+        tr.text().includes("openai") &&
+        tr.findAll('input[type="number"]').length >= 3,
+    );
+    expect(openaiQuotaRow).toBeDefined();
+    const quotaCells = openaiQuotaRow!.findAll('input[type="number"]');
+    expect(
+      (quotaCells[1]!.element as HTMLInputElement).value,
+    ).toBe("12.5");
+    // passkey 开关：未发送 → 保持启用
+    expect(
+      (
+        wrapper.get('[data-testid="passkey-toggle"]')
+          .element as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+  });
+
+  it("密钥回环：未动密钥不发送，填了新密钥才进入 payload", async () => {
+    // SMTP 卡片仅在开启邮箱验证时渲染，这里打开它以获得密钥输入框。
+    getSettings.mockResolvedValueOnce({
+      ...baseSettingsResponse,
+      email_verify_enabled: true,
+      smtp_host: "smtp.example.com",
+    });
+    // 回显 mock 需保持邮箱验证开启（真实瘦身响应根本不含该键，不会改写它）。
+    updateSettings.mockImplementation(async (payload: Record<string, unknown>) => ({
+      ...baseSettingsResponse,
+      email_verify_enabled: true,
+      ...payload,
+    }));
+    const wrapper = mountView();
+
+    await flushPromises();
+    // ① 只改站点名：密钥字段留空 = 未变更，不应随包发送
+    await findInputByPlaceholder(
+      wrapper,
+      "admin.settings.site.siteNamePlaceholder",
+    ).setValue("Secret Round Trip");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+    let payload = updateSettings.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("smtp_password");
+    expect(payload).not.toHaveProperty("turnstile_secret_key");
+
+    // ② 填入新 SMTP 密钥：该字段进入 payload
+    await findInputByPlaceholder(
+      wrapper,
+      "admin.settings.smtp.passwordPlaceholder",
+    ).setValue("new-smtp-secret");
+    await wrapper.find("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(updateSettings).toHaveBeenCalledTimes(2);
+    payload = updateSettings.mock.calls[1][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("site_name");
+    expect(payload).toHaveProperty("smtp_password", "new-smtp-secret");
+    // 保存成功后密钥输入框清空
+    expect(
+      (
+        wrapper
+          .findAll('input[type="password"]')
+          .find(
+            (node) =>
+              node.attributes("placeholder")?.includes(
+                "admin.settings.smtp.passwordPlaceholder",
+              ),
+          )?.element as HTMLInputElement
+      ).value,
+    ).toBe("");
   });
 });
 
@@ -1865,6 +2083,15 @@ describe("admin SettingsView platform quota matrix", () => {
     await flushPromises();
     await openUsersTab(wrapper);
 
+    // 部分 PUT 语义：配额矩阵是一个整体键，先改一个值让该键进入 diff。
+    const inputs = wrapper.findAll('input[type="number"]');
+    const anthropicDailyInput = inputs.find((i) => {
+      const parent = i.element.closest("tr");
+      return parent?.textContent?.includes("anthropic");
+    });
+    expect(anthropicDailyInput).toBeDefined();
+    await anthropicDailyInput!.setValue("3");
+
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
@@ -1884,6 +2111,7 @@ describe("admin SettingsView platform quota matrix", () => {
       expect(pq).toHaveProperty("weekly");
       expect(pq).toHaveProperty("monthly");
     }
+    expect((quotas["anthropic"] as Record<string, unknown>)["daily"]).toBe(3);
 
     // 不应存在旧扁平字段
     expect(payload).not.toHaveProperty("default_platform_quota_anthropic_daily");
@@ -1904,13 +2132,23 @@ describe("admin SettingsView platform quota matrix", () => {
     await flushPromises();
     await openUsersTab(wrapper);
 
+    // 改 anthropic daily，让 default_platform_quotas 作为整体键进入 diff；
+    // 未改的 openai weekly 12.5 随嵌套对象一起提交。
+    const inputs = wrapper.findAll('input[type="number"]');
+    const anthropicDailyInput = inputs.find((i) => {
+      const parent = i.element.closest("tr");
+      return parent?.textContent?.includes("anthropic");
+    });
+    expect(anthropicDailyInput).toBeDefined();
+    await anthropicDailyInput!.setValue("7");
+
     await wrapper.find("form").trigger("submit.prevent");
     await flushPromises();
 
     const payload = updateSettings.mock.calls.at(-1)![0] as Record<string, unknown>;
     const quotas = payload["default_platform_quotas"] as Record<string, Record<string, unknown>>;
 
-    expect(quotas["anthropic"]?.["daily"]).toBe(5);
+    expect(quotas["anthropic"]?.["daily"]).toBe(7);
     expect(quotas["openai"]?.["weekly"]).toBe(12.5);
     // 缺失平台应补全为 null
     expect(quotas["gemini"]).toEqual({ daily: null, weekly: null, monthly: null });


### PR DESCRIPTION
## Problem

Saving the admin system-settings page uploads the **entire settings document** on every save. The document can grow to hundreds of KB on instances with long `home_content`, a base64 `payment_help_image_url`, `login_agreement_documents`, etc. Each save then ships the full document in both directions — a large uncompressed PUT body (browsers do not gzip request bodies) plus a full-document response — and the frontend afterwards refetches the full document twice more (`adminSettingsStore.fetch(true)` and `appStore.fetchPublicSettings(true)`). On a high-latency link a single save takes seconds even though the handler itself completes in milliseconds.

The backend already supports partial updates (omitted keys keep their stored values), but the frontend never used it, and the PUT response always echoed the whole document back.

## Solution

**Backend** — slim the `PUT /settings` response to what the client needs to reconcile:

- New `setting_handler_response_filter.go`: the response contains only the sent fields, plus their read-only companion keys — the two keys the handler re-derives fail-closed on every save (`api_key_acl_trust_forwarded_ip`, `forwarded_client_ip_headers`), `*_configured` for the secret fields, `openai_codex_client_version_synced`, and the `openai_advanced_scheduler_effective_*` keys when scheduler request fields are sent.
- `GET /settings` is unchanged (api-contract golden tests still pass); `setting_handler_update.go` is a single-line change to route the response through the filter.

**Frontend** — send only what changed, and stop refetching after save:

- `SettingsView` captures a per-key fingerprint baseline after load and after each successful save; save computes the diff first and PUTs only the changed fields. An empty diff skips the PUT entirely (the separate web-search config save and the success toast still run). The diff is computed before the step-up wrapper so a step-up retry resends the identical partial payload.
- The partial response is merged back with presence guards, so unsent fields (auth-source defaults, platform quotas, scheduling thresholds, whitelist tags, forwarded headers, WeChat capabilities) are not clobbered by `undefined`.
- The two full refetches after save are replaced by local patches to `adminSettingsStore` (plus a new `setCustomMenuItemsLocal`), and a force-refresh of public settings only when the saved keys intersect a `PUBLIC_SETTINGS_KEYS` allowlist aligned with `setting_public.go`.

## Behavior after the change

| Scenario | Before | After |
|---|---|---|
| Change one field, save | full document up + down, then two full refetches | a few KB up and down |
| Save with no changes | full PUT anyway | no PUT request |
| External writes between load and save (e.g. codex version auto-sync) | silently overwritten by the full rewrite | preserved — only user-changed keys are sent |
| Blank secret field | not sent (keep current value) | unchanged |
| `GET /settings` shape | — | unchanged |

Notes: the first save after load may include a few extra keys whose frontend-normalized form differs from the stored representation; the rewrite is idempotent and the baseline realigns after that first save.

## Validation

- Backend: `go build ./...`, `go test -tags unit ./internal/handler/admin/... ./internal/server/...` (includes the api-contract golden tests) pass. 4 new unit tests pin the slim-response contract (sent + companion keys present, unsent keys absent, no secret plaintext).
- Frontend: `vue-tsc --noEmit` passes; Vitest `SettingsView` suite (41 tests, including 4 new partial-PUT cases: zero-change save sends no PUT, single-field payload, partial-response merge safety, secret round-trip) and `src/api/__tests__` (165 tests) pass.
- Verified end-to-end in a local Docker preview: `PUT {"site_name": ...}` returns exactly `site_name` + the two always-on keys (a few hundred bytes instead of the full document); sending `smtp_password` returns `smtp_password_configured: true` and never the plaintext.

The PR branch was created from `origin/main` and contains only the files related to this change.
