### PR TITLE
fix(antigravity): prevent false failover and Gemini 400s

### DIFF
--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -286,6 +286,55 @@ func TestBuildTools_PreservesWebSearchAlongsideFunctions(t *testing.T) {
 	require.Equal(t, 5, result[1].GoogleSearch.EnhancedContent.ImageSearch.MaxResultCount)
 }
 
+func TestTransformClaudeToGeminiWithOptions_RemovesUnresolvedToolSchemaRefs(t *testing.T) {
+	claudeReq := &ClaudeRequest{
+		Model: "gemini-3.6-flash-high",
+		Messages: []ClaudeMessage{{
+			Role:    "user",
+			Content: json.RawMessage(`"inspect the value"`),
+		}},
+		Tools: []ClaudeTool{{
+			Name:        "inspect_value",
+			Description: "Inspect a structured value",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"direct": map[string]any{"$ref": "#/components/schemas/Value"},
+					"list": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"$ref": "#/components/schemas/Value"},
+					},
+					"nested": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"value": map[string]any{"$ref": "#/components/schemas/Value"},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	body, err := TransformClaudeToGeminiWithOptions(
+		claudeReq,
+		"project-1",
+		"gemini-3.6-flash-high",
+		DefaultTransformOptions(),
+	)
+
+	require.NoError(t, err)
+	require.NotContains(t, string(body), `"$ref"`)
+
+	var req V1InternalRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	params := req.Request.Tools[0].FunctionDeclarations[0].Parameters
+	properties := params["properties"].(map[string]any)
+	require.NotEmpty(t, properties["direct"].(map[string]any)["type"])
+	require.NotEmpty(t, properties["list"].(map[string]any)["items"].(map[string]any)["type"])
+	nested := properties["nested"].(map[string]any)["properties"].(map[string]any)
+	require.NotEmpty(t, nested["value"].(map[string]any)["type"])
+}
+
 func TestBuildGenerationConfig_ThinkingDynamicBudget(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/backend/internal/pkg/antigravity/schema_cleaner.go
+++ b/backend/internal/pkg/antigravity/schema_cleaner.go
@@ -14,7 +14,7 @@ func CleanJSONSchema(schema map[string]any) map[string]any {
 	}
 	// 0. 预处理：展开 $ref (Schema Flattening)
 	// (Go map 是引用的，直接修改 schema)
-	flattenRefs(schema, extractDefs(schema))
+	FlattenJSONSchemaRefs(schema)
 
 	// 递归清理
 	cleaned := cleanJSONSchemaRecursive(schema)
@@ -24,6 +24,17 @@ func CleanJSONSchema(schema map[string]any) map[string]any {
 	}
 
 	return result
+}
+
+// FlattenJSONSchemaRefs expands local JSON Schema references in-place and
+// removes the definitions containers. Callers that need to apply a separate
+// compatibility cleaner afterwards can use this without changing the rest of
+// the schema normalization pipeline.
+func FlattenJSONSchemaRefs(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+	flattenRefs(schema, extractDefs(schema))
 }
 
 // extractDefs 提取并移除定义的 helper

--- a/backend/internal/pkg/antigravity/schema_cleaner.go
+++ b/backend/internal/pkg/antigravity/schema_cleaner.go
@@ -46,43 +46,98 @@ func extractDefs(schema map[string]any) map[string]any {
 
 // flattenRefs 递归展开 $ref
 func flattenRefs(schema map[string]any, defs map[string]any) {
-	if len(defs) == 0 {
-		return // 无需展开
-	}
+	flattenRefsRecursive(schema, defs, make(map[string]bool))
+}
 
+func flattenRefsRecursive(schema map[string]any, defs map[string]any, resolving map[string]bool) {
 	// 检查并替换 $ref
 	if ref, ok := schema["$ref"].(string); ok {
 		delete(schema, "$ref")
-		// 解析引用名 (例如 #/$defs/MyType -> MyType)
-		parts := strings.Split(ref, "/")
-		refName := parts[len(parts)-1]
 
-		if defSchema, exists := defs[refName]; exists {
-			if defMap, ok := defSchema.(map[string]any); ok {
-				// 合并定义内容 (不覆盖现有 key)
-				for k, v := range defMap {
-					if _, has := schema[k]; !has {
-						schema[k] = deepCopy(v) // 需深拷贝避免共享引用
+		resolved := false
+		if refName, local := localDefinitionRefName(ref); local {
+			if defSchema, exists := defs[refName]; exists && !resolving[refName] {
+				if defMap, ok := defSchema.(map[string]any); ok {
+					resolving[refName] = true
+					resolvedDef, _ := deepCopy(defMap).(map[string]any)
+					flattenRefsRecursive(resolvedDef, defs, resolving)
+					delete(resolving, refName)
+					// 合并定义内容 (不覆盖现有 key)
+					for k, v := range resolvedDef {
+						if _, has := schema[k]; !has {
+							schema[k] = v
+						}
 					}
+					resolved = true
 				}
-				// 递归处理刚刚合并进来的内容
-				flattenRefs(schema, defs)
 			}
+		}
+
+		// Gemini 不接受 $ref。外部引用、缺失定义和循环引用无法安全展开时，
+		// 降级为无属性约束的内联对象，保留请求可执行性且不泄漏不支持字段。
+		if !resolved && !hasSchemaShape(schema) {
+			schema["type"] = "object"
 		}
 	}
 
 	// 遍历子节点
 	for _, v := range schema {
 		if subMap, ok := v.(map[string]any); ok {
-			flattenRefs(subMap, defs)
+			flattenRefsRecursive(subMap, defs, resolving)
 		} else if subArr, ok := v.([]any); ok {
 			for _, item := range subArr {
 				if itemMap, ok := item.(map[string]any); ok {
-					flattenRefs(itemMap, defs)
+					flattenRefsRecursive(itemMap, defs, resolving)
 				}
 			}
 		}
 	}
+}
+
+func localDefinitionRefName(ref string) (string, bool) {
+	var token string
+	switch {
+	case strings.HasPrefix(ref, "#/$defs/"):
+		token = strings.TrimPrefix(ref, "#/$defs/")
+	case strings.HasPrefix(ref, "#/definitions/"):
+		token = strings.TrimPrefix(ref, "#/definitions/")
+	default:
+		return "", false
+	}
+	if token == "" || strings.Contains(token, "/") {
+		return "", false
+	}
+
+	var decoded strings.Builder
+	decoded.Grow(len(token))
+	for i := 0; i < len(token); i++ {
+		if token[i] != '~' {
+			decoded.WriteByte(token[i])
+			continue
+		}
+		if i+1 >= len(token) {
+			return "", false
+		}
+		i++
+		switch token[i] {
+		case '0':
+			decoded.WriteByte('~')
+		case '1':
+			decoded.WriteByte('/')
+		default:
+			return "", false
+		}
+	}
+	return decoded.String(), true
+}
+
+func hasSchemaShape(schema map[string]any) bool {
+	for _, key := range []string{"type", "properties", "items", "enum", "anyOf", "oneOf", "allOf"} {
+		if _, ok := schema[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // deepCopy 深拷贝 (简单实现，仅针对 JSON 类型)

--- a/backend/internal/pkg/antigravity/schema_cleaner_test.go
+++ b/backend/internal/pkg/antigravity/schema_cleaner_test.go
@@ -1,0 +1,110 @@
+package antigravity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanJSONSchema_ExpandsLocalDefinitions(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"item": map[string]any{
+				"$ref": "#/definitions/Item",
+			},
+		},
+		"definitions": map[string]any{
+			"Item": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type": "string",
+					},
+				},
+				"required": []any{"name"},
+			},
+		},
+	}
+
+	cleaned := CleanJSONSchema(schema)
+
+	require.NotNil(t, cleaned)
+	encoded, err := json.Marshal(cleaned)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), `"$ref"`)
+	require.NotContains(t, string(encoded), `"definitions"`)
+
+	properties := cleaned["properties"].(map[string]any)
+	item := properties["item"].(map[string]any)
+	require.Equal(t, "object", item["type"])
+	itemProperties := item["properties"].(map[string]any)
+	require.Equal(t, "string", itemProperties["name"].(map[string]any)["type"])
+	require.Equal(t, []any{"name"}, item["required"])
+}
+
+func TestCleanJSONSchema_SelfReferenceTerminatesWithoutRefs(t *testing.T) {
+	schema := map[string]any{
+		"$ref": "#/$defs/Node",
+		"$defs": map[string]any{
+			"Node": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"type": "string",
+					},
+					"next": map[string]any{
+						"$ref": "#/$defs/Node",
+					},
+				},
+			},
+		},
+	}
+
+	cleaned := CleanJSONSchema(schema)
+
+	require.NotNil(t, cleaned)
+	encoded, err := json.Marshal(cleaned)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), `"$ref"`)
+	require.NotContains(t, string(encoded), `"$defs"`)
+	require.Equal(t, "object", cleaned["type"])
+
+	properties := cleaned["properties"].(map[string]any)
+	require.Equal(t, "string", properties["value"].(map[string]any)["type"])
+	require.Equal(t, "object", properties["next"].(map[string]any)["type"])
+}
+
+func TestCleanJSONSchema_ExternalRefDoesNotResolveCollidingLocalDefinition(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"external": map[string]any{
+				"$ref": "https://example.com/schema.json#/$defs/Item",
+			},
+		},
+		"$defs": map[string]any{
+			"Item": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type": "string",
+					},
+				},
+			},
+		},
+	}
+
+	cleaned := CleanJSONSchema(schema)
+
+	require.NotNil(t, cleaned)
+	encoded, err := json.Marshal(cleaned)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), `"$ref"`)
+
+	properties := cleaned["properties"].(map[string]any)
+	external := properties["external"].(map[string]any)
+	require.Equal(t, "object", external["type"])
+	require.NotContains(t, external["properties"], "name")
+}

--- a/backend/internal/service/antigravity_gateway_claude.go
+++ b/backend/internal/service/antigravity_gateway_claude.go
@@ -375,6 +375,10 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 				}
 			}
 
+			if failoverErr := s.handleAntigravityLocationUnsupported(ctx, c, prefix, account, resp.StatusCode, resp.Header, respBody, 0, ""); failoverErr != nil {
+				return nil, failoverErr
+			}
+
 			s.handleUpstreamError(ctx, prefix, account, resp.StatusCode, resp.Header, respBody, originalModel, 0, "", isStickySession)
 
 			// 精确匹配服务端配置类 400 错误，触发同账号重试 + failover

--- a/backend/internal/service/antigravity_gateway_compat.go
+++ b/backend/internal/service/antigravity_gateway_compat.go
@@ -407,6 +407,9 @@ func (s *AntigravityGatewayService) handleAntigravityCompatHTTPError(
 	resp *http.Response,
 ) error {
 	body := s.readUpstreamErrorBody(resp)
+	if failoverErr := s.handleAntigravityLocationUnsupported(ctx, c, call.prefix, account, resp.StatusCode, resp.Header, body, 0, ""); failoverErr != nil {
+		return failoverErr
+	}
 	s.handleUpstreamError(
 		ctx,
 		call.prefix,

--- a/backend/internal/service/antigravity_gateway_compat_test.go
+++ b/backend/internal/service/antigravity_gateway_compat_test.go
@@ -268,6 +268,61 @@ func TestBuildAntigravityCompatGeminiBody_ConfiguresMixedToolInvocations(t *test
 	}
 }
 
+func TestAntigravityCompat_FlattensLocalToolSchemaRefsInFinalUpstreamPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	schema := `{"type":"object","properties":{"item":{"$ref":"#/$defs/Item"}},"required":["item"],"$defs":{"Item":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}}`
+
+	tests := []struct {
+		name string
+		path string
+		body string
+		call func(*AntigravityGatewayService, context.Context, *gin.Context, *Account, []byte) (*ForwardResult, error)
+	}{
+		{
+			name: "chat completions",
+			path: "/v1/chat/completions",
+			body: `{"model":"gemini-3.1-pro-high","messages":[{"role":"user","content":"hello"}],"tools":[{"type":"function","function":{"name":"lookup","description":"Lookup","parameters":` + schema + `}}]}`,
+			call: func(svc *AntigravityGatewayService, ctx context.Context, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsChatCompletions(ctx, c, account, body, nil)
+			},
+		},
+		{
+			name: "responses",
+			path: "/v1/responses",
+			body: `{"model":"gemini-3.1-pro-high","input":"hello","tools":[{"type":"function","name":"lookup","description":"Lookup","parameters":` + schema + `}]}`,
+			call: func(svc *AntigravityGatewayService, ctx context.Context, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsResponses(ctx, c, account, body, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{antigravityCompatSuccessResponse()}}
+			svc := newAntigravityCompatService(
+				config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+				upstream,
+			)
+			c, recorder := newAntigravityCompatContext(http.MethodPost, tt.path, body)
+
+			result, err := tt.call(svc, context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.Len(t, upstream.requestBodies, 1)
+
+			require.Equal(t, "object", gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.functionDeclarations.0.parameters.properties.item.type").String())
+			require.Equal(t, "string", gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.functionDeclarations.0.parameters.properties.item.properties.name.type").String())
+			require.Equal(t, "name", gjson.GetBytes(upstream.requestBodies[0], "request.tools.0.functionDeclarations.0.parameters.properties.item.required.0").String())
+			payload := string(upstream.requestBodies[0])
+			require.NotContains(t, payload, `"$ref"`)
+			require.NotContains(t, payload, `"$defs"`)
+			require.NotContains(t, payload, `"definitions"`)
+		})
+	}
+}
+
 func TestAntigravityCompatPreservesChatTokenLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {

--- a/backend/internal/service/antigravity_gateway_compat_test.go
+++ b/backend/internal/service/antigravity_gateway_compat_test.go
@@ -376,6 +376,64 @@ func TestAntigravityCompatUnauthorizedIsCredentialFailure(t *testing.T) {
 	require.Empty(t, recorder.Body.String())
 }
 
+func TestAntigravityCompatLocationUnsupportedDisablesAccountAndFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name    string
+		path    string
+		body    []byte
+		forward func(*AntigravityGatewayService, context.Context, *gin.Context, *Account, []byte) (*ForwardResult, error)
+	}{
+		{
+			name: "chat completions",
+			path: "/v1/chat/completions",
+			body: []byte(`{"model":"gemini-3.1-pro-high","messages":[{"role":"user","content":"ok"}]}`),
+			forward: func(svc *AntigravityGatewayService, ctx context.Context, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsChatCompletions(ctx, c, account, body, nil)
+			},
+		},
+		{
+			name: "responses",
+			path: "/v1/responses",
+			body: []byte(`{"model":"gemini-3.1-pro-high","input":"ok"}`),
+			forward: func(svc *AntigravityGatewayService, ctx context.Context, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsResponses(ctx, c, account, body, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"X-Request-Id": []string{"location-compat-400"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"code":400,"message":"User location is not supported for the API use.","status":"FAILED_PRECONDITION"}}`)),
+			}}}
+			repo := &locationRestrictionAccountRepoStub{}
+			svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+			svc.accountRepo = repo
+			c, recorder := newAntigravityCompatContext(http.MethodPost, tt.path, tt.body)
+
+			result, err := tt.forward(
+				svc,
+				context.Background(),
+				c,
+				newAntigravityCompatAccount(AccountTypeOAuth),
+				tt.body,
+			)
+
+			require.Nil(t, result)
+			var failoverErr *UpstreamFailoverError
+			require.ErrorAs(t, err, &failoverErr)
+			require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+			require.Equal(t, GatewayFailureScopeAccount, failoverErr.Scope)
+			require.Empty(t, recorder.Body.String())
+			require.Len(t, repo.setErrorCalls, 1)
+			require.Equal(t, int64(3757), repo.setErrorCalls[0].accountID)
+		})
+	}
+}
+
 func TestAntigravityCompatEmptyStreamTriggersFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/antigravity_gateway_gemini.go
+++ b/backend/internal/service/antigravity_gateway_gemini.go
@@ -334,6 +334,9 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 		if unwrapErr != nil || len(unwrappedForOps) == 0 {
 			unwrappedForOps = respBody
 		}
+		if failoverErr := s.handleAntigravityLocationUnsupported(ctx, c, prefix, account, resp.StatusCode, resp.Header, unwrappedForOps, forwardOpts.groupID, forwardOpts.sessionHash); failoverErr != nil {
+			return nil, failoverErr
+		}
 		s.handleUpstreamError(ctx, prefix, account, resp.StatusCode, resp.Header, respBody, originalModel, forwardOpts.groupID, forwardOpts.sessionHash, isStickySession)
 		upstreamMsg := strings.TrimSpace(extractAntigravityErrorMessage(unwrappedForOps))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)

--- a/backend/internal/service/antigravity_gateway_gemini.go
+++ b/backend/internal/service/antigravity_gateway_gemini.go
@@ -487,11 +487,13 @@ func cleanGeminiRequest(body []byte) ([]byte, error) {
 					continue
 				}
 
-				if params, ok := funcMap["parameters"].(map[string]any); ok {
-					antigravity.DeepCleanUndefined(params)
-					cleaned := antigravity.CleanJSONSchema(params)
-					funcMap["parameters"] = cleaned
-					modified = true
+				for _, schemaKey := range []string{"parameters", "parametersJsonSchema", "parameters_json_schema"} {
+					if params, ok := funcMap[schemaKey].(map[string]any); ok {
+						antigravity.DeepCleanUndefined(params)
+						cleaned := antigravity.CleanJSONSchema(params)
+						funcMap[schemaKey] = cleaned
+						modified = true
+					}
 				}
 			}
 		}

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -15,15 +15,17 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 )
 
 const (
-	antigravityStickySessionTTL = time.Hour
-	antigravityMaxRetries       = 3
-	antigravityRetryBaseDelay   = 1 * time.Second
-	antigravityRetryMaxDelay    = 16 * time.Second
+	antigravityStickySessionTTL                  = time.Hour
+	antigravityMaxRetries                        = 3
+	antigravityRetryBaseDelay                    = 1 * time.Second
+	antigravityRetryMaxDelay                     = 16 * time.Second
+	antigravityLocationUnsupportedDisableTimeout = 30 * time.Second
 
 	// 限流相关常量
 	// antigravityRateLimitThreshold 限流等待/切换阈值
@@ -195,6 +197,61 @@ func (s *AntigravityGatewayService) getUpstreamErrorDetail(body []byte) string {
 		return ""
 	}
 	return truncateString(string(body), maxBytes)
+}
+
+func isAntigravityLocationUnsupportedError(respBody []byte) bool {
+	msg := strings.ToLower(strings.TrimSpace(extractAntigravityErrorMessage(respBody)))
+	return strings.Contains(msg, "user location is not supported for the api use")
+}
+
+func (s *AntigravityGatewayService) handleAntigravityLocationUnsupported(
+	ctx context.Context,
+	c *gin.Context,
+	prefix string,
+	account *Account,
+	statusCode int,
+	headers http.Header,
+	body []byte,
+	groupID int64,
+	sessionHash string,
+) *UpstreamFailoverError {
+	if statusCode != http.StatusBadRequest || account == nil || !isAntigravityLocationUnsupportedError(body) {
+		return nil
+	}
+
+	opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), antigravityLocationUnsupportedDisableTimeout)
+	defer cancel()
+
+	if s.accountRepo != nil {
+		const accountError = "Antigravity account location is not supported for API use"
+		if err := s.accountRepo.SetError(opCtx, account.ID, accountError); err != nil {
+			logger.LegacyPrintf("service.antigravity_gateway", "%s location_unsupported_disable_failed account=%d error=%v", prefix, account.ID, err)
+		} else {
+			logger.LegacyPrintf("service.antigravity_gateway", "%s location_unsupported account_disabled=true account=%d", prefix, account.ID)
+		}
+	}
+	s.clearStickySession(opCtx, groupID, sessionHash)
+
+	upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractAntigravityErrorMessage(body)))
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: statusCode,
+		UpstreamRequestID:  headers.Get("x-request-id"),
+		Kind:               "account_location_unsupported",
+		Message:            upstreamMsg,
+		Detail:             s.getUpstreamErrorDetail(body),
+	})
+	return &UpstreamFailoverError{
+		StatusCode:        statusCode,
+		ResponseBody:      body,
+		ResponseHeaders:   headers.Clone(),
+		Stage:             GatewayFailureStageInference,
+		Scope:             GatewayFailureScopeAccount,
+		Reason:            GatewayFailureReason("antigravity_location_unsupported"),
+		NextAccountAction: NextAccountRetry,
+	}
 }
 
 // checkErrorPolicy nil 安全的包装

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -226,6 +226,18 @@ func (s *AntigravityGatewayService) handleAntigravityLocationUnsupported(
 		const accountError = "Antigravity account location is not supported for API use"
 		if err := s.accountRepo.SetError(opCtx, account.ID, accountError); err != nil {
 			logger.LegacyPrintf("service.antigravity_gateway", "%s location_unsupported_disable_failed account=%d error=%v", prefix, account.ID, err)
+			// Permanent isolation is the safety property of this path. If the
+			// durable state write fails, do not claim account-level isolation or
+			// retry into a pool that may immediately select the same account.
+			return &UpstreamFailoverError{
+				StatusCode:        statusCode,
+				ResponseBody:      body,
+				ResponseHeaders:   headers.Clone(),
+				Stage:             GatewayFailureStageInference,
+				Scope:             GatewayFailureScopeProvider,
+				Reason:            GatewayFailureReason("antigravity_location_unsupported_persist_failed"),
+				NextAccountAction: NextAccountStop,
+			}
 		} else {
 			logger.LegacyPrintf("service.antigravity_gateway", "%s location_unsupported account_disabled=true account=%d", prefix, account.ID)
 		}

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -190,6 +190,47 @@ type recordingInternal500CounterCache struct {
 	resetCalls     []int64
 }
 
+type locationRestrictionErrorCall struct {
+	accountID int64
+	reason    string
+	ctxErr    error
+}
+
+type locationRestrictionAccountRepoStub struct {
+	AccountRepository
+	setErrorCalls []locationRestrictionErrorCall
+}
+
+type locationRestrictionCacheCall struct {
+	groupID     int64
+	sessionHash string
+	ctxErr      error
+	deadline    time.Time
+	hasDeadline bool
+}
+
+type locationRestrictionCacheStub struct {
+	GatewayCache
+	deleteCalls []locationRestrictionCacheCall
+}
+
+func (r *locationRestrictionAccountRepoStub) SetError(ctx context.Context, id int64, reason string) error {
+	r.setErrorCalls = append(r.setErrorCalls, locationRestrictionErrorCall{accountID: id, reason: reason, ctxErr: ctx.Err()})
+	return nil
+}
+
+func (c *locationRestrictionCacheStub) DeleteSessionAccountID(ctx context.Context, groupID int64, sessionHash string) error {
+	deadline, hasDeadline := ctx.Deadline()
+	c.deleteCalls = append(c.deleteCalls, locationRestrictionCacheCall{
+		groupID:     groupID,
+		sessionHash: sessionHash,
+		ctxErr:      ctx.Err(),
+		deadline:    deadline,
+		hasDeadline: hasDeadline,
+	})
+	return nil
+}
+
 func (c *recordingInternal500CounterCache) IncrementInternal500Count(_ context.Context, accountID int64) (int64, error) {
 	c.incrementCalls = append(c.incrementCalls, accountID)
 	return int64(len(c.incrementCalls)), nil
@@ -378,6 +419,88 @@ func TestAntigravityGatewayService_ForwardGemini_PreservesServerSideToolInvocati
 	require.NotContains(t, toolConfig, "include_server_side_tool_invocations")
 }
 
+func TestAntigravityGatewayService_ForwardGemini_LocationUnsupportedDisablesAccountAndFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	writer := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(writer)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", bytes.NewReader(body))
+
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"X-Request-Id": []string{"location-native-400"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"code":400,"message":"User location is not supported for the API use.","status":"FAILED_PRECONDITION"}}`)),
+	}}}
+	repo := &locationRestrictionAccountRepoStub{}
+	cache := &stubSmartRetryCache{}
+	svc := &AntigravityGatewayService{
+		accountRepo:    repo,
+		cache:          cache,
+		settingService: NewSettingService(&antigravitySettingRepoStub{}, &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}),
+		tokenProvider:  &AntigravityTokenProvider{},
+		httpUpstream:   upstream,
+	}
+	account := &Account{
+		ID: 104, Name: "native-location-restricted", Platform: PlatformAntigravity, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1,
+		Credentials: map[string]any{"access_token": "token", "project_id": "project-104", "model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"}},
+	}
+
+	result, err := svc.ForwardGemini(context.Background(), c, account, "gemini-2.5-flash", "generateContent", false, body, true, WithForwardGeminiSession(77, "session-location-restricted"))
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.Equal(t, GatewayFailureScopeAccount, failoverErr.Scope)
+	require.Empty(t, writer.Body.String())
+	require.Len(t, repo.setErrorCalls, 1)
+	require.Equal(t, int64(104), repo.setErrorCalls[0].accountID)
+	require.NoError(t, repo.setErrorCalls[0].ctxErr)
+	require.Len(t, cache.deleteCalls, 1)
+	require.Equal(t, int64(77), cache.deleteCalls[0].groupID)
+	require.Equal(t, "session-location-restricted", cache.deleteCalls[0].sessionHash)
+}
+
+func TestAntigravityGatewayService_HandleLocationUnsupportedUsesUncancelledContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	writer := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(writer)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", bytes.NewReader(nil))
+
+	repo := &locationRestrictionAccountRepoStub{}
+	cache := &locationRestrictionCacheStub{}
+	svc := &AntigravityGatewayService{accountRepo: repo, cache: cache}
+	account := &Account{ID: 105, Name: "cancelled-location-restricted", Platform: PlatformAntigravity}
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	startedAt := time.Now()
+
+	failoverErr := svc.handleAntigravityLocationUnsupported(
+		reqCtx,
+		c,
+		"[antigravity-Forward] account=cancelled-location-restricted",
+		account,
+		http.StatusBadRequest,
+		http.Header{"X-Request-Id": []string{"location-cancelled-400"}},
+		[]byte(`{"error":{"message":"User location is not supported for the API use."}}`),
+		77,
+		"session-cancelled-location",
+	)
+
+	require.NotNil(t, failoverErr)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.Len(t, repo.setErrorCalls, 1)
+	require.Equal(t, int64(105), repo.setErrorCalls[0].accountID)
+	require.NoError(t, repo.setErrorCalls[0].ctxErr)
+	require.Len(t, cache.deleteCalls, 1)
+	require.Equal(t, int64(77), cache.deleteCalls[0].groupID)
+	require.Equal(t, "session-cancelled-location", cache.deleteCalls[0].sessionHash)
+	require.NoError(t, cache.deleteCalls[0].ctxErr)
+	require.True(t, cache.deleteCalls[0].hasDeadline)
+	require.WithinDuration(t, startedAt.Add(antigravityLocationUnsupportedDisableTimeout), cache.deleteCalls[0].deadline, time.Second)
+	require.Empty(t, writer.Body.String())
+}
+
 func TestAntigravityGatewayService_ForwardGemini_MissingProjectReturnsLocalError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	writer := httptest.NewRecorder()
@@ -483,6 +606,66 @@ func TestAntigravityGatewayService_Forward_PromptTooLong(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, events, 1)
 	require.Equal(t, "prompt_too_long", events[0].Kind)
+}
+
+func TestAntigravityGatewayService_Forward_LocationUnsupportedDisablesAccountAndFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	writer := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(writer)
+
+	body := []byte(`{"model":"gemini-3.6-flash-high","messages":[{"role":"user","content":"hi"}],"max_tokens":8}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	respBody := []byte(`{"error":{"code":400,"message":"User location is not supported for the API use.","status":"FAILED_PRECONDITION"}}`)
+	upstream := &httpUpstreamStub{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"X-Request-Id": []string{"location-400"}},
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+	}}
+	repo := &locationRestrictionAccountRepoStub{}
+	svc := &AntigravityGatewayService{
+		accountRepo:    repo,
+		settingService: NewSettingService(&antigravitySettingRepoStub{}, &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}),
+		tokenProvider:  &AntigravityTokenProvider{},
+		httpUpstream:   upstream,
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "location-restricted",
+		Platform:    PlatformAntigravity,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"model_mapping": map[string]any{
+				"gemini-3.6-flash-high": "gemini-3.6-flash-high",
+			},
+		},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, body, true)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.Equal(t, GatewayFailureScopeAccount, failoverErr.Scope)
+	require.False(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, writer.Body.String())
+	require.Len(t, repo.setErrorCalls, 1)
+	require.Equal(t, int64(1), repo.setErrorCalls[0].accountID)
+	require.Contains(t, repo.setErrorCalls[0].reason, "location")
+
+	raw, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := raw.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.NotEmpty(t, events)
+	require.Equal(t, "account_location_unsupported", events[len(events)-1].Kind)
 }
 
 // TestAntigravityGatewayService_Forward_ModelRateLimitTriggersFailover

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // antigravityFailingWriter 模拟客户端断开连接的 gin.ResponseWriter
@@ -199,6 +200,7 @@ type locationRestrictionErrorCall struct {
 type locationRestrictionAccountRepoStub struct {
 	AccountRepository
 	setErrorCalls []locationRestrictionErrorCall
+	setErrorErr   error
 }
 
 type locationRestrictionCacheCall struct {
@@ -216,7 +218,7 @@ type locationRestrictionCacheStub struct {
 
 func (r *locationRestrictionAccountRepoStub) SetError(ctx context.Context, id int64, reason string) error {
 	r.setErrorCalls = append(r.setErrorCalls, locationRestrictionErrorCall{accountID: id, reason: reason, ctxErr: ctx.Err()})
-	return nil
+	return r.setErrorErr
 }
 
 func (c *locationRestrictionCacheStub) DeleteSessionAccountID(ctx context.Context, groupID int64, sessionHash string) error {
@@ -419,6 +421,58 @@ func TestAntigravityGatewayService_ForwardGemini_PreservesServerSideToolInvocati
 	require.NotContains(t, toolConfig, "include_server_side_tool_invocations")
 }
 
+func TestAntigravityGatewayService_ForwardGemini_FlattensJSONSchemaRefsInFinalUpstreamPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	schema := `{"type":"object","properties":{"item":{"$ref":"#/$defs/Item"}},"required":["item"],"$defs":{"Item":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}}`
+
+	tests := []struct {
+		name         string
+		declarations string
+		schemaField  string
+	}{
+		{name: "camel parametersJsonSchema", declarations: "functionDeclarations", schemaField: "parametersJsonSchema"},
+		{name: "snake parameters_json_schema", declarations: "function_declarations", schemaField: "parameters_json_schema"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"tools":[{"` + tt.declarations + `":[{"name":"lookup","` + tt.schemaField + `":` + schema + `}]}]}`)
+			writer := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(writer)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", bytes.NewReader(body))
+
+			upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader("data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{}}}\n\n")),
+			}}}
+			svc := &AntigravityGatewayService{
+				settingService: NewSettingService(&antigravitySettingRepoStub{}, &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}),
+				tokenProvider:  &AntigravityTokenProvider{},
+				httpUpstream:   upstream,
+			}
+			account := &Account{
+				ID: 107, Name: "native-schema-ref", Platform: PlatformAntigravity, Type: AccountTypeOAuth, Status: StatusActive, Concurrency: 1,
+				Credentials: map[string]any{"access_token": "token", "project_id": "project-107", "model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"}},
+			}
+
+			result, err := svc.ForwardGemini(context.Background(), c, account, "gemini-2.5-flash", "generateContent", false, body, false)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, upstream.requestBodies, 1)
+
+			path := "request.tools.0." + tt.declarations + ".0." + tt.schemaField
+			require.Equal(t, "object", gjson.GetBytes(upstream.requestBodies[0], path+".properties.item.type").String())
+			require.Equal(t, "string", gjson.GetBytes(upstream.requestBodies[0], path+".properties.item.properties.name.type").String())
+			require.Equal(t, "name", gjson.GetBytes(upstream.requestBodies[0], path+".properties.item.required.0").String())
+			payload := string(upstream.requestBodies[0])
+			require.NotContains(t, payload, `"$ref"`)
+			require.NotContains(t, payload, `"$defs"`)
+			require.NotContains(t, payload, `"definitions"`)
+		})
+	}
+}
+
 func TestAntigravityGatewayService_ForwardGemini_LocationUnsupportedDisablesAccountAndFailsOver(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
@@ -499,6 +553,37 @@ func TestAntigravityGatewayService_HandleLocationUnsupportedUsesUncancelledConte
 	require.True(t, cache.deleteCalls[0].hasDeadline)
 	require.WithinDuration(t, startedAt.Add(antigravityLocationUnsupportedDisableTimeout), cache.deleteCalls[0].deadline, time.Second)
 	require.Empty(t, writer.Body.String())
+}
+
+func TestAntigravityGatewayService_HandleLocationUnsupported_SetErrorFailureStopsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	writer := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(writer)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", bytes.NewReader(nil))
+
+	repo := &locationRestrictionAccountRepoStub{setErrorErr: errors.New("database unavailable")}
+	cache := &locationRestrictionCacheStub{}
+	svc := &AntigravityGatewayService{accountRepo: repo, cache: cache}
+	account := &Account{ID: 106, Name: "persist-failure-location-restricted", Platform: PlatformAntigravity}
+
+	failoverErr := svc.handleAntigravityLocationUnsupported(
+		context.Background(),
+		c,
+		"[antigravity-Forward] account=persist-failure-location-restricted",
+		account,
+		http.StatusBadRequest,
+		http.Header{"X-Request-Id": []string{"location-persist-failure-400"}},
+		[]byte(`{"error":{"message":"User location is not supported for the API use."}}`),
+		77,
+		"session-persist-failure-location",
+	)
+
+	require.NotNil(t, failoverErr)
+	require.Equal(t, NextAccountStop, failoverErr.NextAccountAction)
+	require.Equal(t, GatewayFailureScopeProvider, failoverErr.Scope)
+	require.Equal(t, GatewayFailureReason("antigravity_location_unsupported_persist_failed"), failoverErr.Reason)
+	require.Len(t, repo.setErrorCalls, 1)
+	require.Empty(t, cache.deleteCalls, "do not clear sticky state as if durable isolation succeeded")
 }
 
 func TestAntigravityGatewayService_ForwardGemini_MissingProjectReturnsLocalError(t *testing.T) {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/googleapi"
@@ -3495,6 +3496,11 @@ func convertClaudeToolsToGeminiTools(tools any) []any {
 				"type":       "object",
 				"properties": map[string]any{},
 			}
+		}
+		// 先展开本地 $ref；旧兼容清理器会删除定义容器，不能让它
+		// 在展开前吞掉 $defs/definitions，否则工具参数会退化成空对象。
+		if paramsMap, ok := params.(map[string]any); ok {
+			antigravity.FlattenJSONSchemaRefs(paramsMap)
 		}
 		// 清理 JSON Schema
 		cleanedParams := cleanToolSchema(params)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type geminiCompatHTTPUpstreamStub struct {
@@ -498,6 +499,76 @@ func TestConvertClaudeToolsToGeminiTools_PreservesWebSearchAlongsideFunctions(t 
 	googleSearch, ok := searchDecl["googleSearch"].(map[string]any)
 	require.True(t, ok)
 	require.Empty(t, googleSearch)
+}
+
+func TestConvertClaudeMessagesToGeminiGenerateContent_FlattensToolSchemaRefs(t *testing.T) {
+	newSchema := func() map[string]any {
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"item": map[string]any{"$ref": "#/$defs/Item"},
+			},
+			"required": []any{"item"},
+			"$defs": map[string]any{
+				"Item": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+					"required": []any{"name"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		tool map[string]any
+	}{
+		{
+			name: "standard tool",
+			tool: map[string]any{
+				"name":         "standard_lookup",
+				"description":  "Lookup an item",
+				"input_schema": newSchema(),
+			},
+		},
+		{
+			name: "custom tool",
+			tool: map[string]any{
+				"type": "custom",
+				"name": "custom_lookup",
+				"custom": map[string]any{
+					"description":  "Lookup an item",
+					"input_schema": newSchema(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"messages": []any{
+					map[string]any{"role": "user", "content": "hello"},
+				},
+				"tools": []any{tt.tool},
+			})
+			require.NoError(t, err)
+
+			converted, err := convertClaudeMessagesToGeminiGenerateContent(body)
+			require.NoError(t, err)
+
+			path := "tools.0.functionDeclarations.0.parameters"
+			require.Equal(t, "OBJECT", gjson.GetBytes(converted, path+".properties.item.type").String())
+			require.Equal(t, "STRING", gjson.GetBytes(converted, path+".properties.item.properties.name.type").String())
+			require.Equal(t, "name", gjson.GetBytes(converted, path+".properties.item.required.0").String())
+			payload := string(converted)
+			require.NotContains(t, payload, `"$ref"`)
+			require.NotContains(t, payload, `"$defs"`)
+			require.NotContains(t, payload, `"definitions"`)
+		})
+	}
 }
 
 func TestGeminiHandleNativeNonStreamingResponse_DebugDisabledDoesNotEmitHeaderLogs(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalize Antigravity/Gemini tool schemas before forwarding, including local `$ref` expansion and Gemini-incompatible schema fields.
- Keep location-unsupported failures account-scoped so one upstream response cannot poison the whole Antigravity group.
- Preserve the behavior across Claude-compatible, native Gemini, and compatibility gateway paths.

## Tests

- `go test ./internal/pkg/antigravity ./internal/service -run 'Antigravity|CleanJSONSchema|LocationUnsupported' -count=1`
- Production smoke checks against both `/v1/messages` and `/v1/chat/completions` returned HTTP 200 with `gemini-3.8-flash`.

The branch contains the two focused commits `089da01` and `c5fd91d`; unrelated working-tree changes are not included.