### PR TITLE
fix(codex): preserve Astra Ultra workflow metadata

### DIFF
--- a/backend/internal/service/openai_codex_model_metadata.go
+++ b/backend/internal/service/openai_codex_model_metadata.go
@@ -9,6 +9,7 @@ import (
 
 var codexToolCapabilityFields = []string{
 	"supports_search_tool", "apply_patch_tool_type", "comp_hash", "tool_mode", "use_responses_lite",
+	"multi_agent_reasoning_effort", "multi_agent_version",
 }
 
 func applyCodexToolCapabilities(dst, src map[string]json.RawMessage, overwrite bool) bool {
@@ -18,7 +19,7 @@ func applyCodexToolCapabilities(dst, src map[string]json.RawMessage, overwrite b
 		if len(value) == 0 {
 			continue
 		}
-		// These five Codex fields are nullable booleans or strings, never arbitrary objects.
+		// These Codex fields are nullable booleans or strings, never arbitrary objects.
 		if !bytes.Equal(value, []byte("null")) {
 			if field == "supports_search_tool" || field == "use_responses_lite" {
 				if !bytes.Equal(value, []byte("true")) && !bytes.Equal(value, []byte("false")) {
@@ -396,6 +397,8 @@ func configuredCodexReasoningLevelDescription(level string) string {
 		return "Extra-high reasoning depth for difficult tasks"
 	case "max":
 		return "Maximum reasoning depth for complex tasks"
+	case "ultra":
+		return "Maximum reasoning with automatic task delegation"
 	default:
 		return "Reasoning effort supported by the upstream model"
 	}

--- a/backend/internal/service/openai_codex_model_metadata_test.go
+++ b/backend/internal/service/openai_codex_model_metadata_test.go
@@ -9,6 +9,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAstraUltraCatalogPreservesWorkflowMetadata(t *testing.T) {
+	// Ultra is a Codex workflow. Its inference effort must survive catalog sync,
+	// aliases and group generation instead of silently falling back to max.
+	_, metadata, err := extractUpstreamModelCatalog([]byte(`{"models":[{
+		"slug":"gpt-6-astra","supported_reasoning_levels":[{"effort":"high"},{"effort":"ultra"}],
+		"multi_agent_reasoning_effort":"high","multi_agent_version":"v2"
+	}]}`), false)
+	require.NoError(t, err)
+	account := Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+		"base_url": "https://relay.example/v1", "model_mapping": map[string]any{"public-astra": "gpt-6-astra"},
+	}}
+	account.SetUpstreamModelMetadataSnapshot(UpstreamModelMetadataSnapshot{Models: metadata})
+	body, err := buildCodexModelsManifestForAccounts(PlatformOpenAI, []string{"public-astra"}, []Account{account}, nil, true)
+	require.NoError(t, err)
+	model := decodeCodexManifestModels(t, body)[0]
+	require.Equal(t, "high", model["multi_agent_reasoning_effort"])
+	require.Equal(t, "v2", model["multi_agent_version"])
+	require.Equal(t, []string{"high", "ultra"}, effortsFromManifestModel(t, model))
+
+	peer := Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: account.Credentials}
+	body, err = buildCodexModelsManifestForAccounts(PlatformOpenAI, []string{"public-astra"}, []Account{account, peer}, nil, true)
+	require.NoError(t, err)
+	model = decodeCodexManifestModels(t, body)[0]
+	require.Nil(t, model["multi_agent_reasoning_effort"], "do not advertise one account's override for all peers")
+	require.Nil(t, model["multi_agent_version"])
+}
+
+func TestAstraUltraCatalogPreservesExplicitWorkflowOverrides(t *testing.T) {
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey,
+		Credentials: map[string]any{"base_url": "https://relay.example/v1"}}
+	for _, fields := range []string{
+		`"multi_agent_reasoning_effort":"high","multi_agent_version":"v1"`,
+		`"multi_agent_reasoning_effort":null,"multi_agent_version":null`,
+	} {
+		for _, source := range []string{
+			`{"models":[{"slug":"gpt-6-astra",` + fields + `}]}`,
+			`{"data":[{"id":"gpt-6-astra",` + fields + `}]}`,
+		} {
+			converted := convertOpenAIModelListToCodexManifestForAccount([]byte(source), account)
+			body, err := completeAPIKeyCodexModelsManifestMetadata(converted, true, account)
+			require.NoError(t, err)
+			model := decodeCodexManifestModels(t, body)[0]
+			var expected map[string]any
+			require.NoError(t, json.Unmarshal([]byte(`{`+fields+`}`), &expected))
+			for key, value := range expected {
+				require.Contains(t, model, key)
+				require.Equal(t, value, model[key])
+			}
+		}
+	}
+}
+
 func TestAstraCodexToolCapabilitiesUseAccountScopeAndSharedDeclarations(t *testing.T) {
 	newAccount := func(baseURL string) Account {
 		return Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -361,6 +361,7 @@ type configuredCodexModelDescriptor struct {
 	Description                       string                          `json:"description"`
 	DefaultReasoningLevel             *string                         `json:"default_reasoning_level,omitempty"`
 	SupportedReasoningLevels          []configuredCodexReasoningLevel `json:"supported_reasoning_levels"`
+	MultiAgentReasoningEffort         *string                         `json:"multi_agent_reasoning_effort,omitempty"`
 	ShellType                         string                          `json:"shell_type"`
 	Visibility                        string                          `json:"visibility"`
 	SupportedInAPI                    bool                            `json:"supported_in_api"`
@@ -492,6 +493,11 @@ func newConfiguredCodexModelDescriptor(modelID string) configuredCodexModelDescr
 				descriptor.MaxContextWindow = configuredCodexGPT56MaxContext
 			}
 			if isOpenAIGPT6AstraModel(modelID) {
+				// Codex resolves the Ultra workflow to this effort before inference.
+				// openai/codex a9896da3: codex-rs/models-manager/models.json.
+				multiAgentEffort := "xhigh"
+				descriptor.MultiAgentReasoningEffort = &multiAgentEffort
+				descriptor.MultiAgentVersion = "v2"
 				descriptor.ContextWindow = configuredCodexGPT6AstraContext
 				descriptor.MaxContextWindow = configuredCodexGPT6AstraContext
 			}
@@ -602,7 +608,7 @@ func configuredCodexGPTReasoningLevels(modelID string) []configuredCodexReasonin
 			Description: "Maximum reasoning depth for complex tasks",
 		})
 	}
-	if normalized == "gpt-5.6-sol" || normalized == "gpt-5.6-terra" {
+	if isOpenAIGPT6AstraModel(modelID) || normalized == "gpt-5.6-sol" || normalized == "gpt-5.6-terra" {
 		levels = append(levels, configuredCodexReasoningLevel{
 			Effort:      "ultra",
 			Description: "Maximum reasoning with automatic task delegation",

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -353,8 +353,10 @@ func TestNewConfiguredCodexModelDescriptorUsesProviderMetadataAndSafeFallback(t 
 	require.Equal(t, "GPT-6 Astra", gpt6Astra.DisplayName)
 	require.NotNil(t, gpt6Astra.DefaultReasoningLevel)
 	require.Equal(t, "medium", *gpt6Astra.DefaultReasoningLevel)
-	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max"}, effortsFromConfiguredCodexLevels(gpt6Astra.SupportedReasoningLevels))
-	require.NotContains(t, gpt6Astra.SupportedReasoningLevels, configuredCodexReasoningLevel{Effort: "ultra"})
+	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max", "ultra"}, effortsFromConfiguredCodexLevels(gpt6Astra.SupportedReasoningLevels))
+	require.NotNil(t, gpt6Astra.MultiAgentReasoningEffort)
+	require.Equal(t, "xhigh", *gpt6Astra.MultiAgentReasoningEffort)
+	require.Equal(t, "v2", gpt6Astra.MultiAgentVersion)
 	require.NotContains(t, gpt6Astra.SupportedReasoningLevels, configuredCodexReasoningLevel{Effort: "none"})
 	require.True(t, configuredCodexSupportsPriorityServiceTier("gpt-6-astra"))
 	require.Equal(t, []configuredCodexServiceTier{{
@@ -370,7 +372,8 @@ func TestNewConfiguredCodexModelDescriptorUsesProviderMetadataAndSafeFallback(t 
 	require.Equal(t, int64(1_050_000), gpt6Astra.MaxContextWindow)
 	gpt6 := newConfiguredCodexModelDescriptor("gpt-6")
 	require.Equal(t, "GPT-6 (Astra)", gpt6.DisplayName)
-	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max"}, effortsFromConfiguredCodexLevels(gpt6.SupportedReasoningLevels))
+	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max", "ultra"}, effortsFromConfiguredCodexLevels(gpt6.SupportedReasoningLevels))
+	require.Equal(t, "xhigh", *gpt6.MultiAgentReasoningEffort)
 	require.Equal(t, int64(1_050_000), gpt6.ContextWindow)
 
 	gpt55 := newConfiguredCodexModelDescriptor("gpt-5.5")

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -373,6 +373,7 @@ func TestNewConfiguredCodexModelDescriptorUsesProviderMetadataAndSafeFallback(t 
 	gpt6 := newConfiguredCodexModelDescriptor("gpt-6")
 	require.Equal(t, "GPT-6 (Astra)", gpt6.DisplayName)
 	require.Equal(t, []string{"low", "medium", "high", "xhigh", "max", "ultra"}, effortsFromConfiguredCodexLevels(gpt6.SupportedReasoningLevels))
+	require.NotNil(t, gpt6.MultiAgentReasoningEffort)
 	require.Equal(t, "xhigh", *gpt6.MultiAgentReasoningEffort)
 	require.Equal(t, int64(1_050_000), gpt6.ContextWindow)
 


### PR DESCRIPTION
## Summary

Restore GPT-6 Astra's Ultra option in generated Codex catalogs and preserve the metadata that tells Codex how to execute it. This is a catalog/workflow fix, not a new inference reasoning level.

The current fallback advertises Astra only through `max`. Merely appending `ultra` would also be incorrect: without `multi_agent_reasoning_effort`, Codex falls back to `max`, whereas the official Astra catalog specifies `xhigh`.

## Source of truth

Verified against `openai/codex` commit `a9896da3febcaf30e1c5d7b452fb6334b1a0bc51`:

- [Bundled models.json](https://github.com/openai/codex/blob/a9896da3febcaf30e1c5d7b452fb6334b1a0bc51/codex-rs/models-manager/models.json): Astra advertises `low, medium, high, xhigh, max, ultra`, `multi_agent_reasoning_effort: "xhigh"`, and `multi_agent_version: "v2"`.
- [ModelInfo::resolve_reasoning_effort](https://github.com/openai/codex/blob/a9896da3febcaf30e1c5d7b452fb6334b1a0bc51/codex-rs/protocol/src/openai_models/reasoning_effort.rs): Ultra resolves to the advertised override; otherwise it falls back to `max`, another supported non-Ultra effort, or `medium`.
- [effective_multi_agent_mode](https://github.com/openai/codex/blob/a9896da3febcaf30e1c5d7b452fb6334b1a0bc51/codex-rs/core/src/session/multi_agents.rs): Ultra selects proactive multi-agent behavior under v2 unless explicit mode instructions override it.

## Changes

- Add Astra Ultra to the fallback catalog, together with its `xhigh` inference override and v2 selector; the `gpt-6` alias uses the same descriptor.
- Preserve `multi_agent_reasoning_effort` and `multi_agent_version` through upstream catalog extraction, persisted metadata, routed group catalogs, and standard model-list conversion using the existing nullable-scalar capability path.
- Preserve provider overrides and explicit `null`; conflicting/missing peer metadata keeps the existing conservative intersection behavior.
- Describe Ultra as automatic task delegation, including metadata-synced levels.

This does not alter raw Responses request normalization, billing, group effort limits, or implement server-side subagents. Codex translates Ultra to the ordinary inference effort before requests reach Sub2API. Explicit provider reasoning-level lists retain precedence over the fallback.

## Validation

- `go test ./internal/service -run 'Test(AstraUltra|AstraCodexTool|NewConfiguredCodexModelDescriptor|BuildCodexModelsManifest|CompleteAPIKeyCodexModelsManifest|SyncUpstreamModelCatalog)' -count=1` passed on upstream `ab99d56e9626e6cd731592dae8553c9758a0efa2` plus this patch.
- The same targeted tests passed on the downstream fork in an isolated checkout.
- Installed `codex-cli 0.153.4`, with an isolated home and the corrected catalog, sent `reasoning.effort: "xhigh"` when configured for `ultra`. A loopback-only endpoint captured the request and intentionally returned HTTP 400; no remote inference was performed.
- `git diff --check` passed.

The new regressions cover metadata extraction/snapshot round-trip, aliases, group intersection, native and converted catalogs, and explicit overrides/nulls. Existing descriptor tests verify Astra and its alias; other model expectations remain unchanged.

## Related PRs

Follow-up to #6572 and #6628. The latter explicitly used an Astra fallback without Ultra. Open #6678 addresses stale image modalities and #6690 addresses `reasoning.mode`; neither covers this workflow metadata. No duplicate Ultra PR was found in the open/all-state keyword searches.

Local Codex configuration and catalog files are not included in this PR.
