### PR TITLE
feat(admin): link subscriptions to user usage

### DIFF
--- a/frontend/src/views/admin/SubscriptionsView.vue
+++ b/frontend/src/views/admin/SubscriptionsView.vue
@@ -190,12 +190,15 @@
                   }}
                 </span>
               </div>
-              <span class="font-medium text-gray-900 dark:text-white">
+              <RouterLink
+                :to="{ path: '/admin/usage', query: { user_id: row.user_id } }"
+                class="rounded font-medium text-gray-900 hover:text-primary-600 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:text-white dark:hover:text-primary-400 dark:focus-visible:ring-offset-dark-800"
+              >
                 {{ userColumnMode === 'email'
                   ? (row.user?.email || t('admin.redeem.userPrefix', { id: row.user_id }))
-                  : (row.user?.username || '-')
+                  : (row.user?.username || t('admin.redeem.userPrefix', { id: row.user_id }))
                 }}
-              </span>
+              </RouterLink>
             </div>
           </template>
 

--- a/frontend/src/views/admin/__tests__/SubscriptionsView.userUsageLink.spec.ts
+++ b/frontend/src/views/admin/__tests__/SubscriptionsView.userUsageLink.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+
+import SubscriptionsView from '../SubscriptionsView.vue'
+
+const { listSubscriptions, getAllGroups } = vi.hoisted(() => ({
+  listSubscriptions: vi.fn(),
+  getAllGroups: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    subscriptions: { list: listSubscriptions },
+    groups: { getAll: getAllGroups }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string, params?: { id?: number }) =>
+        key === 'admin.redeem.userPrefix' ? `User #${params?.id}` : key
+    })
+  }
+})
+
+const DataTableStub = {
+  props: ['data'],
+  template: `
+    <div>
+      <div v-for="row in data" :key="row.id">
+        <slot name="cell-user" :row="row" />
+      </div>
+    </div>
+  `
+}
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLink',
+  props: { to: { type: Object, required: true } },
+  template: '<a :href="`${to.path}?user_id=${to.query.user_id}`"><slot /></a>'
+})
+
+describe('admin subscription user usage link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    listSubscriptions.mockResolvedValue({
+      items: [{
+        id: 9,
+        user_id: 42,
+        group_id: 3,
+        status: 'active',
+        starts_at: '2026-01-01T00:00:00Z',
+        expires_at: null,
+        daily_usage_usd: 0,
+        weekly_usage_usd: 0,
+        monthly_usage_usd: 0,
+        daily_window_start: null,
+        weekly_window_start: null,
+        monthly_window_start: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        user: { email: 'reader@example.com', username: 'Reader' }
+      }],
+      total: 1,
+      pages: 1
+    })
+    getAllGroups.mockResolvedValue([])
+  })
+
+  const mountView = () => mount(SubscriptionsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: { template: '<div><slot name="table" /></div>' },
+        DataTable: DataTableStub,
+        RouterLink: RouterLinkStub,
+        Pagination: true,
+        BaseDialog: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        Select: true,
+        GroupBadge: true,
+        GroupOptionItem: true,
+        Icon: true,
+        Teleport: true
+      }
+    }
+  })
+
+  it('renders the user email as a link to that user filtered usage records', async () => {
+    const wrapper = mountView()
+
+    await flushPromises()
+
+    const link = wrapper.getComponent(RouterLinkStub)
+    expect(link.text()).toBe('reader@example.com')
+    expect(link.props('to')).toEqual({ path: '/admin/usage', query: { user_id: 42 } })
+  })
+
+  it('uses the user ID label for the usage link when username mode has no username', async () => {
+    localStorage.setItem('subscription-user-column-mode', 'username')
+    listSubscriptions.mockResolvedValue({
+      items: [{
+        id: 9,
+        user_id: 42,
+        group_id: 3,
+        status: 'active',
+        starts_at: '2026-01-01T00:00:00Z',
+        expires_at: null,
+        daily_usage_usd: 0,
+        weekly_usage_usd: 0,
+        monthly_usage_usd: 0,
+        daily_window_start: null,
+        weekly_window_start: null,
+        monthly_window_start: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        user: { email: 'reader@example.com' }
+      }],
+      total: 1,
+      pages: 1
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const link = wrapper.getComponent(RouterLinkStub)
+    expect(link.text()).toBe('User #42')
+    expect(link.props('to')).toEqual({ path: '/admin/usage', query: { user_id: 42 } })
+  })
+})


### PR DESCRIPTION
## 背景
订阅管理列表展示了用户信息，但管理员无法直接下钻到该用户的使用记录，需要手动复制并重新筛选。

## 改动
- 将订阅列表中的用户邮箱或用户名改为可访问的站内链接。
- 点击后跳转到 `/admin/usage?user_id=<id>`，复用现有用户筛选与标签加载逻辑。
- 用户名缺失时使用用户 ID 标签，避免出现无意义的链接文本。
- 增加聚焦回归测试，覆盖邮箱链接和用户名缺失回退。

## 验证
已验证：
- 前端完整 lint、类型检查与关键测试通过（168 tests）。
- 新增定向测试及相邻测试通过（5 tests）。
- 前端生产构建通过。
- 后端 unit 全量测试重跑通过，integration 全量测试通过。
- golangci-lint v2.13.0 通过（0 issues）。
- Linux 可执行的部署脚本检查通过；macOS 专用权限断言因 Linux stat 语法差异不适用，本次未修改部署脚本。
- `git diff --check` 通过。

Fixes #6723
