### PR TITLE
fix(codex): preserve allowed_tools selection constraints

### DIFF
--- a/backend/internal/service/openai_codex_tool_names.go
+++ b/backend/internal/service/openai_codex_tool_names.go
@@ -115,6 +115,9 @@ func collectOpenAIResponsesToolNameFields(reqBody map[string]any) []codexToolNam
 		}
 	}
 	if choice, ok := reqBody["tool_choice"].(map[string]any); ok {
+		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(choice["type"])), "allowed_tools") {
+			collectTools(choice["tools"])
+		}
 		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(choice["type"])), "function") {
 			appendName(choice, "name")
 			if function, ok := choice["function"].(map[string]any); ok {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -357,6 +357,12 @@ func normalizeCodexToolChoice(reqBody map[string]any) bool {
 	if choiceType == "" {
 		return false
 	}
+	if choiceType == "allowed_tools" {
+		// This is a selection policy, not a declared tool type. Preserve it for
+		// upstream validation (including references to input.additional_tools);
+		// falling back to auto would silently discard the caller's restriction.
+		return false
+	}
 	modified := false
 	if choiceType == "function" {
 		name := strings.TrimSpace(firstNonEmptyString(choiceMap["name"]))

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -475,6 +476,74 @@ func TestApplyCodexOAuthTransform_StringifiesNonStringMessageContentText(t *test
 	part, ok := content[0].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, `["a","b"]`, part["text"])
+}
+
+func TestApplyCodexOAuthTransform_PreservesAllowedTools(t *testing.T) {
+	for _, placement := range []string{"top_level", "additional_tools"} {
+		for _, mode := range []string{"auto", "required"} {
+			t.Run(placement+"/"+mode, func(t *testing.T) {
+				decision := map[string]any{"type": "function", "name": "ProbeAccept"}
+				choice := map[string]any{
+					"type": "allowed_tools", "mode": mode,
+					"tools": []any{map[string]any{"type": "function", "name": "ProbeAccept"}},
+				}
+				tools := []any{
+					map[string]any{"type": "function", "name": "ProbeBase"},
+					map[string]any{"type": "web_search"},
+					map[string]any{"type": "image_generation"},
+				}
+				input := []any{map[string]any{"type": "message", "role": "user", "content": "probe"}}
+				if placement == "top_level" {
+					tools = append(tools, decision)
+				} else {
+					input = append(input, map[string]any{
+						"type": "additional_tools", "role": "developer", "tools": []any{decision},
+					})
+				}
+				reqBody := map[string]any{"tools": tools, "input": input, "tool_choice": choice}
+				before, err := json.Marshal(reqBody)
+				require.NoError(t, err)
+				reqBody["model"] = "gpt-6-astra"
+				result := applyCodexOAuthTransform(reqBody, true, false)
+				require.NoError(t, result.Error)
+				after, err := json.Marshal(map[string]any{
+					"tools": reqBody["tools"], "input": reqBody["input"], "tool_choice": reqBody["tool_choice"],
+				})
+				require.NoError(t, err)
+				require.JSONEq(t, string(before), string(after))
+			})
+		}
+	}
+}
+
+func TestNormalizeCodexToolChoice_InvalidAllowedToolsNeverBecomesAuto(t *testing.T) {
+	for _, choice := range []map[string]any{
+		{"type": "allowed_tools"},
+		{"type": "allowed_tools", "mode": "invalid", "tools": []any{}},
+		{"type": "allowed_tools", "mode": "required", "tools": "invalid"},
+		{"type": "allowed_tools", "mode": "required", "tools": []any{map[string]any{"type": "function", "name": "missing"}}},
+	} {
+		reqBody := map[string]any{"tool_choice": choice}
+		require.False(t, normalizeCodexToolChoice(reqBody))
+		// The upstream owns schema validation. A malformed restriction must never
+		// silently become permission to call every supplied tool.
+		require.Equal(t, choice, reqBody["tool_choice"])
+	}
+}
+
+func TestApplyCodexOAuthTransform_AllowedToolsKeepsReservedNameReferences(t *testing.T) {
+	declaration := map[string]any{"type": "function", "name": "python"}
+	reference := map[string]any{"type": "function", "name": "python"}
+	choice := map[string]any{"type": "allowed_tools", "mode": "required", "tools": []any{reference}}
+	reqBody := map[string]any{
+		"model": "gpt-6-astra", "tools": []any{declaration}, "tool_choice": choice,
+	}
+	result := applyCodexOAuthTransform(reqBody, true, false)
+	require.NoError(t, result.Error)
+	require.Equal(t, choice, reqBody["tool_choice"])
+	require.Equal(t, codexPythonToolAlias, declaration["name"])
+	require.Equal(t, codexPythonToolAlias, reference["name"])
+	require.Equal(t, "python", result.ToolNameReverse[codexPythonToolAlias])
 }
 
 func TestApplyCodexOAuthTransform_DowngradesUnknownToolChoice(t *testing.T) {


### PR DESCRIPTION
## Problem

`normalizeCodexToolChoice` treats object-form `tool_choice.type` as a declared tool type. However, `allowed_tools` is a selection policy, not a tool declaration. Since no tool is declared with that type, the normalizer replaces the policy with `"auto"`, silently dropping the caller's restriction.

This also affects policies referencing functions declared in `input.additional_tools`. Callers should be able to keep a stable top-level tool list for prompt caching while restricting which tools may be called for the current request.

## Changes

- Preserve `tool_choice: {"type":"allowed_tools", ...}` for upstream validation rather than downgrading it to `"auto"`. Malformed policies are likewise left to upstream validation, not silently weakened.
- Include the policy's nested function references in the existing reserved-name alias traversal, so a function such as `python` is renamed consistently in both its declaration and its allowlist reference.
- Add regressions for `auto`/`required` modes, top-level/`additional_tools` declarations, malformed policies, and reserved-name alias consistency.

The production change is 9 added lines across two existing helpers, plus 69 lines of tests. No new configuration, dependencies, database changes, caching implementation, or parallel-call policy changes.

## Validation

- [x] `cd backend && go test ./internal/service -run 'Test.*(CodexOAuthTransform|CodexToolChoice|CodexToolName)' -count=1 -timeout=120s`
- [x] `git diff --check origin/main...HEAD`
- [x] Built and deployed a Linux/amd64 image; smoke-tested `additional_tools` with an `allowed_tools` policy through the gateway. A real client-side confirmation request completed with the expected allowed decision call while `parallel_tool_calls` remained enabled.

Full repository CI is left to the upstream workflow. No separate issue was opened for this focused fix.