### PR TITLE
feat: add opt-in logging for upstream OpenAI engine telemetry

### DIFF
--- a/backend/internal/pkg/enginetrace/trace.go
+++ b/backend/internal/pkg/enginetrace/trace.go
@@ -1,0 +1,162 @@
+// Package enginetrace records upstream engine telemetry without interpreting model identity.
+package enginetrace
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+var outputOnce sync.Once
+var output io.Writer
+
+type Record struct {
+	Time           string          `json:"time"`
+	RequestID      string          `json:"request_id"`
+	AccountID      int64           `json:"account_id"`
+	RequestedModel string          `json:"requested_model"`
+	UpstreamModel  string          `json:"upstream_model"`
+	Transport      string          `json:"transport"`
+	ResponseID     string          `json:"response_id"`
+	ResponseModel  string          `json:"response_model"`
+	EventType      string          `json:"event_type"`
+	Status         string          `json:"status"`
+	EngineIDs      json.RawMessage `json:"engine_ids"`
+	FieldPath      string          `json:"field_path,omitempty"`
+}
+
+// A Trace belongs to one upstream attempt, or to a serial WebSocket relay.
+type Trace struct {
+	writer   io.Writer
+	record   Record
+	terminal bool
+}
+
+func New(requestID string, accountID int64, requestedModel, upstreamModel, transport string) *Trace {
+	path := os.Getenv("SUB2API_ENGINE_LOG")
+	if path == "" {
+		return nil
+	}
+	outputOnce.Do(func() {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			log.Printf("engine trace: cannot create log directory: %v", err)
+			return
+		}
+		output = &lumberjack.Logger{Filename: path, MaxSize: 16, MaxBackups: 7, MaxAge: 14, Compress: true}
+	})
+	if output == nil {
+		return nil
+	}
+	return &Trace{writer: output, record: Record{
+		RequestID: requestID, AccountID: accountID, RequestedModel: requestedModel,
+		UpstreamModel: upstreamModel, Transport: transport, Status: "not_observed",
+	}}
+}
+
+// Models updates the request metadata for the current turn of a persistent relay.
+func (t *Trace) Models(requested, upstream string) {
+	if t != nil {
+		t.record.RequestedModel, t.record.UpstreamModel = requested, upstream
+	}
+}
+
+func (t *Trace) Observe(payload []byte, eventType string) {
+	if t == nil {
+		return
+	}
+	if eventType == "" {
+		eventType = gjson.GetBytes(payload, "type").String()
+	}
+	// Never inspect output items, deltas, tool arguments or arbitrary nested JSON.
+	if strings.HasSuffix(eventType, ".delta") || strings.HasPrefix(eventType, "response.output_item.") || strings.HasPrefix(eventType, "response.function_call_arguments.") {
+		return
+	}
+	if !gjson.ValidBytes(payload) {
+		return
+	}
+	if eventType == "response.created" && t.terminal {
+		t.record.ResponseID, t.record.ResponseModel, t.record.FieldPath = "", "", ""
+		t.record.EngineIDs, t.record.Status, t.terminal = nil, "not_observed", false
+	}
+	for _, path := range []string{"response.id", "response_id", "id"} {
+		if value := gjson.GetBytes(payload, path); value.Type == gjson.String && value.Str != "" {
+			t.record.ResponseID = value.Str
+			break
+		}
+	}
+	for _, path := range []string{"response.model", "model"} {
+		if value := gjson.GetBytes(payload, path); value.Type == gjson.String && value.Str != "" {
+			t.record.ResponseModel = value.Str
+			break
+		}
+	}
+	found := false
+	for _, path := range []string{
+		"timing_metrics.engine_ids", "response.timing_metrics.engine_ids",
+		"metadata.timing_metrics.engine_ids", "response.metadata.timing_metrics.engine_ids",
+	} {
+		value := gjson.GetBytes(payload, path)
+		if !value.Exists() {
+			continue
+		}
+		found = true
+		t.record.EngineIDs = append(json.RawMessage(nil), value.Raw...)
+		t.record.FieldPath = path
+		t.record.Status = "invalid"
+		if value.Type == gjson.Null {
+			t.record.Status = "empty"
+		} else if value.Type == gjson.String {
+			t.record.Status = "observed"
+			if strings.TrimSpace(value.Str) == "" {
+				t.record.Status = "empty"
+			}
+		} else if value.IsArray() {
+			t.record.Status = "empty"
+			for _, id := range value.Array() {
+				if id.Type != gjson.String {
+					t.record.Status = "invalid"
+					break
+				}
+				if strings.TrimSpace(id.Str) != "" {
+					t.record.Status = "observed"
+				}
+			}
+		}
+		t.write(eventType)
+	}
+	switch eventType {
+	case "response.completed", "response.done", "response.failed", "response.incomplete", "response.cancelled", "response.canceled", "error":
+		t.terminal = true
+		if !found {
+			t.write(eventType)
+		}
+	}
+}
+
+// Close records incomplete streams too; absence is never treated as a healthy model.
+func (t *Trace) Close() {
+	if t != nil && !t.terminal {
+		t.write("stream_closed")
+		t.terminal = true
+	}
+}
+
+func (t *Trace) write(eventType string) {
+	t.record.Time = time.Now().UTC().Format(time.RFC3339Nano)
+	t.record.EventType = eventType
+	data, err := json.Marshal(t.record)
+	if err == nil {
+		_, err = t.writer.Write(append(data, '\n'))
+	}
+	if err != nil {
+		log.Printf("engine trace: log write failed: %v", err)
+	}
+}

--- a/backend/internal/pkg/enginetrace/trace_test.go
+++ b/backend/internal/pkg/enginetrace/trace_test.go
@@ -1,0 +1,88 @@
+package enginetrace
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTelemetryLifecycle(t *testing.T) {
+	var out bytes.Buffer
+	trace := &Trace{writer: &out, record: Record{RequestID: "req1", AccountID: 27, RequestedModel: "sol", Status: "not_observed"}}
+	trace.Observe([]byte(`{"type":"response.created","response":{"id":"resp1","model":"sol"}}`), "")
+	trace.Observe([]byte(`{"type":"response.timing","timing_metrics":{"engine_ids":["gpt56lun-codex-a","gpt56sol-codex-b"]}}`), "")
+	trace.Observe([]byte(`{"type":"response.completed","response":{"id":"resp1","model":"sol"}}`), "")
+	trace.Close()
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d records: %s", len(lines), out.String())
+	}
+	var record Record
+	if err := json.Unmarshal([]byte(lines[1]), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Status != "observed" || string(record.EngineIDs) != `["gpt56lun-codex-a","gpt56sol-codex-b"]` || record.ResponseID != "resp1" || record.ResponseModel != "sol" || record.AccountID != 27 {
+		t.Fatalf("lost telemetry or association: %+v", record)
+	}
+	trace.Observe([]byte(`{"type":"response.created","response":{"id":"resp2","model":"sol"}}`), "")
+	trace.Observe([]byte(`{"type":"response.completed","response":{"id":"resp2"}}`), "")
+	lines = strings.Split(strings.TrimSpace(out.String()), "\n")
+	if err := json.Unmarshal([]byte(lines[2]), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Status != "not_observed" || string(record.EngineIDs) != "null" {
+		t.Fatalf("previous turn leaked: %+v", record)
+	}
+}
+
+func TestFieldShapesAndPaths(t *testing.T) {
+	for _, tc := range []struct{ value, status string }{
+		{`"gpt56lun-codex-test"`, "observed"}, {`["a","b"]`, "observed"},
+		{`null`, "empty"}, {`[]`, "empty"}, {`""`, "empty"}, {`[""]`, "empty"},
+		{`123`, "invalid"}, {`["a",42]`, "invalid"}, {`{"x":1}`, "invalid"},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			var out bytes.Buffer
+			trace := &Trace{writer: &out}
+			payload := []byte(`{"type":"response.completed","response":{"metadata":{"timing_metrics":{"engine_ids":` + tc.value + `}}}}`)
+			before := string(payload)
+			trace.Observe(payload, "")
+			if trace.record.Status != tc.status || string(trace.record.EngineIDs) != tc.value || trace.record.FieldPath != "response.metadata.timing_metrics.engine_ids" {
+				t.Fatalf("bad record: %+v", trace.record)
+			}
+			if string(payload) != before {
+				t.Fatal("mutated response")
+			}
+		})
+	}
+}
+
+func TestOutputCannotImpersonateTelemetry(t *testing.T) {
+	var out bytes.Buffer
+	trace := &Trace{writer: &out, record: Record{Status: "not_observed"}}
+	trace.Observe([]byte(`{"type":"response.output_item.done","item":{"timing_metrics":{"engine_ids":"fake"},"text":"secret prompt"}}`), "")
+	trace.Observe([]byte(`{"type":"response.completed","response":{"output":[{"timing_metrics":{"engine_ids":"fake"},"text":"secret answer"}]}}`), "")
+	if trace.record.Status != "not_observed" || strings.Contains(out.String(), "secret") || strings.Contains(out.String(), "fake") {
+		t.Fatalf("captured content: %s", out.String())
+	}
+}
+
+type failedWriter struct{}
+
+func (failedWriter) Write([]byte) (int, error) { return 0, errors.New("disk unavailable") }
+
+func TestDisabledMalformedAndFailedLogging(t *testing.T) {
+	t.Setenv("SUB2API_ENGINE_LOG", "")
+	trace := New("", 0, "", "", "")
+	if trace != nil {
+		t.Fatal("tracing should be disabled")
+	}
+	trace.Observe(nil, "")
+	trace.Close()
+	trace = &Trace{writer: failedWriter{}, record: Record{Status: "not_observed"}}
+	trace.Observe([]byte(`{"timing_metrics":`), "")
+	trace.Observe([]byte(`{"type":"response.completed"}`), "")
+	trace.Close()
+}

--- a/backend/internal/service/openai_engine_trace.go
+++ b/backend/internal/service/openai_engine_trace.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/enginetrace"
+	"github.com/gin-gonic/gin"
+)
+
+func newOpenAIEngineTrace(c *gin.Context, account *Account, requestedModel, upstreamModel, transport string) *enginetrace.Trace {
+	if c == nil || account == nil || account.Platform != PlatformOpenAI {
+		return nil
+	}
+	requestID := ""
+	if c.Request != nil {
+		requestID, _ = c.Request.Context().Value(ctxkey.RequestID).(string)
+	}
+	return enginetrace.New(requestID, account.ID, requestedModel, upstreamModel, transport)
+}

--- a/backend/internal/service/openai_engine_trace_test.go
+++ b/backend/internal/service/openai_engine_trace_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/enginetrace"
+	"github.com/gin-gonic/gin"
+)
+
+func TestOpenAIEngineTrace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "engine.jsonl")
+	t.Setenv("SUB2API_ENGINE_LOG", path)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/responses", nil)
+	c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), ctxkey.RequestID, "request-test"))
+	o := &upstreamResponseModelObserver{engineTrace: newOpenAIEngineTrace(c, &Account{ID: 27, Platform: PlatformOpenAI}, "sol", "sol", "sse")}
+	o.ObserveOpenAI([]byte(`{"type":"response.completed","response":{"id":"resp-test","model":"sol"},"timing_metrics":{"engine_ids":["gpt56lun-codex-test"]}}`), "response.completed")
+	o.engineTrace.Close()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record enginetrace.Record
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.RequestID != "request-test" || record.AccountID != 27 || record.Status != "observed" || string(record.EngineIDs) != `["gpt56lun-codex-test"]` {
+		t.Fatalf("bad record: %+v", record)
+	}
+	if o.Model() != "sol" || o.Conflict() {
+		t.Fatal("telemetry affected response-model observation")
+	}
+}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1837,6 +1837,8 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
 	}
+	observer.engineTrace = newOpenAIEngineTrace(c, account, originalModel, mappedModel, "sse_passthrough")
+	defer observer.engineTrace.Close()
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
 	// SSE headers
@@ -2271,6 +2273,8 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
 	}
+	observer.engineTrace = newOpenAIEngineTrace(c, account, originalModel, mappedModel, "http_passthrough")
+	defer observer.engineTrace.Close()
 	if bodyHasSSEFraming(body) {
 		observeOpenAISSEBody(observer, string(body))
 	} else {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -53,6 +53,8 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
 	}
+	observer.engineTrace = newOpenAIEngineTrace(c, account, originalModel, mappedModel, "sse")
+	defer observer.engineTrace.Close()
 	firstOutputTimeout := time.Duration(0)
 	if account != nil && account.Platform == PlatformOpenAI {
 		firstOutputTimeout = s.openAIFirstOutputTimeout(reasoningEffort)
@@ -1567,6 +1569,8 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
 	}
+	observer.engineTrace = newOpenAIEngineTrace(c, account, originalModel, mappedModel, "http")
+	defer observer.engineTrace.Close()
 	if bodyHasSSEFraming(body) {
 		observeOpenAISSEBody(observer, string(body))
 	} else {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -942,7 +942,8 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 	var rejectedFieldRetryState *openAIResponsesRejectedFieldRetryState
 	sendAndRelay := func(turn int, lease *openAIWSConnLease, payload []byte, payloadBytes int, originalModel string, imageBillingModel string, imageSizeTier string, imageInputSize string, requestedReasoningEffort *string) (*OpenAIForwardResult, error) {
-		responseModelObserver := &upstreamResponseModelObserver{}
+		responseModelObserver := &upstreamResponseModelObserver{engineTrace: newOpenAIEngineTrace(c, account, originalModel, gjson.GetBytes(payload, "model").String(), "websocket_ingress")}
+		defer responseModelObserver.engineTrace.Close()
 		if lease == nil {
 			return nil, errors.New("upstream websocket lease is nil")
 		}

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -37,7 +37,8 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	if s == nil || account == nil {
 		return nil, wrapOpenAIWSFallback("invalid_state", errors.New("service or account is nil"))
 	}
-	responseModelObserver := &upstreamResponseModelObserver{}
+	responseModelObserver := &upstreamResponseModelObserver{engineTrace: newOpenAIEngineTrace(c, account, originalModel, mappedModel, "websocket")}
+	defer responseModelObserver.engineTrace.Close()
 
 	wsURL, err := s.buildOpenAIResponsesWSURL(account)
 	if err != nil {

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -432,7 +432,8 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 	if writeClientMessage == nil {
 		return nil, errors.New("client websocket writer is nil")
 	}
-	responseModelObserver := &upstreamResponseModelObserver{}
+	responseModelObserver := &upstreamResponseModelObserver{engineTrace: newOpenAIEngineTrace(c, account, originalModel, gjson.GetBytes(payload, "model").String(), "sse_ws_bridge")}
+	defer responseModelObserver.engineTrace.Close()
 
 	body, err := prepareOpenAIWSHTTPBridgeBody(account, payload)
 	if err != nil {
@@ -640,6 +641,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 	bareErrorMessage := ""
 	failureAccountSideEffectsApplied := false
 	mappedModel := actualModel
+	responseModelObserver.engineTrace.Models(originalModel, mappedModel)
 	needModelReplace := false
 	var mappedModelBytes []byte
 	if originalModel != "" {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -1162,6 +1162,9 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		firstTurnStartedAt = hooks.InitialTurnStartedAt
 	}
 	failureAccountSideEffectsApplied := false
+	traceRequestedModel, traceUpstreamModel := usageMeta.turnModels("")
+	engineTrace := newOpenAIEngineTrace(c, account, traceRequestedModel, traceUpstreamModel, "websocket_passthrough")
+	defer engineTrace.Close()
 	relayResult, relayExit := openaiwsv2.RunEntry(openaiwsv2.EntryInput{
 		Ctx:                ctx,
 		ClientConn:         policyClientConn,
@@ -1273,6 +1276,9 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				if msgType != coderws.MessageText {
 					return nil
 				}
+				traceRequestedModel, traceUpstreamModel := usageMeta.turnModels("")
+				engineTrace.Models(traceRequestedModel, traceUpstreamModel)
+				engineTrace.Observe(payload, "")
 				eventType, _, _ := parseOpenAIWSEventEnvelope(payload)
 				if eventType == "response.created" {
 					failureAccountSideEffectsApplied = false

--- a/backend/internal/service/upstream_response_model.go
+++ b/backend/internal/service/upstream_response_model.go
@@ -3,6 +3,7 @@ package service
 import (
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/enginetrace"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
@@ -26,9 +27,10 @@ const (
 // separate from the final outbound request tier until usage recording resolves
 // the billable tier for the selected credential protocol.
 type upstreamResponseModelObserver struct {
-	first    string
-	terminal string
-	conflict bool
+	engineTrace *enginetrace.Trace
+	first       string
+	terminal    string
+	conflict    bool
 
 	// firstTier holds the first non-terminal tier declaration; it is discarded
 	// when later non-terminal declarations disagree. terminalTier comes from a
@@ -69,6 +71,9 @@ func normalizeObservedUpstreamResponseModel(model string) string {
 }
 
 func (o *upstreamResponseModelObserver) ObserveOpenAI(payload []byte, eventType string) {
+	if o != nil {
+		o.engineTrace.Observe(payload, eventType)
+	}
 	model := firstValidTrimmedGJSONString(payload, "response.model", "model")
 	terminal := isUpstreamResponseModelTerminalEvent(eventType)
 	o.Observe(model, terminal)


### PR DESCRIPTION
OpenAI-compatible upstream responses can contain timing_metrics.engine_ids, but Sub2API currently persists only the declared response model. This adds an opt-in JSONL collector so operators can inspect the original engine telemetry associated with a request.

Set SUB2API_ENGINE_LOG to a persistent file path to enable collection. Records include request/account/response IDs, requested and mapped model names, transport, the original engine_ids JSON value, its allowlisted field path, and an explicit observed/not_observed/empty/invalid status. Missing telemetry is not interpreted as successful model verification or a model downgrade.

The patch connects to existing response-model observation for native Responses SSE/JSON, HTTP passthrough, pooled WebSocket and ingress/bridge paths, plus the existing upstream callback for WebSocket passthrough. It does not modify forwarding, routing, billing or database schemas. Collection is disabled by default and reuses the existing lumberjack dependency for bounded rotation. Output content, prompts, reasoning, tool arguments and authentication headers are not captured.

Validation:
- Collector unit tests cover raw value shapes, lifecycle and persistent-turn boundaries, missing telemetry, output-content exclusion, immutable payloads and failed logging.
- TestOpenAIEngineTrace verifies request/account association and unchanged response-model observation.
- Both test packages passed in the Docker build based on v0.2.1 (578785ee7fb35030b094b69624efe25670a36f5f).
- A deployed SSE smoke request returned HTTP 200 and produced a matching record. That upstream omitted engine telemetry, and the record correctly reported not_observed.

Draft for maintainer feedback on the opt-in surface and telemetry field locations. Build evidence and reproducible image workflow: https://github.com/HexZeta/sub2api-engine-trace/actions/runs/34080046422