### PR TITLE
fix: 修正区间倍率展示并补齐模型广场 1h 缓存价格

### DIFF
--- a/backend/internal/handler/available_channel_handler.go
+++ b/backend/internal/handler/available_channel_handler.go
@@ -81,15 +81,19 @@ type userSupportedModelPricing struct {
 
 // userPricingIntervalDTO 定价区间白名单（去掉内部 ID、SortOrder 等前端不渲染的字段）。
 type userPricingIntervalDTO struct {
-	MinTokens         int      `json:"min_tokens"`
-	MaxTokens         *int     `json:"max_tokens"`
-	TierLabel         string   `json:"tier_label,omitempty"`
-	InputPrice        *float64 `json:"input_price"`
-	OutputPrice       *float64 `json:"output_price"`
-	CacheWritePrice   *float64 `json:"cache_write_price"`
-	CacheWrite1hPrice *float64 `json:"cache_write_1h_price"`
-	CacheReadPrice    *float64 `json:"cache_read_price"`
-	PerRequestPrice   *float64 `json:"per_request_price"`
+	MinTokens            int      `json:"min_tokens"`
+	MaxTokens            *int     `json:"max_tokens"`
+	TierLabel            string   `json:"tier_label,omitempty"`
+	InputPrice           *float64 `json:"input_price"`
+	OutputPrice          *float64 `json:"output_price"`
+	CacheWritePrice      *float64 `json:"cache_write_price"`
+	CacheWrite1hPrice    *float64 `json:"cache_write_1h_price"`
+	CacheReadPrice       *float64 `json:"cache_read_price"`
+	InputMultiplier      *float64 `json:"input_multiplier"`
+	OutputMultiplier     *float64 `json:"output_multiplier"`
+	CacheWriteMultiplier *float64 `json:"cache_write_multiplier"`
+	CacheReadMultiplier  *float64 `json:"cache_read_multiplier"`
+	PerRequestPrice      *float64 `json:"per_request_price"`
 }
 
 // userSupportedModel 用户可见的支持模型条目。
@@ -295,15 +299,19 @@ func toUserPricingIntervals(src []service.PricingInterval) []userPricingInterval
 	intervals := make([]userPricingIntervalDTO, 0, len(src))
 	for _, iv := range src {
 		intervals = append(intervals, userPricingIntervalDTO{
-			MinTokens:         iv.MinTokens,
-			MaxTokens:         iv.MaxTokens,
-			TierLabel:         iv.TierLabel,
-			InputPrice:        iv.InputPrice,
-			OutputPrice:       iv.OutputPrice,
-			CacheWritePrice:   iv.CacheWritePrice,
-			CacheWrite1hPrice: iv.CacheWrite1hPrice,
-			CacheReadPrice:    iv.CacheReadPrice,
-			PerRequestPrice:   iv.PerRequestPrice,
+			MinTokens:            iv.MinTokens,
+			MaxTokens:            iv.MaxTokens,
+			TierLabel:            iv.TierLabel,
+			InputPrice:           iv.InputPrice,
+			OutputPrice:          iv.OutputPrice,
+			CacheWritePrice:      iv.CacheWritePrice,
+			CacheWrite1hPrice:    iv.CacheWrite1hPrice,
+			CacheReadPrice:       iv.CacheReadPrice,
+			InputMultiplier:      iv.InputMultiplier,
+			OutputMultiplier:     iv.OutputMultiplier,
+			CacheWriteMultiplier: iv.CacheWriteMultiplier,
+			CacheReadMultiplier:  iv.CacheReadMultiplier,
+			PerRequestPrice:      iv.PerRequestPrice,
 		})
 	}
 	return intervals

--- a/backend/internal/handler/available_channel_handler_test.go
+++ b/backend/internal/handler/available_channel_handler_test.go
@@ -113,10 +113,18 @@ func TestUserAvailableChannel_FieldWhitelist(t *testing.T) {
 	}
 
 	// pricing interval 白名单：不应暴露 id / sort_order。
+	inputMultiplier := 2.0
+	outputMultiplier := 1.5
+	cacheWriteMultiplier := 2.0
+	cacheReadMultiplier := 2.0
 	pricing := toUserPricing(&service.ChannelModelPricing{
 		BillingMode: service.BillingModeToken,
 		Intervals: []service.PricingInterval{
-			{ID: 7, MinTokens: 0, MaxTokens: nil, SortOrder: 3},
+			{
+				ID: 7, MinTokens: 0, MaxTokens: nil, SortOrder: 3,
+				InputMultiplier: &inputMultiplier, OutputMultiplier: &outputMultiplier,
+				CacheWriteMultiplier: &cacheWriteMultiplier, CacheReadMultiplier: &cacheReadMultiplier,
+			},
 		},
 	})
 	require.NotNil(t, pricing)
@@ -128,6 +136,14 @@ func TestUserAvailableChannel_FieldWhitelist(t *testing.T) {
 	for _, key := range []string{"id", "pricing_id", "sort_order"} {
 		_, exists := ivDecoded[key]
 		require.Falsef(t, exists, "user pricing interval must not expose %q", key)
+	}
+	for key, want := range map[string]float64{
+		"input_multiplier": inputMultiplier, "output_multiplier": outputMultiplier,
+		"cache_write_multiplier": cacheWriteMultiplier, "cache_read_multiplier": cacheReadMultiplier,
+	} {
+		got, exists := ivDecoded[key]
+		require.Truef(t, exists, "user pricing interval must expose %q", key)
+		require.InDelta(t, want, got.(float64), 1e-12)
 	}
 }
 

--- a/backend/internal/service/billing_context_schedule.go
+++ b/backend/internal/service/billing_context_schedule.go
@@ -19,13 +19,14 @@ const ContextPricingBasisWholeRequest ContextPricingBasis = "whole_request"
 // ContextPricingTier (MinTokens, MaxTokens] 区间内的有效 per-token 单价（USD）。
 // nil 表示该项无价/不计费；MaxTokens 为 nil 表示无上限。
 type ContextPricingTier struct {
-	MinTokens  int
-	MaxTokens  *int
-	Label      string
-	Input      *float64
-	Output     *float64
-	CacheWrite *float64
-	CacheRead  *float64
+	MinTokens    int
+	MaxTokens    *int
+	Label        string
+	Input        *float64
+	Output       *float64
+	CacheWrite   *float64
+	CacheWrite1h *float64
+	CacheRead    *float64
 }
 
 // TimePricingPeriod 分时倍率时段：配置时区当天 [StartTime, EndTime) 内整单费用乘 Multiplier。
@@ -289,6 +290,10 @@ func probeContextTier(seg contextSegment, resolved *ResolvedPricing, probe func(
 		return tier, err
 	}
 	// 输出价只随上下文所在档变化：固定上下文 c，对输出 token 数做差商（固定部分相减抵消）。
+	tier.CacheWrite1h, err = probeComponentPrice(func(n int) UsageTokens { return UsageTokens{CacheCreationTokens: n, CacheCreation1hTokens: n} }, c, delta, probe)
+	if err != nil {
+		return tier, err
+	}
 	tier.Output, err = probeComponentPrice(func(n int) UsageTokens { return UsageTokens{InputTokens: c, OutputTokens: n} }, 0, contextProbeDelta, probe)
 	if err != nil {
 		return tier, err
@@ -298,6 +303,7 @@ func probeContextTier(seg contextSegment, resolved *ResolvedPricing, probe func(
 	tier.Input = contextPricePtr(tier.Input, explicit.input)
 	tier.Output = contextPricePtr(tier.Output, explicit.output)
 	tier.CacheWrite = contextPricePtr(tier.CacheWrite, explicit.cacheWrite)
+	tier.CacheWrite1h = contextPricePtr(tier.CacheWrite1h, explicit.cacheWrite1h)
 	tier.CacheRead = contextPricePtr(tier.CacheRead, explicit.cacheRead)
 	return tier, nil
 }
@@ -341,7 +347,7 @@ func roundContextPrice(v float64) float64 {
 }
 
 type explicitContextFields struct {
-	input, output, cacheWrite, cacheRead bool
+	input, output, cacheWrite, cacheWrite1h, cacheRead bool
 }
 
 // explicitContextPricingFields 判断各项是否被分组卡/渠道定价（含命中区间）显式配置。
@@ -355,11 +361,13 @@ func explicitContextPricingFields(resolved *ResolvedPricing, contextTokens int) 
 	out.input = cp.InputPrice != nil
 	out.output = cp.OutputPrice != nil
 	out.cacheWrite = cp.CacheWritePrice != nil
+	out.cacheWrite1h = cp.CacheWrite1hPrice != nil || cp.CacheWritePrice != nil
 	out.cacheRead = cp.CacheReadPrice != nil
 	if iv := FindMatchingInterval(resolved.Intervals, contextTokens); iv != nil {
 		out.input = out.input || iv.InputPrice != nil
 		out.output = out.output || iv.OutputPrice != nil
 		out.cacheWrite = out.cacheWrite || iv.CacheWritePrice != nil
+		out.cacheWrite1h = out.cacheWrite1h || iv.CacheWrite1hPrice != nil || iv.CacheWritePrice != nil
 		out.cacheRead = out.cacheRead || iv.CacheReadPrice != nil
 	}
 	return out
@@ -393,7 +401,7 @@ func mergeEqualContextTiers(tiers []ContextPricingTier) []ContextPricingTier {
 
 func sameContextPrices(a, b ContextPricingTier) bool {
 	return samePricePtr(a.Input, b.Input) && samePricePtr(a.Output, b.Output) &&
-		samePricePtr(a.CacheWrite, b.CacheWrite) && samePricePtr(a.CacheRead, b.CacheRead)
+		samePricePtr(a.CacheWrite, b.CacheWrite) && samePricePtr(a.CacheWrite1h, b.CacheWrite1h) && samePricePtr(a.CacheRead, b.CacheRead)
 }
 
 func samePricePtr(a, b *float64) bool {

--- a/backend/internal/service/billing_context_schedule_test.go
+++ b/backend/internal/service/billing_context_schedule_test.go
@@ -385,6 +385,24 @@ func TestResolveContextPricingSchedule_NilResolver(t *testing.T) {
 	require.Nil(t, sched)
 }
 
+func TestPlazaSchedulePreservesCacheWrite1h(t *testing.T) {
+	cp := sonnetChannel(PricingInterval{MinTokens: 272000, CacheWriteMultiplier: testPtrFloat64(2)})
+	cp[0].CacheWritePrice = testPtrFloat64(12.5e-6)
+	cp[0].CacheWrite1hPrice = testPtrFloat64(20e-6)
+	group := enabledGroup(PlatformAnthropic)
+	bs, resolver := newScheduleTestEnv(t, scheduleScenario{channel: cp, groupPlatform: PlatformAnthropic})
+	sched, err := bs.ResolveContextPricingSchedule(context.Background(), resolver, ContextPricingScheduleInput{Model: "claude-sonnet-4", Group: group, Platform: PlatformAnthropic})
+	require.NoError(t, err)
+	display := plazaPricingFromSchedule(&cp[0], sched)
+	requirePrice(t, testPtrFloat64(20e-6), display.CacheWrite1hPrice, "base 1h")
+	require.Len(t, display.Intervals, 2)
+	requirePrice(t, testPtrFloat64(25e-6), display.Intervals[1].CacheWritePrice, "tier 5m")
+	requirePrice(t, testPtrFloat64(40e-6), display.Intervals[1].CacheWrite1hPrice, "tier 1h")
+	a := ContextPricingTier{CacheWrite1h: testPtrFloat64(1)}
+	b := ContextPricingTier{CacheWrite1h: testPtrFloat64(2)}
+	require.Len(t, mergeEqualContextTiers([]ContextPricingTier{a, b}), 2)
+}
+
 // --- 对账：阶梯表推算的费用必须等于真实计费函数 ---
 
 type tokenKind int

--- a/backend/internal/service/model_plaza_service.go
+++ b/backend/internal/service/model_plaza_service.go
@@ -269,6 +269,7 @@ func plazaPricingFromSchedule(raw *ChannelModelPricing, sched *ContextPricingSch
 	out.InputPrice = first.Input
 	out.OutputPrice = first.Output
 	out.CacheWritePrice = first.CacheWrite
+	out.CacheWrite1hPrice = first.CacheWrite1h
 	out.CacheReadPrice = first.CacheRead
 	if len(sched.Tiers) > 1 {
 		out.Intervals = plazaIntervalsFromTiers(sched.Tiers)
@@ -280,14 +281,15 @@ func plazaIntervalsFromTiers(tiers []ContextPricingTier) []PricingInterval {
 	intervals := make([]PricingInterval, 0, len(tiers))
 	for i, t := range tiers {
 		intervals = append(intervals, PricingInterval{
-			MinTokens:       t.MinTokens,
-			MaxTokens:       t.MaxTokens,
-			TierLabel:       t.Label,
-			InputPrice:      t.Input,
-			OutputPrice:     t.Output,
-			CacheWritePrice: t.CacheWrite,
-			CacheReadPrice:  t.CacheRead,
-			SortOrder:       i,
+			MinTokens:         t.MinTokens,
+			MaxTokens:         t.MaxTokens,
+			TierLabel:         t.Label,
+			InputPrice:        t.Input,
+			OutputPrice:       t.Output,
+			CacheWritePrice:   t.CacheWrite,
+			CacheWrite1hPrice: t.CacheWrite1h,
+			CacheReadPrice:    t.CacheRead,
+			SortOrder:         i,
 		})
 	}
 	return intervals

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -31,6 +31,10 @@ export interface UserPricingInterval {
   cache_write_price: number | null
   cache_write_1h_price?: number | null
   cache_read_price: number | null
+  input_multiplier?: number | null
+  output_multiplier?: number | null
+  cache_write_multiplier?: number | null
+  cache_read_multiplier?: number | null
   per_request_price: number | null
 }
 

--- a/frontend/src/api/modelPlaza.ts
+++ b/frontend/src/api/modelPlaza.ts
@@ -46,7 +46,7 @@ export interface PlazaTimePricing {
 export interface PlazaModel {
   name: string
   platform: string
-  /** 实收口径的展示定价：多档时 intervals 为各档绝对单价（已由计费服务折算）；均为标准时段价。 */
+  /** 实收口径的展示定价：档位可提供绝对单价或相对基础价倍率；均为标准时段价。 */
   pricing: UserSupportedModelPricing | null
   official_pricing: PlazaOfficialPricing | null
   /** 仅多档模型返回。 */

--- a/frontend/src/components/channels/SupportedModelChip.vue
+++ b/frontend/src/components/channels/SupportedModelChip.vue
@@ -168,7 +168,7 @@
 import { computed, nextTick, onBeforeUnmount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import PricingRow from './PricingRow.vue'
-import { formatScaled } from '@/utils/pricing'
+import { formatScaled, resolveIntervalPrices } from '@/utils/pricing'
 import {
   BILLING_MODE_TOKEN,
   BILLING_MODE_PER_REQUEST,
@@ -245,22 +245,13 @@ function formatRange(min: number, max: number | null): string {
   return `(${min}, ${maxLabel}]`
 }
 
-function effectiveIntervalPrice(
-  price: number | null | undefined,
-  multiplier: number | null | undefined,
-  basePrice: number | null
-): number | null {
-  if (price != null) return price
-  if (multiplier != null && basePrice != null) return basePrice * multiplier
-  return basePrice
-}
-
 function formatInterval(iv: UserPricingInterval, pricing: UserSupportedModelPricing): string {
   if (pricing.billing_mode === BILLING_MODE_PER_REQUEST || pricing.billing_mode === BILLING_MODE_IMAGE) {
     return formatScaled(iv.per_request_price, 1)
   }
-  const input = formatScaled(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, pricing.input_price), perMillionScale)
-  const output = formatScaled(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, pricing.output_price), perMillionScale)
+  const resolved = resolveIntervalPrices(iv, pricing)
+  const input = formatScaled(resolved.input_price, perMillionScale)
+  const output = formatScaled(resolved.output_price, perMillionScale)
   return `${input} / ${output}`
 }
 

--- a/frontend/src/components/channels/SupportedModelChip.vue
+++ b/frontend/src/components/channels/SupportedModelChip.vue
@@ -153,7 +153,7 @@
                     <template v-if="iv.tier_label">{{ iv.tier_label }}</template>
                     <template v-else>{{ formatRange(iv.min_tokens, iv.max_tokens) }}</template>
                   </span>
-                  <span>{{ formatInterval(iv, model.pricing.billing_mode) }}</span>
+                  <span>{{ formatInterval(iv, model.pricing) }}</span>
                 </div>
               </div>
             </div>
@@ -172,12 +172,11 @@ import { formatScaled } from '@/utils/pricing'
 import {
   BILLING_MODE_TOKEN,
   BILLING_MODE_PER_REQUEST,
-  BILLING_MODE_IMAGE,
-  type BillingMode
+  BILLING_MODE_IMAGE
 } from '@/constants/channel'
 // 复用 api/channels.ts 的用户侧最小形态 DTO。
 // admin 侧 ChannelModelPricing 字段更多，但结构上是用户 DTO 的超集，admin 视图传入可直接通过结构化子类型检查。
-import type { UserPricingInterval, UserSupportedModel } from '@/api/channels'
+import type { UserPricingInterval, UserSupportedModel, UserSupportedModelPricing } from '@/api/channels'
 import PlatformIcon from '@/components/common/PlatformIcon.vue'
 import type { GroupPlatform } from '@/types'
 import { platformBadgeClass, platformBorderClass, platformBadgeLightClass } from '@/utils/platformColors'
@@ -246,12 +245,22 @@ function formatRange(min: number, max: number | null): string {
   return `(${min}, ${maxLabel}]`
 }
 
-function formatInterval(iv: UserPricingInterval, mode: BillingMode): string {
-  if (mode === BILLING_MODE_PER_REQUEST || mode === BILLING_MODE_IMAGE) {
+function effectiveIntervalPrice(
+  price: number | null | undefined,
+  multiplier: number | null | undefined,
+  basePrice: number | null
+): number | null {
+  if (price != null) return price
+  if (multiplier != null && basePrice != null) return basePrice * multiplier
+  return basePrice
+}
+
+function formatInterval(iv: UserPricingInterval, pricing: UserSupportedModelPricing): string {
+  if (pricing.billing_mode === BILLING_MODE_PER_REQUEST || pricing.billing_mode === BILLING_MODE_IMAGE) {
     return formatScaled(iv.per_request_price, 1)
   }
-  const input = formatScaled(iv.input_price, perMillionScale)
-  const output = formatScaled(iv.output_price, perMillionScale)
+  const input = formatScaled(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, pricing.input_price), perMillionScale)
+  const output = formatScaled(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, pricing.output_price), perMillionScale)
   return `${input} / ${output}`
 }
 

--- a/frontend/src/components/channels/__tests__/SupportedModelChip.spec.ts
+++ b/frontend/src/components/channels/__tests__/SupportedModelChip.spec.ts
@@ -1,0 +1,54 @@
+import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SupportedModelChip from '../SupportedModelChip.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key })
+  }
+})
+
+describe('SupportedModelChip', () => {
+  it('仅配置区间倍率时按基础价展示 token 档位', async () => {
+    const wrapper = mount(SupportedModelChip, {
+      attachTo: document.body,
+      props: {
+        model: {
+          name: 'gpt-test',
+          platform: '',
+          pricing: {
+            billing_mode: 'token',
+            input_price: 10e-6,
+            output_price: 50e-6,
+            cache_write_price: null,
+            cache_read_price: null,
+            image_input_price: null,
+            image_output_price: null,
+            per_request_price: null,
+            intervals: [{
+              min_tokens: 272000,
+              max_tokens: null,
+              input_price: null,
+              output_price: null,
+              cache_write_price: null,
+              cache_read_price: null,
+              input_multiplier: 2,
+              output_multiplier: 1.5,
+              per_request_price: null
+            }]
+          }
+        },
+        showPlatform: false
+      }
+    })
+
+    await wrapper.find('[tabindex="0"]').trigger('mouseenter')
+    await nextTick()
+
+    expect(document.body.textContent).toContain('$20 / $75')
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -119,7 +119,7 @@
                   class="whitespace-nowrap text-xs leading-5"
                 >
                   <span class="mr-1 font-sans font-normal text-gray-400 dark:text-dark-500" :title="tierHint(m)">{{ tierLabel(iv) }}</span>
-                  {{ paidPerMillion(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, m.pricing?.input_price), period) }}
+                  {{ paidPerMillion(iv.input_price, period) }}
                 </div>
               </template>
               <template v-else>{{ paidPerMillion(m.pricing?.input_price, period) }}</template>
@@ -132,7 +132,7 @@
                   class="whitespace-nowrap text-xs leading-5"
                   :title="tierHint(m)"
                 >
-                  {{ paidPerMillion(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, m.pricing?.output_price), period) }}
+                  {{ paidPerMillion(iv.output_price, period) }}
                 </div>
               </template>
               <template v-else>{{ paidPerMillion(m.pricing?.output_price, period) }}</template>
@@ -145,15 +145,15 @@
                   class="whitespace-nowrap font-mono text-xs leading-5 text-gray-800 dark:text-gray-200"
                   :title="tierHint(m)"
                 >
-                  <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null || iv.cache_write_multiplier != null || iv.cache_read_multiplier != null">
+                  <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null">
                     <span class="font-sans font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheWriteShort') }}</span>
-                    {{ paidPerMillion(effectiveIntervalPrice(iv.cache_write_price, iv.cache_write_multiplier, m.pricing?.cache_write_price), period) }}
-                    <template v-if="effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.pricing?.cache_write_1h_price) != null"
-                      ><span class="font-sans font-normal text-gray-400 dark:text-dark-500"> (1h </span>{{ paidPerMillion(effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.pricing?.cache_write_1h_price), period)
+                    {{ paidPerMillion(iv.cache_write_price, period) }}
+                    <template v-if="iv.cache_write_1h_price != null"
+                      ><span class="font-sans font-normal text-gray-400 dark:text-dark-500"> (1h </span>{{ paidPerMillion(iv.cache_write_1h_price, period)
                       }}<span class="font-sans font-normal text-gray-400 dark:text-dark-500">)</span></template
                     >
                     <span class="ml-1 font-sans font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheReadShort') }}</span>
-                    {{ paidPerMillion(effectiveIntervalPrice(iv.cache_read_price, iv.cache_read_multiplier, m.pricing?.cache_read_price), period) }}
+                    {{ paidPerMillion(iv.cache_read_price, period) }}
                   </template>
                   <span v-else class="text-gray-400 dark:text-dark-500">-</span>
                 </div>
@@ -217,7 +217,7 @@
                 class="whitespace-nowrap leading-5"
               >
                 <span class="mr-1 font-sans text-gray-400 dark:text-dark-500" :title="t('modelPlaza.table.tierHint')">{{ tierLabel(iv) }}</span>
-                {{ official(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, m.official_pricing?.input_price)) }}
+                {{ official(iv.input_price) }}
               </div>
             </template>
             <template v-else>{{ official(m.official_pricing?.input_price) }}</template>
@@ -230,7 +230,7 @@
                 class="whitespace-nowrap leading-5"
                 :title="t('modelPlaza.table.tierHint')"
               >
-                {{ official(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, m.official_pricing?.output_price)) }}
+                {{ official(iv.output_price) }}
               </div>
             </template>
             <template v-else>{{ official(m.official_pricing?.output_price) }}</template>
@@ -243,15 +243,15 @@
                 class="whitespace-nowrap font-mono text-xs leading-5 text-gray-500 dark:text-dark-400"
                 :title="t('modelPlaza.table.tierHint')"
               >
-                <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null || iv.cache_write_multiplier != null || iv.cache_read_multiplier != null">
+                <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null">
                   <span class="font-sans text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheWriteShort') }}</span>
-                  {{ official(effectiveIntervalPrice(iv.cache_write_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_price)) }}
-                  <template v-if="effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_1h_price) != null"
-                    ><span class="font-sans text-gray-400 dark:text-dark-500"> (1h </span>{{ official(effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_1h_price))
+                  {{ official(iv.cache_write_price) }}
+                  <template v-if="iv.cache_write_1h_price != null"
+                    ><span class="font-sans text-gray-400 dark:text-dark-500"> (1h </span>{{ official(iv.cache_write_1h_price)
                     }}<span class="font-sans text-gray-400 dark:text-dark-500">)</span></template
                   >
                   <span class="ml-1 font-sans text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheReadShort') }}</span>
-                  {{ official(effectiveIntervalPrice(iv.cache_read_price, iv.cache_read_multiplier, m.official_pricing?.cache_read_price)) }}
+                  {{ official(iv.cache_read_price) }}
                 </template>
                 <span v-else class="text-gray-400 dark:text-dark-500">-</span>
               </div>
@@ -306,7 +306,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { formatScaled } from '@/utils/pricing'
+import { formatScaled, resolveIntervalPrices } from '@/utils/pricing'
 import { platformAccentColor, platformBadgeLightClass, platformLabel } from '@/utils/platformColors'
 import {
   BILLING_MODE_TOKEN,
@@ -434,16 +434,6 @@ function official(value: number | null | undefined): string {
   return formatScaled(value, PER_MILLION, MIN_DECIMALS)
 }
 
-function effectiveIntervalPrice(
-  price: number | null | undefined,
-  multiplier: number | null | undefined,
-  basePrice: number | null | undefined
-): number | null | undefined {
-  if (price != null) return price
-  if (multiplier != null && basePrice != null) return basePrice * multiplier
-  return basePrice
-}
-
 /** 非 token 计费的单位后缀:按图片 → “/ 张”,按次 → “/ 次”。 */
 function perUnitSuffix(m: PlazaModel): string {
   return billingMode(m) === BILLING_MODE_IMAGE
@@ -495,7 +485,7 @@ function sortByContext(intervals: UserPricingInterval[]): UserPricingInterval[] 
 
 /** token 模式的阶梯定价(内联进输入/输出/缓存列)。 */
 function tokenIntervals(m: PlazaModel): UserPricingInterval[] {
-  return sortByContext(m.pricing?.intervals ?? [])
+  return sortByContext(m.pricing?.intervals ?? []).map(iv => resolveIntervalPrices(iv, m.pricing!))
 }
 
 /** 官方阶梯(后端按目录规则合成,不受分组开关影响)。 */

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="plaza-pricing-table overflow-x-auto" :style="accentStyle">
-    <table class="w-full min-w-[1000px] table-fixed border-collapse text-sm tabular-nums">
+    <table class="w-full min-w-[1000px] table-auto border-collapse text-sm tabular-nums">
       <colgroup>
         <col class="w-[25%]" />
         <col class="w-[11%]" />

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -119,7 +119,7 @@
                   class="whitespace-nowrap text-xs leading-5"
                 >
                   <span class="mr-1 font-sans font-normal text-gray-400 dark:text-dark-500" :title="tierHint(m)">{{ tierLabel(iv) }}</span>
-                  {{ paidPerMillion(iv.input_price, period) }}
+                  {{ paidPerMillion(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, m.pricing?.input_price), period) }}
                 </div>
               </template>
               <template v-else>{{ paidPerMillion(m.pricing?.input_price, period) }}</template>
@@ -132,7 +132,7 @@
                   class="whitespace-nowrap text-xs leading-5"
                   :title="tierHint(m)"
                 >
-                  {{ paidPerMillion(iv.output_price, period) }}
+                  {{ paidPerMillion(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, m.pricing?.output_price), period) }}
                 </div>
               </template>
               <template v-else>{{ paidPerMillion(m.pricing?.output_price, period) }}</template>
@@ -145,15 +145,15 @@
                   class="whitespace-nowrap font-mono text-xs leading-5 text-gray-800 dark:text-gray-200"
                   :title="tierHint(m)"
                 >
-                  <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null">
+                  <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null || iv.cache_write_multiplier != null || iv.cache_read_multiplier != null">
                     <span class="font-sans font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheWriteShort') }}</span>
-                    {{ paidPerMillion(iv.cache_write_price, period) }}
-                    <template v-if="iv.cache_write_1h_price != null"
-                      ><span class="font-sans font-normal text-gray-400 dark:text-dark-500"> (1h </span>{{ paidPerMillion(iv.cache_write_1h_price, period)
+                    {{ paidPerMillion(effectiveIntervalPrice(iv.cache_write_price, iv.cache_write_multiplier, m.pricing?.cache_write_price), period) }}
+                    <template v-if="effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.pricing?.cache_write_1h_price) != null"
+                      ><span class="font-sans font-normal text-gray-400 dark:text-dark-500"> (1h </span>{{ paidPerMillion(effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.pricing?.cache_write_1h_price), period)
                       }}<span class="font-sans font-normal text-gray-400 dark:text-dark-500">)</span></template
                     >
                     <span class="ml-1 font-sans font-normal text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheReadShort') }}</span>
-                    {{ paidPerMillion(iv.cache_read_price, period) }}
+                    {{ paidPerMillion(effectiveIntervalPrice(iv.cache_read_price, iv.cache_read_multiplier, m.pricing?.cache_read_price), period) }}
                   </template>
                   <span v-else class="text-gray-400 dark:text-dark-500">-</span>
                 </div>
@@ -217,7 +217,7 @@
                 class="whitespace-nowrap leading-5"
               >
                 <span class="mr-1 font-sans text-gray-400 dark:text-dark-500" :title="t('modelPlaza.table.tierHint')">{{ tierLabel(iv) }}</span>
-                {{ official(iv.input_price) }}
+                {{ official(effectiveIntervalPrice(iv.input_price, iv.input_multiplier, m.official_pricing?.input_price)) }}
               </div>
             </template>
             <template v-else>{{ official(m.official_pricing?.input_price) }}</template>
@@ -230,7 +230,7 @@
                 class="whitespace-nowrap leading-5"
                 :title="t('modelPlaza.table.tierHint')"
               >
-                {{ official(iv.output_price) }}
+                {{ official(effectiveIntervalPrice(iv.output_price, iv.output_multiplier, m.official_pricing?.output_price)) }}
               </div>
             </template>
             <template v-else>{{ official(m.official_pricing?.output_price) }}</template>
@@ -243,15 +243,15 @@
                 class="whitespace-nowrap font-mono text-xs leading-5 text-gray-500 dark:text-dark-400"
                 :title="t('modelPlaza.table.tierHint')"
               >
-                <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null">
+                <template v-if="iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null || iv.cache_write_multiplier != null || iv.cache_read_multiplier != null">
                   <span class="font-sans text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheWriteShort') }}</span>
-                  {{ official(iv.cache_write_price) }}
-                  <template v-if="iv.cache_write_1h_price != null"
-                    ><span class="font-sans text-gray-400 dark:text-dark-500"> (1h </span>{{ official(iv.cache_write_1h_price)
+                  {{ official(effectiveIntervalPrice(iv.cache_write_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_price)) }}
+                  <template v-if="effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_1h_price) != null"
+                    ><span class="font-sans text-gray-400 dark:text-dark-500"> (1h </span>{{ official(effectiveIntervalPrice(iv.cache_write_1h_price, iv.cache_write_multiplier, m.official_pricing?.cache_write_1h_price))
                     }}<span class="font-sans text-gray-400 dark:text-dark-500">)</span></template
                   >
                   <span class="ml-1 font-sans text-gray-400 dark:text-dark-500">{{ t('modelPlaza.table.cacheReadShort') }}</span>
-                  {{ official(iv.cache_read_price) }}
+                  {{ official(effectiveIntervalPrice(iv.cache_read_price, iv.cache_read_multiplier, m.official_pricing?.cache_read_price)) }}
                 </template>
                 <span v-else class="text-gray-400 dark:text-dark-500">-</span>
               </div>
@@ -434,6 +434,16 @@ function official(value: number | null | undefined): string {
   return formatScaled(value, PER_MILLION, MIN_DECIMALS)
 }
 
+function effectiveIntervalPrice(
+  price: number | null | undefined,
+  multiplier: number | null | undefined,
+  basePrice: number | null | undefined
+): number | null | undefined {
+  if (price != null) return price
+  if (multiplier != null && basePrice != null) return basePrice * multiplier
+  return basePrice
+}
+
 /** 非 token 计费的单位后缀:按图片 → “/ 张”,按次 → “/ 次”。 */
 function perUnitSuffix(m: PlazaModel): string {
   return billingMode(m) === BILLING_MODE_IMAGE
@@ -495,7 +505,10 @@ function officialIntervals(m: PlazaModel): UserPricingInterval[] {
 
 /** 任一档带缓存价才按档渲染缓存列;否则沿用平价的写入/读取两行。 */
 function hasTierCachePricing(intervals: UserPricingInterval[]): boolean {
-  return intervals.some((iv) => iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null)
+  return intervals.some((iv) =>
+    iv.cache_write_price != null || iv.cache_write_1h_price != null || iv.cache_read_price != null ||
+    iv.cache_write_multiplier != null || iv.cache_read_multiplier != null
+  )
 }
 
 /** 档位说明:整单按档计价,或(平台旧规则)仅超出部分按档计价。 */

--- a/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
+++ b/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
@@ -294,6 +294,44 @@ describe('PlazaModelPricingTable', () => {
     expect(text).toContain('$15.00')
   })
 
+  it('仅配置区间倍率时按基础价格展示 input/output/cache 各档价格', () => {
+    const model = tokenModel({
+      pricing: {
+        billing_mode: 'token',
+        input_price: 10e-6,
+        output_price: 50e-6,
+        cache_write_price: 12.5e-6,
+        cache_write_1h_price: 12.5e-6,
+        cache_read_price: 2e-6,
+        image_input_price: null,
+        image_output_price: null,
+        per_request_price: null,
+        intervals: [{
+          min_tokens: 272000,
+          max_tokens: null,
+          tier_label: '>272K',
+          input_price: null,
+          output_price: null,
+          cache_write_price: null,
+          cache_write_1h_price: null,
+          cache_read_price: null,
+          input_multiplier: 2,
+          output_multiplier: 1.5,
+          cache_write_multiplier: 2,
+          cache_read_multiplier: 2,
+          per_request_price: null
+        }]
+      },
+      official_pricing: null
+    })
+
+    const text = mountTable([model], 1).text()
+    expect(text).toContain('$20.00')
+    expect(text).toContain('$75.00')
+    expect(text).toContain('$25.00')
+    expect(text).toContain('$4.00')
+  })
+
   it('生图独立倍率开启时,按图价格 × 独立倍率,不乘分组倍率;倍率列展示独立倍率', () => {
     const model = tokenModel({
       name: 'gpt-image-2',

--- a/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
+++ b/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
@@ -330,6 +330,15 @@ describe('PlazaModelPricingTable', () => {
     expect(text).toContain('$75.00')
     expect(text).toContain('$25.00')
     expect(text).toContain('$4.00')
+    model.pricing!.intervals.unshift({
+      ...model.pricing!.intervals[0], min_tokens: 0, max_tokens: 272000,
+      tier_label: '<=272K', cache_write_multiplier: null, cache_read_multiplier: null
+    })
+    const cells = mountTable([model], 1).findAll('tbody td')
+    expect(cells[3].text()).toContain('$12.50')
+    expect(cells[3].text()).toContain('$2.00')
+    expect(cells[3].text()).toContain('$25.00')
+    expect(cells[3].text()).toContain('$4.00')
   })
 
   it('生图独立倍率开启时,按图价格 × 独立倍率,不乘分组倍率;倍率列展示独立倍率', () => {

--- a/frontend/src/utils/__tests__/intervalPrices.spec.ts
+++ b/frontend/src/utils/__tests__/intervalPrices.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveIntervalPrices } from '../pricing'
+
+const base = { input_price: 10, output_price: 50, cache_write_price: 12.5, cache_write_1h_price: 30, cache_read_price: 2 }
+const interval = { min_tokens: 272000, max_tokens: null, input_price: null, output_price: null, cache_write_price: null, cache_write_1h_price: null, cache_read_price: null, per_request_price: null }
+
+describe('resolveIntervalPrices', () => {
+  it('inherits base prices without overrides', () => {
+    expect(resolveIntervalPrices(interval, base)).toMatchObject(base)
+  })
+  it('applies cache multiplier to both durations', () => {
+    expect(resolveIntervalPrices({ ...interval, cache_write_multiplier: 2 }, base)).toMatchObject({ cache_write_price: 25, cache_write_1h_price: 60 })
+  })
+  it('uses explicit cache write for both durations before multiplier', () => {
+    expect(resolveIntervalPrices({ ...interval, cache_write_price: 20, cache_write_multiplier: 2 }, base)).toMatchObject({ cache_write_price: 20, cache_write_1h_price: 20 })
+  })
+  it('preserves explicit zero and separate 1h override', () => {
+    expect(resolveIntervalPrices({ ...interval, cache_write_price: 0, cache_write_1h_price: 7, cache_write_multiplier: 2 }, base)).toMatchObject({ cache_write_price: 0, cache_write_1h_price: 7 })
+  })
+})

--- a/frontend/src/utils/pricing.ts
+++ b/frontend/src/utils/pricing.ts
@@ -22,3 +22,21 @@ export function formatScaled(value: number | null, scale: number, minFractionDig
   }
   return `$${s}`
 }
+
+import type { UserPricingInterval } from '@/api/channels'
+
+type TokenPrices = Pick<UserPricingInterval, 'input_price' | 'output_price' | 'cache_write_price' | 'cache_write_1h_price' | 'cache_read_price'>
+
+export function resolveIntervalPrices(iv: UserPricingInterval, base: TokenPrices): UserPricingInterval {
+  const price = (absolute: number | null | undefined, multiplier: number | null | undefined, fallback: number | null | undefined) =>
+    absolute ?? (fallback == null ? null : fallback * (multiplier ?? 1))
+  return {
+    ...iv,
+    input_price: price(iv.input_price, iv.input_multiplier, base.input_price),
+    output_price: price(iv.output_price, iv.output_multiplier, base.output_price),
+    cache_write_price: price(iv.cache_write_price, iv.cache_write_multiplier, base.cache_write_price),
+    // Resolver uses an explicit cache-write price for both durations unless 1h is overridden.
+    cache_write_1h_price: iv.cache_write_1h_price ?? iv.cache_write_price ?? price(null, iv.cache_write_multiplier, base.cache_write_1h_price),
+    cache_read_price: price(iv.cache_read_price, iv.cache_read_multiplier, base.cache_read_price)
+  }
+}


### PR DESCRIPTION
## 修复内容

可用渠道接口遗漏区间倍率，导致只配置倍率时弹层无法展示有效 input/output 价格；模型广场正常路径已通过计费服务折算绝对价，但阶梯数据缺少独立的 1h 缓存写价。

- 公开并映射四个区间倍率字段，统一前端有效价格解析，保留显式零价与基础价继承。
- 按 resolver 优先级处理缓存写入：显式 1h 价优先，其次显式 cache_write_price，再按基础 1h 价应用倍率。
- 为计费阶梯增加 1h 单价探针、价格映射及合并比较，保留仅 1h 变化的档位。
- 按解析后的有效价格渲染多档缓存；表格改为按内容分配列宽，防止 1h 内容覆盖相邻列。

Closes #6725

## 验证

- Go handler 单测及相关计费阶梯/模型广场 service 测试通过。
- 33 条定向前端测试、TypeScript 检查及生产构建通过。
- OrbStack 独立实例使用真实 PostgreSQL/Redis，通过管理 API 创建配置并核对返回及页面：仅倍率区间的 input/output/5m/1h/read 为 $20/$75/$25/$40/$4 per MTok；显式缓存写价令 5m/1h 均为 $20；仅 1h 变价的两档保留。
- 可用渠道弹层显示 $20 / $75；桌面与 390px 窄屏检查无单元格内容溢出，窄屏使用表格横向滚动。

验证未发送真实上游模型请求或产生实际扣费。
