### PR TITLE
fix(openai): keep partial tool arguments failover-safe

### DIFF
--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1120,9 +1120,12 @@ func openAIStreamAddedEventStartsClientOutput(payload []byte, eventType string) 
 			}
 			return false
 		case "function_call":
-			return item.Get("arguments").String() != ""
+			// Function arguments are not usable until the item/done boundary. Keep
+			// every partial delta attempt-local so a late capacity failure can be
+			// discarded and retried without leaking half of a JSON document.
+			return false
 		case "custom_tool_call":
-			return item.Get("input").String() != ""
+			return false
 		case "compaction":
 			return item.Get("encrypted_content").String() != ""
 		default:
@@ -1159,6 +1162,11 @@ func openAIStreamDataStartsClientOutput(data, eventType string) bool {
 	}
 	switch strings.TrimSpace(eventType) {
 	case "response.failed":
+		return false
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
+		// A partial tool payload cannot be consumed safely. Buffer through its
+		// corresponding done event; if the upstream sheds capacity first, the
+		// normal pre-output failover path can discard the incomplete attempt.
 		return false
 	case "error":
 		// 上游降载/瞬时故障会先推 {"type":"error"} 帧、再以 response.failed 收尾。

--- a/backend/internal/service/openai_gateway_passthrough_flush_test.go
+++ b/backend/internal/service/openai_gateway_passthrough_flush_test.go
@@ -175,6 +175,43 @@ func TestOpenAIStreamingPassthroughFailedBeforeOutputCanStillFailOverWithoutFlus
 	require.Empty(t, writer.flushBodyLengths)
 }
 
+func TestOpenAIStreamingPassthroughFailedDuringFunctionArgumentsCanFailOverWithoutPartialJSON(t *testing.T) {
+	upstream := "event: response.created\n" +
+		`data: {"type":"response.created","response":{"id":"resp_tool_failover"}}` + "\n\n" +
+		"event: response.output_item.added\n" +
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":""}}` + "\n\n" +
+		"event: response.function_call_arguments.delta\n" +
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"cmd\":\"half"}` + "\n\n" +
+		"event: response.failed\n" +
+		`data: {"type":"response.failed","response":{"id":"resp_tool_failover","error":{"code":"server_is_overloaded","message":"Please retry later."}}}` + "\n\n"
+
+	_, recorder, writer, err := runPassthroughFlushTest(t, io.NopCloser(strings.NewReader(upstream)), -1)
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Empty(t, recorder.Body.String())
+	require.Empty(t, writer.flushBodyLengths)
+}
+
+func TestOpenAIStreamingPassthroughCompleteFunctionArgumentsFlushAtDoneBoundary(t *testing.T) {
+	prefix := "event: response.output_item.added\n" +
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec","arguments":""}}` + "\n\n" +
+		"event: response.function_call_arguments.delta\n" +
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"cmd\":\"pwd\"}"}` + "\n\n"
+	done := "event: response.function_call_arguments.done\n" +
+		`data: {"type":"response.function_call_arguments.done","output_index":0,"item_id":"fc_1","arguments":"{\"cmd\":\"pwd\"}"}` + "\n\n"
+	terminal := "event: response.completed\n" +
+		`data: {"type":"response.completed","response":{"id":"resp_tool_ok","usage":{"input_tokens":3,"output_tokens":2}}}` + "\n\n"
+
+	_, recorder, writer, err := runPassthroughFlushTest(t, io.NopCloser(strings.NewReader(prefix+done+terminal)), -1)
+
+	require.NoError(t, err)
+	require.Equal(t, prefix+done+terminal, recorder.Body.String())
+	require.NotEmpty(t, writer.flushBodyLengths)
+	require.Equal(t, len(prefix)+len(done), writer.flushBodyLengths[0])
+}
+
 func TestOpenAIStreamingPassthroughNonRetryableFailedBeforeOutputFlushesAtBoundary(t *testing.T) {
 	upstream := "event: response.failed\n" +
 		`data: {"type":"response.failed","error":{"code":"content_policy","message":"request blocked by policy"},"usage":{"input_tokens":6,"output_tokens":0,"total_tokens":6}}` + "\n\n"

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -690,7 +690,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			// 写入客户端（客户端断开后继续 drain 上游）
 			if !clientDisconnected && !failureDelivered && !suppressCurrentEvent {
 				shouldFlush := queueDrained && (clientOutputStarted || startsClientOutput)
-				if firstTokenMs == nil && startsVisibleOutput {
+				if firstTokenMs == nil && startsVisibleOutput && startsClientOutput {
 					// 保证首个 token 事件尽快出站，避免影响 TTFT。
 					shouldFlush = true
 				}


### PR DESCRIPTION
## Summary

- keep partial function-call and custom-tool argument events in the existing attempt-local first-output stage
- allow late `response.failed` capacity errors to discard incomplete JSON and use the normal account failover path
- commit completed tool arguments at the corresponding `done` boundary without delaying ordinary text streaming

## Production evidence

On the affected account, capacity failures commonly arrived after a partial function-call payload had already been flushed. The handler consequently recorded `upstream_error_response_already_written=true`, making safe account failover impossible.

## Tests

- added regression coverage for a capacity failure during partial function arguments (zero downstream bytes, failover error returned)
- added coverage that completed arguments flush at the `arguments.done` boundary
- `go test ./internal/service -count=1`
- `git diff --check`