### PR TITLE
fix(billing): apply xAI Grok long-context rate card at 200K threshold

### DIFF
--- a/backend/internal/service/billing_grok_longcontext_test.go
+++ b/backend/internal/service/billing_grok_longcontext_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// newGrokCatalogBillingService 构造「远程目录已命中但缺长上下文字段」的计费服务，
+// 复刻生产环境：LiteLLM 目录的 grok 条目只有基础单价，长上下文规则必须由
+// applyModelSpecificPricingPolicy 从本地价卡回填。
+func newGrokCatalogBillingService(entries map[string]*LiteLLMModelPricing) *BillingService {
+	return NewBillingService(&config.Config{}, &PricingService{pricingData: entries})
+}
+
+func grokCatalogEntry(model string, in, out, cacheRead float64) *LiteLLMModelPricing {
+	return &LiteLLMModelPricing{
+		InputCostPerToken:       in,
+		OutputCostPerToken:      out,
+		CacheReadInputTokenCost: cacheRead,
+		LiteLLMProvider:         "xai",
+		Mode:                    "chat",
+		SupportsPromptCaching:   true,
+	}
+}
+
+// 回归：远程目录命中 grok-4.5 后，长上下文价卡（200K 含边界、2x/2x）必须被回填，
+// 否则 ≥200K 请求按基础单价少计费（目录条目遮蔽 fallback 导致规则失效）。
+func TestCalculateCost_GrokCatalogEntryBackfillsLongContext(t *testing.T) {
+	svc := newGrokCatalogBillingService(map[string]*LiteLLMModelPricing{
+		"grok-4.5": grokCatalogEntry("grok-4.5", 2e-6, 6e-6, 0.3e-6),
+	})
+
+	pricing, err := svc.GetModelPricing("grok-4.5")
+	require.NoError(t, err)
+	require.InDelta(t, 2e-6, pricing.InputPricePerToken, 1e-12, "base rates must come from the catalog entry")
+	require.Equal(t, 200000, pricing.LongContextInputThreshold)
+	require.InDelta(t, 2.0, pricing.LongContextInputMultiplier, 1e-12)
+	require.InDelta(t, 2.0, pricing.LongContextOutputMultiplier, 1e-12)
+	require.True(t, pricing.LongContextThresholdInclusive, "xAI long-context tier is inclusive (>=200K)")
+}
+
+// 边界：恰好 200K（含边界）触发整单加倍；199999 不触发。
+func TestCalculateCost_GrokLongContextInclusiveBoundary(t *testing.T) {
+	svc := newGrokCatalogBillingService(map[string]*LiteLLMModelPricing{
+		"grok-4.5": grokCatalogEntry("grok-4.5", 2e-6, 6e-6, 0.3e-6),
+	})
+
+	atThreshold, err := svc.CalculateCost("grok-4.5", UsageTokens{InputTokens: 200000, OutputTokens: 1000}, 1.0)
+	require.NoError(t, err)
+	require.True(t, atThreshold.LongContextBillingApplied, "exactly 200K input must trigger long-context billing (inclusive)")
+	require.InDelta(t, 200000*2e-6*2, atThreshold.InputCost, 1e-9)
+	require.InDelta(t, 1000*6e-6*2, atThreshold.OutputCost, 1e-9)
+
+	below, err := svc.CalculateCost("grok-4.5", UsageTokens{InputTokens: 199999, OutputTokens: 1000}, 1.0)
+	require.NoError(t, err)
+	require.False(t, below.LongContextBillingApplied)
+	require.InDelta(t, 199999*2e-6, below.InputCost, 1e-9)
+	require.InDelta(t, 1000*6e-6, below.OutputCost, 1e-9)
+}
+
+// cache_read / cache_creation 计入总输入，且触发后同样按 2x 计费（与 #2293 同口径）。
+func TestCalculateCost_GrokLongContextCountsCacheTokens(t *testing.T) {
+	svc := newGrokCatalogBillingService(map[string]*LiteLLMModelPricing{
+		"grok-4.5": grokCatalogEntry("grok-4.5", 2e-6, 6e-6, 0.3e-6),
+	})
+
+	// InputTokens + CacheReadTokens = 1000 + 199000 = 200000，恰好触发
+	tokens := UsageTokens{InputTokens: 1000, CacheReadTokens: 199000, OutputTokens: 1000}
+	cost, err := svc.CalculateCost("grok-4.5", tokens, 1.0)
+	require.NoError(t, err)
+	require.True(t, cost.LongContextBillingApplied)
+	require.InDelta(t, 1000*2e-6*2, cost.InputCost, 1e-9)
+	require.InDelta(t, 199000*0.3e-6*2, cost.CacheReadCost, 1e-9)
+	require.InDelta(t, 1000*6e-6*2, cost.OutputCost, 1e-9)
+}
+
+// 各带长上下文档的 Grok 型号（含别名与 grok-4.20 变体）在目录缺字段时都触发加倍。
+func TestCalculateCost_GrokLongContextCoversAllRateCards(t *testing.T) {
+	catalog := map[string]*LiteLLMModelPricing{
+		"grok-4.6":                 grokCatalogEntry("grok-4.6", 2e-6, 6e-6, 0.5e-6),
+		"grok-4.3":                 grokCatalogEntry("grok-4.3", 1.25e-6, 2.5e-6, 0.2e-6),
+		"grok-4.20-0309-reasoning": grokCatalogEntry("grok-4.20-0309-reasoning", 1.25e-6, 2.5e-6, 0.2e-6),
+		"grok-build-0.1":           grokCatalogEntry("grok-build-0.1", 1e-6, 2e-6, 0.2e-6),
+	}
+	svc := newGrokCatalogBillingService(catalog)
+	tokens := UsageTokens{InputTokens: 250000, OutputTokens: 1000}
+
+	for model, inPrice := range map[string]float64{
+		"grok-4.6":                 2e-6,
+		"grok":                     2e-6, // 别名 → grok-4.6 价卡
+		"grok-4.3":                 1.25e-6,
+		"grok-4.20-0309-reasoning": 1.25e-6,
+		"grok-build-0.1":           1e-6,
+	} {
+		t.Run(model, func(t *testing.T) {
+			cost, err := svc.CalculateCost(model, tokens, 1.0)
+			require.NoError(t, err)
+			require.True(t, cost.LongContextBillingApplied, "model %s must bill long-context at >=200K", model)
+			require.InDelta(t, 250000*inPrice*2, cost.InputCost, 1e-9)
+		})
+	}
+}
+
+// grok-3-mini 价卡没有长上下文档：即使输入超 200K 也按基础单价，不回填。
+func TestCalculateCost_Grok3MiniHasNoLongContextTier(t *testing.T) {
+	svc := newGrokCatalogBillingService(map[string]*LiteLLMModelPricing{
+		"grok-3-mini": grokCatalogEntry("grok-3-mini", 0.3e-6, 0.5e-6, 0.075e-6),
+	})
+
+	cost, err := svc.CalculateCost("grok-3-mini", UsageTokens{InputTokens: 300000, OutputTokens: 1000}, 1.0)
+	require.NoError(t, err)
+	require.False(t, cost.LongContextBillingApplied)
+	require.InDelta(t, 300000*0.3e-6, cost.InputCost, 1e-9)
+	require.InDelta(t, 1000*0.5e-6, cost.OutputCost, 1e-9)
+}
+
+// 非 Grok 模型不受回填影响：目录条目无长上下文字段时保持基础计费。
+func TestCalculateCost_NonGrokModelUnaffectedByGrokPolicy(t *testing.T) {
+	svc := newGrokCatalogBillingService(map[string]*LiteLLMModelPricing{
+		"claude-sonnet-4": {InputCostPerToken: 3e-6, OutputCostPerToken: 15e-6, LiteLLMProvider: "anthropic", Mode: "chat"},
+	})
+
+	cost, err := svc.CalculateCost("claude-sonnet-4", UsageTokens{InputTokens: 300000, OutputTokens: 1000}, 1.0)
+	require.NoError(t, err)
+	require.False(t, cost.LongContextBillingApplied)
+	require.InDelta(t, 300000*3e-6, cost.InputCost, 1e-9)
+}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -217,6 +217,16 @@ func applyCostBreakdownMultiplier(cost *CostBreakdown, multiplier float64) {
 
 const claudeFable51MaxReasoningEffortMultiplier = 3.0
 
+// xAI official long-context rate card: when the whole request's input (including cache)
+// reaches 200K, switch to the long-context unit price (both input and output 2x, threshold inclusive —
+// differs from GPT's strict >272K). The remote LiteLLM catalog's grok entries don't carry these fields,
+// so applyGrokLongContextPolicy backfills them from the fallback card at runtime.
+const (
+	xaiGrokLongContextInputThreshold   = 200000
+	xaiGrokLongContextInputMultiplier  = 2.0
+	xaiGrokLongContextOutputMultiplier = 2.0
+)
+
 func isClaudeFable51Model(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
 	for _, marker := range []string{"fable-5-1", "fable-5.1", "fable5.1", "fable51"} {
@@ -775,10 +785,10 @@ func (s *BillingService) initFallbackPricing() {
 		OutputPricePerToken:           6e-6,
 		CacheReadPricePerToken:        0.3e-6,
 		SupportsCacheBreakdown:        false,
-		LongContextInputThreshold:     200000,
+		LongContextInputThreshold:     xaiGrokLongContextInputThreshold,
 		LongContextThresholdInclusive: true,
-		LongContextInputMultiplier:    2,
-		LongContextOutputMultiplier:   2,
+		LongContextInputMultiplier:    xaiGrokLongContextInputMultiplier,
+		LongContextOutputMultiplier:   xaiGrokLongContextOutputMultiplier,
 	}
 
 	// xAI Grok 4.6: $2 input / $0.50 cached input / $6 output below 200k;
@@ -788,10 +798,10 @@ func (s *BillingService) initFallbackPricing() {
 		OutputPricePerToken:           6e-6,
 		CacheReadPricePerToken:        0.5e-6,
 		SupportsCacheBreakdown:        false,
-		LongContextInputThreshold:     200000,
+		LongContextInputThreshold:     xaiGrokLongContextInputThreshold,
 		LongContextThresholdInclusive: true,
-		LongContextInputMultiplier:    2,
-		LongContextOutputMultiplier:   2,
+		LongContextInputMultiplier:    xaiGrokLongContextInputMultiplier,
+		LongContextOutputMultiplier:   xaiGrokLongContextOutputMultiplier,
 	}
 
 	// xAI Grok 4.3: $1.25 input / $0.20 cached / $2.50 output below 200k;
@@ -801,10 +811,10 @@ func (s *BillingService) initFallbackPricing() {
 		OutputPricePerToken:           2.5e-6,
 		CacheReadPricePerToken:        0.2e-6,
 		SupportsCacheBreakdown:        false,
-		LongContextInputThreshold:     200000,
+		LongContextInputThreshold:     xaiGrokLongContextInputThreshold,
 		LongContextThresholdInclusive: true,
-		LongContextInputMultiplier:    2,
-		LongContextOutputMultiplier:   2,
+		LongContextInputMultiplier:    xaiGrokLongContextInputMultiplier,
+		LongContextOutputMultiplier:   xaiGrokLongContextOutputMultiplier,
 	}
 	// Grok 4.20 variants share the official $1.25 / $0.20 / $2.50 card
 	// (and $2.50 / $0.40 / $5 long-context rates) with Grok 4.3.
@@ -813,10 +823,10 @@ func (s *BillingService) initFallbackPricing() {
 		OutputPricePerToken:           2.5e-6,
 		CacheReadPricePerToken:        0.2e-6,
 		SupportsCacheBreakdown:        false,
-		LongContextInputThreshold:     200000,
+		LongContextInputThreshold:     xaiGrokLongContextInputThreshold,
 		LongContextThresholdInclusive: true,
-		LongContextInputMultiplier:    2,
-		LongContextOutputMultiplier:   2,
+		LongContextInputMultiplier:    xaiGrokLongContextInputMultiplier,
+		LongContextOutputMultiplier:   xaiGrokLongContextOutputMultiplier,
 	}
 
 	// Keep legacy Grok 3 Mini requests on their own historical xAI price card;
@@ -842,10 +852,10 @@ func (s *BillingService) initFallbackPricing() {
 		OutputPricePerToken:           2e-6,
 		CacheReadPricePerToken:        0.2e-6,
 		SupportsCacheBreakdown:        false,
-		LongContextInputThreshold:     200000,
+		LongContextInputThreshold:     xaiGrokLongContextInputThreshold,
 		LongContextThresholdInclusive: true,
-		LongContextInputMultiplier:    2,
-		LongContextOutputMultiplier:   2,
+		LongContextInputMultiplier:    xaiGrokLongContextInputMultiplier,
+		LongContextOutputMultiplier:   xaiGrokLongContextOutputMultiplier,
 	}
 }
 
@@ -1693,7 +1703,11 @@ func (s *BillingService) applyModelSpecificPricingPolicyEx(model string, pricing
 		(pricing.InputPricePerTokenPriority > 0 && pricing.CacheCreationPricePerTokenPriority <= 0))
 	fastRatio := openAIModelFastPricingRatio(normalized)
 	if !needsCacheCreationPolicy && fastRatio <= 0 && !needsMaxReasoningEffortMultiplier {
-		return pricing
+		// General path: no OpenAI/Claude-specific policy applies. For Grok text
+		// models, backfill the xAI long-context tier (the remote LiteLLM catalog
+		// carries no long-context fields). No-op for every other model and for
+		// Grok cards that already carry the rule.
+		return s.applyGrokLongContextPolicy(model, pricing)
 	}
 	cloned := *pricing
 	if needsMaxReasoningEffortMultiplier {
@@ -1711,6 +1725,70 @@ func (s *BillingService) applyModelSpecificPricingPolicyEx(model string, pricing
 		enforceOpenAIFastPricingRatio(&cloned, fastRatio)
 	}
 	return &cloned
+}
+
+// applyGrokLongContextPolicy 为 Grok 文本模型回填 xAI 官方长上下文价卡。
+// 远程 LiteLLM 目录的 grok 条目不带长上下文字段，若不回填，
+// shouldApplySessionLongContextPricing 永远不触发，≥200K 请求会按基础单价少计。
+// 回填只补阈值/倍率、不动单价；对已带规则的条目（内置 catalog / 硬编码
+// fallback）是幂等的。只有回退价卡本身定义了长上下文档的型号才回填，
+// 保证回填规则与实际计价格卡一致（如 grok-3-mini 无长上下文档则不回填）。
+func (s *BillingService) applyGrokLongContextPolicy(model string, pricing *ModelPricing) *ModelPricing {
+	card := s.grokLongContextCard(model)
+	if card == nil {
+		return pricing
+	}
+	if pricing.LongContextInputThreshold > 0 && pricing.LongContextInputMultiplier > 1 &&
+		pricing.LongContextOutputMultiplier > 1 {
+		return pricing
+	}
+	cloned := *pricing
+	if cloned.LongContextInputThreshold <= 0 {
+		cloned.LongContextInputThreshold = card.LongContextInputThreshold
+	}
+	if cloned.LongContextInputMultiplier <= 1 {
+		cloned.LongContextInputMultiplier = card.LongContextInputMultiplier
+	}
+	if cloned.LongContextOutputMultiplier <= 1 {
+		cloned.LongContextOutputMultiplier = card.LongContextOutputMultiplier
+	}
+	// xAI 长上下文档为含边界（≥200K 即高档）；GPT 侧保持严格 > 的既有语义。
+	cloned.LongContextThresholdInclusive = card.LongContextThresholdInclusive
+	return &cloned
+}
+
+// grokLongContextCard 返回模型实际计费所用的 Grok 回退价卡（带长上下文档），
+// 无长上下文档或非 Grok 文本型号返回 nil。
+func (s *BillingService) grokLongContextCard(model string) *ModelPricing {
+	if s == nil {
+		return nil
+	}
+	modelLower := strings.ToLower(model)
+	if !isGrokLongContextTextModel(modelLower) {
+		return nil
+	}
+	card := s.getFallbackPricing(modelLower)
+	if card == nil || card.LongContextInputThreshold <= 0 {
+		return nil
+	}
+	return card
+}
+
+// isGrokLongContextTextModel 判断模型 ID 是否属于 Grok 文本（token 计费）族：
+// 已知长上下文价卡型号，加上未知文本回退族（按 grok-4.6 价卡计费）。
+// 媒体型号（image/video/audio 等按次计费）由 isGrokUnknownTextFamilyModel
+// 内部排除，不会走到 token 价卡。
+func isGrokLongContextTextModel(modelLower string) bool {
+	switch modelLower {
+	case "grok", "grok-latest", "grok-4.6", "grok-4.6-latest",
+		"grok-4.5", "grok-4.5-latest", "grok-4.3",
+		"grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning",
+		"grok-4.20-multi-agent-0309", "grok-4.20-reasoning", "grok-4.20-non-reasoning",
+		"grok-build", "grok-build-latest", "grok-build-0.1",
+		"grok-composer", "grok-composer-2.5-fast", "composer-2.5":
+		return true
+	}
+	return isGrokUnknownTextFamilyModel(modelLower)
 }
 
 // openAIModelFastPricingRatio 返回业务口径下 OpenAI GPT 模型 Fast/priority


### PR DESCRIPTION
## Summary

Remote LiteLLM catalog `grok` entries carry no long-context fields, so the 200K inclusive 2x/2x rate card encoded in the fallback table and built-in catalog **never applied at runtime**: every Grok request resolved from the catalog billed at base rates even at 200K+ total input tokens. This backfills the xAI long-context rule at pricing-policy time so the card matches what the fallback table and built-in catalog already declare.

## Changes

- `applyModelSpecificPricingPolicyEx`: the general path (no OpenAI/Claude-specific policy applies) now runs `applyGrokLongContextPolicy` before returning. Grok models never take the DeepSeek/GPT-5.6/fable-5.1/fast-ratio branches, so there's no ordering interaction.
- New `applyGrokLongContextPolicy(model, pricing)`: for Grok text models whose **fallback card defines a long-context tier**, backfills `LongContextInputThreshold` / `LongContextInputMultiplier` / `LongContextOutputMultiplier` from that card and sets `LongContextThresholdInclusive` to the card's semantics. Base unit prices are never touched.
- New `grokLongContextCard(model)`: resolves the model's actual billing card via `getFallbackPricing`; returns nil for models with no long-context tier.
- New `isGrokLongContextTextModel(model)`: the known long-context Grok text models/aliases plus the unknown-text fallback family (which inherits the `grok-4.6` card); media models are excluded via `isGrokUnknownTextFamilyModel`.
- Fallback cards for `grok-4.5/4.6/4.3/4.20/build-0.1` now reference shared `xaiGrokLongContext*` constants instead of literals, so the backfill and the card can't drift.

No catalog schema change is needed: the LiteLLM conversion already marks xai entries inclusive (`strings.EqualFold(provider, "xai")`), and `shouldApplySessionLongContextPricing` no-ops when the threshold is 0.

## Behavior notes

- **Inclusive boundary**: the xAI tier triggers at exactly 200K total input (incl. cache read/creation), unlike GPT's strict `>272K`.
- **Idempotent**: entries that already carry threshold + multipliers >1 (built-in catalog / hardcoded fallback) are returned unchanged — no double application.
- **grok-3-mini** has no long-context tier on its card, so it is never backfilled and stays on base rates even above 200K.
- Non-Grok models are unaffected (the backfill is a no-op for them).
- `CalculateCost` / group-level long-context toggles behave as before; this only makes catalog-resolved Grok pricing consistent with the fallback card.

## Tests

New `billing_grok_longcontext_test.go` (6 tests, all `unit`):
- catalog-hit Grok entry backfills the 200K inclusive 2x/2x card
- inclusive boundary: exactly 200K triggers, 199999 does not
- cache tokens count toward the threshold and bill at 2x once triggered
- all long-context Grok models/aliases (incl. `grok-4.20-0309-reasoning`, `grok-build-0.1`, bare `grok` alias) apply the tier
- `grok-3-mini` negative case (no tier → base rates)
- non-Grok model unaffected

Verified: `go build ./...`, `go vet`, full `internal/service` unit suite (170s) and `internal/handler` + `internal/domain` suites all pass.
