### PR TITLE
fix:(billing) use official pricing for Fable 5.1 max effort

### DIFF
--- a/backend/internal/handler/admin/channel_handler_test.go
+++ b/backend/internal/handler/admin/channel_handler_test.go
@@ -595,7 +595,7 @@ func TestGetModelDefaultPricing_ReturnsFable51CacheTTLs(t *testing.T) {
 	require.NotNil(t, body.Data.CacheWrite1hPrice)
 	require.InDelta(t, 20e-6, *body.Data.CacheWrite1hPrice, 1e-12)
 	require.NotNil(t, body.Data.MaxReasoningEffortMultiplier)
-	require.Equal(t, 3.0, *body.Data.MaxReasoningEffortMultiplier)
+	require.Equal(t, 1.0, *body.Data.MaxReasoningEffortMultiplier)
 }
 
 func TestGetModelDefaultPricing_OmitsUnsupportedCache1hPrice(t *testing.T) {

--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -19,7 +19,7 @@ import (
 // totalCost 是本次请求的客户计费（倍率前），用于优先级 2。
 // serviceTier 是最终参与用户计费的 OpenAI 服务层级，用于优先级 3。
 // pricingAt 与本次客户计费使用同一时刻，避免跨峰谷请求的成本与售价错位。
-// reasoningEffort 是最终转发等级；Fable 5.1 max 默认按 3 倍额度消耗。
+// reasoningEffort 是最终转发等级；Fable 5.1 max 按官方价格计费。
 func resolveAccountStatsCost(
 	ctx context.Context,
 	channelService *ChannelService,

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -478,7 +478,7 @@ func TestTryModelFilePricing_Success(t *testing.T) {
 	require.InDelta(t, 0.2, *result, 1e-12)
 }
 
-func TestTryModelFilePricing_Fable51MaxEffortUsesTripleQuota(t *testing.T) {
+func TestTryModelFilePricing_Fable51MaxEffortUsesOfficialPricing(t *testing.T) {
 	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{
 		"claude-fable-5-1": {InputPricePerToken: 0.001},
 	})
@@ -487,7 +487,7 @@ func TestTryModelFilePricing_Fable51MaxEffortUsesTripleQuota(t *testing.T) {
 	max := tryModelFilePricing(bs, "claude-fable-5-1", tokens, "", time.Time{}, "max")
 	require.NotNil(t, standard)
 	require.NotNil(t, max)
-	require.InDelta(t, *standard*3, *max, 1e-12)
+	require.InDelta(t, *standard, *max, 1e-12)
 }
 
 func TestTryModelFilePricing_AppliesLongContextPricing(t *testing.T) {

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -215,7 +215,7 @@ func applyCostBreakdownMultiplier(cost *CostBreakdown, multiplier float64) {
 	cost.ActualCost *= multiplier
 }
 
-const claudeFable51MaxReasoningEffortMultiplier = 3.0
+const claudeFable51MaxReasoningEffortMultiplier = 1.0
 
 func isClaudeFable51Model(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1800,7 +1800,7 @@ func TestGetModelPricing_Fable51FallbackPricing(t *testing.T) {
 	require.InDelta(t, 20e-6, pricing.CacheCreation1hPrice, 1e-12)
 	require.InDelta(t, 0.25e-6, pricing.CacheReadPricePerToken, 1e-12)
 	require.NotNil(t, pricing.MaxReasoningEffortMultiplier)
-	require.Equal(t, 3.0, *pricing.MaxReasoningEffortMultiplier)
+	require.Equal(t, 1.0, *pricing.MaxReasoningEffortMultiplier)
 }
 
 func TestGetModelPricingWithChannel_CacheReadPriceAffectsPriority(t *testing.T) {

--- a/backend/internal/service/billing_token_cost_request_test.go
+++ b/backend/internal/service/billing_token_cost_request_test.go
@@ -217,7 +217,7 @@ func TestCalculateTokenCostForRequest_NoResolverFallsBackToCatalog(t *testing.T)
 	require.Equal(t, want, got)
 }
 
-func TestCalculateTokenCostForRequest_Fable51MaxEffortUsesDefaultMultiplier(t *testing.T) {
+func TestCalculateTokenCostForRequest_Fable51MaxEffortUsesOfficialMultiplier(t *testing.T) {
 	bs := NewBillingService(&config.Config{}, nil)
 	tokens := UsageTokens{InputTokens: 1000, OutputTokens: 10}
 	standard, err := bs.CalculateTokenCostForRequest(TokenCostRequest{
@@ -228,10 +228,10 @@ func TestCalculateTokenCostForRequest_Fable51MaxEffortUsesDefaultMultiplier(t *t
 		Model: "claude-fable-5-1", Tokens: tokens, RateMultiplier: 1, ReasoningEffort: "max",
 	})
 	require.NoError(t, err)
-	require.InDelta(t, standard.TotalCost*3, max.TotalCost, 1e-12)
-	require.InDelta(t, standard.ActualCost*3, max.ActualCost, 1e-12)
-	require.InDelta(t, standard.InputCost*3, max.InputCost, 1e-12)
-	require.InDelta(t, standard.OutputCost*3, max.OutputCost, 1e-12)
+	require.InDelta(t, standard.TotalCost, max.TotalCost, 1e-12)
+	require.InDelta(t, standard.ActualCost, max.ActualCost, 1e-12)
+	require.InDelta(t, standard.InputCost, max.InputCost, 1e-12)
+	require.InDelta(t, standard.OutputCost, max.OutputCost, 1e-12)
 }
 
 func TestCalculateTokenCostForRequest_ChannelOverridesFable51MaxEffortMultiplier(t *testing.T) {

--- a/backend/internal/service/model_plaza_service_test.go
+++ b/backend/internal/service/model_plaza_service_test.go
@@ -62,7 +62,7 @@ func TestWithDefaultMaxReasoningEffortMultiplier_Fable51(t *testing.T) {
 	got := withDefaultMaxReasoningEffortMultiplier(base, "claude-fable-5-1")
 	require.NotSame(t, base, got)
 	require.NotNil(t, got.MaxReasoningEffortMultiplier)
-	require.Equal(t, 3.0, *got.MaxReasoningEffortMultiplier)
+	require.Equal(t, 1.0, *got.MaxReasoningEffortMultiplier)
 	require.Nil(t, base.MaxReasoningEffortMultiplier)
 
 	configured := 1.25

--- a/frontend/src/i18n/locales/en/admin/channels.ts
+++ b/frontend/src/i18n/locales/en/admin/channels.ts
@@ -141,7 +141,7 @@ export default {
         fastMultiplier: 'Fast Multiplier',
         flexMultiplier: 'Flex Multiplier',
         maxReasoningEffortMultiplier: 'Max Effort Multiplier',
-        fable51DefaultMaxReasoningMultiplier: 'Default: 3',
+        fable51DefaultMaxReasoningMultiplier: 'Default: 1',
         multiplierPlaceholder: 'Not set',
         multiplierPositive: 'Fast/Flex/Max effort multipliers must be greater than 0',
         inputMultiplier: 'Input Mult.',

--- a/frontend/src/i18n/locales/zh/admin/channels.ts
+++ b/frontend/src/i18n/locales/zh/admin/channels.ts
@@ -141,7 +141,7 @@ export default {
         fastMultiplier: 'Fast 倍率',
         flexMultiplier: 'Flex 倍率',
         maxReasoningEffortMultiplier: 'Max 推理倍率',
-        fable51DefaultMaxReasoningMultiplier: '默认 3',
+        fable51DefaultMaxReasoningMultiplier: '默认 1',
         multiplierPlaceholder: '未配置',
         multiplierPositive: 'Fast/Flex/Max 推理倍率必须大于 0',
         inputMultiplier: '输入倍率',


### PR DESCRIPTION
## Summary
- Use official pricing for Fable 5.1 max reasoning effort instead of the default 3x multiplier.
- Update billing, account-stat, model plaza tests, and admin UI labels.

## Verification
- Updated all related expectations from 3x to 1x.
- PR diff verified against Wei-Shaw/sub2api:main; only the 8 intended files are changed.