### PR TITLE
fix(accounts): populate display names for live test models

### DIFF
--- a/backend/internal/service/account_test_models_test.go
+++ b/backend/internal/service/account_test_models_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchOpenAIAccountModelsOAuthPopulatesPickerFields(t *testing.T) {
+	_, calls := newCodexModelsOAuthCacheServer(t, `{"models":[{"slug":"new-oauth-model"},{"slug":"gpt-6-astra"}]}`)
+	gateway := &OpenAIGatewayService{}
+	svc := &AccountTestService{openaiGatewayService: gateway}
+	account := newCodexModelsTestAccount()
+	ctx := context.Background()
+
+	before, err := gateway.FetchOpenAIModelsList(ctx, account)
+	require.NoError(t, err)
+	models, err := svc.FetchOpenAIAccountModels(ctx, account)
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+	for i, id := range []string{"new-oauth-model", "gpt-6-astra"} {
+		require.Equal(t, id, models[i].ID)
+		require.Equal(t, id, models[i].DisplayName)
+		require.Equal(t, "model", models[i].Type)
+	}
+	after, err := gateway.FetchOpenAIModelsList(ctx, account)
+	require.NoError(t, err)
+	require.Equal(t, before.Body, after.Body, "picker fields must not change the shared catalog")
+	require.NotContains(t, string(after.Body), "display_name")
+	require.EqualValues(t, 1, calls.Load(), "picker must reuse the shared discovery cache")
+}
+
+func TestFetchOpenAIAccountModelsAPIKeyPopulatesPickerFields(t *testing.T) {
+	gateway := newCodexModelsAPIKeyTestService(&codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return ordinaryModelsUpstreamResponse(`{"data":[
+			{"id":"new-api-model","owned_by":"provider","created":123},
+			{"id":"blank-label","display_name":"  ","type":""},
+			{"id":"named-model","display_name":"Provider Model","type":"model"}
+		]}`), nil
+	}})
+	svc := &AccountTestService{openaiGatewayService: gateway}
+	models, err := svc.FetchOpenAIAccountModels(context.Background(), newCodexModelsAPIKeyTestAccount("https://models.example/v1"))
+	require.NoError(t, err)
+	require.Len(t, models, 3)
+	for i, name := range []string{"new-api-model", "blank-label", "Provider Model"} {
+		require.Equal(t, name, models[i].DisplayName)
+		require.Equal(t, "model", models[i].Type)
+	}
+	require.Equal(t, "provider", models[0].OwnedBy)
+	require.EqualValues(t, 123, models[0].Created)
+	require.Equal(t, "named-model", models[2].ID)
+}
+
+func TestFetchOpenAIAccountModelsPreservesEmptyCatalog(t *testing.T) {
+	gateway := newCodexModelsAPIKeyTestService(&codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return ordinaryModelsUpstreamResponse(`{"data":[]}`), nil
+	}})
+	svc := &AccountTestService{openaiGatewayService: gateway}
+	models, err := svc.FetchOpenAIAccountModels(context.Background(), newCodexModelsAPIKeyTestAccount("https://models.example/v1"))
+	require.NoError(t, err)
+	require.Empty(t, models, "an empty upstream catalog must not become a static model list")
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -192,6 +192,17 @@ func (s *AccountTestService) FetchOpenAIAccountModels(ctx context.Context, accou
 	if err := json.Unmarshal(response.Body, &payload); err != nil {
 		return nil, fmt.Errorf("decode OpenAI account models: %w", err)
 	}
+	// Standard model catalogs do not require the fields used by the admin picker.
+	// Populate them here without changing the shared discovery response or cache.
+	for i := range payload.Data {
+		model := &payload.Data[i]
+		if strings.TrimSpace(model.DisplayName) == "" {
+			model.DisplayName = model.ID
+		}
+		if strings.TrimSpace(model.Type) == "" {
+			model.Type = "model"
+		}
+	}
 	return payload.Data, nil
 }
 


### PR DESCRIPTION
## Summary
- Fix blank model labels in the account connection-test picker for OpenAI OAuth and API key accounts.
- Populate missing or whitespace-only display_name from the live model ID and default missing type to model at the admin conversion boundary.
- Preserve upstream labels, metadata, ordering, empty catalogs, and the shared discovery cache; do not substitute a static catalog.

## Root cause
The live discovery path introduced in f88d62ad2 returns standard model entries, which do not require display_name. The admin picker renders that field directly, leaving otherwise valid models invisible.

## Tests
- Added regression tests for OAuth, API key missing/blank/preserved labels, metadata, empty catalogs, and shared-cache isolation/reuse.
- Confirmed the OAuth and API key regressions fail before the fix.
- Passed: go test ./internal/service -run "TestFetchOpenAIAccountModels|TestFetchOpenAIModelsList" -count=1
- Passed: go test ./internal/service ./internal/handler/admin