### PR TITLE
fix(plugin): 提交插件包前先关闭 ZIP 读取器，修正 Windows 下两例单测

### DIFF
--- a/backend/internal/service/content_moderation_runtime_cache_test.go
+++ b/backend/internal/service/content_moderation_runtime_cache_test.go
@@ -276,10 +276,15 @@ func TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig(t *testi
 	decision, err = svc.Check(context.Background(), input)
 	require.NoError(t, err)
 	require.True(t, decision.Blocked)
+	// Windows 单调时钟步进约 0.5ms，两次相邻调用可能读到同一时刻，需反复调用才能观察到 TTL 过期。
 	require.Eventually(t, func() bool {
+		_, _ = svc.Check(context.Background(), input)
 		_, calls := repo.calls()
 		return calls >= 2
 	}, time.Second, time.Millisecond)
+	decision, err = svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
 }
 
 func TestContentModerationRuntimeSnapshotRefreshFailureBacksOff(t *testing.T) {

--- a/backend/internal/service/plugin_package.go
+++ b/backend/internal/service/plugin_package.go
@@ -107,7 +107,14 @@ func (i *PluginPackageInstaller) Install(ctx context.Context, reader io.Reader, 
 	if err != nil {
 		return nil, fmt.Errorf("插件包不是有效的 ZIP: %w", err)
 	}
-	defer func() { _ = archive.Close() }()
+	archiveClosed := false
+	closeArchive := func() {
+		if !archiveClosed {
+			archiveClosed = true
+			_ = archive.Close()
+		}
+	}
+	defer closeArchive()
 	manifest, _, signatureStatus, err := i.inspectArchive(&archive.Reader)
 	if err != nil {
 		return nil, err
@@ -137,6 +144,8 @@ func (i *PluginPackageInstaller) Install(ctx context.Context, reader io.Reader, 
 	if err := i.extractArchive(ctx, &archive.Reader, manifest, extractPath); err != nil {
 		return nil, err
 	}
+	// Windows 不允许重命名仍被打开的文件，提交前先释放 ZIP 读取器。
+	closeArchive()
 	if err := os.Rename(extractPath, installPath); err != nil {
 		return nil, fmt.Errorf("提交插件安装目录: %w", err)
 	}

--- a/backend/internal/service/plugin_package_test.go
+++ b/backend/internal/service/plugin_package_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -33,7 +34,9 @@ func TestPluginPackageInstallerInstallUnsignedDevelopmentPackage(t *testing.T) {
 	assert.FileExists(t, installation.ArtifactPath)
 	info, statErr := os.Stat(installation.BinaryPath)
 	require.NoError(t, statErr)
-	assert.NotZero(t, info.Mode()&0o100)
+	if runtime.GOOS != "windows" {
+		assert.NotZero(t, info.Mode()&0o100)
+	}
 	assert.Contains(t, installation.InstallPath, filepath.Join("installed", "com.example.openai-transport"))
 }
 


### PR DESCRIPTION
## 背景

在 Windows 上上传任何插件包都会失败，错误固定出现在落盘那一步：

```
保存插件包: rename ...\staging\upload-xxx.s2plugin ...\packages\xxx.s2plugin: The process cannot access the file because it is being used by another process.
```

`PluginPackageInstaller.Install` 用 `zip.OpenReader` 打开暂存文件后把 `Close` 推迟到函数返回，而 `os.Rename(tempPath, artifactPath)` 在此之前执行。Windows 不允许重命名仍被打开的文件，所以插件安装在 Windows 部署上必然失败；Linux/macOS 允许，因此 CI 里看不出来。发布物里有 windows 目标，本机跑 `go test -tags=unit ./internal/service/` 时 `TestPluginPackageInstaller*` 4 例稳定失败，就是这个原因。

## 改动

- `plugin_package.go`：解压完成、提交安装目录之前显式关闭 ZIP 读取器，错误路径仍由 defer 兜底；关闭只做一次。
- `plugin_package_test.go`：二进制可执行位断言只在非 Windows 平台执行。Windows 没有 Unix 权限位，`os.Stat` 永远返回 0，这条断言在 Windows 上没有对应的功能语义；Linux CI 照常执行。
- `content_moderation_runtime_cache_test.go`：`TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` 用 1ns TTL 并假设两次相邻 `Check` 之间时钟一定前进。Windows 单调时钟步进约 0.5ms（本机实测 10 万次相邻 `time.Now()` 有 99998 次读数相同），第二次 `Check` 看到的仍是"未过期"，永远不触发刷新。改为在 `Eventually` 里反复 `Check`，并补一条"刷新失败后仍拦截"的断言；Linux 上首轮即满足，行为不变。

## 测试

- Windows 本机：`TestPluginPackageInstaller*` 8 例与 `TestContentModerationRuntimeSnapshot*` 8 例各连跑 5 次全部通过；此前 `go test -tags=unit ./internal/service/` 固定失败的 5 例全部转绿，全量 0 失败。
- `golangci-lint run ./internal/service/` 0 issue。
- 测试改动不改变 Linux 上的断言集合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
