### PR TITLE
fix(antigravity): preserve Google Search alongside Responses function tools

### DIFF
--- a/backend/internal/pkg/apicompat/responses_stream_event_wire.go
+++ b/backend/internal/pkg/apicompat/responses_stream_event_wire.go
@@ -23,6 +23,19 @@ import "encoding/json"
 // events.
 func (e ResponsesStreamEvent) MarshalJSON() ([]byte, error) {
 	switch e.Type {
+	case "response.web_search_call.in_progress", "response.web_search_call.searching", "response.web_search_call.completed":
+		m := e.wireBase()
+		e.putItemID(m)
+		m["output_index"] = e.OutputIndex
+		return json.Marshal(m)
+	case "response.output_text.annotation.added":
+		m := e.wireBase()
+		e.putItemID(m)
+		m["output_index"] = e.OutputIndex
+		m["content_index"] = e.ContentIndex
+		m["annotation_index"] = e.AnnotationIndex
+		m["annotation"] = e.Annotation
+		return json.Marshal(m)
 	case "response.output_text.delta", "response.output_text.done":
 		m := e.wireBase()
 		e.putItemID(m)
@@ -129,13 +142,17 @@ func (e ResponsesStreamEvent) putItemID(m map[string]any) {
 // carrying text/annotations/logprobs (matching cc-switch's push_text_delta).
 func outputTextPartWire(part *ResponsesContentPart) map[string]any {
 	text := ""
+	annotations := []ResponsesAnnotation{}
 	if part != nil {
 		text = part.Text
+		if part.Annotations != nil {
+			annotations = part.Annotations
+		}
 	}
 	return map[string]any{
 		"type":        "output_text",
 		"text":        text,
-		"annotations": []any{},
+		"annotations": annotations,
 		"logprobs":    []any{},
 	}
 }
@@ -201,6 +218,8 @@ func responsesItemWire(item *ResponsesOutput) map[string]any {
 		m["call_id"] = item.CallID
 		m["execution"] = "client"
 		m["arguments"] = toolSearchCallArgumentsJSON(item.Arguments)
+	case "web_search_call":
+		m["action"] = item.Action
 	}
 	return m
 }
@@ -214,7 +233,16 @@ func messageContentWire(parts []ResponsesContentPart) []map[string]any {
 		if typ == "" {
 			typ = "output_text"
 		}
-		out = append(out, map[string]any{"type": typ, "text": p.Text})
+		part := map[string]any{"type": typ, "text": p.Text}
+		if typ == "output_text" {
+			annotations := p.Annotations
+			if annotations == nil {
+				annotations = []ResponsesAnnotation{}
+			}
+			part["annotations"] = annotations
+			part["logprobs"] = []any{}
+		}
+		out = append(out, part)
 	}
 	return out
 }

--- a/backend/internal/pkg/apicompat/responses_stream_event_wire_test.go
+++ b/backend/internal/pkg/apicompat/responses_stream_event_wire_test.go
@@ -35,6 +35,32 @@ func TestWire_IndexFieldsPresentAtZero(t *testing.T) {
 	require.Contains(t, r, "summary_index")
 }
 
+func TestWire_WebSearchActionAndCitationsArePreserved(t *testing.T) {
+	m := marshalEvent(t, ResponsesStreamEvent{
+		Type: "response.output_item.done",
+		Item: &ResponsesOutput{Type: "web_search_call", ID: "ws_1", Status: "completed", Action: &WebSearchAction{
+			Type: "search", Query: "current release", Sources: []ResponsesWebSearchSource{{Type: "url", URL: "https://example.com", Title: "Example"}},
+		}},
+	})
+	item, ok := m["item"].(map[string]any)
+	require.True(t, ok)
+	action, ok := item["action"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "current release", action["query"])
+	require.Len(t, action["sources"], 1)
+
+	m = marshalEvent(t, ResponsesStreamEvent{
+		Type: "response.content_part.done",
+		Part: &ResponsesContentPart{
+			Type: "output_text", Text: "Example",
+			Annotations: []ResponsesAnnotation{{Type: "url_citation", URL: "https://example.com", Title: "Example", StartIndex: 0, EndIndex: 7}},
+		},
+	})
+	part, ok := m["part"].(map[string]any)
+	require.True(t, ok)
+	require.Len(t, part["annotations"], 1)
+}
+
 // TestWire_FunctionCallItemAlwaysComplete guards that a function_call item
 // always carries call_id/name/arguments, including arguments:"" on .added.
 func TestWire_FunctionCallItemAlwaysComplete(t *testing.T) {

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -309,9 +309,10 @@ func (i *ResponsesInputItem) UnmarshalJSON(data []byte) error {
 
 // ResponsesContentPart is a typed content part in a Responses message.
 type ResponsesContentPart struct {
-	Type     string `json:"type"` // "input_text" | "output_text" | "input_image" | "input_file"
-	Text     string `json:"text,omitempty"`
-	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
+	Type        string                `json:"type"` // "input_text" | "output_text" | "input_image" | "input_file"
+	Text        string                `json:"text,omitempty"`
+	ImageURL    string                `json:"image_url,omitempty"` // data URI for input_image
+	Annotations []ResponsesAnnotation `json:"annotations,omitempty"`
 
 	// input_file fields.
 	Filename string `json:"filename,omitempty"`
@@ -491,8 +492,23 @@ func (o *ResponsesOutput) UnmarshalJSON(data []byte) error {
 
 // WebSearchAction describes the search action in a web_search_call output item.
 type WebSearchAction struct {
-	Type  string `json:"type,omitempty"`  // "search"
-	Query string `json:"query,omitempty"` // primary search query
+	Type    string                     `json:"type,omitempty"` // "search"
+	Query   string                     `json:"query,omitempty"`
+	Sources []ResponsesWebSearchSource `json:"sources,omitempty"`
+}
+
+type ResponsesWebSearchSource struct {
+	Type  string `json:"type,omitempty"`
+	URL   string `json:"url"`
+	Title string `json:"title,omitempty"`
+}
+
+type ResponsesAnnotation struct {
+	Type       string `json:"type"`
+	URL        string `json:"url,omitempty"`
+	Title      string `json:"title,omitempty"`
+	StartIndex int    `json:"start_index"`
+	EndIndex   int    `json:"end_index"`
 }
 
 // ResponsesSummary is a summary text block inside a reasoning output.
@@ -636,7 +652,9 @@ type ResponsesStreamEvent struct {
 
 	// response.content_part.added / done and
 	// response.reasoning_summary_part.added / done
-	Part *ResponsesContentPart `json:"part,omitempty"`
+	Part            *ResponsesContentPart `json:"part,omitempty"`
+	Annotation      *ResponsesAnnotation  `json:"annotation,omitempty"`
+	AnnotationIndex int                   `json:"annotation_index,omitempty"`
 
 	// error event fields
 	Code  string `json:"code,omitempty"`

--- a/backend/internal/service/antigravity_gateway_agent_responses.go
+++ b/backend/internal/service/antigravity_gateway_agent_responses.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func agentSearchSources(raw json.RawMessage) []apicompat.ResponsesWebSearchSource {
+	var grounding antigravity.GeminiGroundingMetadata
+	if json.Unmarshal(raw, &grounding) != nil {
+		return nil
+	}
+	var sources []apicompat.ResponsesWebSearchSource
+	seen := map[string]bool{}
+	for _, chunk := range grounding.GroundingChunks {
+		if chunk.Web == nil {
+			continue
+		}
+		parsed, err := url.Parse(chunk.Web.URI)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || seen[chunk.Web.URI] {
+			continue
+		}
+		seen[chunk.Web.URI] = true
+		sources = append(sources, apicompat.ResponsesWebSearchSource{Type: "url", URL: chunk.Web.URI, Title: chunk.Web.Title})
+	}
+	return sources
+}
+
+func addAgentSearchOutputs(response *apicompat.ResponsesResponse, searches []antigravityAgentSearchRecord) {
+	var outputs []apicompat.ResponsesOutput
+	var sourceText strings.Builder
+	var annotations []apicompat.ResponsesAnnotation
+	seen := map[string]bool{}
+	for _, search := range searches {
+		sources := agentSearchSources(search.turn.grounding)
+		outputs = append(outputs, apicompat.ResponsesOutput{
+			ID: "ws_" + uuid.NewString(), Type: "web_search_call", Status: "completed",
+			Action: &apicompat.WebSearchAction{Type: "search", Query: search.query, Sources: sources},
+		})
+		for _, source := range sources {
+			if seen[source.URL] {
+				continue
+			}
+			seen[source.URL] = true
+			if sourceText.Len() == 0 {
+				_, _ = sourceText.WriteString("Search sources:\n")
+			}
+			label := strings.TrimSpace(source.Title)
+			if label == "" {
+				label = source.URL
+			}
+			start := utf8.RuneCountInString(sourceText.String())
+			_, _ = sourceText.WriteString(label)
+			annotations = append(annotations, apicompat.ResponsesAnnotation{Type: "url_citation", URL: source.URL, Title: label, StartIndex: start, EndIndex: start + utf8.RuneCountInString(label)})
+			_ = sourceText.WriteByte('\n')
+		}
+	}
+	// Grounding supports refer to the search response, not the model's later
+	// answer. Label the actual source names rather than inventing claim offsets.
+	if sourceText.Len() > 0 {
+		part := apicompat.ResponsesContentPart{Type: "output_text", Text: sourceText.String(), Annotations: annotations}
+		messageIndex := -1
+		for i := range response.Output {
+			if response.Output[i].Type == "message" {
+				messageIndex = i
+			}
+		}
+		if messageIndex >= 0 {
+			response.Output[messageIndex].Content = append(response.Output[messageIndex].Content, part)
+		} else {
+			response.Output = append(response.Output, apicompat.ResponsesOutput{ID: "msg_" + uuid.NewString(), Type: "message", Role: "assistant", Status: "completed", Content: []apicompat.ResponsesContentPart{part}})
+		}
+	}
+	response.Output = append(outputs, response.Output...)
+}
+
+func (s *AntigravityGatewayService) consumeAntigravityAgentResponses(c *gin.Context, call *antigravityCompatUpstreamCall, resp *http.Response) (*antigravityStreamResult, error) {
+	claudeJSON, result, err := s.collectClaudeStreamResponse(c, resp, call.request.startTime, call.request.originalModel)
+	if err != nil {
+		return nil, s.mapAntigravityCompatCollectionError(c, err)
+	}
+	var claude apicompat.AnthropicResponse
+	if err := json.Unmarshal(claudeJSON, &claude); err != nil {
+		return nil, s.mapAntigravityCompatCollectionError(c, err)
+	}
+	response := apicompat.AnthropicToResponsesResponse(&claude)
+	usage := call.agentResult.usage
+	result.usage = &ClaudeUsage{InputTokens: max(0, usage.PromptTokenCount-usage.CachedContentTokenCount), OutputTokens: usage.CandidatesTokenCount + usage.ThoughtsTokenCount, CacheReadInputTokens: usage.CachedContentTokenCount}
+	response.Usage = &apicompat.ResponsesUsage{
+		InputTokens: usage.PromptTokenCount, OutputTokens: result.usage.OutputTokens,
+		TotalTokens:         usage.PromptTokenCount + result.usage.OutputTokens,
+		InputTokensDetails:  &apicompat.ResponsesInputTokensDetails{CachedTokens: usage.CachedContentTokenCount},
+		OutputTokensDetails: &apicompat.ResponsesOutputTokensDetails{ReasoningTokens: usage.ThoughtsTokenCount},
+	}
+	addAgentSearchOutputs(response, call.agentResult.searches)
+	if !call.request.clientStream {
+		c.JSON(http.StatusOK, response)
+		return result, nil
+	}
+	data, err := agentResponsesSSE(response)
+	if err != nil {
+		return nil, s.mapAntigravityCompatCollectionError(c, err)
+	}
+	if err := c.Request.Context().Err(); err != nil {
+		return nil, err
+	}
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Accel-Buffering", "no")
+	c.Data(http.StatusOK, "text/event-stream", data)
+	c.Writer.Flush()
+	return result, nil
+}
+
+// Internal rounds never commit headers or data. Render one lifecycle after all
+// upstream work succeeds, retaining safe retry/failover before that point.
+func agentResponsesSSE(response *apicompat.ResponsesResponse) ([]byte, error) {
+	var out bytes.Buffer
+	sequence := 0
+	emit := func(event apicompat.ResponsesStreamEvent) error {
+		event.SequenceNumber = sequence
+		sequence++
+		payload, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		// The shared event type omits a zero sequence on lifecycle events.
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &fields); err != nil {
+			return err
+		}
+		fields["sequence_number"] = agentJSON(event.SequenceNumber)
+		payload, err = json.Marshal(fields)
+		if err != nil {
+			return err
+		}
+		if out.Len()+len(payload) > antigravityAgentMaxHistoryBytes {
+			return fmt.Errorf("responses stream exceeds byte limit")
+		}
+		fmt.Fprintf(&out, "event: %s\ndata: %s\n\n", event.Type, payload)
+		return nil
+	}
+	initial := *response
+	initial.Status, initial.Output, initial.Usage = "in_progress", []apicompat.ResponsesOutput{}, nil
+	for _, kind := range []string{"response.created", "response.in_progress"} {
+		if err := emit(apicompat.ResponsesStreamEvent{Type: kind, Response: &initial}); err != nil {
+			return nil, err
+		}
+	}
+	for index, item := range response.Output {
+		added := item
+		added.Status = "in_progress"
+		added.Content, added.Summary, added.Arguments = nil, nil, ""
+		if err := emit(apicompat.ResponsesStreamEvent{Type: "response.output_item.added", OutputIndex: index, Item: &added}); err != nil {
+			return nil, err
+		}
+		base := apicompat.ResponsesStreamEvent{OutputIndex: index, ItemID: item.ID}
+		switch item.Type {
+		case "web_search_call":
+			for _, kind := range []string{"response.web_search_call.in_progress", "response.web_search_call.searching", "response.web_search_call.completed"} {
+				base.Type = kind
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+			}
+		case "message":
+			for contentIndex, part := range item.Content {
+				base.ContentIndex = contentIndex
+				empty := apicompat.ResponsesContentPart{Type: part.Type}
+				base.Type, base.Part = "response.content_part.added", &empty
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Part = nil
+				base.Type, base.Delta = "response.output_text.delta", part.Text
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Delta = ""
+				for annotationIndex, annotation := range part.Annotations {
+					base.Type, base.AnnotationIndex, base.Annotation = "response.output_text.annotation.added", annotationIndex, &annotation
+					if err := emit(base); err != nil {
+						return nil, err
+					}
+				}
+				base.Annotation, base.AnnotationIndex = nil, 0
+				base.Type, base.Text, base.Delta = "response.output_text.done", part.Text, ""
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Type, base.Part, base.Text = "response.content_part.done", &part, ""
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Part = nil
+			}
+		case "function_call":
+			base.CallID, base.Name = item.CallID, item.Name
+			base.Type, base.Delta = "response.function_call_arguments.delta", item.Arguments
+			if err := emit(base); err != nil {
+				return nil, err
+			}
+			base.Type, base.Arguments, base.Delta = "response.function_call_arguments.done", item.Arguments, ""
+			if err := emit(base); err != nil {
+				return nil, err
+			}
+		case "reasoning":
+			for summaryIndex, summary := range item.Summary {
+				base.SummaryIndex = summaryIndex
+				part := apicompat.ResponsesContentPart{Type: "summary_text"}
+				base.Type, base.Part = "response.reasoning_summary_part.added", &part
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Part = nil
+				base.Type, base.Delta = "response.reasoning_summary_text.delta", summary.Text
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Type, base.Text, base.Delta = "response.reasoning_summary_text.done", summary.Text, ""
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				part.Text = summary.Text
+				base.Type, base.Part, base.Text = "response.reasoning_summary_part.done", &part, ""
+				if err := emit(base); err != nil {
+					return nil, err
+				}
+				base.Part = nil
+			}
+		}
+		if err := emit(apicompat.ResponsesStreamEvent{Type: "response.output_item.done", OutputIndex: index, Item: &item}); err != nil {
+			return nil, err
+		}
+	}
+	kind := "response.completed"
+	if response.Status == "incomplete" {
+		kind = "response.incomplete"
+	}
+	if err := emit(apicompat.ResponsesStreamEvent{Type: kind, Response: response}); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}

--- a/backend/internal/service/antigravity_gateway_agent_search.go
+++ b/backend/internal/service/antigravity_gateway_agent_search.go
@@ -170,7 +170,16 @@ func configureAgentToolChoice(body, original []byte) ([]byte, bool, error) {
 		}
 		// Do not silently bypass client search restrictions that Google's
 		// native tool cannot represent through this bridge.
-		if tool["filters"] != nil || string(tool["external_web_access"]) == "false" || tool["user_location"] != nil {
+		if raw, present := tool["external_web_access"]; present {
+			var externalWebAccess *bool
+			if err := json.Unmarshal(raw, &externalWebAccess); err != nil || externalWebAccess == nil {
+				return nil, false, errors.New("external_web_access must be a boolean")
+			}
+			if !*externalWebAccess {
+				return nil, false, errors.New("unsupported Google Search restrictions")
+			}
+		}
+		if tool["filters"] != nil || tool["user_location"] != nil {
 			return nil, false, errors.New("unsupported Google Search restrictions")
 		}
 	}

--- a/backend/internal/service/antigravity_gateway_agent_search.go
+++ b/backend/internal/service/antigravity_gateway_agent_search.go
@@ -1,0 +1,628 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const (
+	antigravityWebSearchBrokerTool       = "__sub2api_google_search"
+	antigravityAgentMaxResponseBytes     = 16 << 20
+	antigravityAgentMaxHistoryBytes      = 64 << 20
+	antigravityAgentDefaultMaxToolRounds = 8
+)
+
+// Raw JSON objects retain unknown protocol fields and opaque signatures. Do not
+// round-trip internal history through the shared Claude request converter.
+type agentJSONObject = map[string]json.RawMessage
+
+func agentDecodeObject(raw []byte) (agentJSONObject, error) {
+	var obj agentJSONObject
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+	if obj == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return obj, nil
+}
+
+func agentJSON(v any) json.RawMessage {
+	// All callers pass JSON-compatible protocol values, never arbitrary objects.
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("invalid internal agent JSON value")
+	}
+	return b
+}
+
+func agentString(raw json.RawMessage) string {
+	var v string
+	_ = json.Unmarshal(raw, &v)
+	return v
+}
+
+func (s *AntigravityGatewayService) agentSearchSetting(ctx context.Context, key, env string) string {
+	v := strings.TrimSpace(os.Getenv(env))
+	if s != nil && s.settingService != nil && s.settingService.settingRepo != nil {
+		if configured, err := s.settingService.settingRepo.GetValue(ctx, key); err == nil && strings.TrimSpace(configured) != "" {
+			v = strings.TrimSpace(configured)
+		}
+	}
+	return v
+}
+
+func (s *AntigravityGatewayService) antigravityAgentWebSearchEnabled(ctx context.Context) bool {
+	v := s.agentSearchSetting(ctx, "antigravity_agent_web_search_enabled", "ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED")
+	if v == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	return err == nil && enabled
+}
+
+func (s *AntigravityGatewayService) antigravityAgentToolRoundLimit(ctx context.Context) int {
+	v := s.agentSearchSetting(ctx, "antigravity_agent_max_tool_rounds", "ANTIGRAVITY_AGENT_MAX_TOOL_ROUNDS")
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return antigravityAgentDefaultMaxToolRounds
+	}
+	return min(n, 32)
+}
+
+// prepareAgentSearch is called only for Gemini Responses, after mapping the
+// model and before the first upstream request. The enable switch is snapshotted
+// here, so disabling it cannot leave an unhandled internal function upstream.
+func prepareAgentSearch(body []byte, enabled bool) ([]byte, bool, error) {
+	envelope, err := agentDecodeObject(body)
+	if err != nil {
+		return nil, false, err
+	}
+	request, err := agentDecodeObject(envelope["request"])
+	if err != nil {
+		return nil, false, err
+	}
+	var tools []agentJSONObject
+	if err := json.Unmarshal(request["tools"], &tools); err != nil {
+		return body, false, nil
+	}
+	hasSearch, hasFunctions, reserved := false, false, false
+	for _, tool := range tools {
+		hasSearch = hasSearch || tool["googleSearch"] != nil
+		var declarations []agentJSONObject
+		if err := json.Unmarshal(tool["functionDeclarations"], &declarations); err == nil {
+			hasFunctions = hasFunctions || len(declarations) > 0
+			for _, declaration := range declarations {
+				if enabled && agentString(declaration["name"]) == antigravityWebSearchBrokerTool {
+					reserved = true
+				}
+			}
+		}
+	}
+	if !hasSearch || !hasFunctions {
+		return body, hasSearch && enabled, nil
+	}
+	if reserved {
+		return nil, false, errors.New("reserved Google Search function name")
+	}
+	var lowered []agentJSONObject
+	for _, tool := range tools {
+		delete(tool, "googleSearch")
+		if len(tool) > 0 {
+			lowered = append(lowered, tool)
+		}
+	}
+	if enabled {
+		lowered = append(lowered, agentJSONObject{"functionDeclarations": agentJSON([]any{map[string]any{
+			"name":        antigravityWebSearchBrokerTool,
+			"description": "Search Google for current information when needed. Returns a grounded summary and sources. This tool is executed by the server.",
+			"parameters":  map[string]any{"type": "OBJECT", "properties": map[string]any{"query": map[string]any{"type": "STRING"}}, "required": []string{"query"}},
+		}})})
+	}
+	request["tools"] = agentJSON(lowered)
+	config, _ := agentDecodeObject(request["toolConfig"])
+	if config != nil {
+		delete(config, "includeServerSideToolInvocations")
+		request["toolConfig"] = agentJSON(config)
+	}
+	envelope["request"] = agentJSON(request)
+	return agentJSON(envelope), enabled, nil
+}
+
+type antigravityAgentTurn struct {
+	content    agentJSONObject
+	grounding  json.RawMessage
+	responseID string
+	usage      antigravity.GeminiUsageMetadata
+	raw        []byte
+}
+
+func configureAgentToolChoice(body, original []byte) ([]byte, bool, error) {
+	client, err := agentDecodeObject(original)
+	if err != nil {
+		return nil, false, err
+	}
+	var originalTools []agentJSONObject
+	if value := client["tools"]; value != nil {
+		if err := json.Unmarshal(value, &originalTools); err != nil {
+			return nil, false, err
+		}
+	}
+	for _, tool := range originalTools {
+		kind := agentString(tool["type"])
+		if kind != "web_search" && kind != "web_search_preview" && kind != "web_search_preview_2025_03_11" {
+			continue
+		}
+		// Do not silently bypass client search restrictions that Google's
+		// native tool cannot represent through this bridge.
+		if tool["filters"] != nil || string(tool["external_web_access"]) == "false" || tool["user_location"] != nil {
+			return nil, false, errors.New("unsupported Google Search restrictions")
+		}
+	}
+	choice := agentString(client["tool_choice"])
+	var named agentJSONObject
+	if len(client["tool_choice"]) > 0 && choice == "" && string(client["tool_choice"]) != "null" {
+		named, err = agentDecodeObject(client["tool_choice"])
+		if err != nil {
+			return nil, false, err
+		}
+		choice = agentString(named["type"])
+	}
+	if choice == "" || choice == "auto" {
+		return body, true, nil
+	}
+	envelope, err := agentDecodeObject(body)
+	if err != nil {
+		return nil, false, err
+	}
+	request, err := agentDecodeObject(envelope["request"])
+	if err != nil {
+		return nil, false, err
+	}
+	var tools []agentJSONObject
+	if err := json.Unmarshal(request["tools"], &tools); err != nil {
+		return nil, false, err
+	}
+	var cleaned []agentJSONObject
+	broker := false
+	for _, tool := range tools {
+		var declarations []agentJSONObject
+		_ = json.Unmarshal(tool["functionDeclarations"], &declarations)
+		var kept []agentJSONObject
+		for _, declaration := range declarations {
+			internal := agentString(declaration["name"]) == antigravityWebSearchBrokerTool
+			broker = broker || internal
+			if choice != "none" || !internal {
+				kept = append(kept, declaration)
+			}
+		}
+		if choice == "none" {
+			delete(tool, "googleSearch")
+			delete(tool, "functionDeclarations")
+			if len(kept) > 0 {
+				tool["functionDeclarations"] = agentJSON(kept)
+			}
+		}
+		if len(tool) > 0 {
+			cleaned = append(cleaned, tool)
+		}
+	}
+	var mode, name string
+	switch choice {
+	case "none":
+		mode = "NONE"
+	case "required":
+		mode = "ANY"
+	case "function":
+		mode, name = "ANY", agentString(named["name"])
+	case "web_search", "web_search_preview":
+		mode, name = "ANY", antigravityWebSearchBrokerTool
+	default:
+		return nil, false, errors.New("unsupported search tool choice")
+	}
+	// Native search-only requests do not accept a function calling config.
+	if !broker && choice != "none" {
+		return body, true, nil
+	}
+	fc := map[string]any{"mode": mode}
+	if name != "" {
+		fc["allowedFunctionNames"] = []string{name}
+	}
+	request["tools"] = agentJSON(cleaned)
+	request["toolConfig"] = agentJSON(map[string]any{"functionCallingConfig": fc})
+	envelope["request"] = agentJSON(request)
+	return agentJSON(envelope), choice != "none", nil
+}
+
+type antigravityAgentSearchRecord struct {
+	callID string
+	query  string
+	turn   antigravityAgentTurn
+}
+
+type antigravityAgentSearchResult struct {
+	usage    antigravity.GeminiUsageMetadata
+	searches []antigravityAgentSearchRecord
+}
+
+// readAntigravityAgentTurn bounds the complete response, not just individual
+// SSE lines. Cancellation closes the body to unblock a pending network read.
+func readAntigravityAgentTurn(ctx context.Context, resp *http.Response, timeout time.Duration) (antigravityAgentTurn, error) {
+	var out antigravityAgentTurn
+	if resp == nil || resp.Body == nil {
+		return out, errors.New("empty agent response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	stop := context.AfterFunc(ctx, func() { _ = resp.Body.Close() })
+	defer stop()
+	var timedOut atomic.Bool
+	var timer *time.Timer
+	if timeout > 0 {
+		timer = time.AfterFunc(timeout, func() { timedOut.Store(true); _ = resp.Body.Close() })
+		defer timer.Stop()
+	}
+	var raw bytes.Buffer
+	limited := &io.LimitedReader{R: resp.Body, N: antigravityAgentMaxResponseBytes + 1}
+	scanner := bufio.NewScanner(io.TeeReader(limited, &raw))
+	scanner.Buffer(make([]byte, 64<<10), antigravityAgentMaxResponseBytes)
+	var data []string
+	var parts []agentJSONObject
+	valid, finished := false, false
+	consume := func() error {
+		if len(data) == 0 {
+			return nil
+		}
+		payload := strings.Join(data, "\n")
+		data = nil
+		if payload == "[DONE]" {
+			return nil
+		}
+		envelope, err := agentDecodeObject([]byte(payload))
+		if err != nil {
+			return errors.New("malformed agent SSE JSON")
+		}
+		response, err := agentDecodeObject(envelope["response"])
+		if err != nil {
+			return errors.New("missing agent response envelope")
+		}
+		valid = true
+		if usage := response["usageMetadata"]; usage != nil {
+			if err := json.Unmarshal(usage, &out.usage); err != nil {
+				return err
+			}
+		}
+		if id := agentString(response["responseId"]); id != "" {
+			out.responseID = id
+		}
+		var candidates []agentJSONObject
+		if value := response["candidates"]; value != nil {
+			if err := json.Unmarshal(value, &candidates); err != nil {
+				return err
+			}
+		}
+		if len(candidates) > 1 {
+			return errors.New("multiple agent candidates are unsupported")
+		}
+		if len(candidates) == 0 {
+			return nil
+		}
+		candidate := candidates[0]
+		finished = finished || agentString(candidate["finishReason"]) != ""
+		if value := candidate["content"]; value != nil {
+			content, err := agentDecodeObject(value)
+			if err != nil {
+				return err
+			}
+			var chunk []agentJSONObject
+			if err := json.Unmarshal(content["parts"], &chunk); err != nil {
+				return err
+			}
+			for _, part := range chunk {
+				if fc := part["functionCall"]; fc != nil {
+					call, err := agentDecodeObject(fc)
+					if err != nil {
+						return err
+					}
+					if agentString(call["id"]) == "" {
+						call["id"] = agentJSON("call_" + uuid.NewString())
+						part["functionCall"] = agentJSON(call)
+					}
+				}
+				// Preserve signature-only chunks as explicit empty text parts.
+				if part["thoughtSignature"] != nil {
+					hasData := false
+					for _, field := range []string{"text", "inlineData", "fileData", "functionCall", "functionResponse", "executableCode", "codeExecutionResult"} {
+						hasData = hasData || part[field] != nil
+					}
+					if !hasData {
+						part["text"] = agentJSON("")
+					}
+				}
+				parts = append(parts, part)
+			}
+			out.content = content
+		}
+		if value := candidate["groundingMetadata"]; value != nil {
+			out.grounding = append(json.RawMessage(nil), value...)
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		if timer != nil {
+			timer.Reset(timeout)
+		}
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if line == "" {
+			if err := consume(); err != nil {
+				return out, err
+			}
+		} else if strings.HasPrefix(line, "data:") {
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+	if ctx.Err() != nil {
+		return out, ctx.Err()
+	}
+	if timedOut.Load() {
+		return out, errors.New("stream data interval timeout")
+	}
+	if limited.N <= 0 {
+		return out, errors.New("agent response exceeds byte limit")
+	}
+	if err := scanner.Err(); err != nil {
+		return out, err
+	}
+	if err := consume(); err != nil {
+		return out, err
+	}
+	if !valid || !finished {
+		return out, errors.New("incomplete agent response")
+	}
+	if out.content == nil {
+		out.content = agentJSONObject{"role": agentJSON("model")}
+	}
+	out.content["parts"] = agentJSON(parts)
+	out.raw = raw.Bytes()
+	return out, nil
+}
+
+func agentFunctionCalls(content agentJSONObject) ([]agentJSONObject, error) {
+	var parts []agentJSONObject
+	if err := json.Unmarshal(content["parts"], &parts); err != nil {
+		return nil, err
+	}
+	var calls []agentJSONObject
+	seen := map[string]bool{}
+	for _, part := range parts {
+		if part["functionCall"] == nil {
+			continue
+		}
+		call, err := agentDecodeObject(part["functionCall"])
+		if err != nil {
+			return nil, err
+		}
+		id := agentString(call["id"])
+		if id == "" || seen[id] {
+			return nil, errors.New("missing or duplicate agent call ID")
+		}
+		seen[id] = true
+		calls = append(calls, call)
+	}
+	return calls, nil
+}
+
+func buildAgentSearchOnlyBody(body []byte, query string) ([]byte, error) {
+	envelope, err := agentDecodeObject(body)
+	if err != nil {
+		return nil, err
+	}
+	request, err := agentDecodeObject(envelope["request"])
+	if err != nil {
+		return nil, err
+	}
+	request["contents"] = agentJSON([]any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": query}}}})
+	request["systemInstruction"] = agentJSON(map[string]any{"role": "user", "parts": []any{map[string]any{"text": "Search Google for the requested information. Return a concise factual summary grounded in sources."}}})
+	request["tools"] = agentJSON([]any{map[string]any{"googleSearch": map[string]any{}}})
+	delete(request, "toolConfig")
+	// A client's output schema governs the final answer, not the search summary.
+	if generation, err := agentDecodeObject(request["generationConfig"]); err == nil {
+		delete(generation, "responseSchema")
+		delete(generation, "responseJsonSchema")
+		delete(generation, "responseMimeType")
+		request["generationConfig"] = agentJSON(generation)
+	}
+	envelope["requestId"] = agentJSON("agent-search-" + uuid.NewString())
+	envelope["request"] = agentJSON(request)
+	return agentJSON(envelope), nil
+}
+
+func appendAgentToolRound(body []byte, model agentJSONObject, results map[string]json.RawMessage) ([]byte, error) {
+	envelope, err := agentDecodeObject(body)
+	if err != nil {
+		return nil, err
+	}
+	request, err := agentDecodeObject(envelope["request"])
+	if err != nil {
+		return nil, err
+	}
+	var contents []json.RawMessage
+	if err := json.Unmarshal(request["contents"], &contents); err != nil {
+		return nil, err
+	}
+	calls, err := agentFunctionCalls(model)
+	if err != nil {
+		return nil, err
+	}
+	var parts []any
+	for _, call := range calls {
+		id, name := agentString(call["id"]), agentString(call["name"])
+		result, ok := results[id]
+		if !ok {
+			if name == antigravityWebSearchBrokerTool {
+				return nil, errors.New("unpaired search result")
+			}
+			result = agentJSON(map[string]any{"ok": false, "deferred": true, "message": "Client tool not executed; decide again after reading the search results."})
+		}
+		parts = append(parts, map[string]any{"functionResponse": map[string]any{"id": id, "name": name, "response": result}})
+	}
+	contents = append(contents, agentJSON(model), agentJSON(map[string]any{"role": "user", "parts": parts}))
+	request["contents"] = agentJSON(contents)
+	// A forced/required tool choice is satisfied by the internal search. Do
+	// not force it again on every continuation and manufacture an endless loop.
+	request["toolConfig"] = agentJSON(map[string]any{"functionCallingConfig": map[string]any{"mode": "AUTO"}})
+	envelope["request"] = agentJSON(request)
+	envelope["requestId"] = agentJSON("agent-continue-" + uuid.NewString())
+	out := agentJSON(envelope)
+	if len(out) > antigravityAgentMaxHistoryBytes {
+		return nil, errors.New("agent history exceeds byte limit")
+	}
+	return out, nil
+}
+
+func addAgentUsage(dst *antigravity.GeminiUsageMetadata, src antigravity.GeminiUsageMetadata) {
+	dst.PromptTokenCount += src.PromptTokenCount
+	dst.CandidatesTokenCount += src.CandidatesTokenCount
+	dst.CachedContentTokenCount += src.CachedContentTokenCount
+	dst.ThoughtsTokenCount += src.ThoughtsTokenCount
+	dst.TotalTokenCount += src.TotalTokenCount
+}
+
+func agentToolError(code string) json.RawMessage {
+	return agentJSON(map[string]any{"ok": false, "error": map[string]any{"code": code, "message": "Search could not be completed; revise the query or answer without claiming verified search results."}})
+}
+
+func (s *AntigravityGatewayService) runAntigravityWebSearchAgentLoop(ctx context.Context, c *gin.Context, account *Account, call *antigravityCompatUpstreamCall, first *http.Response) (*http.Response, error) {
+	body, resp := call.geminiBody, first
+	result := &antigravityAgentSearchResult{}
+	limit := s.antigravityAgentToolRoundLimit(ctx)
+	lastQuery, repeated := "", 0
+	searchAttempts := 0
+	for round := 0; ; round++ {
+		if resp.StatusCode >= 400 {
+			return resp, nil
+		}
+		turn, err := readAntigravityAgentTurn(ctx, resp, s.antigravityCompatStreamTimeout())
+		if err != nil {
+			return nil, err
+		}
+		addAgentUsage(&result.usage, turn.usage)
+		calls, err := agentFunctionCalls(turn.content)
+		if err != nil {
+			return nil, err
+		}
+		var searches []agentJSONObject
+		for _, fc := range calls {
+			if agentString(fc["name"]) == antigravityWebSearchBrokerTool {
+				searches = append(searches, fc)
+			}
+		}
+		if len(searches) == 0 {
+			if turn.grounding != nil {
+				var grounding antigravity.GeminiGroundingMetadata
+				if json.Unmarshal(turn.grounding, &grounding) == nil && len(grounding.WebSearchQueries) > 0 {
+					result.searches = append(result.searches, antigravityAgentSearchRecord{query: strings.Join(grounding.WebSearchQueries, "; "), turn: turn})
+				}
+			}
+			call.agentResult = result
+			resp.Body = io.NopCloser(bytes.NewReader(turn.raw))
+			return resp, nil
+		}
+		if round >= limit {
+			return nil, errors.New("google search tool round limit reached")
+		}
+		if len(searches) > 32 {
+			return nil, errors.New("too many Google Search calls in one round")
+		}
+		results := make(map[string]json.RawMessage, len(searches))
+		for _, fc := range searches {
+			id := agentString(fc["id"])
+			if searchAttempts >= 32 {
+				results[id] = agentToolError("search_call_limit")
+				continue
+			}
+			args, _ := agentDecodeObject(fc["args"])
+			query := strings.TrimSpace(agentString(args["query"]))
+			if query == "" || len(query) > 8192 {
+				results[id] = agentToolError("invalid_query")
+				continue
+			}
+			if query == lastQuery {
+				repeated++
+			} else {
+				lastQuery, repeated = query, 1
+			}
+			if repeated >= 3 {
+				results[id] = agentToolError("repeated_query")
+				continue
+			}
+			searchBody, err := buildAgentSearchOnlyBody(body, query)
+			if err != nil {
+				return nil, err
+			}
+			searchAttempts++
+			searchResp, err := s.doAntigravityAgentRequest(ctx, c, account, call, searchBody)
+			if err != nil {
+				return nil, err
+			}
+			if searchResp.StatusCode >= 400 {
+				if searchResp.StatusCode != http.StatusBadRequest {
+					return searchResp, nil
+				}
+				_ = searchResp.Body.Close()
+				results[id] = agentToolError("upstream_rejected_search")
+				continue
+			}
+			searchTurn, err := readAntigravityAgentTurn(ctx, searchResp, s.antigravityCompatStreamTimeout())
+			if err != nil {
+				return nil, err
+			}
+			addAgentUsage(&result.usage, searchTurn.usage)
+			searchTurn.raw = nil
+			var grounding antigravity.GeminiGroundingMetadata
+			if json.Unmarshal(searchTurn.grounding, &grounding) != nil || (len(grounding.WebSearchQueries) == 0 && len(grounding.GroundingChunks) == 0) {
+				results[id] = agentToolError("no_search_grounding")
+				continue
+			}
+			// Keep the real search candidate and opaque signatures with its own
+			// result. Grounding offsets are never moved onto unrelated final text.
+			results[id] = agentJSON(map[string]any{"ok": true, "query": query, "call_id": id, "response_id": searchTurn.responseID, "content": searchTurn.content, "groundingMetadata": searchTurn.grounding})
+			result.searches = append(result.searches, antigravityAgentSearchRecord{callID: id, query: query, turn: searchTurn})
+		}
+		body, err = appendAgentToolRound(body, turn.content, results)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = s.doAntigravityAgentRequest(ctx, c, account, call, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (s *AntigravityGatewayService) doAntigravityAgentRequest(ctx context.Context, c *gin.Context, account *Account, call *antigravityCompatUpstreamCall, body []byte) (*http.Response, error) {
+	result, err := s.antigravityRetryLoop(antigravityRetryLoopParams{
+		ctx: ctx, prefix: call.prefix, account: account, proxyURL: call.proxyURL, accessToken: call.accessToken,
+		action: "streamGenerateContent", body: body, c: c, httpUpstream: s.httpUpstream,
+		settingService: s.settingService, accountRepo: s.accountRepo, handleError: s.handleUpstreamError,
+		requestedModel: call.request.originalModel,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent upstream request: %w", err)
+	}
+	return result.resp, nil
+}

--- a/backend/internal/service/antigravity_gateway_agent_search_test.go
+++ b/backend/internal/service/antigravity_gateway_agent_search_test.go
@@ -304,3 +304,62 @@ func TestAgentSearchRestrictionsAreNotSilentlyDiscarded(t *testing.T) {
 		require.Error(t, err)
 	}
 }
+
+func TestAgentExternalWebAccessRequiresBoolean(t *testing.T) {
+	body, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	for _, kind := range []string{"web_search", "web_search_preview", "web_search_preview_2025_03_11"} {
+		for _, tc := range []struct {
+			name, value string
+			allowed     bool
+		}{
+			{"omitted", "", true},
+			{"true", "true", true},
+			{"true_whitespace", "\n true \t", true},
+			{"false", "false", false},
+			{"false_whitespace", "\n false \t", false},
+			{"string_false", `"false"`, false},
+			{"string_true", `"true"`, false},
+			{"null", "null", false},
+			{"number", "0", false},
+			{"object", "{}", false},
+			{"array", "[]", false},
+		} {
+			t.Run(kind+"/"+tc.name, func(t *testing.T) {
+				option := ""
+				if tc.value != "" {
+					option = `,"external_web_access":` + tc.value
+				}
+				original := []byte(`{"tools":[{"type":"` + kind + `"` + option + `}]}`)
+				_, active, err := configureAgentToolChoice(body, original)
+				if tc.allowed {
+					require.NoError(t, err)
+					require.True(t, active)
+				} else {
+					require.Error(t, err)
+					require.False(t, active)
+				}
+			})
+		}
+	}
+}
+
+func TestAgentExternalWebAccessRejectedBeforeUpstream(t *testing.T) {
+	t.Setenv("ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED", "true")
+	for _, value := range []string{"false", "\n false \t", `"false"`, `"true"`, "null", "0", "{}", "[]"} {
+		for _, mixed := range []bool{false, true} {
+			upstream := &queuedHTTPUpstreamStub{}
+			svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+			clientTool := ""
+			if mixed {
+				clientTool = `,{"type":"function","name":"client_tool","parameters":{"type":"object"}}`
+			}
+			body := []byte(`{"model":"gemini-3.1-pro-high","input":"Example","tools":[{"type":"web_search","external_web_access":` + value + `}` + clientTool + `]}`)
+			c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", body)
+			_, err := svc.ForwardAsResponses(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), body, nil)
+			require.Error(t, err)
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			require.Zero(t, upstream.callCount)
+		}
+	}
+}

--- a/backend/internal/service/antigravity_gateway_agent_search_test.go
+++ b/backend/internal/service/antigravity_gateway_agent_search_test.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const agentTestEnvelope = `{"project":"example-project","model":"gemini-3.8-flash","requestId":"example-request","unknown":{"integer":9007199254740993},"request":{"contents":[{"role":"user","parts":[{"text":"Find current information"}]}],"tools":[{"googleSearch":{},"functionDeclarations":[{"name":"client_tool","parameters":{"type":"OBJECT"}}]}],"toolConfig":{"includeServerSideToolInvocations":true},"unknownRequestField":true}}`
+
+func agentTestResponse(parts, grounding string) *http.Response {
+	if grounding == "" {
+		grounding = `{}`
+	}
+	data := `{"response":{"responseId":"example-response","candidates":[{"content":{"role":"model","parts":` + parts + `},"finishReason":"STOP","groundingMetadata":` + grounding + `}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"cachedContentTokenCount":1,"thoughtsTokenCount":1,"totalTokenCount":13}}}`
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader("data: " + data + "\n\n"))}
+}
+
+func agentTestCall(id, name, query string) string {
+	return string(agentJSON(map[string]any{"functionCall": map[string]any{"id": id, "name": name, "args": map[string]any{"query": query}}, "thoughtSignature": "fake-signature-" + id}))
+}
+
+func TestPrepareAgentSearchIsolation(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		body, active, err := prepareAgentSearch([]byte(agentTestEnvelope), enabled)
+		require.NoError(t, err)
+		require.Equal(t, enabled, active)
+		require.NotContains(t, string(body), `"googleSearch"`)
+		require.Contains(t, string(body), `"client_tool"`)
+		require.Equal(t, enabled, strings.Contains(string(body), antigravityWebSearchBrokerTool))
+		require.NotContains(t, string(body), "includeServerSideToolInvocations")
+		require.Equal(t, "9007199254740993", gjson.GetBytes(body, "unknown.integer").Raw)
+		require.True(t, gjson.GetBytes(body, "request.unknownRequestField").Bool())
+	}
+	pure := strings.Replace(agentTestEnvelope, `{"googleSearch":{},"functionDeclarations":[{"name":"client_tool","parameters":{"type":"OBJECT"}}]}`, `{"googleSearch":{}}`, 1)
+	body, active, err := prepareAgentSearch([]byte(pure), true)
+	require.NoError(t, err)
+	require.True(t, active)
+	require.JSONEq(t, pure, string(body))
+	functions := strings.Replace(agentTestEnvelope, `"googleSearch":{},`, "", 1)
+	body, active, err = prepareAgentSearch([]byte(functions), true)
+	require.NoError(t, err)
+	require.False(t, active)
+	require.JSONEq(t, functions, string(body))
+}
+
+func TestAgentToolChoice(t *testing.T) {
+	body, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		choice     string
+		active     bool
+		mode, name string
+	}{
+		{`"none"`, false, "NONE", ""},
+		{`"required"`, true, "ANY", ""},
+		{`{"type":"web_search"}`, true, "ANY", antigravityWebSearchBrokerTool},
+		{`{"type":"function","name":"client_tool"}`, true, "ANY", "client_tool"},
+	} {
+		configured, active, err := configureAgentToolChoice(body, []byte(`{"tool_choice":`+tc.choice+`}`))
+		require.NoError(t, err)
+		require.Equal(t, tc.active, active)
+		require.Equal(t, tc.mode, gjson.GetBytes(configured, "request.toolConfig.functionCallingConfig.mode").String())
+		require.Equal(t, tc.name, gjson.GetBytes(configured, "request.toolConfig.functionCallingConfig.allowedFunctionNames.0").String())
+		if !active {
+			require.NotContains(t, string(configured), antigravityWebSearchBrokerTool)
+		}
+	}
+}
+
+func TestAntigravityAgentDisabledDoesNotInjectOrLoop(t *testing.T) {
+	t.Setenv("ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED", "false")
+	var requests [][]byte
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{agentTestResponse(`[{"text":"No search"}]`, "")}, onCall: func(req *http.Request, _ *queuedHTTPUpstreamStub) {
+		raw, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		requests = append(requests, raw)
+	}}
+	svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+	body := []byte(`{"model":"gemini-3.1-pro-high","input":"Example","tools":[{"type":"web_search"},{"type":"function","name":"client_tool","parameters":{"type":"object"}}]}`)
+	c, _ := newAntigravityCompatContext(http.MethodPost, "/v1/responses", body)
+	_, err := svc.ForwardAsResponses(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), body, nil)
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	require.NotContains(t, string(requests[0]), antigravityWebSearchBrokerTool)
+	require.NotContains(t, string(requests[0]), `"googleSearch"`)
+	require.Contains(t, string(requests[0]), `"client_tool"`)
+}
+
+func TestAntigravityAgentSearchErrorIsPaired(t *testing.T) {
+	t.Setenv("ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED", "true")
+	var requests [][]byte
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{
+		{StatusCode: 400, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"synthetic rejection"}}`))},
+		agentTestResponse(`[{"text":"Search was unavailable"}]`, ""),
+	}, onCall: func(req *http.Request, _ *queuedHTTPUpstreamStub) {
+		raw, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		requests = append(requests, raw)
+	}}
+	svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+	c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", []byte(`{}`))
+	prepared, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	call := &antigravityCompatUpstreamCall{geminiBody: prepared, request: antigravityCompatRequest{originalModel: "gemini-3.8-flash"}}
+	resp, err := svc.runAntigravityWebSearchAgentLoop(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), call, agentTestResponse(`[`+agentTestCall("search-error", antigravityWebSearchBrokerTool, "example")+`]`, ""))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_ = resp.Body.Close()
+	require.Len(t, requests, 2)
+	require.Equal(t, "search-error", gjson.GetBytes(requests[1], "request.contents.2.parts.0.functionResponse.id").String())
+	require.Equal(t, "upstream_rejected_search", gjson.GetBytes(requests[1], "request.contents.2.parts.0.functionResponse.response.error.code").String())
+	require.Empty(t, recorder.Body.String())
+	require.Empty(t, call.agentResult.searches)
+}
+
+func TestAntigravityAgentRoundLimitLeavesResponseUncommitted(t *testing.T) {
+	t.Setenv("ANTIGRAVITY_AGENT_MAX_TOOL_ROUNDS", "1")
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{agentTestResponse(`[{"text":"Search result"}]`, ""), agentTestResponse(`[`+agentTestCall("search-again", antigravityWebSearchBrokerTool, "again")+`]`, "")}}
+	svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+	c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", []byte(`{}`))
+	prepared, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	call := &antigravityCompatUpstreamCall{geminiBody: prepared, request: antigravityCompatRequest{originalModel: "gemini-3.8-flash"}}
+	_, err = svc.runAntigravityWebSearchAgentLoop(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), call, agentTestResponse(`[`+agentTestCall("search-first", antigravityWebSearchBrokerTool, "first")+`]`, ""))
+	require.ErrorContains(t, err, "round limit")
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestAgentSearchRoundTripPreservesSignaturesAndPairs(t *testing.T) {
+	parts := `[` + agentTestCall("search-a", antigravityWebSearchBrokerTool, "alpha") + `,` + agentTestCall("search-b", antigravityWebSearchBrokerTool, "beta") + `,` + agentTestCall("client-a", "client_tool", "unused") + `,{"thought":true,"thoughtSignature":"fake-tail-signature"}]`
+	turn, err := readAntigravityAgentTurn(context.Background(), agentTestResponse(parts, ""), 0)
+	require.NoError(t, err)
+	body, err := appendAgentToolRound([]byte(agentTestEnvelope), turn.content, map[string]json.RawMessage{"search-a": agentJSON(map[string]string{"text": "alpha result"}), "search-b": agentJSON(map[string]string{"text": "beta result"})})
+	require.NoError(t, err)
+	require.Equal(t, "fake-signature-search-a", gjson.GetBytes(body, "request.contents.1.parts.0.thoughtSignature").String())
+	require.Equal(t, "fake-tail-signature", gjson.GetBytes(body, "request.contents.1.parts.3.thoughtSignature").String())
+	require.True(t, gjson.GetBytes(body, "request.contents.1.parts.3.text").Exists())
+	require.Equal(t, "search-a", gjson.GetBytes(body, "request.contents.2.parts.0.functionResponse.id").String())
+	require.Equal(t, "alpha result", gjson.GetBytes(body, "request.contents.2.parts.0.functionResponse.response.text").String())
+	require.Equal(t, "beta result", gjson.GetBytes(body, "request.contents.2.parts.1.functionResponse.response.text").String())
+	require.True(t, gjson.GetBytes(body, "request.contents.2.parts.2.functionResponse.response.deferred").Bool())
+	require.Equal(t, "9007199254740993", gjson.GetBytes(body, "unknown.integer").Raw)
+}
+
+func TestAgentTurnRejectsMalformedTruncatedAndOversizedStreams(t *testing.T) {
+	for _, input := range []string{"data: {invalid}\n\n", "data: {}\n\n", `data: {"response":{"candidates":[]}}` + "\n\n", strings.Repeat(": heartbeat\n", antigravityAgentMaxResponseBytes/12+1)} {
+		resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(input))}
+		_, err := readAntigravityAgentTurn(context.Background(), resp, 0)
+		require.Error(t, err)
+	}
+}
+
+func TestAgentTurnCancellationAndIdleTimeout(t *testing.T) {
+	for _, cancelRequest := range []bool{false, true} {
+		reader, writer := io.Pipe()
+		ctx, cancel := context.WithCancel(context.Background())
+		if cancelRequest {
+			cancel()
+		}
+		_, err := readAntigravityAgentTurn(ctx, &http.Response{StatusCode: 200, Body: reader}, 10*time.Millisecond)
+		cancel()
+		_ = writer.Close()
+		require.Error(t, err)
+		if cancelRequest {
+			require.ErrorIs(t, err, context.Canceled)
+		} else {
+			require.Contains(t, err.Error(), "interval timeout")
+		}
+	}
+}
+
+func TestAntigravityAgentMultipleSearchesAndClientTools(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Setenv("ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED", "true")
+		parts := `[` + agentTestCall("search-a", antigravityWebSearchBrokerTool, "alpha") + `,` + agentTestCall("search-b", antigravityWebSearchBrokerTool, "beta") + `,` + agentTestCall("client-pending", "client_tool", "pending") + `]`
+		grounding := `{"webSearchQueries":["example query"],"groundingChunks":[{"web":{"uri":"https://example.com/source","title":"Example source"}}],"groundingSupports":[{"segment":{"startIndex":0,"endIndex":5,"text":"alpha"},"groundingChunkIndices":[0]}]}`
+		var requests [][]byte
+		upstream := &queuedHTTPUpstreamStub{
+			responses: []*http.Response{agentTestResponse(parts, ""), agentTestResponse(`[{"text":"alpha result","thoughtSignature":"fake-search-signature-a"}]`, grounding), agentTestResponse(`[{"text":"beta result"}]`, grounding), agentTestResponse(`[`+agentTestCall("client-final", "client_tool", "complete")+`]`, "")},
+			onCall: func(req *http.Request, _ *queuedHTTPUpstreamStub) {
+				raw, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				requests = append(requests, raw)
+			},
+		}
+		svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+		body := agentJSON(map[string]any{"model": "gemini-3.1-pro-high", "input": "Find current information", "stream": stream, "tools": []any{map[string]any{"type": "web_search"}, map[string]any{"type": "function", "name": "client_tool", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}}}})
+		c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", body)
+		result, err := svc.ForwardAsResponses(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), body, nil)
+		require.NoError(t, err)
+		require.Len(t, requests, 4)
+		for _, request := range requests {
+			require.False(t, strings.Contains(string(request), `"googleSearch"`) && strings.Contains(string(request), `"functionDeclarations"`))
+		}
+		require.Equal(t, "alpha", gjson.GetBytes(requests[1], "request.contents.0.parts.0.text").String())
+		require.Equal(t, "beta", gjson.GetBytes(requests[2], "request.contents.0.parts.0.text").String())
+		require.Contains(t, string(requests[3]), "fake-search-signature-a")
+		require.True(t, gjson.GetBytes(requests[3], "request.contents.2.parts.2.functionResponse.response.deferred").Bool())
+		require.Equal(t, 36, result.Usage.InputTokens)
+		require.Equal(t, 12, result.Usage.OutputTokens)
+		require.Equal(t, 4, result.Usage.CacheReadInputTokens)
+		require.NotContains(t, recorder.Body.String(), antigravityWebSearchBrokerTool)
+		require.Contains(t, recorder.Body.String(), `"url_citation"`)
+		require.Contains(t, recorder.Body.String(), `"client_tool"`)
+		if stream {
+			sequence, searches, created, completed := 0, 0, 0, 0
+			for _, line := range strings.Split(recorder.Body.String(), "\n") {
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				event := gjson.Parse(strings.TrimPrefix(line, "data: "))
+				require.True(t, event.Get("sequence_number").Exists())
+				require.Equal(t, int64(sequence), event.Get("sequence_number").Int())
+				sequence++
+				switch event.Get("type").String() {
+				case "response.created":
+					created++
+				case "response.completed":
+					completed++
+				case "response.web_search_call.completed":
+					searches++
+					require.True(t, event.Get("output_index").Exists())
+				}
+			}
+			require.Equal(t, 2, searches)
+			require.Equal(t, 1, created)
+			require.Equal(t, 1, completed)
+		} else {
+			var response apicompat.ResponsesResponse
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			require.Equal(t, "alpha", response.Output[0].Action.Query)
+			require.Equal(t, "beta", response.Output[1].Action.Query)
+			require.Equal(t, 52, response.Usage.TotalTokens)
+			part := response.Output[3].Content[0]
+			for _, annotation := range part.Annotations {
+				require.Greater(t, annotation.EndIndex, annotation.StartIndex)
+				require.Equal(t, "Example source", string([]rune(part.Text)[annotation.StartIndex:annotation.EndIndex]))
+			}
+		}
+	}
+}
+
+func TestAntigravityAgentRepeatedSearchIsNotExecuted(t *testing.T) {
+	var requests [][]byte
+	decision := func(id string) *http.Response {
+		return agentTestResponse(`[`+agentTestCall(id, antigravityWebSearchBrokerTool, "same query")+`]`, "")
+	}
+	search := func() *http.Response {
+		return agentTestResponse(`[{"text":"Example result"}]`, `{"webSearchQueries":["same query"]}`)
+	}
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{search(), decision("second"), search(), decision("third"), agentTestResponse(`[{"text":"Final answer"}]`, "")}, onCall: func(req *http.Request, _ *queuedHTTPUpstreamStub) {
+		raw, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		requests = append(requests, raw)
+	}}
+	svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+	c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", []byte(`{}`))
+	prepared, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	call := &antigravityCompatUpstreamCall{geminiBody: prepared, request: antigravityCompatRequest{originalModel: "gemini-3.8-flash"}}
+	resp, err := svc.runAntigravityWebSearchAgentLoop(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), call, decision("first"))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Len(t, requests, 5)
+	require.Contains(t, string(requests[4]), `"code":"repeated_query"`)
+	require.Len(t, call.agentResult.searches, 2)
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestAntigravityAgentNativeSearchStaysNative(t *testing.T) {
+	t.Setenv("ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED", "true")
+	var sent []byte
+	upstream := &queuedHTTPUpstreamStub{responses: []*http.Response{agentTestResponse(`[{"text":"Example result"}]`, `{"webSearchQueries":["example query"],"groundingChunks":[{"web":{"uri":"https://example.org/","title":"Example"}}]}`)}, onCall: func(req *http.Request, _ *queuedHTTPUpstreamStub) {
+		raw, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		sent = raw
+	}}
+	svc := newAntigravityCompatService(config.GatewayConfig{MaxLineSize: defaultMaxLineSize}, upstream)
+	body := []byte(`{"model":"gemini-3.1-pro-high","input":"Search the web","tools":[{"type":"web_search"}]}`)
+	c, recorder := newAntigravityCompatContext(http.MethodPost, "/v1/responses", body)
+	_, err := svc.ForwardAsResponses(context.Background(), c, newAntigravityCompatAccount(AccountTypeOAuth), body, nil)
+	require.NoError(t, err)
+	require.Contains(t, string(sent), `"googleSearch"`)
+	require.NotContains(t, string(sent), `"functionDeclarations"`)
+	require.Contains(t, recorder.Body.String(), `"web_search_call"`)
+	require.Contains(t, recorder.Body.String(), `"url_citation"`)
+}
+
+func TestAgentSearchRestrictionsAreNotSilentlyDiscarded(t *testing.T) {
+	body, _, err := prepareAgentSearch([]byte(agentTestEnvelope), true)
+	require.NoError(t, err)
+	for _, option := range []string{`"external_web_access":false`, `"filters":{"allowed_domains":["example.org"]}`, `"user_location":{"type":"approximate","country":"US"}`} {
+		_, _, err := configureAgentToolChoice(body, []byte(`{"tools":[{"type":"web_search",`+option+`}]}`))
+		require.Error(t, err)
+	}
+}

--- a/backend/internal/service/antigravity_gateway_compat.go
+++ b/backend/internal/service/antigravity_gateway_compat.go
@@ -49,6 +49,8 @@ type antigravityCompatUpstreamCall struct {
 	proxyURL     string
 	accessToken  string
 	geminiBody   []byte
+	agentSearch  bool
+	agentResult  *antigravityAgentSearchResult
 }
 
 // ForwardAsChatCompletions 使用 Antigravity 原生 OAuth 账号转发 Chat Completions 请求。
@@ -198,7 +200,17 @@ func (s *AntigravityGatewayService) forwardAntigravityCompat(
 		return nil, s.handleAntigravityCompatTransportError(c, err)
 	}
 
-	return s.consumeAntigravityCompatResponse(ctx, c, account, call, result.resp)
+	resp := result.resp
+	if call.agentSearch {
+		resp, err = s.runAntigravityWebSearchAgentLoop(ctx, c, account, call, resp)
+		if err != nil {
+			if _, ok := IsAntigravityAccountSwitchError(err); ok {
+				return nil, s.handleAntigravityCompatTransportError(c, err)
+			}
+			return nil, s.mapAntigravityCompatCollectionError(c, err)
+		}
+	}
+	return s.consumeAntigravityCompatResponse(ctx, c, account, call, resp)
 }
 
 func (s *AntigravityGatewayService) prepareAntigravityCompatCall(
@@ -243,6 +255,16 @@ func (s *AntigravityGatewayService) prepareAntigravityCompatCall(
 		return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", "Invalid request")
 	}
 
+	agentSearch := false
+	if request.protocol == antigravityCompatResponses && strings.HasPrefix(strings.ToLower(mappedModel), "gemini-") {
+		geminiBody, agentSearch, err = prepareAgentSearch(geminiBody, s.antigravityAgentWebSearchEnabled(ctx))
+		if err == nil && agentSearch {
+			geminiBody, agentSearch, err = configureAgentToolChoice(geminiBody, request.originalBody)
+		}
+		if err != nil {
+			return nil, s.writeAntigravityCompatError(c, http.StatusBadRequest, "invalid_request_error", "Invalid Google Search tool configuration")
+		}
+	}
 	request.reasoningEffort = ApplyThinkingEnabledFallback(request.reasoningEffort, request.originalBody, mappedModel)
 	return &antigravityCompatUpstreamCall{
 		request:      request,
@@ -251,6 +273,7 @@ func (s *AntigravityGatewayService) prepareAntigravityCompatCall(
 		proxyURL:     antigravityCompatProxyURL(account),
 		accessToken:  accessToken,
 		geminiBody:   geminiBody,
+		agentSearch:  agentSearch,
 	}, nil
 }
 
@@ -383,6 +406,9 @@ func (s *AntigravityGatewayService) consumeAntigravityCompatSuccess(
 	call *antigravityCompatUpstreamCall,
 	resp *http.Response,
 ) (*antigravityStreamResult, error) {
+	if call.agentResult != nil {
+		return s.consumeAntigravityAgentResponses(c, call, resp)
+	}
 	if call.request.clientStream {
 		if call.request.protocol == antigravityCompatChatCompletions {
 			return s.handleChatCompletionsStreamingFromAntigravity(

--- a/docs/antigravity-responses-web-search.md
+++ b/docs/antigravity-responses-web-search.md
@@ -1,0 +1,61 @@
+# Antigravity Google Search with Responses function tools
+
+Some Antigravity Gemini upstreams reject a request containing both native
+`googleSearch` and `functionDeclarations`, even with
+`includeServerSideToolInvocations=true` (see #6464).
+
+For Gemini Responses requests with both tools, the gateway exposes a reserved
+function to the model and executes it internally only when the model requests
+search. Each search uses a separate request containing native Google Search
+and no client functions. The original model candidate, call IDs, opaque thought
+signatures and individual search results are retained for the continuation.
+Client functions are never executed by the gateway. When a candidate contains
+both search and client calls, the client calls receive explicit deferred
+results and the model decides again after reading the search results.
+
+Search-only requests continue to use native Google Search directly. Function-only
+requests and Chat Completions keep their existing paths. This change does not
+implement a `codeExecution` loop or change model discovery, aliases or pricing.
+Search filters, offline-only search and user-location options are rejected on
+this path instead of silently ignoring restrictions the bridge cannot enforce.
+
+## Configuration
+
+| Persisted setting | Environment fallback | Default |
+| --- | --- | --- |
+| `antigravity_agent_web_search_enabled` | `ANTIGRAVITY_AGENT_WEB_SEARCH_ENABLED` | `true` |
+| `antigravity_agent_max_tool_rounds` | `ANTIGRAVITY_AGENT_MAX_TOOL_ROUNDS` | `8` |
+
+A nonempty persisted setting overrides the environment. The round limit accepts
+1–32; values above 32 are clamped, and invalid/nonpositive values use 8. Eight is
+a gateway safety default, not a claim about the official client's loop limit.
+The third consecutive identical search is returned to the model as a structured
+tool error. At most 32 search attempts are allowed per request. Reaching the
+round limit fails the request without emitting a partial Responses lifecycle.
+
+Disabling the feature removes incompatible Google Search from mixed requests
+without injecting the reserved function. Standalone native search remains
+available. The reserved name `__sub2api_google_search` cannot also be used by a
+client function in an enabled mixed request.
+
+## Results and limits
+
+Internal rounds are buffered. Successful grounded searches become separate
+`web_search_call` items, followed by the final model output in one Responses
+lifecycle with contiguous sequence numbers and output indexes. Search call
+actions retain the query and sources. The answer includes a separate source-list
+text part with URL citations over the actual source labels. Search-response
+grounding offsets are **not** applied to unrelated generated answer text.
+
+A search rejection is returned to the model as a structured tool error without
+the upstream error body. Credential and service failures retain account failover
+handling; another account starts from the original client request. Responses
+without search grounding are not reported as successful searches. Cancellation,
+idle timeout, malformed/truncated SSE and oversized responses abort collection.
+Each upstream response is limited to 16 MiB and the accumulated request history
+and rendered SSE to 64 MiB.
+
+All decision, search and final usage is aggregated for the successful request,
+with one existing gateway billing settlement. Internal buffering delays the
+first client-visible event until the loop ends. No OAuth credentials, raw
+official-client traces or diagnostic logs are needed in tests or PR attachments.


### PR DESCRIPTION
## Problem

Refs #6464. Some Antigravity Gemini upstreams return HTTP 400 when native `googleSearch` and `functionDeclarations` are sent together, including requests with `includeServerSideToolInvocations=true`.

Removing search avoids the incompatible combination but loses requested functionality. This change keeps search on demand for the Gemini Responses path; it does not pre-search every prompt.

## Implementation

- Lower mixed native search to the reserved server-owned `__sub2api_google_search` function for model decisions. Execute each requested search in a separate native-search-only upstream call, then continue the model with individually paired results.
- Preserve raw candidate parts, opaque thought signatures, call IDs, grounding metadata and response IDs through internal rounds. Defer client function calls in mixed candidates explicitly; only the client executes client functions.
- Keep search-only requests native and leave function-only requests, Chat Completions, model lists, aliases, pricing and `codeExecution` outside this change.
- Buffer internal rounds and emit one Responses lifecycle, separate `web_search_call` items, action queries/sources and URL annotations on actual source-label text. Search grounding offsets are not transplanted onto unrelated final-answer claims.
- Aggregate usage across decision/search/continuation calls for one existing billing settlement. Keep one account/project/model per loop and retain pre-output failover handling.
- Add runtime enable/round-limit settings, bounded response/history sizes, cancellation and idle-timeout handling, per-call structured search errors and repeated-query protection. Disabling the feature drops incompatible mixed search without injecting an internal function.

The default eight-round circuit breaker is a gateway safety policy, not an experimentally established official-client limit. This implementation does not claim that `battleModeConfig.maxTurns=0` describes the main Agent loop. Unsupported search restrictions are rejected rather than silently ignored. See the focused documentation for configuration and compatibility boundaries.

## Validation

- Full backend unit suite: passed (`go test -tags=unit ./...`, Go 1.27.0).
- Full backend integration suite: passed on the final commit (`go test -tags=integration ./...`, Docker-backed test containers available and `CI=true`).
- golangci-lint v2.13.0: passed, zero issues.
- Regression coverage includes disabled mode, standalone search, mixed and multiple search calls, signatures/IDs, deferred client calls, error pairing, cancellation, malformed/truncated/oversized streams, repeated queries, round limits, source annotations and contiguous streaming events.
- Final diff and the new commits were scanned with Gitleaks v8.30.1 (redacted output), plus a targeted personal-data review; no findings. Tests contain synthetic fixtures only. No credentials, deployment files, raw client traces or diagnostic logs are included.

## Live verification

Initial verification completed against the exact gateway implementation in commit `14e93ddf0fc4b3d551a339d94ec597c39a7cf8e5`, using real Antigravity OAuth upstream requests with Gemini 3.8 Flash. The harness invoked `ForwardAsResponses` directly; this was not a mocked upstream test or a Codex UI test.

| Scenario | Upstream calls | Search items | Client function calls | Result |
| --- | ---: | ---: | ---: | --- |
| Forced search, non-streaming | 3 | 1 | 1 | Passed, citations present |
| Forced search, streaming | 3 | 1 | 1 | Passed, citations present |
| Automatic tool choice, non-streaming | 3 | 1 | 1 | Passed, citations present |
| Automatic tool choice, streaming | 3 | 1 | 1 | Passed, citations present |
| No-search control with both tools available | 1 | 0 | 0 | Passed, no pre-search |

The automatic-choice search cases each followed `decision -> native search -> continuation`, with HTTP 200 at all three stages. The continuation returned the requested client function; the gateway did not execute that function. Checks also confirmed:

- No upstream request combined native `googleSearch` with `functionDeclarations`.
- The decision and search thought-signature values were retained in continuation history (two real signatures checked per automatic-choice case), and the internal function call had a matching result ID/name.
- Aggregated uncached input, cached input and output usage matched the observed upstream totals.
- Streaming emitted one created/completed lifecycle with 21 consecutive sequence numbers in the automatic-choice case.
- Search citations were present and the reserved internal function name was absent from client output.

## Review follow-up: strict external web access validation

Fixed in `6d4fc41b3ddfe2df84f465b28b0009c60e26ae66`. An explicitly supplied `external_web_access` must now be a JSON boolean. Omission and `true` retain existing behavior; `false` is rejected because this bridge cannot provide offline-only search. Strings, `null`, numbers, objects and arrays are rejected instead of silently allowing search.

The original whitespace-bypass explanation did not reproduce: the current JSON decoding path strips whitespace around scalar values. The confirmed gap was missing type validation. Regression tests cover both points, including all three tool types recognized by this validation and both pure-search/mixed-tool forwarding paths. Rejected requests return HTTP 400 before any upstream call.

Validation after this change:

- Full backend unit suite: passed.
- Full backend integration suite: passed with `CI=true` and Docker available.
- Focused boolean-validation and pre-upstream rejection tests: passed.
- golangci-lint v2.13.0: passed, zero issues.
- Diff and both new commits: Gitleaks v8.30.1 passed with redacted output; no findings.
- Real Gemini 3.8 Flash automatic-choice non-streaming and streaming search: passed again on this revision. Each used three upstream calls (all HTTP 200), produced one search item with citations and one client function call, preserved the two observed signatures and matched the internal call/result pair. Usage totals matched; no mixed native/function request or internal function name leak occurred. The streaming run had one lifecycle with 20 consecutive events.
- Real no-search control: passed again, one upstream call and no search or client function call.

The earlier forced-search runs in the table above remain baseline results from `14e93ddf`; the automatic-choice and no-search controls were revalidated on `6d4fc41b`. No credentials or raw live traces are included.
