### PR TITLE
fix: respect registration visibility on login

### DIFF
--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -197,7 +197,7 @@
     </div>
 
     <!-- Footer -->
-    <template v-if="!backendModeEnabled" #footer>
+    <template v-if="!backendModeEnabled && publicSettingsLoaded && registrationEnabled" #footer>
       <p class="text-gray-500 dark:text-dark-400">
         {{ t('auth.dontHaveAccount') }}
         <router-link
@@ -270,6 +270,7 @@ const showPassword = ref<boolean>(false)
 const publicSettingsLoaded = ref<boolean>(false)
 
 // Public settings
+const registrationEnabled = ref<boolean>(false)
 const turnstileEnabled = ref<boolean>(false)
 const turnstileSiteKey = ref<string>('')
 const tencentCaptchaEnabled = ref<boolean>(false)
@@ -381,6 +382,7 @@ onMounted(async () => {
 
   try {
     const settings = await getPublicSettings()
+    registrationEnabled.value = settings.registration_enabled === true
     turnstileEnabled.value = settings.turnstile_enabled
     turnstileSiteKey.value = settings.turnstile_site_key || ''
     tencentCaptchaEnabled.value = settings.tencent_captcha_enabled === true

--- a/frontend/src/views/auth/__tests__/LoginView.spec.ts
+++ b/frontend/src/views/auth/__tests__/LoginView.spec.ts
@@ -1,0 +1,118 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginView from '@/views/auth/LoginView.vue'
+
+const { getPublicSettingsMock, pushMock } = vi.hoisted(() => ({
+  getPublicSettingsMock: vi.fn(),
+  pushMock: vi.fn()
+}))
+
+const publicSettings = {
+  registration_enabled: true,
+  turnstile_enabled: false,
+  turnstile_site_key: '',
+  tencent_captcha_enabled: false,
+  tencent_captcha_app_id: '',
+  aliyun_captcha_enabled: false,
+  aliyun_captcha_scene_id: '',
+  aliyun_captcha_prefix: '',
+  linuxdo_oauth_enabled: false,
+  dingtalk_oauth_enabled: false,
+  wechat_oauth_enabled: false,
+  backend_mode_enabled: false,
+  oidc_oauth_enabled: false,
+  oidc_oauth_provider_name: 'OIDC',
+  github_oauth_enabled: false,
+  google_oauth_enabled: false,
+  password_reset_enabled: false,
+  passkey_enabled: false,
+  login_agreement_enabled: false,
+  login_agreement_documents: []
+}
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    currentRoute: { value: { query: {} } }
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  createI18n: () => ({
+    global: {
+      t: (key: string) => key
+    }
+  }),
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('@/stores', () => ({
+  useAuthStore: () => ({
+    login: vi.fn(),
+    loginWithPasskey: vi.fn(),
+    login2FA: vi.fn()
+  }),
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showWarning: vi.fn()
+  })
+}))
+
+vi.mock('@/api/auth', () => ({
+  buildOAuthLoginStartURL: vi.fn(),
+  getPublicSettings: (...args: unknown[]) => getPublicSettingsMock(...args),
+  isTotp2FARequired: vi.fn(() => false),
+  isWeChatWebOAuthEnabled: vi.fn(() => false),
+  startOAuthLogin: vi.fn()
+}))
+
+function mountLogin() {
+  return mount(LoginView, {
+    global: {
+      stubs: {
+        AuthLayout: { template: '<div><slot /><slot name="footer" /></div>' },
+        DingTalkOAuthSection: true,
+        EmailOAuthButtons: true,
+        Icon: true,
+        LinuxDoOAuthSection: true,
+        LoginAgreementPrompt: true,
+        OidcOAuthSection: true,
+        RouterLink: { template: '<a><slot /></a>' },
+        TotpLoginModal: true,
+        TurnstileWidget: true,
+        WechatOAuthSection: true,
+        transition: false
+      }
+    }
+  })
+}
+
+describe('LoginView registration entry', () => {
+  beforeEach(() => {
+    getPublicSettingsMock.mockReset()
+    pushMock.mockReset()
+    getPublicSettingsMock.mockResolvedValue(publicSettings)
+  })
+
+  it('shows the registration entry when registration is enabled', async () => {
+    const wrapper = mountLogin()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('auth.signUp')
+  })
+
+  it('hides the registration entry when registration is disabled', async () => {
+    getPublicSettingsMock.mockResolvedValueOnce({
+      ...publicSettings,
+      registration_enabled: false
+    })
+
+    const wrapper = mountLogin()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('auth.signUp')
+  })
+})


### PR DESCRIPTION
Fixes the login-page registration entry so it follows the existing registration_enabled public setting. The entry stays hidden while public settings are loading or when registration is disabled.

Added tests for enabled and disabled registration states. Verified auth view tests, TypeScript typecheck, and ESLint.

Fixes #6823
