### PR TITLE
fix(antigravity): preserve OAuth plan_type when saving accounts

### DIFF
--- a/backend/internal/service/antigravity_oauth_service.go
+++ b/backend/internal/service/antigravity_oauth_service.go
@@ -90,7 +90,7 @@ type AntigravityTokenInfo struct {
 	Email            string `json:"email,omitempty"`
 	ProjectID        string `json:"project_id,omitempty"`
 	ProjectIDMissing bool   `json:"-"`
-	PlanType         string `json:"-"`
+	PlanType         string `json:"plan_type,omitempty"`
 	PrivacyMode      string `json:"-"`
 }
 

--- a/backend/internal/service/antigravity_oauth_service_test.go
+++ b/backend/internal/service/antigravity_oauth_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -76,6 +77,29 @@ func TestResolveDefaultTierID(t *testing.T) {
 			got := resolveDefaultTierID(tc.loadRaw)
 			if got != tc.want {
 				t.Fatalf("resolveDefaultTierID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The OAuth handler serializes this DTO before the browser creates or reauthorizes an account.
+func TestAntigravityTokenInfoPreservesPlanTypeJSON(t *testing.T) {
+	for _, plan := range []string{"pro", "ultra", "free", ""} {
+		t.Run(plan, func(t *testing.T) {
+			data, err := json.Marshal(AntigravityTokenInfo{PlanType: plan})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var response map[string]any
+			if err := json.Unmarshal(data, &response); err != nil {
+				t.Fatal(err)
+			}
+			if plan == "" {
+				if _, exists := response["plan_type"]; exists {
+					t.Fatal("unknown plan must remain omitted")
+				}
+			} else if response["plan_type"] != plan {
+				t.Fatalf("OAuth response plan_type = %v, want %q", response["plan_type"], plan)
 			}
 		})
 	}

--- a/frontend/src/api/admin/antigravity.ts
+++ b/frontend/src/api/admin/antigravity.ts
@@ -29,6 +29,7 @@ export interface AntigravityTokenInfo {
   expires_at?: number | string
   expires_in?: number
   project_id?: string
+  plan_type?: string
   email?: string
   [key: string]: unknown
 }

--- a/frontend/src/composables/__tests__/useAntigravityOAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useAntigravityOAuth.spec.ts
@@ -54,3 +54,17 @@ describe('useAntigravityOAuth.buildCredentials', () => {
     expect(credentials.refresh_token).toBe('rotated-refresh-token')
   })
 })
+
+// This builder is shared by OAuth creation, refresh-token import and reauthorization.
+describe('Antigravity subscription metadata', () => {
+  it.each(['pro', 'ultra', 'free'])('preserves the upstream %s plan when saving credentials', (plan) => {
+    const oauth = useAntigravityOAuth()
+    const credentials = oauth.buildCredentials({ plan_type: plan })
+    expect(credentials.plan_type).toBe(plan)
+  })
+
+  it('does not invent a plan when subscription discovery is unavailable', () => {
+    const credentials = useAntigravityOAuth().buildCredentials({})
+    expect(credentials).not.toHaveProperty('plan_type')
+  })
+})

--- a/frontend/src/composables/useAntigravityOAuth.ts
+++ b/frontend/src/composables/useAntigravityOAuth.ts
@@ -132,7 +132,8 @@ export function useAntigravityOAuth() {
       token_type: tokenInfo.token_type,
       expires_at: expiresAt,
       project_id: tokenInfo.project_id,
-      email: tokenInfo.email
+      email: tokenInfo.email,
+      ...(tokenInfo.plan_type ? { plan_type: tokenInfo.plan_type } : {})
     }
   }
 


### PR DESCRIPTION
## Problem and fix
Closes #6820.

The Antigravity OAuth service discovers the subscription plan, but its response DTO hides PlanType and the frontend credential builder drops plan_type. A newly authorized paid account consequently misses the paid-tier endpoint selection introduced in #5612 until subscription metadata is repaired or refreshed.

Expose plan_type as an optional JSON field and preserve it in the shared frontend builder used by account creation, refresh-token import and reauthorization. Unknown plans stay omitted; no plan is inferred or forced. The frontend API type now declares the field explicitly. Background refresh and endpoint-selection policies are unchanged.

## Validation
- Added regression tests failed against unmodified main for pro, ultra and free, at both JSON serialization and frontend credential construction boundaries.
- Targeted Go service tests passed: TestAntigravityTokenInfo, TestResolveDefaultTierID, TestResolveAntigravityForwardBaseURL.
- Vitest: useAntigravityOAuth and CreateAccountModal, 39 tests passed.
- Frontend vue-tsc --noEmit passed.
- git diff --check and Gitleaks staged-diff scan passed.

The live symptom was confirmed separately: preserving the Google-reported pro value made the real admin account test succeed. A fresh interactive Google authorization using this patch has not yet been exercised; the regression tests cover the two lossy boundaries without requiring live credentials.
