### PR TITLE
fix(gemini): avoid daily cooldown for Vertex 429s

### DIFF
--- a/backend/internal/service/gemini_error_policy_test.go
+++ b/backend/internal/service/gemini_error_policy_test.go
@@ -606,6 +606,29 @@ func TestHandleGeminiUpstreamError_PoolMode429(t *testing.T) {
 	}
 }
 
+func TestHandleGeminiUpstreamError_VertexServiceAccountUsesShortFallback(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{
+		ID:       605,
+		Platform: PlatformGemini,
+		Type:     AccountTypeServiceAccount,
+	}
+	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Resource exhausted"}}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.Equal(t, account.ID, repo.lastRateLimitID)
+	require.WithinDuration(t, before.Add(time.Duration(defaultRateLimit429CooldownSeconds)*time.Second), repo.lastRateLimitReset, 2*time.Second)
+	require.True(t, repo.lastRateLimitReset.Before(after.Add(time.Minute)), "Vertex transient 429 must not pause the account until daily reset")
+}
+
 type geminiErrorPolicyRepo struct {
 	mockAccountRepoForGemini
 	setErrorCalls            int

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3052,6 +3052,20 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
+		// Vertex AI may return transient RESOURCE_EXHAUSTED responses without a
+		// quota reset timestamp. Do not treat those as AI Studio daily quota
+		// exhaustion and park the whole service account until PST midnight.
+		if account.Type == AccountTypeServiceAccount {
+			if s.rateLimitService != nil {
+				s.rateLimitService.apply429FallbackRateLimit(ctx, account, "gemini_vertex_no_reset_time")
+				return
+			}
+			ra := time.Now().Add(time.Duration(defaultRateLimit429CooldownSeconds) * time.Second)
+			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Vertex Service Account) rate limited, fallback cooldown=%v", account.ID, time.Until(ra).Truncate(time.Second))
+			_ = s.accountRepo.SetRateLimited(ctx, account.ID, ra)
+			return
+		}
+
 		// 根据账号类型使用不同的默认重置时间
 		var ra time.Time
 		if isCodeAssist || oauthType == "google_one" {
@@ -3098,10 +3112,13 @@ func ParseGeminiRateLimitResetTime(body []byte) *int64 {
 		}
 	}
 
-	// 遍历 error.details 查找 quotaResetDelay
+	// 遍历 error.details 查找 quotaResetDelay 或标准 RetryInfo.retryDelay。
 	var found *int64
 	gjson.GetBytes(body, "error.details").ForEach(func(_, detail gjson.Result) bool {
 		v := detail.Get("metadata.quotaResetDelay").String()
+		if v == "" {
+			v = detail.Get("retryDelay").String()
+		}
 		if v == "" {
 			return true
 		}

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -990,6 +990,12 @@ func TestParseGeminiRateLimitResetTime(t *testing.T) {
 			approxDelta: 13, // 向上取整 12.345 -> 13
 		},
 		{
+			name:        "标准 RetryInfo retryDelay",
+			input:       `{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"10.1s"}]}}`,
+			wantNil:     false,
+			approxDelta: 11, // 向上取整 10.1 -> 11
+		},
+		{
 			name:        "daily quota",
 			input:       `{"error":{"message":"quota per day exceeded"}}`,
 			wantNil:     false,


### PR DESCRIPTION
## Summary

- treat Vertex AI Service Account 429 responses without reset metadata as transient cooldowns instead of AI Studio daily quota exhaustion
- parse standard `google.rpc.RetryInfo.retryDelay` metadata
- add regression coverage for Vertex fallback cooldown and RetryInfo parsing

## Problem

Vertex Service Accounts currently fall through to the API Key and AI Studio fallback branch. A transient `RESOURCE_EXHAUSTED` response without recognized reset metadata therefore parks the account until PST midnight. In multi-instance deployments the persisted account state removes the account from scheduling on every node.

## Testing

- `go test ./internal/service -run TestParseGeminiRateLimitResetTime|TestHandleGeminiUpstreamError_\(VertexServiceAccountUsesShortFallback\|PoolMode429\) -count=1`
- full `go test ./internal/service -count=1` passed on the downstream branch before cherry-picking onto current upstream main