### PR TITLE
fix(ollama): 修复 Ollama Cloud DeepSeek 推理归一化并补齐全转发路径输出上限

### DIFF
--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -254,10 +254,13 @@ type ccStreamScanState struct {
 // scanCCStream 驱动两条 CC 回退路径共享的 SSE 读循环：提取 data 行、在 [DONE]
 // 哨兵处停止、保留最新 usage、记录首 token 时延，并把每个解析成功的 chunk 交给
 // emit 回调做各自的协议转换与写出。读错误按既有约定过滤 context 取消类噪声后
-// 记入 Warn 日志。
+// 记入 Warn 日志。account 与 upstreamModel 用于在解析成 chunk 之前对原始 SSE 行
+// 做 Ollama Cloud DeepSeek reasoning 归一化（未命中时字节级透传，语义等同不挂）。
 func (s *OpenAIGatewayService) scanCCStream(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
+	upstreamModel string,
 	logPrefix string,
 	requestID string,
 	startTime time.Time,
@@ -268,6 +271,9 @@ func (s *OpenAIGatewayService) scanCCStream(
 	scanner := s.newUpstreamSSEScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// Ollama Cloud DeepSeek 出站：在解析成 chunk 之前把 reasoning/thinking 归一化
+		// 成 reasoning_content，让协议转换器看到与官方 DeepSeek 完全一致的形态。
+		line = applyOllamaCloudRawChatCompletionsSSELine(account, upstreamModel, line)
 		payload, ok := extractOpenAISSEDataLine(line)
 		if !ok {
 			continue
@@ -326,10 +332,14 @@ func logCCStreamMissingDoneSentinel(logPrefix, requestID string) {
 }
 
 // readCCUpstreamJSONResponse 读取并解析 CC 非流式 JSON 响应，失败时以调用方
-// 端点格式回写错误；成功时顺带提取 usage。
+// 端点格式回写错误；成功时顺带提取 usage。account 与 upstreamModel 用于在解析
+// 成结构体之前对原始响应体做 Ollama Cloud DeepSeek reasoning 归一化（未命中时
+// 字节级透传，语义等同不挂）。
 func (s *OpenAIGatewayService) readCCUpstreamJSONResponse(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
+	upstreamModel string,
 	writeError compatErrorWriter,
 ) (*apicompat.ChatCompletionsResponse, OpenAIUsage, error) {
 	respBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
@@ -339,6 +349,11 @@ func (s *OpenAIGatewayService) readCCUpstreamJSONResponse(
 		}
 		return nil, OpenAIUsage{}, fmt.Errorf("read upstream body: %w", err)
 	}
+
+	// Ollama Cloud DeepSeek 出站：在解析成结构体之前把 message/delta 里的
+	// reasoning/thinking 归一化成 reasoning_content，让协议转换器看到与官方
+	// DeepSeek 完全一致的形态。
+	respBody = applyOllamaCloudRawChatCompletionsResponse(account, upstreamModel, respBody)
 
 	var ccResp apicompat.ChatCompletionsResponse
 	if err := json.Unmarshal(respBody, &ccResp); err != nil {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -359,6 +359,12 @@ func (s *OpenAIGatewayService) forwardAsChatCompletions(
 	responsesBody = updatedBody
 	responsesReq.ServiceTier = normalizedOpenAIServiceTierValue(gjson.GetBytes(responsesBody, "service_tier").String())
 
+	// Ollama Cloud 原生 Responses 出站 clamp：与 /v1/responses 入站路径（Forward）同一
+	// 判据（实际 Responses 上游为 ollama.com + 映射后的出站模型为 DeepSeek 系），在此
+	// 转换路径（Chat Completions 入站 → Responses 出站）独立补齐，模型映射与服务层
+	// 改写全部完成后、构建上游请求前最后一次改写 body。
+	responsesBody = ollamaCloudClampResponsesMaxOutputTokensBody(account, upstreamModel, responsesBody)
+
 	// 5. Get access token
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -162,7 +162,7 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 			return nil, fmt.Errorf("sanitize Grok unsupported fields: %w", err)
 		}
 	}
-	upstreamBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamBody)
+	upstreamBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamModel, upstreamBody)
 	upstreamBody = clampOllamaCloudUpstreamMaxTokens(account, upstreamBody)
 
 	logger.L().Debug("openai chat_completions raw: forwarding without protocol conversion",
@@ -345,7 +345,7 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 				}
 			}
 		}
-		line = applyOllamaCloudRawChatCompletionsSSELine(account, line)
+		line = applyOllamaCloudRawChatCompletionsSSELine(account, upstreamModel, line)
 		line = stripEmptyChatToolCallIdentityFromSSELine(line)
 
 		writeLine(line)
@@ -517,7 +517,7 @@ func (s *OpenAIGatewayService) bufferRawChatCompletions(
 		upstreamRequestID := firstNonEmpty(requestID, resp.Header.Get("xai-request-id"))
 		return nil, newGrokMissingUsageFailoverError(c, account, upstreamRequestID)
 	}
-	respBody = applyOllamaCloudRawChatCompletionsResponse(account, respBody)
+	respBody = applyOllamaCloudRawChatCompletionsResponse(account, upstreamModel, respBody)
 
 	if s.responseHeaderFilter != nil {
 		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -633,8 +633,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	// ollama.com 以 400 拒绝）。在 `!isCodexCLI` 归一化块之后独立调用：非 Codex 时
 	// 位于平台字段归一化之后，不跳过原有平台 switch（patch 按追加顺序应用，set 在
 	// 先前的 delete/set 之后生效）；Codex 请求不做归一化，直接按 body 现值判定。
-	if clampedCap, ok := ollamaCloudResponsesMaxOutputTokensClamp(account, upstreamModel, body); ok {
+	// 生效值来自 max_tokens（无 max_output_tokens 的非 openai 平台）时，
+	// markPatchDelete("max_tokens") 与第 601 行一样按追加顺序在 set 之后应用。
+	if clampedCap, ok, sourceField := ollamaCloudResponsesMaxOutputTokensClamp(account, upstreamModel, body); ok {
 		markPatchSet("max_output_tokens", clampedCap)
+		if sourceField == "max_tokens" {
+			markPatchDelete("max_tokens")
+		}
 	}
 	if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 &&
 		!account.IsOpenAIApiKey() && gjson.GetBytes(body, "previous_response_id").Exists() {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -331,6 +331,12 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		}
 	}
 
+	// Ollama Cloud 原生 Responses 出站 clamp：与 /v1/responses 入站路径（Forward）同一
+	// 判据（实际 Responses 上游为 ollama.com + 映射后的出站模型为 DeepSeek 系），在此
+	// 转换路径（Anthropic Messages 入站 → Responses 出站）独立补齐，模型映射与服务层
+	// 改写全部完成后、构建上游请求前最后一次改写 body。
+	responsesBody = ollamaCloudClampResponsesMaxOutputTokensBody(account, upstreamModel, responsesBody)
+
 	// 5. Get access token
 	token, _, err := s.getRequestCredential(ctx, c, account)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -100,6 +100,13 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	// so the converted Chat Completions body never contains one and the policy
 	// would always be a no-op on this path.
 
+	// Ollama Cloud → DeepSeek 出站（chatReq.Model 已是模型映射后的 upstreamModel）：
+	// 与 raw 路径同序——先归一化 request（历史 assistant 消息
+	// reasoning_content → reasoning）、再 clamp max_tokens（>65535 → 65535）。
+	// 官方 DeepSeek/glm 等未命中时字节级透传。
+	chatBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamModel, chatBody)
+	chatBody = clampOllamaCloudUpstreamMaxTokens(account, chatBody)
+
 	logger.L().Debug("openai messages: forwarding via raw chat completions",
 		zap.Int64("account_id", account.ID),
 		zap.String("original_model", originalModel),
@@ -132,14 +139,15 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 
 	// 5. Convert response
 	if clientStream {
-		return s.streamChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+		return s.streamChatCompletionsAsAnthropic(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
-	return s.bufferChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+	return s.bufferChatCompletionsAsAnthropic(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 }
 
 func (s *OpenAIGatewayService) bufferChatCompletionsAsAnthropic(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -148,7 +156,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsAnthropic(
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
 	requestID := resp.Header.Get("x-request-id")
-	ccResp, usage, err := s.readCCUpstreamJSONResponse(c, resp, writeAnthropicError)
+	ccResp, usage, err := s.readCCUpstreamJSONResponse(c, resp, account, upstreamModel, writeAnthropicError)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +185,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsAnthropic(
 func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -214,7 +223,7 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 		}
 	}
 
-	scan := s.scanCCStream(c, resp, "openai messages chat fallback", requestID, startTime, emitChunk)
+	scan := s.scanCCStream(c, resp, account, upstreamModel, "openai messages chat fallback", requestID, startTime, emitChunk)
 	usage := scan.Usage
 
 	if scan.Err != nil {

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_ollama_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_ollama_test.go
@@ -1,0 +1,145 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// runOllamaMessagesChatFallback 直接走 /v1/messages → raw CC 降级桥
+// forwardAnthropicViaRawChatCompletions（与 messages 桥既有测试同风格，直接调桥函数）。
+func runOllamaMessagesChatFallback(t *testing.T, account *Account, body []byte, upstreamBody string, stream bool) (*httptest.ResponseRecorder, *httpUpstreamRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	contentType := "application/json"
+	if stream {
+		contentType = "text/event-stream"
+	}
+	upstreamResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{contentType},
+			"x-request-id": []string{"rid_ollama_messages_fallback"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}
+	upstream := &httpUpstreamRecorder{resp: upstreamResp}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	result, err := svc.forwardAnthropicViaRawChatCompletions(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return rec, upstream
+}
+
+func TestMessagesChatFallback_OllamaDeepSeek_ClampMaxTokens(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 701)
+
+	t.Run("256000 clamps to 65535", func(t *testing.T) {
+		body := []byte(`{"model":"deepseek-v4-flash","max_tokens":256000,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+		upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+		_, upstream := runOllamaMessagesChatFallback(t, account, body, upstreamJSON, false)
+		require.Equal(t, "deepseek-v4-flash", gjson.GetBytes(upstream.lastBody, "model").String())
+		require.Equal(t, int64(65535), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	})
+
+	t.Run("1000 stays 1000", func(t *testing.T) {
+		body := []byte(`{"model":"deepseek-v4-flash","max_tokens":1000,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+		upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+		_, upstream := runOllamaMessagesChatFallback(t, account, body, upstreamJSON, false)
+		require.Equal(t, int64(1000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	})
+}
+
+// TestMessagesChatFallback_OllamaDeepSeek_ReasoningAliasStreaming 验证流式响应侧
+// 归一化：上游 delta.reasoning / delta.thinking 与官方形态 delta.reasoning_content
+// 在归一化之后产出完全相同的 thinking 输出（同一转换路径跑多个输入对比）。
+func TestMessagesChatFallback_OllamaDeepSeek_ReasoningAliasStreaming(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 702)
+	body := []byte(`{"model":"deepseek-v4-flash","max_tokens":1000,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+
+	run := func(reasoningField string) string {
+		upstreamBody := strings.Join([]string{
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{` + reasoningField + `},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"final answer"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n")
+		rec, _ := runOllamaMessagesChatFallback(t, account, body, upstreamBody, true)
+		return rec.Body.String()
+	}
+
+	baseline := run(`"reasoning_content":"abc"`)
+	for _, tc := range []struct {
+		name  string
+		field string
+	}{
+		{name: "delta.reasoning alias", field: `"reasoning":"abc"`},
+		{name: "delta.thinking alias", field: `"thinking":"abc"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := run(tc.field)
+			require.Equal(t, baseline, out, "归一化后输出必须与 reasoning_content 基线完全一致")
+			require.Contains(t, out, "event: content_block_start")
+			require.Contains(t, out, `"type":"thinking"`)
+			require.Contains(t, out, `"thinking":"abc"`)
+			require.Contains(t, out, `"type":"text"`)
+			require.Contains(t, out, `"text":"final answer"`)
+		})
+	}
+}
+
+func TestMessagesChatFallback_OllamaDeepSeek_ThinkingAliasNonStreaming(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 703)
+	body := []byte(`{"model":"deepseek-v4-flash","max_tokens":1000,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, _ := runOllamaMessagesChatFallback(t, account, body, upstreamJSON, false)
+	require.Equal(t, "thinking", gjson.Get(rec.Body.String(), "content.0.type").String())
+	require.Equal(t, "abc", gjson.Get(rec.Body.String(), "content.0.thinking").String())
+	require.Equal(t, "text", gjson.Get(rec.Body.String(), "content.1.type").String())
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "content.1.text").String())
+}
+
+func TestMessagesChatFallback_OfficialDeepSeek_Untouched(t *testing.T) {
+	official := officialDeepSeekTestAccount(704)
+	body := []byte(`{"model":"deepseek-v4-flash","max_tokens":256000,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	// thinking 不归一化：转换器只认 reasoning_content/reasoning，thinking 被丢弃，
+	// 输出不出现 thinking 块（与不挂钩子的原始路径行为一致）。
+	upstreamJSON := `{"id":"chatcmpl_official","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, upstream := runOllamaMessagesChatFallback(t, official, body, upstreamJSON, false)
+	require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	require.NotContains(t, rec.Body.String(), `"type":"thinking"`)
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "content.0.text").String())
+}
+
+func TestMessagesChatFallback_OllamaGLM_Untouched(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 705)
+	body := []byte(`{"model":"glm-5.3-flash","max_tokens":256000,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"glm-5.3-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, upstream := runOllamaMessagesChatFallback(t, account, body, upstreamJSON, false)
+	require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	require.NotContains(t, rec.Body.String(), `"type":"thinking"`)
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "content.0.text").String())
+}

--- a/backend/internal/service/openai_gateway_ollama_cloud_cc_reasoning.go
+++ b/backend/internal/service/openai_gateway_ollama_cloud_cc_reasoning.go
@@ -47,24 +47,40 @@ func accountHasOllamaCloudUsageExtra(account *Account) bool {
 	return false
 }
 
+// isOllamaCloudDeepSeekUpstream 判断本次出站是否命中 Ollama Cloud 上托管的
+// DeepSeek 模型：出站 base_url 是 Ollama Cloud（GetOpenAIBaseURL，与
+// clampOllamaCloudUpstreamMaxTokens 的取值一致）且映射后的出站模型是 DeepSeek 系。
+// 不看 platform / account.Type / responses-mode，不读 usage extra；同一分组内
+// 官方 DeepSeek 账号（api.deepseek.com）不命中，保持字节级透传。后续其它出站
+// 路径复用同一判定。nil account / 空模型返回 false。
+func isOllamaCloudDeepSeekUpstream(account *Account, upstreamModel string) bool {
+	if account == nil {
+		return false
+	}
+	if !isOllamaCloudBaseURL(account.GetOpenAIBaseURL()) {
+		return false
+	}
+	return isDeepSeekModel(upstreamModel)
+}
+
 // applyOllamaCloudRawChatCompletionsRequest 只做 Ollama Cloud reasoning 归一化；
 // max_tokens clamp 已解耦到独立钩子 clampOllamaCloudUpstreamMaxTokens，由出站方依次调用。
-func applyOllamaCloudRawChatCompletionsRequest(account *Account, body []byte) []byte {
-	if !isOllamaCloudRawChatCompletionsAccount(account) || len(body) == 0 {
+func applyOllamaCloudRawChatCompletionsRequest(account *Account, upstreamModel string, body []byte) []byte {
+	if !isOllamaCloudDeepSeekUpstream(account, upstreamModel) || len(body) == 0 {
 		return body
 	}
 	return normalizeOllamaCloudChatCompletionsRequest(body)
 }
 
-func applyOllamaCloudRawChatCompletionsResponse(account *Account, body []byte) []byte {
-	if !isOllamaCloudRawChatCompletionsAccount(account) || len(body) == 0 {
+func applyOllamaCloudRawChatCompletionsResponse(account *Account, upstreamModel string, body []byte) []byte {
+	if !isOllamaCloudDeepSeekUpstream(account, upstreamModel) || len(body) == 0 {
 		return body
 	}
 	return normalizeOllamaCloudChatCompletionsResponseJSON(body)
 }
 
-func applyOllamaCloudRawChatCompletionsSSELine(account *Account, line string) string {
-	if !isOllamaCloudRawChatCompletionsAccount(account) || line == "" {
+func applyOllamaCloudRawChatCompletionsSSELine(account *Account, upstreamModel string, line string) string {
+	if !isOllamaCloudDeepSeekUpstream(account, upstreamModel) || line == "" {
 		return line
 	}
 	return normalizeOllamaCloudChatCompletionsSSELine(line)

--- a/backend/internal/service/openai_gateway_ollama_cloud_cc_reasoning_test.go
+++ b/backend/internal/service/openai_gateway_ollama_cloud_cc_reasoning_test.go
@@ -174,9 +174,11 @@ func TestApplyOllamaCloudRawChatCompletionsLeavesForeignAccountsUnchanged(t *tes
 	}
 
 	for _, account := range []*Account{official, opencode} {
-		require.Equal(t, reqBody, applyOllamaCloudRawChatCompletionsRequest(account, reqBody))
-		require.Equal(t, respBody, applyOllamaCloudRawChatCompletionsResponse(account, respBody))
-		require.Equal(t, sseLine, applyOllamaCloudRawChatCompletionsSSELine(account, sseLine))
+		// 出站 base_url 都不是 ollama.com，即使模型是 DeepSeek 系、即使带残留
+		// usage extra，reasoning 归一化门控不命中，字节级不变。
+		require.Equal(t, reqBody, applyOllamaCloudRawChatCompletionsRequest(account, "deepseek-v4-flash", reqBody))
+		require.Equal(t, respBody, applyOllamaCloudRawChatCompletionsResponse(account, "deepseek-v4-flash", respBody))
+		require.Equal(t, sseLine, applyOllamaCloudRawChatCompletionsSSELine(account, "deepseek-v4-flash", sseLine))
 	}
 }
 
@@ -266,4 +268,78 @@ func TestForwardAsRawChatCompletions_OllamaCloudThinkingAliasNonStreaming(t *tes
 	require.Equal(t, "abc", gjson.Get(rec.Body.String(), "choices.0.message.reasoning_content").String())
 	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "choices.0.message.content").String())
 	require.Equal(t, int64(4), gjson.Get(rec.Body.String(), "usage.completion_tokens_details.reasoning_tokens").Int())
+}
+
+// TestIsOllamaCloudDeepSeekUpstream 验证唯一判据：出站 base_url 是 Ollama Cloud &&
+// 出站模型是 DeepSeek 系，不看 platform / account.Type / responses-mode / usage extra。
+func TestIsOllamaCloudDeepSeekUpstream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ollama.com + deepseek model regardless of platform", func(t *testing.T) {
+		t.Parallel()
+		for _, platform := range []string{PlatformDeepseek, PlatformZhipu, PlatformOpenAI} {
+			require.True(t, isOllamaCloudDeepSeekUpstream(ollamaUpstreamTestAccount(platform, 410), "deepseek-v4-flash"),
+				"platform %s should be recognized", platform)
+		}
+	})
+
+	t.Run("ollama.com + non-deepseek model", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, isOllamaCloudDeepSeekUpstream(ollamaUpstreamTestAccount(PlatformDeepseek, 411), "glm-5.3-flash"))
+	})
+
+	t.Run("official deepseek upstream is untouched", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, isOllamaCloudDeepSeekUpstream(officialDeepSeekTestAccount(412), "deepseek-v4-flash"))
+	})
+
+	t.Run("nil account", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, isOllamaCloudDeepSeekUpstream(nil, "deepseek-v4-flash"))
+	})
+}
+
+// TestApplyOllamaCloudRawChatCompletionsByUpstream 验证三个 apply* 包装函数按唯一
+// 判据（出站 base_url 是 Ollama Cloud && 出站模型是 DeepSeek 系）生效，不看
+// platform / account.Type / responses-mode / usage extra；官方 DeepSeek 字节级不变。
+func TestApplyOllamaCloudRawChatCompletionsByUpstream(t *testing.T) {
+	t.Parallel()
+
+	reqBody := []byte(`{"messages":[{"role":"assistant","reasoning_content":"prev","content":""}]}`)
+	respBody := []byte(`{"choices":[{"delta":{"reasoning":"abc"}}]}`)
+	sseLine := `data: {"choices":[{"delta":{"reasoning":"abc"}}]}`
+
+	t.Run("deepseek platform ollama account + deepseek model is normalized", func(t *testing.T) {
+		t.Parallel()
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, 401)
+		normalizedReq := applyOllamaCloudRawChatCompletionsRequest(account, "deepseek-v4-flash", reqBody)
+		require.Equal(t, "prev", gjson.GetBytes(normalizedReq, "messages.0.reasoning").String())
+		require.Equal(t, "prev", gjson.GetBytes(normalizedReq, "messages.0.reasoning_content").String())
+
+		normalizedResp := applyOllamaCloudRawChatCompletionsResponse(account, "deepseek-v4-flash", respBody)
+		require.Equal(t, "abc", gjson.GetBytes(normalizedResp, "choices.0.delta.reasoning").String())
+		require.Equal(t, "abc", gjson.GetBytes(normalizedResp, "choices.0.delta.reasoning_content").String())
+
+		normalizedLine := applyOllamaCloudRawChatCompletionsSSELine(account, "deepseek-v4-flash", sseLine)
+		require.True(t, strings.HasPrefix(normalizedLine, "data: "))
+		payload := strings.TrimPrefix(normalizedLine, "data: ")
+		require.Equal(t, "abc", gjson.Get(payload, "choices.0.delta.reasoning").String())
+		require.Equal(t, "abc", gjson.Get(payload, "choices.0.delta.reasoning_content").String())
+	})
+
+	t.Run("official deepseek account is byte-identical", func(t *testing.T) {
+		t.Parallel()
+		official := officialDeepSeekTestAccount(402)
+		require.Equal(t, reqBody, applyOllamaCloudRawChatCompletionsRequest(official, "deepseek-v4-flash", reqBody))
+		require.Equal(t, respBody, applyOllamaCloudRawChatCompletionsResponse(official, "deepseek-v4-flash", respBody))
+		require.Equal(t, sseLine, applyOllamaCloudRawChatCompletionsSSELine(official, "deepseek-v4-flash", sseLine))
+	})
+
+	t.Run("ollama account with non-deepseek model is byte-identical", func(t *testing.T) {
+		t.Parallel()
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, 403)
+		require.Equal(t, reqBody, applyOllamaCloudRawChatCompletionsRequest(account, "glm-5.3-flash", reqBody))
+		require.Equal(t, respBody, applyOllamaCloudRawChatCompletionsResponse(account, "glm-5.3-flash", respBody))
+		require.Equal(t, sseLine, applyOllamaCloudRawChatCompletionsSSELine(account, "glm-5.3-flash", sseLine))
+	})
 }

--- a/backend/internal/service/openai_gateway_ollama_cloud_max_tokens.go
+++ b/backend/internal/service/openai_gateway_ollama_cloud_max_tokens.go
@@ -51,26 +51,54 @@ func ollamaCloudResponsesUpstreamBaseURL(account *Account) string {
 // ollamaCloudResponsesMaxOutputTokensClamp 是原生 /v1/responses 路径的 clamp：在
 // 平台字段归一化之后独立调用，不改写原有的 max_output_tokens 平台 switch。判定：
 // 实际 Responses 上游（ollamaCloudResponsesUpstreamBaseURL）为 ollama.com 的
-// APIKey 账号 + 映射后的出站模型是 DeepSeek 系；openai 平台 max_tokens 刚被归一化
-// patch 到 max_output_tokens 时取 max_tokens 为生效值。未命中返回 ok=false。
+// APIKey 账号 + 映射后的出站模型是 DeepSeek 系；body 无 max_output_tokens 时回退读
+// max_tokens 为生效值（不限定平台——客户端按 Chat Completions 习惯只发 max_tokens
+// 时，任何平台的 ollama+deepseek 命中判据都要 clamp）。返回 (cap, ok, sourceField)，
+// sourceField 为生效字段名（"max_tokens" / ""），供调用方在值来自 max_tokens 时清除
+// 残留的 max_tokens。未命中返回 ok=false。
 // 实测：ollama.com/v1/responses max_output_tokens=256000 被上游以 "max_tokens
 // (256000) exceeds model's maximum output tokens (65536)" 400 拒绝（DeepSeek 模型）。
-func ollamaCloudResponsesMaxOutputTokensClamp(account *Account, upstreamModel string, body []byte) (int64, bool) {
+func ollamaCloudResponsesMaxOutputTokensClamp(account *Account, upstreamModel string, body []byte) (int64, bool, string) {
 	if account == nil || account.Type != AccountTypeAPIKey || !isDeepSeekModel(upstreamModel) {
-		return 0, false
+		return 0, false, ""
 	}
 	if !isOllamaCloudBaseURL(ollamaCloudResponsesUpstreamBaseURL(account)) {
-		return 0, false
+		return 0, false, ""
 	}
 	value := gjson.GetBytes(body, "max_output_tokens")
-	if !value.Exists() && account.Platform == PlatformOpenAI {
-		value = gjson.GetBytes(body, "max_tokens")
+	sourceField := ""
+	if !value.Exists() {
+		if fallback := gjson.GetBytes(body, "max_tokens"); fallback.Exists() {
+			value = fallback
+			sourceField = "max_tokens"
+		}
 	}
 	cap := ollamaCloudMaxTokensCap(account)
 	if cap <= 0 || !value.Exists() || value.Type != gjson.Number || value.Int() <= cap {
-		return 0, false
+		return 0, false, ""
 	}
-	return cap, true
+	return cap, true, sourceField
+}
+
+// ollamaCloudClampResponsesMaxOutputTokensBody 是原生 /v1/responses 出站 body 的
+// 字节级 clamp 应用（供 CC→Responses、Messages→Responses 转换路径使用）：命中
+// ollama.com + DeepSeek 时把 max_output_tokens 改写为 cap，生效值来自 max_tokens 时
+// 一并清除残留的 max_tokens。未命中或改写失败时原样返回。
+func ollamaCloudClampResponsesMaxOutputTokensBody(account *Account, upstreamModel string, body []byte) []byte {
+	cap, ok, sourceField := ollamaCloudResponsesMaxOutputTokensClamp(account, upstreamModel, body)
+	if !ok {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "max_output_tokens", cap)
+	if err != nil {
+		return body
+	}
+	if sourceField == "max_tokens" {
+		if stripped, err := sjson.DeleteBytes(out, "max_tokens"); err == nil {
+			out = stripped
+		}
+	}
+	return out
 }
 
 // ollamaCloudMaxTokensCap 返回账号配置的 max_tokens 上限。账号为 nil 或 extra 中

--- a/backend/internal/service/openai_gateway_ollama_cloud_max_tokens_test.go
+++ b/backend/internal/service/openai_gateway_ollama_cloud_max_tokens_test.go
@@ -140,9 +140,10 @@ func TestOllamaCloudMaxTokensCap(t *testing.T) {
 func TestApplyOllamaCloudRawChatCompletionsRequestClampsMaxTokens(t *testing.T) {
 	body := []byte(`{"model":"deepseek-chat","max_tokens":100000}`)
 
-	// Ollama Cloud 账号：reasoning 钩子不再 clamp，字节级原样。
+	// Ollama Cloud 账号：reasoning 钩子命中（ollama.com + deepseek-chat），但 body
+	// 无可归一化的 reasoning 结构，字节级原样；max_tokens 不再由 reasoning 钩子 clamp。
 	ollama := ollamaCloudRawChatCompletionsTestAccount()
-	require.Equal(t, string(body), string(applyOllamaCloudRawChatCompletionsRequest(ollama, body)))
+	require.Equal(t, string(body), string(applyOllamaCloudRawChatCompletionsRequest(ollama, "deepseek-chat", body)))
 	// 独立 token 钩子接续 clamp 到既有默认 cap。
 	require.JSONEq(t, `{"model":"deepseek-chat","max_tokens":65535}`,
 		string(clampOllamaCloudUpstreamMaxTokens(ollama, body)))
@@ -153,20 +154,21 @@ func TestApplyOllamaCloudRawChatCompletionsRequestClampsMaxTokens(t *testing.T) 
 	official.Extra = map[string]any{
 		openai_compat.ExtraKeyResponsesMode: string(openai_compat.ResponsesSupportModeForceChatCompletions),
 	}
-	require.Equal(t, body, applyOllamaCloudRawChatCompletionsRequest(official, body))
+	require.Equal(t, body, applyOllamaCloudRawChatCompletionsRequest(official, "deepseek-chat", body))
 	require.Equal(t, string(body), string(clampOllamaCloudUpstreamMaxTokens(official, body)))
 
-	// ollama.com 但无 force_chat_completions：reasoning 钩子不生效；独立钩子按
-	// DeepSeek 系模型判定仍 clamp（DeepSeek 覆盖不依赖 responses_mode extra）。
+	// ollama.com 但无 force_chat_completions：reasoning 钩子按新判据命中（判定不看
+	// responses-mode），body 无可归一化内容故仍字节不变；独立钩子按 DeepSeek 系模型
+	// 判定仍 clamp（DeepSeek 覆盖不依赖 responses_mode extra）。
 	noForce := ollamaCloudRawChatCompletionsTestAccount()
 	noForce.Extra = nil
-	require.Equal(t, body, applyOllamaCloudRawChatCompletionsRequest(noForce, body))
+	require.Equal(t, body, applyOllamaCloudRawChatCompletionsRequest(noForce, "deepseek-chat", body))
 	require.JSONEq(t, `{"model":"deepseek-chat","max_tokens":65535}`,
 		string(clampOllamaCloudUpstreamMaxTokens(noForce, body)))
 
 	// 空 body → 原样返回。
-	require.Equal(t, []byte(nil), applyOllamaCloudRawChatCompletionsRequest(ollama, nil))
-	require.Equal(t, []byte{}, applyOllamaCloudRawChatCompletionsRequest(ollama, []byte{}))
+	require.Equal(t, []byte(nil), applyOllamaCloudRawChatCompletionsRequest(ollama, "deepseek-chat", nil))
+	require.Equal(t, []byte{}, applyOllamaCloudRawChatCompletionsRequest(ollama, "deepseek-chat", []byte{}))
 }
 
 // ollamaUpstreamTestAccount 构造挂在实际 ollama.com 上游的 APIKey 账号。平台标签

--- a/backend/internal/service/openai_gateway_ollama_cloud_max_tokens_test.go
+++ b/backend/internal/service/openai_gateway_ollama_cloud_max_tokens_test.go
@@ -553,3 +553,206 @@ func TestForwardResponsesClampsOllamaCloudMaxOutputTokensForCodexClients(t *test
 		})
 	}
 }
+
+// TestForwardResponses_DeepseekOllamaCloudClampsClientMaxTokensFallback 覆盖问题 1：
+// 原生 /v1/responses 入站只带 max_tokens（无 max_output_tokens）的 deepseek 平台
+// ollama 账号，clamp 判据不限定平台——出站 patch 为 max_output_tokens=cap，并清除
+// 残留的 max_tokens。
+func TestForwardResponses_DeepseekOllamaCloudClampsClientMaxTokensFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newAccount := func(id int64) *Account {
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, id)
+		account.Credentials["api_protocol"] = APIProtocolResponses
+		return account
+	}
+	run := func(account *Account, body []byte) (*httpUpstreamRecorder, error) {
+		upstream := &httpUpstreamRecorder{err: errors.New("stop after capture")}
+		svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+		_, err := svc.Forward(context.Background(), adaptiveProtocolTestContext("/v1/responses", body), account, body)
+		return upstream, err
+	}
+
+	t.Run("max_tokens above cap is clamped and removed", func(t *testing.T) {
+		account := newAccount(351)
+		body := []byte(`{"model":"deepseek-v4-flash","input":"Reply with exactly OK and nothing else.","max_tokens":256000,"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.Equal(t, "https://ollama.com/v1/responses", upstream.lastReq.URL.String())
+		require.Equal(t, int64(65535), gjson.GetBytes(upstream.lastBody, "max_output_tokens").Int())
+		require.False(t, gjson.GetBytes(upstream.lastBody, "max_tokens").Exists())
+	})
+
+	t.Run("max_tokens at or below cap is not rewritten", func(t *testing.T) {
+		account := newAccount(352)
+		body := []byte(`{"model":"deepseek-v4-flash","input":"Reply with exactly OK and nothing else.","max_tokens":1000,"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.False(t, gjson.GetBytes(upstream.lastBody, "max_output_tokens").Exists())
+		// 既有行为：非 openai 平台只发 max_tokens（≤cap）时残留 max_tokens，本次不处理。
+		require.Equal(t, int64(1000), gjson.GetBytes(upstream.lastBody, "max_tokens").Int())
+	})
+}
+
+// TestForwardAsChatCompletions_DeepseekOllamaCloudClampsMaxOutputTokens 覆盖问题 2 的
+// CC 入站路径：/v1/chat/completions 入站、账号出站协议为原生 Responses 时，转换生成的
+// max_output_tokens 在发出前被 clamp；≤cap 保持转换后的原值。
+func TestForwardAsChatCompletions_DeepseekOllamaCloudClampsMaxOutputTokens(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newAccount := func(id int64) *Account {
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, id)
+		account.Credentials["api_protocol"] = APIProtocolResponses
+		return account
+	}
+	run := func(account *Account, body []byte) (*httpUpstreamRecorder, error) {
+		upstream := &httpUpstreamRecorder{err: errors.New("stop after capture")}
+		svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+		_, err := svc.ForwardAsChatCompletions(context.Background(), adaptiveProtocolTestContext("/v1/chat/completions", body), account, body, "", "")
+		return upstream, err
+	}
+
+	t.Run("max_tokens above cap is clamped", func(t *testing.T) {
+		account := newAccount(361)
+		body := []byte(`{"model":"deepseek-chat","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.Equal(t, "https://ollama.com/v1/responses", upstream.lastReq.URL.String())
+		require.Equal(t, "deepseek-chat", gjson.GetBytes(upstream.lastBody, "model").String())
+		require.Equal(t, int64(65535), gjson.GetBytes(upstream.lastBody, "max_output_tokens").Int())
+	})
+
+	t.Run("max_tokens at or below cap is preserved", func(t *testing.T) {
+		account := newAccount(362)
+		body := []byte(`{"model":"deepseek-chat","max_tokens":1000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.Equal(t, int64(1000), gjson.GetBytes(upstream.lastBody, "max_output_tokens").Int())
+	})
+}
+
+// TestForwardAsAnthropic_DeepseekOllamaCloudClampsMaxOutputTokens 覆盖问题 2 的
+// Messages 入站路径：/v1/messages 入站、账号出站协议为原生 Responses 时，转换生成的
+// max_output_tokens 在发出前被 clamp；≤cap 保持转换后的原值。
+func TestForwardAsAnthropic_DeepseekOllamaCloudClampsMaxOutputTokens(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newAccount := func(id int64) *Account {
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, id)
+		account.Credentials["api_protocol"] = APIProtocolResponses
+		return account
+	}
+	run := func(account *Account, body []byte) (*httpUpstreamRecorder, error) {
+		upstream := &httpUpstreamRecorder{err: errors.New("stop after capture")}
+		svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+		_, err := svc.ForwardAsAnthropic(context.Background(), adaptiveProtocolTestContext("/v1/messages", body), account, body, "", "")
+		return upstream, err
+	}
+
+	t.Run("max_tokens above cap is clamped", func(t *testing.T) {
+		account := newAccount(371)
+		body := []byte(`{"model":"deepseek-chat","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.Equal(t, "https://ollama.com/v1/responses", upstream.lastReq.URL.String())
+		require.Equal(t, "deepseek-chat", gjson.GetBytes(upstream.lastBody, "model").String())
+		require.Equal(t, int64(65535), gjson.GetBytes(upstream.lastBody, "max_output_tokens").Int())
+	})
+
+	t.Run("max_tokens at or below cap is preserved", func(t *testing.T) {
+		account := newAccount(372)
+		body := []byte(`{"model":"deepseek-chat","max_tokens":1000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		upstream, err := run(account, body)
+		require.Error(t, err)
+		require.Equal(t, int64(1000), gjson.GetBytes(upstream.lastBody, "max_output_tokens").Int())
+	})
+}
+
+// TestResponsesPathNotClampedForOfficialDeepseekOrNonDeepSeekModel 对照用例（问题 1/2）：
+// 官方 deepseek（api.deepseek.com）与 ollama.com + 非 DeepSeek 模型的账号，同一判据不
+// 命中——三个出站入口的出站 body 保持 256000、不做任何改写。
+func TestResponsesPathNotClampedForOfficialDeepseekOrNonDeepSeekModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type entry struct {
+		name    string
+		path    string
+		body    []byte
+		forward func(*OpenAIGatewayService, *gin.Context, *Account, []byte) error
+	}
+	entries := []entry{
+		{
+			name: "responses ingress",
+			path: "/v1/responses",
+			body: []byte(`{"model":"deepseek-v4-flash","input":"Reply with exactly OK and nothing else.","max_tokens":256000,"stream":false}`),
+			forward: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) error {
+				_, err := svc.Forward(context.Background(), c, account, body)
+				return err
+			},
+		},
+		{
+			name: "chat completions ingress",
+			path: "/v1/chat/completions",
+			body: []byte(`{"model":"deepseek-chat","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`),
+			forward: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) error {
+				_, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
+				return err
+			},
+		},
+		{
+			name: "messages ingress",
+			path: "/v1/messages",
+			body: []byte(`{"model":"deepseek-chat","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`),
+			forward: func(svc *OpenAIGatewayService, c *gin.Context, account *Account, body []byte) error {
+				_, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+				return err
+			},
+		},
+	}
+
+	run := func(account *Account, e entry) *httpUpstreamRecorder {
+		upstream := &httpUpstreamRecorder{err: errors.New("stop after capture")}
+		svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+		err := e.forward(svc, adaptiveProtocolTestContext(e.path, e.body), account, e.body)
+		require.Error(t, err)
+		return upstream
+	}
+
+	t.Run("official deepseek keeps 256000", func(t *testing.T) {
+		account := officialDeepSeekTestAccount(381)
+		account.Credentials["api_protocol"] = APIProtocolResponses
+		for _, e := range entries {
+			t.Run(e.name, func(t *testing.T) {
+				upstream := run(account, e)
+				require.Equal(t, "https://api.deepseek.com/responses", upstream.lastReq.URL.String())
+				// 原生 Responses 入站只发 max_tokens 时保持原样（无 max_output_tokens）；
+				// 转换路径经转换器生成 max_output_tokens=256000，均不做 clamp。
+				if out := gjson.GetBytes(upstream.lastBody, "max_output_tokens"); out.Exists() {
+					require.Equal(t, int64(256000), out.Int())
+				} else {
+					require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_tokens").Int())
+				}
+			})
+		}
+	})
+
+	t.Run("ollama account with non-deepseek model keeps 256000", func(t *testing.T) {
+		account := ollamaUpstreamTestAccount(PlatformDeepseek, 382)
+		account.Credentials["api_protocol"] = APIProtocolResponses
+		glmEntries := entries
+		glmEntries[0].body = []byte(`{"model":"glm-5.3-flash","input":"Reply with exactly OK and nothing else.","max_tokens":256000,"stream":false}`)
+		glmEntries[1].body = []byte(`{"model":"glm-5.3-flash","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		glmEntries[2].body = []byte(`{"model":"glm-5.3-flash","max_tokens":256000,"messages":[{"role":"user","content":"hi"}],"stream":false}`)
+		for _, e := range glmEntries {
+			t.Run(e.name, func(t *testing.T) {
+				upstream := run(account, e)
+				require.Equal(t, "https://ollama.com/v1/responses", upstream.lastReq.URL.String())
+				if out := gjson.GetBytes(upstream.lastBody, "max_output_tokens"); out.Exists() {
+					require.Equal(t, int64(256000), out.Int())
+				} else {
+					require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_tokens").Int())
+				}
+			})
+		}
+	})
+}

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -89,6 +89,9 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	}
 	// /v1/responses 降级到 raw CC 的出站与 forwardAsRawChatCompletions 共用同一个
 	// 独立 Ollama Cloud token 钩子；chatReq.Model 已是模型映射后的 upstreamModel。
+	// reasoning 归一化与 raw 路径同序：先归一化 request（历史 assistant 消息的
+	// reasoning_content → reasoning）再 clamp max_tokens。
+	chatBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamModel, chatBody)
 	chatBody = clampOllamaCloudUpstreamMaxTokens(account, chatBody)
 	// Keep the final outbound tier for usage-time reconciliation. A policy
 	// filter that removes the field therefore leaves this nil.
@@ -123,14 +126,15 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	}
 
 	if clientStream {
-		return s.streamChatCompletionsAsResponses(c, resp, originalModel, customTools, functionTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+		return s.streamChatCompletionsAsResponses(c, resp, account, originalModel, customTools, functionTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
-	return s.bufferChatCompletionsAsResponses(c, resp, originalModel, customTools, functionTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+	return s.bufferChatCompletionsAsResponses(c, resp, account, originalModel, customTools, functionTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 }
 
 func (s *OpenAIGatewayService) bufferChatCompletionsAsResponses(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
 	originalModel string,
 	customTools map[string]bool,
 	functionTools map[string]bool,
@@ -143,7 +147,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsResponses(
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
 	requestID := resp.Header.Get("x-request-id")
-	ccResp, usage, err := s.readCCUpstreamJSONResponse(c, resp, writeOpenAIResponsesFallbackError)
+	ccResp, usage, err := s.readCCUpstreamJSONResponse(c, resp, account, upstreamModel, writeOpenAIResponsesFallbackError)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +177,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsResponses(
 func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
 	originalModel string,
 	customTools map[string]bool,
 	functionTools map[string]bool,
@@ -220,7 +225,7 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 		c.Writer.Flush()
 	}
 
-	scan := s.scanCCStream(c, resp, "openai responses chat fallback", requestID, startTime, func(chunk *apicompat.ChatCompletionsChunk) {
+	scan := s.scanCCStream(c, resp, account, upstreamModel, "openai responses chat fallback", requestID, startTime, func(chunk *apicompat.ChatCompletionsChunk) {
 		events := apicompat.ChatCompletionsChunkToResponsesEvents(chunk, state)
 		s.cacheReasoningItemsFromEvents(events)
 		writeEvents(events)

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_ollama_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_ollama_test.go
@@ -1,0 +1,148 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// runOllamaResponsesChatFallback 直接走 /v1/responses → raw CC 降级桥
+// forwardResponsesViaRawChatCompletions（与 raw 路径测试同风格，直接调桥函数）。
+func runOllamaResponsesChatFallback(t *testing.T, account *Account, body []byte, upstreamBody string, stream bool) (*httptest.ResponseRecorder, *httpUpstreamRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	contentType := "application/json"
+	if stream {
+		contentType = "text/event-stream"
+	}
+	upstreamResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{contentType},
+			"x-request-id": []string{"rid_ollama_responses_fallback"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}
+	upstream := &httpUpstreamRecorder{resp: upstreamResp}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	result, err := svc.forwardResponsesViaRawChatCompletions(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return rec, upstream
+}
+
+func TestResponsesChatFallback_OllamaDeepSeek_ClampMaxOutputTokens(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 601)
+
+	t.Run("256000 clamps to 65535", func(t *testing.T) {
+		body := []byte(`{"model":"deepseek-v4-flash","input":"hello","max_output_tokens":256000,"stream":false}`)
+		upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+		_, upstream := runOllamaResponsesChatFallback(t, account, body, upstreamJSON, false)
+		require.Equal(t, "deepseek-v4-flash", gjson.GetBytes(upstream.lastBody, "model").String())
+		require.Equal(t, int64(65535), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	})
+
+	t.Run("1000 stays 1000", func(t *testing.T) {
+		body := []byte(`{"model":"deepseek-v4-flash","input":"hello","max_output_tokens":1000,"stream":false}`)
+		upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+		_, upstream := runOllamaResponsesChatFallback(t, account, body, upstreamJSON, false)
+		require.Equal(t, int64(1000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	})
+}
+
+// TestResponsesChatFallback_OllamaDeepSeek_ReasoningAliasStreaming 验证流式响应侧
+// 归一化：上游 delta.reasoning / delta.thinking 与官方形态 delta.reasoning_content
+// 在归一化之后产出完全相同的 reasoning 输出（同一转换路径跑多个输入对比）。
+// normalizeStreamIDs 抹平响应里每次运行随机生成的 item id 与 created_at 时间戳，
+// 使两条输入路径的 SSE 输出可做语义级字节比较。
+var normalizeStreamIDs = regexp.MustCompile(`("item_[0-9a-f]+"|"created_at":[0-9]+)`)
+
+func TestResponsesChatFallback_OllamaDeepSeek_ReasoningAliasStreaming(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 602)
+	body := []byte(`{"model":"deepseek-v4-flash","input":"hello","max_output_tokens":1000,"stream":true}`)
+
+	run := func(reasoningField string) string {
+		upstreamBody := strings.Join([]string{
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{` + reasoningField + `},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"final answer"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"chatcmpl_ollama","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n")
+		rec, _ := runOllamaResponsesChatFallback(t, account, body, upstreamBody, true)
+		return normalizeStreamIDs.ReplaceAllString(rec.Body.String(), `"item_x"`)
+	}
+
+	baseline := run(`"reasoning_content":"abc"`)
+	require.Contains(t, baseline, "response.reasoning_summary_text.delta")
+	require.Contains(t, baseline, `"delta":"abc"`)
+	require.Contains(t, baseline, `"delta":"final answer"`)
+	for _, tc := range []struct {
+		name  string
+		field string
+	}{
+		{name: "delta.reasoning alias", field: `"reasoning":"abc"`},
+		{name: "delta.thinking alias", field: `"thinking":"abc"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, baseline, run(tc.field), "归一化后输出必须与 reasoning_content 基线完全一致")
+		})
+	}
+}
+
+func TestResponsesChatFallback_OllamaDeepSeek_ThinkingAliasNonStreaming(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 603)
+	body := []byte(`{"model":"deepseek-v4-flash","input":"hello","max_output_tokens":1000,"stream":false}`)
+	upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, _ := runOllamaResponsesChatFallback(t, account, body, upstreamJSON, false)
+	require.Equal(t, "reasoning", gjson.Get(rec.Body.String(), "output.0.type").String())
+	require.Equal(t, "abc", gjson.Get(rec.Body.String(), "output.0.summary.0.text").String())
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "output.1.content.0.text").String())
+}
+
+func TestResponsesChatFallback_OfficialDeepSeek_Untouched(t *testing.T) {
+	official := officialDeepSeekTestAccount(604)
+	body := []byte(`{"model":"deepseek-v4-flash","input":"hello","max_output_tokens":256000,"stream":false}`)
+	// thinking 不归一化：转换器只认 reasoning_content/reasoning，thinking 被丢弃，
+	// 输出不出现 reasoning item（与不挂钩子的原始路径行为一致）。
+	upstreamJSON := `{"id":"chatcmpl_official","object":"chat.completion","model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, upstream := runOllamaResponsesChatFallback(t, official, body, upstreamJSON, false)
+	// 请求侧不被 clamp：max_completion_tokens 保持 256000。
+	require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	// 响应侧不归一化：输出只有 message item，没有 reasoning item。
+	require.NotContains(t, rec.Body.String(), `"type":"reasoning"`)
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
+}
+
+func TestResponsesChatFallback_OllamaGLM_Untouched(t *testing.T) {
+	account := ollamaUpstreamTestAccount(PlatformDeepseek, 605)
+	body := []byte(`{"model":"glm-5.3-flash","input":"hello","max_output_tokens":256000,"stream":false}`)
+	upstreamJSON := `{"id":"chatcmpl_ollama","object":"chat.completion","model":"glm-5.3-flash","choices":[{"index":0,"message":{"role":"assistant","thinking":"abc","content":"final answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`
+	rec, upstream := runOllamaResponsesChatFallback(t, account, body, upstreamJSON, false)
+	require.Equal(t, int64(256000), gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Int())
+	require.NotContains(t, rec.Body.String(), `"type":"reasoning"`)
+	require.Equal(t, "final answer", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
+}


### PR DESCRIPTION
## 问题

Ollama Cloud（ollama.com）托管的 DeepSeek 模型把思维链放在 `reasoning` / `thinking` 字段而非 OpenAI 规范的 `reasoning_content`，且输出上限为 65535（超出会被上游以 400 拒绝）。#6767 已补齐 `max_tokens` clamp，但 reasoning 别名补齐仍被 `isOllamaCloudRawChatCompletionsAccount` 的 `Platform == openai` + `force_chat_completions` 门控限制：挂在 deepseek / zhipu / kimi 等 OpenAI 兼容平台分组下的 Ollama 账号（`ollama_cloud_usage.go` 注释中明确支持的用法）拿不到补齐，客户端会丢失整条思维链；当模型把输出预算全部花在 reasoning 上时，客户端收到零内容 + `finish_reason=length`。此外，`/v1/responses` → 原始 Chat Completions 的 fallback、`messages → chat/completions` 桥、以及 `ForwardAsChatCompletions` / `ForwardAsAnthropic` 两条“转换后打原生 Responses”的路径仍未应用 clamp。

## 改动

- **判据**：新增单一判据 `isOllamaCloudDeepSeekUpstream(account, upstreamModel)`——出站 base_url 是 ollama.com 且映射后的出站模型为 `deepseek-` 前缀，不再看 platform / responses-mode / usage extra。raw chat/completions 路径的三个 reasoning 钩子改用它，`upstreamModel` 从请求侧穿参，不依赖上游回显。`isOllamaCloudRawChatCompletionsAccount` 保留给 clamp 的旧兜底分支。
- **桥路径**：`responses → chat/completions` 降级桥补请求侧 reasoning 归一化；`messages → chat/completions` 桥补 clamp + reasoning 归一化；响应侧统一挂在两桥共用的 `openai_gateway_cc_pipeline.go`（`scanCCStream` 解析 SSE 行之前、`readCCUpstreamJSONResponse` 反序列化之前），让协议转换器看到与官方 DeepSeek 一致的形态。
- **原生 Responses**：`ollamaCloudResponsesMaxOutputTokensClamp` 去掉 `max_tokens` 回退的 platform 限制并返回生效字段名，`Forward` 调用点在生效值来自 `max_tokens` 时追加删除该字段；`ForwardAsChatCompletions` / `ForwardAsAnthropic` 两条“转换后打原生 Responses”路径此前绕过 `Forward` 里的 clamp，补上 `ollamaCloudClampResponsesMaxOutputTokensBody`。
- **不变**：官方 `api.deepseek.com` 账号字节级透传；非 DeepSeek 模型不受影响（别名补齐对已发 `reasoning_content` 的上游是 no-op；clamp 仅 DeepSeek）。

## 测试

新增/更新 `-tags unit` 用例：judgment 不看 platform、官方账号不变、GLM 不变、桥的 `256000 → 65535`、流式/非流式输出与 `reasoning_content` 基线逐字节一致。

```bash
go test ./internal/service/ -tags unit
```

全量通过。

## 验证

已部署，`/v1/chat/completions`、`/v1/responses`、`/v1/messages` 三端点对 deepseek-v4-flash 真实调用 `max_tokens=256000` 均返回 200，流式与非流式均带回 reasoning。

关联：Follow-up to #6767。
