### PR TITLE
fix(proxies): reject malformed list responses

### DIFF
--- a/frontend/src/api/__tests__/admin.proxies.spec.ts
+++ b/frontend/src/api/__tests__/admin.proxies.spec.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }))
+vi.mock('@/api/client', () => ({ apiClient: { get } }))
+
+import { getAll, getAllWithCount, list } from '@/api/admin/proxies'
+
+describe.each([
+  { name: 'paginated list', load: () => list(), wrap: (items: unknown[]) => ({ items, total: items.length, pages: 1 }) },
+  { name: 'account selector', load: getAll, wrap: (items: unknown[]) => items },
+  { name: 'account selector with counts', load: getAllWithCount, wrap: (items: unknown[]) => items },
+])('$name', ({ load, wrap }) => {
+  beforeEach(() => { get.mockReset() })
+
+  it.each(['', undefined, null, {}, { items: null }, { items: {} }])(
+    'rejects an empty or malformed successful response: %j',
+    async (data) => {
+      get.mockResolvedValue({ data })
+      await expect(load()).rejects.toThrow('Invalid proxy list response')
+    },
+  )
+
+  it.each([{ items: [] }, { items: [{ id: 1, name: 'valid proxy' }] }])('preserves valid rows: %j', async ({ items }) => {
+    const data = wrap(items)
+    get.mockResolvedValue({ data })
+    await expect(load()).resolves.toBe(data)
+  })
+})

--- a/frontend/src/api/admin/proxies.ts
+++ b/frontend/src/api/admin/proxies.ts
@@ -15,6 +15,12 @@ import type {
   AdminDataImportResult
 } from '@/types'
 
+function assertProxyArray(value: unknown): asserts value is Proxy[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid proxy list response')
+  }
+}
+
 /**
  * List all proxies with pagination
  * @param page - Page number (default: 1)
@@ -44,6 +50,7 @@ export async function list(
     },
     signal: options?.signal
   })
+  assertProxyArray(data?.items)
   return data
 }
 
@@ -53,6 +60,7 @@ export async function list(
  */
 export async function getAll(): Promise<Proxy[]> {
   const { data } = await apiClient.get<Proxy[]>('/admin/proxies/all')
+  assertProxyArray(data)
   return data
 }
 
@@ -64,6 +72,7 @@ export async function getAllWithCount(): Promise<Proxy[]> {
   const { data } = await apiClient.get<Proxy[]>('/admin/proxies/all', {
     params: { with_count: 'true' }
   })
+  assertProxyArray(data)
   return data
 }
 


### PR DESCRIPTION
An empty HTTP 200 response from the proxy API is currently accepted as data: the paginated view assigns `undefined` to its rows, and the unpaginated selectors accept a non-array value. Validate the list shape at the API boundary so failed loads reject before replacing existing table/selector data. Valid empty and populated arrays are preserved unchanged.

Related to #6763. I reproduced the empty-body path with the current Gin version and the same time conversion/response envelope when a millisecond timestamp is interpreted as Unix seconds. The reporter’s stored data has not been confirmed. This change handles the malformed response; it does not repair existing invalid records or fix server serialization.

#6810 already covers preventing out-of-range proxy expiry writes. This PR complements that work with frontend response validation only, including records that may already exist.

Validation: 44 Vitest tests passed (24 new proxy API cases plus 20 existing client tests), full frontend typecheck passed, and ESLint passed for the changed files. Tests cover empty/malformed successful responses across all three proxy list methods and preserve valid empty/populated results.
