### PR TITLE
fix(gateway): accept Claude Code max_tokens=1 probes for any model

### DIFF
--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -89,6 +89,10 @@ func claudeCodeBodyMapFromParsedRequest(parsedReq *service.ParsedRequest) map[st
 	bodyMap := map[string]any{
 		"model": parsedReq.Model,
 	}
+	// 探测识别（max_tokens=1）需要看到该字段，复用已解析请求时一并带上。
+	if parsedReq.MaxTokens > 0 {
+		bodyMap["max_tokens"] = parsedReq.MaxTokens
+	}
 	if parsedReq.HasSystem {
 		if system, ok := parsedReq.SystemValue(); ok {
 			bodyMap["system"] = system

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -500,3 +500,19 @@ type helperConcurrencyCacheStubWithError struct {
 func (s *helperConcurrencyCacheStubWithError) AcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
 	return false, s.err
 }
+
+func TestSetClaudeCodeClientContext_ParsedRequestProbeWithoutSystemPrompt(t *testing.T) {
+	c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
+	c.Request.Header.Set("User-Agent", "claude-cli/2.1.260 (external, cli)")
+
+	// The hot path reuses ParsedRequest instead of re-parsing the body; the probe
+	// marker must survive that projection or the exemption only works cold.
+	parsed := &service.ParsedRequest{Model: "claude-sonnet-4-5", MaxTokens: 1}
+	SetClaudeCodeClientContext(c, nil, parsed)
+	require.True(t, service.IsClaudeCodeClient(c.Request.Context()))
+
+	c2, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
+	c2.Request.Header.Set("User-Agent", "claude-cli/2.1.260 (external, cli)")
+	SetClaudeCodeClientContext(c2, nil, &service.ParsedRequest{Model: "claude-sonnet-4-5", MaxTokens: 64})
+	require.False(t, service.IsClaudeCodeClient(c2.Request.Context()))
+}

--- a/backend/internal/service/claude_code_validator.go
+++ b/backend/internal/service/claude_code_validator.go
@@ -104,6 +104,12 @@ func (v *ClaudeCodeValidator) Validate(r *http.Request, body map[string]any) boo
 	if isMaxTokensOneHaiku, ok := IsMaxTokensOneHaikuRequestFromContext(r.Context()); ok && isMaxTokensOneHaiku {
 		return true // 绕过 system prompt 检查，UA 已在 Step 1 验证
 	}
+	// 探测请求并不总是打到 haiku：CLI 切换模型、刷新上下文用量时会向当前模型发
+	// max_tokens=1 的轻量请求，同样不携带 system。UA 已过 Step 1，且 1 个输出 token
+	// 对滥用者没有价值，故按请求体放行，不再限定模型名。
+	if isMaxTokensOneBody(body) {
+		return true
+	}
 
 	// Step 4: messages 路径，进行严格验证
 
@@ -152,6 +158,24 @@ func (v *ClaudeCodeValidator) Validate(r *http.Request, body map[string]any) boo
 
 func isMessagesCountTokensPath(path string) bool {
 	return strings.HasSuffix(path, "/messages/count_tokens")
+}
+
+// isMaxTokensOneBody 判断请求体是否显式声明 max_tokens=1。
+// 兼容 JSON 反序列化出的 float64 与 ParsedRequest 复用时的 int。
+func isMaxTokensOneBody(body map[string]any) bool {
+	if body == nil {
+		return false
+	}
+	switch v := body["max_tokens"].(type) {
+	case float64:
+		return v == 1
+	case int:
+		return v == 1
+	case int64:
+		return v == 1
+	default:
+		return false
+	}
 }
 
 // hasClaudeCodeSystemPrompt 检查请求是否包含 Claude Code 系统提示词

--- a/backend/internal/service/claude_code_validator_test.go
+++ b/backend/internal/service/claude_code_validator_test.go
@@ -45,9 +45,10 @@ func TestClaudeCodeValidator_MessagesWithoutProbeStillNeedStrictValidation(t *te
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
 	req.Header.Set("User-Agent", "claude-cli/1.2.3 (darwin; arm64)")
 
+	// max_tokens=2 不是探测请求：没有 system prompt 仍走严格校验并被拒。
 	ok := validator.Validate(req, map[string]any{
 		"model":      "claude-haiku-4-5",
-		"max_tokens": 1,
+		"max_tokens": 2,
 	})
 	require.False(t, ok)
 }
@@ -573,4 +574,27 @@ func TestSetGetClaudeCodeVersion(t *testing.T) {
 
 	ctx = SetClaudeCodeVersion(ctx, "2.1.63")
 	require.Equal(t, "2.1.63", GetClaudeCodeVersion(ctx))
+}
+
+func TestClaudeCodeValidator_MaxTokensOneProbeIsNotLimitedToHaiku(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+
+	for _, model := range []string{"claude-sonnet-4-5", "claude-opus-4-1", "claude-haiku-4-5"} {
+		t.Run(model, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+			req.Header.Set("User-Agent", "claude-cli/2.1.260 (external, cli)")
+			// No context flag, no system prompt, no extra headers: the body alone marks the probe.
+			for _, mt := range []any{float64(1), 1} {
+				require.True(t, validator.Validate(req, map[string]any{"model": model, "max_tokens": mt}), "max_tokens=%v (%T)", mt, mt)
+			}
+		})
+	}
+}
+
+func TestClaudeCodeValidator_MaxTokensOneProbeStillRequiresClaudeCodeUA(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+	req.Header.Set("User-Agent", "python-requests/2.32")
+
+	require.False(t, validator.Validate(req, map[string]any{"model": "claude-sonnet-4-5", "max_tokens": 1}))
 }


### PR DESCRIPTION
Fixes #6591

## 背景

`claude_code_only` 的探测豁免 `isMaxTokensOneHaikuRequest` 要求模型名含 `haiku`。Claude Code 在 `/model` 切换、`/context` 刷新用量时，会向**当前使用的模型**发 `max_tokens=1`、不带 system 的轻量请求；模型是 sonnet / opus 时豁免不成立，请求落入 system 相似度检查，被当作非 Claude Code 客户端拒绝（`this group only allows Claude Code clients`）。这就是 #2909 里被 #2919 搁置的"部分 `stream=false /v1/messages`"那一半。

## 改动

- `ClaudeCodeValidator.Validate`：UA 通过 Step 1 后，请求体 `max_tokens == 1` 即视为探测放行，不再限定模型名。
- `claudeCodeBodyMapFromParsedRequest`：复用已解析请求的热路径把 `max_tokens` 一并投影出来，否则豁免只在冷路径生效。
- haiku 的 context 标记与本地拦截 `InterceptTypeMaxTokensOneHaiku` 保持原样；非 haiku 探测作为普通 1 token 请求走池子。
- 安全面：能伪造 `claude-cli` UA 的客户端本来也能伪造 system 与请求头，1 个输出 token 对它没有额外价值，不扩大攻击面。

非测试改动约 30 行，无行为变化之外的重构。

## 测试

- 新增：sonnet / opus / haiku 三种模型的 `max_tokens=1` 均放行，`float64` 与 `int` 两种取值都覆盖；非 CLI UA 的 `max_tokens=1` 仍拒；`ParsedRequest` 热路径上 `MaxTokens=1` 放行、`MaxTokens=64` 仍严格校验。
- 调整：原 `MessagesWithoutProbeStillNeedStrictValidation` 用 haiku + `max_tokens=1` 表达"无 context 标记就严格校验"，该组合现在本身就是探测，改用 `max_tokens=2` 表达同一意图。
- 本地：`gofmt` / `go vet` / `go build ./...` 通过；`golangci-lint run`（v2.13）0 issues；`go test ./internal/service/ -run 'ClaudeCode|Detection|Probe'` 与 `go test -tags=unit ./internal/handler/` 全部通过。