### PR TITLE
fix(grok): 移除 Chat Completions 中不支持的 external_web_access 参数

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -156,6 +156,10 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		if err != nil {
 			return nil, fmt.Errorf("normalize Grok chat reasoning effort: %w", err)
 		}
+		upstreamBody, err = sanitizeGrokUnsupportedFields(upstreamBody)
+		if err != nil {
+			return nil, fmt.Errorf("sanitize Grok unsupported fields: %w", err)
+		}
 	}
 	upstreamBody = applyOllamaCloudRawChatCompletionsRequest(account, upstreamBody)
 

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -752,11 +752,14 @@ func grokSupportsReasoningEffort(model string) bool {
 	}
 }
 
-var grokResponsesUnsupportedRecursiveFields = map[string]struct{}{
+// grokUnsupportedRecursiveFields 定义 Grok 平台（Responses 和 Chat Completions）不支持的字段
+var grokUnsupportedRecursiveFields = map[string]struct{}{
 	"external_web_access": {},
 }
 
-func sanitizeGrokResponsesUnsupportedFields(body []byte) ([]byte, error) {
+// sanitizeGrokUnsupportedFields 递归移除 Grok 平台不支持的字段
+// 适用于 Responses API 和 Chat Completions API
+func sanitizeGrokUnsupportedFields(body []byte) ([]byte, error) {
 	if !bytes.Contains(body, []byte(`"external_web_access"`)) {
 		return body, nil
 	}
@@ -765,11 +768,14 @@ func sanitizeGrokResponsesUnsupportedFields(body []byte) ([]byte, error) {
 	if err := decodeOpenAIJSONUseNumber(body, &payload); err != nil {
 		return nil, err
 	}
-	if !deleteJSONFields(payload, grokResponsesUnsupportedRecursiveFields) {
+	if !deleteJSONFields(payload, grokUnsupportedRecursiveFields) {
 		return body, nil
 	}
 	return marshalOpenAIUpstreamJSON(payload)
 }
+
+// sanitizeGrokResponsesUnsupportedFields 保留旧函数名作为别名，向后兼容
+var sanitizeGrokResponsesUnsupportedFields = sanitizeGrokUnsupportedFields
 
 func deleteJSONFields(value any, fields map[string]struct{}) bool {
 	switch typed := value.(type) {


### PR DESCRIPTION
## 问题

Grok OAuth 账户从 8 月 28 日开始出现 400 错误：`Argument not supported: external_web_access`

## 根因

- 8 月 24 日 OAuth plugin system 上线后，部分 Grok 请求改走 Chat Completions raw 路径
- 该路径缺少 `external_web_access` 参数过滤（Responses API 路径已有）
- `external_web_access` 不是 Grok Build 官方参数，xAI Responses API 拒绝该参数

## 修复

1. 重命名 `sanitizeGrokResponsesUnsupportedFields` → `sanitizeGrokUnsupportedFields` 供两条路径复用
2. 在 Chat Completions raw 路径添加参数过滤调用
3. 保留向后兼容别名

## 验证

- ✅ 递归删除逻辑已通过本地 demo 验证
- ⏳ 待部署后验证真实 API 调用无 400 错误

## 影响范围

仅影响 Grok 平台 Chat Completions API 请求体处理，不影响其他平台和 Responses API 路径。

## 提交信息

```
commit: c8deeb0b0571fb22f9c1b17b2481800633ece8d0
author: mason0510 <zhangke_2021@126.com>
date: Tue Sep 8 16:41:09 2026 +0800
```