### PR TITLE
test(groups): initialize Pinia in Codex manifest regression

### DIFF
--- a/frontend/src/views/admin/__tests__/GroupsView.codexManifest.spec.ts
+++ b/frontend/src/views/admin/__tests__/GroupsView.codexManifest.spec.ts
@@ -1,5 +1,6 @@
 import { defineComponent, h, type PropType } from "vue";
 import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AdminGroup, CodexModelsManifestConfig } from "@/types";
@@ -7,13 +8,13 @@ import GroupsView from "@/views/admin/GroupsView.vue";
 
 const {
   listGroups,
-  getModelsListCandidates,
+  getModelAllowlistCandidates,
   getUsageSummary,
   getCapacitySummary,
   getLiveCapability,
 } = vi.hoisted(() => ({
   listGroups: vi.fn(),
-  getModelsListCandidates: vi.fn(),
+  getModelAllowlistCandidates: vi.fn(),
   getUsageSummary: vi.fn(),
   getCapacitySummary: vi.fn(),
   getLiveCapability: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock("@/api/admin", () => ({
     groups: {
       list: listGroups,
       getAll: vi.fn(),
-      getModelsListCandidates,
+      getModelAllowlistCandidates,
       getUsageSummary,
       getCapacitySummary,
       getLiveCapability,
@@ -204,6 +205,7 @@ const CodexManifestAccountsFieldStub = defineComponent({
 const mountView = () =>
   mount(GroupsView, {
     global: {
+      plugins: [createPinia()],
       stubs: {
         AppLayout: AppLayoutStub,
         TablePageLayout: TablePageLayoutStub,
@@ -230,7 +232,7 @@ describe("GroupsView Codex manifest binding", () => {
   beforeEach(() => {
     localStorage.clear();
     listGroups.mockReset();
-    getModelsListCandidates.mockReset();
+    getModelAllowlistCandidates.mockReset();
     getUsageSummary.mockReset();
     getCapacitySummary.mockReset();
     getLiveCapability.mockReset();
@@ -242,7 +244,7 @@ describe("GroupsView Codex manifest binding", () => {
       page_size: 20,
       pages: 1,
     });
-    getModelsListCandidates.mockResolvedValue([]);
+    getModelAllowlistCandidates.mockResolvedValue([]);
     getUsageSummary.mockResolvedValue([]);
     getCapacitySummary.mockResolvedValue([]);
     getLiveCapability.mockResolvedValue({ supported: false });


### PR DESCRIPTION
The Codex manifest regression mounts GroupsView without Pinia even though the page now uses the auth store, so it fails before exercising the form updates. Install a fresh Pinia instance when mounting and update the stale model-allowlist API mock to the method the page currently calls.

Validation: reproduced the original getActivePinia failure; the existing regression and all 176 critical frontend tests pass. Full frontend ESLint and TypeScript checks also pass.

Fixes #6837.