### PR TITLE
fix(ops): prioritize time and response in error details

### DIFF
--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -276,6 +276,7 @@ watch(
 
           <OpsErrorLogTable
             class="min-h-0 flex-1"
+            summary-first
             :rows="rows"
             :total="total"
             :loading="loading"

--- a/frontend/src/views/admin/ops/components/OpsErrorLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorLogTable.vue
@@ -215,11 +215,18 @@ const allColumns = computed<Column[]>(() => [
 ])
 
 // 传入 visibleColumnKeys 时按其过滤(列设置);未传则全量(Ops 弹窗等使用方)
-const columns = computed<Column[]>(() =>
-  props.visibleColumnKeys
+const columns = computed<Column[]>(() => {
+  const visibleColumns = props.visibleColumnKeys
     ? allColumns.value.filter((c) => props.visibleColumnKeys!.includes(c.key))
     : allColumns.value
-)
+  if (!props.summaryFirst) return visibleColumns
+
+  return [
+    ...visibleColumns.filter((c) => c.key === 'created_at'),
+    ...visibleColumns.filter((c) => c.key === 'message'),
+    ...visibleColumns.filter((c) => c.key !== 'created_at' && c.key !== 'message'),
+  ]
+})
 
 function isUpstreamRow(log: OpsErrorLog): boolean {
   const phase = String(log.phase || '').toLowerCase()
@@ -288,6 +295,8 @@ interface Props {
   userClickable?: boolean
   /** 列设置:仅显示这些 key 的列;不传则全量 */
   visibleColumnKeys?: string[]
+  /** 运维弹窗优先展示时间和响应内容 */
+  summaryFirst?: boolean
   /** 嵌入统一卡片内使用：去掉自身卡片外观 */
   flat?: boolean
 }

--- a/frontend/src/views/admin/ops/components/__tests__/OpsErrorLogTable.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsErrorLogTable.spec.ts
@@ -75,6 +75,37 @@ describe('OpsErrorLogTable user/api-key/account columns', () => {
   })
 })
 
+describe('OpsErrorLogTable column order', () => {
+  it('puts time and response content first for ops without changing time sorting', async () => {
+    const wrapper = mountTable({})
+    await wrapper.setProps({ summaryFirst: true })
+
+    const headers = wrapper.findAll('thead th')
+    expect(headers.slice(0, 3).map((header) => header.text())).toEqual([
+      'admin.ops.errorLog.time',
+      'admin.ops.errorLog.message',
+      'admin.ops.errorLog.user',
+    ])
+    expect(wrapper.findAll('tbody td')[1].text()).toBe('boom')
+
+    await headers[0].trigger('click')
+    expect(wrapper.emitted('sort')).toEqual([['created_at', 'asc']])
+    wrapper.unmount()
+  })
+
+  it('preserves the usage column order and visibility by default', async () => {
+    const wrapper = mountTable({})
+    await wrapper.setProps({ visibleColumnKeys: ['created_at', 'user', 'message'] })
+
+    expect(wrapper.findAll('thead th').map((header) => header.text())).toEqual([
+      'admin.ops.errorLog.user',
+      'admin.ops.errorLog.message',
+      'admin.ops.errorLog.time',
+    ])
+    wrapper.unmount()
+  })
+})
+
 // 防回归:组件用 admin.ops.errorLog.* 命名空间。若 i18n 键写错命名空间(如误放到
 // errorDetail),真实 vue-i18n 会回退返回 key 本身 → 界面显示原始路径字符串。
 // 这里用真实 locale 校验键确实可解析(返回译文而非 key)。


### PR DESCRIPTION
In the operations error-details dialog, the timestamp and response message sit after the identity and request columns, making recent failures harder to inspect. Put time and response content first in that dialog through an optional table prop. The shared table retains its existing default order and column filtering.

Validation: 6 error-table tests, 176 critical frontend tests, full frontend ESLint, and TypeScript checks passed. The regression checks rendered column positions and timestamp sorting.

Fixes #6808.