### PR TITLE
fix(openai): 出图主控模型换用 gpt-5.6-luna 并支持 SUB2API_IMAGES_MAIN_MODEL 运行时覆盖（gpt-5.4-mini 已被 OpenAI 下线）

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1216,10 +1216,11 @@ func normalizeOpenAIResponsesImageOnlyModel(reqBody map[string]any) bool {
 		reqBody["tool_choice"] = map[string]any{"type": "image_generation"}
 		modified = true
 	}
-	if imageModel != openAIImagesResponsesMainModel {
+	imagesMainModel := openAIImagesResponsesMainModelValue()
+	if imageModel != imagesMainModel {
 		modified = true
 	}
-	reqBody["model"] = openAIImagesResponsesMainModel
+	reqBody["model"] = imagesMainModel
 	return modified
 }
 

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -14,6 +14,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -39,9 +40,22 @@ const (
 	openAIImageBackendUserAgent            = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 	openAIImageMaxDownloadBytes            = 20 << 20 // 20MB per image download
 	openAIImageMaxUploadPartSize           = 20 << 20 // 20MB per multipart upload part
-	openAIImagesResponsesMainModel         = "gpt-5.4-mini"
+	openAIImagesResponsesMainModel         = "gpt-5.6-luna"
+	openAIImagesMainModelEnv               = "SUB2API_IMAGES_MAIN_MODEL"
 	openAIImagesVerbatimPromptInstructions = "When invoking the image_generation tool, use the user's image prompt verbatim. Do not rewrite, expand, summarize, embellish, translate, normalize punctuation, or add or remove visual details or constraints. Preserve the original language, wording, capitalization, quotes, and punctuation exactly."
 )
+
+// openAIImagesResponsesMainModelValue returns the main (driver) model used to
+// carry image_generation tool calls on ChatGPT accounts. The default can be
+// overridden via the SUB2API_IMAGES_MAIN_MODEL environment variable so that an
+// upstream model retirement (e.g. gpt-5.4-mini on 2026-09-08) can be handled
+// without shipping a new build.
+func openAIImagesResponsesMainModelValue() string {
+	if v := strings.TrimSpace(os.Getenv(openAIImagesMainModelEnv)); v != "" {
+		return v
+	}
+	return openAIImagesResponsesMainModel
+}
 
 type OpenAIImagesCapability string
 

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -382,7 +382,7 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 	}
 
 	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
-	req, _ = sjson.SetBytes(req, "model", openAIImagesResponsesMainModel)
+	req, _ = sjson.SetBytes(req, "model", openAIImagesResponsesMainModelValue())
 	req, _ = sjson.SetBytes(req, "instructions", openAIImagesVerbatimPromptInstructions)
 
 	input := []byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`)

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -2231,3 +2231,11 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingDrainsAfterClientDiscon
 	require.Equal(t, 9, result.Usage.OutputTokens)
 	require.Equal(t, 4, result.Usage.ImageOutputTokens)
 }
+
+func TestOpenAIImagesResponsesMainModelValue(t *testing.T) {
+	t.Setenv(openAIImagesMainModelEnv, "")
+	require.Equal(t, openAIImagesResponsesMainModel, openAIImagesResponsesMainModelValue())
+
+	t.Setenv(openAIImagesMainModelEnv, " custom-images-model ")
+	require.Equal(t, "custom-images-model", openAIImagesResponsesMainModelValue())
+}


### PR DESCRIPTION
## 背景

2026-09-08 UTC 16:13 起，OpenAI 将 gpt-5.4 系从 ChatGPT 套餐的 Codex 通道下线（[官方帮助中心](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan)，指定替代为 gpt-5.6-luna）。出图管线硬编码的主控模型 `gpt-5.4-mini` 随即全线 400：

```
{"error":{"message":"The 'gpt-5.4-mini' model is not supported when using Codex with a ChatGPT account.","type":"invalid_request_error"}}
```

连锁效应：每次 400 触发账号冷却，账号池被打空后客户端统一收到 `503 No available compatible accounts`。详细复现见 #6856。

## 改动

1. **默认主控模型换成官方指定替代 `gpt-5.6-luna`**（`openai_images.go`）。
2. **新增运行时覆盖口 `SUB2API_IMAGES_MAIN_MODEL`**：新增 `openAIImagesResponsesMainModelValue()`，两处使用点（`openai_codex_transform.go` 的 model 覆写、`openai_images_responses.go` 的自建请求）改为经该函数取值。下次 OpenAI 再下线模型时，改一个 env 重启即可恢复，无需发版——也部分回应了 #2085 的可配置诉求。

改动刻意保持最小：不引入配置结构变更，env 未设置时行为与现状完全一致（仅默认值从已下线的 gpt-5.4-mini 换为 luna）。

## 测试

- `go build ./...` 通过
- 既有行为测试全部通过（未改动任何既有断言）：
  - `TestNormalizeOpenAIResponsesImageOnlyModel_BuildsImageToolRequest` ✅
  - `TestNormalizeOpenAIResponsesImageOnlyModel_PreservesExistingImageTool` ✅
  - `TestOpenAIGatewayService_Forward_ImageToolWithImageOnlyModelIsNormalized` ✅
  - `TestOpenAIGatewayService_Forward_ImageOnlyModelKeepsSupportedVerbosity` ✅
- 新增 `TestOpenAIImagesResponsesMainModelValue`：默认值回退 + env 覆盖（含 TrimSpace）✅

Fixes #6856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
