### PR TITLE
fix(openai): accept full heartbeat bootstrap envelopes

### DIFF
--- a/backend/internal/handler/openai_automation_bootstrap_test.go
+++ b/backend/internal/handler/openai_automation_bootstrap_test.go
@@ -166,3 +166,44 @@ func TestNormalizeCodexAutomationBootstrapPreservesOrderAndIsIdempotent(t *testi
 	require.False(t, changedAgain)
 	require.Equal(t, got, again)
 }
+
+func TestNormalizeCodexAutomationBootstrapFullHeartbeat(t *testing.T) {
+	const output = `<heartbeat>
+  <automation_id>flutter</automation_id>
+  <current_time_iso>2026-09-09T00:33:34.775Z</current_time_iso>
+  <instructions>
+Read the reference index and report changes. Preserve A &amp; B and &lt;tags&gt;.
+  </instructions>
+</heartbeat>`
+	body := codexAutomationBootstrapBody(t, output, "")
+	got, changed := normalizeCodexAutomationBootstrap(body)
+	require.True(t, changed)
+	require.Equal(t, "user", gjson.GetBytes(got, "input.0.role").String())
+	require.Equal(t, output, gjson.GetBytes(got, "input.0.content.0.text").String())
+	again, changedAgain := normalizeCodexAutomationBootstrap(got)
+	require.False(t, changedAgain)
+	require.Equal(t, got, again)
+
+	for _, field := range []string{"automation_id", "current_time_iso", "instructions"} {
+		duplicate := strings.Replace(output, "</heartbeat>", "<"+field+">duplicate</"+field+"></heartbeat>", 1)
+		require.False(t, validCodexAutomationHeartbeat(duplicate), field)
+	}
+	for _, invalid := range []string{
+		strings.Replace(output, "2026-09-09T00:33:34.775Z", "yesterday", 1),
+		strings.Replace(output, "<current_time_iso>2026-09-09T00:33:34.775Z</current_time_iso>", "", 1),
+		strings.Replace(output, "Read the reference index and report changes. Preserve A &amp; B and &lt;tags&gt;.", " ", 1),
+		strings.Replace(output, "<instructions>", `<instructions source="other">`, 1),
+		strings.Replace(output, "<instructions>", "<instructions><nested/>", 1),
+	} {
+		require.False(t, validCodexAutomationHeartbeat(invalid))
+	}
+	for _, guarded := range [][]byte{
+		codexAutomationBootstrapBody(t, output, `,"call_id":"call-1"`),
+		[]byte(strings.Replace(string(body), `"model":"gpt-5"`, `"model":"gpt-5","previous_response_id":"resp-1"`, 1)),
+		[]byte(strings.Replace(string(body), `"namespace":"codex_app"`, `"namespace":"other"`, 1)),
+	} {
+		unchanged, normalized := normalizeCodexAutomationBootstrap(guarded)
+		require.False(t, normalized)
+		require.Equal(t, guarded, unchanged)
+	}
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1889,12 +1889,24 @@ func validCodexAutomationLastRun(value string) bool {
 func validCodexAutomationHeartbeat(value string) bool {
 	decoder := xml.NewDecoder(strings.NewReader(value))
 	var rootSeen, automationIDSeen bool
-	var automationID bytes.Buffer
+	var childName string
+	var childText bytes.Buffer
+	fields := make(map[string]string)
 	depth := 0
 	for {
 		token, err := decoder.Token()
 		if err == io.EOF {
-			id := automationID.String()
+			id := fields["automation_id"]
+			timestamp, hasTime := fields["current_time_iso"]
+			instructions, hasInstructions := fields["instructions"]
+			if hasTime != hasInstructions {
+				return false
+			}
+			if hasTime {
+				if _, err := time.Parse(time.RFC3339Nano, timestamp); err != nil || strings.TrimSpace(instructions) == "" {
+					return false
+				}
+			}
 			return rootSeen && automationIDSeen && depth == 0 &&
 				strings.TrimSpace(id) == id && validCodexAutomationID(id)
 		}
@@ -1912,13 +1924,25 @@ func validCodexAutomationHeartbeat(value string) bool {
 					return false
 				}
 				rootSeen = true
-			} else if automationIDSeen || current.Name.Local != "automation_id" {
-				return false
+			} else {
+				childName = current.Name.Local
+				switch childName {
+				case "automation_id", "current_time_iso", "instructions":
+				default:
+					return false
+				}
+				if _, duplicate := fields[childName]; duplicate {
+					return false
+				}
+				childText.Reset()
 			}
-			automationIDSeen = depth == 2
 		case xml.EndElement:
 			if current.Name.Space != "" {
 				return false
+			}
+			if depth == 2 {
+				fields[childName] = childText.String()
+				automationIDSeen = automationIDSeen || childName == "automation_id"
 			}
 			depth--
 			if depth < 0 {
@@ -1926,7 +1950,7 @@ func validCodexAutomationHeartbeat(value string) bool {
 			}
 		case xml.CharData:
 			if depth == 2 {
-				_, _ = automationID.Write(current)
+				_, _ = childText.Write(current)
 			} else if len(bytes.TrimSpace(current)) != 0 {
 				return false
 			}


### PR DESCRIPTION
Fixes #6868. Follow-up to #6553 and #6547.

Codex Desktop sends automation bootstrap outputs containing `automation_id`, `current_time_iso`, and `instructions`. The current heartbeat matcher accepts only `automation_id`, so full envelopes are not normalized and HTTP requests fail with `function_call_output requires call_id` before inference.

Accept the full envelope with a valid RFC3339 timestamp and non-empty instructions, while retaining the existing ID-only format. Preserve the original output text and reject duplicate/unknown fields, attributes, nested elements, namespaces, and malformed XML. Existing namespace, call ID, and response-context gates remain unchanged; ordinary tool-output validation is not relaxed.

Regression coverage includes the full observed envelope shape with a sanitized prompt, lossless normalization, idempotency, invalid timestamps, incomplete envelopes, duplicate fields, and protected call contexts.

### Validation

Checked the repository `DEV_GUIDE.md` pre-PR checklist and CI configuration. Local commands ran in the official `golang:1.27` container (resolved to Go 1.27.1 linux/arm64; CI pins Go 1.27.0).

- Passed: `go test ./internal/handler -run TestNormalizeCodex -count=1 -timeout=120s`.
- Passed: `gofmt` and `git diff --check`.
- Attempted: `go test -tags=unit ./... -timeout=180s`. The handler package passed; the service package compiler was killed. Container cgroup counters confirmed an OOM kill, so the full unit suite did not pass.
- Exited successfully: `go test -tags=integration ./... -timeout=180s`. Docker-dependent tests are skipped by the existing harness because the test container has no Docker socket; this is not complete integration validation.
- Attempted: `golangci-lint run ./... --timeout=5m` with v2.13.0. The process was killed (exit 137), so lint is not verified.

Full CI validation remains required. No frontend dependencies, interfaces, or Ent schemas changed.