### PR TITLE
fix(openai): use Luna for OAuth image responses

### DIFF
--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -39,7 +39,7 @@ const (
 	openAIImageBackendUserAgent            = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 	openAIImageMaxDownloadBytes            = 20 << 20 // 20MB per image download
 	openAIImageMaxUploadPartSize           = 20 << 20 // 20MB per multipart upload part
-	openAIImagesResponsesMainModel         = "gpt-5.4-mini"
+	openAIImagesResponsesMainModel         = "gpt-5.6-luna"
 	openAIImagesVerbatimPromptInstructions = "When invoking the image_generation tool, use the user's image prompt verbatim. Do not rewrite, expand, summarize, embellish, translate, normalize punctuation, or add or remove visual details or constraints. Preserve the original language, wording, capitalization, quotes, and punctuation exactly."
 )
 

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -1973,6 +1973,7 @@ func TestBuildOpenAIImagesResponsesRequest_ForcesImageToolChoice(t *testing.T) {
 	body, err := buildOpenAIImagesResponsesRequest(parsed, "gpt-image-2")
 	require.NoError(t, err)
 	require.NotNil(t, body)
+	require.Equal(t, "gpt-5.6-luna", gjson.GetBytes(body, "model").String())
 	require.Equal(t, "image_generation", gjson.GetBytes(body, "tool_choice.type").String())
 	require.Equal(t, "image_generation", gjson.GetBytes(body, "tools.0.type").String())
 	require.Equal(t, "gpt-image-2", gjson.GetBytes(body, "tools.0.model").String())


### PR DESCRIPTION
## Summary

- use `gpt-5.6-luna` as the top-level Codex Responses controller model for OAuth image requests
- keep the requested image model, such as `gpt-image-2`, on the `image_generation` tool
- add an explicit regression assertion for the controller/tool model split

## Background

ChatGPT OAuth accounts reject the previous `gpt-5.4-mini` controller model before the image tool can run. The resulting plan-gated errors can exhaust the compatible account pool even though `gpt-image-2` remains the requested image tool model.

## Tests

- `go test ./internal/service -run 'TestBuildOpenAIImagesResponsesRequest|TestOpenAIGatewayService_Forward_ImageToolWithImageOnlyModelIsNormalized|TestOpenAIGatewayService_Forward_OpenAIImagesOAuth' -count=1`
- `go test ./internal/service -count=1`
