### PR TITLE
fix(gateway): answer non-haiku Claude Code probes locally instead of forwarding them

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -205,6 +205,19 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		return
 	}
 
+	// 非 haiku 模型的 Claude Code 探测（max_tokens=1，不带 system；切换模型时的模型校验、
+	// 网关模式下的配额探测）在这里本地应答。这类请求此前会被 claude_code_only 校验拒绝（503），
+	// #6838 放行后若继续上行，会被订阅账号的风控判为 429 并把账号推进冷却。haiku 探测沿用
+	// 原有路径（选号后按账号级"拦截预热请求"开关决定是否 mock），行为不变。
+	if isNonHaikuClaudeCodeProbe(isClaudeCodeClient, reqModel, parsedReq.MaxTokens) {
+		if reqStream {
+			sendMockInterceptStream(c, reqModel, InterceptTypeMaxTokensOneHaiku)
+		} else {
+			sendMockInterceptResponse(c, reqModel, InterceptTypeMaxTokensOneHaiku)
+		}
+		return
+	}
+
 	// 在请求上下文中记录 thinking 状态，供 Antigravity 最终模型 key 推导/模型维度限流使用
 	c.Request = c.Request.WithContext(service.WithThinkingEnabled(c.Request.Context(), parsedReq.ThinkingEnabled, h.metadataBridgeEnabled()))
 
@@ -2221,6 +2234,12 @@ func isHaikuModel(model string) bool {
 // 条件：max_tokens == 1 且 model 包含 "haiku"
 func isMaxTokensOneHaikuRequest(model string, maxTokens int) bool {
 	return maxTokens == 1 && isHaikuModel(model)
+}
+
+// isNonHaikuClaudeCodeProbe 判定已通过 Claude Code 客户端校验、打到非 haiku 模型的 max_tokens=1 探测。
+// 这是 #6838 之后唯一会从校验门放行却没有任何拦截兜底的探测形态，由 Messages 入口在选号前本地应答。
+func isNonHaikuClaudeCodeProbe(isClaudeCodeClient bool, model string, maxTokens int) bool {
+	return isClaudeCodeClient && maxTokens == 1 && !isHaikuModel(model)
 }
 
 // detectInterceptType 检测请求是否需要拦截，返回拦截类型

--- a/backend/internal/handler/gateway_handler_intercept_test.go
+++ b/backend/internal/handler/gateway_handler_intercept_test.go
@@ -63,3 +63,15 @@ func TestSendMockInterceptResponse_MaxTokensOneHaiku(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, float64(1), usage["output_tokens"])
 }
+
+func TestIsNonHaikuClaudeCodeProbe(t *testing.T) {
+	// Probes to non-haiku models are the only shape that #6838 lets through the
+	// gate without any interception behind it; they are answered at the entry.
+	require.True(t, isNonHaikuClaudeCodeProbe(true, "claude-sonnet-4-5", 1))
+	require.True(t, isNonHaikuClaudeCodeProbe(true, "claude-opus-4-1", 1))
+	// haiku keeps the original path (per-account intercept toggle after selection).
+	require.False(t, isNonHaikuClaudeCodeProbe(true, "claude-haiku-4-5", 1))
+	// Still gated on the Claude Code client check, and only max_tokens=1 is a probe.
+	require.False(t, isNonHaikuClaudeCodeProbe(false, "claude-sonnet-4-5", 1))
+	require.False(t, isNonHaikuClaudeCodeProbe(true, "claude-sonnet-4-5", 2))
+}


### PR DESCRIPTION
Follow-up to #6838（已合并），refs #6591。**建议在下一个 tag 之前合入**：#6838 单独发版会让开启 `claude_code_only` 的部署把探测请求转发到上游。

## 问题

#6838 让 Claude Code 打到非 haiku 模型的 `max_tokens=1` 探测通过 `claude_code_only` 校验，但这类请求在放行之后没有任何拦截兜底：现有的本地拦截 `InterceptTypeMaxTokensOneHaiku` 只匹配 haiku，且位于选号之后、受账号级「拦截预热请求」开关控制。结果是这些探测被真的转发到 Anthropic。

Claude Code 会向**当前使用的模型**发这类探测：切换模型时的 `model_validation`，以及网关模式（`ANTHROPIC_BASE_URL` 指向网关）下的配额探测 `probeQuotaStatus`（`max_tokens:1`，`messages:[{role:"user",content:"quota"}]`，用于读取 `anthropic-ratelimit-unified-*` 响应头）。`/context` 和状态栏刷新都会触发后者。

订阅 OAuth 账号收到这种不带 system 的裸请求，上游返回 429 `rate_limit_error`（`{"message":"Error","type":"rate_limit_error"}`），`handle429` 把账号标为限流进入冷却；每个探测在分组内逐账号故障转移，一次 `/context` 实测产生 38 条 429 / 503 交错记录，之后所有请求 503 `no available accounts`。实测于 sub2api `main`@4e9b01fd5 之后的自建镜像，Claude Code 2.1.266。

## 改动

只做一件事：**在 `Messages` 入口、客户端校验通过之后、分组解析与选号之前，对"非 haiku 模型的 Claude Code max_tokens=1 探测"直接返回既有的合成应答**（与 haiku 拦截相同：`#`、`stop_reason: max_tokens`）。

刻意不动的部分：

- haiku 探测沿用原路径，仍由选号后的拦截和账号级开关决定是否 mock；
- `detectInterceptType`、`isMaxTokensOneHaikuRequest`、校验器的探测标记均保持原样；
- 「拦截预热请求」开关语义不变。

因此与 #6838 之前的行为相比，**唯一差异**是：此前被校验门以 503 拒绝的非 haiku 探测，现在以 200 本地应答。其余请求形态的处理路径逐一相同。非测试改动 19 行。

Claude Code 侧：配额探测读不到限流响应头时不显示配额区块，与此前被 503 拒绝时一致；模型校验探测得到 200，切换模型不再出现无谓的失败日志。

## 安全面

早返回仍以 Claude Code 客户端校验为门。能伪造 `claude-cli` UA 的客户端本来就能伪造 system 与请求头；本地应答不消耗任何上游资源，比放行上行更保守。

## 测试

- 新增 `TestIsNonHaikuClaudeCodeProbe`：sonnet / opus 的 `max_tokens=1` 命中；haiku 不命中（保持原路径）；非 Claude Code 客户端不命中；`max_tokens=2` 不命中。
- 现有 haiku 拦截测试与 mock 应答测试不变。
- 本地：`gofmt` / `go vet` / `go build ./...` 通过；`golangci-lint run`（v2.13）0 issues；`go test -tags=unit ./internal/handler/` 全部通过。