### PR TITLE
fix(openai): filter account test models by model mapping

### DIFF
--- a/backend/internal/service/account_test_models_test.go
+++ b/backend/internal/service/account_test_models_test.go
@@ -53,6 +53,37 @@ func TestFetchOpenAIAccountModelsAPIKeyPopulatesPickerFields(t *testing.T) {
 	require.Equal(t, "named-model", models[2].ID)
 }
 
+func TestFetchOpenAIAccountModelsAPIKeyAppliesAccountModelMapping(t *testing.T) {
+	gateway := newCodexModelsAPIKeyTestService(&codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return ordinaryModelsUpstreamResponse(`{"data":[
+			{"id":"upstream-target","owned_by":"provider","created":123},
+			{"id":"direct-model","owned_by":"provider"},
+			{"id":"unconfigured-model","owned_by":"provider"}
+		]}`), nil
+	}})
+	svc := &AccountTestService{openaiGatewayService: gateway}
+	account := newCodexModelsAPIKeyTestAccount("https://models.example/v1")
+	account.Credentials["model_mapping"] = map[string]any{
+		"configured-alias": "upstream-target",
+		"direct-model":     "direct-model",
+	}
+
+	models, err := svc.FetchOpenAIAccountModels(context.Background(), account)
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+	ids := []string{models[0].ID, models[1].ID}
+	require.ElementsMatch(t, []string{"configured-alias", "direct-model"}, ids)
+	require.NotContains(t, ids, "unconfigured-model")
+	alias := models[0]
+	if alias.ID != "configured-alias" {
+		alias = models[1]
+	}
+	require.Equal(t, "configured-alias", alias.ID)
+	require.Equal(t, "configured-alias", alias.DisplayName)
+	require.Equal(t, "provider", alias.OwnedBy)
+	require.EqualValues(t, 123, alias.Created)
+}
+
 func TestFetchOpenAIAccountModelsPreservesEmptyCatalog(t *testing.T) {
 	gateway := newCodexModelsAPIKeyTestService(&codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 		return ordinaryModelsUpstreamResponse(`{"data":[]}`), nil

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -186,10 +186,17 @@ func (s *AccountTestService) FetchOpenAIAccountModels(ctx context.Context, accou
 	if err != nil {
 		return nil, err
 	}
+	// The shared discovery response is the raw upstream catalog. Project it
+	// through the account mapping before exposing it in the admin picker so
+	// configured aliases remain public names and unconfigured models stay out.
+	projectedBody, err := projectAccountModelsBody(response.Body, account, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("project OpenAI account models: %w", err)
+	}
 	var payload struct {
 		Data []openai.Model `json:"data"`
 	}
-	if err := json.Unmarshal(response.Body, &payload); err != nil {
+	if err := json.Unmarshal(projectedBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode OpenAI account models: %w", err)
 	}
 	// Standard model catalogs do not require the fields used by the admin picker.


### PR DESCRIPTION
## 问题

在 `v0.2.1` 版本中，OpenAI 账号“测试连接”中的模型下拉框只会显示账号已配置的模型限制和模型映射。

升级到 `v0.2.3` 后，测试模型列表改为优先读取上游实时模型目录。但实时目录返回后没有继续应用账号级的 `model_mapping` 过滤，导致上游存在但账号未配置的模型也出现在测试模型下拉框中。

例如账号只配置了 `gpt-5.5`，下拉框中仍可能出现：

- `gpt-4o-audio-preview`
- `gpt-5.2`
- `gpt-5.4`
- 其他上游返回但账号未配置的模型

这与 `v0.2.1` 的行为不一致，也可能导致测试连接请求使用账号未允许的模型。

## 改动

在获取 OpenAI 账号实时模型目录后，继续应用账号级模型映射和模型限制：

- 已配置的直接模型会正常保留；
- 已配置的模型别名会以别名形式显示；
- 未配置的上游模型会被过滤；
- 未配置模型映射或启用 OpenAI 透传时，仍保留原有的实时模型目录行为；
- 增加对应的回归测试。

## 测试

- `gofmt` 通过；
- `git diff --check` 通过；
- 新增测试覆盖模型别名、直接映射和未配置模型过滤。