### PR TITLE
fix(upstream): retry peer HTTP/2 stream resets instead of failing over

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -217,6 +217,9 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 	client := s.httpClientForUpstreamRequest(entry.client, req)
 	client = httpClientWithGrokAccessDeniedFallback(client)
 	resp, err := servertiming.Do(client, req)
+	if err != nil && shouldRetryUpstreamStreamReset(entry.protocolMode, req, err) {
+		resp, err = s.retryUpstreamStreamReset(client, entry, req, accountID, err)
+	}
 	if err != nil {
 		s.recordOpenAIHTTP2Failure(profile, entry.protocolMode, entry.proxyKey, err)
 		// 请求失败，立即减少计数
@@ -1086,6 +1089,120 @@ func isOpenAIHTTP2CompatibilityError(err error) bool {
 		}
 	}
 	return false
+}
+
+// idleConnectionCloser 由 *http.Transport 实现。抽成接口是为了让重试路径的连接
+// 剔除行为可以被测试替身断言；调用方必须传入缓存条目里的原始 client，因为执行
+// 请求时的 client 已被 httpClientWithGrokAccessDeniedFallback 包过一层。
+type idleConnectionCloser interface {
+	CloseIdleConnections()
+}
+
+// isExplicitHTTP2ProtocolMode 报告该协议模式是否由本服务显式配置为 HTTP/2。
+// 只有这些模式才可能产生对端 RST_STREAM，也只有它们需要下面的补充重试。
+func isExplicitHTTP2ProtocolMode(protocolMode string) bool {
+	return protocolMode == upstreamProtocolModeOpenAIH2 ||
+		protocolMode == upstreamProtocolModeLongStreamH2
+}
+
+// isUpstreamHTTP2StreamReset 判断错误是否为“对端在响应头之前单独重置了这一条流”。
+//
+// 这类 RST_STREAM（PROTOCOL_ERROR / INTERNAL_ERROR）只影响单条流，连接本身仍然
+// 健康——同一条连接上先前的流通常都已正常完成。但 Go 的 HTTP/2 传输层在
+// canRetryError 里只重试 REFUSED_STREAM：
+//
+//	if se, ok := err.(StreamError); ok {
+//	    return se.Code == ErrCodeRefusedStream
+//	}
+//
+// （go1.27 起实际生效的是 net/http/internal/http2/transport.go；golang.org/x/net
+// 在 go1.27 && !http2legacy 下只是标准库实现的包装，其同名函数逻辑一致。）
+// 于是 PROTOCOL_ERROR 会原样冒泡到 http.Client.Do，上层不补重试就只能直接走换
+// 账号故障转移——用另一个账号的额度和限流预算去补一次传输层抖动。
+//
+// 标准库的 StreamError 实现了 As 方法，可转换为 x/net/http2.StreamError，因此
+// 这里的类型断言在两种实现下都成立。
+func isUpstreamHTTP2StreamReset(err error) bool {
+	if err == nil {
+		return false
+	}
+	var streamErr http2.StreamError
+	if !errors.As(err, &streamErr) {
+		return false
+	}
+	switch streamErr.Code {
+	case http2.ErrCodeProtocol, http2.ErrCodeInternal:
+		return true
+	default:
+		return false
+	}
+}
+
+// shouldRetryUpstreamStreamReset 判断这次失败是否值得原地重放一次。
+//
+// http.Client.Do 返回错误意味着响应头从未到达：上游没有应答、没有产生计费，也
+// 没有任何字节写给客户端。只要请求体可以通过 GetBody 重放（网关侧的上游请求都
+// 由 bytes.Reader 构造，标准库会自动填充 GetBody），重放就是安全的。
+func shouldRetryUpstreamStreamReset(protocolMode string, req *http.Request, err error) bool {
+	if !isExplicitHTTP2ProtocolMode(protocolMode) {
+		return false
+	}
+	if req == nil || req.GetBody == nil {
+		return false
+	}
+	// 客户端已断开或整体超时，重放没有意义。
+	if req.Context().Err() != nil {
+		return false
+	}
+	return isUpstreamHTTP2StreamReset(err)
+}
+
+// retryUpstreamStreamReset 重放一次被对端重置的请求，最多一次。
+//
+// 分级处理：第一次失败先原样重放（代价只是一次往返，多数偶发 reset 到此为止）；
+// 只有重放也失败，才剔除该客户端池中的空闲连接——那种情况下问题多半在连接级状态
+// 上，必须换一条新连接才能恢复。CloseIdleConnections 只关空闲连接，不会打断在途
+// 请求；账号级隔离策略下作用域仅限当前账号自己的池。
+func (s *httpUpstreamService) retryUpstreamStreamReset(
+	client *http.Client,
+	entry *upstreamClientEntry,
+	req *http.Request,
+	accountID int64,
+	cause error,
+) (*http.Response, error) {
+	body, err := req.GetBody()
+	if err != nil {
+		// 无法重放就保留原始错误，避免把诊断信息替换成次要的 GetBody 失败。
+		slog.Warn("upstream_http2_stream_reset_retry_skipped",
+			"account_id", accountID,
+			"protocol_mode", entry.protocolMode,
+			"cause", cause.Error(),
+			"reason", err.Error())
+		return nil, cause
+	}
+	retryReq := req.Clone(req.Context())
+	retryReq.Body = body
+
+	resp, err := servertiming.Do(client, retryReq)
+	if err != nil {
+		idleConnsClosed := false
+		if closer, ok := entry.client.Transport.(idleConnectionCloser); ok {
+			closer.CloseIdleConnections()
+			idleConnsClosed = true
+		}
+		slog.Warn("upstream_http2_stream_reset_retry_failed",
+			"account_id", accountID,
+			"protocol_mode", entry.protocolMode,
+			"cause", cause.Error(),
+			"retry_error", err.Error(),
+			"idle_conns_closed", idleConnsClosed)
+		return resp, err
+	}
+	slog.Warn("upstream_http2_stream_reset_recovered",
+		"account_id", accountID,
+		"protocol_mode", entry.protocolMode,
+		"cause", cause.Error())
+	return resp, nil
 }
 
 func isUpstreamTimeoutError(err error) bool {

--- a/backend/internal/repository/http_upstream_http2_stream_reset_test.go
+++ b/backend/internal/repository/http_upstream_http2_stream_reset_test.go
@@ -1,0 +1,279 @@
+package repository
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// streamResetTestTransport 同时实现 http.RoundTripper 与 idleConnectionCloser，
+// 用于断言“重放仍失败时剔除空闲连接”这一行为真的发生了。
+type streamResetTestTransport struct {
+	roundTrip          func(*http.Request) (*http.Response, error)
+	closeIdleCallCount int
+}
+
+func (t *streamResetTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.roundTrip(req)
+}
+
+func (t *streamResetTestTransport) CloseIdleConnections() { t.closeIdleCallCount++ }
+
+// peerStreamReset 构造与生产日志同形的错误：对端在响应头之前重置了这条流。
+func peerStreamReset(streamID uint32, code http2.ErrCode) error {
+	return http2.StreamError{StreamID: streamID, Code: code, Cause: errors.New("received from peer")}
+}
+
+func openAIH2TestService(t *testing.T) *httpUpstreamService {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIHTTP2.Enabled = true
+	svc, ok := NewHTTPUpstream(cfg).(*httpUpstreamService)
+	require.True(t, ok)
+	return svc
+}
+
+// seedOpenAIH2Entry 预置一个 openai_h2 模式的客户端条目，让 Do 走到重试逻辑而不真正建连。
+func seedOpenAIH2Entry(t *testing.T, svc *httpUpstreamService, accountID int64, transport http.RoundTripper) {
+	t.Helper()
+	isolation := svc.getIsolationMode()
+	profile := service.HTTPUpstreamProfileOpenAI
+	proxyKey := directProxyKey
+	protocolMode := svc.resolveProtocolMode(profile, proxyKey, nil)
+	require.Equal(t, upstreamProtocolModeOpenAIH2, protocolMode,
+		"用例前提：直连 + OpenAI profile 必须解析为 openai_h2")
+	settings := svc.applyProfilePoolSettings(svc.resolvePoolSettings(isolation, 1), profile)
+	svc.clients[buildCacheKey(isolation, proxyKey, accountID, protocolMode)] = &upstreamClientEntry{
+		client:       &http.Client{Transport: transport},
+		proxyKey:     proxyKey,
+		poolKey:      buildPoolKey(settings, protocolMode),
+		protocolMode: protocolMode,
+	}
+}
+
+func newUpstreamPostRequest(t *testing.T, body []byte) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/responses", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody, "bytes.Reader 构造的请求必须自带 GetBody，否则重放不成立")
+	return req
+}
+
+// 真实 HTTP/2 对端在响应头之前重置流时，错误必须能被识别出来。
+//
+// 这条用例锁的是整条链路上最脆弱的一环：go1.27 起实际生效的是 net/http 内建的
+// HTTP/2 实现，它产生的 StreamError 位于 internal 包、类型未导出，只有其自带的
+// As 方法才能转换成 x/net/http2.StreamError。一旦该转换失效，类型断言会静默返回
+// false，重试跟着静默消失——而单测若只用手工构造的错误是发现不了的。
+func TestIsUpstreamHTTP2StreamReset_RealPeerReset(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// 在写响应头之前中止 → 服务端发 RST_STREAM，客户端 Do 直接返回错误。
+		panic(http.ErrAbortHandler)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	tr, err := buildUpstreamTransport(http2KeepAliveTestPoolSettings(), nil, upstreamProtocolModeOpenAIH2)
+	require.NoError(t, err)
+	defer tr.CloseIdleConnections()
+	require.NotNil(t, tr.TLSClientConfig)
+	roots := x509.NewCertPool()
+	roots.AddCert(srv.Certificate())
+	tr.TLSClientConfig.RootCAs = roots
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := (&http.Client{Transport: tr}).Do(req) //nolint:bodyclose // 出错路径没有响应体
+	require.Nil(t, resp)
+	require.Error(t, err)
+	// 只有 HTTP/2 才会产生 stream error，这同时确认了用例确实跑在 h2 上。
+	require.Contains(t, err.Error(), "stream error", "用例前提：必须协商到 HTTP/2")
+	require.True(t, isUpstreamHTTP2StreamReset(err), "真实对端重置必须被识别，实际错误：%v", err)
+}
+
+func TestIsUpstreamHTTP2StreamReset_Classification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// 现场原始错误：
+			// Post "https://chatgpt.com/backend-api/codex/responses":
+			// stream error: stream ID 35; PROTOCOL_ERROR; received from peer
+			name: "对端 PROTOCOL_ERROR 需要重试",
+			err:  peerStreamReset(35, http2.ErrCodeProtocol),
+			want: true,
+		},
+		{
+			name: "对端 INTERNAL_ERROR 需要重试",
+			err:  peerStreamReset(7, http2.ErrCodeInternal),
+			want: true,
+		},
+		{
+			// REFUSED_STREAM 已由 Go 传输层自己重试（canRetryError 覆盖），
+			// 这里再补一次会变成重复重试。
+			name: "REFUSED_STREAM 已由 Go 自行重试，不重复处理",
+			err:  peerStreamReset(9, http2.ErrCodeRefusedStream),
+			want: false,
+		},
+		{name: "空错误", err: nil, want: false},
+		{name: "非 HTTP/2 错误", err: errors.New("connection refused"), want: false},
+		{name: "超时错误不属于流重置", err: context.DeadlineExceeded, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isUpstreamHTTP2StreamReset(tc.err))
+		})
+	}
+}
+
+func TestShouldRetryUpstreamStreamReset_Gating(t *testing.T) {
+	resetErr := peerStreamReset(35, http2.ErrCodeProtocol)
+
+	t.Run("openai_h2 下的流重置需要重试", func(t *testing.T) {
+		require.True(t, shouldRetryUpstreamStreamReset(
+			upstreamProtocolModeOpenAIH2, newUpstreamPostRequest(t, []byte(`{"model":"gpt-5.4"}`)), resetErr))
+	})
+
+	t.Run("long_stream_h2 同样需要重试", func(t *testing.T) {
+		require.True(t, shouldRetryUpstreamStreamReset(
+			upstreamProtocolModeLongStreamH2, newUpstreamPostRequest(t, []byte(`{}`)), resetErr))
+	})
+
+	t.Run("非显式 h2 模式不介入", func(t *testing.T) {
+		for _, mode := range []string{
+			upstreamProtocolModeDefault,
+			upstreamProtocolModeOpenAIH1,
+			upstreamProtocolModeOpenAIH1Fallback,
+			upstreamProtocolModeGrok,
+		} {
+			require.False(t, shouldRetryUpstreamStreamReset(
+				mode, newUpstreamPostRequest(t, []byte(`{}`)), resetErr), "mode=%s", mode)
+		}
+	})
+
+	t.Run("请求体不可重放时不重试", func(t *testing.T) {
+		req := newUpstreamPostRequest(t, []byte(`{}`))
+		req.GetBody = nil
+		require.False(t, shouldRetryUpstreamStreamReset(upstreamProtocolModeOpenAIH2, req, resetErr))
+	})
+
+	t.Run("上下文已取消时不重试", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req := newUpstreamPostRequest(t, []byte(`{}`)).WithContext(ctx)
+		require.False(t, shouldRetryUpstreamStreamReset(upstreamProtocolModeOpenAIH2, req, resetErr))
+	})
+}
+
+// 单条流被对端重置属于传输层抖动：必须在同一个账号上原地重放，而不是直接换账号
+// 故障转移——后者会拿另一个账号的额度和限流预算去补一次网络抖动。
+func TestHTTPUpstreamDo_RetriesStreamResetOnSameAccount(t *testing.T) {
+	svc := openAIH2TestService(t)
+	const accountID int64 = 7781
+	payload := []byte(`{"model":"gpt-5.4","input":"hello"}`)
+
+	var seenBodies [][]byte
+	transport := &streamResetTestTransport{}
+	transport.roundTrip = func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		seenBodies = append(seenBodies, body)
+		if len(seenBodies) == 1 {
+			return nil, peerStreamReset(35, http2.ErrCodeProtocol)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"resp-ok"}`))),
+			Request:    req,
+		}, nil
+	}
+	seedOpenAIH2Entry(t, svc, accountID, transport)
+
+	req := newUpstreamPostRequest(t, payload)
+	req = req.WithContext(service.WithHTTPUpstreamProfile(req.Context(), service.HTTPUpstreamProfileOpenAI))
+
+	resp, err := svc.Do(req, "", accountID, 1)
+	require.NoError(t, err, "重放成功后调用方不应看到错误")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	require.Len(t, seenBodies, 2, "必须恰好重放一次")
+	require.Equal(t, payload, seenBodies[0])
+	require.Equal(t, payload, seenBodies[1], "重放必须携带完整且一致的请求体")
+	require.Zero(t, transport.closeIdleCallCount, "重放成功时不应丢弃连接池")
+}
+
+// 重放仍失败说明问题多半在连接级状态上：必须剔除空闲连接，让下一个请求换新连接，
+// 否则后续请求会继续落在同一条已被上游标记的连接上。
+func TestHTTPUpstreamDo_StreamResetRetryFailureEvictsIdleConnections(t *testing.T) {
+	svc := openAIH2TestService(t)
+	const accountID int64 = 7782
+
+	calls := 0
+	transport := &streamResetTestTransport{}
+	transport.roundTrip = func(req *http.Request) (*http.Response, error) {
+		calls++
+		_, _ = io.Copy(io.Discard, req.Body)
+		return nil, peerStreamReset(uint32(33+2*calls), http2.ErrCodeProtocol) //nolint:gosec // G115: 测试用小整数
+	}
+	seedOpenAIH2Entry(t, svc, accountID, transport)
+
+	req := newUpstreamPostRequest(t, []byte(`{"model":"gpt-5.4"}`))
+	req = req.WithContext(service.WithHTTPUpstreamProfile(req.Context(), service.HTTPUpstreamProfileOpenAI))
+
+	resp, err := svc.Do(req, "", accountID, 1) //nolint:bodyclose // 出错路径没有响应体
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.True(t, isUpstreamHTTP2StreamReset(err), "最终仍应透出流重置错误，便于上层分类")
+	require.Equal(t, 2, calls, "最多重放一次")
+	require.Equal(t, 1, transport.closeIdleCallCount, "重放失败后必须剔除空闲连接")
+}
+
+// 重试只针对显式 HTTP/2 的上游路径，不得波及 Claude/Gemini 等其它上游的热路径。
+func TestHTTPUpstreamDo_DoesNotRetryOutsideExplicitHTTP2(t *testing.T) {
+	svc := openAIH2TestService(t)
+	const accountID int64 = 7783
+
+	isolation := svc.getIsolationMode()
+	profile := service.HTTPUpstreamProfileDefault
+	protocolMode := svc.resolveProtocolMode(profile, directProxyKey, nil)
+	require.Equal(t, upstreamProtocolModeDefault, protocolMode)
+	settings := svc.applyProfilePoolSettings(svc.resolvePoolSettings(isolation, 1), profile)
+
+	calls := 0
+	transport := &streamResetTestTransport{}
+	transport.roundTrip = func(req *http.Request) (*http.Response, error) {
+		calls++
+		_, _ = io.Copy(io.Discard, req.Body)
+		return nil, peerStreamReset(35, http2.ErrCodeProtocol)
+	}
+	svc.clients[buildCacheKey(isolation, directProxyKey, accountID, protocolMode)] = &upstreamClientEntry{
+		client:       &http.Client{Transport: transport},
+		proxyKey:     directProxyKey,
+		poolKey:      buildPoolKey(settings, protocolMode),
+		protocolMode: protocolMode,
+	}
+
+	req := newUpstreamPostRequest(t, []byte(`{"model":"claude"}`))
+	resp, err := svc.Do(req, "", accountID, 1) //nolint:bodyclose // 出错路径没有响应体
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, 1, calls, "非显式 h2 路径不得重试")
+	require.Zero(t, transport.closeIdleCallCount)
+}


### PR DESCRIPTION
## 问题

上游在一条健康的 HTTP/2 连接上单独重置某条流时，请求会以这种形式失败：

```
Post "https://chatgpt.com/backend-api/codex/responses":
stream error: stream ID 35; PROTOCOL_ERROR; received from peer
```

流号远大于 1 —— 说明 ALPN 协商、SETTINGS 交换、同连接上先前的十几条流全部正常。这是**单条流级别的拒绝**，不是"代理/网络不支持 HTTP/2"（那会在 ALPN 或 stream 1 就失败）。

## 根因

Go 的 HTTP/2 传输层在 `canRetryError` 里**只重试 `REFUSED_STREAM`**：

```go
func canRetryError(err error) bool {
	if err == errClientConnUnusable || err == errClientConnGotGoAway {
		return true
	}
	if se, ok := err.(StreamError); ok {
		return se.Code == ErrCodeRefusedStream
	}
	return false
}
```

go1.27 起实际生效的是 `net/http/internal/http2/transport.go`；`golang.org/x/net` 在 `go1.27 && !http2legacy` 下只是标准库实现的包装（见 `http2/transport_wrap.go` 的 build tag），其同名函数逻辑一致。

所以 `roundTripViaPool` 里那个最多 7 次、带指数退避的重试循环，**对 `PROTOCOL_ERROR` 一次都不会进**，错误第一次发生就冒泡到 `http.Client.Do`。

而这次失败的性质是：

- 发生在**响应头之前** —— 上游没有应答、没有产生计费、没有任何字节写给客户端；
- 网关侧的上游请求都由 `bytes.NewReader(body)` 构造，标准库自动填充 `GetBody`，**请求体可完整重放**。

即这是一次**可证明安全、代价极低**的重试。而当前实现跳过重试、直接返回 `*UpstreamFailoverError` 换账号 —— 用另一个账号的额度和限流预算，去补一次传输层抖动，同时把一个网络层事件记成了账号级故障。

## 与 #6884 的区别

[#6884](https://github.com/Wei-Shaw/sub2api/issues/6884) 报告过同样的错误信息，但提出的方案是"把 socks5/socks5h 加进 H2→H1.1 自动降级的白名单"。**本 PR 不走那个方向**，也不改动任何降级逻辑或代理判断：

- 那个讨论围绕**代理类型**；本 PR 与代理类型无关 —— 直连同样会遇到；
- 那个方案是"整条链路降级到 HTTP/1.1"；本 PR 是"这一个请求重放一次"，代价小几个数量级，也不牺牲多路复用和 H2 PING 保活；
- 本 PR 的依据是 `canRetryError` 的实际行为，可直接在 go.mod 锁定的版本里验证。

## 改动

仅作用于显式 HTTP/2 的上游路径。

- **识别**对端发来的 `PROTOCOL_ERROR` / `INTERNAL_ERROR` 流重置。标准库的 `StreamError` 自带 `As` 方法可转换为 `x/net/http2.StreamError`，类型断言在两种实现下都成立。`REFUSED_STREAM` 交由 Go 自行重试，不重复处理。
- **门控按协议模式而非 profile**：新增 `isExplicitHTTP2ProtocolMode`，覆盖 `openai_h2` 与 `long_stream_h2`（协议模式本身已经编码了"这是我们显式配置的 H2 传输"，profile 判断是冗余的）。`default` / `openai_h1` / `openai_h1_fallback` / `grok` 一律不介入，Claude / Gemini 等热路径不受影响。
- **分级处理**：第一次失败先原样重放一次（代价只是一次往返，多数偶发 reset 到此为止）；只有重放**也**失败，才对该账号自己的连接池调用 `CloseIdleConnections`，让下一个请求换新连接 —— 那种情况下问题多半在连接级状态上。`CloseIdleConnections` 只关空闲连接，不打断在途请求。
- **可观测**：补 `upstream_http2_stream_reset_recovered` / `_retry_failed` / `_retry_skipped` 三条稳定日志事件，用于区分"个别连接抖动"与"系统性拒绝"。此前这类失败只在 Ops 里留一条 `request_error`，等于没有信号。

不重试的情况：`req.GetBody == nil`（请求体不可重放）、`req.Context().Err() != nil`（客户端已断开或整体超时）、非显式 h2 模式。

`classifyUpstreamTransportError` **刻意不动** —— `PROTOCOL_ERROR` 不应判为 Persistent，那是传输层问题不是账号问题，冷却账号属于误伤。

## 测试

`go test ./internal/repository/... ./internal/service/...` 全绿。

新增用例中有一条是端到端的：用真实 HTTP/2 服务端在写响应头之前 `panic(http.ErrAbortHandler)` 触发 `RST_STREAM`，验证 `errors.As` 能穿透标准库 internal 包的未导出 `StreamError`。**这条锁的是整条链路上最脆弱的一环** —— 该转换一旦失效，类型断言会静默返回 false、重试跟着无声消失，而只用手工构造的错误是发现不了的。

其余覆盖：错误分类（含 `REFUSED_STREAM` 不重复重试）、`long_stream_h2` 同样走重试、四种非 h2 模式一律不介入、`GetBody` 为 nil / ctx 已取消不重试、重放成功且请求体一致、重放失败后剔除空闲连接、非显式 h2 路径不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7PDkxGzypoSyF9TEWpmHG
