### PR TITLE
fix(openai): honor temp cooldown rules for stream failures

### DIFF
--- a/backend/internal/service/openai_capacity_shed_test.go
+++ b/backend/internal/service/openai_capacity_shed_test.go
@@ -21,11 +21,28 @@ import (
 type capacityShedAccountRepoStub struct {
 	AccountRepository // 嵌入接口，未实现的方法会 panic（不应被调用）
 
-	tempUnschedCalls int
+	tempUnschedCalls    int
+	modelRateLimitCalls []capacityShedModelRateLimitCall
+}
+
+type capacityShedModelRateLimitCall struct {
+	accountID int64
+	scope     string
+	resetAt   time.Time
+	reason    string
 }
 
 func (r *capacityShedAccountRepoStub) SetTempUnschedulable(_ context.Context, _ int64, _ time.Time, _ string) error {
 	r.tempUnschedCalls++
+	return nil
+}
+
+func (r *capacityShedAccountRepoStub) SetModelRateLimit(_ context.Context, id int64, scope string, resetAt time.Time, reason ...string) error {
+	call := capacityShedModelRateLimitCall{accountID: id, scope: scope, resetAt: resetAt}
+	if len(reason) > 0 {
+		call.reason = reason[0]
+	}
+	r.modelRateLimitCalls = append(r.modelRateLimitCalls, call)
 	return nil
 }
 
@@ -75,6 +92,70 @@ func TestStreamFailedEventCapacityShedRetriesOnSameAccount(t *testing.T) {
 	other := []byte(`{"type":"response.failed","response":{"error":{"code":"server_error"}}}`)
 	require.False(t, isOpenAIUpstreamCapacityShedEvent(other))
 	require.False(t, openAIStreamFailedEventRetryableOnSameAccount(nonPool, other, "boom"))
+}
+
+func TestOpenAIStreamTerminalCapacityShedHonorsConfiguredTempRule(t *testing.T) {
+	payload := []byte(`{"type":"response.failed","response":{"model":"gpt-5.6-terra","error":{"code":"server_error","message":"Our servers are currently overloaded. Please try again later."}}}`)
+
+	t.Run("configured rule creates model cooldown", func(t *testing.T) {
+		repo := &capacityShedAccountRepoStub{}
+		rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		gateway := &OpenAIGatewayService{rateLimitService: rateLimitService}
+		account := &Account{
+			ID:          1,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Credentials: map[string]any{
+				"temp_unschedulable_enabled": true,
+				"temp_unschedulable_rules": []any{
+					map[string]any{
+						"error_code":       float64(http.StatusServiceUnavailable),
+						"keywords":         []any{"overloaded"},
+						"duration_minutes": float64(5),
+					},
+				},
+			},
+		}
+
+		status, handled := gateway.handleOpenAIStreamTerminalAccountSideEffects(
+			nil,
+			account,
+			payload,
+			"Our servers are currently overloaded. Please try again later.",
+			nil,
+			"gpt-5.6-terra",
+		)
+
+		require.Equal(t, http.StatusServiceUnavailable, status)
+		require.True(t, handled)
+		require.Zero(t, repo.tempUnschedCalls)
+		require.Len(t, repo.modelRateLimitCalls, 1)
+		require.Equal(t, "gpt-5.6-terra", repo.modelRateLimitCalls[0].scope)
+		require.WithinDuration(t, time.Now().Add(5*time.Minute), repo.modelRateLimitCalls[0].resetAt, 5*time.Second)
+	})
+
+	t.Run("default policy keeps request scoped behavior", func(t *testing.T) {
+		repo := &capacityShedAccountRepoStub{}
+		rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		gateway := &OpenAIGatewayService{rateLimitService: rateLimitService}
+		account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+		status, handled := gateway.handleOpenAIStreamTerminalAccountSideEffects(
+			nil,
+			account,
+			payload,
+			"Our servers are currently overloaded. Please try again later.",
+			nil,
+			"gpt-5.6-terra",
+		)
+
+		require.Equal(t, http.StatusServiceUnavailable, status)
+		require.False(t, handled)
+		require.Zero(t, repo.tempUnschedCalls)
+		require.Empty(t, repo.modelRateLimitCalls)
+	})
 }
 
 func TestOpenAIHTTPCapacityShedIsRequestScopedForOAuthAccounts(t *testing.T) {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1611,6 +1611,25 @@ func (s *OpenAIGatewayService) handleOpenAIStreamTerminalAccountSideEffects(
 	canonicalModel ...string,
 ) (int, bool) {
 	statusCode := openAIStreamFailureStatus(payload, message)
+	ctx := context.Background()
+	if c != nil && c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	model := firstNonEmpty(canonicalModel...)
+	if model == "" {
+		model = firstNonEmpty(gjson.GetBytes(payload, "model").String(), gjson.GetBytes(payload, "response.model").String())
+	}
+	// response.failed is carried inside an HTTP 200 stream, so it bypasses the
+	// normal HTTP error path. Honor an administrator's explicit temporary
+	// unschedulable rule before applying the built-in terminal-event policy.
+	if statusCode != http.StatusUnauthorized && s != nil && s.rateLimitService != nil {
+		stateCtx, cancel := openAIAccountStateContext(ctx)
+		matched := s.rateLimitService.HandleTempUnschedulable(stateCtx, account, statusCode, payload, model)
+		cancel()
+		if matched {
+			return statusCode, true
+		}
+	}
 	switch statusCode {
 	case http.StatusForbidden:
 		if !openAIStream403AccountFailure(payload, message) {
@@ -1618,14 +1637,6 @@ func (s *OpenAIGatewayService) handleOpenAIStreamTerminalAccountSideEffects(
 		}
 		fallthrough
 	case http.StatusUnauthorized, http.StatusTooManyRequests, 529:
-		ctx := context.Background()
-		if c != nil && c.Request != nil {
-			ctx = c.Request.Context()
-		}
-		model := firstNonEmpty(canonicalModel...)
-		if model == "" {
-			model = firstNonEmpty(gjson.GetBytes(payload, "model").String(), gjson.GetBytes(payload, "response.model").String())
-		}
 		accountHeaders := headers
 		if statusCode == http.StatusTooManyRequests {
 			// 普通模型的流式 429 不能继承外层 HTTP 200 的全局 quota 快照；


### PR DESCRIPTION
## Problem

OpenAI Responses can return an HTTP 200 SSE stream that terminates with a semantic 503 `response.failed` event. The event is recorded correctly, but `handleOpenAIStreamTerminalAccountSideEffects` only forwards a small built-in status set to account health handling. As a result, an administrator-configured temporary-unschedulable rule such as `503 + overloaded` is never evaluated.

## Change

- evaluate explicit temporary-unschedulable rules for in-stream terminal errors before the built-in terminal-event policy
- preserve the existing default behavior for capacity-shed errors when no rule is configured
- keep known-model cooldowns scoped to the selected account and canonical model
- add regression coverage for both configured and default behavior

## Verification

- `gofmt`
- `git diff --check`
- added targeted service tests
- targeted `go test` was attempted locally, but dependency compilation stopped because the local filesystem had no free space; repository CI should run the tests in a clean environment

Related: #6631, #5165
