### PR TITLE
fix(redeem): align subscription duration limit with the backend

### DIFF
--- a/frontend/src/views/admin/RedeemView.vue
+++ b/frontend/src/views/admin/RedeemView.vue
@@ -350,7 +350,7 @@
                   v-model.number="generateForm.validity_days"
                   type="number"
                   min="1"
-                  max="365"
+                  max="36500"
                   required
                   class="input"
                 />


### PR DESCRIPTION
The subscription redeem-code form rejects durations over 365 days even though SubscriptionService already supports up to 36,500 days. Align the input maximum with MaxValidityDays so longer subscriptions can be generated. This is a one-line UI change; the existing subscription expiry cap and separate redeem-code expiry remain unchanged.

Validation: full frontend ESLint and typecheck; all 14 Makefile critical suites plus the redeem view regression suite (177 tests); native HTML validity checks for 1, 365, 730 and 36,500 days, rejection of empty/zero/36,501 days, and the separate 3,650-day code-expiry limit; git diff --check.

Fixes #2106.