### PR TITLE
fix(risk-control): clarify the async processed counter label

### DIFF
--- a/frontend/src/i18n/locales/en/admin/channels.ts
+++ b/frontend/src/i18n/locales/en/admin/channels.ts
@@ -427,7 +427,7 @@ export default {
       workerActive: 'Processing an async audit or record task',
       workerIdle: 'Started, idle and ready',
       workerDisabled: 'Risk control or content audit is disabled',
-      processed: 'Processed',
+      processed: 'Async processed',
       droppedErrors: 'Dropped / Errors',
       autoRefresh: 'Auto refresh every 15s',
       lastCleanup: 'Last cleanup: {time}',

--- a/frontend/src/i18n/locales/zh/admin/channels.ts
+++ b/frontend/src/i18n/locales/zh/admin/channels.ts
@@ -427,7 +427,7 @@ export default {
       workerActive: '正在处理异步审计或记录任务',
       workerIdle: '已启动，当前空闲可用',
       workerDisabled: '风控或内容审计未启用',
-      processed: '已处理',
+      processed: '异步已处理',
       droppedErrors: '丢弃/异常',
       autoRefresh: '每 15 秒自动刷新',
       lastCleanup: '上次清理：{time}',


### PR DESCRIPTION
Label the worker processed counter as Async processed / 异步已处理. The existing pre-block counters and worker hint already explain the separate synchronous path, but the generic Processed label can still make a zero async count look like no requests were audited. This changes only the two translations and leaves all counters and moderation behavior intact.

Validation: locale completeness and RiskControlView suites (7 tests); all 14 Makefile critical suites (176 tests); full frontend ESLint, typecheck and git diff --check.

Fixes #2734.