### PR TITLE
feat(grok): 接入网页重置卡查询与手动兑换

### DIFF
--- a/backend/internal/handler/admin/grok_usage_resets.go
+++ b/backend/internal/handler/admin/grok_usage_resets.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"strconv"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+type grokUsageResetRequest struct {
+	SSOToken string `json:"sso_token" binding:"required,max=16384"`
+	TokenID  string `json:"token_id" binding:"max=1024"`
+}
+
+func (h *GrokOAuthHandler) QueryUsageResetCards(c *gin.Context) { h.usageResetCards(c, false) }
+func (h *GrokOAuthHandler) RedeemUsageResetCard(c *gin.Context) { h.usageResetCards(c, true) }
+
+func (h *GrokOAuthHandler) usageResetCards(c *gin.Context, redeem bool) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || accountID <= 0 {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	if h.quotaService == nil {
+		response.BadRequest(c, "Grok quota service is unavailable")
+		return
+	}
+	var input grokUsageResetRequest
+	if c.ShouldBindJSON(&input) != nil || (redeem && input.TokenID == "") {
+		// Never include validation errors or request data: SSO is a credential.
+		response.BadRequest(c, "A Web SSO session and, for redemption, a reset card ID are required")
+		return
+	}
+	if redeem {
+		result, err := h.quotaService.RedeemUsageResetCard(c.Request.Context(), accountID, input.SSOToken, input.TokenID)
+		if err != nil {
+			response.ErrorFrom(c, err)
+			return
+		}
+		response.Success(c, result)
+		return
+	}
+	result, err := h.quotaService.QueryUsageResetCards(c.Request.Context(), accountID, input.SSOToken)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, result)
+}

--- a/backend/internal/handler/admin/grok_usage_resets_test.go
+++ b/backend/internal/handler/admin/grok_usage_resets_test.go
@@ -1,0 +1,36 @@
+//go:build unit
+
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrokUsageResetHandlersValidateWithoutExposingSSO(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GrokOAuthHandler{quotaService: &service.GrokQuotaService{}}
+	router := gin.New()
+	router.POST("/accounts/:id/reset-cards/query", h.QueryUsageResetCards)
+	router.POST("/accounts/:id/reset-cards/redeem", h.RedeemUsageResetCard)
+	for _, input := range []struct{ path, body string }{
+		{"/accounts/invalid/reset-cards/query", `{"sso_token":"web-session-secret"}`},
+		{"/accounts/12/reset-cards/query", `{}`},
+		{"/accounts/12/reset-cards/query", `{"sso_token":"web-session-secret`},
+		{"/accounts/12/reset-cards/query", `{"sso_token":"` + strings.Repeat("web-session-secret", 1000) + `"}`},
+		{"/accounts/12/reset-cards/redeem", `{"sso_token":"web-session-secret"}`},
+	} {
+		request := httptest.NewRequest(http.MethodPost, input.path, strings.NewReader(input.body))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		require.NotContains(t, recorder.Body.String(), "web-session-secret")
+	}
+}

--- a/backend/internal/pkg/xai/usage_resets.go
+++ b/backend/internal/pkg/xai/usage_resets.go
@@ -1,0 +1,221 @@
+package xai
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// These are the Web billing facade RPCs, not the Build OAuth billing endpoint.
+const (
+	UsageResetsListURL    = "https://grok.com/grok_api_v2.GrokBuildBilling/GetRemainingResets"
+	UsageResetRedeemURL   = "https://grok.com/grok_api_v2.GrokBuildBilling/RedeemReset"
+	usageResetMaxResponse = 1 << 20
+)
+
+type UsageResetCard struct {
+	TokenID   string    `json:"token_id"`
+	ValidFrom time.Time `json:"valid_from"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (c UsageResetCard) Available(now time.Time) bool {
+	return c.TokenID != "" && !now.Before(c.ValidFrom) && now.Before(c.ExpiresAt)
+}
+
+// UsageResetRPCError deliberately excludes upstream text, which may contain
+// session information. HTTP 200 alone is not proof of gRPC-Web success.
+type UsageResetRPCError struct{ HTTPStatus, GRPCStatus int }
+
+func (e *UsageResetRPCError) Error() string {
+	return fmt.Sprintf("Grok usage reset RPC failed (HTTP %d, gRPC %d)", e.HTTPStatus, e.GRPCStatus)
+}
+
+// NewUsageResetRequest uses an ephemeral Web SSO, supplied by an administrator.
+// The caller must disable redirects and must not retry a redemption request.
+func NewUsageResetRequest(ctx context.Context, sso, cardID string, redeem bool) (*http.Request, error) {
+	if len(sso) > ssoMaxTokenLength || strings.ContainsAny(sso, "\r\n") {
+		return nil, errors.New("a valid Grok Web SSO session is required")
+	}
+	sso = NormalizeSSOToken(sso)
+	if sso == "" || strings.ContainsAny(sso, "\r\n\t \"") {
+		return nil, errors.New("a valid Grok Web SSO session is required")
+	}
+	endpoint := UsageResetsListURL
+	var message []byte
+	if redeem {
+		if strings.TrimSpace(cardID) == "" || len(cardID) > 1024 {
+			return nil, errors.New("a reset card ID is required")
+		}
+		endpoint = UsageResetRedeemURL
+		message = protowire.AppendString(protowire.AppendTag(nil, 1, protowire.BytesType), cardID)
+	}
+	frame := make([]byte, 5, 5+len(message))
+	binary.BigEndian.PutUint32(frame[1:], uint32(len(message)))
+	frame = append(frame, message...)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(frame))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/grpc-web+proto")
+	req.Header.Set("Accept", "application/grpc-web+proto")
+	req.Header.Set("X-Grpc-Web", "1")
+	req.Header.Set("X-User-Agent", "connect-es/2.1.1")
+	req.Header.Set("Origin", "https://grok.com")
+	req.Header.Set("Referer", "https://grok.com/")
+	req.Header.Set("User-Agent", ssoDefaultUA)
+	req.AddCookie(&http.Cookie{Name: "sso", Value: sso})
+	req.AddCookie(&http.Cookie{Name: "sso-rw", Value: sso})
+	return req, nil
+}
+
+// ParseUsageResetResponse decodes both the list's tokens and a redemption's
+// still_redeemable fields: both are repeated ResetToken messages at field 1.
+func ParseUsageResetResponse(resp *http.Response) ([]UsageResetCard, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, errors.New("empty Grok reset response")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &UsageResetRPCError{HTTPStatus: resp.StatusCode, GRPCStatus: -1}
+	}
+	if !strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Type")), "application/grpc-web+proto") {
+		return nil, errors.New("unexpected Grok reset response format")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, usageResetMaxResponse+1))
+	if err != nil || len(body) > usageResetMaxResponse {
+		return nil, errors.New("could not read Grok reset response")
+	}
+	var message []byte
+	seenMessage, seenTrailers := false, false
+	status := -1
+	for len(body) > 0 {
+		if seenTrailers || len(body) < 5 {
+			return nil, errors.New("invalid Grok reset response framing")
+		}
+		flag, size := body[0], uint64(binary.BigEndian.Uint32(body[1:5]))
+		body = body[5:]
+		if size > uint64(len(body)) {
+			return nil, errors.New("truncated Grok reset response")
+		}
+		payload := body[:int(size)]
+		body = body[int(size):]
+		switch flag {
+		case 0:
+			if seenMessage {
+				return nil, errors.New("unexpected multiple Grok reset messages")
+			}
+			message, seenMessage = payload, true
+		case 128:
+			seenTrailers = true
+			foundStatus := false
+			for _, line := range strings.Split(string(payload), "\n") {
+				key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+				if !ok || !strings.EqualFold(key, "grpc-status") {
+					continue
+				}
+				if foundStatus {
+					return nil, errors.New("duplicate Grok reset status")
+				}
+				foundStatus = true
+				status, err = strconv.Atoi(strings.TrimSpace(value))
+				if err != nil || status < 0 {
+					return nil, errors.New("invalid Grok reset status")
+				}
+			}
+		default:
+			return nil, errors.New("unsupported Grok reset frame")
+		}
+	}
+	if !seenTrailers || status < 0 {
+		return nil, errors.New("Grok reset response has no final status")
+	}
+	if status != 0 {
+		return nil, &UsageResetRPCError{HTTPStatus: resp.StatusCode, GRPCStatus: status}
+	}
+	if !seenMessage {
+		return nil, errors.New("Grok reset response has no result")
+	}
+	cards := make([]UsageResetCard, 0)
+	err = walkResetFields(message, 1, func(number protowire.Number, value []byte) error {
+		if number != 1 {
+			return nil
+		}
+		card, err := parseUsageResetCard(value)
+		if err != nil {
+			return err
+		}
+		cards = append(cards, card)
+		return nil
+	})
+	return cards, err
+}
+
+func walkResetFields(message []byte, knownFields protowire.Number, field func(protowire.Number, []byte) error) error {
+	for len(message) > 0 {
+		number, wireType, n := protowire.ConsumeTag(message)
+		if n < 0 {
+			return errors.New("invalid Grok reset protobuf tag")
+		}
+		message = message[n:]
+		if number <= knownFields && wireType != protowire.BytesType {
+			return errors.New("unexpected Grok reset protobuf field type")
+		}
+		if wireType == protowire.BytesType {
+			value, consumed := protowire.ConsumeBytes(message)
+			if consumed < 0 {
+				return errors.New("invalid Grok reset protobuf field")
+			}
+			if err := field(number, value); err != nil {
+				return err
+			}
+			message = message[consumed:]
+		} else {
+			consumed := protowire.ConsumeFieldValue(number, wireType, message)
+			if consumed < 0 {
+				return errors.New("invalid Grok reset protobuf value")
+			}
+			message = message[consumed:]
+		}
+	}
+	return nil
+}
+
+func parseUsageResetCard(message []byte) (UsageResetCard, error) {
+	var card UsageResetCard
+	err := walkResetFields(message, 3, func(number protowire.Number, value []byte) error {
+		switch number {
+		case 1:
+			card.TokenID = string(value)
+		case 2, 3:
+			var timestamp timestamppb.Timestamp
+			if proto.Unmarshal(value, &timestamp) != nil || timestamp.CheckValid() != nil {
+				return errors.New("invalid Grok reset validity period")
+			}
+			if number == 2 {
+				card.ValidFrom = timestamp.AsTime()
+			} else {
+				card.ExpiresAt = timestamp.AsTime()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return card, err
+	}
+	if card.TokenID == "" || len(card.TokenID) > 1024 || !utf8.ValidString(card.TokenID) || card.ExpiresAt.IsZero() || !card.ExpiresAt.After(card.ValidFrom) {
+		return card, errors.New("incomplete Grok reset card")
+	}
+	return card, nil
+}

--- a/backend/internal/pkg/xai/usage_resets.go
+++ b/backend/internal/pkg/xai/usage_resets.go
@@ -139,13 +139,13 @@ func ParseUsageResetResponse(resp *http.Response) ([]UsageResetCard, error) {
 		}
 	}
 	if !seenTrailers || status < 0 {
-		return nil, errors.New("Grok reset response has no final status")
+		return nil, errors.New("missing final status in Grok reset response")
 	}
 	if status != 0 {
 		return nil, &UsageResetRPCError{HTTPStatus: resp.StatusCode, GRPCStatus: status}
 	}
 	if !seenMessage {
-		return nil, errors.New("Grok reset response has no result")
+		return nil, errors.New("missing result in Grok reset response")
 	}
 	cards := make([]UsageResetCard, 0)
 	err = walkResetFields(message, 1, func(number protowire.Number, value []byte) error {

--- a/backend/internal/pkg/xai/usage_resets_test.go
+++ b/backend/internal/pkg/xai/usage_resets_test.go
@@ -1,0 +1,105 @@
+package xai
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Synthetic wire fixture using the published GrokBuildBilling descriptor:
+// response.tokens = 1; ResetToken.token_id/validity_start/validity_end = 1/2/3.
+const resetCardsFixture = "000000001a0a180a06636172642d3112060880f2d6ca061a06088095dcca06800000000f677270632d7374617475733a300d0a"
+
+func resetTestResponse(body []byte) *http.Response {
+	return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"application/grpc-web+proto"}}, Body: io.NopCloser(bytes.NewReader(body))}
+}
+
+func TestUsageResetWireContract(t *testing.T) {
+	body, err := hex.DecodeString(resetCardsFixture)
+	require.NoError(t, err)
+	cards, err := ParseUsageResetResponse(resetTestResponse(body))
+	require.NoError(t, err)
+	require.Len(t, cards, 1)
+	require.Equal(t, "card-1", cards[0].TokenID)
+	require.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), cards[0].ValidFrom)
+	require.Equal(t, time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC), cards[0].ExpiresAt)
+	require.False(t, cards[0].Available(cards[0].ValidFrom.Add(-time.Second)))
+	require.True(t, cards[0].Available(cards[0].ValidFrom))
+	require.False(t, cards[0].Available(cards[0].ExpiresAt))
+
+	req, err := NewUsageResetRequest(context.Background(), "sso=web-session; ignored=secret", "", false)
+	require.NoError(t, err)
+	require.Equal(t, UsageResetsListURL, req.URL.String())
+	payload, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0, 0, 0, 0, 0}, payload)
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.NotContains(t, req.Header.Get("Cookie"), "ignored")
+	require.Contains(t, req.Header.Get("Cookie"), "sso=web-session")
+
+	req, err = NewUsageResetRequest(context.Background(), "web-session", "card-1", true)
+	require.NoError(t, err)
+	require.Equal(t, UsageResetRedeemURL, req.URL.String())
+	payload, err = io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, "00000000080a06636172642d31", hex.EncodeToString(payload))
+}
+
+func TestUsageResetRejectsUnconfirmedOrMalformedResponses(t *testing.T) {
+	valid, err := hex.DecodeString(resetCardsFixture)
+	require.NoError(t, err)
+	emptyResult := []byte{0, 0, 0, 0, 0}
+	trailer := valid[31:]
+	tests := map[string][]byte{
+		"missing trailers":       valid[:31],
+		"missing result":         trailer,
+		"truncated header":       {0, 0},
+		"truncated message":      {0, 0, 0, 0, 9, 0},
+		"compressed message":     append([]byte{1}, valid[1:]...),
+		"multiple results":       append(append([]byte{}, emptyResult...), valid...),
+		"data after trailers":    append(append([]byte{}, valid...), emptyResult...),
+		"missing grpc status":    append(emptyResult, 128, 0, 0, 0, 0),
+		"wrong token field type": append([]byte{0, 0, 0, 0, 2, 8, 1}, trailer...),
+		"invalid nested token":   append([]byte{0, 0, 0, 0, 3, 10, 1, 255}, trailer...),
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) { _, err := ParseUsageResetResponse(resetTestResponse(body)); require.Error(t, err) })
+	}
+	cards, err := ParseUsageResetResponse(resetTestResponse(append(emptyResult, trailer...)))
+	require.NoError(t, err)
+	require.Empty(t, cards)
+	response := resetTestResponse(valid)
+	response.Header.Set("Content-Type", "application/grpc")
+	_, err = ParseUsageResetResponse(response)
+	require.Error(t, err)
+}
+
+func TestUsageResetErrorsDoNotExposeSessionData(t *testing.T) {
+	for _, status := range []int{401, 403, 500} {
+		response := resetTestResponse([]byte("web-session-secret"))
+		response.StatusCode = status
+		_, err := ParseUsageResetResponse(response)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "web-session-secret")
+	}
+	trailer := "grpc-status:16\r\ngrpc-message:web-session-secret\r\n"
+	body := append([]byte{128, 0, 0, 0, byte(len(trailer))}, []byte(trailer)...)
+	_, err := ParseUsageResetResponse(resetTestResponse(body))
+	var rpcErr *UsageResetRPCError
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, 16, rpcErr.GRPCStatus)
+	require.NotContains(t, err.Error(), "web-session-secret")
+	_, err = ParseUsageResetResponse(resetTestResponse([]byte(strings.Repeat("x", usageResetMaxResponse+1))))
+	require.Error(t, err)
+	for _, sso := range []string{"", "bad\r\nCookie:secret", strings.Repeat("x", 16385)} {
+		_, err := NewUsageResetRequest(context.Background(), sso, "card-1", true)
+		require.Error(t, err)
+	}
+}

--- a/backend/internal/server/middleware/audit_log.go
+++ b/backend/internal/server/middleware/audit_log.go
@@ -147,6 +147,8 @@ var auditActionOverrides = map[string]string{
 // auditBodyOmittedRoutes 请求体几乎整体由凭证构成的路由（如整块粘贴 auth JSON 的导入接口）。
 // 这类 body 的凭证内嵌在普通字符串值里，键级脱敏无法覆盖，整体不入库。
 var auditBodyOmittedRoutes = map[string]struct{}{
+	"POST /api/v1/admin/grok/accounts/:id/reset-cards/query":    {},
+	"POST /api/v1/admin/grok/accounts/:id/reset-cards/redeem":   {},
 	"POST /api/v1/auth/passkey/login/finish":                    {},
 	"POST /api/v1/user/passkeys/register/finish":                {},
 	"POST /api/v1/admin/accounts/import/codex-session":          {},

--- a/backend/internal/server/middleware/audit_log_test.go
+++ b/backend/internal/server/middleware/audit_log_test.go
@@ -33,6 +33,34 @@ func TestDeriveAuditAction(t *testing.T) {
 	}
 }
 
+func TestGrokUsageResetAuditOmitsWebSessionBodies(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repository := &auditCaptureRepository{}
+	auditService := service.NewAuditLogService(repository, nil)
+	auditService.Start()
+	router := gin.New()
+	router.Use(gin.HandlerFunc(NewAuditLogMiddleware(auditService)))
+	for _, operation := range []string{"query", "redeem"} {
+		router.POST("/api/v1/admin/grok/accounts/:id/reset-cards/"+operation, func(c *gin.Context) {
+			var input map[string]string
+			require.NoError(t, c.ShouldBindJSON(&input))
+			require.Equal(t, "web-session-canary", input["sso_token"])
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost, "/api/v1/admin/grok/accounts/12/reset-cards/"+operation,
+			bytes.NewBufferString(`{"sso_token":"web-session-canary","token_id":"card-canary","extra":"web-session-canary"}`))
+		request.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(httptest.NewRecorder(), request)
+	}
+	auditService.Stop()
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	require.Len(t, repository.logs, 2)
+	for _, entry := range repository.logs {
+		require.Equal(t, "<credential-bearing body omitted>", entry.RequestBody)
+	}
+}
+
 type auditCaptureRepository struct {
 	mu   sync.Mutex
 	logs []*service.AuditLog

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -490,6 +490,8 @@ func registerGrokOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		grok.POST("/accounts/:id/refresh", h.Admin.GrokOAuth.RefreshAccountToken)
 		grok.GET("/accounts/:id/quota", h.Admin.GrokOAuth.QueryQuota)
 		grok.POST("/accounts/:id/reset-quota", h.Admin.GrokOAuth.ResetQuota)
+		grok.POST("/accounts/:id/reset-cards/query", h.Admin.GrokOAuth.QueryUsageResetCards)
+		grok.POST("/accounts/:id/reset-cards/redeem", h.Admin.GrokOAuth.RedeemUsageResetCard)
 		grok.GET("/runtime-sanity", h.Admin.GrokOAuth.RuntimeSanity)
 	}
 }

--- a/backend/internal/service/grok_usage_resets.go
+++ b/backend/internal/service/grok_usage_resets.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+type GrokUsageResetCards struct {
+	Cards []xai.UsageResetCard `json:"cards"`
+}
+
+// Web SSO is used only for this operation. In particular it is never persisted
+// in account credentials, quota snapshots, logs or a shared request cache.
+func (s *GrokQuotaService) QueryUsageResetCards(ctx context.Context, accountID int64, sso string) (*GrokUsageResetCards, error) {
+	return s.callUsageResetCards(ctx, accountID, sso, "", false)
+}
+
+func (s *GrokQuotaService) RedeemUsageResetCard(ctx context.Context, accountID int64, sso, cardID string) (*GrokUsageResetCards, error) {
+	// Re-query with the supplied session so expired, already-used, or different
+	// session cards cannot be submitted from a stale browser view.
+	current, err := s.QueryUsageResetCards(ctx, accountID, sso)
+	if err != nil {
+		return nil, err
+	}
+	for _, card := range current.Cards {
+		if card.TokenID == cardID {
+			return s.callUsageResetCards(ctx, accountID, sso, cardID, true)
+		}
+	}
+	return nil, infraerrors.New(http.StatusConflict, "GROK_RESET_CARD_UNAVAILABLE", "This reset card is no longer available; query the cards again")
+}
+
+func (s *GrokQuotaService) callUsageResetCards(ctx context.Context, accountID int64, sso, cardID string, redeem bool) (*GrokUsageResetCards, error) {
+	account, err := s.loadGrokOAuthAccount(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if s.httpUpstream == nil {
+		return nil, infraerrors.New(http.StatusServiceUnavailable, "GROK_RESET_NOT_CONFIGURED", "Grok reset service is unavailable")
+	}
+	proxyURL := s.resolveProxyURL(ctx, account)
+	if account.ProxyID != nil && account.Proxy == nil {
+		return nil, infraerrors.New(http.StatusBadGateway, "GROK_RESET_PROXY_UNAVAILABLE", "The account's configured proxy is unavailable")
+	}
+	ctx, cancel := context.WithTimeout(WithHTTPUpstreamRedirectsDisabled(ctx), 20*time.Second)
+	defer cancel()
+	req, err := xai.NewUsageResetRequest(ctx, sso, cardID, redeem)
+	if err != nil {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_RESET_INVALID_INPUT", err.Error())
+	}
+	// Always call the official Web host. Never apply account URL/header
+	// overrides or send this Web session to an OAuth/custom upstream.
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil || resp == nil || resp.Body == nil {
+		return nil, grokUsageResetCallError(redeem)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	cards, err := xai.ParseUsageResetResponse(resp)
+	if err != nil {
+		var rpcErr *xai.UsageResetRPCError
+		if errors.As(err, &rpcErr) && (rpcErr.HTTPStatus == 401 || rpcErr.HTTPStatus == 403 || rpcErr.GRPCStatus == 7 || rpcErr.GRPCStatus == 16) {
+			return nil, infraerrors.New(http.StatusBadGateway, "GROK_RESET_WEB_SESSION_REJECTED", "Grok rejected the Web session or proxy; check the SSO session or redeem on grok.com")
+		}
+		return nil, grokUsageResetCallError(redeem)
+	}
+	available := make([]xai.UsageResetCard, 0, len(cards))
+	now := time.Now()
+	for _, card := range cards {
+		if redeem && card.TokenID == cardID {
+			return nil, grokUsageResetCallError(true)
+		}
+		if card.Available(now) {
+			available = append(available, card)
+		}
+	}
+	sort.Slice(available, func(i, j int) bool { return available[i].ExpiresAt.Before(available[j].ExpiresAt) })
+	// A Web SSO can belong to a different account from the selected OAuth
+	// credential. Do not clear scheduling cooldowns or rewrite its quota here.
+	return &GrokUsageResetCards{Cards: available}, nil
+}
+
+func grokUsageResetCallError(redeem bool) error {
+	if redeem {
+		return infraerrors.New(http.StatusBadGateway, "GROK_RESET_RESULT_UNKNOWN", "Could not confirm redemption; query the cards again before retrying")
+	}
+	return infraerrors.New(http.StatusBadGateway, "GROK_RESET_QUERY_FAILED", "Could not query Grok reset cards; try again or open grok.com")
+}

--- a/backend/internal/service/grok_usage_resets_test.go
+++ b/backend/internal/service/grok_usage_resets_test.go
@@ -1,0 +1,126 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type usageResetUpstream struct {
+	httpUpstreamRecorder
+	requests   []*http.Request
+	responses  [][]byte
+	failRedeem bool
+}
+
+func (u *usageResetUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	u.requests = append(u.requests, req)
+	if u.failRedeem && req.URL.String() == xai.UsageResetRedeemURL {
+		return nil, errors.New("uncertain write: web-session-secret")
+	}
+	index := len(u.requests) - 1
+	if index >= len(u.responses) {
+		return nil, errors.New("unexpected request")
+	}
+	return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"application/grpc-web+proto"}}, Body: io.NopCloser(bytes.NewReader(u.responses[index]))}, nil
+}
+
+func resetCardsWire(t *testing.T, cards ...xai.UsageResetCard) []byte {
+	t.Helper()
+	var message []byte
+	for _, card := range cards {
+		start, err := proto.Marshal(timestamppb.New(card.ValidFrom))
+		require.NoError(t, err)
+		end, err := proto.Marshal(timestamppb.New(card.ExpiresAt))
+		require.NoError(t, err)
+		token := protowire.AppendString(protowire.AppendTag(nil, 1, protowire.BytesType), card.TokenID)
+		token = protowire.AppendBytes(protowire.AppendTag(token, 2, protowire.BytesType), start)
+		token = protowire.AppendBytes(protowire.AppendTag(token, 3, protowire.BytesType), end)
+		message = protowire.AppendBytes(protowire.AppendTag(message, 1, protowire.BytesType), token)
+	}
+	frame := make([]byte, 5)
+	binary.BigEndian.PutUint32(frame[1:], uint32(len(message)))
+	frame = append(frame, message...)
+	frame = append(frame, 128, 0, 0, 0, 15)
+	return append(frame, []byte("grpc-status:0\r\n")...)
+}
+
+func newUsageResetTestService(upstream *usageResetUpstream) (*GrokQuotaService, *grokQuotaAccountRepo, *Account) {
+	account := healthyGrokQuotaOAuthAccount(100)
+	future := time.Now().Add(time.Hour)
+	account.TempUnschedulableUntil = &future
+	account.TempUnschedulableReason = "grok payment required"
+	account.Credentials["base_url"] = "https://custom-upstream.example/v1"
+	repo := &grokQuotaAccountRepo{mockAccountRepoForPlatform: &mockAccountRepoForPlatform{accountsByID: map[int64]*Account{account.ID: account}}}
+	return NewGrokQuotaService(repo, nil, nil, upstream, nil), repo, account
+}
+
+func TestGrokUsageResetsUseEphemeralWebSessionDuringCooldown(t *testing.T) {
+	now := time.Now()
+	live := xai.UsageResetCard{TokenID: "available", ValidFrom: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour)}
+	expired := xai.UsageResetCard{TokenID: "expired", ValidFrom: now.Add(-2 * time.Hour), ExpiresAt: now.Add(-time.Hour)}
+	future := xai.UsageResetCard{TokenID: "future", ValidFrom: now.Add(time.Hour), ExpiresAt: now.Add(2 * time.Hour)}
+	u := &usageResetUpstream{responses: [][]byte{resetCardsWire(t, expired, live, future), resetCardsWire(t, live), resetCardsWire(t)}}
+	svc, repo, account := newUsageResetTestService(u)
+	result, err := svc.QueryUsageResetCards(context.Background(), account.ID, "web-session")
+	require.NoError(t, err)
+	require.Len(t, result.Cards, 1)
+	require.Equal(t, live.TokenID, result.Cards[0].TokenID)
+	result, err = svc.RedeemUsageResetCard(context.Background(), account.ID, "web-session", live.TokenID)
+	require.NoError(t, err)
+	require.Empty(t, result.Cards)
+	require.Len(t, u.requests, 3)
+	require.Equal(t, xai.UsageResetRedeemURL, u.requests[2].URL.String())
+	for _, req := range u.requests {
+		require.Equal(t, "grok.com", req.URL.Host)
+		require.True(t, HTTPUpstreamRedirectsDisabled(req.Context()))
+		require.Contains(t, req.Header.Get("Cookie"), "sso=web-session")
+		require.Empty(t, req.Header.Get("Authorization"))
+	}
+	require.Zero(t, repo.updateCalls)
+	require.Zero(t, repo.recoveryClearCalls)
+	require.False(t, account.IsSchedulable())
+	require.NotContains(t, account.Credentials, "sso_token")
+}
+
+func TestGrokUsageResetsRequireFreshCardAndDoNotRetryUnknownWrites(t *testing.T) {
+	now := time.Now()
+	card := xai.UsageResetCard{TokenID: "card-one", ValidFrom: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour)}
+	t.Run("stale card", func(t *testing.T) {
+		u := &usageResetUpstream{responses: [][]byte{resetCardsWire(t)}}
+		svc, _, account := newUsageResetTestService(u)
+		_, err := svc.RedeemUsageResetCard(context.Background(), account.ID, "web-session", card.TokenID)
+		require.ErrorContains(t, err, "GROK_RESET_CARD_UNAVAILABLE")
+		require.Len(t, u.requests, 1)
+	})
+	t.Run("unknown result", func(t *testing.T) {
+		u := &usageResetUpstream{responses: [][]byte{resetCardsWire(t, card)}, failRedeem: true}
+		svc, _, account := newUsageResetTestService(u)
+		_, err := svc.RedeemUsageResetCard(context.Background(), account.ID, "web-session-secret", card.TokenID)
+		require.ErrorContains(t, err, "GROK_RESET_RESULT_UNKNOWN")
+		require.NotContains(t, err.Error(), "web-session-secret")
+		require.Len(t, u.requests, 2)
+	})
+	t.Run("missing proxy", func(t *testing.T) {
+		u := &usageResetUpstream{}
+		svc, _, account := newUsageResetTestService(u)
+		id := int64(9)
+		account.ProxyID = &id
+		_, err := svc.QueryUsageResetCards(context.Background(), account.ID, "web-session")
+		require.ErrorContains(t, err, "GROK_RESET_PROXY_UNAVAILABLE")
+		require.Empty(t, u.requests)
+	})
+}

--- a/docs/grok-usage-reset-cards.md
+++ b/docs/grok-usage-reset-cards.md
@@ -1,0 +1,58 @@
+# Grok usage reset cards
+
+Grok's website can offer a one-use reset card for the shared weekly usage pool.
+The account's normal weekly reset time and a Sub2API scheduling cooldown are
+separate from this consumable card.
+
+In an OAuth account's quota area, **Grok reset cards** opens a manual Web SSO
+flow. Supply the SSO for the Grok account to reset, query the available cards,
+and confirm redemption of the selected card. The selected Sub2API account
+supplies the proxy only; the supplied Web session determines which Grok account
+is queried and reset. Sub2API does not claim that a supplied SSO belongs to the
+selected OAuth identity, and does not clear its scheduling cooldown or rewrite
+its cached billing after redemption. Refresh quota and recover state separately
+if needed.
+
+The SSO is held only for the open dialog and the current server request. It is
+not saved in account credentials, snapshots, browser storage, or request caches.
+Changing the selected account or closing the dialog clears the SSO and cards.
+Only administrators can use the endpoints. No redemption happens on page load,
+quota refresh, or without confirmation.
+
+## Protocol and evidence
+
+The official website's `grok_api_v2.GrokBuildBilling` service exposes:
+
+- `POST https://grok.com/grok_api_v2.GrokBuildBilling/GetRemainingResets`
+- `POST https://grok.com/grok_api_v2.GrokBuildBilling/RedeemReset`
+
+These use binary gRPC-Web (`application/grpc-web+proto`), not JSON Responses
+requests. An empty query is a five-byte uncompressed empty message frame.
+The list response's `tokens`, the redeem request's `token_id`, and the redeem
+response's `still_redeemable` are field 1. Each ResetToken contains `token_id`
+(string, field 1), `validity_start` (Timestamp, field 2), and `validity_end`
+(Timestamp, field 3). The final `grpc-status: 0` trailer must be present before
+the response is treated as successful.
+
+The contract was checked against the official website's published protobuf
+descriptor and a read-only successful list request on 2026-09-09. Redemption is
+covered with synthetic protocol and service tests; no real card was consumed
+during development. The official Grok Build 1.0.24 release and its published
+billing source did not expose an equivalent Build OAuth reset operation. A
+Build OAuth credential must not be silently substituted for the Web SSO.
+
+References:
+
+- [Official Web billing descriptor](https://cdn.grok.com/_next/static/chunks/3e0azggdug22h.js)
+- [Official Web reset hooks](https://cdn.grok.com/_next/static/chunks/3bspeqfgwzzdy.js)
+- [Official Grok Build billing extension](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/src/extensions/billing.rs)
+- [grok2api Web quota transport reference](https://github.com/chenyme/grok2api/blob/8913b53/backend/internal/infra/provider/web/quota.go)
+
+The backend pins the destination to grok.com, disables redirects, honors the
+selected proxy without a direct fallback, and never forwards this SSO to an
+account's custom OAuth upstream. Immediately before redemption it re-queries
+the cards with the same SSO and checks that the chosen card is still valid.
+Redemption is sent once. Network failures, malformed responses, and missing
+success trailers require a fresh query; they never trigger automatic retries.
+Session/proxy rejection is surfaced without attempting to bypass website access
+controls. The official usage page remains available as a fallback.

--- a/frontend/src/api/__tests__/admin.grok.spec.ts
+++ b/frontend/src/api/__tests__/admin.grok.spec.ts
@@ -8,7 +8,7 @@ vi.mock('@/api/client', () => ({
   apiClient: { post },
 }))
 
-import { authorizePassword, createFromSSO, getGrokSSOImportTimeout } from '@/api/admin/grok'
+import { authorizePassword, createFromSSO, getGrokSSOImportTimeout, queryUsageResetCards, redeemUsageResetCard } from '@/api/admin/grok'
 
 describe('admin Grok SSO import API', () => {
   beforeEach(() => {
@@ -49,5 +49,15 @@ describe('admin Grok SSO import API', () => {
       },
       { timeout: 120_000 },
     )
+  })
+
+  it('sends reset credentials only in POST bodies to the admin endpoints', async () => {
+    post.mockResolvedValue({ data: { cards: [] } })
+    await queryUsageResetCards(12, 'web-session-secret')
+    expect(post).toHaveBeenLastCalledWith('/admin/grok/accounts/12/reset-cards/query', { sso_token: 'web-session-secret' })
+    await redeemUsageResetCard(12, 'web-session-secret', 'card-one')
+    expect(post).toHaveBeenLastCalledWith('/admin/grok/accounts/12/reset-cards/redeem', {
+      sso_token: 'web-session-secret', token_id: 'card-one'
+    })
   })
 })

--- a/frontend/src/api/admin/grok.ts
+++ b/frontend/src/api/admin/grok.ts
@@ -130,6 +130,33 @@ export interface GrokQuotaResetResult {
   message: string
 }
 
+export interface GrokUsageResetCard {
+  token_id: string
+  valid_from: string
+  expires_at: string
+}
+
+export interface GrokUsageResetCards {
+  cards: GrokUsageResetCard[]
+}
+
+// Web SSO is sent only in these administrator-initiated request bodies. It must
+// never be placed in a URL, account credential, browser storage, or query key.
+export async function queryUsageResetCards(id: number, ssoToken: string): Promise<GrokUsageResetCards> {
+  const { data } = await apiClient.post<GrokUsageResetCards>(`/admin/grok/accounts/${id}/reset-cards/query`, {
+    sso_token: ssoToken
+  })
+  return data
+}
+
+export async function redeemUsageResetCard(id: number, ssoToken: string, tokenId: string): Promise<GrokUsageResetCards> {
+  const { data } = await apiClient.post<GrokUsageResetCards>(`/admin/grok/accounts/${id}/reset-cards/redeem`, {
+    sso_token: ssoToken,
+    token_id: tokenId
+  })
+  return data
+}
+
 export async function generateAuthUrl(
   payload: GrokAuthUrlRequest
 ): Promise<GrokAuthUrlResponse> {

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -422,12 +422,11 @@
         <div v-if="grokRetryAfterLabel" class="text-[10px] text-amber-600 dark:text-amber-400">
           {{ t('admin.accounts.usageWindow.grokRetryAfter', { time: grokRetryAfterLabel }) }}
         </div>
-        <GrokQuotaProbeCell :account="account" compact @probed="handleGrokProbed" />
       </div>
       <div v-else class="space-y-1">
         <div class="text-xs text-gray-400">-</div>
-        <GrokQuotaProbeCell :account="account" compact @probed="handleGrokProbed" />
       </div>
+      <GrokQuotaProbeCell :account="account" compact @probed="handleGrokProbed" />
     </template>
 
     <!-- CN providers (Kimi / Zhipu / DeepSeek): coding-plan quota or payg balance -->

--- a/frontend/src/components/account/GrokQuotaProbeCell.vue
+++ b/frontend/src/components/account/GrokQuotaProbeCell.vue
@@ -24,7 +24,16 @@
         </svg>
         {{ t('admin.accounts.usageWindow.grokProbe') }}
       </button>
+      <button
+        type="button"
+        class="rounded px-1.5 py-0.5 text-[10px] font-medium text-cyan-700 hover:bg-cyan-50 dark:text-cyan-300 dark:hover:bg-cyan-900/30"
+        @click="showResetCards = true"
+      >
+        {{ t('admin.accounts.grokReset.title') }}
+      </button>
     </div>
+
+    <GrokUsageResetDialog v-if="showResetCards" :show="showResetCards" :account="account" @close="showResetCards = false" />
 
     <!-- Compact mode: parent already shows 7d/30d/prepaid or 24h — only surface errors. -->
     <div
@@ -40,11 +49,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { adminAPI } from '@/api/admin'
 import type { GrokQuotaProbeResult } from '@/api/admin/grok'
 import type { Account } from '@/types'
+
+const GrokUsageResetDialog = defineAsyncComponent(() => import('./GrokUsageResetDialog.vue'))
 
 const props = withDefaults(
   defineProps<{
@@ -61,6 +72,7 @@ const { t } = useI18n()
 
 const visible = computed(() => props.account.platform === 'grok' && props.account.type === 'oauth')
 const loading = ref(false)
+const showResetCards = ref(false)
 const error = ref<string | null>(null)
 const data = ref<GrokQuotaProbeResult | null>(null)
 
@@ -114,6 +126,7 @@ const handleProbe = async () => {
 watch(
   () => props.account.id,
   () => {
+    showResetCards.value = false
     data.value = null
     error.value = null
     loading.value = false

--- a/frontend/src/components/account/GrokUsageResetDialog.vue
+++ b/frontend/src/components/account/GrokUsageResetDialog.vue
@@ -1,0 +1,155 @@
+<template>
+  <BaseDialog
+    :show="show"
+    :title="t('admin.accounts.grokReset.title')"
+    width="normal"
+    :show-close-button="!loading"
+    :close-on-escape="!loading"
+    @close="close"
+  >
+    <div class="space-y-4">
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        {{ t('admin.accounts.grokReset.sessionHint', { account: account.name }) }}
+      </p>
+      <template v-if="!succeeded">
+        <label class="block text-sm font-medium">
+          {{ t('admin.accounts.grokReset.sessionLabel') }}
+          <input
+            v-model="sso"
+            type="password"
+            autocomplete="off"
+            :disabled="loading || confirming"
+            class="input mt-1 w-full"
+            :aria-label="t('admin.accounts.grokReset.sessionLabel')"
+          />
+        </label>
+        <p class="text-xs text-gray-500">{{ t('admin.accounts.grokReset.sessionPrivacy') }}</p>
+        <button v-if="!confirming" type="button" class="btn btn-secondary" :disabled="loading || !sso.trim()" @click="query">
+          {{ t('admin.accounts.grokReset.query') }}
+        </button>
+        <template v-if="queried">
+          <p v-if="!cards.length" class="text-sm text-gray-500">{{ t('admin.accounts.grokReset.empty') }}</p>
+          <label v-for="card in cards" :key="card.token_id" class="flex items-center gap-2 text-sm">
+            <input v-model="selectedID" type="radio" :value="card.token_id" :disabled="loading || confirming" />
+            {{ t('admin.accounts.grokReset.expires', { time: formatExpiry(card.expires_at) }) }}
+          </label>
+        </template>
+        <p v-if="confirming" class="text-sm text-amber-700 dark:text-amber-300">
+          {{ t('admin.accounts.grokReset.confirmMessage', { time: formatExpiry(selectedCard?.expires_at || '') }) }}
+        </p>
+      </template>
+      <p v-if="succeeded" role="status" class="text-sm text-green-700 dark:text-green-300">{{ t('admin.accounts.grokReset.success') }}</p>
+      <p v-if="error" role="alert" class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+      <a class="text-sm text-primary-600 hover:underline" href="https://grok.com/?_s=usage" target="_blank" rel="noopener noreferrer">
+        {{ t('admin.accounts.grokReset.openOfficial') }}
+      </a>
+    </div>
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <button type="button" class="btn btn-secondary" :disabled="loading" @click="confirming ? confirming = false : close()">
+          {{ t(confirming ? 'common.cancel' : 'common.close') }}
+        </button>
+        <button v-if="!succeeded && selectedCard" type="button" class="btn btn-primary" :disabled="loading" @click="confirming ? redeem() : confirming = true">
+          {{ t(confirming ? 'admin.accounts.grokReset.confirm' : 'admin.accounts.grokReset.redeem') }}
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import { queryUsageResetCards, redeemUsageResetCard, type GrokUsageResetCard } from '@/api/admin/grok'
+import type { Account } from '@/types'
+
+const props = defineProps<{ show: boolean; account: Account }>()
+const emit = defineEmits<{ close: []; redeemed: [] }>()
+const { t, locale } = useI18n()
+const sso = ref('')
+const cards = ref<GrokUsageResetCard[]>([])
+const selectedID = ref('')
+const loading = ref(false)
+const queried = ref(false)
+const confirming = ref(false)
+const succeeded = ref(false)
+const error = ref('')
+let generation = 0
+
+const selectedCard = computed(() => cards.value.find(card => card.token_id === selectedID.value))
+const formatExpiry = (value: string) => value ? new Date(value).toLocaleString(locale.value) : ''
+
+function clearCards() {
+  cards.value = []
+  selectedID.value = ''
+  queried.value = false
+  confirming.value = false
+}
+
+function clearSession() {
+  generation++
+  sso.value = ''
+  clearCards()
+  loading.value = false
+  succeeded.value = false
+  error.value = ''
+}
+
+function close() {
+  if (loading.value) return
+  clearSession()
+  emit('close')
+}
+
+async function query() {
+  if (loading.value || !sso.value.trim()) return
+  const attempt = ++generation
+  loading.value = true
+  error.value = ''
+  clearCards()
+  try {
+    const result = await queryUsageResetCards(props.account.id, sso.value)
+    if (attempt !== generation) return
+    cards.value = result.cards
+    selectedID.value = result.cards[0]?.token_id || ''
+    queried.value = true
+  } catch {
+    if (attempt === generation) error.value = t('admin.accounts.grokReset.queryFailed')
+  } finally {
+    if (attempt === generation) loading.value = false
+  }
+}
+
+async function redeem() {
+  if (loading.value || !confirming.value || !selectedCard.value) return
+  if (new Date(selectedCard.value.expires_at).getTime() <= Date.now()) {
+    clearCards()
+    error.value = t('admin.accounts.grokReset.queryAgain')
+    return
+  }
+  const attempt = ++generation
+  loading.value = true
+  error.value = ''
+  try {
+    await redeemUsageResetCard(props.account.id, sso.value, selectedID.value)
+    if (attempt !== generation) return
+    succeeded.value = true
+    sso.value = ''
+    clearCards()
+    emit('redeemed')
+  } catch {
+    if (attempt !== generation) return
+    // A timeout can occur after redemption. Require a fresh card query instead
+    // of retaining an enabled retry button for a possibly consumed card.
+    clearCards()
+    error.value = t('admin.accounts.grokReset.redeemUnknown')
+  } finally {
+    if (attempt === generation) loading.value = false
+  }
+}
+
+watch(sso, clearCards)
+watch([() => props.show, () => props.account.id], clearSession)
+onBeforeUnmount(clearSession)
+</script>

--- a/frontend/src/components/account/__tests__/GrokUsageResetDialog.spec.ts
+++ b/frontend/src/components/account/__tests__/GrokUsageResetDialog.spec.ts
@@ -1,0 +1,108 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import GrokUsageResetDialog from '../GrokUsageResetDialog.vue'
+import type { Account } from '@/types'
+
+const { queryUsageResetCards, redeemUsageResetCard } = vi.hoisted(() => ({
+  queryUsageResetCards: vi.fn(),
+  redeemUsageResetCard: vi.fn()
+}))
+
+vi.mock('@/api/admin/grok', () => ({ queryUsageResetCards, redeemUsageResetCard }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } }) }))
+
+const card = { token_id: 'card-one', valid_from: '2026-01-01T00:00:00Z', expires_at: '2100-01-01T00:00:00Z' }
+const account = { id: 12, name: 'Test Grok', platform: 'grok', type: 'oauth' } as Account
+
+function setup() {
+  return mount(GrokUsageResetDialog, {
+    props: { show: true, account },
+    global: { stubs: { BaseDialog: { props: ['show'], template: '<div v-if="show"><slot /><slot name="footer" /></div>' } } }
+  })
+}
+
+function button(wrapper: ReturnType<typeof setup>, label: string) {
+  const match = wrapper.findAll('button').find(item => item.text() === label)
+  expect(match).toBeDefined()
+  return match!
+}
+
+async function loadCards(wrapper: ReturnType<typeof setup>) {
+  await wrapper.get('input[type=password]').setValue('web-session-secret')
+  await button(wrapper, 'admin.accounts.grokReset.query').trigger('click')
+  await flushPromises()
+}
+
+describe('GrokUsageResetDialog', () => {
+  beforeEach(() => {
+    queryUsageResetCards.mockReset().mockResolvedValue({ cards: [card] })
+    redeemUsageResetCard.mockReset().mockResolvedValue({ cards: [] })
+  })
+
+  it('queries without redeeming and requires explicit confirmation', async () => {
+    const wrapper = setup()
+    await loadCards(wrapper)
+    expect(queryUsageResetCards).toHaveBeenCalledWith(12, 'web-session-secret')
+    expect(redeemUsageResetCard).not.toHaveBeenCalled()
+    await button(wrapper, 'admin.accounts.grokReset.redeem').trigger('click')
+    expect(wrapper.text()).toContain('admin.accounts.grokReset.confirmMessage')
+    expect(redeemUsageResetCard).not.toHaveBeenCalled()
+    await button(wrapper, 'admin.accounts.grokReset.confirm').trigger('click')
+    await flushPromises()
+    expect(redeemUsageResetCard).toHaveBeenCalledTimes(1)
+    expect(redeemUsageResetCard).toHaveBeenCalledWith(12, 'web-session-secret', 'card-one')
+    expect(wrapper.emitted('redeemed')).toHaveLength(1)
+    expect(wrapper.find('input[type=password]').exists()).toBe(false)
+  })
+
+  it('requires another query after an uncertain redemption and hides raw errors', async () => {
+    redeemUsageResetCard.mockRejectedValue(new Error('timeout with web-session-secret'))
+    const wrapper = setup()
+    await loadCards(wrapper)
+    await button(wrapper, 'admin.accounts.grokReset.redeem').trigger('click')
+    await button(wrapper, 'admin.accounts.grokReset.confirm').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('admin.accounts.grokReset.redeemUnknown')
+    expect(wrapper.text()).not.toContain('web-session-secret')
+    expect(wrapper.find('input[type=radio]').exists()).toBe(false)
+    expect(redeemUsageResetCard).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears SSO and cards on close and ignores a late query for another account', async () => {
+    let resolveQuery!: (value: { cards: typeof card[] }) => void
+    queryUsageResetCards.mockReturnValue(new Promise(resolve => { resolveQuery = resolve }))
+    const wrapper = setup()
+    await loadCards(wrapper)
+    await wrapper.setProps({ account: { ...account, id: 13 } })
+    resolveQuery({ cards: [card] })
+    await flushPromises()
+    expect((wrapper.get('input[type=password]').element as HTMLInputElement).value).toBe('')
+    expect(wrapper.find('input[type=radio]').exists()).toBe(false)
+    await wrapper.get('input[type=password]').setValue('new-session')
+    await button(wrapper, 'common.close').trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    expect((wrapper.get('input[type=password]').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('drops the selected card when the supplied web session changes', async () => {
+    const wrapper = setup()
+    await loadCards(wrapper)
+    await wrapper.get('input[type=password]').setValue('different-web-session')
+    expect(wrapper.find('input[type=radio]').exists()).toBe(false)
+    expect(redeemUsageResetCard).not.toHaveBeenCalled()
+  })
+
+  it('does not submit duplicate redemptions while the first is pending', async () => {
+    let resolveRedeem!: (value: { cards: typeof card[] }) => void
+    redeemUsageResetCard.mockReturnValue(new Promise(resolve => { resolveRedeem = resolve }))
+    const wrapper = setup()
+    await loadCards(wrapper)
+    await button(wrapper, 'admin.accounts.grokReset.redeem').trigger('click')
+    const confirm = button(wrapper, 'admin.accounts.grokReset.confirm')
+    await confirm.trigger('click')
+    await confirm.trigger('click')
+    expect(redeemUsageResetCard).toHaveBeenCalledTimes(1)
+    resolveRedeem({ cards: [] })
+    await flushPromises()
+  })
+})

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -1,5 +1,22 @@
 export default {
     accounts: {
+      grokReset: {
+        title: 'Grok reset cards',
+        sessionLabel: 'Grok Web SSO',
+        sessionHint: 'Use the Web SSO of the Grok account you want to reset. The selected Sub2API account ({account}) supplies only the proxy; redemption applies to the supplied Web session.',
+        sessionPrivacy: 'Used only for this query and redemption. It is not saved; closing this dialog clears it.',
+        query: 'Query reset cards',
+        empty: 'No reset cards are currently available.',
+        expires: 'Expires {time}',
+        redeem: 'Use reset card',
+        confirm: 'Confirm redemption',
+        confirmMessage: 'This consumes the card expiring {time} and resets the weekly usage of the supplied Grok Web session.',
+        success: 'Reset redeemed. Usage may take a moment to update. Refresh quota and recover the account state if needed.',
+        queryFailed: 'Could not query cards. Check the Web SSO and account proxy, or use the official usage page.',
+        redeemUnknown: 'Redemption was not confirmed. Query the cards again before retrying; the card may already have been used.',
+        queryAgain: 'This card has expired. Query the cards again.',
+        openOfficial: 'Open Grok usage',
+      },
       title: 'Account Management',
       description: 'Manage AI platform accounts and credentials',
       createAccount: 'Create Account',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -1,5 +1,22 @@
 export default {
     accounts: {
+      grokReset: {
+        title: 'Grok 重置卡',
+        sessionLabel: 'Grok 网页 SSO',
+        sessionHint: '填写要重置的 Grok 账号的网页 SSO。所选 Sub2API 账号（{account}）仅提供代理，兑换针对所填写的网页登录账号生效。',
+        sessionPrivacy: '仅用于本次查询与兑换，不会保存；关闭窗口即清空。',
+        query: '查询重置卡',
+        empty: '当前没有可用的重置卡。',
+        expires: '到期时间：{time}',
+        redeem: '使用重置卡',
+        confirm: '确认兑换',
+        confirmMessage: '将消耗到期时间为 {time} 的重置卡，并重置所填写的 Grok 网页账号的本周用量。',
+        success: '重置卡已兑换，额度更新可能稍有延迟。请刷新额度，必要时恢复账号状态。',
+        queryFailed: '查询失败，请检查网页 SSO 和账号代理，或前往官方使用量页面。',
+        redeemUnknown: '未能确认兑换结果。卡片可能已使用，请重新查询后再操作。',
+        queryAgain: '此卡已过期，请重新查询重置卡。',
+        openOfficial: '打开 Grok 使用量页面',
+      },
       title: '账号管理',
       description: '管理 AI 平台账号和 Cookie',
       createAccount: '添加账号',


### PR DESCRIPTION
Grok 官网显示可用重置卡时，Sub2API 的 OAuth 账号目前没有查询和兑换入口。此 PR 在 Grok 额度区域增加手动重置卡弹窗，支持查询可用卡片、展示到期时间及确认兑换；即使 Build 额度查询失败，入口仍可使用。

使用官网 `GrokBuildBilling.GetRemainingResets` / `RedeemReset` gRPC-Web 接口。Build OAuth 凭据不能直接替代网页登录会话，因此管理员需临时填写 Web SSO。SSO 决定实际查询和兑换的 Grok 账号，所选 Sub2API 账号仅提供代理；兑换后不会自动修改该 OAuth 账号的额度快照或调度状态。SSO 不落库、不进入审计请求体，关闭弹窗即清空。

兑换前重新查询卡片有效性，禁止重定向及自动重试，并校验最终 gRPC 状态。无法确认兑换结果时，要求重新查询卡片。协议与鉴权依据见 `docs/grok-usage-reset-cards.md`，参考了 grok2api 的网页配额传输实现及官方网页协议。

验证：
- 官网真实会话的只读查询成功，返回有效 gRPC-Web 消息及 `grpc-status: 0`。
- 后端协议、服务、参数校验与审计测试（含 race）通过；前端相关 58 个测试通过。
- 前端 lint、i18n 检查、类型检查及生产构建通过；后端构建通过。
- 兑换路径使用合成协议数据和模拟上游测试，开发中未消耗真实重置卡；从部署服务器到官网的 Web SSO 请求尚未进行真实验证。

本 PR 独立于额度查询冷却修复 #6920，可单独审查。
