### PR TITLE
fix(openai): preserve Claude Code harness semantics

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_claude_code_harness_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_claude_code_harness_test.go
@@ -1,0 +1,84 @@
+//go:build unit
+
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicToResponses_ClaudeCodeReplaysCodexReasoningAndToolError(t *testing.T) {
+	var req AnthropicRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"model":"gpt-5.6-sol",
+		"max_tokens":1024,
+		"system":[{"type":"text","text":"sanitized Claude Code system fixture"}],
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"sanitized summary","signature":"gAAAA-sanitized-codex-ciphertext"},
+				{"type":"tool_use","id":"call_fixture_1","name":"Bash","input":{"command":"false","description":"fixture"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_fixture_1","is_error":true,"content":"exit code 1"},
+				{"type":"text","text":"recover and continue"}
+			]}
+		],
+		"tools":[{"name":"Bash","description":"run a command","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}]
+	}`), &req))
+
+	converted, err := AnthropicToResponses(&req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(converted.Input, &items))
+	require.Len(t, items, 5)
+	require.Equal(t, "developer", items[0].Role)
+	require.Equal(t, "reasoning", items[1].Type)
+	require.Equal(t, "gAAAA-sanitized-codex-ciphertext", items[1].EncryptedContent)
+	require.Equal(t, "function_call", items[2].Type)
+	require.Equal(t, "call_fixture_1", items[2].CallID)
+	require.Equal(t, "function_call_output", items[3].Type)
+	require.Equal(t, "call_fixture_1", items[3].CallID)
+	require.Equal(t, "Error: exit code 1", items[3].Output)
+	require.Equal(t, "user", items[4].Role)
+	require.NotNil(t, converted.ParallelToolCalls)
+	require.True(t, *converted.ParallelToolCalls)
+	require.Contains(t, converted.Include, "reasoning.encrypted_content")
+}
+
+func TestResponsesToAnthropic_RefusalRemainsVisibleToClaudeCode(t *testing.T) {
+	resp := &ResponsesResponse{
+		ID:     "resp_refusal",
+		Model:  "gpt-5.6-sol",
+		Status: "completed",
+		Output: []ResponsesOutput{{
+			Type: "message",
+			Content: []ResponsesContentPart{{
+				Type:    "refusal",
+				Refusal: "sanitized refusal reason",
+			}},
+		}},
+	}
+
+	converted := ResponsesToAnthropic(resp, "claude-opus-5")
+	require.Len(t, converted.Content, 1)
+	require.Equal(t, "text", converted.Content[0].Type)
+	require.Equal(t, "Refusal: sanitized refusal reason", converted.Content[0].Text)
+}
+
+func TestResponsesToAnthropic_StreamingRefusalRemainsVisibleToClaudeCode(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.Model = "claude-opus-5"
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:  "response.refusal.delta",
+		Delta: "sanitized refusal reason",
+	}, state)
+
+	require.Len(t, events, 2)
+	require.Equal(t, "content_block_start", events[0].Type)
+	require.Equal(t, "content_block_delta", events[1].Type)
+	require.Equal(t, "text_delta", events[1].Delta.Type)
+	require.Equal(t, "Refusal: sanitized refusal reason", events[1].Delta.Text)
+}

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -287,9 +287,12 @@ func anthropicAssistantToResponses(raw json.RawMessage) ([]ResponsesInputItem, e
 			continue
 		}
 		sig := strings.TrimSpace(b.Signature)
-		// Only replay provider ciphertext. Skip GPT/Codex-style gAAAA blobs and
-		// empty placeholders — xAI returns 400 on decrypt for foreign signatures.
-		if sig == "" || strings.HasPrefix(sig, "gAAAA") {
+		// The signature is opaque provider state. Preserve it verbatim so a
+		// stateless Responses request can resume GPT/Codex reasoning after a
+		// gateway restart or continuation-cache miss. Provider switches that
+		// reject foreign ciphertext are recovered by the provider-specific
+		// invalid_encrypted_content retry in the gateway.
+		if sig == "" {
 			continue
 		}
 		items = append(items, ResponsesInputItem{
@@ -368,7 +371,7 @@ func anthropicImageToDataURI(src *AnthropicImageSource) string {
 // (the Responses API output field only accepts strings).
 func convertToolResultOutput(b AnthropicContentBlock) (string, []ResponsesContentPart) {
 	if len(b.Content) == 0 {
-		return "(empty)", nil
+		return formatAnthropicToolResultOutput("(empty)", b.IsError), nil
 	}
 
 	// Try plain string content.
@@ -377,13 +380,13 @@ func convertToolResultOutput(b AnthropicContentBlock) (string, []ResponsesConten
 		if s == "" {
 			s = "(empty)"
 		}
-		return s, nil
+		return formatAnthropicToolResultOutput(s, b.IsError), nil
 	}
 
 	// Array of content blocks — may contain text and/or images.
 	var inner []AnthropicContentBlock
 	if err := json.Unmarshal(b.Content, &inner); err != nil {
-		return "(empty)", nil
+		return formatAnthropicToolResultOutput("(empty)", b.IsError), nil
 	}
 
 	// Separate text (for function_call_output) from images (for user message).
@@ -406,7 +409,14 @@ func convertToolResultOutput(b AnthropicContentBlock) (string, []ResponsesConten
 	if text == "" {
 		text = "(empty)"
 	}
-	return text, imageParts
+	return formatAnthropicToolResultOutput(text, b.IsError), imageParts
+}
+
+func formatAnthropicToolResultOutput(text string, isError bool) string {
+	if !isError {
+		return text
+	}
+	return "Error: " + text
 }
 
 // extractAnthropicTextFromBlocks joins all text blocks, ignoring thinking/

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -45,10 +45,17 @@ func ResponsesToAnthropic(resp *ResponsesResponse, model string) *AnthropicRespo
 			}
 		case "message":
 			for _, part := range item.Content {
-				if part.Type == "output_text" && part.Text != "" {
+				text := ""
+				switch part.Type {
+				case "output_text":
+					text = part.Text
+				case "refusal":
+					text = visibleOpenAIRefusal(part.Refusal)
+				}
+				if text != "" {
 					blocks = append(blocks, AnthropicContentBlock{
 						Type: "text",
-						Text: part.Text,
+						Text: text,
 					})
 				}
 			}
@@ -223,6 +230,13 @@ func ResponsesEventToAnthropicEvents(
 		return resToAnthHandleTextDelta(evt, state)
 	case "response.output_text.done":
 		return resToAnthHandleBlockDone(state)
+	case "response.refusal.delta":
+		if evt.Delta != "" {
+			evt.Delta = visibleOpenAIRefusal(evt.Delta)
+		}
+		return resToAnthHandleTextDelta(evt, state)
+	case "response.refusal.done":
+		return resToAnthHandleBlockDone(state)
 	case "response.function_call_arguments.delta",
 		// custom/freeform 工具的输入增量与 function_call 参数增量同形。
 		"response.custom_tool_call_input.delta":
@@ -247,6 +261,14 @@ func ResponsesEventToAnthropicEvents(
 	default:
 		return nil
 	}
+}
+
+func visibleOpenAIRefusal(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	return "Refusal: " + text
 }
 
 // FinalizeResponsesAnthropicStream emits synthetic termination events if the

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -309,8 +309,9 @@ func (i *ResponsesInputItem) UnmarshalJSON(data []byte) error {
 
 // ResponsesContentPart is a typed content part in a Responses message.
 type ResponsesContentPart struct {
-	Type     string `json:"type"` // "input_text" | "output_text" | "input_image" | "input_file"
+	Type     string `json:"type"` // "input_text" | "output_text" | "refusal" | "input_image" | "input_file"
 	Text     string `json:"text,omitempty"`
+	Refusal  string `json:"refusal,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
 
 	// input_file fields.

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -559,7 +559,7 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 
 // handleAnthropicBufferedStreamingResponse reads all Responses SSE events from
 // the upstream streaming response, finds the terminal event (response.completed
-// / response.incomplete / response.failed), converts the complete response to
+// / response.incomplete / response.failed / response.cancelled), converts the complete response to
 // Anthropic Messages JSON format, and writes it to the client.
 // This is used when the client requested stream=false but the upstream is always
 // streaming.
@@ -632,6 +632,12 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 		writeAnthropicError(c, http.StatusBadGateway, "api_error", message)
 		return nil, fmt.Errorf("upstream response failed: %s", message)
 	}
+	if isOpenAICompatCancelledStatus(finalResponse.Status) {
+		message := "Upstream response was cancelled"
+		s.recordOpenAIMessagesStreamUpstreamError(c, account, requestID, "stream_cancelled", message)
+		writeAnthropicError(c, http.StatusBadGateway, "api_error", message)
+		return nil, fmt.Errorf("upstream response cancelled")
+	}
 	if strings.TrimSpace(finalResponse.Status) == "completed" {
 		logOpenAISuccessMissingUsage(c.Request.Context(), c, account, resp, &usage, "response.completed", false)
 	}
@@ -680,6 +686,11 @@ func isOpenAICompatResponsesTerminalEvent(eventType string) bool {
 	default:
 		return false
 	}
+}
+
+func isOpenAICompatCancelledStatus(status string) bool {
+	status = strings.TrimSpace(status)
+	return status == "cancelled" || status == "canceled"
 }
 
 func (s *OpenAIGatewayService) recordOpenAIMessagesStreamUpstreamError(c *gin.Context, account *Account, upstreamRequestID, kind, message string) {
@@ -1079,6 +1090,24 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 					}
 				}
 				streamNonFailoverErr = fmt.Errorf("upstream response failed: %s", errMsg)
+				return true
+			}
+			if eventType == "response.cancelled" || eventType == "response.canceled" ||
+				(event.Response != nil && isOpenAICompatCancelledStatus(event.Response.Status)) {
+				message := "Upstream response was cancelled"
+				s.recordOpenAIMessagesStreamUpstreamError(c, account, requestID, "stream_cancelled", message)
+				if !clientDisconnected {
+					if !clientOutputStarted {
+						writeAnthropicError(c, http.StatusBadGateway, "api_error", message)
+						clientOutputStarted = true
+					} else {
+						writeStreamHeaders()
+						if _, err := fmt.Fprint(c.Writer, buildAnthropicStreamErrorSSE("api_error", message)); err == nil {
+							c.Writer.Flush()
+						}
+					}
+				}
+				streamNonFailoverErr = fmt.Errorf("upstream response cancelled")
 				return true
 			}
 		}

--- a/backend/internal/service/openai_gateway_messages_cancelled_test.go
+++ b/backend/internal/service/openai_gateway_messages_cancelled_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func responsesCancelledSSE(streamStarted bool) string {
+	frames := []string{}
+	if streamStarted {
+		frames = append(frames,
+			`data: {"type":"response.created","response":{"id":"resp_cancelled","object":"response","model":"gpt-5.6-sol","status":"in_progress","output":[]}}`,
+			"",
+			`data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"partial"}`,
+			"",
+		)
+	}
+	frames = append(frames,
+		`data: {"type":"response.cancelled","response":{"id":"resp_cancelled","object":"response","model":"gpt-5.6-sol","status":"cancelled","output":[],"usage":{"input_tokens":8,"output_tokens":1,"total_tokens":9}}}`,
+		"",
+		`data: [DONE]`,
+		"",
+	)
+	return strings.Join(frames, "\n")
+}
+
+func runCancelledMessagesFixture(t *testing.T, stream bool) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-5.6-sol","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":` + map[bool]string{true: "true", false: "false"}[stream] + `}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(responsesCancelledSSE(stream))),
+	}}
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+	account := rawChatCompletionsTestAccount()
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+	return rec, err
+}
+
+func TestForwardAsAnthropic_BufferedCancelledIsVisibleError(t *testing.T) {
+	rec, err := runCancelledMessagesFixture(t, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cancelled")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), `"type":"error"`)
+	require.NotContains(t, rec.Body.String(), `"type":"message"`)
+}
+
+func TestForwardAsAnthropic_StreamingCancelledAfterOutputIsVisibleError(t *testing.T) {
+	rec, err := runCancelledMessagesFixture(t, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cancelled")
+	require.Contains(t, rec.Body.String(), `"text":"partial"`)
+	require.Contains(t, rec.Body.String(), "event: error")
+	require.NotContains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestOpenAICompatResponsesTerminalEventIncludesCancellation(t *testing.T) {
+	require.True(t, isOpenAICompatResponsesTerminalEvent("response.cancelled"))
+	require.True(t, isOpenAICompatResponsesTerminalEvent("response.canceled"))
+}


### PR DESCRIPTION
The Anthropic Messages to OpenAI Responses bridge could lose state or report a false success in four Claude Code workflows: opaque encrypted reasoning was dropped, failed tool results were indistinguishable from successful output, refusal content disappeared, and cancelled Responses streams were not surfaced as errors.

This change preserves non-empty opaque reasoning signatures for stateless replay, marks failed tool output explicitly, maps buffered and streaming refusal content to visible text, and turns both cancelled event spellings into Anthropic API/SSE errors. It retains provider-specific invalid-ciphertext recovery in the gateway and adds focused regression coverage for each behavior.

Validation:

- Focused compatibility tests pass on current `main` for reasoning replay, tool failures, refusal, and buffered/streaming cancellation.
- Full `internal/pkg/apicompat` tests pass in an isolated network namespace.
- The only isolated-network failure in the full `internal/service` package is the pre-existing DNS-dependent `TestValidateCreateParams_CheckModeMatrix`; the same subtests fail on unmodified `main` because DNS isolation is observed before their expected parameter errors.
