### PR TITLE
fix(codex): hide redundant family aliases in model picker

### DIFF
--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -946,9 +946,57 @@ func buildCodexModelsManifest(
 		}
 		models = append(models, encoded)
 	}
+	models, _ = preferCanonicalCodexPickerModels(models)
 	return json.Marshal(struct {
 		Models []json.RawMessage `json:"models"`
 	}{Models: models})
+}
+
+func codexPickerAliasTarget(modelID string) string {
+	switch canonicalizeOpenAIModelAliasSpelling(modelID) {
+	case "gpt-5.6":
+		return "gpt-5.6-sol"
+	case "gpt-6":
+		return "gpt-6-astra"
+	default:
+		return ""
+	}
+}
+
+// Keep family aliases routable while avoiding duplicate rows when the same
+// picker response already contains the concrete model they resolve to.
+func preferCanonicalCodexPickerModels(models []json.RawMessage) ([]json.RawMessage, bool) {
+	canonicalModels := make(map[string]struct{}, len(models))
+	for _, rawModel := range models {
+		var descriptor struct {
+			Slug string `json:"slug"`
+		}
+		if err := json.Unmarshal(rawModel, &descriptor); err != nil {
+			continue
+		}
+		normalized := canonicalizeOpenAIModelAliasSpelling(descriptor.Slug)
+		if normalized != "" {
+			canonicalModels[normalized] = struct{}{}
+		}
+	}
+
+	filtered := make([]json.RawMessage, 0, len(models))
+	changed := false
+	for _, rawModel := range models {
+		var descriptor struct {
+			Slug string `json:"slug"`
+		}
+		if err := json.Unmarshal(rawModel, &descriptor); err == nil {
+			if target := codexPickerAliasTarget(descriptor.Slug); target != "" {
+				if _, exists := canonicalModels[target]; exists {
+					changed = true
+					continue
+				}
+			}
+		}
+		filtered = append(filtered, rawModel)
+	}
+	return filtered, changed
 }
 
 func codexCatalogMetadataModels(
@@ -1377,6 +1425,9 @@ func mergeConfiguredCodexModelsManifest(
 		seen[modelID] = struct{}{}
 		changed = true
 	}
+	var aliasesRemoved bool
+	merged, aliasesRemoved = preferCanonicalCodexPickerModels(merged)
+	changed = changed || aliasesRemoved
 	if !changed {
 		return body, false, nil
 	}

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -476,6 +476,32 @@ func TestBuildCodexModelsManifestKeepsKnownReasoningChoices(t *testing.T) {
 	require.NotEqual(t, "none", firstLevel["effort"])
 }
 
+func TestBuildCodexModelsManifestPrefersCanonicalPickerModels(t *testing.T) {
+	t.Parallel()
+
+	body, err := BuildCodexModelsManifest([]string{
+		"gpt-5.6",
+		"gpt-5.6-sol",
+		"gpt-5.6-luna",
+		"gpt-6",
+		"gpt-6-astra",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"gpt-5.6-sol",
+		"gpt-5.6-luna",
+		"gpt-6-astra",
+	}, codexManifestModelSlugs(t, body))
+}
+
+func TestBuildCodexModelsManifestKeepsAliasWithoutCanonicalModel(t *testing.T) {
+	t.Parallel()
+
+	body, err := BuildCodexModelsManifest([]string{"gpt-5.6", "gpt-6"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"gpt-5.6", "gpt-6"}, codexManifestModelSlugs(t, body))
+}
+
 // Scenario: 支持 Fast 的 GPT 型号在目录中声明 priority service tier。
 func TestBuildCodexModelsManifestAdvertisesPriorityServiceTierForFastGPTModels(t *testing.T) {
 	t.Parallel()
@@ -1129,6 +1155,19 @@ func TestMergeGroupConfiguredCodexModelsInjectsCurrentGroupAliases(t *testing.T)
 	require.Len(t, models[1]["supported_reasoning_levels"], 3)
 	require.NotContains(t, string(manifest.Body), "other-group-model")
 	require.Equal(t, codexModelsManifestBodyETag(manifest.Body), manifest.ETag)
+}
+
+func TestMergeConfiguredCodexModelsManifestPrefersCanonicalPickerModels(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"models":[{"slug":"gpt-5.6"},{"slug":"gpt-5.6-sol"},{"slug":"gpt-6"},{"slug":"gpt-6-astra"}],"metadata":{"version":1}}`)
+	merged, changed, err := mergeConfiguredCodexModelsManifest(body, nil, nil, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, []string{"gpt-5.6-sol", "gpt-6-astra"}, codexManifestModelSlugs(t, merged))
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(merged, &envelope))
+	require.JSONEq(t, `{"version":1}`, string(envelope["metadata"]))
 }
 
 // Mixed groups retain configured metadata alongside defaults for unmapped accounts.


### PR DESCRIPTION
## Problem

When OpenAI account mappings expose both `gpt-5.6` and `gpt-5.6-sol`, or both `gpt-6` and `gpt-6-astra`, the Codex manifest includes separate picker entries for the family alias and concrete model. Codex displays both slugs, producing duplicate-looking Sol and Astra choices.

## Change

- Prefer the concrete model in generated and merged Codex manifests when both known family names are present.
- Keep a family alias visible when its concrete counterpart is absent.
- Preserve the order and metadata of retained entries and the top-level manifest envelope.
- Leave account mappings and request routing unchanged. This applies the existing built-in family-alias convention; it does not infer equivalence for arbitrary custom aliases.

## Validation

Before rebasing onto the subsequent version-only main commit, four focused service tests passed: the three new cases covering generated catalogs, alias-only catalogs and merged catalogs, plus the existing group-alias injection test. The production binary and derived image built successfully.

A local v0.2.4 deployment was checked before and after the change: the authenticated `/models` response changed from 18 entries to 16, removing only `gpt-5.6` and `gpt-6`; the Codex disk catalog subsequently refreshed to the same 16 entries. No billable model-generation request was used for this verification.

No deployment settings, credentials, local paths or generated artifacts are included in this PR.
