### PR TITLE
fix(openai): preserve OAuth image model routing

### DIFF
--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -1622,6 +1622,42 @@ func TestOpenAIGatewayServiceRecordUsage_UsesRequestedModelAndUpstreamModelMetad
 	require.Equal(t, 1, userRepo.deductCalls)
 }
 
+func TestOpenAIGatewayServiceRecordUsage_PersistsImageUpstreamModelMismatch(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:             "img_model_mismatch",
+			Model:                 "gpt-image-2.5-flare",
+			UpstreamModel:         "gpt-image-2.5-flare",
+			UpstreamResponseModel: "gpt-image-2-codex",
+			ImageCount:            1,
+			ImageSize:             "4K",
+			Usage: OpenAIUsage{
+				InputTokens:       10,
+				OutputTokens:      20,
+				ImageOutputTokens: 30,
+			},
+			Duration: time.Second,
+		},
+		APIKey:  &APIKey{ID: 101},
+		User:    &User{ID: 201},
+		Account: &Account{ID: 301, Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModel)
+	require.Equal(t, "gpt-image-2.5-flare", *usageRepo.lastLog.UpstreamModel)
+	require.NotNil(t, usageRepo.lastLog.UpstreamResponseModel)
+	require.Equal(t, "gpt-image-2-codex", *usageRepo.lastLog.UpstreamResponseModel)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModelMismatch)
+	require.True(t, *usageRepo.lastLog.UpstreamModelMismatch)
+}
+
 func TestOpenAIGatewayServiceRecordUsage_PersistsRequestedReasoningEffort(t *testing.T) {
 	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
 	userRepo := &openAIRecordUsageUserRepoStub{}

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -575,7 +575,7 @@ func (s *OpenAIGatewayService) ForwardImages(
 	case AccountTypeAPIKey:
 		return s.forwardOpenAIImagesAPIKey(ctx, c, account, body, parsed, channelMappedModel)
 	case AccountTypeOAuth, AccountTypeSetupToken:
-		return s.forwardOpenAIImagesOAuth(ctx, c, account, parsed, channelMappedModel)
+		return s.forwardOpenAIImagesOAuthDirect(ctx, c, account, parsed, channelMappedModel)
 	default:
 		return nil, fmt.Errorf("unsupported account type: %s", account.Type)
 	}

--- a/backend/internal/service/openai_images_actual_size_test.go
+++ b/backend/internal/service/openai_images_actual_size_test.go
@@ -42,8 +42,9 @@ func TestDetectOpenAIImageResultSize(t *testing.T) {
 func TestOpenAIGatewayServiceForwardImages_OAuthUsesDecodedOutputDimensions(t *testing.T) {
 	run := runOpenAIOAuthImageActualSizeTest(t, false)
 
-	require.Equal(t, "3840x2160", gjson.GetBytes(run.upstream.lastBody, "tools.0.size").String())
-	require.Equal(t, "low", gjson.GetBytes(run.upstream.lastBody, "tools.0.quality").String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(run.upstream.lastBody, "model").String())
+	require.Equal(t, "3840x2160", gjson.GetBytes(run.upstream.lastBody, "size").String())
+	require.Equal(t, "low", gjson.GetBytes(run.upstream.lastBody, "quality").String())
 	require.Equal(t, "1672x941", gjson.Get(run.recorder.Body.String(), "size").String())
 	require.Equal(t, "auto", gjson.Get(run.recorder.Body.String(), "quality").String())
 	require.Equal(t, []string{"1672x941"}, run.result.ImageOutputSizes)

--- a/backend/internal/service/openai_images_codex_direct.go
+++ b/backend/internal/service/openai_images_codex_direct.go
@@ -1,0 +1,699 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/imroc/req/v3"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	openAICodexImagesGenerationsURL = "https://chatgpt.com/backend-api/codex/images/generations"
+	openAICodexImagesEditsURL       = "https://chatgpt.com/backend-api/codex/images/edits"
+	openAICodexImagesOriginator     = "codex-tui"
+)
+
+// forwardOpenAIImagesOAuthDirect keeps native image requests out of the
+// Responses image_generation bridge. The bridge is a text-oriented transport
+// and the Codex backend may silently replace native image controls there.
+func (s *OpenAIGatewayService) forwardOpenAIImagesOAuthDirect(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	parsed *OpenAIImagesRequest,
+	channelMappedModel string,
+) (*OpenAIForwardResult, error) {
+	startTime := time.Now()
+	beginUpstreamResponseModelObservation(c)
+
+	requestModel := strings.TrimSpace(parsed.Model)
+	if mapped := strings.TrimSpace(channelMappedModel); mapped != "" {
+		requestModel = mapped
+	}
+	if requestModel == "" {
+		requestModel = "gpt-image-2"
+	}
+	if err := validateOpenAIImagesModel(requestModel); err != nil {
+		return nil, err
+	}
+
+	targetEndpoint := openAICodexImagesGenerationsURL
+	if parsed.IsEdits() {
+		targetEndpoint = openAICodexImagesEditsURL
+	}
+	SetActualOpenAIUpstreamEndpoint(c, codexImagesEndpointPath(targetEndpoint))
+	SetOpsUpstreamModel(c, requestModel)
+	logger.LegacyPrintf(
+		"service.openai_gateway",
+		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s oauth_transport=codex_images uploads=%d",
+		requestModel,
+		parsed.Endpoint,
+		account.Type,
+		len(parsed.Uploads),
+	)
+
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	defer releaseUpstreamCtx()
+	upstreamCtx = withOpenAIImagesSelfBuiltRequest(upstreamCtx)
+
+	token, _, err := s.GetAccessToken(upstreamCtx, account)
+	if err != nil {
+		return nil, err
+	}
+	directBody, err := buildOpenAICodexImagesRequestBody(parsed, requestModel)
+	if err != nil {
+		return nil, err
+	}
+	upstreamReq, err := s.buildOpenAICodexImagesRequest(
+		upstreamCtx,
+		c,
+		account,
+		directBody,
+		token,
+		targetEndpoint,
+		parsed.StickySessionSeed(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	upstreamStart := time.Now()
+	resp, err := s.doOpenAIUpstream(upstreamReq, proxyURL, account)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			ProxyID:            opsUpstreamProxyID(account),
+			ProxyName:          opsUpstreamProxyName(account),
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("upstream returned an empty response")
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		respBody := s.readUpstreamErrorBody(resp)
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		if s.shouldFailoverOpenAIUpstreamResponse(account, resp.StatusCode, upstreamMsg, respBody) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				ProxyID:            opsUpstreamProxyID(account),
+				ProxyName:          opsUpstreamProxyName(account),
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp.StatusCode,
+				UpstreamRequestID:  resp.Header.Get("x-request-id"),
+				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
+			shouldDisable := s.handleFailoverSideEffects(upstreamCtx, resp, account, respBody, requestModel)
+			return nil, s.newOpenAIAccountFailoverError(
+				account,
+				resp.StatusCode,
+				resp.Header,
+				respBody,
+				upstreamMsg,
+				shouldDisable,
+				!shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			)
+		}
+		return s.handleOpenAIImagesErrorResponse(upstreamCtx, resp, c, account, requestModel)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	writerSizeBeforeResponse := OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c)
+	usage, imageCount, imageOutputSizes, firstTokenMs, err := s.handleOpenAICodexImagesResponse(
+		upstreamCtx,
+		resp,
+		c,
+		parsed,
+		requestModel,
+		upstreamReq.Header,
+		proxyURL,
+	)
+	if err != nil {
+		return nil, s.handleOpenAIImagesOAuthResponseError(
+			upstreamCtx,
+			c,
+			account,
+			requestModel,
+			safeUpstreamURL(upstreamReq.URL.String()),
+			resp,
+			writerSizeBeforeResponse,
+			err,
+		)
+	}
+	if imageCount <= 0 {
+		imageCount = parsed.N
+	}
+	return &OpenAIForwardResult{
+		RequestID:                     resp.Header.Get("x-request-id"),
+		UpstreamHeaders:               resp.Header.Clone(),
+		Usage:                         usage,
+		Model:                         requestModel,
+		UpstreamModel:                 requestModel,
+		UpstreamResponseModel:         observedUpstreamResponseModel(c),
+		UpstreamResponseModelConflict: observedUpstreamResponseModelConflict(c),
+		UpstreamEndpoint:              codexImagesEndpointPath(targetEndpoint),
+		Stream:                        parsed.Stream,
+		ResponseHeaders:               resp.Header.Clone(),
+		Duration:                      time.Since(startTime),
+		FirstTokenMs:                  firstTokenMs,
+		ImageCount:                    imageCount,
+		ImageSize:                     parsed.SizeTier,
+		ImageInputSize:                parsed.Size,
+		ImageOutputSizes:              imageOutputSizes,
+	}, nil
+}
+
+func codexImagesEndpointPath(endpoint string) string {
+	if parsed, err := http.NewRequest(http.MethodPost, endpoint, nil); err == nil && parsed.URL != nil {
+		return parsed.URL.Path
+	}
+	return endpoint
+}
+
+func buildOpenAICodexImagesRequestBody(parsed *OpenAIImagesRequest, imageModel string) ([]byte, error) {
+	if parsed == nil {
+		return nil, fmt.Errorf("parsed images request is required")
+	}
+	prompt := strings.TrimSpace(parsed.Prompt)
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	body := []byte(`{"model":"","prompt":"","n":1,"output_format":"png"}`)
+	body, _ = sjson.SetBytes(body, "model", strings.TrimSpace(imageModel))
+	body, _ = sjson.SetBytes(body, "prompt", prompt)
+	n := parsed.N
+	if n <= 0 {
+		n = 1
+	}
+	body, _ = sjson.SetBytes(body, "n", n)
+
+	outputFormat := strings.TrimSpace(parsed.OutputFormat)
+	if outputFormat == "" {
+		outputFormat = "png"
+	}
+	body, _ = sjson.SetBytes(body, "output_format", outputFormat)
+	for _, field := range []struct {
+		path  string
+		value string
+	}{
+		{path: "size", value: parsed.Size},
+		{path: "quality", value: parsed.Quality},
+		{path: "background", value: parsed.Background},
+		{path: "moderation", value: parsed.Moderation},
+	} {
+		if trimmed := strings.TrimSpace(field.value); trimmed != "" {
+			body, _ = sjson.SetBytes(body, field.path, trimmed)
+		}
+	}
+	if inputFidelity := strings.TrimSpace(parsed.InputFidelity); inputFidelity != "" &&
+		!strings.EqualFold(strings.TrimSpace(imageModel), "gpt-image-2") {
+		body, _ = sjson.SetBytes(body, "input_fidelity", inputFidelity)
+	}
+	if parsed.OutputCompression != nil {
+		body, _ = sjson.SetBytes(body, "output_compression", *parsed.OutputCompression)
+	}
+	if parsed.PartialImages != nil {
+		body, _ = sjson.SetBytes(body, "partial_images", *parsed.PartialImages)
+	}
+
+	if !parsed.IsEdits() {
+		return body, nil
+	}
+	inputImages := make([]string, 0, len(parsed.InputImageURLs)+len(parsed.Uploads))
+	for _, imageURL := range parsed.InputImageURLs {
+		if trimmed := strings.TrimSpace(imageURL); trimmed != "" {
+			inputImages = append(inputImages, trimmed)
+		}
+	}
+	for _, upload := range parsed.Uploads {
+		dataURL, err := openAIImageUploadToDataURL(upload)
+		if err != nil {
+			return nil, err
+		}
+		inputImages = append(inputImages, dataURL)
+	}
+	if len(inputImages) == 0 {
+		return nil, fmt.Errorf("image input is required")
+	}
+	body, _ = sjson.SetRawBytes(body, "images", []byte(`[]`))
+	for _, imageURL := range inputImages {
+		item := []byte(`{"image_url":""}`)
+		item, _ = sjson.SetBytes(item, "image_url", imageURL)
+		body, _ = sjson.SetRawBytes(body, "images.-1", item)
+	}
+
+	maskImageURL := strings.TrimSpace(parsed.MaskImageURL)
+	if parsed.MaskUpload != nil {
+		dataURL, err := openAIImageUploadToDataURL(*parsed.MaskUpload)
+		if err != nil {
+			return nil, err
+		}
+		maskImageURL = dataURL
+	}
+	if maskImageURL != "" {
+		mask := []byte(`{"image_url":""}`)
+		mask, _ = sjson.SetBytes(mask, "image_url", maskImageURL)
+		body, _ = sjson.SetRawBytes(body, "mask", mask)
+	}
+	return body, nil
+}
+
+func (s *OpenAIGatewayService) buildOpenAICodexImagesRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+	targetURL string,
+	sessionSeed string,
+) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	request = request.WithContext(WithHTTPUpstreamProfile(request.Context(), HTTPUpstreamProfileOpenAI))
+
+	authHeaders, err := s.buildOpenAIAuthenticationHeaders(ctx, account, token)
+	if err != nil {
+		return nil, fmt.Errorf("build openai authentication headers: %w", err)
+	}
+	for key, values := range authHeaders {
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+	request.Host = "chatgpt.com"
+	if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, request.Header, account); err != nil {
+		return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Connection", "Keep-Alive")
+	request.Header.Set("Originator", openAICodexImagesOriginator)
+	request.Header.Set("User-Agent", s.openAICodexImagesUserAgent(ctx, account))
+	request.Header.Set(
+		"Session_id",
+		generateSessionUUID(isolateOpenAIUpstreamSessionID(
+			getAPIKeyIDFromContext(c),
+			codexAccountIdentitySource(c, account),
+			sessionSeed,
+		)),
+	)
+	request.Header.Set("X-Client-Request-Id", uuid.NewString())
+	applyCodexAccountIdentityHeaders(request.Header, codexAccountIdentitySource(c, account), getAPIKeyIDFromContext(c))
+	enforceCodexIdentityHeadersWithUA(request.Header, s.codexIdentityOverrideUA(account))
+	setOpenAICodexRoutingHintFromBody(request.Header, account, body)
+	account.ApplyHeaderOverrides(request.Header)
+	return request, nil
+}
+
+func (s *OpenAIGatewayService) openAICodexImagesUserAgent(ctx context.Context, account *Account) string {
+	if customUA := strings.TrimSpace(account.GetOpenAIUserAgent()); customUA != "" {
+		return customUA
+	}
+	if s != nil && s.settingService != nil {
+		if configured := strings.TrimSpace(s.settingService.GetOpenAICodexUserAgent(ctx)); configured != "" {
+			return configured
+		}
+	}
+	return DefaultOpenAICodexUserAgent
+}
+
+func (s *OpenAIGatewayService) handleOpenAICodexImagesResponse(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	parsed *OpenAIImagesRequest,
+	fallbackModel string,
+	upstreamHeaders http.Header,
+	proxyURL string,
+) (OpenAIUsage, int, []string, *int, error) {
+	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	if openAICodexImagesLooksLikeSSE(resp, body) {
+		replay := *resp
+		replay.Body = io.NopCloser(bytes.NewReader(body))
+		if parsed.Stream {
+			return s.handleOpenAIImagesOAuthStreamingResponse(
+				&replay,
+				c,
+				time.Now(),
+				parsed.ResponseFormat,
+				openAIImagesStreamPrefix(parsed),
+				fallbackModel,
+			)
+		}
+		usage, count, sizes, err := s.handleOpenAIImagesOAuthNonStreamingResponse(
+			&replay,
+			c,
+			parsed.ResponseFormat,
+			fallbackModel,
+		)
+		return usage, count, sizes, nil, err
+	}
+
+	if upstreamErr := openAICodexImagesUpstreamErrorFromJSON(resp, body); upstreamErr != nil {
+		setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
+		if !IsOpenAIImagesRetryableUpstreamError(upstreamErr) {
+			writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+		}
+		return OpenAIUsage{}, 0, nil, nil, upstreamErr
+	}
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return OpenAIUsage{}, 0, nil, nil, fmt.Errorf("upstream returned invalid image JSON")
+	}
+
+	root := gjson.ParseBytes(body)
+	observeOpenAICodexImagesResponseModel(c, root)
+	fallbackMeta := openAIResponsesImageResult{
+		OutputFormat: strings.TrimSpace(parsed.OutputFormat),
+		Size:         strings.TrimSpace(parsed.Size),
+		Background:   strings.TrimSpace(parsed.Background),
+		Quality:      strings.TrimSpace(parsed.Quality),
+		Model:        strings.TrimSpace(fallbackModel),
+	}
+	if fallbackMeta.OutputFormat == "" {
+		fallbackMeta.OutputFormat = "png"
+	}
+	results, firstMeta, err := collectOpenAICodexImagesDirectJSON(ctx, upstreamHeaders, proxyURL, root, fallbackMeta)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	if len(results) == 0 {
+		return OpenAIUsage{}, 0, nil, nil, fmt.Errorf("upstream did not return image output")
+	}
+	firstMeta.Model = strings.TrimSpace(fallbackModel)
+	normalizeOpenAIResponsesImageClientModel(&firstMeta, fallbackModel)
+
+	usage, _ := extractOpenAIUsageFromJSONBytes(body)
+	var usageRaw []byte
+	if rawUsage := root.Get("usage"); rawUsage.Exists() && rawUsage.IsObject() {
+		usageRaw = []byte(rawUsage.Raw)
+	}
+	createdAt := root.Get("created").Int()
+	if createdAt <= 0 {
+		createdAt = root.Get("created_at").Int()
+	}
+	if parsed.Stream {
+		firstTokenMs, streamErr := s.writeOpenAICodexImagesSyntheticStreamResponse(
+			resp,
+			c,
+			parsed.ResponseFormat,
+			openAIImagesStreamPrefix(parsed),
+			results,
+			createdAt,
+			usageRaw,
+		)
+		return usage, len(results), openAIResponsesImageResultSizes(results), firstTokenMs, streamErr
+	}
+
+	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, parsed.ResponseFormat)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
+	return usage, len(results), openAIResponsesImageResultSizes(results), nil, nil
+}
+
+func openAICodexImagesLooksLikeSSE(resp *http.Response, body []byte) bool {
+	if resp != nil && isEventStreamResponse(resp.Header) {
+		return true
+	}
+	trimmed := bytes.TrimSpace(body)
+	return bytes.HasPrefix(trimmed, []byte("data:")) || bytes.Contains(trimmed, []byte("\ndata:"))
+}
+
+func observeOpenAICodexImagesResponseModel(c *gin.Context, root gjson.Result) {
+	model := strings.TrimSpace(root.Get("model").String())
+	if model == "" {
+		model = strings.TrimSpace(root.Get("response.model").String())
+	}
+	if model == "" {
+		model = strings.TrimSpace(root.Get("data.0.model").String())
+	}
+	if observer := upstreamResponseModelObserverFromContext(c); observer != nil {
+		observer.Observe(model, true)
+	}
+}
+
+func openAICodexImagesUpstreamErrorFromJSON(resp *http.Response, body []byte) *OpenAIImagesUpstreamError {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return nil
+	}
+	errorObj := gjson.GetBytes(body, "error")
+	if !errorObj.Exists() {
+		return nil
+	}
+	requestID := ""
+	if resp != nil {
+		requestID = strings.TrimSpace(resp.Header.Get("x-request-id"))
+	}
+	upstreamErr := openAIImagesUpstreamErrorFromGJSON(errorObj, requestID)
+	if upstreamErr != nil && upstreamErr.StatusCode < http.StatusBadRequest {
+		upstreamErr.StatusCode = http.StatusBadGateway
+	}
+	return upstreamErr
+}
+
+func collectOpenAICodexImagesDirectJSON(
+	ctx context.Context,
+	headers http.Header,
+	proxyURL string,
+	root gjson.Result,
+	fallbackMeta openAIResponsesImageResult,
+) ([]openAIResponsesImageResult, openAIResponsesImageResult, error) {
+	firstMeta := openAIResponsesImageResult{
+		OutputFormat: strings.TrimSpace(root.Get("output_format").String()),
+		Size:         strings.TrimSpace(root.Get("size").String()),
+		Background:   strings.TrimSpace(root.Get("background").String()),
+		Quality:      strings.TrimSpace(root.Get("quality").String()),
+		Model:        strings.TrimSpace(root.Get("model").String()),
+	}
+	fillOpenAICodexImagesMeta(&firstMeta, fallbackMeta)
+
+	var downloader *req.Client
+	results := make([]openAIResponsesImageResult, 0)
+	seen := make(map[string]struct{})
+	var collectErr error
+	appendItems := func(items gjson.Result) {
+		if !items.IsArray() || collectErr != nil {
+			return
+		}
+		for _, item := range items.Array() {
+			result, detectedFormat, err := openAICodexImagesResultB64FromItem(
+				ctx,
+				&downloader,
+				headers,
+				proxyURL,
+				item,
+			)
+			if err != nil {
+				collectErr = err
+				return
+			}
+			if result == "" {
+				continue
+			}
+			entry := openAIResponsesImageResult{
+				Result:        result,
+				RevisedPrompt: strings.TrimSpace(item.Get("revised_prompt").String()),
+				OutputFormat:  strings.TrimSpace(item.Get("output_format").String()),
+				Size:          strings.TrimSpace(item.Get("size").String()),
+				Background:    strings.TrimSpace(item.Get("background").String()),
+				Quality:       strings.TrimSpace(item.Get("quality").String()),
+				Model:         strings.TrimSpace(item.Get("model").String()),
+			}
+			if entry.OutputFormat == "" {
+				entry.OutputFormat = detectedFormat
+			}
+			fillOpenAICodexImagesMeta(&entry, firstMeta)
+			appendOpenAIResponsesImageResultDedup(&results, seen, "", entry)
+		}
+	}
+	appendItems(root.Get("data"))
+	appendItems(root.Get("output"))
+	appendItems(root.Get("response.output"))
+	if collectErr != nil {
+		return nil, openAIResponsesImageResult{}, collectErr
+	}
+	return results, firstMeta, nil
+}
+
+func fillOpenAICodexImagesMeta(dst *openAIResponsesImageResult, fallback openAIResponsesImageResult) {
+	if dst == nil {
+		return
+	}
+	if strings.TrimSpace(dst.OutputFormat) == "" {
+		dst.OutputFormat = strings.TrimSpace(fallback.OutputFormat)
+	}
+	if strings.TrimSpace(dst.Size) == "" {
+		dst.Size = strings.TrimSpace(fallback.Size)
+	}
+	if strings.TrimSpace(dst.Background) == "" {
+		dst.Background = strings.TrimSpace(fallback.Background)
+	}
+	if strings.TrimSpace(dst.Quality) == "" {
+		dst.Quality = strings.TrimSpace(fallback.Quality)
+	}
+	if strings.TrimSpace(dst.Model) == "" {
+		dst.Model = strings.TrimSpace(fallback.Model)
+	}
+}
+
+func (s *OpenAIGatewayService) writeOpenAICodexImagesSyntheticStreamResponse(
+	resp *http.Response,
+	c *gin.Context,
+	responseFormat string,
+	streamPrefix string,
+	results []openAIResponsesImageResult,
+	createdAt int64,
+	usageRaw []byte,
+) (*int, error) {
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Status(resp.StatusCode)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("streaming is not supported by response writer")
+	}
+	firstTokenMs := 0
+	eventName := streamPrefix + ".completed"
+	for _, img := range results {
+		payload := buildOpenAIImagesStreamCompletedPayload(eventName, img, responseFormat, createdAt, usageRaw)
+		if err := s.writeOpenAIImagesStreamEvent(c, flusher, eventName, payload); err != nil {
+			return &firstTokenMs, err
+		}
+	}
+	if _, err := io.WriteString(c.Writer, "data: [DONE]\n\n"); err != nil {
+		return &firstTokenMs, err
+	}
+	flusher.Flush()
+	return &firstTokenMs, nil
+}
+
+func openAICodexImagesResultB64FromItem(
+	ctx context.Context,
+	downloadClient **req.Client,
+	headers http.Header,
+	proxyURL string,
+	item gjson.Result,
+) (string, string, error) {
+	for _, path := range []string{"b64_json", "result"} {
+		if result := strings.TrimSpace(item.Get(path).String()); result != "" {
+			if b64, format := openAICodexImagesDataURLToB64(result); b64 != "" {
+				return b64, format, nil
+			}
+			return result, "", nil
+		}
+	}
+	for _, path := range []string{"url", "image_url"} {
+		value := strings.TrimSpace(item.Get(path).String())
+		if b64, format := openAICodexImagesDataURLToB64(value); b64 != "" {
+			return b64, format, nil
+		}
+		if !openAICodexImagesIsHTTPURL(value) {
+			continue
+		}
+		if downloadClient != nil && *downloadClient == nil {
+			client := req.C()
+			if trimmedProxy := strings.TrimSpace(proxyURL); trimmedProxy != "" {
+				client.SetProxyURL(trimmedProxy)
+			}
+			*downloadClient = client
+		}
+		if downloadClient == nil || *downloadClient == nil {
+			return "", "", fmt.Errorf("image URL downloader is unavailable")
+		}
+		imageBytes, err := downloadOpenAIImageBytes(ctx, *downloadClient, headers, value, openAIUpstreamErrorBodyReadLimit)
+		if err != nil {
+			return "", "", err
+		}
+		format := openAICodexImagesOutputFormatFromURL(value)
+		if format == "" {
+			detected := strings.ToLower(strings.TrimSpace(http.DetectContentType(imageBytes)))
+			if strings.HasPrefix(detected, "image/") {
+				format = strings.TrimPrefix(detected, "image/")
+			}
+		}
+		return base64.StdEncoding.EncodeToString(imageBytes), format, nil
+	}
+	return "", "", nil
+}
+
+func openAICodexImagesIsHTTPURL(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
+func openAICodexImagesOutputFormatFromURL(value string) string {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, suffix := range []struct {
+		needle string
+		format string
+	}{
+		{needle: ".png", format: "png"},
+		{needle: ".jpg", format: "jpeg"},
+		{needle: ".jpeg", format: "jpeg"},
+		{needle: ".webp", format: "webp"},
+	} {
+		if strings.Contains(lower, suffix.needle) {
+			return suffix.format
+		}
+	}
+	return ""
+}
+
+func openAICodexImagesDataURLToB64(value string) (string, string) {
+	if !strings.HasPrefix(strings.ToLower(value), "data:") {
+		return "", ""
+	}
+	comma := strings.Index(value, ",")
+	if comma < 0 {
+		return "", ""
+	}
+	meta := value[:comma]
+	if !strings.Contains(strings.ToLower(meta), ";base64") {
+		return "", ""
+	}
+	mimeType := strings.TrimPrefix(strings.Split(meta, ";")[0], "data:")
+	format := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "image/")
+	return strings.TrimSpace(value[comma+1:]), format
+}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -190,6 +189,21 @@ func mergeOpenAIResponsesImageMeta(dst *openAIResponsesImageResult, src openAIRe
 	}
 }
 
+func normalizeOpenAIResponsesImageClientModel(meta *openAIResponsesImageResult, requestedModel string) {
+	if meta == nil {
+		return
+	}
+	if requestedModel = strings.TrimSpace(requestedModel); requestedModel != "" {
+		meta.Model = requestedModel
+	}
+}
+
+func observeOpenAIResponsesImageModel(c *gin.Context, model string, terminal bool) {
+	if observer := upstreamResponseModelObserverFromContext(c); observer != nil {
+		observer.Observe(model, terminal)
+	}
+}
+
 func openAIResponsesImageResultSizes(results []openAIResponsesImageResult) []string {
 	if len(results) == 0 {
 		return nil
@@ -335,9 +349,10 @@ func openAIImageUploadToDataURL(upload OpenAIImagesUpload) (string, error) {
 	return "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(upload.Data), nil
 }
 
-// openAIImagesSelfBuiltRequestContextKey marks a request whose upstream body was
-// fully constructed by buildOpenAIImagesResponsesRequest, i.e. tool_choice and the
-// matching image_generation tool are always both present and never client-controlled.
+// openAIImagesSelfBuiltRequestContextKey marks a request whose image upstream
+// body was fully constructed by the gateway and is not client-controlled.
+// This covers both the legacy Responses bridge and the native Codex Images
+// transport, so capability-loss handling remains consistent across transports.
 type openAIImagesSelfBuiltRequestContextKey struct{}
 
 func withOpenAIImagesSelfBuiltRequest(ctx context.Context) context.Context {
@@ -1387,9 +1402,11 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 			RetryableOnSameAccount: true,
 		}
 	}
+	observeOpenAIResponsesImageModel(c, firstMeta.Model, true)
 	if strings.TrimSpace(firstMeta.Model) == "" {
 		firstMeta.Model = strings.TrimSpace(fallbackModel)
 	}
+	normalizeOpenAIResponsesImageClientModel(&firstMeta, fallbackModel)
 
 	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
 	if err != nil {
@@ -1464,7 +1481,10 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 			return
 		}
 		if meta, eventCreatedAt, ok := extractOpenAIResponsesImageMetaFromLifecycleEvent(dataBytes); ok {
+			eventType := gjson.GetBytes(dataBytes, "type").String()
+			observeOpenAIResponsesImageModel(c, meta.Model, eventType == "response.completed")
 			mergeOpenAIResponsesImageMeta(&streamMeta, meta)
+			normalizeOpenAIResponsesImageClientModel(&streamMeta, fallbackModel)
 			if eventCreatedAt > 0 {
 				createdAt = eventCreatedAt
 			}
@@ -1524,6 +1544,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 				return
 			}
 			mergeOpenAIResponsesImageMeta(&streamMeta, firstMeta)
+			normalizeOpenAIResponsesImageClientModel(&streamMeta, fallbackModel)
 			finalResults := make([]openAIResponsesImageResult, 0, len(results)+len(pendingResults))
 			finalSeen := make(map[string]struct{})
 			for _, img := range results {
@@ -1612,6 +1633,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 			finalResults := append([]openAIResponsesImageResult(nil), pendingResults...)
 			for i := range finalResults {
 				mergeOpenAIResponsesImageMeta(&finalResults[i], streamMeta)
+				normalizeOpenAIResponsesImageClientModel(&finalResults[i], fallbackModel)
 			}
 			reconcileOpenAIResponsesImageResultSizes(finalResults, nil)
 			for _, img := range finalResults {
@@ -1786,193 +1808,6 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 			lastDownstreamWriteAt = time.Now()
 		}
 	}
-}
-
-func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
-	ctx context.Context,
-	c *gin.Context,
-	account *Account,
-	parsed *OpenAIImagesRequest,
-	channelMappedModel string,
-) (*OpenAIForwardResult, error) {
-	startTime := time.Now()
-	requestModel := strings.TrimSpace(parsed.Model)
-	if mapped := strings.TrimSpace(channelMappedModel); mapped != "" {
-		requestModel = mapped
-	}
-	if requestModel == "" {
-		requestModel = "gpt-image-2"
-	}
-	if err := validateOpenAIImagesModel(requestModel); err != nil {
-		return nil, err
-	}
-	logger.LegacyPrintf(
-		"service.openai_gateway",
-		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s uploads=%d",
-		requestModel,
-		parsed.Endpoint,
-		account.Type,
-		len(parsed.Uploads),
-	)
-	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
-	defer releaseUpstreamCtx()
-
-	token, _, err := s.GetAccessToken(upstreamCtx, account)
-	if err != nil {
-		return nil, err
-	}
-
-	responsesBody, err := buildOpenAIImagesResponsesRequest(parsed, requestModel)
-	if err != nil {
-		return nil, err
-	}
-	upstreamCtx = withOpenAIImagesSelfBuiltRequest(upstreamCtx)
-	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, parsed.StickySessionSeed(), false)
-	if err != nil {
-		return nil, err
-	}
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	upstreamReq.Header.Set("Accept", "text/event-stream")
-	upstreamReq.Header.Set("OpenAI-Beta", "responses=experimental")
-
-	proxyURL := ""
-	if account.ProxyID != nil && account.Proxy != nil {
-		proxyURL = account.Proxy.URL()
-	}
-	upstreamStart := time.Now()
-	resp, err := s.doOpenAIUpstream(upstreamReq, proxyURL, account)
-	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
-	if err != nil {
-		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			ProxyID:            opsUpstreamProxyID(account),
-			ProxyName:          opsUpstreamProxyName(account),
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
-	}
-	if resp.StatusCode >= 400 {
-		respBody := s.readUpstreamErrorBody(resp)
-		_ = resp.Body.Close()
-		respBody = s.redactAgentIdentitySensitiveBody(upstreamCtx, account, respBody)
-		if !agentIdentityTaskRecoveryWasTried(ctx) && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, respBody) {
-			expectedTaskID := account.GetCredential("task_id")
-			if err := s.recoverAgentIdentityTask(ctx, account, expectedTaskID); err != nil {
-				return nil, fmt.Errorf("agent identity task recovery failed: %w", err)
-			}
-			return s.forwardOpenAIImagesOAuth(markAgentIdentityTaskRecoveryTried(ctx), c, account, parsed, channelMappedModel)
-		}
-		resp.Body = io.NopCloser(bytes.NewReader(respBody))
-		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
-		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
-		if s.shouldFailoverOpenAIUpstreamResponse(account, resp.StatusCode, upstreamMsg, respBody) {
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				ProxyID:            opsUpstreamProxyID(account),
-				ProxyName:          opsUpstreamProxyName(account),
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: resp.StatusCode,
-				UpstreamRequestID:  resp.Header.Get("x-request-id"),
-				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-				Kind:               "failover",
-				Message:            upstreamMsg,
-			})
-			shouldDisable := s.handleFailoverSideEffects(upstreamCtx, resp, account, respBody, requestModel)
-			return nil, s.newOpenAIAccountFailoverError(
-				account,
-				resp.StatusCode,
-				resp.Header,
-				respBody,
-				upstreamMsg,
-				shouldDisable,
-				!shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
-			)
-		}
-		return s.handleOpenAIImagesErrorResponse(upstreamCtx, resp, c, account, requestModel)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var (
-		usage            OpenAIUsage
-		imageCount       int
-		imageOutputSizes []string
-		firstTokenMs     *int
-	)
-	// 与 handleOpenAIImagesOAuthResponseError 的比较端同口径：排除非流式 JSON
-	// keepalive 心跳字节，避免 failover 第 2 轮起把上一轮心跳残留误判为已写响应。
-	writerSizeBeforeResponse := OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c)
-	if parsed.Stream {
-		usage, imageCount, imageOutputSizes, firstTokenMs, err = s.handleOpenAIImagesOAuthStreamingResponse(resp, c, startTime, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), requestModel)
-		if err != nil {
-			if imageCount > 0 {
-				return &OpenAIForwardResult{
-					RequestID:        resp.Header.Get("x-request-id"),
-					UpstreamHeaders:  resp.Header,
-					Usage:            usage,
-					Model:            requestModel,
-					UpstreamModel:    requestModel,
-					Stream:           parsed.Stream,
-					ResponseHeaders:  resp.Header.Clone(),
-					Duration:         time.Since(startTime),
-					FirstTokenMs:     firstTokenMs,
-					ImageCount:       imageCount,
-					ImageSize:        parsed.SizeTier,
-					ImageInputSize:   parsed.Size,
-					ImageOutputSizes: imageOutputSizes,
-				}, err
-			}
-			return nil, s.handleOpenAIImagesOAuthResponseError(
-				upstreamCtx,
-				c,
-				account,
-				requestModel,
-				safeUpstreamURL(upstreamReq.URL.String()),
-				resp,
-				writerSizeBeforeResponse,
-				err,
-			)
-		}
-	} else {
-		usage, imageCount, imageOutputSizes, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel)
-		if err != nil {
-			return nil, s.handleOpenAIImagesOAuthResponseError(
-				upstreamCtx,
-				c,
-				account,
-				requestModel,
-				safeUpstreamURL(upstreamReq.URL.String()),
-				resp,
-				writerSizeBeforeResponse,
-				err,
-			)
-		}
-	}
-	if imageCount <= 0 {
-		imageCount = parsed.N
-	}
-	return &OpenAIForwardResult{
-		RequestID:        resp.Header.Get("x-request-id"),
-		UpstreamHeaders:  resp.Header,
-		Usage:            usage,
-		Model:            requestModel,
-		UpstreamModel:    requestModel,
-		Stream:           parsed.Stream,
-		ResponseHeaders:  resp.Header.Clone(),
-		Duration:         time.Since(startTime),
-		FirstTokenMs:     firstTokenMs,
-		ImageCount:       imageCount,
-		ImageSize:        parsed.SizeTier,
-		ImageInputSize:   parsed.Size,
-		ImageOutputSizes: imageOutputSizes,
-	}, nil
 }
 
 const (

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -812,7 +812,7 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 				"X-Request-Id": []string{"req_img_123"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"usage\":{\"input_tokens\":11,\"output_tokens\":22,\"input_tokens_details\":{\"cached_tokens\":3},\"output_tokens_details\":{\"image_tokens\":7}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":3}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMQ==\",\"revised_prompt\":\"draw a cat 1\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMg==\",\"revised_prompt\":\"draw a cat 2\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMw==\",\"revised_prompt\":\"draw a cat 3\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2-codex\"}],\"usage\":{\"input_tokens\":11,\"output_tokens\":22,\"input_tokens_details\":{\"cached_tokens\":3},\"output_tokens_details\":{\"image_tokens\":7}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":3}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMQ==\",\"revised_prompt\":\"draw a cat 1\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMg==\",\"revised_prompt\":\"draw a cat 2\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMw==\",\"revised_prompt\":\"draw a cat 3\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
 					"data: [DONE]\n\n",
 			)),
 		},
@@ -835,29 +835,37 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.NotNil(t, result)
 	require.Equal(t, "gpt-image-2", result.Model)
 	require.Equal(t, "gpt-image-2", result.UpstreamModel)
+	require.Equal(t, "gpt-image-2-codex", result.UpstreamResponseModel)
+	require.False(t, result.UpstreamResponseModelConflict)
+	mismatch := upstreamModelMismatch(result.UpstreamModel, result.UpstreamResponseModel)
+	require.NotNil(t, mismatch)
+	require.True(t, *mismatch)
 	require.Equal(t, 3, result.ImageCount)
 	require.Equal(t, 46, result.Usage.InputTokens)
 	require.Equal(t, 2459, result.Usage.OutputTokens)
 	require.Equal(t, 2459, result.Usage.ImageOutputTokens)
 
 	require.NotNil(t, upstream.lastReq)
-	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
+	require.Equal(t, openAICodexImagesGenerationsURL, upstream.lastReq.URL.String())
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.lastReq.Context()))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
-	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
 	require.Equal(t, "acct-123", upstream.lastReq.Header.Get("chatgpt-account-id"))
-	require.Equal(t, "responses=experimental", upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Equal(t, openAICodexImagesOriginator, upstream.lastReq.Header.Get("Originator"))
+	require.Equal(t, DefaultOpenAICodexUserAgent, upstream.lastReq.Header.Get("User-Agent"))
+	require.NotEmpty(t, upstream.lastReq.Header.Get("Session_id"))
+	require.NotEmpty(t, upstream.lastReq.Header.Get("X-Client-Request-Id"))
+	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
 
-	require.Equal(t, openAIImagesResponsesMainModel, gjson.GetBytes(upstream.lastBody, "model").String())
-	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
-	require.Equal(t, "image_generation", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
-	require.Equal(t, "generate", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "tools.0.model").String())
-	require.Equal(t, "1024x1024", gjson.GetBytes(upstream.lastBody, "tools.0.size").String())
-	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "tools.0.quality").String())
-	require.Equal(t, int64(3), gjson.GetBytes(upstream.lastBody, "tools.0.n").Int())
-	require.Equal(t, "draw a cat", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "draw a cat", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.Equal(t, "1024x1024", gjson.GetBytes(upstream.lastBody, "size").String())
+	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "quality").String())
+	require.Equal(t, "png", gjson.GetBytes(upstream.lastBody, "output_format").String())
+	require.Equal(t, int64(3), gjson.GetBytes(upstream.lastBody, "n").Int())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "stream").Exists())
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "gpt-image-2", gjson.Get(rec.Body.String(), "model").String())
@@ -867,6 +875,89 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, "aW1hZ2UtMw==", gjson.Get(rec.Body.String(), "data.2.b64_json").String())
 	require.Equal(t, "draw a cat 1", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
 	require.Equal(t, "draw a cat 3", gjson.Get(rec.Body.String(), "data.2.revised_prompt").String())
+}
+
+func TestOpenAIImagesOAuthNonStreamingResponseUsesRequestedModelForSupportedImageModels(t *testing.T) {
+	for _, requestedModel := range []string{"gpt-image-1", "gpt-image-2", "gpt-image-2.5-flare"} {
+		t.Run(requestedModel, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body: io.NopCloser(strings.NewReader(
+					"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2-codex\"}],\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2U=\",\"output_format\":\"png\"}]}}\n\n" +
+						"data: [DONE]\n\n",
+				)),
+			}
+
+			svc := &OpenAIGatewayService{}
+			_, imageCount, _, err := svc.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, "b64_json", requestedModel)
+			require.NoError(t, err)
+			require.Equal(t, 1, imageCount)
+			require.Equal(t, requestedModel, gjson.Get(rec.Body.String(), "model").String())
+		})
+	}
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthDirectPreservesRequestedModelAndAuditsUpstreamModel(t *testing.T) {
+	for _, requestedModel := range []string{"gpt-image-1", "gpt-image-2", "gpt-image-2.5-flare"} {
+		t.Run(requestedModel, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			body := []byte(`{"model":"` + requestedModel + `","prompt":"draw a cat","size":"3840x2160","quality":"high"}`)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("api_key", &APIKey{ID: 91})
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Request-Id": []string{"req_img_model_audit"},
+				},
+				Body: io.NopCloser(strings.NewReader(
+					`{"created":1710000011,"model":"gpt-image-2-codex","size":"auto","quality":"auto","data":[{"b64_json":"aW1hZ2U=","size":"auto","quality":"auto"}]}`,
+				)),
+			}}
+			svc := &OpenAIGatewayService{httpUpstream: upstream}
+			parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+			require.NoError(t, err)
+
+			account := &Account{
+				ID:       91,
+				Name:     "openai-oauth",
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Credentials: map[string]any{
+					"access_token": "token-123",
+				},
+			}
+			result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			require.Equal(t, requestedModel, gjson.GetBytes(upstream.lastBody, "model").String())
+			require.Equal(t, "3840x2160", gjson.GetBytes(upstream.lastBody, "size").String())
+			require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "quality").String())
+			require.Equal(t, requestedModel, result.Model)
+			require.Equal(t, requestedModel, result.UpstreamModel)
+			require.Equal(t, "gpt-image-2-codex", result.UpstreamResponseModel)
+			require.Equal(t, openAICodexImagesGenerationsURL, upstream.lastReq.URL.String())
+			require.Equal(t, "/backend-api/codex/images/generations", result.UpstreamEndpoint)
+
+			mismatch := upstreamModelMismatch(result.UpstreamModel, result.UpstreamResponseModel)
+			require.NotNil(t, mismatch)
+			require.True(t, *mismatch)
+			require.Equal(t, requestedModel, gjson.Get(rec.Body.String(), "model").String())
+			require.Equal(t, "auto", gjson.Get(rec.Body.String(), "size").String())
+			require.Equal(t, "auto", gjson.Get(rec.Body.String(), "quality").String())
+		})
+	}
 }
 
 func TestParseOpenAIImagesSSEUsageBytes_ToolUsagePrecedenceAndFallback(t *testing.T) {
@@ -1677,9 +1768,9 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 				"X-Request-Id": []string{"req_img_stream"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000001,\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2\",\"background\":\"auto\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
+				"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000001,\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2-codex\",\"background\":\"auto\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
 					"data: {\"type\":\"response.image_generation_call.partial_image\",\"partial_image_b64\":\"cGFydGlhbA==\",\"partial_image_index\":0,\"output_format\":\"png\",\"background\":\"auto\"}\n\n" +
-					"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000001,\"usage\":{\"input_tokens\":5,\"output_tokens\":9,\"output_tokens_details\":{\"image_tokens\":4}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":1}},\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2\",\"background\":\"auto\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}],\"output\":[{\"type\":\"image_generation_call\",\"result\":\"ZmluYWw=\",\"output_format\":\"png\"}]}}\n\n" +
+					"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000001,\"usage\":{\"input_tokens\":5,\"output_tokens\":9,\"output_tokens_details\":{\"image_tokens\":4}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":1}},\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2-codex\",\"background\":\"auto\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}],\"output\":[{\"type\":\"image_generation_call\",\"result\":\"ZmluYWw=\",\"output_format\":\"png\"}]}}\n\n" +
 					"data: [DONE]\n\n",
 			)),
 		},
@@ -1701,6 +1792,8 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
 	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, "gpt-image-2-codex", result.UpstreamResponseModel)
+	require.False(t, result.UpstreamResponseModelConflict)
 	require.Equal(t, OpenAIUsage{InputTokens: 46, OutputTokens: 2459, ImageOutputTokens: 2459}, result.Usage)
 	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
 	partial, ok := findOpenAIImageTestSSEEvent(events, "image_generation.partial_image")
@@ -1785,7 +1878,7 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyStreamingDrainsAfterClientDisco
 	require.Equal(t, 2, result.Usage.ImageOutputTokens)
 }
 
-func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t *testing.T) {
+func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesCodexImagesAPI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var body bytes.Buffer
@@ -1829,12 +1922,11 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t
 		resp: &http.Response{
 			StatusCode: http.StatusOK,
 			Header: http.Header{
-				"Content-Type": []string{"text/event-stream"},
+				"Content-Type": []string{"application/json"},
 				"X-Request-Id": []string{"req_img_edit_123"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000002,\"usage\":{\"input_tokens\":13,\"output_tokens\":21,\"output_tokens_details\":{\"image_tokens\":8}},\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"ZWRpdGVk\",\"revised_prompt\":\"replace background with aurora\",\"output_format\":\"webp\",\"quality\":\"high\"}]}}\n\n" +
-					"data: [DONE]\n\n",
+				`{"created":1710000002,"model":"gpt-image-2","output_format":"webp","quality":"high","usage":{"input_tokens":13,"output_tokens":21,"output_tokens_details":{"image_tokens":8}},"data":[{"b64_json":"ZWRpdGVk","revised_prompt":"replace background with aurora","output_format":"webp","quality":"high"}]}`,
 			)),
 		},
 	}
@@ -1854,13 +1946,14 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 1, result.ImageCount)
-	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "tools.0.model").String())
-	require.Equal(t, "edit", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "tools.0.input_fidelity").Exists())
-	require.Equal(t, "webp", gjson.GetBytes(upstream.lastBody, "tools.0.output_format").String())
-	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "input.0.content.1.image_url").String(), "data:image/png;base64,"))
-	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "tools.0.input_image_mask.image_url").String(), "data:image/png;base64,"))
-	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, openAICodexImagesEditsURL, upstream.lastReq.URL.String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input_fidelity").Exists())
+	require.Equal(t, "webp", gjson.GetBytes(upstream.lastBody, "output_format").String())
+	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "images.0.image_url").String(), "data:image/png;base64,"))
+	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "mask.image_url").String(), "data:image/png;base64,"))
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
 	require.Equal(t, "ZWRpdGVk", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 	require.Equal(t, "replace background with aurora", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
 }
@@ -1890,13 +1983,10 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsStreamingTransformsEvents(t
 		resp: &http.Response{
 			StatusCode: http.StatusOK,
 			Header: http.Header{
-				"Content-Type": []string{"text/event-stream"},
+				"Content-Type": []string{"application/json"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000003,\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2\",\"background\":\"transparent\",\"output_format\":\"webp\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
-					"data: {\"type\":\"response.image_generation_call.partial_image\",\"partial_image_b64\":\"cGFydGlhbA==\",\"partial_image_index\":0,\"output_format\":\"webp\",\"background\":\"transparent\"}\n\n" +
-					"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000003,\"usage\":{\"input_tokens\":7,\"output_tokens\":10,\"output_tokens_details\":{\"image_tokens\":5}},\"tool_usage\":{\"image_gen\":{\"images\":1}},\"tools\":[{\"type\":\"image_generation\",\"model\":\"gpt-image-2\",\"background\":\"transparent\",\"output_format\":\"webp\",\"quality\":\"high\",\"size\":\"1024x1024\"}],\"output\":[{\"type\":\"image_generation_call\",\"result\":\"ZWRpdGVk\",\"revised_prompt\":\"replace background with aurora\",\"output_format\":\"webp\"}]}}\n\n" +
-					"data: [DONE]\n\n",
+				`{"created":1710000003,"model":"gpt-image-2","background":"transparent","output_format":"webp","quality":"high","size":"1024x1024","usage":{"input_tokens":7,"output_tokens":10,"output_tokens_details":{"image_tokens":5}},"data":[{"b64_json":"ZWRpdGVk","revised_prompt":"replace background with aurora","output_format":"webp","background":"transparent","quality":"high","size":"1024x1024"}]}`,
 			)),
 		},
 	}
@@ -1916,21 +2006,15 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsStreamingTransformsEvents(t
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 1, result.ImageCount)
-	require.Equal(t, "edit", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.Equal(t, "https://example.com/source.png", gjson.GetBytes(upstream.lastBody, "input.0.content.1.image_url").String())
-	require.Equal(t, "https://example.com/mask.png", gjson.GetBytes(upstream.lastBody, "tools.0.input_image_mask.image_url").String())
+	require.Equal(t, openAICodexImagesEditsURL, upstream.lastReq.URL.String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.Equal(t, "https://example.com/source.png", gjson.GetBytes(upstream.lastBody, "images.0.image_url").String())
+	require.Equal(t, "https://example.com/mask.png", gjson.GetBytes(upstream.lastBody, "mask.image_url").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
 	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
-	partial, ok := findOpenAIImageTestSSEEvent(events, "image_edit.partial_image")
-	require.True(t, ok)
-	require.Equal(t, "image_edit.partial_image", gjson.Get(partial.Data, "type").String())
-	require.Equal(t, int64(1710000003), gjson.Get(partial.Data, "created_at").Int())
-	require.Equal(t, "cGFydGlhbA==", gjson.Get(partial.Data, "b64_json").String())
-	require.Equal(t, "data:image/webp;base64,cGFydGlhbA==", gjson.Get(partial.Data, "url").String())
-	require.Equal(t, "gpt-image-2", gjson.Get(partial.Data, "model").String())
-	require.Equal(t, "webp", gjson.Get(partial.Data, "output_format").String())
-	require.Equal(t, "high", gjson.Get(partial.Data, "quality").String())
-	require.Equal(t, "1024x1024", gjson.Get(partial.Data, "size").String())
-	require.Equal(t, "transparent", gjson.Get(partial.Data, "background").String())
+	_, ok := findOpenAIImageTestSSEEvent(events, "image_edit.partial_image")
+	require.False(t, ok)
 
 	completed, ok := findOpenAIImageTestSSEEvent(events, "image_edit.completed")
 	require.True(t, ok)
@@ -1943,7 +2027,7 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsStreamingTransformsEvents(t
 	require.Equal(t, "high", gjson.Get(completed.Data, "quality").String())
 	require.Equal(t, "1024x1024", gjson.Get(completed.Data, "size").String())
 	require.Equal(t, "transparent", gjson.Get(completed.Data, "background").String())
-	require.JSONEq(t, `{"images":1}`, gjson.Get(completed.Data, "usage").Raw)
+	require.JSONEq(t, `{"input_tokens":7,"output_tokens":10,"output_tokens_details":{"image_tokens":5}}`, gjson.Get(completed.Data, "usage").Raw)
 	require.False(t, gjson.Get(completed.Data, "revised_prompt").Exists())
 }
 

--- a/backend/internal/service/openai_setup_token_compat_test.go
+++ b/backend/internal/service/openai_setup_token_compat_test.go
@@ -67,7 +67,7 @@ func TestOpenAIGatewayServiceGetAccessTokenSetupToken(t *testing.T) {
 	}
 }
 
-func TestOpenAISetupTokenImagesUsesOAuthResponsesPath(t *testing.T) {
+func TestOpenAISetupTokenImagesUsesCodexImagesPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
@@ -100,7 +100,7 @@ func TestOpenAISetupTokenImagesUsesOAuthResponsesPath(t *testing.T) {
 	require.Equal(t, http.StatusTooManyRequests, failoverErr.StatusCode)
 	require.True(t, failoverErr.RetryableOnSameAccount)
 	require.False(t, failoverErr.SameAccountRetryDeadline.IsZero())
-	require.Contains(t, upstream.lastReq.URL.String(), "/backend-api/codex/responses")
+	require.Contains(t, upstream.lastReq.URL.String(), "/backend-api/codex/images/generations")
 }
 
 func TestOpenAISetupTokenWSCompatibility(t *testing.T) {


### PR DESCRIPTION
## Summary

- Route OpenAI OAuth and Setup Token `/v1/images/generations` and `/v1/images/edits` requests through ChatGPT's dedicated Codex Images endpoints.
- Forward the requested image model and native image parameters without translating them into the Responses `image_generation` bridge.
- Keep the existing OpenAI Images API response shape, including JSON, SSE, multi-image, edit, URL-to-`b64_json`, and downstream streaming compatibility.
- Preserve the upstream response model separately from the model sent by the gateway, and mark mismatches in usage records.

## Motivation

The official `v0.2.4` release fixed the controller-side Image 2.5 model selection, but it did not fully resolve the OAuth/Codex execution path. The previous bridge could accept a request for `gpt-image-2.5-*` while the upstream lifecycle response reported `gpt-image-2-codex` with `auto` image parameters. That makes a successful HTTP response misleading and hides the actual executor from usage records.

The dedicated Codex Images transport sends, for example:

```json
{
  "model": "gpt-image-2.5-flare",
  "prompt": "...",
  "size": "3840x2160",
  "quality": "high",
  "n": 1
}
```

If the upstream still declares another processing model, the client-facing image response remains compatible while the usage record retains both values and sets `upstream_model_mismatch=true`.

## Scope

This PR fixes the dedicated `/v1/images/*` OAuth path covered by the related reports. Mixed `/v1/responses` requests continue to use Responses semantics; their image-tool routing remains a separate compatibility path and is intentionally not rewritten into an Images API response here.

## Validation

- `go test -tags=unit ./...`
- `git diff --check`
- Added regression coverage for `gpt-image-1`, `gpt-image-2`, and `gpt-image-2.5-flare`, including final usage-log persistence.

## Related Issues

Refs #3302
Refs #6905
Refs #6896