### PR TITLE
fix(openai): 修复 API Key 流内容量失败的冷却、粘性逃逸与收尾

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ FRONTEND_CRITICAL_VITEST := \
 	src/views/user/__tests__/ChannelStatusView.mode.spec.ts \
 	src/components/user/profile/__tests__/ProfileInfoCard.spec.ts \
 	src/views/admin/__tests__/SettingsView.spec.ts \
+	src/views/admin/settings/__tests__/OpenAIAPIKeyHealthSettings.spec.ts \
 	src/features/channel-monitor-v2/__tests__/designSystem.structure.spec.ts \
 	src/features/channel-monitor-v2/__tests__/monitorFormat.spec.ts \
 	src/features/channel-monitor-v2/__tests__/monitorZoom.spec.ts

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -184,7 +184,11 @@ func runMainServer() {
 
 	log.Println("Shutting down server...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownTimeout := time.Duration(cfg.Server.ShutdownTimeoutSeconds) * time.Second
+	if shutdownTimeout <= 0 {
+		shutdownTimeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	if err := app.Server.Shutdown(ctx); err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -678,12 +678,13 @@ type PricingConfig struct {
 type ServerConfig struct {
 	Host                     string    `mapstructure:"host"`
 	Port                     int       `mapstructure:"port"`
-	Mode                     string    `mapstructure:"mode"`                  // debug/release
-	EnableServerTiming       bool      `mapstructure:"enable_server_timing"`  // Admin UI Server-Timing response header
-	FrontendURL              string    `mapstructure:"frontend_url"`          // 前端基础 URL，用于生成邮件中的外部链接
-	ReadHeaderTimeout        int       `mapstructure:"read_header_timeout"`   // 读取请求头超时（秒）
-	MaxHeaderBytes           int       `mapstructure:"max_header_bytes"`      // 请求头最大字节数（HTTP/2 映射为 header-list 上限）
-	IdleTimeout              int       `mapstructure:"idle_timeout"`          // 空闲连接超时（秒）
+	Mode                     string    `mapstructure:"mode"`                 // debug/release
+	EnableServerTiming       bool      `mapstructure:"enable_server_timing"` // Admin UI Server-Timing response header
+	FrontendURL              string    `mapstructure:"frontend_url"`         // 前端基础 URL，用于生成邮件中的外部链接
+	ReadHeaderTimeout        int       `mapstructure:"read_header_timeout"`  // 读取请求头超时（秒）
+	MaxHeaderBytes           int       `mapstructure:"max_header_bytes"`     // 请求头最大字节数（HTTP/2 映射为 header-list 上限）
+	IdleTimeout              int       `mapstructure:"idle_timeout"`         // 空闲连接超时（秒）
+	ShutdownTimeoutSeconds   int       `mapstructure:"shutdown_timeout_seconds"`
 	TrustedProxies           []string  `mapstructure:"trusted_proxies"`       // 可信代理列表（CIDR/IP）
 	TrustedProxiesConfigured bool      `mapstructure:"-" json:"-" yaml:"-"`   // 是否显式配置了可信代理列表
 	MaxRequestBodySize       int64     `mapstructure:"max_request_body_size"` // 全局最大请求体限制
@@ -1998,6 +1999,7 @@ func setDefaults() {
 	viper.SetDefault("server.read_header_timeout", 10) // 10秒读取请求头
 	viper.SetDefault("server.max_header_bytes", 64*1024)
 	viper.SetDefault("server.idle_timeout", 120) // 120秒空闲超时
+	viper.SetDefault("server.shutdown_timeout_seconds", 5)
 	viper.SetDefault("server.max_request_body_size", int64(256*1024*1024))
 	// H2C 默认配置
 	viper.SetDefault("server.h2c.enabled", false)
@@ -2674,6 +2676,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Server.IdleTimeout <= 0 {
 		return fmt.Errorf("server.idle_timeout must be positive")
+	}
+	if c.Server.ShutdownTimeoutSeconds < 0 || c.Server.ShutdownTimeoutSeconds > 3600 {
+		return fmt.Errorf("server.shutdown_timeout_seconds must be between 0 and 3600")
 	}
 	if c.Server.MaxRequestBodySize < 0 {
 		return fmt.Errorf("server.max_request_body_size must be non-negative")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -79,6 +79,28 @@ func TestLoadServerTimingConfig(t *testing.T) {
 	})
 }
 
+func TestLoadServerShutdownTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		value   string
+		want    int
+		invalid bool
+	}{
+		{"", 5, false}, {"0", 0, false}, {"600", 600, false}, {"-1", 0, true}, {"3601", 0, true},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			resetViperWithJWTSecret(t)
+			t.Setenv("SERVER_SHUTDOWN_TIMEOUT_SECONDS", tc.value)
+			cfg, err := Load()
+			if tc.invalid {
+				require.ErrorContains(t, err, "server.shutdown_timeout_seconds")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, cfg.Server.ShutdownTimeoutSeconds)
+			}
+		})
+	}
+}
+
 func TestLoadRedisUsernameFromEnvironment(t *testing.T) {
 	resetViperWithJWTSecret(t)
 	t.Setenv("REDIS_USERNAME", "app-user")

--- a/backend/internal/handler/admin/setting_handler_openai_health_test.go
+++ b/backend/internal/handler/admin/setting_handler_openai_health_test.go
@@ -1,0 +1,62 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type openAIHealthSettingsRepo struct{ settingHandlerRepoStub }
+
+func (r *openAIHealthSettingsRepo) Set(_ context.Context, key, value string) error {
+	r.values[key] = value
+	return nil
+}
+
+func TestOpenAIHealthSettingsRoundTripAndValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &openAIHealthSettingsRepo{settingHandlerRepoStub{values: map[string]string{}}}
+	svc := service.NewSettingService(repo, &config.Config{})
+	handler := NewSettingHandler(svc, nil, nil, nil, nil, nil, nil)
+	router := gin.New()
+	router.GET("/health", handler.GetOpenAIAPIKeyHealthBreakerSettings)
+	router.PUT("/health", handler.UpdateOpenAIAPIKeyHealthBreakerSettings)
+	request := func(method, body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, "/health", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+	before := request(http.MethodGet, "")
+	require.Equal(t, http.StatusOK, before.Code)
+	require.False(t, gjson.GetBytes(before.Body.Bytes(), "data.enabled").Bool())
+	require.Empty(t, repo.values, "reading defaults must not enable the breaker")
+
+	updated := request(http.MethodPut, `{"enabled":true,"window_minutes":10,"failure_threshold":3,"cooldown_minutes":2}`)
+	require.Equal(t, http.StatusOK, updated.Code)
+	read := request(http.MethodGet, "")
+	require.True(t, gjson.GetBytes(read.Body.Bytes(), "data.enabled").Bool(), "saving must invalidate the cached disabled value")
+	require.Equal(t, int64(3), gjson.GetBytes(read.Body.Bytes(), "data.failure_threshold").Int())
+	stored := repo.values[service.SettingKeyOpenAIAPIKeyHealthBreakerSettings]
+	for _, body := range []string{
+		`{"enabled":true,"window_minutes":0,"failure_threshold":3,"cooldown_minutes":2}`,
+		`{"enabled":true,"window_minutes":10,"failure_threshold":10001,"cooldown_minutes":2}`,
+		`{"enabled":true,"window_minutes":10,"failure_threshold":3,"cooldown_minutes":61}`,
+		`{"enabled":"yes"}`,
+	} {
+		require.Equal(t, http.StatusBadRequest, request(http.MethodPut, body).Code)
+		require.Equal(t, stored, repo.values[service.SettingKeyOpenAIAPIKeyHealthBreakerSettings])
+	}
+	disabled := request(http.MethodPut, `{"enabled":false,"window_minutes":10,"failure_threshold":3,"cooldown_minutes":2}`)
+	require.Equal(t, http.StatusOK, disabled.Code)
+	require.False(t, gjson.GetBytes(disabled.Body.Bytes(), "data.enabled").Bool())
+}

--- a/backend/internal/handler/admin/setting_handler_runtime.go
+++ b/backend/internal/handler/admin/setting_handler_runtime.go
@@ -65,6 +65,29 @@ func (h *SettingHandler) GetOverloadCooldownSettings(c *gin.Context) {
 	})
 }
 
+func (h *SettingHandler) GetOpenAIAPIKeyHealthBreakerSettings(c *gin.Context) {
+	settings, err := h.settingService.GetOpenAIAPIKeyHealthBreakerSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, dto.OpenAIAPIKeyHealthBreakerSettings(*settings))
+}
+
+func (h *SettingHandler) UpdateOpenAIAPIKeyHealthBreakerSettings(c *gin.Context) {
+	var req dto.OpenAIAPIKeyHealthBreakerSettings
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	settings := service.OpenAIAPIKeyHealthBreakerSettings(req)
+	if err := h.settingService.SetOpenAIAPIKeyHealthBreakerSettings(c.Request.Context(), &settings); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+	h.GetOpenAIAPIKeyHealthBreakerSettings(c)
+}
+
 // UpdateOverloadCooldownSettingsRequest 更新529过载冷却配置请求
 type UpdateOverloadCooldownSettingsRequest struct {
 	Enabled         bool `json:"enabled"`

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -445,6 +445,13 @@ type OverloadCooldownSettings struct {
 	CooldownMinutes int  `json:"cooldown_minutes"`
 }
 
+type OpenAIAPIKeyHealthBreakerSettings struct {
+	Enabled          bool `json:"enabled"`
+	WindowMinutes    int  `json:"window_minutes"`
+	FailureThreshold int  `json:"failure_threshold"`
+	CooldownMinutes  int  `json:"cooldown_minutes"`
+}
+
 // RateLimit429CooldownSettings 429默认回避配置 DTO
 type RateLimit429CooldownSettings struct {
 	Enabled         bool `json:"enabled"`

--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -329,6 +329,8 @@ func needForceCacheBilling(hasBoundSession bool, failoverErr *service.UpstreamFa
 	return (hasBoundSession && !sameAccountRetry) || (failoverErr != nil && failoverErr.ForceCacheBilling)
 }
 
+const opsClientDisconnectedKey = "ops_client_disconnected"
+
 // failoverClientGone 判断下游客户端是否已断开（请求 context 已取消）。
 // 客户端断开后 failover 必须静默终止：用已取消的 context 重新选号只会得到
 // context.Canceled，并被误报成账号耗尽（通用 502）；上游 detach 的在途请求
@@ -338,6 +340,7 @@ func failoverClientGone(c *gin.Context) bool {
 	if c == nil || c.Request == nil || c.Request.Context().Err() == nil {
 		return false
 	}
+	c.Set(opsClientDisconnectedKey, true)
 	// 先停 compact 心跳（接管 ResponseWriter，建立 happens-before），与
 	// handleStreamingAwareError/errorResponse 等终结路径对齐，避免心跳
 	// goroutine 与下面的状态标记并发触碰同一 writer。心跳已提交 200 时

--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -102,6 +102,11 @@ func sameAccountRetryAllowed(failoverErr *service.UpstreamFailoverError, retryCo
 	return retryLimit > 0 && retryCount < retryLimit
 }
 
+func shouldReportOpenAIFailoverAttempt(account *service.Account, err *service.UpstreamFailoverError, retryCount int) bool {
+	return err != nil && err.ShouldReportAccountScheduleFailure() &&
+		(!err.ShouldRetryNextAccount() || !sameAccountRetryAllowed(err, retryCount, effectiveSameAccountRetryLimit(err, account)))
+}
+
 // sameAccountRetryDeadlineAllows prevents a retry from starting after the
 // service-provided same-account retry window has elapsed.
 func sameAccountRetryDeadlineAllows(failoverErr *service.UpstreamFailoverError) bool {

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -204,8 +204,8 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			return
 		}
 
-		h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, requestedModel, false, result), false, nil, err)
 		if c.Writer.Size() != writerSizeBeforeForward {
+			h.gatewayService.ObserveOpenAIAccountHealthFailure(c.Request.Context(), account, err)
 			h.handleFailoverExhausted(c, failoverErr, true)
 			return
 		}
@@ -236,6 +236,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 				continue
 			}
 		}
+		h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, requestedModel, false, result), false, nil, err)
 		h.gatewayService.RecordOpenAIAccountSwitch()
 		failedAccountIDs[account.ID] = struct{}{}
 		lastFailoverErr = failoverErr

--- a/backend/internal/handler/openai_capacity_recovery_test.go
+++ b/backend/internal/handler/openai_capacity_recovery_test.go
@@ -98,8 +98,9 @@ func (b *capacityHandlerBody) Close() error {
 
 type capacityHandlerUpstream struct {
 	service.HTTPUpstream
-	mode  string
-	calls []int64
+	mode       string
+	calls      []int64
+	failedBody *capacityHandlerBody
 }
 
 func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
@@ -109,16 +110,21 @@ func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64,
 		resp.Body = io.NopCloser(strings.NewReader(capacityHandlerSuccess))
 		return resp, nil
 	}
-	if u.mode != "post_output" {
+	if u.mode != "post_output" && u.mode != "keepalive" {
 		resp.Body = io.NopCloser(strings.NewReader(capacityHandlerError))
 		return resp, nil
 	}
 	reader, writer := io.Pipe()
 	body := &capacityHandlerBody{PipeReader: reader, closed: make(chan struct{})}
+	u.failedBody = body
 	resp.Body = body
 	go func() {
 		defer writer.Close()
-		_, _ = io.WriteString(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"+capacityHandlerError)
+		preamble := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_attempt\"}}\n\ndata: {\"type\":\"keepalive\"}\n\n"
+		if u.mode == "post_output" {
+			preamble += "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"
+		}
+		_, _ = io.WriteString(writer, preamble+capacityHandlerError)
 		<-body.closed
 	}()
 	return resp, nil
@@ -164,6 +170,28 @@ func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (
 		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg), nil, nil, nil, nil, cfg)
 	handler.maxAccountSwitches = 2
 	return handler, upstream, repo, cache, health
+}
+
+func TestOpenAICapacityKeepaliveFailsOverWithinRequest(t *testing.T) {
+	handler, upstream, repo, slots, health := newCapacityRecoveryHandler(t, "keepalive", true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, rec := newOpenAIResponsesFailoverTestContext(t, ctx)
+	c.Request.Body = io.NopCloser(strings.NewReader(`{"model":"gpt-5.1","stream":true,"input":"hello"}`))
+	c.Request.Header.Set("session_id", "same-session")
+	handler.Responses(c)
+	require.Equal(t, []int64{1, 2}, upstream.calls, "heartbeat-only failure must switch before returning to the client")
+	require.False(t, repo.accounts[0].IsSchedulableForModelWithContext(context.Background(), "gpt-5.1"))
+	require.Zero(t, health.calls)
+	require.Equal(t, int32(2), atomic.LoadInt32(&slots.releaseAccountCalled))
+	require.Contains(t, rec.Body.String(), "response_ok")
+	require.NotContains(t, rec.Body.String(), "resp_attempt", "failed attempt preamble must remain private")
+	require.NotContains(t, rec.Body.String(), "overloaded")
+	select {
+	case <-upstream.failedBody.closed:
+	default:
+		t.Fatal("failed upstream connection was not closed")
+	}
 }
 
 func TestOpenAICapacityClientReconnectAvoidsCooledStickyAccount(t *testing.T) {

--- a/backend/internal/handler/openai_capacity_recovery_test.go
+++ b/backend/internal/handler/openai_capacity_recovery_test.go
@@ -13,7 +13,11 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/repository"
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,6 +71,8 @@ func (u *capacityHandlerUsage) Create(context.Context, *service.UsageLog) (bool,
 
 type capacityHandlerSettings struct{ service.SettingRepository }
 
+func (*capacityHandlerSettings) SetMultiple(context.Context, map[string]string) error { return nil }
+
 func (*capacityHandlerSettings) GetValue(context.Context, string) (string, error) {
 	return `{"enabled":true,"window_minutes":10,"failure_threshold":100,"cooldown_minutes":2}`, nil
 }
@@ -101,11 +107,19 @@ type capacityHandlerUpstream struct {
 	mode       string
 	calls      []int64
 	failedBody *capacityHandlerBody
+	onError    func()
 }
 
 func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
 	u.calls = append(u.calls, accountID)
 	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"text/event-stream"}}}
+	if u.mode == "canceled_524" || u.mode == "canceled_only" {
+		u.onError()
+		if u.mode == "canceled_only" {
+			return nil, context.Canceled
+		}
+		return &http.Response{StatusCode: 524, Header: http.Header{"Content-Type": []string{"text/html"}}, Body: io.NopCloser(strings.NewReader("error code: 524"))}, nil
+	}
 	if u.mode == "healthy" || (accountID == 2 && u.mode != "all_failed") {
 		resp.Body = io.NopCloser(strings.NewReader(capacityHandlerSuccess))
 		return resp, nil
@@ -130,10 +144,31 @@ func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64,
 	return resp, nil
 }
 
-func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (*OpenAIGatewayHandler, *capacityHandlerUpstream, *capacityHandlerRepo, *concurrencyCacheMock, *capacityHandlerHealth) {
+func TestOpenAICapacityCanceledRequestStillObservesConfirmedFailure(t *testing.T) {
+	for _, mode := range []string{"canceled_524", "canceled_only"} {
+		t.Run(mode, func(t *testing.T) {
+			handler, upstream, _, slots, health := newCapacityRecoveryHandler(t, mode, false)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			upstream.onError = cancel
+			c, _ := newOpenAIResponsesFailoverTestContext(t, ctx)
+			handler.Responses(c)
+			require.Equal(t, []int64{1}, upstream.calls, "never replay after cancellation")
+			require.Equal(t, int32(1), atomic.LoadInt32(&slots.releaseAccountCalled))
+			if mode == "canceled_524" {
+				require.Equal(t, 1, health.calls, "confirmed upstream failure must be observed exactly once")
+			} else {
+				require.Zero(t, health.calls, "client cancellation is not an account failure")
+			}
+		})
+	}
+}
+
+func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool, stickyCache ...service.GatewayCache) (*OpenAIGatewayHandler, *capacityHandlerUpstream, *capacityHandlerRepo, *concurrencyCacheMock, *capacityHandlerHealth) {
 	t.Helper()
 	repo := &capacityHandlerRepo{changed: make(chan struct{}, 4)}
 	for i := int64(1); i <= 2; i++ {
+		rate := 0.2
 		credentials := map[string]any{"api_key": "test-only", "pool_mode": true, "pool_mode_retry_count": float64(2)}
 		if explicitRules {
 			credentials["temp_unschedulable_enabled"] = true
@@ -144,7 +179,7 @@ func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (
 		repo.accounts = append(repo.accounts, service.Account{
 			ID: i, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey,
 			Status: service.StatusActive, Schedulable: true, Concurrency: 1, Priority: int(i),
-			Credentials: credentials, GroupIDs: []int64{3131},
+			Credentials: credentials, GroupIDs: []int64{3131}, RateMultiplier: &rate,
 		})
 	}
 	cfg := &config.Config{RunMode: config.RunModeSimple}
@@ -161,8 +196,12 @@ func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (
 	upstream := &capacityHandlerUpstream{mode: mode}
 	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
 	t.Cleanup(billingCache.Stop)
+	var sticky service.GatewayCache = &capacityHandlerSticky{}
+	if len(stickyCache) > 0 {
+		sticky = stickyCache[0]
+	}
 	gateway := service.NewOpenAIGatewayService(
-		repo, &capacityHandlerUsage{}, nil, nil, nil, nil, &capacityHandlerSticky{}, cfg, nil, concurrency,
+		repo, &capacityHandlerUsage{}, nil, nil, nil, nil, sticky, cfg, nil, concurrency,
 		service.NewBillingService(cfg, nil), rateLimit, billingCache, upstream,
 		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
 	)
@@ -170,6 +209,42 @@ func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (
 		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg), nil, nil, nil, nil, cfg)
 	handler.maxAccountSwitches = 2
 	return handler, upstream, repo, cache, health
+}
+
+func TestOpenAIStickySuccessHandlerFailureRecoveryAndNextRequest(t *testing.T) {
+	settings := service.NewSettingService(&capacityHandlerSettings{}, &config.Config{})
+	require.NoError(t, settings.UpdateSettings(context.Background(), &service.SystemSettings{
+		OpenAIAdvancedSchedulerEnabled: true, OpenAIAdvancedSchedulerStickyWeightedEnabled: true,
+	}))
+	t.Cleanup(func() { require.NoError(t, settings.UpdateSettings(context.Background(), &service.SystemSettings{})) })
+	r := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: r.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	cache := repository.NewGatewayCache(client)
+	handler, upstream, repo, _, _ := newCapacityRecoveryHandler(t, "keepalive", true, cache)
+	group := &service.Group{ID: 3131, Hydrated: true, Status: service.StatusActive, Platform: service.PlatformOpenAI, RateMultiplier: 1, ProfitControlEnabled: true, ProfitMinMargin: 0.5}
+	ctx := context.WithValue(context.Background(), ctxkey.Group, group)
+	first, rec := newOpenAIResponsesFailoverTestContext(t, ctx)
+	first.Request.Header.Set("session_id", "success-session")
+	first.Request.Body = io.NopCloser(strings.NewReader(`{"model":"gpt-5.1","stream":true,"input":"hello"}`))
+	sessionHash := handler.gatewayService.GenerateSessionHash(first, nil)
+	require.NoError(t, cache.SetSessionAccountID(ctx, group.ID, "openai:"+sessionHash, 1, time.Hour))
+	handler.Responses(first)
+	require.Equal(t, []int64{1, 2}, upstream.calls)
+	require.Contains(t, rec.Body.String(), "response_ok")
+	successCache, ok := cache.(service.OpenAIStickySuccessCache)
+	require.True(t, ok)
+	preference, err := successCache.GetOpenAIStickySuccess(ctx, group.ID, sessionHash, "gpt-5.1")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), preference.AccountID)
+	// The old account has recovered. It must not reclaim this model's affinity.
+	repo.accounts[0].Extra = nil
+	upstream.mode = "healthy"
+	next, nextRec := newOpenAIResponsesFailoverTestContext(t, ctx)
+	next.Request.Header.Set("session_id", "success-session")
+	handler.Responses(next)
+	require.Equal(t, []int64{1, 2, 2}, upstream.calls)
+	require.Contains(t, nextRec.Body.String(), "response_ok")
 }
 
 func TestOpenAICapacityKeepaliveFailsOverWithinRequest(t *testing.T) {

--- a/backend/internal/handler/openai_capacity_recovery_test.go
+++ b/backend/internal/handler/openai_capacity_recovery_test.go
@@ -120,7 +120,7 @@ func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64,
 	resp.Body = body
 	go func() {
 		defer writer.Close()
-		preamble := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_attempt\"}}\n\ndata: {\"type\":\"keepalive\"}\n\n"
+		preamble := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_attempt\"}}\n\ndata: {\"type\":\"keepalive\",\"sequence_number\":1}\n\n"
 		if u.mode == "post_output" {
 			preamble += "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"
 		}

--- a/backend/internal/handler/openai_capacity_recovery_test.go
+++ b/backend/internal/handler/openai_capacity_recovery_test.go
@@ -1,0 +1,232 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+const capacityHandlerError = "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",\"type\":\"service_unavailable_error\",\"message\":\"Our servers are currently overloaded. Please try again later.\"}}\n\n"
+const capacityHandlerSuccess = "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"response_ok\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+
+type capacityHandlerRepo struct {
+	openAIImagesFailoverAccountRepo
+	changed chan struct{}
+}
+
+func (r *capacityHandlerRepo) SetModelRateLimit(_ context.Context, id int64, model string, until time.Time, reason ...string) error {
+	for i := range r.accounts {
+		if r.accounts[i].ID == id {
+			r.accounts[i].Extra = map[string]any{"model_rate_limits": map[string]any{
+				model: map[string]any{"rate_limit_reset_at": until.UTC().Format(time.RFC3339)},
+			}}
+		}
+	}
+	select {
+	case r.changed <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+type capacityHandlerSticky struct{ service.GatewayCache }
+
+func (*capacityHandlerSticky) GetSessionAccountID(context.Context, int64, string) (int64, error) {
+	return 1, nil
+}
+func (*capacityHandlerSticky) SetSessionAccountID(context.Context, int64, string, int64, time.Duration) error {
+	return nil
+}
+func (*capacityHandlerSticky) RefreshSessionTTL(context.Context, int64, string, time.Duration) error {
+	return nil
+}
+func (*capacityHandlerSticky) DeleteSessionAccountID(context.Context, int64, string) error {
+	return nil
+}
+
+type capacityHandlerUsage struct {
+	service.UsageLogRepository
+	calls int
+}
+
+func (u *capacityHandlerUsage) Create(context.Context, *service.UsageLog) (bool, error) {
+	u.calls++
+	return true, nil
+}
+
+type capacityHandlerSettings struct{ service.SettingRepository }
+
+func (*capacityHandlerSettings) GetValue(context.Context, string) (string, error) {
+	return `{"enabled":true,"window_minutes":10,"failure_threshold":100,"cooldown_minutes":2}`, nil
+}
+
+func (*capacityHandlerSettings) GetMultiple(context.Context, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+type capacityHandlerHealth struct {
+	service.TempUnschedCache
+	calls int
+}
+
+func (h *capacityHandlerHealth) RecordOpenAIAPIKeyHealthFailure(context.Context, int64, int, int) (int64, bool, error) {
+	h.calls++
+	return int64(h.calls), false, nil
+}
+
+type capacityHandlerBody struct {
+	*io.PipeReader
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (b *capacityHandlerBody) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return b.PipeReader.Close()
+}
+
+type capacityHandlerUpstream struct {
+	service.HTTPUpstream
+	mode  string
+	calls []int64
+}
+
+func (u *capacityHandlerUpstream) Do(_ *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
+	u.calls = append(u.calls, accountID)
+	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"text/event-stream"}}}
+	if u.mode == "healthy" || (accountID == 2 && u.mode != "all_failed") {
+		resp.Body = io.NopCloser(strings.NewReader(capacityHandlerSuccess))
+		return resp, nil
+	}
+	if u.mode != "post_output" {
+		resp.Body = io.NopCloser(strings.NewReader(capacityHandlerError))
+		return resp, nil
+	}
+	reader, writer := io.Pipe()
+	body := &capacityHandlerBody{PipeReader: reader, closed: make(chan struct{})}
+	resp.Body = body
+	go func() {
+		defer writer.Close()
+		_, _ = io.WriteString(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"+capacityHandlerError)
+		<-body.closed
+	}()
+	return resp, nil
+}
+
+func newCapacityRecoveryHandler(t *testing.T, mode string, explicitRules bool) (*OpenAIGatewayHandler, *capacityHandlerUpstream, *capacityHandlerRepo, *concurrencyCacheMock, *capacityHandlerHealth) {
+	t.Helper()
+	repo := &capacityHandlerRepo{changed: make(chan struct{}, 4)}
+	for i := int64(1); i <= 2; i++ {
+		credentials := map[string]any{"api_key": "test-only", "pool_mode": true, "pool_mode_retry_count": float64(2)}
+		if explicitRules {
+			credentials["temp_unschedulable_enabled"] = true
+			credentials["temp_unschedulable_rules"] = []any{map[string]any{
+				"error_code": float64(503), "keywords": []any{"overloaded"}, "duration_minutes": float64(2),
+			}}
+		}
+		repo.accounts = append(repo.accounts, service.Account{
+			ID: i, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey,
+			Status: service.StatusActive, Schedulable: true, Concurrency: 1, Priority: int(i),
+			Credentials: credentials, GroupIDs: []int64{3131},
+		})
+	}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Gateway.StreamDataIntervalTimeout = 180
+	cache := &concurrencyCacheMock{
+		acquireAccountSlotFn: func(context.Context, int64, int, string) (bool, error) { return true, nil },
+		acquireUserSlotFn:    func(context.Context, int64, int, string) (bool, error) { return true, nil },
+	}
+	concurrency := service.NewConcurrencyService(cache)
+	health := &capacityHandlerHealth{}
+	rateLimit := service.NewRateLimitService(repo, nil, cfg, nil, nil)
+	rateLimit.SetSettingService(service.NewSettingService(&capacityHandlerSettings{}, cfg))
+	rateLimit.SetOpenAIAPIKeyHealthCache(health)
+	upstream := &capacityHandlerUpstream{mode: mode}
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		repo, &capacityHandlerUsage{}, nil, nil, nil, nil, &capacityHandlerSticky{}, cfg, nil, concurrency,
+		service.NewBillingService(cfg, nil), rateLimit, billingCache, upstream,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	handler := NewOpenAIGatewayHandler(gateway, concurrency, billingCache,
+		service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg), nil, nil, nil, nil, cfg)
+	handler.maxAccountSwitches = 2
+	return handler, upstream, repo, cache, health
+}
+
+func TestOpenAICapacityClientReconnectAvoidsCooledStickyAccount(t *testing.T) {
+	handler, upstream, repo, slots, health := newCapacityRecoveryHandler(t, "post_output", true)
+	c, rec := newOpenAIResponsesFailoverTestContext(t, nil)
+	c.Request.Body = io.NopCloser(strings.NewReader(`{"model":"gpt-5.1","stream":true,"input":"hello"}`))
+	c.Request.Header.Set("session_id", "same-session")
+	started := time.Now()
+	done := make(chan struct{})
+	go func() { defer close(done); handler.Responses(c) }()
+	select {
+	case <-repo.changed:
+	case <-done:
+		t.Fatalf("request ended before cooling: status=%d body=%s", rec.Code, rec.Body.String())
+	case <-time.After(3 * time.Second):
+		t.Fatal("capacity observation did not reach account policy")
+	}
+	require.Equal(t, []int64{1}, upstream.calls)
+	require.False(t, repo.accounts[0].IsSchedulableForModelWithContext(context.Background(), "gpt-5.1"))
+	require.Zero(t, health.calls, "an explicit rule must not also count towards whole-account health")
+	require.Zero(t, atomic.LoadInt32(&slots.releaseAccountCalled), "slot is held only for bounded usage collection")
+	<-done
+	require.Less(t, time.Since(started), 5*time.Second)
+	require.Equal(t, int32(1), atomic.LoadInt32(&slots.releaseAccountCalled))
+	require.Contains(t, rec.Body.String(), "partial")
+	require.NotContains(t, rec.Body.String(), "response_ok", "committed stream must not replay")
+
+	retry, retryRec := newOpenAIResponsesFailoverTestContext(t, nil)
+	retry.Request.Header.Set("session_id", "same-session")
+	handler.Responses(retry)
+	require.Equal(t, []int64{1, 2}, upstream.calls, "even a stale sticky cache returning account 1 must not bypass cooling")
+	require.Contains(t, retryRec.Body.String(), "response_ok")
+	require.Equal(t, int32(2), atomic.LoadInt32(&slots.releaseAccountCalled))
+}
+
+func TestOpenAICapacityPoolExhaustionAndRecovery(t *testing.T) {
+	handler, upstream, repo, slots, _ := newCapacityRecoveryHandler(t, "all_failed", true)
+	c, _ := newOpenAIResponsesFailoverTestContext(t, nil)
+	handler.Responses(c)
+	require.Equal(t, []int64{1, 2}, upstream.calls, "explicit rules bypass same-account retries")
+	require.Equal(t, int32(2), atomic.LoadInt32(&slots.releaseAccountCalled))
+	retry, _ := newOpenAIResponsesFailoverTestContext(t, nil)
+	handler.Responses(retry)
+	require.Equal(t, []int64{1, 2}, upstream.calls, "all-cooled pool must not revive candidates")
+	for i := range repo.accounts {
+		repo.accounts[i].Extra["model_rate_limits"] = map[string]any{
+			"gpt-5.1": map[string]any{"rate_limit_reset_at": time.Now().Add(-time.Second).UTC().Format(time.RFC3339)},
+		}
+	}
+	upstream.mode = "healthy"
+	// Administrative suspension remains effective after capacity cooldown expiry.
+	repo.accounts[0].Schedulable = false
+	recovered, rec := newOpenAIResponsesFailoverTestContext(t, nil)
+	handler.Responses(recovered)
+	require.Equal(t, []int64{1, 2, 2}, upstream.calls)
+	require.Contains(t, rec.Body.String(), "response_ok")
+}
+
+func TestOpenAICapacitySameAccountRetryHealthIsTerminal(t *testing.T) {
+	handler, upstream, _, _, health := newCapacityRecoveryHandler(t, "pre_output", false)
+	c, rec := newOpenAIResponsesFailoverTestContext(t, nil)
+	handler.Responses(c)
+	require.Equal(t, []int64{1, 1, 1, 2}, upstream.calls)
+	require.Equal(t, 1, health.calls, "two retries plus the original attempt count as one terminal account failure")
+	require.Contains(t, rec.Body.String(), "response_ok")
+}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -330,7 +330,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 						h.handleFailoverExhausted(c, failoverErr, true)
 						return
 					}
-					if failoverErr.ShouldReportAccountScheduleFailure() {
+					if shouldReportOpenAIFailoverAttempt(account, failoverErr, sameAccountRetryCount[account.ID]) {
 						h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, reqModel, false, nil), false, nil, err)
 					}
 					if !failoverErr.ShouldRetryNextAccount() {

--- a/backend/internal/handler/openai_gateway_first_output_timeout_test.go
+++ b/backend/internal/handler/openai_gateway_first_output_timeout_test.go
@@ -49,3 +49,17 @@ func TestOpenAIRequestAllowsFailoverReplayStopsCanceledClient(t *testing.T) {
 	cancel()
 	require.False(t, openAIRequestAllowsFailoverReplay(c))
 }
+
+func TestOpenAICapacityFailoverAttemptCountsOnlyAfterRetries(t *testing.T) {
+	account := &service.Account{Type: service.AccountTypeAPIKey, Credentials: map[string]any{
+		"pool_mode": true, "pool_mode_retry_count": float64(3),
+	}}
+	err := &service.UpstreamFailoverError{StatusCode: 503, RetryableOnSameAccount: true, RequestScopedTransient: true}
+	for attempt := 0; attempt < 3; attempt++ {
+		require.False(t, shouldReportOpenAIFailoverAttempt(account, err, attempt))
+	}
+	require.True(t, shouldReportOpenAIFailoverAttempt(account, err, 3))
+	err.RetryableOnSameAccount = false
+	err.AccountHealthHandled = true
+	require.True(t, shouldReportOpenAIFailoverAttempt(account, err, 0), "explicit rules skip the remaining retries")
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -70,6 +70,7 @@ func advanceOpenAIWSCyberBlockState(blocked, pending, marked bool, turnErr error
 }
 
 var errOpenAIWSUnsupportedModelSwitch = errors.New("selected account does not support websocket model switch")
+var errOpenAIWSAccountUnavailable = errors.New("bound account is no longer schedulable")
 
 func newOpenAIWSUnsupportedModelSwitchError(model string) error {
 	cause := fmt.Errorf("%w: model %q", errOpenAIWSUnsupportedModelSwitch, strings.TrimSpace(model))
@@ -77,7 +78,7 @@ func newOpenAIWSUnsupportedModelSwitchError(model string) error {
 }
 
 func shouldReportOpenAIWSProxyAccountFailure(err error) bool {
-	return err != nil && !errors.Is(err, errOpenAIWSUnsupportedModelSwitch) && !service.IsOpenAIWSSessionPreemptedError(err)
+	return err != nil && !errors.Is(err, errOpenAIWSUnsupportedModelSwitch) && !errors.Is(err, errOpenAIWSAccountUnavailable) && !service.IsOpenAIWSSessionPreemptedError(err)
 }
 
 // openAIWSIngressEndedByClient reports whether a finished ingress WebSocket turn
@@ -877,7 +878,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 					if c.Writer.Written() {
 						streamStarted = true
 					}
-					if failoverErr.ShouldReportAccountScheduleFailure() {
+					if shouldReportOpenAIFailoverAttempt(account, failoverErr, sameAccountRetryCount[account.ID]) {
 						h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, forwardModel, requireCompact, nil), false, nil, err)
 					}
 					if !failoverErr.ShouldRetryNextAccount() {
@@ -1437,7 +1438,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 						h.handleAnthropicFailoverExhausted(c, failoverErr, true)
 						return
 					}
-					if failoverErr.ShouldReportAccountScheduleFailure() {
+					if shouldReportOpenAIFailoverAttempt(account, failoverErr, sameAccountRetryCount[account.ID]) {
 						h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, currentRoutingModel, false, nil), false, nil, err)
 					}
 					if !failoverErr.ShouldRetryNextAccount() {
@@ -2813,6 +2814,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				}
 				setOpsRequestContext(c, model, true)
 				mapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(ctx, apiKey.GroupID, model)
+				if turn > 1 && !h.gatewayService.OpenAIWSAPIKeyAccountAvailable(ctx, account, apiKey.GroupID, mapping.MappedModel) {
+					return "", service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is temporarily unavailable, please reconnect", errOpenAIWSAccountUnavailable)
+				}
 				mappedModelUnchanged := false
 				if previous := turnChannelMapping.Load(); previous != nil && previous.turn < turn {
 					mappedModelUnchanged = strings.TrimSpace(previous.mapping.MappedModel) == strings.TrimSpace(mapping.MappedModel)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -639,6 +639,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 生图意图只影响能力路由与图片计费，不关门：混合 /v1/responses 请求的
 	// token 计费部分仍受利润门保护，独立图片/视频端点才在门外。
 	pricingCtx, pricingAt := h.gatewayService.WithOpenAIRequestPricingContext(c.Request.Context(), apiKey.GroupID)
+	if requestPlatform == service.PlatformOpenAI && !legacyCompact && !nativeV2 {
+		pricingCtx = h.gatewayService.BeginOpenAIStickySuccess(pricingCtx, apiKey.GroupID, sessionHash, forwardModel)
+	}
 	c.Request = c.Request.WithContext(pricingCtx)
 
 	for {
@@ -837,6 +840,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		if err != nil {
 			if result != nil && result.ClientDisconnect {
+				c.Set(opsClientDisconnectedKey, true)
+				h.gatewayService.ReportOpenAIFailureAfterDisconnect(account, openAIAccountScheduleModel(c, account, forwardModel, requireCompact, result), err)
 				reqLog.Info("openai.client_disconnected",
 					zap.Int64("account_id", account.ID),
 					zap.Error(err),
@@ -845,6 +850,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				return
 			}
 			if failoverClientGone(c) {
+				h.gatewayService.ReportOpenAIFailureAfterDisconnect(account, openAIAccountScheduleModel(c, account, forwardModel, requireCompact, result), err)
 				reqLog.Info("openai.client_disconnected",
 					zap.Int64("account_id", account.ID),
 					zap.Error(err),
@@ -862,6 +868,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				var failoverErr *service.UpstreamFailoverError
 				if errors.As(err, &failoverErr) {
 					if failoverClientGone(c) {
+						h.gatewayService.ReportOpenAIFailureAfterDisconnect(account, openAIAccountScheduleModel(c, account, forwardModel, requireCompact, result), err)
 						reqLog.Info("openai.failover_aborted_client_disconnected",
 							zap.Int64("account_id", account.ID),
 							zap.Int("upstream_status", failoverErr.StatusCode),
@@ -963,6 +970,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			}
 		}
 		if result != nil {
+			if err == nil {
+				h.gatewayService.CommitOpenAIStickySuccess(c.Request.Context(), account, result)
+			}
 			// 排除 spark 影子:其 codex_* 仅由 QueryUsage(/wham/usage bengalfox)更新(外审第7轮 P1)。
 			if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -291,8 +291,8 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				}
 				var failoverErr *service.UpstreamFailoverError
 				if errors.As(err, &failoverErr) {
-					h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, requestModel, false, result), false, nil, err)
 					if service.OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c) != writerSizeBeforeForward {
+						h.gatewayService.ObserveOpenAIAccountHealthFailure(c.Request.Context(), account, err)
 						reqLog.Warn("openai.images.upstream_failover_skipped_after_flush",
 							zap.Int64("account_id", account.ID),
 							zap.Int("upstream_status", failoverErr.StatusCode),
@@ -327,6 +327,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 							continue
 						}
 					}
+					h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, requestModel, false, result), false, nil, err)
 					h.gatewayService.RecordOpenAIAccountSwitch()
 					failedAccountIDs[account.ID] = struct{}{}
 					lastFailoverErr = failoverErr

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1120,6 +1120,11 @@ func OpsErrorLoggerMiddleware(ops *service.OpsService) gin.HandlerFunc {
 		if status < 400 {
 			if parsed.StreamFailure {
 				status = inferStreamFailureStatus(c, parsed)
+			} else if c.GetBool(opsClientDisconnectedKey) && len(service.GetOpsStreamErrors(c)) == 0 {
+				// A heartbeat may have committed 200 before the client left. It is
+				// not evidence that any recorded upstream attempt recovered.
+				status = statusClientClosedRequest
+				parsed.Message = "Client disconnected before request completion"
 			} else {
 				// A marked in-band error is a visible request failure even though its
 				// wire status is already 200. Otherwise retain recovered attempts as a

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -375,6 +375,36 @@ func TestOpsErrorLoggerMiddleware_RecordsRecoveredUpstreamTelemetryOutsideFailur
 	require.Equal(t, http.StatusTooManyRequests, persistedEvents[0].UpstreamStatusCode)
 }
 
+func TestOpsErrorLoggerMiddleware_DisconnectAfterHeartbeatIsNotRecovered(t *testing.T) {
+	setupOpsErrorLogTestQueue(t, 2)
+	gin.SetMode(gin.TestMode)
+	ops := service.NewOpsService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	router := gin.New()
+	router.Use(OpsErrorLoggerMiddleware(ops))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	router.POST("/v1/responses", func(c *gin.Context) {
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{UpstreamStatusCode: 524, Message: "upstream timeout"}})
+		c.Header("Content-Type", "text/event-stream")
+		_, _ = c.Writer.WriteString(": ping\n\n")
+		c.Writer.Flush()
+		cancel()
+		require.True(t, failoverClientGone(c))
+	})
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/responses", nil).WithContext(ctx))
+	require.Equal(t, http.StatusOK, recorder.Code, "wire headers were already committed")
+	require.Equal(t, int64(1), OpsErrorLogQueueLength())
+	job := <-opsErrorLogQueue
+	require.Equal(t, statusClientClosedRequest, job.entry.StatusCode)
+	require.NotContains(t, job.entry.ErrorMessage, "Recovered")
+	require.NotNil(t, job.entry.UpstreamErrorsJSON)
+	events, err := service.ParseOpsUpstreamErrors(*job.entry.UpstreamErrorsJSON)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, 524, events[0].UpstreamStatusCode)
+}
+
 func TestOpsErrorLoggerMiddleware_RecoveredTelemetryFiltersSkipMonitoringAttempts(t *testing.T) {
 	setupOpsErrorLogTestQueue(t, 2)
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2283,7 +2283,11 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 			extra = jsonb_set(
 				jsonb_set(COALESCE(extra, '{}'::jsonb), '{model_rate_limits}'::text[], COALESCE(extra->'model_rate_limits', '{}'::jsonb), true),
 				ARRAY['model_rate_limits', $1]::text[],
-				$2::jsonb,
+				CASE
+					WHEN NULLIF(extra #>> ARRAY['model_rate_limits', $1, 'rate_limit_reset_at'], '')::timestamptz > $4
+					THEN extra #> ARRAY['model_rate_limits', $1]
+					ELSE $2::jsonb
+				END,
 				true
 			),
 			updated_at = NOW()
@@ -2291,6 +2295,7 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 		scope,
 		raw,
 		id,
+		resetAt,
 	)
 	if err != nil {
 		return err

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -1073,6 +1073,31 @@ func (s *AccountRepoSuite) TestSetTempUnschedulableSkipsOutboxWhenWindowDoesNotE
 	s.Require().WithinDuration(until, *got.TempUnschedulableUntil, time.Second)
 }
 
+func (s *AccountRepoSuite) TestModelRateLimitNeverShortensExistingPause() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name: "model-cooldown-preserves-quota", Platform: service.PlatformOpenAI,
+		Type: service.AccountTypeAPIKey, Status: service.StatusActive, Schedulable: true,
+	})
+	cache := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cache
+	quotaUntil := time.Now().Add(4 * time.Hour).UTC().Truncate(time.Second)
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.1", quotaUntil, "quota"))
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.1", time.Now().Add(2*time.Minute), "capacity"))
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	state := got.Extra["model_rate_limits"].(map[string]any)["gpt-5.1"].(map[string]any)
+	s.Require().Equal(quotaUntil.Format(time.RFC3339), state["rate_limit_reset_at"])
+	s.Require().Equal("quota", state["reason"])
+	s.Require().False(got.IsSchedulableForModelWithContext(s.ctx, "gpt-5.1"))
+	s.Require().True(got.IsSchedulableForModelWithContext(s.ctx, "gpt-5.2"))
+	s.Require().Equal(got.Extra, cache.accounts[account.ID].Extra)
+	later := quotaUntil.Add(time.Hour)
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, "gpt-5.1", later, "extended"))
+	state = cache.accounts[account.ID].Extra["model_rate_limits"].(map[string]any)["gpt-5.1"].(map[string]any)
+	s.Require().Equal(later.Format(time.RFC3339), state["rate_limit_reset_at"])
+	s.Require().Equal("extended", state["reason"])
+}
+
 func (s *AccountRepoSuite) TestClearModelRateLimits_SyncsSchedulerSnapshot() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name: "acc-clear-model-rate",

--- a/backend/internal/repository/openai_sticky_success_cache.go
+++ b/backend/internal/repository/openai_sticky_success_cache.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/redis/go-redis/v9"
+)
+
+func openAIStickySuccessCacheKey(groupID int64, sessionHash, model string) string {
+	return buildSessionKey(groupID, "openai:success:"+sessionHash+":"+service.DeriveSessionHashFromSeed(model))
+}
+
+func (c *gatewayCache) GetOpenAIStickySuccess(ctx context.Context, groupID int64, sessionHash, model string) (service.OpenAIStickySuccessBinding, error) {
+	var binding service.OpenAIStickySuccessBinding
+	data, err := c.rdb.Get(ctx, openAIStickySuccessCacheKey(groupID, sessionHash, model)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return binding, service.ErrStickySessionNotFound
+	}
+	if err != nil {
+		return binding, err
+	}
+	err = json.Unmarshal(data, &binding)
+	return binding, err
+}
+
+var compareAndSwapOpenAIStickySuccess = redis.NewScript(`
+local current = redis.call('GET', KEYS[1]) or ''
+if current ~= ARGV[1] then return 0 end
+redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+return 1
+`)
+
+func (c *gatewayCache) CompareAndSwapOpenAIStickySuccess(ctx context.Context, groupID int64, sessionHash, model string, expected, next service.OpenAIStickySuccessBinding, ttl time.Duration) (bool, error) {
+	previous := ""
+	if expected.AccountID > 0 {
+		data, err := json.Marshal(expected)
+		if err != nil {
+			return false, err
+		}
+		previous = string(data)
+	}
+	data, err := json.Marshal(next)
+	if err != nil {
+		return false, err
+	}
+	changed, err := compareAndSwapOpenAIStickySuccess.Run(ctx, c.rdb, []string{openAIStickySuccessCacheKey(groupID, sessionHash, model)}, previous, string(data), ttl.Milliseconds()).Int()
+	return changed == 1, err
+}

--- a/backend/internal/repository/openai_sticky_success_cache_test.go
+++ b/backend/internal/repository/openai_sticky_success_cache_test.go
@@ -1,0 +1,46 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIStickySuccessCacheIsolationAndCAS(t *testing.T) {
+	r := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: r.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	cache, ok := NewGatewayCache(client).(service.OpenAIStickySuccessCache)
+	require.True(t, ok)
+	ctx := context.Background()
+	empty := service.OpenAIStickySuccessBinding{}
+	one := service.OpenAIStickySuccessBinding{AccountID: 1, Revision: "first"}
+	two := service.OpenAIStickySuccessBinding{AccountID: 1, Revision: "new-success-same-account"}
+	changed, err := cache.CompareAndSwapOpenAIStickySuccess(ctx, 7, "session", "model", empty, one, time.Minute)
+	require.NoError(t, err)
+	require.True(t, changed)
+	changed, err = cache.CompareAndSwapOpenAIStickySuccess(ctx, 7, "session", "model", one, two, time.Minute)
+	require.NoError(t, err)
+	require.True(t, changed)
+	changed, err = cache.CompareAndSwapOpenAIStickySuccess(ctx, 7, "session", "model", one, service.OpenAIStickySuccessBinding{AccountID: 2, Revision: "stale"}, time.Minute)
+	require.NoError(t, err)
+	require.False(t, changed)
+	got, err := cache.GetOpenAIStickySuccess(ctx, 7, "session", "model")
+	require.NoError(t, err)
+	require.Equal(t, two, got)
+	for _, scope := range []struct {
+		group          int64
+		session, model string
+	}{{8, "session", "model"}, {7, "other", "model"}, {7, "session", "other"}} {
+		_, err := cache.GetOpenAIStickySuccess(ctx, scope.group, scope.session, scope.model)
+		require.ErrorIs(t, err, service.ErrStickySessionNotFound)
+	}
+	r.FastForward(time.Minute)
+	_, err = cache.GetOpenAIStickySuccess(ctx, 7, "session", "model")
+	require.ErrorIs(t, err, service.ErrStickySessionNotFound)
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -573,6 +573,8 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		// 529过载冷却配置
 		adminSettings.GET("/overload-cooldown", h.Admin.Setting.GetOverloadCooldownSettings)
 		adminSettings.PUT("/overload-cooldown", h.Admin.Setting.UpdateOverloadCooldownSettings)
+		adminSettings.GET("/openai-apikey-health-breaker", h.Admin.Setting.GetOpenAIAPIKeyHealthBreakerSettings)
+		adminSettings.PUT("/openai-apikey-health-breaker", h.Admin.Setting.UpdateOpenAIAPIKeyHealthBreakerSettings)
 		// 429默认回避配置
 		adminSettings.GET("/rate-limit-429-cooldown", h.Admin.Setting.GetRateLimit429CooldownSettings)
 		adminSettings.PUT("/rate-limit-429-cooldown", h.Admin.Setting.UpdateRateLimit429CooldownSettings)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -693,6 +693,7 @@ type UpstreamFailoverError struct {
 	SameAccountRetryDeadline time.Time     // 同账号重试截止时间；零值表示仅受 retryLimit 限制
 	SameAccountRetryMax      int           // 可选的错误级同账号重试上限，低于 handler 默认预算时优先采用
 	RequestScopedTransient   bool          // 故障因素与账号无关（如上游按客户端身份/模型容量降载）：可同账号重试，但不得据此对账号做临时封禁
+	AccountHealthHandled     bool          // 显式策略或终结失败观察已处理，避免重复累计健康失败
 	SafeToFailoverAfterWrite bool          // 仅写出 SSE 注释等非语义字节时，仍可在同一客户端流中切换账号
 	Stage                    GatewayFailureStage
 	Scope                    GatewayFailureScope

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -100,9 +100,16 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 	if s != nil {
 		scheduleOllamaCloudUsageActivity(s.deferredService, account)
 	}
-	// Capacity shedding describes this request, not account health. Keep the
-	// account schedulable while the request-local retry budget handles recovery.
+	// Explicit API-key rules precede the default request-scoped capacity exemption.
 	if account != nil && account.Platform == PlatformOpenAI && isOpenAIRequestScopedCapacityShed("", responseBody) {
+		if s != nil && s.rateLimitService != nil && isOpenAIAPIKeyCapacityFailure(account, responseBody) {
+			stateCtx, cancel := openAIAccountStateContext(ctx)
+			defer cancel()
+			status := openAIStreamFailureStatus(responseBody, "")
+			if account.ShouldHandleErrorCode(status) {
+				return s.rateLimitService.tryTempUnschedulable(stateCtx, account, status, responseBody, canonicalModel...)
+			}
+		}
 		return false
 	}
 	stateCtx, cancel := openAIAccountStateContext(ctx)

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1018,7 +1018,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 			weights.Reset*resetFactor +
 			weights.QuotaHeadroom*quotaHeadroomFactor +
 			weights.UpstreamCost*(upstreamCostFactor-openAIUpstreamCostNeutralFactor)
-		if req.StickyWeighted {
+		if req.StickyWeighted && !s.shouldEscapeWeightedStickyAccount(req, item.account.ID) {
 			if req.PreviousResponseCanMove && req.StickyPreviousAccountID > 0 && item.account.ID == req.StickyPreviousAccountID {
 				item.score += weights.Previous
 			}
@@ -1049,6 +1049,22 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 		if len(pool) == 0 || plan.topK <= 0 {
 			return nil
 		}
+		var escaped []openAIAccountCandidateScore
+		if req.StickyWeighted {
+			preferred := make([]openAIAccountCandidateScore, 0, len(pool))
+			for _, candidate := range pool {
+				if s.shouldEscapeWeightedStickyAccount(req, candidate.account.ID) {
+					escaped = append(escaped, candidate)
+				} else {
+					preferred = append(preferred, candidate)
+				}
+			}
+			if len(preferred) > 0 {
+				pool = preferred
+			} else {
+				escaped = nil
+			}
+		}
 		groupTopK := plan.topK
 		if groupTopK > len(pool) {
 			groupTopK = len(pool)
@@ -1057,7 +1073,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 		var primary []openAIAccountCandidateScore
 		if req.StickyWeighted {
 			for _, stickyID := range []int64{req.StickyPreviousAccountID, req.StickyAccountID} {
-				if stickyID <= 0 {
+				if stickyID <= 0 || s.shouldEscapeWeightedStickyAccount(req, stickyID) {
 					continue
 				}
 				for i, candidate := range ranked {
@@ -1076,7 +1092,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 			primary = buildOpenAIWeightedSelectionOrder(ranked, req)
 		}
 		if !plan.includeOverflowFallback || groupTopK >= len(pool) {
-			return primary
+			return append(primary, escaped...)
 		}
 
 		selected := make(map[int64]struct{}, len(primary))
@@ -1092,7 +1108,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 		sort.Slice(overflow, func(i, j int) bool {
 			return isOpenAIAccountCandidateBetter(overflow[i], overflow[j])
 		})
-		return append(primary, overflow...)
+		return append(append(primary, overflow...), escaped...)
 	}
 
 	if req.RequireCompact {
@@ -1116,6 +1132,15 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 	}
 
 	return buildSelectionOrder(plan.candidates)
+}
+
+func (s *defaultOpenAIAccountScheduler) shouldEscapeWeightedStickyAccount(req OpenAIAccountScheduleRequest, accountID int64) bool {
+	if !req.StickyWeighted || s.service == nil ||
+		(accountID != req.StickyAccountID && (!req.PreviousResponseCanMove || accountID != req.StickyPreviousAccountID)) {
+		return false
+	}
+	_, _, _, escape := s.shouldEscapeStickyAccount(accountID, s.service.openAIStickyEscapeConfig())
+	return escape
 }
 
 func sortOpenAICompactRetryCandidates(pool []openAIAccountCandidateScore) []openAIAccountCandidateScore {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -2365,7 +2367,9 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	}
 
 	var stickyAccountID int64
-	if sessionHash != "" && s.cache != nil {
+	if state := openAIStickySuccessFromContext(ctx); state != nil && state.groupID == derefGroupID(groupID) && state.sessionHash == sessionHash && state.model == strings.TrimSpace(requestedModel) {
+		stickyAccountID = state.originalID
+	} else if sessionHash != "" && s.cache != nil {
 		if accountID, err := s.getStickySessionAccountID(ctx, groupID, sessionHash); err == nil && accountID > 0 {
 			stickyAccountID = accountID
 		}
@@ -2377,7 +2381,7 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 		stickyPreviousAccountID = s.ResolveAccountIDByPreviousResponseIDForScheduler(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
 	}
 
-	return scheduler.Select(ctx, OpenAIAccountScheduleRequest{
+	selection, decision, err := scheduler.Select(ctx, OpenAIAccountScheduleRequest{
 		GroupID:                 groupID,
 		Platform:                platform,
 		SessionHash:             sessionHash,
@@ -2398,6 +2402,20 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 		RequireCompact:          requireCompact,
 		ExcludedIDs:             excludedIDs,
 	})
+	if state := openAIStickySuccessFromContext(ctx); state != nil && selection != nil && selection.Account != nil {
+		reason := ""
+		var errorRate, ttft float64
+		if active, ok := scheduler.(*defaultOpenAIAccountScheduler); ok {
+			reason, errorRate, ttft, _ = active.shouldEscapeStickyAccount(stickyAccountID, s.openAIStickyEscapeConfig())
+		}
+		logger.FromContext(ctx).Info("openai.sticky_selection",
+			zap.Int64("group_id", derefGroupID(groupID)), zap.String("model", requestedModel),
+			zap.Int64("sticky_account_id", stickyAccountID), zap.Int64("account_id", selection.Account.ID),
+			zap.Bool("success_preference", state.expected.AccountID > 0),
+			zap.Bool("sticky_hit", stickyAccountID == selection.Account.ID), zap.String("layer", decision.Layer),
+			zap.String("escape_reason", reason), zap.Float64("sticky_error_rate", errorRate), zap.Float64("sticky_ttft_ms", ttft))
+	}
+	return selection, decision, err
 }
 
 func accountSupportsOpenAICapabilities(account *Account, requiredCapability OpenAIEndpointCapability, requiredImageCapability OpenAIImagesCapability) bool {

--- a/backend/internal/service/openai_apikey_health_breaker.go
+++ b/backend/internal/service/openai_apikey_health_breaker.go
@@ -26,6 +26,13 @@ func classifyOpenAIAPIKeyHealthFailure(err error) (int, []byte, bool) {
 
 	var failoverErr *UpstreamFailoverError
 	if errors.As(err, &failoverErr) {
+		if failoverErr.AccountHealthHandled {
+			return failoverErr.StatusCode, failoverErr.ResponseBody, false
+		}
+		if !failoverErr.IsCredentialFailure() && failoverErr.Scope != GatewayFailureScopeProvider &&
+			isOpenAICapacityHealthPayload(failoverErr.ResponseBody) {
+			return http.StatusServiceUnavailable, failoverErr.ResponseBody, true
+		}
 		// These failures already have dedicated recovery/state handling or are not
 		// attributable to the selected account.
 		if failoverErr.IsCredentialFailure() ||
@@ -39,6 +46,11 @@ func classifyOpenAIAPIKeyHealthFailure(err error) (int, []byte, bool) {
 			return failoverErr.StatusCode, failoverErr.ResponseBody, true
 		}
 		return failoverErr.StatusCode, failoverErr.ResponseBody, false
+	}
+	var streamErr *OpenAIStreamTerminalError
+	if errors.As(err, &streamErr) {
+		return streamErr.StatusCode, streamErr.ResponseBody, !streamErr.healthHandled &&
+			isOpenAICapacityHealthPayload(streamErr.ResponseBody)
 	}
 
 	var imageErr *OpenAIImagesUpstreamError
@@ -55,9 +67,12 @@ func (s *RateLimitService) ObserveOpenAIAPIKeyHealthFailure(ctx context.Context,
 		return false
 	}
 	statusCode, responseBody, eligible := classifyOpenAIAPIKeyHealthFailure(upstreamErr)
-	if !eligible {
+	if !eligible || !account.ShouldHandleErrorCode(statusCode) {
 		return false
 	}
+	markOpenAIHealthHandled(upstreamErr)
+	ctx, cancel := openAIAccountStateContext(ctx)
+	defer cancel()
 	settings, err := s.settingService.GetOpenAIAPIKeyHealthBreakerSettings(ctx)
 	if err != nil {
 		logger.L().Warn("openai.apikey_health_breaker_settings_failed", zap.Int64("account_id", account.ID), zap.Error(err))
@@ -72,6 +87,10 @@ func (s *RateLimitService) ObserveOpenAIAPIKeyHealthFailure(ctx context.Context,
 		logger.L().Warn("openai.apikey_health_breaker_record_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 		return false
 	}
+	logger.FromContext(ctx).Info("openai.apikey_health_failure_observed",
+		zap.Int64("account_id", account.ID), zap.Int64("failure_count", count),
+		zap.Int("failure_threshold", settings.FailureThreshold), zap.Int("window_minutes", settings.WindowMinutes),
+		zap.Int("upstream_status", statusCode), zap.Bool("tripped", tripped))
 	if !tripped {
 		return false
 	}

--- a/backend/internal/service/openai_capacity_recovery.go
+++ b/backend/internal/service/openai_capacity_recovery.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
+)
+
+const openAICapacityUsageDrainTimeout = 2 * time.Second
+
+// A persistent WS binding must not bypass state written by a previous turn.
+func (s *OpenAIGatewayService) OpenAIWSAPIKeyAccountAvailable(ctx context.Context, account *Account, groupID *int64, model string) bool {
+	if account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeAPIKey {
+		return true
+	}
+	if s.accountRepo == nil {
+		return false
+	}
+	latest, err := s.accountRepo.GetByID(ctx, account.ID)
+	return err == nil && latest != nil && s.openAIAccountMatchesSchedulingGroup(latest, groupID) &&
+		isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, latest, PlatformOpenAI, model, false, OpenAIEndpointCapabilityResponses) &&
+		!s.isOpenAIAccountRequestRuntimeBlocked(latest, model)
+}
+
+// OpenAIStreamTerminalError retains a committed failure without making it replayable.
+type OpenAIStreamTerminalError struct {
+	StatusCode    int
+	ResponseBody  []byte
+	Message       string
+	healthHandled bool
+}
+
+func (e *OpenAIStreamTerminalError) Error() string {
+	return fmt.Sprintf("upstream response failed: %s", e.Message)
+}
+
+func isOpenAIAPIKeyCapacityFailure(account *Account, payload []byte) bool {
+	return account != nil && account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey &&
+		isOpenAICapacityHealthPayload(payload)
+}
+
+func isOpenAICapacityHealthPayload(payload []byte) bool {
+	if openAIStreamFailureStatus(payload, "") != http.StatusServiceUnavailable || isOpenAIContextWindowError("", payload) {
+		return false
+	}
+	cyber, _, _ := detectOpenAICyberPolicy(payload)
+	return !cyber && isOpenAIRequestScopedCapacityShed("", payload)
+}
+
+func markOpenAIHealthHandled(err error) {
+	var streamErr *OpenAIStreamTerminalError
+	if errors.As(err, &streamErr) {
+		streamErr.healthHandled = true
+	}
+	var failoverErr *UpstreamFailoverError
+	if errors.As(err, &failoverErr) {
+		failoverErr.AccountHealthHandled = true
+	}
+}
+
+func (s *OpenAIGatewayService) observeOpenAICapacityTerminalFailure(ctx context.Context, account *Account, model string, headers http.Header, payload []byte, message string) *OpenAIStreamTerminalError {
+	err := &OpenAIStreamTerminalError{
+		StatusCode:   openAIStreamFailureStatus(payload, message),
+		ResponseBody: append([]byte(nil), payload...),
+		Message:      sanitizeUpstreamErrorMessage(message),
+	}
+	err.healthHandled = s.handleOpenAIAccountUpstreamError(ctx, account, err.StatusCode, headers, payload, model)
+	policyMatched := err.healthHandled
+	s.ObserveOpenAIAccountHealthFailure(ctx, account, err)
+	logger.FromContext(ctx).Info("openai.capacity_terminal_observed",
+		zap.Int64("account_id", account.ID), zap.String("upstream_model", model),
+		zap.Int("upstream_status", err.StatusCode), zap.Bool("explicit_rule_handled", policyMatched))
+	return err
+}
+
+// Only Close runs in the timer goroutine. Parsing, health and downstream writes
+// stay in the stream owner. Closing also bounds the timeout-disabled Scan path.
+type openAICapacityUsageDrain struct {
+	timer   *time.Timer
+	done    chan struct{}
+	expired atomic.Bool
+}
+
+func (d *openAICapacityUsageDrain) start(body io.Closer) {
+	if d.timer != nil {
+		return
+	}
+	d.done = make(chan struct{})
+	d.timer = time.AfterFunc(openAICapacityUsageDrainTimeout, func() {
+		defer close(d.done)
+		d.expired.Store(true)
+		_ = body.Close()
+	})
+}
+
+func (d *openAICapacityUsageDrain) stop() {
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.done
+	}
+}
+
+type openAICapacityStreamDiagnostics struct {
+	firstSemanticAt    time.Time
+	firstSemanticEvent string
+	semanticBytes      int
+	errorObservedAt    time.Time
+	failureDeliveredAt time.Time
+	finishReason       string
+}
+
+func (d *openAICapacityStreamDiagnostics) committed(eventType string, size int) {
+	if d.firstSemanticAt.IsZero() {
+		d.firstSemanticAt = time.Now()
+		d.firstSemanticEvent = eventType
+	}
+	d.semanticBytes += size
+}
+
+func (d *openAICapacityStreamDiagnostics) finish(ctx context.Context, account *Account, model, path, requestID string, usage *OpenAIUsage, drainExpired, disconnected bool) {
+	if drainExpired {
+		d.finishReason = "usage_drain_timed_out"
+	} else if d.finishReason == "" {
+		d.finishReason = "upstream_end"
+	}
+	fields := []zap.Field{
+		zap.Int64("account_id", account.ID), zap.String("upstream_model", model),
+		zap.String("path", path), zap.String("upstream_request_id", requestID),
+		zap.String("first_semantic_event", d.firstSemanticEvent), zap.Int("semantic_bytes", d.semanticBytes),
+		zap.Time("error_observed_at", d.errorObservedAt), zap.Time("finished_at", time.Now()),
+		zap.String("finish_reason", d.finishReason), zap.Bool("client_disconnected", disconnected),
+		zap.Bool("usage_observed", usage != nil && (usage.InputTokens > 0 || usage.OutputTokens > 0 || usage.CacheReadInputTokens > 0)),
+	}
+	if !d.firstSemanticAt.IsZero() {
+		fields = append(fields, zap.Time("first_semantic_committed_at", d.firstSemanticAt))
+	}
+	if !d.failureDeliveredAt.IsZero() {
+		fields = append(fields, zap.Time("failure_flushed_at", d.failureDeliveredAt))
+	}
+	logger.FromContext(ctx).Warn("openai.capacity_stream_finished", fields...)
+}

--- a/backend/internal/service/openai_capacity_recovery.go
+++ b/backend/internal/service/openai_capacity_recovery.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -113,6 +114,58 @@ type openAICapacityStreamDiagnostics struct {
 	errorObservedAt    time.Time
 	failureDeliveredAt time.Time
 	finishReason       string
+	keepaliveLogged    bool
+}
+
+// Record only the shape of the first unrecognized heartbeat in an attempt.
+// Values and nested keys can contain user content and must not enter the log.
+func (d *openAICapacityStreamDiagnostics) unrecognizedKeepalive(ctx context.Context, account *Account, path string, data []byte) {
+	if d.keepaliveLogged || account == nil || !account.IsOpenAIApiKey() {
+		return
+	}
+	d.keepaliveLogged = true
+	kindOf := func(value gjson.Result) string {
+		switch value.Type {
+		case gjson.String:
+			return "string"
+		case gjson.Number:
+			return "number"
+		case gjson.True, gjson.False:
+			return "boolean"
+		case gjson.JSON:
+			if value.IsArray() {
+				return "array"
+			}
+			return "object"
+		default:
+			return "null"
+		}
+	}
+	kind := "invalid_json"
+	fieldTypes := make(map[string]string)
+	omitted := false
+	if gjson.ValidBytes(data) {
+		payload := gjson.ParseBytes(data)
+		kind = kindOf(payload)
+		if payload.IsObject() {
+			payload.ForEach(func(key, value gjson.Result) bool {
+				if len(fieldTypes) >= 16 {
+					omitted = true
+					return false
+				}
+				if len(key.Str) > 64 {
+					omitted = true
+					return true
+				}
+				fieldTypes[key.Str] = kindOf(value)
+				return true
+			})
+		}
+	}
+	logger.FromContext(ctx).Warn("openai.unrecognized_keepalive",
+		zap.Int64("account_id", account.ID), zap.String("path", path),
+		zap.Int("data_bytes", len(data)), zap.String("payload_kind", kind),
+		zap.Any("field_types", fieldTypes), zap.Bool("fields_omitted", omitted))
 }
 
 func (d *openAICapacityStreamDiagnostics) committed(eventType string, size int) {

--- a/backend/internal/service/openai_capacity_recovery_test.go
+++ b/backend/internal/service/openai_capacity_recovery_test.go
@@ -84,7 +84,7 @@ func TestOpenAICapacityBlockingStreamRecovery(t *testing.T) {
 								gotErr, gotUsage = err, result.usage
 							}
 						}()
-						_, err := io.WriteString(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n")
+						_, err := io.WriteString(writer, openAIUpstreamKeepaliveFixture+"data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n")
 						require.NoError(t, err)
 						synctest.Wait()
 						started := time.Now()

--- a/backend/internal/service/openai_capacity_recovery_test.go
+++ b/backend/internal/service/openai_capacity_recovery_test.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const capacityBareFixture = `{"type":"error","error":{"code":"server_error","type":"service_unavailable_error","message":"Our servers are currently overloaded. Please try again later."}}`
+const capacityFailedUsageFixture = `{"type":"response.failed","response":{"id":"resp_capacity","status":"failed","error":{"code":"server_error","type":"service_unavailable_error","message":"Our servers are currently overloaded. Please try again later."},"usage":{"input_tokens":11,"output_tokens":2,"total_tokens":13}}}`
+
+type capacityRecoveryRepo struct {
+	AccountRepository
+	models []string
+	until  time.Time
+}
+
+func (r *capacityRecoveryRepo) SetModelRateLimit(_ context.Context, _ int64, model string, until time.Time, _ ...string) error {
+	r.models = append(r.models, model)
+	r.until = until
+	return nil
+}
+
+type capacityBlockingBody struct {
+	*io.PipeReader
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (b *capacityBlockingBody) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return b.PipeReader.Close()
+}
+
+func capacityRuleAccount() *Account {
+	a := openAIHealthPoolAccount()
+	a.Credentials["temp_unschedulable_enabled"] = true
+	a.Credentials["temp_unschedulable_rules"] = []any{map[string]any{
+		"error_code": float64(503), "keywords": []any{"overloaded"}, "duration_minutes": float64(2),
+	}}
+	return a
+}
+
+func TestOpenAICapacityBlockingStreamRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, passthrough := range []bool{false, true} {
+		for _, interval := range []int{0, 180} {
+			for _, mode := range []string{"silent", "heartbeat", "usage", "failed"} {
+				t.Run(fmt.Sprintf("passthrough=%t/interval=%d/%s", passthrough, interval, mode), func(t *testing.T) {
+					synctest.Test(t, func(t *testing.T) {
+						reader, writer := io.Pipe()
+						body := &capacityBlockingBody{PipeReader: reader, closed: make(chan struct{})}
+						t.Cleanup(func() { _ = writer.Close(); _ = body.Close() })
+						repo := &capacityRecoveryRepo{}
+						cfg := &config.Config{Gateway: config.GatewayConfig{StreamDataIntervalTimeout: interval}}
+						svc := &OpenAIGatewayService{cfg: cfg, rateLimitService: &RateLimitService{accountRepo: repo}}
+						account := capacityRuleAccount()
+						rec := httptest.NewRecorder()
+						c, _ := gin.CreateTestContext(rec)
+						c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+						resp := &http.Response{StatusCode: 200, Header: http.Header{}, Body: body}
+						done := make(chan struct{})
+						var gotErr error
+						var gotUsage *OpenAIUsage
+						go func() {
+							defer close(done)
+							if passthrough {
+								result, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, account, time.Now(), "public", "upstream")
+								gotErr, gotUsage = err, result.usage
+							} else {
+								result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, account, time.Now(), "public", "upstream")
+								gotErr, gotUsage = err, result.usage
+							}
+						}()
+						_, err := io.WriteString(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n")
+						require.NoError(t, err)
+						synctest.Wait()
+						started := time.Now()
+						payload := capacityBareFixture
+						if mode == "failed" {
+							payload = capacityFailedUsageFixture
+						}
+						_, err = io.WriteString(writer, "data: "+payload+"\n\n")
+						require.NoError(t, err)
+						synctest.Wait()
+						require.Equal(t, []string{"upstream"}, repo.models, "health action must precede drain timeout")
+						require.Equal(t, started.Add(2*time.Minute), repo.until)
+						if mode != "failed" {
+							select {
+							case <-done:
+								t.Fatal("bare error closed before usage grace period")
+							default:
+							}
+							time.Sleep(time.Second)
+							switch mode {
+							case "usage":
+								_, err = io.WriteString(writer, "data: "+capacityFailedUsageFixture+"\n\n")
+								require.NoError(t, err)
+							case "heartbeat":
+								_, err = io.WriteString(writer, ": heartbeat\n\n")
+								require.NoError(t, err)
+							}
+						}
+						<-done
+						var terminal *OpenAIStreamTerminalError
+						require.ErrorAs(t, gotErr, &terminal)
+						var replay *UpstreamFailoverError
+						require.False(t, errors.As(gotErr, &replay))
+						select {
+						case <-body.closed:
+						default:
+							t.Fatal("upstream body still open after failure")
+						}
+						if mode == "usage" || mode == "failed" {
+							require.Equal(t, 11, gotUsage.InputTokens)
+							require.Equal(t, 2, gotUsage.OutputTokens)
+							require.Less(t, time.Since(started), openAICapacityUsageDrainTimeout)
+						} else {
+							require.Equal(t, openAICapacityUsageDrainTimeout, time.Since(started))
+						}
+						require.Len(t, repo.models, 1, "error and response.failed must not apply the rule twice")
+						require.Equal(t, 1, strings.Count(rec.Body.String(), `"partial"`))
+						require.Equal(t, 1, strings.Count(rec.Body.String(), `"type":"service_unavailable_error"`))
+					})
+				})
+			}
+		}
+	}
+}
+
+func TestOpenAICapacityPolicyAndHealth(t *testing.T) {
+	payload := []byte(capacityBareFixture)
+	t.Run("pool explicit rule skips retries without custom error codes", func(t *testing.T) {
+		repo := &capacityRecoveryRepo{}
+		svc := &OpenAIGatewayService{rateLimitService: &RateLimitService{accountRepo: repo}}
+		account := capacityRuleAccount()
+		err := svc.newOpenAIStreamFailoverErrorWithModel(nil, account, false, "request", payload, "overloaded", "upstream")
+		require.False(t, err.RetryableOnSameAccount)
+		require.True(t, err.AccountHealthHandled)
+		require.Equal(t, []string{"upstream"}, repo.models)
+	})
+	t.Run("explicit ignore still wins", func(t *testing.T) {
+		repo := &capacityRecoveryRepo{}
+		svc := &OpenAIGatewayService{rateLimitService: &RateLimitService{accountRepo: repo}}
+		account := capacityRuleAccount()
+		account.Credentials["custom_error_codes_enabled"] = true
+		account.Credentials["custom_error_codes"] = []any{float64(401)}
+		require.False(t, svc.handleOpenAIAccountUpstreamError(context.Background(), account, 503, nil, payload, "upstream"))
+		require.Empty(t, repo.models)
+	})
+	t.Run("terminal capacity is counted only once", func(t *testing.T) {
+		settings := NewSettingService(&openAIAPIKeyHealthSettingRepo{value: `{"enabled":true,"window_minutes":10,"failure_threshold":3,"cooldown_minutes":2}`}, &config.Config{})
+		cache := &openAIAPIKeyHealthCacheStub{}
+		rateLimit := &RateLimitService{accountRepo: &capacityRecoveryRepo{}, settingService: settings, openAIAPIKeyHealth: cache}
+		svc := &OpenAIGatewayService{rateLimitService: rateLimit}
+		account := openAIHealthPoolAccount()
+		err := svc.observeOpenAICapacityTerminalFailure(context.Background(), account, "upstream", nil, payload, "overloaded")
+		require.Equal(t, 1, cache.recordCalls)
+		svc.ObserveOpenAIAccountHealthFailure(context.Background(), account, err)
+		require.Equal(t, 1, cache.recordCalls)
+	})
+}
+
+func TestOpenAIWeightedStickyCapacityEscape(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	stats := newOpenAIAccountRuntimeStats()
+	for range 5 {
+		stats.report(42, false, nil)
+	}
+	scheduler := &defaultOpenAIAccountScheduler{service: svc, stats: stats}
+	plan := openAIAccountLoadPlan{topK: 1, candidates: []openAIAccountCandidateScore{
+		{account: &Account{ID: 42}, score: 100}, {account: &Account{ID: 43}, score: 1},
+	}}
+	req := OpenAIAccountScheduleRequest{StickyWeighted: true, StickyAccountID: 42, SessionHash: "same-session"}
+	order := scheduler.buildOpenAISelectionOrder(req, plan)
+	require.Equal(t, int64(43), order[0].account.ID, "even Top-K=1 must escape an unhealthy sticky candidate")
+	plan.candidates = plan.candidates[:1]
+	order = scheduler.buildOpenAISelectionOrder(req, plan)
+	require.Equal(t, int64(42), order[0].account.ID, "soft escape alone must not disable the only candidate")
+}
+
+func TestOpenAICapacityWSV2FirstFailureAndCommittedHealth(t *testing.T) {
+	for _, payload := range []string{capacityBareFixture, capacityFailedUsageFixture} {
+		for _, committed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("failed=%t/committed=%t", strings.Contains(payload, "response.failed"), committed), func(t *testing.T) {
+				cfg := newOpenAIWSV2TestConfig()
+				cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+				cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 2
+				cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 2
+				events := [][]byte{[]byte(`{"type":"response.created","response":{"id":"resp_capacity"}}`)}
+				if committed {
+					events = append(events, []byte(`{"type":"response.output_text.delta","delta":"partial"}`))
+				}
+				events = append(events, []byte(payload))
+				pool := newOpenAIWSConnPool(cfg)
+				pool.setClientDialerForTest(&openAIWSCaptureDialer{conn: &openAIWSCaptureConn{events: events}})
+				t.Cleanup(pool.Close)
+				repo := &capacityRecoveryRepo{}
+				svc := &OpenAIGatewayService{cfg: cfg, rateLimitService: &RateLimitService{accountRepo: repo},
+					cache: &stubGatewayCache{}, httpUpstream: &httpUpstreamRecorder{},
+					openaiWSResolver: NewOpenAIWSProtocolResolver(cfg), toolCorrector: NewCodexToolCorrector(), openaiWSPool: pool}
+				account := capacityRuleAccount()
+				account.Credentials["api_key"] = "test-only"
+				account.Extra = map[string]any{"responses_websockets_v2_enabled": true}
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+				result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.1","stream":true,"input":"hello"}`))
+				require.Equal(t, []string{"gpt-5.1"}, repo.models)
+				var failover *UpstreamFailoverError
+				if !committed {
+					require.ErrorAs(t, err, &failover)
+					require.False(t, failover.RetryableOnSameAccount)
+					require.Empty(t, rec.Body.String())
+				} else {
+					require.False(t, errors.As(err, &failover))
+					require.NotNil(t, result)
+					require.Equal(t, "response.failed", result.UpstreamTerminalEvent)
+					require.Contains(t, rec.Body.String(), "partial")
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAICapacityWSHTTPBridgeDoesNotUndoConfirmedHealth(t *testing.T) {
+	for _, accountType := range []string{AccountTypeAPIKey, AccountTypeOAuth} {
+		t.Run(accountType, func(t *testing.T) {
+			body := "data: " + capacityBareFixture + "\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_late\",\"status\":\"completed\",\"usage\":{\"input_tokens\":7,\"output_tokens\":1}}}\n\n"
+			repo := &capacityRecoveryRepo{}
+			upstream := &httpUpstreamRecorder{resp: &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream, rateLimitService: &RateLimitService{accountRepo: repo}}
+			account := capacityRuleAccount()
+			account.Type = accountType
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest("GET", "/v1/responses", nil)
+			payload := []byte(`{"type":"response.create","model":"gpt-5.1","input":"hello"}`)
+			var writes []string
+			result, err := svc.proxyOpenAIWSHTTPBridgeTurn(context.Background(), c, account, "test-only", payload, len(payload), "gpt-5.1", "", "", "", "", 2, func(message []byte) error { writes = append(writes, string(message)); return nil })
+			require.NotNil(t, result)
+			if accountType == AccountTypeAPIKey {
+				require.Error(t, err)
+				require.Equal(t, "response.failed", result.UpstreamTerminalEvent)
+				require.Equal(t, []string{"gpt-5.1"}, repo.models)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "response.completed", result.UpstreamTerminalEvent)
+				require.Empty(t, repo.models)
+			}
+			require.Len(t, writes, 1)
+		})
+	}
+}
+
+func TestOpenAICapacityWSBindingRechecksPause(t *testing.T) {
+	account := capacityRuleAccount()
+	account.Status, account.Schedulable = StatusActive, true
+	repo := &stubOpenAIAccountRepo{accounts: []Account{*account}}
+	svc := &OpenAIGatewayService{accountRepo: repo, cfg: &config.Config{RunMode: config.RunModeSimple}}
+	require.True(t, svc.OpenAIWSAPIKeyAccountAvailable(context.Background(), account, nil, "gpt-5.1"))
+	repo.accounts[0].Extra = map[string]any{"model_rate_limits": map[string]any{"gpt-5.1": map[string]any{"rate_limit_reset_at": time.Now().Add(time.Minute).UTC().Format(time.RFC3339)}}}
+	require.False(t, svc.OpenAIWSAPIKeyAccountAvailable(context.Background(), account, nil, "gpt-5.1"))
+	require.True(t, svc.OpenAIWSAPIKeyAccountAvailable(context.Background(), account, nil, "gpt-5.2"))
+	repo.accounts[0].Schedulable = false
+	require.False(t, svc.OpenAIWSAPIKeyAccountAvailable(context.Background(), account, nil, "gpt-5.2"))
+}

--- a/backend/internal/service/openai_client_disconnect.go
+++ b/backend/internal/service/openai_client_disconnect.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// Cancellation forbids replay, but must not erase an already confirmed upstream
+// failure. A transport cancellation alone is not evidence of account failure.
+func (s *OpenAIGatewayService) ReportOpenAIFailureAfterDisconnect(account *Account, model string, err error) {
+	if shouldReportOpenAIFailureAfterDisconnect(err) {
+		s.ReportOpenAIAccountScheduleResult(account, model, false, nil, err)
+	}
+}
+
+func shouldReportOpenAIFailureAfterDisconnect(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var failover *UpstreamFailoverError
+	if errors.As(err, &failover) {
+		if failover.Scope == GatewayFailureScopeProvider {
+			return false
+		}
+		if !failover.IsCredentialFailure() && isOpenAICapacityHealthPayload(failover.ResponseBody) {
+			return true
+		}
+		return failover.Scope != GatewayFailureScopeRequest && !failover.RequestScopedTransient &&
+			failover.ShouldReportAccountScheduleFailure() &&
+			(failover.StatusCode == http.StatusTooManyRequests || failover.StatusCode >= http.StatusInternalServerError)
+	}
+	var terminal *OpenAIStreamTerminalError
+	return errors.As(err, &terminal) && terminal.StatusCode >= http.StatusInternalServerError
+}

--- a/backend/internal/service/openai_client_disconnect_test.go
+++ b/backend/internal/service/openai_client_disconnect_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIFailureAfterDisconnectClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"upstream_524", &UpstreamFailoverError{StatusCode: 524}, true},
+		{"already_health_handled", &UpstreamFailoverError{StatusCode: 524, AccountHealthHandled: true}, true},
+		{"capacity", &UpstreamFailoverError{StatusCode: 503, RequestScopedTransient: true, ResponseBody: []byte(`{"error":{"message":"Our servers are currently overloaded. Please try again later."}}`)}, true},
+		{"provider_scope", &UpstreamFailoverError{StatusCode: 503, Scope: GatewayFailureScopeProvider}, false},
+		{"request_scope", &UpstreamFailoverError{StatusCode: 503, Scope: GatewayFailureScopeRequest}, false},
+		{"request_transient", &UpstreamFailoverError{StatusCode: 503, RequestScopedTransient: true}, false},
+		{"client_canceled", context.Canceled, false},
+		{"deadline", context.DeadlineExceeded, false},
+		{"transport", errors.New("connection closed"), false},
+		{"bad_request", &UpstreamFailoverError{StatusCode: 400}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldReportOpenAIFailureAfterDisconnect(tc.err))
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -966,6 +966,17 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 			break
 		}
+		if wsResult != nil {
+			wsResult.UpstreamModel = upstreamModel
+			if wsResult.BillingModel == "" {
+				wsResult.BillingModel = billingModel
+			}
+			if wsResult.ImageCount > 0 {
+				wsResult.ImageSize = imageSizeTier
+				wsResult.ImageInputSize = imageInputSize
+				wsResult.BillingModel = imageBillingModel
+			}
+		}
 		if wsErr == nil {
 			firstTokenMs := int64(0)
 			hasFirstTokenMs := wsResult != nil && wsResult.FirstTokenMs != nil
@@ -985,16 +996,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				firstTokenMs,
 				wsAttempts,
 			)
-			wsResult.UpstreamModel = upstreamModel
-			if wsResult.BillingModel == "" {
-				wsResult.BillingModel = billingModel
-			}
-			if wsResult.ImageCount > 0 {
-				wsResult.ImageSize = imageSizeTier
-				wsResult.ImageInputSize = imageInputSize
-				wsResult.BillingModel = imageBillingModel
-			}
 			return wsResult, nil
+		}
+		// A committed capacity failure still carries any usage already received.
+		var terminalErr *OpenAIStreamTerminalError
+		if wsResult != nil && errors.As(wsErr, &terminalErr) {
+			return wsResult, wsErr
 		}
 		s.writeOpenAIWSFallbackErrorResponse(c, account, wsErr)
 		return nil, wsErr

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1161,8 +1161,8 @@ func openAIStreamAddedEventStartsClientOutput(payload []byte, eventType string) 
 	}
 }
 
-// Only minimal heartbeat objects are known to be non-semantic. An event name
-// alone must not make an unknown vendor payload safe to replay.
+// A heartbeat may carry an event sequence number, but no content-bearing fields.
+// An event name alone must not make an unknown vendor payload safe to replay.
 func openAIStreamDataIsKeepalive(data, eventType string) bool {
 	eventType = strings.TrimSpace(eventType)
 	if eventType != "" && eventType != "keepalive" {
@@ -1177,7 +1177,15 @@ func openAIStreamDataIsKeepalive(data, eventType string) bool {
 	}
 	keepalive := true
 	payload.ForEach(func(key, value gjson.Result) bool {
-		keepalive = key.Str == "type" && value.Type == gjson.String && value.Str == "keepalive"
+		switch key.Str {
+		case "type":
+			keepalive = value.Type == gjson.String && value.Str == "keepalive"
+		case "sequence_number":
+			_, err := strconv.ParseUint(value.Raw, 10, 64)
+			keepalive = value.Type == gjson.Number && err == nil
+		default:
+			keepalive = false
+		}
 		return keepalive
 	})
 	return keepalive

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1611,6 +1611,14 @@ func (s *OpenAIGatewayService) handleOpenAIStreamTerminalAccountSideEffects(
 	canonicalModel ...string,
 ) (int, bool) {
 	statusCode := openAIStreamFailureStatus(payload, message)
+	if isOpenAIAPIKeyCapacityFailure(account, payload) {
+		ctx := context.Background()
+		if c != nil && c.Request != nil {
+			ctx = c.Request.Context()
+		}
+		model := firstNonEmpty(firstNonEmpty(canonicalModel...), gjson.GetBytes(payload, "response.model").String(), gjson.GetBytes(payload, "model").String())
+		return statusCode, s.handleOpenAIAccountUpstreamError(ctx, account, statusCode, headers, payload, model)
+	}
 	switch statusCode {
 	case http.StatusForbidden:
 		if !openAIStream403AccountFailure(payload, message) {
@@ -1832,7 +1840,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	startTime time.Time,
 	originalModel string,
 	mappedModel string,
-) (*openaiStreamingResultPassthrough, error) {
+) (streamResult *openaiStreamingResultPassthrough, streamErr error) {
 	observer := upstreamResponseModelObserverFromContext(c)
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
@@ -1877,6 +1885,19 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	var bareErrorPayload []byte
 	bareErrorAccountSideEffectsPending := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
+	var capacityFailure *OpenAIStreamTerminalError
+	var capacityDrain openAICapacityUsageDrain
+	var capacityDiag openAICapacityStreamDiagnostics
+	capacityEventType := ""
+	semanticEventType, semanticEventBytes := "", 0
+	defer func() {
+		capacityDrain.stop()
+		if capacityFailure != nil {
+			_ = resp.Body.Close()
+			streamErr = capacityFailure
+			capacityDiag.finish(ctx, account, mappedModel, "passthrough_sse", upstreamRequestID, usage, capacityDrain.expired.Load(), clientDisconnected)
+		}
+	}()
 	// pendingLines 在首个可见输出前保留前导事件，确保无输出失败仍可安全 failover。
 	pendingLines := make([]string, 0, 8)
 
@@ -1926,6 +1947,10 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 		flusher.Flush()
 		flushPending = false
+		if semanticEventBytes > 0 {
+			capacityDiag.committed(semanticEventType, semanticEventBytes)
+			semanticEventBytes = 0
+		}
 	}
 	defer flushPendingOutput()
 	writePendingLines := func() bool {
@@ -1958,6 +1983,9 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		failureDelivered = true
 		flushPending = true
 		flushPendingOutput()
+		if capacityFailure != nil && !clientDisconnected {
+			capacityDiag.failureDeliveredAt = time.Now()
+		}
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -1982,6 +2010,9 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	}
 
 	for documentScanner.Scan() {
+		if capacityDrain.expired.Load() {
+			break
+		}
 		line := documentScanner.Text()
 		if eventType, ok := extractOpenAISSEEventLine(line); ok {
 			pendingSSEEventType = eventType
@@ -2071,7 +2102,14 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 					}
 				}
 				if outputStarted && !cyberHit {
-					if codexFailureTerminal && eventType == "error" {
+					if capacityFailure != nil || isOpenAIAPIKeyCapacityFailure(account, dataBytes) {
+						if capacityFailure == nil {
+							capacityDiag.errorObservedAt = time.Now()
+							capacityFailure = s.observeOpenAICapacityTerminalFailure(ctx, account, mappedModel, resp.Header, dataBytes, failedMessage)
+						}
+						capacityEventType = eventType
+						bareErrorAccountSideEffectsPending = false
+					} else if codexFailureTerminal && eventType == "error" {
 						// Wait for the authoritative response.failed before mutating
 						// account health; EOF synthesis applies the pending effect.
 						bareErrorAccountSideEffectsPending = true
@@ -2144,6 +2182,8 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			lineStartsClientOutput = forceFlushFailedEvent || openAIStreamDataStartsClientOutput(trimmedData, eventType)
 			if lineStartsClientOutput && trimmedData != "[DONE]" && !openAIStreamEventTypeIsTerminal(eventType) {
 				semanticOutputSeen = true
+				semanticEventType = eventType
+				semanticEventBytes += len(dataBytes)
 			}
 			// OpenAI Responses streams that terminate with an empty
 			// response.completed (no output, no usage, no error, nothing sent
@@ -2162,6 +2202,10 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 		if line == "" {
 			pendingSSEEventType = ""
+			if capacityFailure != nil && capacityEventType == "error" {
+				capacityDrain.start(resp.Body)
+				capacityEventType = ""
+			}
 			if suppressCurrentEvent {
 				suppressCurrentEvent = false
 				responseFailedPending = false
@@ -2198,9 +2242,23 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		if line == "" && responseFailedPending {
 			responseFailedPending = false
 			failureDelivered = true
+			if capacityFailure != nil && !clientDisconnected {
+				capacityDiag.failureDeliveredAt = time.Now()
+			}
+		}
+		if line == "" && capacityFailure != nil && capacityEventType == "response.failed" {
+			capacityDiag.finishReason = "response.failed"
+			return resultWithUsage(), capacityFailure
 		}
 	}
 	ensureResponseFailedTerminal()
+	if capacityFailure != nil {
+		capacityDiag.finishReason = "upstream_eof"
+		if documentScanner.Err() != nil {
+			capacityDiag.finishReason = "upstream_read_error"
+		}
+		return resultWithUsage(), capacityFailure
+	}
 	if err := documentScanner.Err(); err != nil {
 		if (sawDone || sawTerminalEvent) && !sawFailedEvent {
 			s.clearOpenAIProxyStreamDisconnect(account)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1161,9 +1161,34 @@ func openAIStreamAddedEventStartsClientOutput(payload []byte, eventType string) 
 	}
 }
 
+// Only minimal heartbeat objects are known to be non-semantic. An event name
+// alone must not make an unknown vendor payload safe to replay.
+func openAIStreamDataIsKeepalive(data, eventType string) bool {
+	eventType = strings.TrimSpace(eventType)
+	if eventType != "" && eventType != "keepalive" {
+		return false
+	}
+	if !gjson.Valid(data) {
+		return false
+	}
+	payload := gjson.Parse(data)
+	if !payload.IsObject() || (eventType == "" && payload.Get("type").String() != "keepalive") {
+		return false
+	}
+	keepalive := true
+	payload.ForEach(func(key, value gjson.Result) bool {
+		keepalive = key.Str == "type" && value.Type == gjson.String && value.Str == "keepalive"
+		return keepalive
+	})
+	return keepalive
+}
+
 func openAIStreamDataStartsClientOutput(data, eventType string) bool {
 	trimmed := strings.TrimSpace(data)
 	if trimmed == "" {
+		return false
+	}
+	if openAIStreamDataIsKeepalive(trimmed, eventType) {
 		return false
 	}
 	switch strings.TrimSpace(eventType) {
@@ -1245,6 +1270,9 @@ func openAIStreamDataStartsVisibleOutput(data, eventType string) bool {
 func openAIStreamDataStartsSemanticTTFT(data, eventType string) bool {
 	trimmed := strings.TrimSpace(data)
 	if trimmed == "" || trimmed == "[DONE]" {
+		return false
+	}
+	if openAIStreamDataIsKeepalive(trimmed, eventType) {
 		return false
 	}
 	eventType = strings.TrimSpace(eventType)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -2208,6 +2208,9 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				line = "data: " + string(sanitizedData)
 			}
 			lineStartsClientOutput = forceFlushFailedEvent || openAIStreamDataStartsClientOutput(trimmedData, eventType)
+			if lineStartsClientOutput && eventType == "keepalive" {
+				capacityDiag.unrecognizedKeepalive(ctx, account, "passthrough_sse", dataBytes)
+			}
 			if lineStartsClientOutput && trimmedData != "[DONE]" && !openAIStreamEventTypeIsTerminal(eventType) {
 				semanticOutputSeen = true
 				semanticEventType = eventType

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -718,6 +718,9 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				line = s.replaceModelInSSELine(line, mappedModel, originalModel)
 			}
 			startsClientOutput := forceFlushFailedEvent || openAIStreamDataStartsClientOutput(data, eventType)
+			if startsClientOutput && eventType == "keepalive" {
+				capacityDiag.unrecognizedKeepalive(ctx, account, "native_sse", dataBytes)
+			}
 			startsVisibleOutput := openAIStreamDataStartsVisibleOutput(data, eventType)
 			startsTTFTOutput := openAIStreamDataStartsTTFT(data, eventType, forceFlushFailedEvent, ttftMode)
 			if stageFirstOutput {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -48,7 +48,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	return s.handleStreamingResponseWithReasoning(ctx, resp, c, account, startTime, originalModel, mappedModel, "")
 }
 
-func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel, reasoningEffort string) (*openaiStreamingResult, error) {
+func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel, reasoningEffort string) (streamResult *openaiStreamingResult, streamErr error) {
 	observer := upstreamResponseModelObserverFromContext(c)
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
@@ -255,6 +255,19 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 	clientOutputStarted := false
 	codexFailureTerminal := account != nil && account.IsOpenAIOAuthLike()
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
+	var capacityFailure *OpenAIStreamTerminalError
+	var capacityDrain openAICapacityUsageDrain
+	var capacityDiag openAICapacityStreamDiagnostics
+	capacityEventType := ""
+	semanticEventType, semanticEventBytes := "", 0
+	defer func() {
+		capacityDrain.stop()
+		if capacityFailure != nil {
+			_ = resp.Body.Close()
+			streamErr = capacityFailure
+			capacityDiag.finish(ctx, account, mappedModel, "native_sse", upstreamRequestID, usage, capacityDrain.expired.Load(), clientDisconnected)
+		}
+	}()
 	var streamEarlyErr error
 	terminalFailurePending := false
 	failureDelivered := false
@@ -298,6 +311,10 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				} else {
 					clientOutputStarted = true
 					lastDownstreamWriteAt = time.Now()
+					if semanticEventBytes > 0 {
+						capacityDiag.committed(semanticEventType, semanticEventBytes)
+						semanticEventBytes = 0
+					}
 				}
 			}
 		}
@@ -368,6 +385,9 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		lastDownstreamWriteAt = time.Now()
 	}
 	finalizeStream := func() (*openaiStreamingResult, error) {
+		if capacityFailure != nil && capacityDiag.finishReason == "" {
+			capacityDiag.finishReason = "upstream_eof"
+		}
 		if stageFirstOutput && eventInProgress {
 			// EOF dispatches the final SSE event even without a trailing blank line.
 			completeGuardedEvent(true)
@@ -413,6 +433,11 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 	handleScanErr := func(scanErr error) (*openaiStreamingResult, error, bool) {
 		if scanErr == nil {
 			return nil, nil, false
+		}
+		if capacityFailure != nil {
+			capacityDiag.finishReason = "upstream_read_error"
+			result, err := finalizeStream()
+			return result, err, true
 		}
 		if errors.Is(scanErr, errOpenAIFirstOutputScannerLimit) && !firstOutputProgressObserved {
 			logger.LegacyPrintf("service.openai_gateway", "SSE token exceeded guarded first-output limit: account=%d limit=%d error=%v", account.ID, openAIFirstOutputStageMaxBytes+openAIFirstOutputScannerFramingAllowance, scanErr)
@@ -469,6 +494,24 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 		return resultWithUsage(), fmt.Errorf("stream read error: %w", scanErr), true
 	}
 	processSSELine := func(line string, queueDrained bool) {
+		defer func() {
+			if line == "" && capacityFailure != nil {
+				if failureDelivered && !clientDisconnected && capacityDiag.failureDeliveredAt.IsZero() {
+					capacityDiag.failureDeliveredAt = time.Now()
+				}
+				switch capacityEventType {
+				case "response.failed":
+					capacityDiag.finishReason = "response.failed"
+					streamEarlyErr = capacityFailure
+				case "error":
+					capacityDrain.start(resp.Body)
+				}
+				capacityEventType = ""
+			}
+		}()
+		if capacityDrain.expired.Load() {
+			streamEarlyErr = capacityFailure
+		}
 		if streamEarlyErr != nil {
 			return
 		}
@@ -553,7 +596,14 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 					}
 				}
 				if outputStarted && !cyberHit {
-					if codexFailureTerminal && eventType == "error" {
+					if capacityFailure != nil || isOpenAIAPIKeyCapacityFailure(account, dataBytes) {
+						if capacityFailure == nil {
+							capacityDiag.errorObservedAt = time.Now()
+							capacityFailure = s.observeOpenAICapacityTerminalFailure(ctx, account, mappedModel, resp.Header, dataBytes, failedMessage)
+						}
+						capacityEventType = eventType
+						bareErrorAccountSideEffectsPending = false
+					} else if codexFailureTerminal && eventType == "error" {
 						// OpenAI commonly follows a bare error with response.failed.
 						// Defer account health updates so the pair is applied once.
 						bareErrorAccountSideEffectsPending = true
@@ -679,6 +729,8 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			}
 			if startsClientOutput && !openAIStreamEventTypeIsTerminal(eventType) {
 				responsesSemanticOutputSeen = true
+				semanticEventType = eventType
+				semanticEventBytes += len(dataBytes)
 			}
 			// OpenAI Responses streams that terminate with an empty
 			// response.completed (no output, no usage, no error, nothing sent
@@ -700,7 +752,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 					// 保证首个 token 事件尽快出站，避免影响 TTFT。
 					shouldFlush = true
 				}
-				eventShouldFlush = eventShouldFlush || shouldFlush
+				eventShouldFlush = eventShouldFlush || shouldFlush || (forceFlushFailedEvent && capacityFailure != nil)
 				if _, err := writePendingString(line); err != nil {
 					handlePendingWriteError(err)
 				} else if _, err := writePendingString("\n"); err != nil {
@@ -861,7 +913,14 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			_ = sendEvent(scanEvent{err: err})
 		}
 	}(scanBuf)
-	defer close(done)
+	defer func() {
+		close(done)
+		if capacityFailure != nil {
+			_ = resp.Body.Close()
+			for range events {
+			}
+		}
+	}()
 
 	for {
 		select {
@@ -885,6 +944,9 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 			}
 
 		case <-intervalCh:
+			if capacityFailure != nil {
+				continue
+			}
 			if failureDelivered {
 				return resultWithUsage(), fmt.Errorf("upstream response failed: %s", failedMessage)
 			}

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -388,6 +388,10 @@ func (s *OpenAIGatewayService) newOpenAIAccountFailoverErrorWithClassificationHe
 		upstreamMsg,
 		retryableOnSameAccount || oauth429Retry,
 	)
+	if shouldDisable && isOpenAIAPIKeyCapacityFailure(account, responseBody) {
+		failoverErr.RetryableOnSameAccount = false
+		failoverErr.AccountHealthHandled = true
+	}
 	if oauth429Retry {
 		failoverErr.SameAccountRetryDeadline = s.openAIOAuth429RetryDeadline(account)
 		failoverErr.SameAccountRetryDelay = openAIOAuth429SameAccountRetryDelay(responseHeaders, failoverErr.SameAccountRetryDeadline)

--- a/backend/internal/service/openai_sticky_compat.go
+++ b/backend/internal/service/openai_sticky_compat.go
@@ -200,6 +200,11 @@ func (s *OpenAIGatewayService) refreshStickySessionTTL(ctx context.Context, grou
 }
 
 func (s *OpenAIGatewayService) deleteStickySessionAccountID(ctx context.Context, groupID *int64, sessionHash string) error {
+	if state := openAIStickySuccessFromContext(ctx); state != nil && state.expected.AccountID > 0 && state.groupID == derefGroupID(groupID) && state.sessionHash == sessionHash {
+		// The selected preference belongs to one model, not the legacy binding.
+		// Keep its revision until a successful replacement commits with CAS.
+		return nil
+	}
 	if s == nil || s.cache == nil {
 		return nil
 	}

--- a/backend/internal/service/openai_sticky_success.go
+++ b/backend/internal/service/openai_sticky_success.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// OpenAIStickySuccessBinding is model-scoped so a fallback for one model cannot
+// replace another model's working affinity. Revision also fences late completions.
+type OpenAIStickySuccessBinding struct {
+	AccountID int64  `json:"account_id"`
+	Revision  string `json:"revision"`
+}
+
+type OpenAIStickySuccessCache interface {
+	GetOpenAIStickySuccess(context.Context, int64, string, string) (OpenAIStickySuccessBinding, error)
+	CompareAndSwapOpenAIStickySuccess(context.Context, int64, string, string, OpenAIStickySuccessBinding, OpenAIStickySuccessBinding, time.Duration) (bool, error)
+}
+
+type openAIStickySuccessKey struct{}
+
+type openAIStickySuccessState struct {
+	groupID        int64
+	sessionHash    string
+	model          string
+	expected       OpenAIStickySuccessBinding
+	originalID     int64
+	preservePolicy bool
+}
+
+// BeginOpenAIStickySuccess leaves the original profit-policy binding intact.
+// Only completed inference can establish the model-scoped success preference.
+func (s *OpenAIGatewayService) BeginOpenAIStickySuccess(ctx context.Context, groupID *int64, sessionHash, model string) context.Context {
+	if s == nil || s.cache == nil || !gatewayProfitControlGateActive(ctx) ||
+		preserveOpenAIGuardianParentBinding(ctx, sessionHash) || sessionHash == "" || strings.TrimSpace(model) == "" {
+		return ctx
+	}
+	cache, ok := s.cache.(OpenAIStickySuccessCache)
+	if !ok || s.getOpenAIAccountScheduler(ctx) == nil {
+		return ctx
+	}
+	state := &openAIStickySuccessState{groupID: derefGroupID(groupID), sessionHash: sessionHash, model: strings.TrimSpace(model)}
+	binding, err := cache.GetOpenAIStickySuccess(ctx, state.groupID, sessionHash, state.model)
+	if err != nil && !errors.Is(err, ErrStickySessionNotFound) {
+		logger.FromContext(ctx).Warn("openai.sticky_success_read_failed", zap.Error(err))
+		return ctx
+	}
+	state.expected = binding
+	state.originalID = binding.AccountID
+	if state.originalID == 0 {
+		state.originalID, _ = s.getStickySessionAccountID(ctx, groupID, sessionHash)
+	}
+	if state.originalID > 0 {
+		account, err := s.getSchedulableAccount(ctx, state.originalID)
+		if err != nil {
+			return ctx
+		}
+		if account != nil {
+			state.preservePolicy, _ = openAIProfitControlVetoReason(ctx, account)
+		}
+	}
+	return context.WithValue(ctx, openAIStickySuccessKey{}, state)
+}
+
+func openAIStickySuccessFromContext(ctx context.Context) *openAIStickySuccessState {
+	state, _ := ctx.Value(openAIStickySuccessKey{}).(*openAIStickySuccessState)
+	return state
+}
+
+func (s *OpenAIGatewayService) CommitOpenAIStickySuccess(ctx context.Context, account *Account, result *OpenAIForwardResult) {
+	state := openAIStickySuccessFromContext(ctx)
+	if state == nil || state.preservePolicy || account == nil || result == nil || result.ClientDisconnect || !result.SucceededForScheduling() || ctx.Err() != nil {
+		return
+	}
+	cache, ok := s.cache.(OpenAIStickySuccessCache)
+	if !ok {
+		return
+	}
+	binding := OpenAIStickySuccessBinding{AccountID: account.ID, Revision: uuid.NewString()}
+	updated, err := cache.CompareAndSwapOpenAIStickySuccess(ctx, state.groupID, state.sessionHash, state.model, state.expected, binding, s.openAIWSSessionStickyTTL())
+	if err != nil {
+		logger.FromContext(ctx).Warn("openai.sticky_success_commit_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+		return
+	}
+	if updated && state.originalID != account.ID {
+		logger.FromContext(ctx).Info("openai.sticky_success_rebound", zap.Int64("previous_account_id", state.originalID),
+			zap.Int64("account_id", account.ID), zap.Int64("group_id", state.groupID), zap.String("model", state.model))
+	}
+}

--- a/backend/internal/service/openai_sticky_success_test.go
+++ b/backend/internal/service/openai_sticky_success_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stickySuccessTestCache struct {
+	schedulerTestGatewayCache
+	bindings map[string]OpenAIStickySuccessBinding
+}
+
+func (c *stickySuccessTestCache) GetOpenAIStickySuccess(_ context.Context, group int64, session, model string) (OpenAIStickySuccessBinding, error) {
+	binding, ok := c.bindings[fmt.Sprintf("%d/%s/%s", group, session, model)]
+	if !ok {
+		return binding, ErrStickySessionNotFound
+	}
+	return binding, nil
+}
+
+func (c *stickySuccessTestCache) CompareAndSwapOpenAIStickySuccess(_ context.Context, group int64, session, model string, expected, next OpenAIStickySuccessBinding, _ time.Duration) (bool, error) {
+	key := fmt.Sprintf("%d/%s/%s", group, session, model)
+	if c.bindings[key] != expected {
+		return false, nil
+	}
+	c.bindings[key] = next
+	return true, nil
+}
+
+func TestOpenAIStickySuccessRebindAndPolicy(t *testing.T) {
+	for _, policyVeto := range []bool{false, true} {
+		t.Run(fmt.Sprintf("policy_veto_%t", policyVeto), func(t *testing.T) {
+			cache := &stickySuccessTestCache{
+				schedulerTestGatewayCache: schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:session": 1}},
+				bindings:                  map[string]OpenAIStickySuccessBinding{},
+			}
+			rate := 0.2
+			accounts := []Account{
+				{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, GroupIDs: []int64{81}, RateMultiplier: &rate},
+				{ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, GroupIDs: []int64{81}, RateMultiplier: &rate},
+			}
+			if policyVeto {
+				expensive := 0.9
+				accounts[0].RateMultiplier = &expensive
+			}
+			svc := &OpenAIGatewayService{
+				cache: cache, accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts},
+				rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true", "true"),
+			}
+			t.Cleanup(resetOpenAIAdvancedSchedulerSettingCacheForTest)
+			group := profitControlTestGroup(81, 0.5, 0)
+			base, _ := svc.WithOpenAIRequestPricingContext(profitControlTestCtx(group), &group.ID)
+			first := svc.BeginOpenAIStickySuccess(base, &group.ID, "session", "gpt-test")
+			require.NotNil(t, openAIStickySuccessFromContext(first))
+			selected, _, err := svc.SelectAccountWithScheduler(first, &group.ID, "", "session", "gpt-test", map[int64]struct{}{1: {}}, OpenAIUpstreamTransportHTTPSSE, false)
+			require.NoError(t, err)
+			require.Equal(t, int64(2), selected.Account.ID)
+			svc.CommitOpenAIStickySuccess(first, selected.Account, &OpenAIForwardResult{})
+			require.Equal(t, int64(1), cache.sessionBindings["openai:session"], "legacy policy binding stays intact")
+			next := svc.BeginOpenAIStickySuccess(base, &group.ID, "session", "gpt-test")
+			state := openAIStickySuccessFromContext(next)
+			if policyVeto {
+				require.Zero(t, state.expected.AccountID, "policy-only fallback must not acquire success preference")
+				return
+			}
+			require.Equal(t, int64(2), state.originalID)
+			selected, _, err = svc.SelectAccountWithScheduler(next, &group.ID, "", "session", "gpt-test", nil, OpenAIUpstreamTransportHTTPSSE, false)
+			require.NoError(t, err)
+			require.Equal(t, int64(2), selected.Account.ID, "healthy success must be preferred on the next request")
+			accounts[1].Schedulable = false
+			selected, _, err = svc.SelectAccountWithScheduler(next, &group.ID, "", "session", "gpt-test", nil, OpenAIUpstreamTransportHTTPSSE, false)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), selected.Account.ID, "success preference cannot bypass administrative suspension")
+			other := svc.BeginOpenAIStickySuccess(base, &group.ID, "session", "other-model")
+			require.Equal(t, int64(1), openAIStickySuccessFromContext(other).originalID)
+		})
+	}
+}
+
+func TestOpenAIStickySuccessOnlyCommitsSuccessfulConnectedResults(t *testing.T) {
+	cache := &stickySuccessTestCache{bindings: map[string]OpenAIStickySuccessBinding{}}
+	svc := &OpenAIGatewayService{cache: cache}
+	state := &openAIStickySuccessState{groupID: 1, sessionHash: "s", model: "m"}
+	ctx := context.WithValue(context.Background(), openAIStickySuccessKey{}, state)
+	account := &Account{ID: 2}
+	for _, result := range []*OpenAIForwardResult{nil, {ClientDisconnect: true}, {OpenAIWSMode: true, UpstreamTerminalEvent: "response.failed"}} {
+		svc.CommitOpenAIStickySuccess(ctx, account, result)
+		require.Empty(t, cache.bindings)
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	svc.CommitOpenAIStickySuccess(canceled, account, &OpenAIForwardResult{})
+	require.Empty(t, cache.bindings)
+	svc.CommitOpenAIStickySuccess(ctx, account, &OpenAIForwardResult{})
+	current := cache.bindings["1/s/m"]
+	require.Equal(t, int64(2), current.AccountID)
+	svc.CommitOpenAIStickySuccess(ctx, &Account{ID: 3}, &OpenAIForwardResult{})
+	require.Equal(t, current, cache.bindings["1/s/m"], "late completion cannot overwrite a newer success")
+}

--- a/backend/internal/service/openai_upstream_keepalive_test.go
+++ b/backend/internal/service/openai_upstream_keepalive_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const openAIUpstreamKeepaliveFixture = "data: {\"type\":\"keepalive\"}\n\n"
+const openAIUpstreamKeepaliveFixture = "data: {\"type\":\"keepalive\",\"sequence_number\":1}\n\n"
 
 func TestOpenAIUnrecognizedKeepaliveDiagnostics(t *testing.T) {
 	for _, passthrough := range []bool{false, true} {
@@ -86,6 +86,15 @@ func TestOpenAIUpstreamKeepaliveOutputClassification(t *testing.T) {
 		{"typed heartbeat", `{"type":"keepalive"}`, "keepalive", false},
 		{"data-only heartbeat", `{"type":"keepalive"}`, "", false},
 		{"named heartbeat", `{}`, "keepalive", false},
+		{"sequenced heartbeat", `{"type":"keepalive","sequence_number":1}`, "keepalive", false},
+		{"data-only sequenced heartbeat", `{"sequence_number":0,"type":"keepalive"}`, "", false},
+		{"named sequenced heartbeat", `{"sequence_number":2}`, "keepalive", false},
+		{"sequence is not an event type", `{"sequence_number":1}`, "", true},
+		{"string sequence", `{"type":"keepalive","sequence_number":"1"}`, "keepalive", true},
+		{"negative sequence", `{"type":"keepalive","sequence_number":-1}`, "keepalive", true},
+		{"fractional sequence", `{"type":"keepalive","sequence_number":1.5}`, "keepalive", true},
+		{"sequence with content", `{"type":"keepalive","sequence_number":1,"delta":"hello"}`, "keepalive", true},
+		{"sequence with metadata", `{"type":"keepalive","sequence_number":1,"metadata":{}}`, "keepalive", true},
 		{"empty data", "", "keepalive", false},
 		{"unknown event", `{}`, "vendor.keepalive", true},
 		{"conflicting event", `{"type":"keepalive"}`, "response.output_text.delta", true},
@@ -140,7 +149,7 @@ func TestOpenAIUpstreamKeepalivePreservesPreOutputFailover(t *testing.T) {
 					}()
 					heartbeat := openAIUpstreamKeepaliveFixture
 					if named {
-						heartbeat = "event: keepalive\ndata: {}\n\n"
+						heartbeat = "event: keepalive\ndata: {\"sequence_number\":1}\n\n"
 					}
 					_, err := io.WriteString(writer, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_attempt\"}}\n\n"+heartbeat)
 					require.NoError(t, err)

--- a/backend/internal/service/openai_upstream_keepalive_test.go
+++ b/backend/internal/service/openai_upstream_keepalive_test.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +19,64 @@ import (
 )
 
 const openAIUpstreamKeepaliveFixture = "data: {\"type\":\"keepalive\"}\n\n"
+
+func TestOpenAIUnrecognizedKeepaliveDiagnostics(t *testing.T) {
+	for _, passthrough := range []bool{false, true} {
+		t.Run(fmt.Sprintf("passthrough=%t", passthrough), func(t *testing.T) {
+			logSink, restore := captureStructuredLog(t)
+			defer restore()
+			reader, writer := io.Pipe()
+			body := &capacityBlockingBody{PipeReader: reader, closed: make(chan struct{})}
+			t.Cleanup(func() { _ = writer.Close(); _ = body.Close() })
+			svc := &OpenAIGatewayService{cfg: &config.Config{}}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: body}
+			payload := `{"type":"keepalive","timestamp":1234567,"message":"private-user-text","metadata":{"secret":"private-key"}}`
+			go func() {
+				defer func() { _ = writer.Close() }()
+				_, _ = io.WriteString(writer, openAIUpstreamKeepaliveFixture+"data: "+payload+"\n\ndata: "+payload+"\n\ndata: "+capacityFailedUsageFixture+"\n\n")
+			}()
+			var gotErr error
+			if passthrough {
+				_, gotErr = svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, capacityRuleAccount(), time.Now(), "public", "upstream")
+			} else {
+				_, gotErr = svc.handleStreamingResponse(c.Request.Context(), resp, c, capacityRuleAccount(), time.Now(), "public", "upstream")
+			}
+			var failover *UpstreamFailoverError
+			require.Error(t, gotErr)
+			require.False(t, errors.As(gotErr, &failover), "diagnostics must not relax replay safety")
+			require.Contains(t, rec.Body.String(), payload, "unknown frames remain untouched")
+			logSink.mu.Lock()
+			defer logSink.mu.Unlock()
+			count := 0
+			for _, event := range logSink.events {
+				if event.Message != "openai.unrecognized_keepalive" {
+					continue
+				}
+				count++
+				encoded, err := json.Marshal(event.Fields)
+				require.NoError(t, err)
+				require.Contains(t, string(encoded), `"timestamp":"number"`)
+				require.Contains(t, string(encoded), `"message":"string"`)
+				require.Contains(t, string(encoded), `"metadata":"object"`)
+				for _, secret := range []string{"1234567", "private-user-text", "private-key", `"secret"`} {
+					require.NotContains(t, string(encoded), secret)
+				}
+			}
+			require.Equal(t, 1, count, "log once per attempt, not once per heartbeat")
+		})
+	}
+}
+
+func TestOpenAIUnrecognizedKeepaliveDiagnosticsSkipsOAuth(t *testing.T) {
+	logSink, restore := captureStructuredLog(t)
+	defer restore()
+	var diag openAICapacityStreamDiagnostics
+	diag.unrecognizedKeepalive(context.Background(), &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}, "native_sse", []byte(`{"type":"keepalive","timestamp":1}`))
+	require.False(t, logSink.ContainsMessage("openai.unrecognized_keepalive"))
+}
 
 func TestOpenAIUpstreamKeepaliveOutputClassification(t *testing.T) {
 	for _, tc := range []struct {

--- a/backend/internal/service/openai_upstream_keepalive_test.go
+++ b/backend/internal/service/openai_upstream_keepalive_test.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const openAIUpstreamKeepaliveFixture = "data: {\"type\":\"keepalive\"}\n\n"
+
+func TestOpenAIUpstreamKeepaliveOutputClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name, data, eventType string
+		wantOutput            bool
+	}{
+		{"typed heartbeat", `{"type":"keepalive"}`, "keepalive", false},
+		{"data-only heartbeat", `{"type":"keepalive"}`, "", false},
+		{"named heartbeat", `{}`, "keepalive", false},
+		{"empty data", "", "keepalive", false},
+		{"unknown event", `{}`, "vendor.keepalive", true},
+		{"conflicting event", `{"type":"keepalive"}`, "response.output_text.delta", true},
+		{"conflicting type", `{"type":"response.output_text.delta","delta":"hello"}`, "keepalive", true},
+		{"extra content", `{"type":"keepalive","delta":"hello"}`, "keepalive", true},
+		{"unknown metadata", `{"type":"keepalive","metadata":{}}`, "keepalive", true},
+		{"malformed payload", `{"type":"keepalive"`, "keepalive", true},
+		{"non-object payload", `[]`, "keepalive", true},
+		{"unknown empty object", `{}`, "", true},
+		{"text output", `{"type":"response.output_text.delta","delta":"hello"}`, "response.output_text.delta", true},
+		{"reasoning output", `{"type":"response.reasoning_summary_text.delta","delta":"thinking"}`, "response.reasoning_summary_text.delta", true},
+		{"tool arguments", `{"type":"response.function_call_arguments.delta","delta":"{}"}`, "response.function_call_arguments.delta", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.wantOutput, openAIStreamDataStartsClientOutput(tc.data, tc.eventType))
+			require.Equal(t, tc.wantOutput, openAIStreamDataStartsSemanticTTFT(tc.data, tc.eventType))
+		})
+	}
+}
+
+func TestOpenAIUpstreamKeepalivePreservesPreOutputFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, passthrough := range []bool{false, true} {
+		for _, named := range []bool{false, true} {
+			t.Run(fmt.Sprintf("passthrough=%t/named=%t", passthrough, named), func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					reader, writer := io.Pipe()
+					body := &capacityBlockingBody{PipeReader: reader, closed: make(chan struct{})}
+					t.Cleanup(func() { _ = writer.Close(); _ = body.Close() })
+					repo := &capacityRecoveryRepo{}
+					svc := &OpenAIGatewayService{
+						cfg:              &config.Config{Gateway: config.GatewayConfig{StreamDataIntervalTimeout: 180}},
+						rateLimitService: &RateLimitService{accountRepo: repo},
+					}
+					rec := httptest.NewRecorder()
+					c, _ := gin.CreateTestContext(rec)
+					c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+					resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: body}
+					done := make(chan struct{})
+					var gotErr error
+					var firstTokenMs *int
+					go func() {
+						defer close(done)
+						defer func() { _ = body.Close() }()
+						if passthrough {
+							result, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, capacityRuleAccount(), time.Now(), "public", "upstream")
+							gotErr, firstTokenMs = err, result.firstTokenMs
+						} else {
+							result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, capacityRuleAccount(), time.Now(), "public", "upstream")
+							gotErr, firstTokenMs = err, result.firstTokenMs
+						}
+					}()
+					heartbeat := openAIUpstreamKeepaliveFixture
+					if named {
+						heartbeat = "event: keepalive\ndata: {}\n\n"
+					}
+					_, err := io.WriteString(writer, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_attempt\"}}\n\n"+heartbeat)
+					require.NoError(t, err)
+					synctest.Wait()
+					require.Empty(t, rec.Body.String(), "heartbeat must not flush the attempt preamble")
+					started := time.Now()
+					_, err = io.WriteString(writer, "data: "+capacityBareFixture+"\n\n")
+					require.NoError(t, err)
+					// The upstream deliberately remains open after the error.
+					<-done
+					var failover *UpstreamFailoverError
+					require.ErrorAs(t, gotErr, &failover)
+					require.False(t, failover.RetryableOnSameAccount)
+					require.Zero(t, time.Since(started), "pre-output failure must not wait for the usage drain")
+					require.Nil(t, firstTokenMs)
+					require.Empty(t, rec.Body.String())
+					require.Equal(t, []string{"upstream"}, repo.models)
+				})
+			})
+		}
+	}
+}
+
+func TestOpenAIUpstreamKeepaliveDoesNotDisarmFirstOutputTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	synctest.Test(t, func(t *testing.T) {
+		reader, writer := io.Pipe()
+		body := &capacityBlockingBody{PipeReader: reader, closed: make(chan struct{})}
+		t.Cleanup(func() { _ = writer.Close(); _ = body.Close() })
+		svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{
+			OpenAIFirstOutputTimeoutSeconds: 2,
+			StreamKeepaliveInterval:         1,
+		}}}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+		resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: body}
+		writerDone := make(chan struct{})
+		go func() {
+			defer close(writerDone)
+			for range 10 {
+				if _, err := io.WriteString(writer, openAIUpstreamKeepaliveFixture); err != nil {
+					return
+				}
+				select {
+				case <-body.closed:
+					return
+				case <-time.After(250 * time.Millisecond):
+				}
+			}
+			_ = writer.Close()
+		}()
+		started := time.Now()
+		result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, capacityRuleAccount(), started, "public", "upstream")
+		var failover *UpstreamFailoverError
+		require.ErrorAs(t, err, &failover)
+		require.Contains(t, string(failover.ResponseBody), "first_output_timeout")
+		require.True(t, failover.SafeToFailoverAfterWrite)
+		require.Equal(t, 2*time.Second, time.Since(started))
+		require.Nil(t, result.firstTokenMs)
+		require.NotEmpty(t, rec.Body.String(), "gateway keepalive must remain enabled")
+		for line := range strings.SplitSeq(rec.Body.String(), "\n") {
+			require.True(t, line == "" || strings.HasPrefix(line, ":"), "only gateway comments may precede failover: %q", line)
+		}
+		<-writerDone
+	})
+}

--- a/backend/internal/service/openai_visible_ttft_test.go
+++ b/backend/internal/service/openai_visible_ttft_test.go
@@ -21,6 +21,7 @@ func TestOpenAIVisibleOutputClassification(t *testing.T) {
 		want      bool
 	}{
 		{name: "keepalive", data: `{"type":"keepalive"}`, want: false},
+		{name: "sequenced keepalive", data: `{"type":"keepalive","sequence_number":1}`, want: false},
 		{name: "created", data: `{"type":"response.created"}`, want: false},
 		{name: "empty output item", data: `{"type":"response.output_item.added","item":{"id":"item_test","type":"reasoning","summary":[]}}`, want: false},
 		{name: "empty delta", data: `{"type":"response.output_text.delta","delta":""}`, want: false},

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -972,6 +972,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 		responseID := ""
 		usage := OpenAIUsage{}
+		var capacityFailure *OpenAIStreamTerminalError
 		imageCounter := newOpenAIImageOutputCounter()
 		var firstTokenMs *int
 		reqStream := openAIWSPayloadBoolFromRaw(payload, "stream", true)
@@ -1031,9 +1032,21 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			if eventType == "error" || eventType == "response.failed" {
 				markOpenAICyberPolicyEvent(c, upstreamMessage, http.StatusOK, &usage)
+				if isOpenAIAPIKeyCapacityFailure(account, upstreamMessage) {
+					message := extractOpenAISSEErrorMessage(upstreamMessage)
+					if !wroteDownstream && turn == 1 {
+						lease.MarkBroken()
+						return nil, s.newOpenAIStreamFailoverErrorWithModel(c, account, false, lease.HandshakeHeaders().Get("x-request-id"), upstreamMessage, message, mappedModel, lease.HandshakeHeaders())
+					}
+					if capacityFailure == nil {
+						capacityFailure = s.observeOpenAICapacityTerminalFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), upstreamMessage, message)
+					}
+				}
 			}
 			if eventType == "error" {
-				s.handleOpenAIWSErrorEventTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), upstreamMessage)
+				if capacityFailure == nil {
+					s.handleOpenAIWSErrorEventTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), upstreamMessage)
+				}
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(upstreamMessage)
 				statusCode := openAIWSRejectedFieldRetryHTTPStatus(upstreamMessage)
 				if !wroteDownstream && statusCode == http.StatusBadRequest && rejectedFieldRetryState != nil {
@@ -1200,7 +1213,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				}
 			}
 			if isTerminalEvent {
-				terminalEvent := s.handleOpenAIWSTerminalTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), upstreamMessage)
+				terminalEvent := normalizeOpenAIWSTerminalEvent(eventType)
+				if capacityFailure == nil {
+					terminalEvent = s.handleOpenAIWSTerminalTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), upstreamMessage)
+				}
 				// 客户端已断连时，上游连接的 session 状态不可信，标记 broken 避免回池复用。
 				if clientDisconnected {
 					lease.MarkBroken()

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -337,6 +337,10 @@ func (s *OpenAIGatewayService) handleOpenAIWSErrorEventTransientFailure(ctx cont
 // applying the same transition twice for an error/response.failed pair.
 func (s *OpenAIGatewayService) handleOpenAIWSFailureAccountSideEffects(ctx context.Context, account *Account, canonicalModel string, headers http.Header, payload []byte) bool {
 	message := extractOpenAISSEErrorMessage(payload)
+	if isOpenAIAPIKeyCapacityFailure(account, payload) {
+		_ = s.observeOpenAICapacityTerminalFailure(ctx, account, canonicalModel, headers, payload, message)
+		return true
+	}
 	status := openAIStreamFailureStatus(payload, message)
 	switch status {
 	case http.StatusUnauthorized, http.StatusTooManyRequests, 529:

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -658,10 +658,20 @@ readLoop:
 
 		if eventType == "error" || eventType == "response.failed" {
 			markOpenAICyberPolicyEvent(c, message, http.StatusOK, usage)
+			if !wroteDownstream && isOpenAIAPIKeyCapacityFailure(account, message) {
+				lease.MarkBroken()
+				return nil, s.newOpenAIStreamFailoverErrorWithModel(c, account, false, lease.HandshakeHeaders().Get("x-request-id"), message, extractOpenAISSEErrorMessage(message), mappedModel, lease.HandshakeHeaders())
+			}
 		}
 
 		if eventType == "error" {
-			s.handleOpenAIWSErrorEventTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), message)
+			var capacityFailure *OpenAIStreamTerminalError
+			if isOpenAIAPIKeyCapacityFailure(account, message) {
+				upstreamMessage := extractOpenAISSEErrorMessage(message)
+				capacityFailure = s.observeOpenAICapacityTerminalFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), message, upstreamMessage)
+			} else {
+				s.handleOpenAIWSErrorEventTransientFailure(ctx, account, mappedModel, lease.HandshakeHeaders(), message)
+			}
 			errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(message)
 			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw, mappedModel)
 			errMsg := strings.TrimSpace(errMsgRaw)
@@ -725,6 +735,10 @@ readLoop:
 						"message": errMsg,
 					},
 				})
+			}
+			if capacityFailure != nil {
+				upstreamTerminalEvent = "response.failed"
+				return resultWithUsage(), capacityFailure
 			}
 			return nil, fmt.Errorf("openai ws error event: %s", errMsg)
 		}

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -793,7 +793,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 		replayCollector.AddEvent(eventType, upstreamMessage)
 
 		var upstreamEventErr error
-		if officialOpenAIResponses && bareErrorPending && (eventType == "response.completed" || eventType == "response.done") {
+		if officialOpenAIResponses && bareErrorPending && !isOpenAIAPIKeyCapacityFailure(account, bareErrorPayload) && (eventType == "response.completed" || eventType == "response.done") {
 			// Some upstreams emit a recoverable bare error before the authoritative
 			// successful terminal. Do not replace that terminal with a synthetic
 			// failure or retain side effects from the superseded error.
@@ -841,7 +841,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 				return nil, s.newOpenAIStreamFailoverErrorWithModel(c, account, true, resp.Header.Get("x-request-id"), upstreamMessage, errMessage, mappedModel, resp.Header)
 			}
 			if account.Platform != PlatformGrok && !failureAccountSideEffectsApplied {
-				if eventType == "response.failed" || (!officialOpenAIResponses && shouldFailover && !requestScopedCapacity) {
+				if eventType == "response.failed" || isOpenAIAPIKeyCapacityFailure(account, upstreamMessage) || (!officialOpenAIResponses && shouldFailover && !requestScopedCapacity) {
 					failureAccountSideEffectsApplied = s.handleOpenAIWSFailureAccountSideEffects(ctx, account, mappedModel, resp.Header, upstreamMessage)
 				}
 			}

--- a/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
+++ b/backend/internal/service/openai_ws_ingress_capacity_shed_test.go
@@ -50,6 +50,7 @@ func TestProxyResponsesWebSocketFromClient_RewritesCapacityShedCodeForClient(t *
 		{
 			name: "capacity_shed_error_and_failed_are_rewritten",
 			upstreamEvents: [][]byte{
+				[]byte(`{"type":"response.output_text.delta","delta":"partial"}`),
 				[]byte(`{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}`),
 				[]byte(`{"type":"response.failed","response":{"id":"resp_shed","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}`),
 			},

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -1286,6 +1286,10 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 					return nil
 				}
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(payload)
+				if (eventType == "error" || eventType == "response.failed") && !wroteDownstream &&
+					completedTurns.Load() == 0 && isOpenAIAPIKeyCapacityFailure(account, payload) {
+					return s.newOpenAIStreamFailoverErrorWithModel(c, account, true, handshakeHeaders.Get("x-request-id"), payload, errMsgRaw, capturedSessionModel, handshakeHeaders)
+				}
 				isPreOutputRateLimit := eventType == "error" && !wroteDownstream && isOpenAIWSRateLimitError(errCodeRaw, errTypeRaw, errMsgRaw)
 				if (eventType == "error" || eventType == "response.failed") && !failureAccountSideEffectsApplied && !isPreOutputRateLimit {
 					failureAccountSideEffectsApplied = s.handleOpenAIWSFailureAccountSideEffects(ctx, account, capturedSessionModel, handshakeHeaders, payload)

--- a/backend/internal/service/setting_openai_apikey_health.go
+++ b/backend/internal/service/setting_openai_apikey_health.go
@@ -66,3 +66,22 @@ func (s *SettingService) GetOpenAIAPIKeyHealthBreakerSettings(ctx context.Contex
 	result := *settings
 	return &result, nil
 }
+
+func (s *SettingService) SetOpenAIAPIKeyHealthBreakerSettings(ctx context.Context, settings *OpenAIAPIKeyHealthBreakerSettings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+	normalized := normalizeOpenAIAPIKeyHealthBreakerSettings(settings)
+	if settings.Enabled && *normalized != *settings {
+		return fmt.Errorf("window_minutes and cooldown_minutes must be between 1-60; failure_threshold must be between 1-10000")
+	}
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return err
+	}
+	if err := s.settingRepo.Set(ctx, SettingKeyOpenAIAPIKeyHealthBreakerSettings, string(data)); err != nil {
+		return fmt.Errorf("set OpenAI API key health breaker settings: %w", err)
+	}
+	s.openAIAPIKeyHealthBreakerCache.Store(&cachedOpenAIAPIKeyHealthBreakerSettings{})
+	return nil
+}

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -36,6 +36,10 @@ server:
   # Keep-alive idle timeout in seconds.
   # Keep-Alive 空闲连接超时（秒）。
   idle_timeout: 120
+  # Wait for active HTTP requests during shutdown; container stop grace must be longer.
+  # 停机时等待在途 HTTP 请求；容器 stop_grace_period 必须更长。0 回退到 5 秒。
+  # WebSocket/hijacked connections still require an external drain before shutdown.
+  shutdown_timeout_seconds: 5
   # Trusted proxies used when security.trust_forwarded_ip_for_api_key_acl is false.
   # List only the exact proxy addresses that connect directly to Sub2API.
   # Set [] explicitly to disable forwarded-IP trust in high-security mode.

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -1558,7 +1558,32 @@ export async function resetWebSearchUsage(payload: {
   );
 }
 
+export interface OpenAIAPIKeyHealthBreakerSettings {
+  enabled: boolean;
+  window_minutes: number;
+  failure_threshold: number;
+  cooldown_minutes: number;
+}
+
+export async function getOpenAIAPIKeyHealthBreakerSettings(): Promise<OpenAIAPIKeyHealthBreakerSettings> {
+  const { data } = await apiClient.get<OpenAIAPIKeyHealthBreakerSettings>(
+    "/admin/settings/openai-apikey-health-breaker",
+  );
+  return data;
+}
+
+export async function updateOpenAIAPIKeyHealthBreakerSettings(
+  settings: OpenAIAPIKeyHealthBreakerSettings,
+): Promise<OpenAIAPIKeyHealthBreakerSettings> {
+  const { data } = await apiClient.put<OpenAIAPIKeyHealthBreakerSettings>(
+    "/admin/settings/openai-apikey-health-breaker", settings,
+  );
+  return data;
+}
+
 export const settingsAPI = {
+  getOpenAIAPIKeyHealthBreakerSettings,
+  updateOpenAIAPIKeyHealthBreakerSettings,
   getSettings,
   updateSettings,
   testSmtpConnection,

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -4559,6 +4559,15 @@ const geminiHelpLinks = {
 const presetMappings = computed(() => getPresetMappingsByPlatform(form.platform))
 const tempUnschedPresets = computed(() => [
   {
+    label: t('admin.accounts.tempUnschedulable.presets.capacityLabel'),
+    rule: {
+      error_code: 503,
+      keywords: 'overloaded, server_is_overloaded, slow_down',
+      duration_minutes: 2,
+      description: t('admin.accounts.tempUnschedulable.presets.capacityDesc')
+    }
+  },
+  {
     label: t('admin.accounts.tempUnschedulable.presets.overloadLabel'),
     rule: {
       error_code: 529,

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -3690,6 +3690,15 @@ const openAICompactStatusKey = computed(() => {
 const presetMappings = computed(() => getPresetMappingsByPlatform(props.account?.platform || 'anthropic'))
 const tempUnschedPresets = computed(() => [
   {
+    label: t('admin.accounts.tempUnschedulable.presets.capacityLabel'),
+    rule: {
+      error_code: 503,
+      keywords: 'overloaded, server_is_overloaded, slow_down',
+      duration_minutes: 2,
+      description: t('admin.accounts.tempUnschedulable.presets.capacityDesc')
+    }
+  },
+  {
     label: t('admin.accounts.tempUnschedulable.presets.overloadLabel'),
     rule: {
       error_code: 529,

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -358,7 +358,7 @@ export default {
       tempUnschedulable: {
         title: 'Temp Unschedulable',
         statusTitle: 'Temp Unschedulable Status',
-        hint: 'Disable accounts temporarily when error code and keyword both match.',
+        hint: 'One matching status and keyword triggers a temporary pause. For OpenAI, a known upstream model pauses only that model on this account; unknown models pause the account. Pool mode does not require custom error codes; an enabled error-code ignore policy still takes precedence.',
         notice: 'Rules are evaluated in order and require both error code and keyword match.',
         addRule: 'Add Rule',
         ruleOrder: 'Rule Order',
@@ -394,6 +394,8 @@ export default {
         remainingHours: 'About {hours} hours',
         remainingHoursMinutes: 'About {hours} hours {minutes} minutes',
         presets: {
+          capacityLabel: '503 Capacity overload',
+          capacityDesc: 'Capacity overload - avoid the current model for 2 minutes',
           overloadLabel: '529 Overloaded',
           overloadDesc: 'Overloaded - pause 60 minutes',
           rateLimitLabel: '429 Rate Limit',

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -991,6 +991,18 @@ export default {
         securityWarning: 'Warning: This key provides full admin access. Keep it secure.',
         usage: 'Usage: Add to request header - x-api-key: <your-admin-api-key>'
       },
+      openaiAPIKeyHealth: {
+        title: 'OpenAI Pool Account Health Breaker',
+        description: 'Accumulated terminal failures for OpenAI pool API keys, including confirmed capacity errors. Disabled by default.',
+        enabled: 'Enable accumulated health breaker',
+        window_minutes: 'Window (minutes, 1-60)',
+        failure_threshold: 'Failure threshold (1-10000)',
+        cooldown_minutes: 'Account cooldown (minutes, 1-60)',
+        scopeHint: 'The threshold pauses the whole account. Success does not reset the window. Explicit temporary rules take precedence and pause only the known model. A fully cooled pool may have no available accounts. Disabling does not clear existing pauses.',
+        loadFailed: 'Failed to load health breaker settings',
+        saved: 'Health breaker settings saved',
+        saveFailed: 'Failed to save health breaker settings'
+      },
       overloadCooldown: {
         title: '529 Overload Cooldown',
         description: 'Configure account scheduling pause strategy when upstream returns 529 (overloaded)',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -406,7 +406,7 @@ export default {
       tempUnschedulable: {
         title: '临时不可调度',
         statusTitle: '临时不可调度状态',
-        hint: '当错误码与关键词同时匹配时，账号会在指定时间内被临时禁用。',
+        hint: '错误码与关键词同时匹配即触发一次临时暂停。OpenAI 已知上游模型仅暂停该账号的当前模型；模型未知时暂停账号。池模式无需开启自定义错误码，已启用的错误码忽略策略仍优先。',
         notice: '规则按顺序匹配，需同时满足错误码与关键词。',
         addRule: '添加规则',
         ruleOrder: '规则序号',
@@ -442,6 +442,8 @@ export default {
         remainingHours: '约 {hours} 小时',
         remainingHoursMinutes: '约 {hours} 小时 {minutes} 分钟',
         presets: {
+          capacityLabel: '503 容量过载',
+          capacityDesc: '容量过载 - 暂避当前模型 2 分钟',
           overloadLabel: '529 过载',
           overloadDesc: '服务过载 - 暂停 60 分钟',
           rateLimitLabel: '429 限流',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -985,6 +985,18 @@ export default {
         securityWarning: '警告：此密钥拥有完整的管理员权限，请妥善保管。',
         usage: '使用方法：在请求头中添加 x-api-key: <your-admin-api-key>'
       },
+      openaiAPIKeyHealth: {
+        title: 'OpenAI 池账号健康熔断',
+        description: 'OpenAI 池模式 API Key 的累计终结失败策略，包含已确认的容量过载；默认关闭。',
+        enabled: '启用累计健康熔断',
+        window_minutes: '统计窗口（分钟，1-60）',
+        failure_threshold: '失败阈值（次，1-10000）',
+        cooldown_minutes: '账号暂停（分钟，1-60）',
+        scopeHint: '达到阈值后暂停整个账号。成功不会清空累计窗口；显式临时规则优先，已知模型的规则只暂停该模型。全池冷却期间可能无可用账号，关闭开关不会清除已有暂停。',
+        loadFailed: '加载健康熔断设置失败',
+        saved: '健康熔断设置已保存',
+        saveFailed: '保存健康熔断设置失败'
+      },
       overloadCooldown: {
         title: '529 过载冷却',
         description: '配置上游返回 529（过载）时的账号调度暂停策略',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -203,6 +203,7 @@
 
         <!-- Tab: Gateway -->
         <div v-show="activeTab === 'gateway'" class="space-y-6">
+          <OpenAIAPIKeyHealthSettings />
           <!-- Overload Cooldown (529) Settings -->
           <div class="card">
             <div
@@ -8826,6 +8827,7 @@ import ImageUpload from "@/components/common/ImageUpload.vue";
 import BackupSettings from "@/views/admin/BackupView.vue";
 import EmailTemplateEditor from "@/views/admin/settings/EmailTemplateEditor.vue";
 import OpenAIFastPolicyUserSelector from "@/views/admin/settings/OpenAIFastPolicyUserSelector.vue";
+import OpenAIAPIKeyHealthSettings from "@/views/admin/settings/OpenAIAPIKeyHealthSettings.vue";
 import { useClipboard } from "@/composables/useClipboard";
 import {
   useStepUp,

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -8,6 +8,10 @@ import zhCommon from "@/i18n/locales/zh/common";
 import zhSettings from "@/i18n/locales/zh/admin/settings";
 import SettingsView from "../SettingsView.vue";
 
+vi.mock("../settings/OpenAIAPIKeyHealthSettings.vue", () => ({
+  default: { template: '<section data-testid="openai-health-settings" />' },
+}));
+
 const {
   getSettings,
   updateSettings,

--- a/frontend/src/views/admin/settings/OpenAIAPIKeyHealthSettings.vue
+++ b/frontend/src/views/admin/settings/OpenAIAPIKeyHealthSettings.vue
@@ -1,0 +1,111 @@
+<template>
+  <section class="card" aria-labelledby="openai-health-title">
+    <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+      <h2 id="openai-health-title" class="text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('admin.settings.openaiAPIKeyHealth.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('admin.settings.openaiAPIKeyHealth.description') }}
+      </p>
+    </div>
+    <div class="space-y-5 p-6">
+      <p v-if="loading" role="status">{{ t('common.loading') }}</p>
+      <div v-else-if="loadFailed" class="flex flex-wrap items-center gap-3">
+        <p role="alert" class="text-sm text-red-600">{{ t('admin.settings.openaiAPIKeyHealth.loadFailed') }}</p>
+        <button type="button" class="btn btn-secondary btn-sm" @click="load">
+          <Icon name="refresh" size="sm" class="mr-1" />
+          {{ t('common.refresh') }}
+        </button>
+      </div>
+      <template v-else>
+        <div class="flex items-center justify-between gap-4">
+          <label id="openai-health-enabled" class="font-medium text-gray-900 dark:text-white">
+            {{ t('admin.settings.openaiAPIKeyHealth.enabled') }}
+          </label>
+          <Toggle v-model="form.enabled" :disabled="saving" aria-labelledby="openai-health-enabled" />
+        </div>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div v-for="field in fields" :key="field.key" class="min-w-0">
+            <label :for="`health-${field.key}`" class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              {{ t(`admin.settings.openaiAPIKeyHealth.${field.key}`) }}
+            </label>
+            <input
+              :id="`health-${field.key}`"
+              v-model.number="form[field.key]"
+              type="number"
+              min="1"
+              :max="field.max"
+              step="1"
+              :disabled="saving"
+              class="input w-full max-w-40"
+            />
+          </div>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('admin.settings.openaiAPIKeyHealth.scopeHint') }}</p>
+        <div class="flex justify-end border-t border-gray-100 pt-4 dark:border-dark-700">
+          <button type="button" class="btn btn-primary btn-sm" :disabled="saving || !valid" @click="save">
+            <Icon :name="saving ? 'refresh' : 'check'" size="sm" :class="['mr-1', { 'animate-spin': saving }]" />
+            {{ t(saving ? 'common.saving' : 'common.save') }}
+          </button>
+        </div>
+      </template>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAppStore } from '@/stores/app'
+import Toggle from '@/components/common/Toggle.vue'
+import Icon from '@/components/icons/Icon.vue'
+import {
+  getOpenAIAPIKeyHealthBreakerSettings,
+  updateOpenAIAPIKeyHealthBreakerSettings,
+  type OpenAIAPIKeyHealthBreakerSettings,
+} from '@/api/admin/settings'
+
+const { t } = useI18n()
+const appStore = useAppStore()
+const loading = ref(true)
+const saving = ref(false)
+const loadFailed = ref(false)
+const form = reactive<OpenAIAPIKeyHealthBreakerSettings>({
+  enabled: false, window_minutes: 2, failure_threshold: 10, cooldown_minutes: 5,
+})
+const fields = [
+  { key: 'window_minutes', max: 60 },
+  { key: 'failure_threshold', max: 10000 },
+  { key: 'cooldown_minutes', max: 60 },
+] as const
+const valid = computed(() => fields.every(({ key, max }) =>
+  Number.isInteger(form[key]) && form[key] >= 1 && form[key] <= max,
+))
+
+async function load() {
+  loading.value = true
+  loadFailed.value = false
+  try {
+    Object.assign(form, await getOpenAIAPIKeyHealthBreakerSettings())
+  } catch {
+    loadFailed.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  if (saving.value || !valid.value) return
+  saving.value = true
+  try {
+    Object.assign(form, await updateOpenAIAPIKeyHealthBreakerSettings({ ...form }))
+    appStore.showSuccess(t('admin.settings.openaiAPIKeyHealth.saved'))
+  } catch {
+    appStore.showError(t('admin.settings.openaiAPIKeyHealth.saveFailed'))
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/views/admin/settings/__tests__/OpenAIAPIKeyHealthSettings.spec.ts
+++ b/frontend/src/views/admin/settings/__tests__/OpenAIAPIKeyHealthSettings.spec.ts
@@ -1,0 +1,69 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import OpenAIAPIKeyHealthSettings from '../OpenAIAPIKeyHealthSettings.vue'
+
+const mocks = vi.hoisted(() => ({ load: vi.fn(), save: vi.fn(), success: vi.fn(), error: vi.fn() }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('@/stores/app', () => ({ useAppStore: () => ({ showSuccess: mocks.success, showError: mocks.error }) }))
+vi.mock('@/api/admin/settings', () => ({
+  getOpenAIAPIKeyHealthBreakerSettings: mocks.load,
+  updateOpenAIAPIKeyHealthBreakerSettings: mocks.save,
+}))
+
+describe('OpenAIAPIKeyHealthSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.load.mockResolvedValue({ enabled: false, window_minutes: 10, failure_threshold: 3, cooldown_minutes: 2 })
+    mocks.save.mockImplementation(async (value) => value)
+  })
+
+  it('loads without enabling and saves exactly the four existing fields', async () => {
+    const wrapper = mount(OpenAIAPIKeyHealthSettings)
+    await flushPromises()
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(wrapper.get('[role="switch"]').attributes('aria-checked')).toBe('false')
+    await wrapper.get('[role="switch"]').trigger('click')
+    await wrapper.get('#health-failure_threshold').setValue(4)
+    await wrapper.get('.btn-primary').trigger('click')
+    await flushPromises()
+    expect(mocks.save).toHaveBeenCalledWith({ enabled: true, window_minutes: 10, failure_threshold: 4, cooldown_minutes: 2 })
+    expect(mocks.success).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  it('blocks invalid ranges and fractional counts', async () => {
+    const wrapper = mount(OpenAIAPIKeyHealthSettings)
+    await flushPromises()
+    for (const value of [0, 10001, 1.5]) {
+      await wrapper.get('#health-failure_threshold').setValue(value)
+      expect(wrapper.get('.btn-primary').attributes('disabled')).toBeDefined()
+    }
+    expect(mocks.save).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('does not expose a default save form after a load error and can retry', async () => {
+    mocks.load.mockRejectedValueOnce(new Error('unavailable'))
+    const wrapper = mount(OpenAIAPIKeyHealthSettings)
+    await flushPromises()
+    expect(wrapper.get('[role="alert"]').text()).toContain('loadFailed')
+    expect(wrapper.find('.btn-primary').exists()).toBe(false)
+    await wrapper.get('.btn-secondary').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('#health-window_minutes').exists()).toBe(true)
+    expect(mocks.save).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('keeps the form on save failure and never reports success', async () => {
+    mocks.save.mockRejectedValueOnce(new Error('unavailable'))
+    const wrapper = mount(OpenAIAPIKeyHealthSettings)
+    await flushPromises()
+    await wrapper.get('.btn-primary').trigger('click')
+    await flushPromises()
+    expect(mocks.error).toHaveBeenCalledOnce()
+    expect(mocks.success).not.toHaveBeenCalled()
+    expect(wrapper.get('.btn-primary').attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 问题

OpenAI API Key 上游可以先返回 HTTP 200/SSE，再在流内发送容量过载错误。当前路径有几个相互独立的缺口：

- 容量错误的请求级豁免早于管理员显式临时规则，流内失败未完整进入既有账号健康策略。
- 语义输出已提交后应禁止重放，但这不应同时跳过健康处理，使后续请求继续命中故障账号。
- 裸 `error` 后上游既不发送完整终态、也不关闭连接时，请求可能继续占用上游连接和账号并发槽位，等待正常流的间隔检查。
- 加权粘性的加分和置首没有完整复用已有粘性逃逸配置。
- 最小 `keepalive` 帧被误判为输出开始，正文尚未输出时也会阻止安全切号，并提前记录 semantic TTFT。

## 修改

1. 对已确认的 OpenAI API Key 容量失败，先执行现有显式临时规则，再按原开关观察池账号累计健康熔断。池模式无需开启自定义错误码；已配置的显式忽略仍优先。
2. 用独立流错误类型保留不可重放的失败；已提交失败立即处理健康状态，同账号内部重试仅在终结失败时累计一次，`error`、`response.failed` 和返回链不重复计数。显式规则已处理时不再叠加累计熔断。
3. HTTP 原生 SSE/passthrough：完整 `response.failed` 解析真实 usage 后立即收尾；裸容量 `error` 保留一次性 2 秒用量补齐窗口。心跳不续期，正常超时全部关闭时也能 Close 上游并退出阻塞读取。
4. 加权粘性使用已有逃逸阈值；WS 后续 turn 复核 API Key 账号状态；模型级短冷却不缩短已有更长的暂停。
5. 补齐已有 `openai_apikey_health_breaker_settings` 的管理 GET/PUT、设置页四字段和中英文文案；账号编辑器增加“503 容量过载”两分钟预设。新增组件用例纳入现有 frontend CI。
6. 独立追加保活边界修正：最小 `keepalive` JSON 帧不再触发客户端输出提交或 semantic TTFT，沿用现有前导缓冲，保留首输出前的安全切号能力。原生 SSE、passthrough 及共用该判定的 WS HTTP bridge 使用同一边界。

## 兼容边界

- 未输出时继续遵守现有重试和切号预算；已提交语义输出后不重放，不拼接第二份响应。
- 不默认启用全局熔断，不调整首输出或正常数据间隔超时，不新增 migration。
- 显式规则对已知上游模型沿用模型级暂停；累计熔断仍是池账号级、累计失败窗口，成功不清空窗口。
- 全池冷却时有界失败，不绕过管理员暂停、认证或配额限制，不引入半开探测。
- 正常成功流、OAuth 裸错误后恢复成功及其他平台维持原有策略。
- 保活识别接受 `{"type":"keepalive"}`（可有同名 SSE event）或 `event: keepalive` 搭配空 JSON 对象，两者均可带可选非负整数 `sequence_number`。序号只表示事件顺序，不构成正文；其他额外字段、未知事件变体、非对象或损坏的 JSON 维持原判定，不按事件名称一概放宽重放。不关闭下游注释心跳，不调整首输出或数据间隔超时参数。
- **取舍**：裸容量错误后超过 2 秒才补发的 usage 可能无法取得。保留已接收的真实用量，不估算或伪造用量，不改变价格和结算规则。

## 验证重点

- 使用 `io.Pipe` 构造可阻塞、可 Close 的假上游，覆盖静默、持续心跳、补发 usage、完整失败终态，以及 interval=0/180。分别断言错误确认时的健康动作与之后的资源回收，不能用立即 EOF 的 fixture 替代。
- 完整 handler 验证“失败 -> 冷却 -> 携带旧粘性绑定重连 -> 其他账号成功”、全池故障/到期恢复/人工停用、内部重试最终失败只累计一次。
- 追加保活回归：只有保活后过载，在同一请求内切到另一账号成功且不泄漏失败账号前导事件；保活后已输出正文仍不重放；持续保活不提前解除原生首输出超时，且网关注释心跳继续发送。上游在错误后保持连接不关闭。新分类与 handler 用例已先在修改前运行，分别复现“保活被算作输出”和“只调用首个账号、不切号”。
- 覆盖 WS V2/HTTP bridge、OAuth 成功恢复、显式错误码忽略，以及数据库暂停截止时间与调度快照同步。
- 前端验证读取、四字段保存、非法值、加载失败重试与保存失败状态；新增配置默认关闭。

所有复现均使用合成请求、测试账号和内存或隔离测试依赖，不包含部署配置、生产日志、域名、真实用户/账号信息或凭据。

## 本地结果

初始提炼提交的验证结果：

- `go test -p 4 -tags=unit ./...`：通过。
- `golangci-lint run`（v2.13.0）：通过。
- 容量恢复、WS、handler 重连与设置读写的定向 `go test -race`：通过。
- 独立 PostgreSQL 17.8 的 `TestAccountRepoSuite/TestModelRateLimitNeverShortensExistingPause`：通过。
- `make test-frontend`：lint、typecheck 和 15 个关键测试文件 / 180 个用例通过，包含本次新增设置组件。
- 额外执行前端全量测试：1972 通过、2 失败。`ChannelMonitorView.grok.spec.ts` 的 provider 数量断言和 `GroupsView.codexManifest.spec.ts` 的 Pinia 测试装配问题，均在同一依赖环境下的干净上游基线 `98d86915b` 单独复现，非本 PR 引入；不在本次容量恢复补丁中修改这两处无关文件。

保活边界追加提交已通过 service/handler 聚焦测试、定向 race 和 `golangci-lint run`。覆盖新增保活识别、阻塞上游、同请求切号、已输出后禁止重放、首输出超时，以及已有容量恢复、WS 与 TTFT 回归。本轮未改前端或数据库，完整云端测试按最新提交重新运行。

## 未知保活格式诊断

追加 `openai.unrecognized_keepalive` 结构化日志，便于确认额外保活字段，不必等待用户报告或记录完整响应。仅针对 OpenAI API Key 的原生和透传 SSE 路径，每次账号尝试最多一条；只记录单帧 data 长度、JSON 类型和最多 16 个顶层字段的类型，不记录字段值或嵌套内容。已知最小保活不触发日志，未知保活的转发和重放判定保持不变。

新增用例验证两条 SSE 路径、重复保活去重、敏感值不进入日志以及 OAuth 不受影响。聚焦测试、定向 race 和 service lint 已通过。诊断是取证补充，不将未知生产格式表述为已修复。

## 云端 CI

最新提交 `3437384e7` 继续补齐三处恢复链路：利润控制组的 HTTP Responses 按分组/会话/模型保存成功账号偏好（Redis CAS 防止旧请求覆盖新结果，原利润绑定保留）；客户端取消后仍观察已确认的上游失败，但不再重放；心跳已提交 200 后取消不再被记录为 Recovered。增加可配置的 `server.shutdown_timeout_seconds`，默认仍为 5 秒，部署端需配套更长的容器停止宽限期并提前排空 WebSocket。具体账号、生产规则和超时调参不包含在 PR 中。

新增阻塞假上游的端到端回归：旧账号失败→新账号成功→旧账号恢复后下一条仍选新账号；同时覆盖模型/会话/分组隔离、利润不合格不覆盖、暂停账号不复活、CAS 迟到结果、524+取消只记一次健康、纯取消不记及不再重试、取消不标恢复。完整后端单测、聚焦回归、定向 race 和 lint 已通过。当前完整 HEAD `3437384e7b2af4b3a7287857c9211a31fbfe31b8` 的7项适用云端 CI 于 `2026-09-10T17:38:21Z` 全部通过，cla-lock条件跳过，无失败/待完成项：[最新运行记录](https://github.com/Wei-Shaw/sub2api/actions/runs/34508397812)。下面各次通过记录仅属于历史提交。

上一轮 `51178074fc07403f1e1722123b9ff5f4f230c240`：结构诊断确认了仅带 `type` 和数字型 `sequence_number` 的保活变体。按该字段结构重建合成样本，在修改前复现误判后，只允许可选非负整数序号；不放行其他metadata/内容字段。service/handler聚焦、定向race和lint已通过，包含保活后同请求切号、已有正文禁止重放、首输出超时、TTFT及诊断去重。原始字段值、生产日志和账号信息没有进入本PR。该HEAD的7项适用检查于 `2026-09-10 15:44:39 UTC` 全部通过，cla-lock条件跳过，没有失败或待完成项。[历史运行记录](https://github.com/Wei-Shaw/sub2api/actions/runs/34496512165)。

保活边界修正提交 `b795f29323a4373b6f87d071a9ce4fc27352c69d` 的 7 项适用检查于 `2026-09-10 08:36:52 UTC` 全部通过：`test`（完整 Unit tests + Integration tests）、`frontend`、`golangci-lint`、`shell`、`backend-security`、`frontend-security`、`cla-check`。`cla-lock` 按工作流条件跳过。

诊断追加提交 `8b0d68e469fbaa8c17291c4421216738d7c18b86` 的云端 CI 已于 `2026-09-10 15:02:18 UTC` 全部完成：上述 7 项适用检查通过，`cla-lock` 条件跳过，无失败或待完成项。[当前提交运行记录](https://github.com/Wei-Shaw/sub2api/actions/runs/34491790528)。本地追加的隐私、去重和重放边界回归、定向 race 与 service lint 也通过。

前一次保活边界 CI workflow：[历史运行记录](https://github.com/Wei-Shaw/sub2api/actions/runs/34455192020)。各次结果分别对应各自提交，不复用旧提交的成功状态。

额外前端全量测试中的两项上游既有失败仍如上披露，不将 CI 通过表述为全部额外测试均通过。
