### PR TITLE
fix(gateway): 不再剥离客户端 system 上的 cache_control / stop stripping client system cache_control

### DIFF
--- a/backend/internal/service/gateway_claude_oauth_body.go
+++ b/backend/internal/service/gateway_claude_oauth_body.go
@@ -42,9 +42,8 @@ func (s *GatewayService) replaceModelInBody(body []byte, newModel string) []byte
 }
 
 type claudeOAuthNormalizeOptions struct {
-	injectMetadata          bool
-	metadataUserID          string
-	stripSystemCacheControl bool
+	injectMetadata bool
+	metadataUserID string
 }
 
 // sanitizeSystemText rewrites only the fixed OpenCode identity sentence (if present).
@@ -141,7 +140,14 @@ func deleteJSONPathBytes(body []byte, path string) ([]byte, bool) {
 	return next, true
 }
 
-func normalizeClaudeOAuthSystemBody(body []byte, opts claudeOAuthNormalizeOptions) ([]byte, bool) {
+// normalizeClaudeOAuthSystemBody 只做 system 文本的规范化，**不动 cache_control**。
+//
+// 这里曾经按 opts 剥离客户端打在 system 上的断点。那个动作是「system 必然被整个
+// 重写」时代的配套：内容都搬进 messages 了，残留断点指着空气。system 注入变成
+// 可配置之后前提就没了——注入开启时留在 system 上的断点是我们自己拼的稳定锚点，
+// 注入关闭时它是客户端的缓存意图，两种情形都没有删它的理由。
+// 4 块上限属于上游硬约束，由 enforceCacheControlLimit 在各条出口兜底。
+func normalizeClaudeOAuthSystemBody(body []byte) ([]byte, bool) {
 	sys := gjson.GetBytes(body, "system")
 	if !sys.Exists() {
 		return body, false
@@ -173,13 +179,6 @@ func normalizeClaudeOAuthSystemBody(body []byte, opts claudeOAuthNormalizeOption
 							modified = true
 						}
 					}
-				}
-			}
-
-			if opts.stripSystemCacheControl && item.Get("cache_control").Exists() {
-				if next, ok := deleteJSONPathBytes(out, fmt.Sprintf("system.%d.cache_control", index)); ok {
-					out = next
-					modified = true
 				}
 			}
 
@@ -229,7 +228,7 @@ func normalizeClaudeOAuthRequestBody(body []byte, modelID string, opts claudeOAu
 	out := body
 	modified := false
 
-	if next, changed := normalizeClaudeOAuthSystemBody(out, opts); changed {
+	if next, changed := normalizeClaudeOAuthSystemBody(out); changed {
 		out = next
 		modified = true
 	}
@@ -389,14 +388,12 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 	}
 
 	systemPromptInjectionEnabled, systemPrompt, systemPromptBlocks := s.claudeOAuthSystemPromptInjectionSettings(ctx)
-	systemRewritten := false
 	if systemPromptInjectionEnabled {
 		systemPromptBlocks = claudeOAuthSystemPromptBlocksForModel(model, systemPromptBlocks)
 		body = rewriteSystemForNonClaudeCodeWithPromptBlocks(body, normalizeSystemParam(systemRaw), systemPrompt, systemPromptBlocks)
-		systemRewritten = true
 	}
 
-	normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: !systemRewritten}
+	normalizeOpts := claudeOAuthNormalizeOptions{}
 
 	if s.identityService != nil && c != nil && c.Request != nil {
 		if fp, err := s.identityService.GetOrCreateFingerprint(ctx, account.ID, c.Request.Header); err == nil && fp != nil {

--- a/backend/internal/service/gateway_count_tokens.go
+++ b/backend/internal/service/gateway_count_tokens.go
@@ -59,9 +59,8 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCodeCT
 
 	if shouldMimicClaudeCode {
-		normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: true}
 		var normalizedBody []byte
-		normalizedBody, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, normalizeOpts)
+		normalizedBody, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, claudeOAuthNormalizeOptions{})
 		if err := replaceBody(normalizedBody); err != nil {
 			return err
 		}
@@ -77,6 +76,13 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 			if err := replaceBody(applyToolsLastCacheBreakpoint(body)); err != nil {
 				return err
 			}
+		}
+
+		// 4 块上限的兜底：其余四条出口都在自己的转发路径上调过一次，只有这里没有。
+		// 不再剥离客户端 system 断点之后，「客户端 system + 客户端 messages +
+		// 上面刚注入的 tools[-1]」可以直接顶到 5 块，而上游对超限是 400。
+		if err := replaceBody(enforceCacheControlLimit(body)); err != nil {
+			return err
 		}
 	}
 

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -201,20 +201,15 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		// Code..." system prompt 但缺少 billing attribution block，导致 Anthropic
 		// 检测到"有 CC prompt 但无 billing block"的不一致而判为 third-party。
 		// Parrot 的 transform_request 从不检查客户端 system 内容，直接覆盖。
-		systemRewritten := false
 		systemRaw, _ := parsed.SystemValue()
 		systemPromptInjectionEnabled, systemPrompt, systemPromptBlocks := s.claudeOAuthSystemPromptInjectionSettings(ctx)
 		if systemPromptInjectionEnabled {
 			if err := replaceBody(rewriteSystemForNonClaudeCodeWithPromptBlocks(body, systemRaw, systemPrompt, systemPromptBlocks)); err != nil {
 				return nil, err
 			}
-			systemRewritten = true
 		}
 
-		// system 被重写时保留 CC prompt 的 cache_control: ephemeral（匹配真实 Claude Code 行为）；
-		// 未重写时（注入开关关闭）剥离客户端 cache_control，与原有行为一致。
-		// 两种情况下 enforceCacheControlLimit 都会兜底处理上限。
-		normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: !systemRewritten}
+		normalizeOpts := claudeOAuthNormalizeOptions{}
 		if s.identityService != nil && c != nil {
 			fp, err := s.identityService.GetOrCreateFingerprint(ctx, account.ID, c.Request.Header)
 			if err == nil && fp != nil {

--- a/backend/internal/service/gateway_system_cache_control_test.go
+++ b/backend/internal/service/gateway_system_cache_control_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// 客户端打在 system 上的 cache_control 是它自己的缓存意图，网关不该替它删掉。
+//
+// 这些用例守的是 #2369 里被漏掉的那一半：messages 层的同类改写已经收进
+// rewrite_message_cache_control 开关（默认不动客户端断点），system 层却一直没有
+// 对应的保护——mimic 路径无条件剥离，且不打日志、不报错。
+//
+// 剥离在两种情形下都没有成立的前提：注入开启时 system 已被整个替换、客户端断点
+// 早就不在了；注入关闭时 system 是客户端原样，断点就是它的意图。
+
+// 多块 system 各自带断点时，一块都不能少：Anthropic 允许最多 4 个，
+// 真正的上限兜底是 enforceCacheControlLimit 的事，不该在这里提前砍。
+func TestNormalizeClaudeOAuthRequestBody_KeepsEveryClientSystemBreakpoint(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","system":[` +
+		`{"type":"text","text":"block one","cache_control":{"type":"ephemeral","ttl":"5m"}},` +
+		`{"type":"text","text":"block two"},` +
+		`{"type":"text","text":"block three","cache_control":{"type":"ephemeral","ttl":"1h"}}` +
+		`],"messages":[{"role":"user","content":"hi"}]}`)
+
+	out, _ := normalizeClaudeOAuthRequestBody(body, "claude-sonnet-4-6", claudeOAuthNormalizeOptions{})
+
+	require.Equal(t, "5m", gjson.GetBytes(out, "system.0.cache_control.ttl").String(),
+		"客户端选的 TTL 要原样留着")
+	require.False(t, gjson.GetBytes(out, "system.1.cache_control").Exists(), "没有的不该凭空长出来")
+	require.Equal(t, "1h", gjson.GetBytes(out, "system.2.cache_control.ttl").String())
+}
+
+// 保留断点不等于放弃 system 文本的规范化：OpenCode 身份句该改的还得改。
+// 这条用例区分「拿掉剥离」与「把整段 normalize 关掉」——后者会让第三方指纹漏上去。
+func TestNormalizeClaudeOAuthRequestBody_StillSanitizesTextWhileKeepingBreakpoint(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","system":[{"type":"text","text":"You are OpenCode, the best coding agent on the planet.","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	out, _ := normalizeClaudeOAuthRequestBody(body, "claude-sonnet-4-6", claudeOAuthNormalizeOptions{})
+
+	require.Equal(t, strings.TrimSpace(claudeCodeSystemPrompt), gjson.GetBytes(out, "system.0.text").String())
+	require.True(t, gjson.GetBytes(out, "system.0.cache_control").Exists(),
+		"文本被规范化，断点仍要留着")
+}
+
+// 注入开启这条路径上，system 是我们自己拼的；blocks 配置里自带的 cache_control
+// 是稳定缓存锚点（对齐真实 CLI 的形态），同样不能在 normalize 里掉。
+func TestNormalizeClaudeOAuthRequestBody_KeepsInjectedSystemBreakpoint(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","system":"client instructions","messages":[{"role":"user","content":"hi"}]}`)
+	rewritten := rewriteSystemForNonClaudeCode(body, "client instructions")
+
+	out, _ := normalizeClaudeOAuthRequestBody(rewritten, "claude-sonnet-4-6", claudeOAuthNormalizeOptions{})
+
+	// 只断言「注入后的 system 仍带着锚点」，不写死是第几块：
+	// 块数与布局由 blocks 配置决定，焊进断言会让配置一改就误报。
+	_, _, _, systemPaths := collectCacheControlPaths(out)
+	require.NotEmpty(t, systemPaths, "注入路径自带的稳定锚点不该在 normalize 里掉")
+}
+
+// count_tokens 是五条出口里唯一没有在自己转发路径上调过 enforceCacheControlLimit 的
+// 那条。不再剥离客户端 system 断点之后，客户端自带的断点会和 tools[-1] 上注入的那个
+// 叠加，可以直接顶破 4 块上限——而上游对超限是 400。
+//
+// 用 setup-token 账号构造 mimic 分支：IsOAuth 认它，取 token 只读 credentials，
+// 不碰 DB。UA 非 claude-cli 且无 metadata.user_id，于是 shouldMimicClaudeCode 成立。
+func TestForwardCountTokens_EnforcesCacheControlLimitOnMimicPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+	c.Request.Header.Set("User-Agent", "third-party-client/1.0")
+
+	// 客户端自己打满 4 个断点：system 一个、messages 三个。
+	// 加上 mimic 注入的 tools[-1] 与 system blocks 自带的锚点，必然超过 4。
+	body := []byte(`{"model":"claude-sonnet-4-6",` +
+		`"system":[{"type":"text","text":"stable client prefix","cache_control":{"type":"ephemeral","ttl":"5m"}}],` +
+		`"tools":[{"name":"probe","description":"d","input_schema":{"type":"object"}}],` +
+		`"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"one","cache_control":{"type":"ephemeral"}}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"two","cache_control":{"type":"ephemeral"}}]},` +
+		`{"role":"user","content":[{"type":"text","text":"three","cache_control":{"type":"ephemeral"}}]}` +
+		`]}`)
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-6"}
+
+	upstream := &anthropicHTTPUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":42}`)),
+		},
+	}
+	svc := &GatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}},
+		httpUpstream:     upstream,
+		rateLimitService: &RateLimitService{},
+	}
+	account := &Account{
+		ID:          401,
+		Name:        "count-tokens-ceiling-test",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeSetupToken,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-oauth-token"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	require.NoError(t, svc.ForwardCountTokens(context.Background(), c, account, parsed))
+
+	_, messagePaths, toolPaths, systemPaths := collectCacheControlPaths(upstream.lastBody)
+	total := len(messagePaths) + len(toolPaths) + len(systemPaths)
+	require.LessOrEqual(t, total, maxCacheControlBlocks,
+		"出站 body 的 cache_control 块数必须被砍到上限内，实测 %d 块", total)
+}


### PR DESCRIPTION
## 问题

OAuth mimic 路径会无条件删除客户端打在 `system[*].cache_control` 上的缓存断点，删的时候不打日志、不报错。对那些把稳定前缀锚在 system 上的客户端（数组形式 system + 某块带 `cache_control`，标准 Anthropic 用法），表现是 `cache_creation_input_tokens` 与 `cache_read_input_tokens` **双 0** —— 不是没命中，是连写都没写。

三处调用点，语义还不一致：

| 位置 | 原值 |
|---|---|
| `gateway_forward.go` | `stripSystemCacheControl: !systemRewritten` |
| `gateway_claude_oauth_body.go`（通用 mimicry） | `stripSystemCacheControl: !systemRewritten` |
| `gateway_count_tokens.go` | `stripSystemCacheControl: true`（硬编码） |

## 为什么这是缺陷而不是设计

剥离这个动作是 46e5ac9 引进的，当时 mimic 路径**必然**把 system 整个重写成 CC 形态、客户端的 system 内容必然被搬进 messages。在那个前提下删掉残留断点是对的：内容都不在 system 里了，断点指着空气。**剥离是「system 被重写」的配套动作，两者本来是一体的。**

后来 system 注入变成可配置（`enable_claude_oauth_system_prompt_injection`），于是长出了原设计里不存在的组合：**system 没被重写，断点照删**。剥离失去了它赖以成立的前提，但代码还在。`gateway_forward.go` 那行注释自己也说了 ——「未重写时（注入开关关闭）剥离客户端 cache_control，与原有行为一致」：保留的是一个语境已经消失的动作。

`stripSystemCacheControl: !systemRewritten` 还把两件无关的事绑在了一个开关上。关掉 system 注入的人想要的是「别改我的 system」，拿到的却是「删掉你的缓存断点」。

## 与 #2369 的关系

#2369 处理的是 messages 层的同类改写，结论是收进 `rewrite_message_cache_control`、默认不动客户端断点。那个 issue 的评论里已经点名了 system 层：

> `stripSystemCacheControl: true`（硬编码路径）……客户端如果用数组形式 system + 在某个 block 上打 `cache_control`（标准 Anthropic 用法），这条路径会直接清掉。

9377c96 只落地了 messages 那一条。这个 PR 补上 system 那一半。

## 为什么直接移除，而不是再加一个开关

因为剥离在两种情形下都没有成立的前提：

- **注入开启**：system 已被 `rewriteSystemForNonClaudeCodeWithPromptBlocks` 整个替换，客户端断点早就不在了；此时还留在 system 上的断点是我们自己拼进去的稳定锚点，更不该删
- **注入关闭**：system 是客户端原样，断点就是它的缓存意图

需要开关的是有取舍的行为，这个没有。加 flag 反而是把一个不该存在的动作制度化。

## 顺带补上 count_tokens 的上限兜底

写这个 PR 时发现，`ForwardCountTokens` 是五条出口里**唯一没有在自己的转发路径上调过 `enforceCacheControlLimit`** 的那条（另外四条：`gateway_forward.go:267`、`gateway_forward_as_chat_completions.go:106`、`gateway_forward_as_responses.go:119`、两个 `openai_gateway_*_anthropic_native.go`）。

也就是说，原先那句 `stripSystemCacheControl: true` 是这条路上**唯一**压制断点数量的东西。只拿掉它而不补兜底，「客户端 system 断点 + 客户端 messages 断点（默认开关关闭，不改写）+ `applyToolsLastCacheBreakpoint` 刚注入的 tools[-1]」会直接顶破上限 —— 新增的测试实测到 **5 块**，而上游对超限是 400。

所以本 PR 在 count_tokens 的 mimic 分支末尾补了一次 `enforceCacheControlLimit`，与另外四条出口对齐。撤掉这一行，新测试立刻变红。

## 实测

OAuth 账号，同一个账号、逐字节相同的 body、8 秒间隔连打三次：

| 客户端形态 | 断点位置 | `cache_creation` | `cache_read` |
|---|---|---|---|
| 第三方（走 mimic） | system | **0** | **0** |
| Claude Code 形态（不走 mimic） | system | 1965 → 0 | 0 → **1965** |

补丁后第一种形态与第二种一致：首次写入、后续命中。

## 测试

新增 `gateway_system_cache_control_test.go`，4 个用例：

- 多块客户端断点一块不少，含客户端自选的 TTL
- 文本 sanitize 仍生效 —— 区分「拿掉剥离」与「把整段 normalize 关掉」
- 注入路径自带的锚点不掉
- count_tokens 出口的断点数被砍进上限（撤掉修复即红，实测 5 块）

这个行为此前**没有任何测试覆盖** —— 全仓搜 `stripSystemCacheControl`，`_test.go` 里零命中。

`go build ./...`、`go vet ./internal/service/`、`golangci-lint run ./internal/service/...`、`go test ./...` 全绿。

## 没在这个 PR 里做的三件事

都能独立成 PR，写在这里免得被当成漏掉的：

1. **`enforceCacheControlLimit` 应该收到 wire 边界**。现在是 5 处散点调用，count_tokens 漏掉正是散点的代价。它和 `stripDeferredToolCacheControl` 是同一类东西（上游硬约束的最终归一化），后者已经放在 `gateway_upstream_request.go:22` 那个位置了。挪过去、删掉散点，上限就变成不可绕过的出口不变量。这次先按现有形态补齐，没动结构。

2. **`applyToolsLastCacheBreakpoint` 仍然无条件在 `tools[-1]` 注入一个客户端没要的断点**，占掉 4 个名额之一、改变前缀签名。按本 PR 自己的判据它是**有取舍**的（对不管理缓存的客户端有益，对自己有缓存设计的有害），因此该有开关 —— 但不建议再加第三个独立 toggle。三条路（messages 有 flag、tools 硬编码、system 本次移除）目前是三种机制，正解是一个统一的策略决定「代理是否接管缓存断点」，三层同进同退。

3. **`normalizeClaudeOAuthSystemBody` 现在几乎总是空转**。删掉 strip 之后它唯一还会生效的是替换一句固定的 OpenCode 身份句，但每个请求仍要付一次 `gjson.GetBytes`（会整段复制 system 的 Raw）+ 逐块子扫描 + `String()` 的二次复制。一个 `bytes.Contains` 预检就能短路，属于纯性能改动，没有混进这个 bug 修复里。

---

## English

### Problem

The OAuth mimic path unconditionally deletes client-supplied `system[*].cache_control` breakpoints, silently — no log, no error. For clients that anchor a stable prefix on `system` (array-form system with `cache_control` on a block — standard Anthropic usage), the result is `cache_creation_input_tokens` **and** `cache_read_input_tokens` both zero: not a miss, nothing was ever written.

Three call sites with inconsistent semantics: two use `!systemRewritten`, while `gateway_count_tokens.go` hardcodes `true`.

### Why this is a defect, not a design

The strip was introduced in 46e5ac9, when the mimic path **always** rewrote `system` into CC shape and migrated the client's system content into `messages`. Under that premise, dropping the leftover breakpoints was correct — the content they pointed at was gone. **The strip was a companion action to "system gets rewritten", not an independent behavior.**

Once system injection became configurable, a combination the original design never had appeared: system is *not* rewritten, yet breakpoints are still deleted. The inline comment acknowledges it keeps the old behavior — but the context that justified it is gone.

`stripSystemCacheControl: !systemRewritten` also couples two unrelated decisions to one switch. Someone turning off system injection wants "don't touch my system"; what they get is "your cache breakpoints are deleted".

### Relation to #2369

#2369 covered the same class of rewrite at the messages layer and was resolved by gating it behind `rewrite_message_cache_control` (default: leave client breakpoints alone). That issue's comments explicitly named the system layer too; 9377c96 only landed the messages half. This PR completes the other half.

### Why remove rather than add another flag

The strip has no valid premise in either branch: with injection on, `system` has already been replaced wholesale and the remaining breakpoints are ours, deliberately placed; with injection off, the breakpoints are the client's intent. A flag is for behavior with a genuine trade-off — this has none.

### Also: the missing ceiling guard on count_tokens

`ForwardCountTokens` turns out to be the only one of five egress paths that never calls `enforceCacheControlLimit`. The `stripSystemCacheControl: true` line was therefore the *only* thing capping breakpoint count on that path. Removing it without a guard lets "client system + client messages + the freshly injected `tools[-1]`" exceed the limit — the new test measures **5 blocks**, and upstream answers 400 on overflow. This PR adds the missing `enforceCacheControlLimit` call at the end of the count_tokens mimic branch, matching the other four paths. Revert that one line and the new test goes red.

### Verification

Same OAuth account, byte-identical body, three calls 8s apart: the third-party shape went from `creation=0, read=0` to write-then-hit, matching the Claude Code shape that never went through the strip.

### Tests

New `gateway_system_cache_control_test.go`, 4 cases: every client breakpoint across multiple blocks preserved (including the client-chosen TTL); text sanitization still applied (distinguishing "drop the strip" from "disable normalize entirely"); injected anchors preserved; and the count_tokens egress capped at the limit. This behavior had **zero** test coverage before — `stripSystemCacheControl` appeared in no `_test.go` file.

`go build ./...`, `go vet`, `golangci-lint run ./internal/service/...` and `go test ./...` all pass.

### Deliberately out of scope

Three follow-ups, each worth its own PR: (1) move `enforceCacheControlLimit` to the wire boundary next to `stripDeferredToolCacheControl` so the ceiling becomes an unavoidable egress invariant instead of 5 scattered calls; (2) `applyToolsLastCacheBreakpoint` still force-injects a breakpoint the client never asked for — that one *does* have a trade-off and deserves gating, ideally via a single policy shared by all three layers rather than a third independent toggle; (3) `normalizeClaudeOAuthSystemBody` is now almost always a no-op yet still pays a full `gjson` parse per request — a `bytes.Contains` pre-check would short-circuit it, but that's a pure performance change and doesn't belong in a bug fix.
