### PR TITLE
feat(openai): 自动用卡阈值支持按窗口关闭

### DIFF
--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -528,11 +528,11 @@ func shouldAutoPauseOpenAIAccountByQuota(ctx context.Context, account *Account) 
 		now := time.Now()
 		utilization5h, has5h := resolveOpenAIQuotaUtilization(account.Extra, "5h", now)
 		utilization7d, has7d := resolveOpenAIQuotaUtilization(account.Extra, "7d", now)
-		if has5h && utilization5h >= config.Threshold5h {
+		if has5h && config.Threshold5h > 0 && utilization5h >= config.Threshold5h {
 			notifyOpenAIAutoReset(account.ID)
 			return true, openAIQuotaAutoPauseDecision{window: "5h", threshold: config.Threshold5h, utilization: utilization5h, reason: "quota_auto_reset_pending_5h"}
 		}
-		if has7d && utilization7d >= config.Threshold7d {
+		if has7d && config.Threshold7d > 0 && utilization7d >= config.Threshold7d {
 			notifyOpenAIAutoReset(account.ID)
 			return true, openAIQuotaAutoPauseDecision{window: "7d", threshold: config.Threshold7d, utilization: utilization7d, reason: "quota_auto_reset_pending_7d"}
 		}

--- a/backend/internal/service/openai_quota_auto_reset.go
+++ b/backend/internal/service/openai_quota_auto_reset.go
@@ -288,7 +288,7 @@ func (s *OpenAIQuotaAutoResetService) evaluateAccount(ctx context.Context, accou
 	now := time.Now()
 	assessment := s.assessExtra(account, config, now)
 	state := openAIAutoResetStateFromExtra(account.Extra)
-	needsQuery := openAIAutoResetSnapshotStale(account.Extra, now) || assessment.resetReached
+	needsQuery := (openAIAutoResetSnapshotStale(account.Extra, now) && config.thresholdActive()) || assessment.resetReached
 	if assessment.pauseReached && !assessment.resetReached {
 		needsQuery = needsQuery || state == nil || state.Status == OpenAIAutoResetStatusChecking || state.Status == OpenAIAutoResetStatusFailed || openAIAutoResetStateStale(state, now)
 	}
@@ -519,8 +519,8 @@ func (s *OpenAIQuotaAutoResetService) buildAssessment(account *Account, config O
 		threshold5h:   config.Threshold5h,
 		threshold7d:   config.Threshold7d,
 	}
-	reset5h := utilization5h >= config.Threshold5h
-	reset7d := utilization7d >= config.Threshold7d
+	reset5h := config.Threshold5h > 0 && utilization5h >= config.Threshold5h
+	reset7d := config.Threshold7d > 0 && utilization7d >= config.Threshold7d
 	assessment.resetReached = reset5h || reset7d
 	assessment.triggerWindow = joinOpenAIAutoResetWindows(reset5h, reset7d)
 

--- a/backend/internal/service/openai_quota_auto_reset_config.go
+++ b/backend/internal/service/openai_quota_auto_reset_config.go
@@ -16,8 +16,9 @@ const (
 	OpenAIAutoResetCredit7dThresholdExtraKey = "auto_reset_credit_7d_threshold"
 	OpenAIAutoResetCreditStateExtraKey       = "codex_auto_reset_credit_state"
 
-	openAIAutoResetCreditDefaultThreshold = 1.0
-	openAIAutoResetCreditMinimumThreshold = 0.001
+	openAIAutoResetCreditDefaultThreshold   = 1.0
+	openAIAutoResetCreditDefault5hThreshold = 0.0
+	openAIAutoResetCreditMinimumThreshold   = 0.001
 )
 
 // OpenAIAutoResetCreditConfig 是账号级自动用卡配置。阈值采用 0-1 比例，
@@ -28,11 +29,15 @@ type OpenAIAutoResetCreditConfig struct {
 	Threshold7d float64
 }
 
+func (c OpenAIAutoResetCreditConfig) thresholdActive() bool {
+	return c.Enabled && (c.Threshold5h > 0 || c.Threshold7d > 0)
+}
+
 // ResolveOpenAIAutoResetCreditConfig 只接受 OpenAI OAuth 母账号；历史账号未配置时
 // 始终保持关闭，防止升级后产生意外消费。
 func ResolveOpenAIAutoResetCreditConfig(account *Account) OpenAIAutoResetCreditConfig {
 	config := OpenAIAutoResetCreditConfig{
-		Threshold5h: openAIAutoResetCreditDefaultThreshold,
+		Threshold5h: openAIAutoResetCreditDefault5hThreshold,
 		Threshold7d: openAIAutoResetCreditDefaultThreshold,
 	}
 	if !isOpenAIAutoResetCreditAccount(account) || account.Extra == nil {
@@ -53,7 +58,7 @@ func isOpenAIAutoResetCreditAccount(account *Account) bool {
 }
 
 // normalizeOpenAIAutoResetCreditExtra 校验管理请求中的配置并剥离服务运行态。
-// enabled=true 时补齐两个 100% 默认阈值；关闭时保留已设置阈值，方便再次开启。
+// enabled=true 时补齐默认阈值（5h 关闭、7d 100%）；关闭时保留已设置阈值，方便再次开启。
 func normalizeOpenAIAutoResetCreditExtra(platform, accountType string, isShadow bool, extra map[string]any) (map[string]any, error) {
 	if extra == nil {
 		return nil, nil
@@ -79,19 +84,19 @@ func normalizeOpenAIAutoResetCreditExtra(platform, accountType string, isShadow 
 		}
 		enabled = value
 	}
-	for key, present := range map[string]bool{
-		OpenAIAutoResetCredit5hThresholdExtraKey: has5h,
-		OpenAIAutoResetCredit7dThresholdExtraKey: has7d,
+	for key, defaultValue := range map[string]float64{
+		OpenAIAutoResetCredit5hThresholdExtraKey: openAIAutoResetCreditDefault5hThreshold,
+		OpenAIAutoResetCredit7dThresholdExtraKey: openAIAutoResetCreditDefaultThreshold,
 	} {
-		if !present {
+		if _, present := normalized[key]; !present {
 			if enabled {
-				normalized[key] = openAIAutoResetCreditDefaultThreshold
+				normalized[key] = defaultValue
 			}
 			continue
 		}
 		value, ok := parseOpenAIAutoResetThreshold(normalized[key])
 		if !ok || !isValidOpenAIAutoResetThreshold(value) {
-			return nil, infraerrors.Newf(http.StatusBadRequest, "OPENAI_AUTO_RESET_CREDIT_THRESHOLD_INVALID", "%s must be between 0.001 and 1.0", key)
+			return nil, infraerrors.Newf(http.StatusBadRequest, "OPENAI_AUTO_RESET_CREDIT_THRESHOLD_INVALID", "%s must be 0 (disabled) or between 0.001 and 1.0", key)
 		}
 		normalized[key] = value
 	}
@@ -132,8 +137,9 @@ func parseOpenAIAutoResetThreshold(value any) (float64, bool) {
 	}
 }
 
+// 0 表示该窗口不参与阈值触发。
 func isValidOpenAIAutoResetThreshold(value float64) bool {
-	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= openAIAutoResetCreditMinimumThreshold && value <= 1
+	return value == 0 || (!math.IsNaN(value) && !math.IsInf(value, 0) && value >= openAIAutoResetCreditMinimumThreshold && value <= 1)
 }
 
 func cloneOpenAIAutoResetExtra(source map[string]any) map[string]any {

--- a/backend/internal/service/openai_quota_auto_reset_test.go
+++ b/backend/internal/service/openai_quota_auto_reset_test.go
@@ -16,17 +16,17 @@ func TestNormalizeOpenAIAutoResetCreditExtra(t *testing.T) {
 		account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
 		config := ResolveOpenAIAutoResetCreditConfig(account)
 		require.False(t, config.Enabled)
-		require.Equal(t, 1.0, config.Threshold5h)
+		require.Equal(t, 0.0, config.Threshold5h)
 		require.Equal(t, 1.0, config.Threshold7d)
 	})
 
-	t.Run("开启时补齐两个百分百阈值并剥离运行态", func(t *testing.T) {
+	t.Run("开启时补齐默认阈值并剥离运行态", func(t *testing.T) {
 		extra, err := normalizeOpenAIAutoResetCreditExtra(PlatformOpenAI, AccountTypeOAuth, false, map[string]any{
 			OpenAIAutoResetCreditEnabledExtraKey: true,
 			OpenAIAutoResetCreditStateExtraKey:   map[string]any{"status": "success"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1.0, extra[OpenAIAutoResetCredit5hThresholdExtraKey])
+		require.Equal(t, 0.0, extra[OpenAIAutoResetCredit5hThresholdExtraKey])
 		require.Equal(t, 1.0, extra[OpenAIAutoResetCredit7dThresholdExtraKey])
 		require.NotContains(t, extra, OpenAIAutoResetCreditStateExtraKey)
 	})
@@ -175,6 +175,7 @@ func (r *autoResetTestAccountRepo) UpdateExtra(_ context.Context, id int64, upda
 type autoResetTestQuota struct {
 	usage        *OpenAIQuotaUsage
 	resetCalls   atomic.Int32
+	queryCalls   atomic.Int32
 	resetEntered chan struct{}
 	releaseReset chan struct{}
 	enterOnce    sync.Once
@@ -184,6 +185,7 @@ type autoResetTestQuota struct {
 }
 
 func (q *autoResetTestQuota) QueryUsage(context.Context, int64) (*OpenAIQuotaUsage, error) {
+	q.queryCalls.Add(1)
 	copy := *q.usage
 	return &copy, nil
 }
@@ -333,4 +335,72 @@ func TestOpenAIQuotaAutoResetService_TimeoutRetryReusesRequestBody(t *testing.T)
 	quota.mu.Unlock()
 	require.Len(t, args, 2)
 	require.Equal(t, args[0], args[1], "超时重试必须复用相同 credit_id 与 redeem_request_id")
+}
+
+func TestOpenAIQuotaAutoResetService_DisabledThresholdWindows(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		fiveHour, sevenDay float64
+	}{
+		{name: "关闭5h", fiveHour: 0, sevenDay: 1},
+		{name: "关闭7d", fiveHour: 1, sevenDay: 0},
+		{name: "全部关闭", fiveHour: 0, sevenDay: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			extra, err := normalizeOpenAIAutoResetCreditExtra(PlatformOpenAI, AccountTypeOAuth, false, map[string]any{
+				OpenAIAutoResetCreditEnabledExtraKey:     true,
+				OpenAIAutoResetCredit5hThresholdExtraKey: tc.fiveHour,
+				OpenAIAutoResetCredit7dThresholdExtraKey: tc.sevenDay,
+				"auto_pause_5h_disabled":                 true,
+				"auto_pause_7d_disabled":                 true,
+				"codex_5h_used_percent":                  (1 - tc.fiveHour) * 100,
+				"codex_7d_used_percent":                  (1 - tc.sevenDay) * 100,
+				"codex_usage_updated_at":                 now.Format(time.RFC3339),
+				"codex_5h_reset_at":                      now.Add(time.Hour).Format(time.RFC3339),
+				"codex_7d_reset_at":                      now.Add(time.Hour).Format(time.RFC3339),
+			})
+			require.NoError(t, err)
+			account := &Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: extra}
+			config := ResolveOpenAIAutoResetCreditConfig(account)
+			require.Equal(t, tc.fiveHour, config.Threshold5h)
+			require.Equal(t, tc.sevenDay, config.Threshold7d)
+			service := &OpenAIQuotaAutoResetService{}
+			assessment := service.buildAssessment(account, config, 1-tc.fiveHour, 1-tc.sevenDay)
+			require.False(t, assessment.resetReached)
+			paused, _ := shouldAutoPauseOpenAIAccountByQuota(context.Background(), account)
+			require.False(t, paused)
+		})
+	}
+}
+
+func TestOpenAIQuotaAutoResetService_AllThresholdsDisabledSkipSnapshotPoll(t *testing.T) {
+	now := time.Now().UTC()
+	account := &Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Extra: map[string]any{
+		OpenAIAutoResetCreditEnabledExtraKey:     true,
+		OpenAIAutoResetCredit5hThresholdExtraKey: 0.0,
+		OpenAIAutoResetCredit7dThresholdExtraKey: 0.0,
+		"auto_pause_5h_disabled":                 true,
+		"auto_pause_7d_disabled":                 true,
+		"codex_usage_updated_at":                 now.Add(-time.Hour).Format(time.RFC3339),
+	}}
+	repo := &autoResetTestAccountRepo{account: account}
+	quota := &autoResetTestQuota{usage: &OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{}, RateLimitResetCredits: &OpenAIRateLimitResetCredits{}}}
+	service := NewOpenAIQuotaAutoResetService(repo, quota, autoResetTestRecoverer{}, nil, nil, nil, nil)
+	t.Cleanup(service.Stop)
+	require.NoError(t, service.evaluateAccount(context.Background(), account.ID))
+	require.Equal(t, int32(0), quota.queryCalls.Load())
+	require.Equal(t, int32(0), quota.resetCalls.Load())
+}
+
+func TestNormalizeOpenAIAutoResetCreditExtra_PreservesSavedThresholds(t *testing.T) {
+	extra, err := normalizeOpenAIAutoResetCreditExtra(PlatformOpenAI, AccountTypeOAuth, false, map[string]any{
+		OpenAIAutoResetCreditEnabledExtraKey:     true,
+		OpenAIAutoResetCredit5hThresholdExtraKey: 1.0,
+		OpenAIAutoResetCredit7dThresholdExtraKey: 0.85,
+	})
+	require.NoError(t, err)
+	config := ResolveOpenAIAutoResetCreditConfig(&Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: extra})
+	require.Equal(t, 1.0, config.Threshold5h)
+	require.Equal(t, 0.85, config.Threshold7d)
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2429,7 +2429,7 @@
             <input
               v-model.number="autoResetCredit5hThreshold"
               type="number"
-              min="0.1"
+              min="0"
               max="100"
               step="0.1"
               class="input"
@@ -2442,7 +2442,7 @@
             <input
               v-model.number="autoResetCredit7dThreshold"
               type="number"
-              min="0.1"
+              min="0"
               max="100"
               step="0.1"
               class="input"
@@ -3350,7 +3350,7 @@ const autoPause7dThreshold = ref<number | null>(null)
 const autoPause5hDisabled = ref(false)
 const autoPause7dDisabled = ref(false)
 const autoResetCreditEnabled = ref(false)
-const autoResetCredit5hThreshold = ref(100)
+const autoResetCredit5hThreshold = ref(0)
 const autoResetCredit7dThreshold = ref(100)
 const upstreamBillingAutoProbeEnabled = ref(false)
 const upstreamBillingRateSyncEnabled = ref(false)
@@ -3892,7 +3892,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 	autoPause7dDisabled.value = extra?.auto_pause_7d_disabled === true
 	autoResetCreditEnabled.value = extra?.auto_reset_credit_enabled === true
 	autoResetCredit5hThreshold.value =
-		typeof extra?.auto_reset_credit_5h_threshold === 'number' ? extra.auto_reset_credit_5h_threshold * 100 : 100
+		typeof extra?.auto_reset_credit_5h_threshold === 'number' ? extra.auto_reset_credit_5h_threshold * 100 : 0
 	autoResetCredit7dThreshold.value =
 		typeof extra?.auto_reset_credit_7d_threshold === 'number' ? extra.auto_reset_credit_7d_threshold * 100 : 100
 	upstreamBillingAutoProbeEnabled.value = extra?.upstream_billing_probe_enabled === true
@@ -4855,7 +4855,7 @@ const handleSubmit = async () => {
   }
 	if (autoResetCreditEnabled.value) {
 		const thresholds = [autoResetCredit5hThreshold.value, autoResetCredit7dThreshold.value]
-		if (thresholds.some((value) => !Number.isFinite(value) || value < 0.1 || value > 100)) {
+		if (thresholds.some((value) => !Number.isFinite(value) || (value !== 0 && value < 0.1) || value > 100)) {
 			appStore.showError(t('admin.accounts.autoResetCredit.thresholdInvalid'))
 			return
 		}

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -1573,10 +1573,10 @@ describe('EditAccountModal OpenAI 自动使用重置卡', () => {
     checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
   })
 
-  it('仅对 OpenAI OAuth 母账号显示，默认关闭且阈值为 100/100', () => {
+  it('仅对 OpenAI OAuth 母账号显示，默认关闭且阈值为 0/100', () => {
     const parent = mountModal(buildOpenAIOAuthParentAccount())
     expect(parent.find('[data-testid="auto-reset-credit-settings"]').exists()).toBe(true)
-    expect((parent.get('[data-testid="auto-reset-credit-5h-threshold"]').element as HTMLInputElement).value).toBe('100')
+    expect((parent.get('[data-testid="auto-reset-credit-5h-threshold"]').element as HTMLInputElement).value).toBe('0')
     expect((parent.get('[data-testid="auto-reset-credit-7d-threshold"]').element as HTMLInputElement).value).toBe('100')
     expect(parent.get('[data-testid="auto-reset-credit-5h-threshold"]').attributes('disabled')).toBeDefined()
     parent.unmount()
@@ -1616,10 +1616,37 @@ describe('EditAccountModal OpenAI 自动使用重置卡', () => {
     wrapper.unmount()
   })
 
-  it('开启后拒绝超出 0.1–100 范围的任一阈值', async () => {
+  it.each([[0, 100], [100, 0], [0, 0]])('允许保存窗口阈值 %s/%s', async (fiveHour, sevenDay) => {
+    const account = buildOpenAIOAuthParentAccount()
+    updateAccountMock.mockResolvedValue(account)
+    const wrapper = mountModal(account)
+    await wrapper.get('[data-testid="auto-reset-credit-enabled"]').trigger('click')
+    await wrapper.get('[data-testid="auto-reset-credit-5h-threshold"]').setValue(String(fiveHour))
+    await wrapper.get('[data-testid="auto-reset-credit-7d-threshold"]').setValue(String(sevenDay))
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).toMatchObject({
+      auto_reset_credit_enabled: true,
+      auto_reset_credit_5h_threshold: fiveHour / 100,
+      auto_reset_credit_7d_threshold: sevenDay / 100
+    })
+    wrapper.unmount()
+  })
+
+  it('保存已有账号时保留原阈值', async () => {
+    const account = buildOpenAIOAuthParentAccount()
+    account.extra = { auto_reset_credit_enabled: true, auto_reset_credit_5h_threshold: 1, auto_reset_credit_7d_threshold: 0.85 }
+    updateAccountMock.mockResolvedValue(account)
+    const wrapper = mountModal(account)
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).toMatchObject(account.extra)
+    wrapper.unmount()
+  })
+
+  it('开启后拒绝非零且低于 0.1 的阈值', async () => {
     const wrapper = mountModal(buildOpenAIOAuthParentAccount())
     await wrapper.get('[data-testid="auto-reset-credit-enabled"]').trigger('click')
-    await wrapper.get('[data-testid="auto-reset-credit-5h-threshold"]').setValue('0')
+    await wrapper.get('[data-testid="auto-reset-credit-5h-threshold"]').setValue('0.05')
     await wrapper.get('form#edit-account-form').trigger('submit.prevent')
     expect(updateAccountMock).not.toHaveBeenCalled()
     wrapper.unmount()

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -883,8 +883,8 @@ export default {
 	    hint: 'Uses the earliest-expiring available credit only when actual usage reaches a threshold. Off by default; the account remains paused if no credit is available or reset fails.',
 	    threshold5h: '5h auto-reset threshold (%)',
 	    threshold7d: '7d auto-reset threshold (%)',
-	    thresholdHint: 'Each window is evaluated independently. Enter 0.1–100; both default to 100.',
-	    thresholdInvalid: 'Automatic reset-credit thresholds must be between 0.1% and 100%.'
+	    thresholdHint: 'Each window is evaluated independently. 0 disables that window; enter 0 or 0.1–100. Defaults: 5h = 0, 7d = 100.',
+	    thresholdInvalid: 'Automatic reset-credit thresholds must be 0 (disabled) or between 0.1% and 100%.'
 	  },
       // Quota control (Anthropic OAuth/SetupToken only)
       quotaControl: {

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -955,8 +955,8 @@ export default {
 	    hint: '仅在实际用量达到阈值时使用最早到期的可用卡；默认关闭。无卡或失败时账号保持暂停。',
 	    threshold5h: '5h 自动用卡阈值(%)',
 	    threshold7d: '7d 自动用卡阈值(%)',
-	    thresholdHint: '两个窗口独立判断，任一达到自身阈值即触发。可填写 0.1–100，默认均为 100。',
-	    thresholdInvalid: '自动使用重置卡阈值必须在 0.1% 到 100% 之间。'
+	    thresholdHint: '两个窗口独立判断，任一达到自身阈值即触发。填 0 表示该窗口不触发；可填 0 或 0.1–100，默认 5h 为 0、7d 为 100。',
+	    thresholdInvalid: '自动使用重置卡阈值必须为 0（不触发）或 0.1% 到 100% 之间。'
 	  },
       // Quota control (Anthropic OAuth/SetupToken only)
       quotaControl: {


### PR DESCRIPTION
## 问题与行为

自动用卡原先要求 5h、7d 两个窗口都配置非零阈值，无法只按其中一个窗口触发。本 PR 允许将任一窗口的阈值设为 0，表示该窗口不参与自动用卡判断，解决 #6546。

例如，5h = 0、7d = 100% 时，5h 用量达到 100% 不会触发用卡或“待用卡”暂停；7d 达到 100% 时仍按现有流程使用重置卡。两个窗口都设为 0 时，不再仅因用量快照过期发起自动用卡查询。

- 未配置阈值时，默认值改为 5h = 0、7d = 100%；自动用卡总开关仍默认关闭。
- 已显式保存的阈值保持不变；非零阈值仍须在 0.1%–100% 之间。
- 后端参数校验、用卡评估、调度暂停判断与前端输入校验、中英文提示同步调整。

这是从 #6744 提取的独立改动，基于当前 main，不包含到期调度、每日刷新和状态展示调整。

## 验证

- `internal/service` 全量单测通过；相关用例覆盖窗口分别关闭、全部关闭、快照轮询门控、已有阈值保留及既有自动用卡流程。
- `go test -p 2 -tags=integration ./... -run '^$'` 通过，仅完成集成测试编译检查，未执行集成用例。
- 编辑账号与国际化测试共 64 项通过，新增默认值和零阈值用例已验证先失败、后通过。
- 前端类型检查、全量 ESLint 通过；`golangci-lint run --new-from-rev=98d86915 --timeout=10m ./...` 无新增问题；`git diff --check` 通过。
- Windows 全量单测发现 4 个仓储用例失败：`TestAliyunCaptchaVerifier_TransportError` 与 3 个 `TestPgDumper*`。已用上游 `98d86915` 的源码 overlay 复现相同失败；后 3 项因环境缺少 `sh`，这些模块不在本 PR 改动范围内。

Closes #6546
