### PR TITLE
fix(antigravity): preserve Gemini tool calls in non-streaming responses

### DIFF
--- a/backend/internal/service/antigravity_gateway_nonstream_tools_test.go
+++ b/backend/internal/service/antigravity_gateway_nonstream_tools_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGeminiStreamToNonStreamingPreservesAllParts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tc := range []struct {
+		name      string
+		chunks    []string
+		wantParts string
+	}{
+		{
+			name: "tool call followed by empty terminal text",
+			chunks: []string{
+				`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"bash","args":{"command":"printf OK"}},"thoughtSignature":"tool-signature"}]}}]}`,
+				`{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":7}}`,
+			},
+			wantParts: `[{"functionCall":{"id":"call_1","name":"bash","args":{"command":"printf OK"}},"thoughtSignature":"tool-signature"}]`,
+		},
+		{
+			name: "ordered text thinking tools signatures and image",
+			chunks: []string{
+				`{"candidates":[{"content":{"parts":[{"text":"Private reasoning","thought":true,"thoughtSignature":"thinking-signature"},{"text":"I will "}]}}]}`,
+				`{"candidates":[{"content":{"parts":[{"text":"inspect."},{"functionCall":{"name":"bash","args":{"command":"pwd"}},"thoughtSignature":"first-tool"}]}}]}`,
+				`{"candidates":[{"content":{"parts":[{"functionCall":{"name":"bash","args":{"command":"ls"}},"thoughtSignature":"second-tool"},{"inlineData":{"mimeType":"image/png","data":"aW1hZ2U="}},{"text":"Signed text","thoughtSignature":"text-signature"}]}}]}`,
+				`{"candidates":[{"content":{"parts":[{"text":"After "},{"text":"tools."}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":7}}`,
+			},
+			wantParts: `[{"text":"Private reasoning","thought":true,"thoughtSignature":"thinking-signature"},{"text":"I will inspect."},{"functionCall":{"name":"bash","args":{"command":"pwd"}},"thoughtSignature":"first-tool"},{"functionCall":{"name":"bash","args":{"command":"ls"}},"thoughtSignature":"second-tool"},{"inlineData":{"mimeType":"image/png","data":"aW1hZ2U="}},{"text":"Signed text","thoughtSignature":"text-signature"},{"text":"After tools."}]`,
+		},
+		{
+			name: "tool call with empty text in the same part and usage only tail",
+			chunks: []string{
+				`{"candidates":[{"content":{"parts":[{"text":"","functionCall":{"name":"bash","args":{}},"thoughtSignature":"signature"}]},"finishReason":"STOP"}]}`,
+				`{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":7}}`,
+			},
+			wantParts: `[{"text":"","functionCall":{"name":"bash","args":{}},"thoughtSignature":"signature"}]`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newAntigravityTestService(&config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}})
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+			var stream strings.Builder
+			for _, chunk := range tc.chunks {
+				stream.WriteString("data: {\"response\":" + chunk + "}\n\n")
+			}
+			stream.WriteString("data: [DONE]\n\n")
+			resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(stream.String()))}
+			result, err := svc.handleGeminiStreamToNonStreaming(ctx, resp, time.Now())
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, recorder.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+			parts, err := json.Marshal(extractGeminiParts(body))
+			require.NoError(t, err)
+			require.JSONEq(t, tc.wantParts, string(parts))
+			require.Equal(t, "STOP", extractGeminiFinishReason(body))
+			require.Equal(t, 10, result.usage.InputTokens)
+			require.Equal(t, 7, result.usage.OutputTokens)
+			require.NotNil(t, result.firstTokenMs)
+		})
+	}
+}

--- a/backend/internal/service/antigravity_gateway_streaming.go
+++ b/backend/internal/service/antigravity_gateway_streaming.go
@@ -337,8 +337,7 @@ func (s *AntigravityGatewayService) handleGeminiStreamToNonStreaming(c *gin.Cont
 	var firstTokenMs *int
 	var last map[string]any
 	var lastWithParts map[string]any
-	var collectedImageParts []map[string]any // 收集所有包含图片的 parts
-	var collectedTextParts []string          // 收集所有文本片段
+	var collectedParts []map[string]any // 按顺序保留工具调用、签名、思考、文本及图片
 
 	type scanEvent struct {
 		line string
@@ -457,16 +456,7 @@ func (s *AntigravityGatewayService) handleGeminiStreamToNonStreaming(c *gin.Cont
 			// 保留最后一个有 parts 的响应
 			if parts := extractGeminiParts(parsed); len(parts) > 0 {
 				lastWithParts = parsed
-				// 收集包含图片和文本的 parts
-				for _, part := range parts {
-					if inlineData, ok := part["inlineData"].(map[string]any); ok {
-						collectedImageParts = append(collectedImageParts, part)
-						_ = inlineData // 避免 unused 警告
-					}
-					if text, ok := part["text"].(string); ok && text != "" {
-						collectedTextParts = append(collectedTextParts, text)
-					}
-				}
+				collectedParts = append(collectedParts, parts...)
 			}
 
 		case <-intervalCh:
@@ -493,15 +483,8 @@ returnResponse:
 		}
 	}
 
-	// 如果收集到了图片 parts，需要合并到最终响应中
-	if len(collectedImageParts) > 0 {
-		finalResponse = mergeImagePartsToResponse(finalResponse, collectedImageParts)
-	}
-
-	// 如果收集到了文本，需要合并到最终响应中
-	if len(collectedTextParts) > 0 {
-		finalResponse = mergeTextPartsToResponse(finalResponse, collectedTextParts)
-	}
+	// 尾块可能只有空文本；必须合并整个流的 parts，不能仅使用最后一个内容块。
+	finalResponse = mergeCollectedPartsToResponse(finalResponse, collectedParts)
 
 	respBody, err := json.Marshal(finalResponse)
 	if err != nil {
@@ -582,17 +565,9 @@ func mergeCollectedPartsToResponse(response map[string]any, collectedParts []map
 	}
 
 	for _, part := range collectedParts {
-		// 检查是否是普通 text part
-		if text, ok := part["text"].(string); ok {
-			// 检查是否有 thought 标记
-			if thought, _ := part["thought"].(bool); thought {
-				// thinking part，先刷新 text buffer，然后保留原样
-				flushTextBuffer()
-				mergedParts = append(mergedParts, part)
-			} else {
-				// 普通 text，累积到 buffer
-				_, _ = textBuffer.WriteString(text)
-			}
+		// 仅合并纯文本，避免丢失同一 part 上的签名、工具调用或其他元数据。
+		if text, ok := part["text"].(string); ok && len(part) == 1 {
+			_, _ = textBuffer.WriteString(text)
 		} else {
 			// 非 text part（functionCall、inlineData 等），先刷新 text buffer，然后保留原样
 			flushTextBuffer()


### PR DESCRIPTION
当 Antigravity 上游先返回包含 `functionCall` 的 SSE 块，再发送 `{"text":""}` 收尾块时，非流式 `generateContent` 会返回 HTTP 200 和空文本，丢失实际工具调用；同一请求使用流式接口则正常。经 OpenAI 兼容层转发后，这表现为 Chat Completions 缺少 `tool_calls`，或 Responses 的 `output` 为空。

原因是 `handleGeminiStreamToNonStreaming` 只累计文本和图片，并将最后一个含 `parts` 的块作为最终响应。本修改按顺序收集完整 `parts`，复用 `mergeCollectedPartsToResponse` 合并；仅合并不带其他字段的纯文本块，保留 `functionCall`、`thoughtSignature`、thinking 和图片等内容及其顺序。

新增回归测试覆盖：

- 工具调用后出现空文本收尾块。
- 多个工具调用与文本、thinking、图片混排，保留调用顺序与签名。
- 同一 part 同时包含空文本和工具调用，以及仅含 usage 的尾块。

验证：

- 原实现能复现回归测试失败，修复后通过。
- `cd backend && go test ./internal/service -run 'Gemini|Antigravity' -count=1`
- `cd backend && go test -tags=unit ./internal/service -run 'Gemini|Antigravity' -count=1`
- 实际接口验证通过：Gemini 流式与非流式工具调用、携带签名的工具结果回传，以及 Chat Completions / Responses 工具调用。

关联 #2669 中的非流式 parts 收集问题。本 PR 基于当前 `main`，聚焦响应收集和对应回归测试。
