### PR TITLE
fix(apicompat): chat 桥保留 Codex agent_message 任务正文

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -523,6 +523,21 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 			})
 			pendingReasoning = ""
 			continue
+		case "agent_message":
+			// Codex multi_agent_v2 用 agent_message 在父线程与子智能体之间传递任务和回复：
+			// input_text 是信封（消息类型、任务名、发送者），正文放在 encrypted_content 片段里
+			// （自定义 provider 下为明文）。chat 上游没有对应条目，按原顺序拼成一条 user 消息，
+			// 否则子智能体收不到任务却仍返回 200。
+			text := agentMessageText(item["content"])
+			if text == "" {
+				pendingReasoning = ""
+				continue
+			}
+			content, _ := json.Marshal(text)
+			messages = append(messages, ChatMessage{Role: "user", Content: content})
+			pendingReasoning = ""
+			lastTurnReasoning = ""
+			continue
 		case "input_text", "text":
 			content, _ := json.Marshal(rawString(item["text"]))
 			messages = append(messages, ChatMessage{Role: "user", Content: content})
@@ -580,6 +595,32 @@ func buildChatMessagesFromItems(messages []ChatMessage, rawItems []json.RawMessa
 	}
 
 	return messages, mediaByCallID, nil
+}
+
+// agentMessageText 按原顺序拼接 agent_message 里 input_text 与 encrypted_content 片段的文本。
+func agentMessageText(raw json.RawMessage) string {
+	raw = bytesTrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var parts []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		switch rawString(part["type"]) {
+		case "input_text", "text":
+			_, _ = b.WriteString(rawString(part["text"]))
+		case "encrypted_content":
+			_, _ = b.WriteString(rawString(part["encrypted_content"]))
+		}
+	}
+	return b.String()
 }
 
 // extractToolOutputMedia rewrites only recognized image nodes. Media-free

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_additional_tools_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_additional_tools_test.go
@@ -1,0 +1,52 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #6653：Codex 把运行时工具放在 input[].additional_tools 里，force_chat_completions
+// 下必须仍降级成标准 chat 工具随 /v1/chat/completions 发出，而不是因无法转换退回 Responses。
+func TestResponsesToChatCompletionsRequest_LowersAdditionalToolsForChatOnlyUpstream(t *testing.T) {
+	body := `{
+		"model":"gpt-5.6-luna","stream":true,"store":false,
+		"reasoning":{"effort":"medium","context":"all_turns"},
+		"tool_choice":"auto","parallel_tool_calls":false,
+		"include":["reasoning.encrypted_content"],
+		"input":[
+			{"type":"additional_tools","role":"developer","tools":[
+				{"type":"custom","name":"exec","description":"run a shell command","format":{"type":"grammar","syntax":"lark","definition":"start: /.*/"}},
+				{"type":"function","name":"wait","strict":false,"parameters":{"type":"object"}},
+				{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}
+			]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"reply ok"}]}
+		]
+	}`
+	var req ResponsesRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &req))
+
+	tools, err := EffectiveResponsesTools(&req)
+	require.NoError(t, err)
+	require.Len(t, tools, 3, "additional_tools 里的 custom / function / namespace 都要被提升")
+	require.True(t, CustomToolNames(tools)["exec"])
+	require.Equal(t, "collaboration", NamespaceToolNames(tools)["collaboration__spawn_agent"].Namespace)
+
+	chat, err := ResponsesToChatCompletionsRequest(&req)
+	require.NoError(t, err)
+	require.Len(t, chat.Messages, 1, "additional_tools 不能变成 chat 消息")
+	require.Equal(t, "user", chat.Messages[0].Role)
+
+	names := make([]string, 0, len(chat.Tools))
+	for _, tool := range chat.Tools {
+		require.Equal(t, "function", tool.Type, "chat 上游只认 function 工具")
+		require.NotNil(t, tool.Function)
+		names = append(names, tool.Function.Name)
+	}
+	require.Equal(t, []string{"exec", "wait", "collaboration__spawn_agent"}, names)
+	require.JSONEq(t, customToolInputSchema, string(chat.Tools[0].Function.Parameters), "custom 工具降级为单一 input 字符串参数")
+	require.NotNil(t, chat.ParallelToolCalls)
+	require.False(t, *chat.ParallelToolCalls)
+	require.Equal(t, "medium", chat.ReasoningEffort)
+}

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_agent_message_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_agent_message_test.go
@@ -1,0 +1,58 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #6887：Codex multi_agent_v2 用 agent_message 条目在父线程与子智能体之间传递任务和回复，
+// 任务正文放在 encrypted_content 片段里（自定义 provider 下为明文）。chat 上游没有对应条目，
+// 桥必须把它按原顺序拼成一条 user 消息，否则子智能体收不到任务。
+func TestResponsesToChatCompletionsRequest_AgentMessageBecomesUserMessage(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "glm-5.3",
+		Input: json.RawMessage(`[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>cwd</environment_context>"}]},
+			{"type":"agent_message","id":"amsg_1","author":"/root","recipient":"/root/alpha_task","content":[
+				{"type":"input_text","text":"Message Type: NEW_TASK\nTask name: /root/alpha_task\nSender: /root\nPayload:\n"},
+				{"type":"encrypted_content","encrypted_content":"Reply with the single word: ALPHA"}
+			]},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"just answer"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ALPHA"}]},
+			{"type":"agent_message","id":"amsg_2","author":"/root/alpha_task","recipient":"/root","content":[
+				{"type":"input_text","text":"Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/alpha_task\nPayload:\nALPHA"}
+			]}
+		]`),
+	}
+
+	out, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 4)
+
+	require.Equal(t, "user", out.Messages[0].Role)
+	require.Equal(t, "user", out.Messages[1].Role, "父线程发来的任务要成为 user 消息")
+	require.JSONEq(t, `"Message Type: NEW_TASK\nTask name: /root/alpha_task\nSender: /root\nPayload:\nReply with the single word: ALPHA"`, string(out.Messages[1].Content), "信封与 encrypted_content 里的正文要按原顺序拼接")
+	require.Equal(t, "assistant", out.Messages[2].Role)
+	require.JSONEq(t, `"ALPHA"`, string(out.Messages[2].Content))
+	require.Equal(t, "user", out.Messages[3].Role, "子智能体回给父线程的消息同样是 user 消息")
+	require.JSONEq(t, `"Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/alpha_task\nPayload:\nALPHA"`, string(out.Messages[3].Content))
+}
+
+func TestResponsesToChatCompletionsRequest_AgentMessageWithoutTextIsSkipped(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "glm-5.3",
+		Input: json.RawMessage(`[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"agent_message","author":"/root","recipient":"/root/a","content":[]},
+			{"type":"agent_message","author":"/root","recipient":"/root/a"},
+			{"type":"agent_message","author":"/root","recipient":"/root/a","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}
+		]`),
+	}
+
+	out, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1, "没有文本正文的 agent_message 不产生消息")
+	require.Equal(t, "user", out.Messages[0].Role)
+}


### PR DESCRIPTION
## 问题

Codex 开启 `multi_agent_v2` 后，父线程与子智能体之间的任务和回复通过 `input[]` 里的 `agent_message` 条目传递：`input_text` 是信封（`Message Type: NEW_TASK` / 任务名 / 发送者），任务正文放在 `encrypted_content` 片段里，自定义 provider 下是明文。子智能体的第一轮请求里，任务只存在于这条 `agent_message` 中。

`openai_responses_mode=force_chat_completions` 走 Responses → Chat Completions 桥时，`buildChatMessagesFromItems` 对不认识的条目类型直接跳过，`agent_message` 因此被整条丢掉：网关返回 200、账号路由正常、没有任何日志，但子智能体收到的是一段没有任务的历史，只能回“请告诉我要做什么”。父线程随后反复重发任务、反复 `wait`，直到放弃。

用 codex 0.153.4 经网关（apikey 账号、只支持 `/v1/chat/completions` 的上游）复现，任务是“派生一个子智能体让它回复 ALPHA”：修复前 20 个请求、115 秒，子智能体三次收到 `NEW_TASK` 都回“尚未收到任务”；父线程从子智能体收到的 `FINAL_ANSWER` 同样是 `agent_message`，也一并被丢掉。

## 修复

- `buildChatMessagesFromItems` 增加 `agent_message` 分支：按原顺序拼接 `content[]` 里 `input_text` / `text` 的文本与 `encrypted_content` 的字符串，作为一条 `user` 消息发给 chat 上游；没有文本正文的条目仍跳过。`author` / `recipient` 不另加信封，`input_text` 里已经有任务名与发送者。
- 顺带补一条 additional_tools 走 chat 桥的回归用例（#6653 的原始请求形状），不改产品代码。

不在本次范围：Responses → Anthropic 方向的转换没有处理 `agent_message`，另行处理。

## 回归验证

- 新增单测：`agent_message`（NEW_TASK 带 `encrypted_content`、FINAL_ANSWER 仅 `input_text`）转换为 `user` 消息且与前后消息顺序一致；没有文本正文的条目不产生消息。
- `go test ./internal/pkg/apicompat/` 通过；golangci-lint v2.13.2：0 issues；`git diff --check` 通过。

## 实测数据

抓包得到的子智能体请求里的任务条目（codex 0.153.4，`--enable multi_agent_v2`，apikey 账号 + `force_chat_completions`，只简化了 id）：

```json
{"type":"agent_message","id":"amsg_…","author":"/root","recipient":"/root/alpha_task",
 "content":[{"type":"input_text","text":"Message Type: NEW_TASK\nTask name: /root/alpha_task\nSender: /root\nPayload:\n"},
            {"type":"encrypted_content","encrypted_content":"Reply with the single word: ALPHA"}]}
```

父线程后续请求里子智能体的回复同样是 `agent_message`：`author` 与 `recipient` 对调，只有 `input_text`，正文以 `Message Type: FINAL_ANSWER` 开头。

同一网关、同一分组、同一任务，修复前后对照：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 桥转换结果 | 任务条目整条丢弃，chat 消息里没有任务（单测在修复前失败复现） | 转成一条 `user` 消息，信封与正文按原顺序拼接 |
| 只含 `agent_message` 任务的最小 `/v1/responses` 请求，3 次 | 同上，上游收不到任务 | 3 次都回复 `ALPHA` |
| codex 派生一个子智能体让它回复 ALPHA：请求数 / 耗时 | 20 个 / 115 秒 | 4 个 / 13 秒 |
| 子智能体收到 `NEW_TASK` 后的回复 | 三次都是“尚未收到任务，请给我需求” | `ALPHA` |
| 父线程对子智能体 `FINAL_ANSWER` 的处理 | 条目丢弃，只能靠 `wait` 工具输出拿到结果 | 转成 `user` 消息，原样汇报 |

关联 #6887。#6062 里有更早的大范围实现，本 PR 只取最小修法；additional_tools 用例关联 #6653。
