### PR TITLE
fix(antigravity): send thinkingLevel so Gemini 3.x returns thought summaries

### DIFF
--- a/backend/internal/pkg/antigravity/gemini_types.go
+++ b/backend/internal/pkg/antigravity/gemini_types.go
@@ -77,9 +77,14 @@ type GeminiImageConfig struct {
 }
 
 // GeminiThinkingConfig Gemini thinking 配置
+//
+// ThinkingLevel controls reasoning depth for Gemini 3.x models
+// ("low" / "medium" / "high"). Antigravity only returns thought summaries when
+// it is set; a positive ThinkingBudget suppresses them.
 type GeminiThinkingConfig struct {
-	IncludeThoughts bool `json:"includeThoughts"`
-	ThinkingBudget  int  `json:"thinkingBudget,omitempty"`
+	IncludeThoughts bool   `json:"includeThoughts"`
+	ThinkingBudget  int    `json:"thinkingBudget,omitempty"`
+	ThinkingLevel   string `json:"thinkingLevel,omitempty"`
 }
 
 // GeminiToolDeclaration Gemini 工具声明

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -618,6 +618,30 @@ func isAntigravityOpusHighTierModel(model string) bool {
 		strings.HasPrefix(lower, "claude-opus-4-8")
 }
 
+// antigravityGeminiThinkingLevelModel reports whether the model expresses its
+// reasoning depth through Antigravity's thinkingLevel field (Gemini 3.x)
+// instead of thinkingBudget.
+func antigravityGeminiThinkingLevelModel(model string) bool {
+	lower := strings.ToLower(strings.TrimPrefix(model, "models/"))
+	return strings.HasPrefix(lower, "gemini-3")
+}
+
+// antigravityGeminiThinkingLevel derives thinkingLevel from the model variant
+// suffix. Antigravity only returns thought summaries when thinkingLevel is set
+// (a positive thinkingBudget suppresses them); models without an explicit
+// low/medium/high suffix default to "high".
+func antigravityGeminiThinkingLevel(model string) string {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "-low"):
+		return "low"
+	case strings.Contains(lower, "-medium"):
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
 func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {
 	maxLimit := maxOutputTokensLimit(req.Model)
 	config := &GeminiGenerationConfig{
@@ -640,31 +664,38 @@ func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {
 			IncludeThoughts: true,
 		}
 
-		// - thinking.type=enabled：budget_tokens>0 用显式预算
-		// - thinking.type=adaptive：在 Antigravity 的高阶 Opus（4.6+）上覆写为 （24576）
-		budget := -1
-		if req.Thinking.BudgetTokens > 0 {
-			budget = req.Thinking.BudgetTokens
-		}
-		if req.Thinking.Type == "adaptive" && isAntigravityOpusHighTierModel(req.Model) {
-			budget = ClaudeAdaptiveHighThinkingBudgetTokens
-		}
-
-		// 正预算需要做上限与 max_tokens 约束；动态预算（-1）直接透传给上游。
-		if budget > 0 {
-			// gemini-2.5-flash 上限
-			if strings.Contains(req.Model, "gemini-2.5-flash") && budget > Gemini25FlashThinkingBudgetLimit {
-				budget = Gemini25FlashThinkingBudgetLimit
+		if antigravityGeminiThinkingLevelModel(req.Model) {
+			// Gemini 3.x on Antigravity addresses reasoning depth via
+			// thinkingLevel. A positive thinkingBudget suppresses the thought
+			// summary, so only thinkingLevel is emitted for these models.
+			config.ThinkingConfig.ThinkingLevel = antigravityGeminiThinkingLevel(req.Model)
+		} else {
+			// - thinking.type=enabled：budget_tokens>0 用显式预算
+			// - thinking.type=adaptive：在 Antigravity 的高阶 Opus（4.6+）上覆写为 （24576）
+			budget := -1
+			if req.Thinking.BudgetTokens > 0 {
+				budget = req.Thinking.BudgetTokens
+			}
+			if req.Thinking.Type == "adaptive" && isAntigravityOpusHighTierModel(req.Model) {
+				budget = ClaudeAdaptiveHighThinkingBudgetTokens
 			}
 
-			// 自动修正：max_tokens 必须大于 budget_tokens（Claude 上游要求）
-			if adjusted, ok := ensureMaxTokensGreaterThanBudget(config.MaxOutputTokens, budget); ok {
-				log.Printf("[Antigravity] Auto-adjusted max_tokens from %d to %d (must be > budget_tokens=%d)",
-					config.MaxOutputTokens, adjusted, budget)
-				config.MaxOutputTokens = adjusted
+			// 正预算需要做上限与 max_tokens 约束；动态预算（-1）直接透传给上游。
+			if budget > 0 {
+				// gemini-2.5-flash 上限
+				if strings.Contains(req.Model, "gemini-2.5-flash") && budget > Gemini25FlashThinkingBudgetLimit {
+					budget = Gemini25FlashThinkingBudgetLimit
+				}
+
+				// 自动修正：max_tokens 必须大于 budget_tokens（Claude 上游要求）
+				if adjusted, ok := ensureMaxTokensGreaterThanBudget(config.MaxOutputTokens, budget); ok {
+					log.Printf("[Antigravity] Auto-adjusted max_tokens from %d to %d (must be > budget_tokens=%d)",
+						config.MaxOutputTokens, adjusted, budget)
+					config.MaxOutputTokens = adjusted
+				}
 			}
+			config.ThinkingConfig.ThinkingBudget = budget
 		}
-		config.ThinkingConfig.ThinkingBudget = budget
 	}
 
 	if config.MaxOutputTokens > maxLimit {

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -376,6 +376,71 @@ func TestBuildGenerationConfig_ThinkingDynamicBudget(t *testing.T) {
 	}
 }
 
+func TestBuildGenerationConfig_GeminiThinkingLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		wantLevel  string
+		wantBudget int
+	}{
+		{
+			name:       "gemini-3.8 tiered uses thinkingLevel high and omits budget",
+			model:      "gemini-3.8-flash-tiered",
+			wantLevel:  "high",
+			wantBudget: 0,
+		},
+		{
+			name:       "gemini-3.8 high maps to high",
+			model:      "gemini-3.8-flash-high",
+			wantLevel:  "high",
+			wantBudget: 0,
+		},
+		{
+			name:       "gemini-3.8 medium maps to medium",
+			model:      "gemini-3.8-flash-medium",
+			wantLevel:  "medium",
+			wantBudget: 0,
+		},
+		{
+			name:       "gemini-3.8 low maps to low",
+			model:      "gemini-3.8-flash-low",
+			wantLevel:  "low",
+			wantBudget: 0,
+		},
+		{
+			name:       "gemini-3.1 pro low maps to low",
+			model:      "gemini-3.1-pro-low",
+			wantLevel:  "low",
+			wantBudget: 0,
+		},
+		{
+			name:       "gemini-2.5 flash keeps thinkingBudget and no level",
+			model:      "gemini-2.5-flash",
+			wantLevel:  "",
+			wantBudget: 4096,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &ClaudeRequest{
+				Model:    tt.model,
+				Thinking: &ThinkingConfig{Type: "enabled", BudgetTokens: 4096},
+			}
+			cfg := buildGenerationConfig(req)
+			if cfg.ThinkingConfig == nil || !cfg.ThinkingConfig.IncludeThoughts {
+				t.Fatalf("expected includeThoughts=true")
+			}
+			if cfg.ThinkingConfig.ThinkingLevel != tt.wantLevel {
+				t.Fatalf("expected thinkingLevel=%q, got %q", tt.wantLevel, cfg.ThinkingConfig.ThinkingLevel)
+			}
+			if cfg.ThinkingConfig.ThinkingBudget != tt.wantBudget {
+				t.Fatalf("expected thinkingBudget=%d, got %d", tt.wantBudget, cfg.ThinkingConfig.ThinkingBudget)
+			}
+		})
+	}
+}
+
 func TestTransformClaudeToGeminiWithOptions_PreservesBillingHeaderSystemBlock(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Problem

When a client enables thinking (e.g. Claude Code / any Anthropic-compatible client) and calls an **Antigravity Gemini 3.x** model through `/antigravity/v1/messages`, the upstream **does not return any `thinking` block**, so the client never sees the reasoning.

Claude models on the same account/path work fine, so this is specific to the Antigravity Gemini path.

## Root cause

Antigravity's Gemini 3.x models express reasoning depth through `generationConfig.thinkingConfig.thinkingLevel` (`low` / `medium` / `high`). `buildGenerationConfig` only emits `includeThoughts` + `thinkingBudget`, and a **positive `thinkingBudget` suppresses the thought summary** upstream.

Direct probes against the Antigravity `daily-cloudcode-pa` endpoint with the same OAuth token:

| thinkingConfig | thought summary returned |
| --- | --- |
| `{includeThoughts:true}` | ❌ |
| `{includeThoughts:true, thinkingBudget:2048}` | ❌ |
| `{includeThoughts:true, thinkingLevel:"high"}` | ✅ |
| `{thinkingLevel:"high"}` | ❌ |

So both `includeThoughts` **and** `thinkingLevel` are required, and `thinkingBudget` must not be sent for these models.

## Fix

- `GeminiThinkingConfig` gains a `ThinkingLevel` field.
- For Gemini 3.x models (`gemini-3*`), `buildGenerationConfig` now emits `thinkingLevel` (derived from the `-low` / `-medium` / `-high` variant suffix, defaulting to `high` for `-tiered` and bare ids) and omits `thinkingBudget`.
- Claude and Gemini 2.5 models keep the existing budget-based behavior.

## Testing

- Added `TestBuildGenerationConfig_GeminiThinkingLevel` covering `-tiered` / `-high` / `-medium` / `-low`, `gemini-3.1-pro-low`, and a `gemini-2.5-flash` regression case (still budget-based).
- Manually verified against a live Antigravity account: `gemini-3.8-flash-tiered` via `/antigravity/v1/messages` now streams `thinking_delta` events for non-trivial prompts (simple prompts may legitimately produce no summary — upstream behavior).

Note: the model catalog entries for Gemini 3.7/3.8 are tracked separately in #6575; this change only concerns the thinking configuration for models already routable (3.6 and earlier).
