### PR TITLE
fix(ci): 修复 main 分支 golangci-lint 红灯（setup_test.go errcheck）

### DIFF
--- a/backend/internal/setup/setup_test.go
+++ b/backend/internal/setup/setup_test.go
@@ -270,7 +270,7 @@ func TestDatabaseConnectionUsesConfiguredTargetBeforeBootstrapDatabase(t *testin
 	if err != nil {
 		t.Fatalf("sqlmock.New() error = %v", err)
 	}
-	defer targetDB.Close()
+	defer func() { _ = targetDB.Close() }()
 
 	var opened []string
 	openDatabase := func(_ *DatabaseConfig, dbName string) (*sql.DB, error) {
@@ -292,12 +292,12 @@ func TestDatabaseConnectionUsesLegacyBootstrapOnlyForMissingTarget(t *testing.T)
 	if err != nil {
 		t.Fatalf("sqlmock.New() bootstrap error = %v", err)
 	}
-	defer bootstrapDB.Close()
+	defer func() { _ = bootstrapDB.Close() }()
 	targetDB, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New() target error = %v", err)
 	}
-	defer targetDB.Close()
+	defer func() { _ = targetDB.Close() }()
 
 	bootstrapMock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM pg_database WHERE datname = \$1\)`).
 		WithArgs(cfg.DBName).


### PR DESCRIPTION
## 问题

远程 `main` 的 CI 处于红灯状态，`golangci-lint` job 持续失败，并且会**传染给所有后续 PR**（PR 的 CI 跑在 main 的 merge ref 上，因此 #6832、#6841 等完全不相关的 PR 也都因为同一个报错而失败）。

失败内容固定为 3 条：

```
backend/internal/setup/setup_test.go:273:22: Error return value of `(*database/sql.DB).Close` is not checked (errcheck)
backend/internal/setup/setup_test.go:295:25: Error return value of `(*database/sql.DB).Close` is not checked (errcheck)
backend/internal/setup/setup_test.go:300:22: Error return value of `(*database/sql.DB).Close` is not checked (errcheck)
```

## 根因

1. PR #6499（`fix(setup): avoid hardcoded postgres connection`，合入提交 `8ed48e27a` / merge `264cbbec2`）新增的两个测试里使用了裸写法 `defer targetDB.Close()`。
2. 本仓库 `backend/.golangci.yml` 的 errcheck 配置显式设置了 `disable-default-exclusions: true`，因此 errcheck **不再豁免** `(*database/sql.DB).Close`，这种裸 defer 一定会被报出来。仓库既有写法统一是 `defer func() { _ = x.Close() }()`。
3. 该 PR 的 head commit **从未跑过 CI**（fork PR 的 workflow 停在 `action_required`，`8ed48e27a` 上只有 CLA 的 check run），所以问题直接进了 main 才暴露。

## 修复

把这 3 处改为仓库既有约定 `defer func() { _ = db.Close() }()`，纯 lint 合规修复，不改变任何测试语义。

## 验证

- `gofmt -l internal/setup/` 无输出
- `go vet ./internal/setup/` 通过
- `go test ./internal/setup/` → `ok  github.com/Wei-Shaw/sub2api/internal/setup`

## 后续建议（不在本 PR 范围）

fork PR 需要手动 approve 才会跑 workflow，合并前请确认 head commit 上确实有绿色的 CI run，而不是只看 CLA check。