### PR TITLE
fix(openai): 隐私/账号检查客户端改用 Firefox 指纹，规避 chatgpt.com Cloudflare 质询

### DIFF
--- a/backend/internal/repository/req_client_pool.go
+++ b/backend/internal/repository/req_client_pool.go
@@ -17,7 +17,7 @@ import (
 type reqClientOptions struct {
 	ProxyURL    string        // 代理 URL（支持 http/https/socks5）
 	Timeout     time.Duration // 请求超时时间
-	Impersonate bool          // 是否模拟 Chrome 浏览器指纹
+	Impersonate bool          // 是否模拟浏览器指纹（当前为 Firefox，Chrome 伪装会被 chatgpt.com 的 Cloudflare 质询）
 	ForceHTTP2  bool          // 是否强制使用 HTTP/2
 }
 
@@ -50,7 +50,12 @@ func getSharedReqClient(opts reqClientOptions) (*req.Client, error) {
 		client = client.EnableForceHTTP2()
 	}
 	if opts.Impersonate {
-		client = client.ImpersonateChrome()
+		// chatgpt.com 的 Cloudflare 会对 req 内置的 Chrome 伪装（UA 固定为 Chrome/120，
+		// 与 sec-ch-ua 等 Client Hints 一起已明显过时）直接返回 403 cf-mitigated=challenge，
+		// 导致 accounts/check、subscriptions、隐私设置等 backend-api 调用全部失败，
+		// 订阅到期时间因此长期不更新（见 issue #4825）。Firefox 伪装的 UA/头部组合
+		// 在同一出口 IP 下稳定通过，故改用 Firefox 指纹。
+		client = client.ImpersonateFirefox()
 	}
 	trimmed, _, err := proxyurl.Parse(opts.ProxyURL)
 	if err != nil {
@@ -95,6 +100,6 @@ func CreatePrivacyReqClient(proxyURL string) (*req.Client, error) {
 	return getSharedReqClient(reqClientOptions{
 		ProxyURL:    proxyURL,
 		Timeout:     30 * time.Second,
-		Impersonate: true, // Enable Chrome TLS fingerprint impersonation
+		Impersonate: true, // Enable browser TLS fingerprint impersonation (Firefox, see getSharedReqClient)
 	})
 }

--- a/backend/internal/repository/req_client_pool_test.go
+++ b/backend/internal/repository/req_client_pool_test.go
@@ -140,3 +140,12 @@ func TestInstrumentReqClientRecordsDependency(t *testing.T) {
 	header := collector.HeaderValue(time.Now(), "bypass")
 	require.True(t, strings.Contains(header, "dep_http;dur="), header)
 }
+
+func TestGetSharedReqClient_ImpersonateUsesFirefoxFingerprint(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	client, err := getSharedReqClient(reqClientOptions{Timeout: time.Second, Impersonate: true})
+	require.NoError(t, err)
+	// chatgpt.com 的 Cloudflare 会质询 req 内置的 Chrome/120 伪装，必须保持 Firefox 指纹。
+	require.Contains(t, client.Headers.Get("User-Agent"), "Firefox/")
+	require.NotContains(t, client.Headers.Get("User-Agent"), "Chrome/")
+}

--- a/backend/internal/service/openai_privacy_cf_challenge_test.go
+++ b/backend/internal/service/openai_privacy_cf_challenge_test.go
@@ -1,0 +1,25 @@
+package service
+
+import "testing"
+
+func TestIsCloudflareChallengeResponse(t *testing.T) {
+	cases := []struct {
+		name        string
+		cfMitigated string
+		body        string
+		want        bool
+	}{
+		{"cf-mitigated challenge header", "challenge", "<html>...</html>", true},
+		{"header case-insensitive with spaces", " Challenge ", "", true},
+		{"body marker only", "", "<title>Just a moment...</title>", true},
+		{"plain json error", "", `{"detail":"Unauthorized"}`, false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCloudflareChallengeResponse(tc.cfMitigated, tc.body); got != tc.want {
+				t.Fatalf("isCloudflareChallengeResponse(%q, %q) = %v, want %v", tc.cfMitigated, tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -71,7 +71,7 @@ func disableOpenAITraining(ctx context.Context, clientFactory PrivacyClientFacto
 
 	if resp.StatusCode == 403 || resp.StatusCode == 503 {
 		body := resp.String()
-		if strings.Contains(body, "cloudflare") || strings.Contains(body, "cf-") || strings.Contains(body, "Just a moment") {
+		if isCloudflareChallengeResponse(resp.Header.Get("cf-mitigated"), body) {
 			slog.Warn("openai_privacy_cf_blocked", "status", resp.StatusCode)
 			return PrivacyModeCFBlocked
 		}
@@ -84,6 +84,15 @@ func disableOpenAITraining(ctx context.Context, clientFactory PrivacyClientFacto
 
 	slog.Info("openai_privacy_training_disabled")
 	return PrivacyModeTrainingOff
+}
+
+// isCloudflareChallengeResponse 判断 chatgpt.com 返回的是否为 Cloudflare 质询/拦截页。
+// 优先看 cf-mitigated 响应头（质询时为 "challenge"），再回退到正文关键字。
+func isCloudflareChallengeResponse(cfMitigated, body string) bool {
+	if strings.EqualFold(strings.TrimSpace(cfMitigated), "challenge") {
+		return true
+	}
+	return strings.Contains(body, "cloudflare") || strings.Contains(body, "cf-") || strings.Contains(body, "Just a moment")
 }
 
 // ChatGPTAccountInfo 从 chatgpt.com/backend-api/accounts/check 获取的账号信息
@@ -131,12 +140,12 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 		Get(chatGPTAccountsCheckURL)
 
 	if err != nil {
-		slog.Debug("chatgpt_account_check_request_error", "error", err.Error())
+		slog.Warn("chatgpt_account_check_request_error", "error", err.Error())
 		return nil
 	}
 
 	if !resp.IsSuccessState() {
-		slog.Debug("chatgpt_account_check_failed", "status", resp.StatusCode, "body", truncate(resp.String(), 200))
+		slog.Warn("chatgpt_account_check_failed", "status", resp.StatusCode, "cf_challenge", isCloudflareChallengeResponse(resp.Header.Get("cf-mitigated"), resp.String()), "body", truncate(resp.String(), 200))
 		return nil
 	}
 
@@ -247,11 +256,11 @@ func fetchChatGPTSubscriptionExpiresAt(ctx context.Context, clientFactory Privac
 		SetQueryParam("account_id", accountID).
 		Get(chatGPTSubscriptionsURL)
 	if err != nil {
-		slog.Debug("chatgpt_subscription_request_error", "error", err.Error())
+		slog.Warn("chatgpt_subscription_request_error", "error", err.Error())
 		return ""
 	}
 	if !resp.IsSuccessState() {
-		slog.Debug("chatgpt_subscription_failed", "status", resp.StatusCode, "body", truncate(resp.String(), 200))
+		slog.Warn("chatgpt_subscription_failed", "status", resp.StatusCode, "cf_challenge", isCloudflareChallengeResponse(resp.Header.Get("cf-mitigated"), resp.String()), "body", truncate(resp.String(), 200))
 		return ""
 	}
 


### PR DESCRIPTION
## 问题

OpenAI OAuth 账号的 `subscription_expires_at`（订阅到期时间）在 token 刷新后不更新，隐私开关在账号列表里显示 **Fail**。刷新那一刻日志只有一条：

```
WARN openai_privacy_failed {"status": 403, "body": "<html>..."}
```

返回体是 Cloudflare 质询页（响应头 `cf-mitigated: challenge`）。`accounts/check` 和 `subscriptions` 用同一个 `CreatePrivacyReqClient`，同样被质询，但这两处只打 Debug 日志，所以到期时间失败是静默的。与 #4825 现象一致。

## 根因

`getSharedReqClient` 在 `Impersonate: true` 时调用 req 的 `ImpersonateChrome()`。req v3.59 到最新 v3.61 内置的 Chrome 伪装 TLS/HTTP2 指纹与 UA 都停在 Chrome/120，chatgpt.com 的 Cloudflare 目前对这套指纹判定为机器人。

在生产服务器的 sub2api 容器网络命名空间内实测（每组连打 3 次，`accounts/check`）：

| 客户端 | 结果 |
|---|---|
| `ImpersonateChrome()` 原样 | 403(cf) ×3 |
| `ImpersonateChrome()` + UA 改为 124 / 132 / 136 / 140 / 153 | 403(cf) ×3 |
| `ImpersonateChrome()` + UA 153 + 同步改 `sec-ch-ua` | 403(cf) ×3 |
| `ImpersonateChrome()` + UA 128 | 一轮 200 ×3，下一轮 403 ×3（漂移） |
| `ImpersonateFirefox()` | 200 ×3，多轮累计 20+ 次零失败 |

只改 UA 版本号无效，因为 TLS/HTTP2 指纹仍是 120；Firefox 伪装是库内另一套自洽的完整指纹。

## 改动

- `req_client_pool.go`：`Impersonate: true` 改用 `ImpersonateFirefox()`。该选项目前仅 `CreatePrivacyReqClient` 使用，Anthropic OAuth 自己那条 `ImpersonateChrome` 不受影响。
- `openai_privacy_service.go`：
  - 新增 `isCloudflareChallengeResponse`，优先用 `cf-mitigated` 头识别质询页，隐私设置失败时能正确落到 `training_set_cf_blocked`（前端已有 CF 标签）而不是笼统的 Fail。
  - `chatgpt_account_check_*` / `chatgpt_subscription_*` 失败日志由 Debug 提升为 Warn，并附 `cf_challenge` 字段。
- 新增单元测试：`TestGetSharedReqClient_ImpersonateUsesFirefoxFingerprint`、`TestIsCloudflareChallengeResponse`。

## 验证

- `go build ./...`；`go test ./internal/repository/` 全量通过；`go test ./internal/service/ -run 'OpenAI|Privacy|Token|Refresh|Enrich'` 通过。
- 用改动后的 `repository.CreatePrivacyReqClient("")` 交叉编译为 Linux 二进制，在生产宿主机与 `--network container:sub2api` 内分别对 `accounts/check` 连打 4 次均 200；对 `settings/account_user_setting` 的 PATCH 返回 200 `{"training_allowed":false}`。

Closes #4825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
