### PR TITLE
fix: resolve transparent Codex identity consistently

### DIFF
--- a/backend/internal/service/openai_codex_identity.go
+++ b/backend/internal/service/openai_codex_identity.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/google/uuid"
+	"golang.org/x/mod/semver"
 )
 
 // codexUpstreamMinVersion 上游 /backend-api/codex 接受的最低 version 头：
@@ -223,28 +224,27 @@ func enforceCodexIdentityHeadersWithUA(h http.Header, overrideUA string) {
 	if h == nil || h.Get("originator") == "" {
 		return
 	}
-	if !codexIdentityEnforcement.Load() {
-		pairCodexIdentityHeaders(h)
-		return
+	var identity codexOutboundIdentity
+	if codexIdentityEnforcement.Load() {
+		identity = resolveCodexOutboundIdentity(overrideUA)
+	} else {
+		identity = resolveCodexTransparentIdentity(h.Get("user-agent"), resolveCodexOutboundIdentity(""))
 	}
-	identity := resolveCodexOutboundIdentity(overrideUA)
 	h.Set("user-agent", identity.userAgent)
 	h.Set("originator", identity.originator)
 	h.Set("version", identity.version)
 }
 
-// pairCodexIdentityHeaders 是关闭强制统一后的兜底收口：保留客户端真实身份，
-// 仅保证 originator 与最终 User-Agent 首段配套、version 不低于上游门槛（issue #3901）。
-func pairCodexIdentityHeaders(h http.Header) {
-	originator, pairedUA, ok := openai.PairCodexClientIdentity(h.Get("user-agent"))
+// resolveCodexTransparentIdentity selects one complete identity without mutating
+// headers. Unsupported identities fall back as a unit, never field by field.
+func resolveCodexTransparentIdentity(userAgent string, fallback codexOutboundIdentity) codexOutboundIdentity {
+	originator, pairedUA, ok := openai.PairCodexClientIdentity(userAgent)
 	if !ok {
-		identity := resolveCodexOutboundIdentity("")
-		originator, pairedUA = identity.originator, identity.userAgent
-		h.Set("version", identity.version)
+		return fallback
 	}
-	h.Set("user-agent", pairedUA)
-	h.Set("originator", originator)
-	if v := strings.TrimSpace(h.Get("version")); v != "" && CompareVersions(v, codexUpstreamMinVersion) < 0 {
-		h.Set("version", resolveCodexOutboundIdentity("").version)
+	version := NormalizeCodexClientVersion(openai.CodexUserAgentVersion(pairedUA))
+	if !semver.IsValid("v"+version) || semver.Compare("v"+version, "v"+codexUpstreamMinVersion) < 0 {
+		return fallback
 	}
+	return codexOutboundIdentity{userAgent: pairedUA, originator: originator, version: version}
 }

--- a/backend/internal/service/openai_transparent_identity_test.go
+++ b/backend/internal/service/openai_transparent_identity_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCodexTransparentIdentityPolicy(t *testing.T) {
+	fallback := codexOutboundIdentity{
+		userAgent:  "codex-tui/0.146.0 (Linux)",
+		originator: "codex-tui",
+		version:    "0.146.0",
+	}
+	cases := []struct {
+		name        string
+		ua          string
+		wantVersion string
+	}{
+		{"minimum", "codex-tui/0.144.0 (Mac OS X; arm64)", "0.144.0"},
+		{"two_parts", "codex-tui/0.144 (Linux)", "0.144"},
+		{"windows", "codex_cli_rs/0.145.2 (Windows NT; x86_64)", "0.145.2"},
+		{"desktop", "Codex Desktop/0.145.2 (Mac OS X; arm64)", "0.145.2"},
+		{"later_prerelease", "codex-tui/0.144.1-alpha.1 (Linux)", "0.144.1-alpha.1"},
+		{"minimum_prerelease", "codex-tui/0.144.0-alpha.1 (Linux)", ""},
+		{"old", "codex-tui/0.143.9 (Mac OS X; arm64)", ""},
+		{"missing", "", ""},
+		{"invalid_version", "codex-tui/not-a-version (Linux)", ""},
+		{"missing_version", "codex-tui/ (Linux)", ""},
+		{"four_parts", "codex-tui/0.144.0.1 (Linux)", ""},
+		{"leading_zero", "codex-tui/00.144.0 (Linux)", ""},
+		{"third_party", "other-client/1.0.0", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			identity := resolveCodexTransparentIdentity(tc.ua, fallback)
+			if tc.wantVersion == "" {
+				require.Equal(t, fallback, identity)
+			} else {
+				require.Equal(t, tc.ua, identity.userAgent)
+				require.Equal(t, tc.wantVersion, identity.version)
+			}
+			require.Equal(t, identity.version, openai.CodexUserAgentVersion(identity.userAgent))
+			originator, _, ok := openai.PairCodexClientIdentity(identity.userAgent)
+			require.True(t, ok)
+			require.Equal(t, originator, identity.originator)
+			require.Equal(t, identity, resolveCodexTransparentIdentity(identity.userAgent, fallback))
+		})
+	}
+}
+
+func TestTransparentCodexIdentityHTTPAndWebSocketAgree(t *testing.T) {
+	wasEnabled := codexIdentityEnforcement.Load()
+	SetCodexIdentityEnforcementEnabled(false)
+	t.Cleanup(func() { SetCodexIdentityEnforcementEnabled(wasEnabled) })
+
+	for _, tc := range []struct {
+		ua, wantUA, version string
+	}{
+		{"codex-tui/0.145.2 (Mac OS X 14.0; arm64) iTerm", "codex-tui/0.145.2 (Mac OS X 14.0; arm64) iTerm", "0.145.2"},
+		{"codex_cli_rs/0.144.0 (Windows NT; x86_64)", "codex_cli_rs/0.144.0 (Windows NT; x86_64)", "0.144.0"},
+		{"codex-tui/0.143.9 (Mac OS X; arm64)", codexCLIUserAgent, codexCLIVersion},
+		{"codex-tui/0.144.0-alpha.1 (Linux)", codexCLIUserAgent, codexCLIVersion},
+		{"codex-tui/invalid (Linux)", codexCLIUserAgent, codexCLIVersion},
+	} {
+		t.Run(tc.ua, func(t *testing.T) {
+			body := []byte(`{"model":"audit-model","stream":true}`)
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+			c.Request.Header.Set("User-Agent", tc.ua)
+			account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+				Credentials: map[string]any{"chatgpt_account_id": "audit-account"}}
+			svc := &OpenAIGatewayService{}
+			req, err := svc.buildUpstreamRequest(context.Background(), c, account, body, "dummy-token", true, "", true)
+			require.NoError(t, err)
+			headers, _, err := svc.buildOpenAIWSHeaders(context.Background(), c, account, "dummy-token",
+				OpenAIWSProtocolDecision{Transport: OpenAIUpstreamTransportResponsesWebsocketV2}, true, "", "", "", "", "")
+			require.NoError(t, err)
+			originator, _, ok := openai.PairCodexClientIdentity(tc.wantUA)
+			require.True(t, ok)
+			for _, h := range []http.Header{req.Header, headers} {
+				require.Equal(t, tc.wantUA, h.Get("User-Agent"))
+				require.Equal(t, tc.version, h.Get("version"))
+				require.Equal(t, originator, h.Get("originator"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix: resolve transparent Codex identity consistently

Suggested status: **Draft**, pending agreement on fallback policy. PR1 (#6924)
has already been merged into `main`; this PR contains only the follow-up
transparent-identity policy change.

## Summary

Resolve a complete `codexOutboundIdentity` before writing UA, originator and
version. Reuse the existing shared HTTP/WebSocket handling and identity type.

## Reproduction

With identity enforcement disabled, supply:

```text
User-Agent: codex-tui/0.145.2 (Mac OS X 14.0; arm64) iTerm
originator: codex-tui
version: 0.200.0
```

The baseline preserves the conflicting version. A missing version can also stay
missing. The proposed policy derives it from a supported, valid UA version.

## Proposed Policy

| Candidate identity | Result |
| --- | --- |
| Recognized UA with valid version at/above 0.144.0 | Preserve paired UA; derive originator and version from it |
| Missing, unrecognized, invalid-version, or older identity | Use the entire existing canonical fallback |
| Explicit version conflicting with a supported UA | UA version takes precedence |
| 0.144.0-alpha.1 | Below the minimum; complete fallback |
| 0.144.1-alpha.1 | Supported prerelease; preserve |
| Two-component semantic version | Accepted if it meets the minimum |
| Four-component or leading-zero version | Complete fallback |

Version ordering uses the project's existing `golang.org/x/mod/semver` dependency.
The shared legacy version normalizer is not globally changed.

## Maintainer Decision

When identity enforcement is disabled, should unsupported identities retain
their original declarations, or should the complete outbound identity fall back
to the canonical identity? This draft implements the latter.

This is a behavior change, not merely a refactor. Older clients may lose their
platform/client suffix in the fallback. Agreeing on the policy is necessary
before marking this ready for review.

## Boundaries

- No change to the default identity-enforcement setting.
- No change to forced-mode resolution, installation/session IDs or routing.
- Relies on the UA-validation behavior merged by PR1 (#6924); this patch does
  not duplicate that validation in the transparent-policy layer.
- No assertion that this fixes issue #6911 or improves TTFT/output quality.

## Testing

Independent verification results are recorded in the accompanying `README.md`.
Coverage includes supported/unsupported versions, prereleases, client families,
conflicting version headers, idempotence, and HTTP/WebSocket construction.

Not verified: full backend suite, race detector, live inference, or performance.
