### PR TITLE
fix(subscriptions): clear assignment user before search debounce

### DIFF
--- a/frontend/src/views/admin/SubscriptionsView.vue
+++ b/frontend/src/views/admin/SubscriptionsView.vue
@@ -1126,6 +1126,11 @@ const clearFilterUser = () => {
 
 // User search with debounce
 const debounceSearchUsers = () => {
+  // Invalidate the assignment target before the debounced search runs.
+  if (selectedUser.value && userSearchKeyword.value.trim() !== selectedUser.value.email) {
+    selectedUser.value = null
+    assignForm.user_id = null
+  }
   if (userSearchTimeout) {
     clearTimeout(userSearchTimeout)
   }
@@ -1134,12 +1139,6 @@ const debounceSearchUsers = () => {
 
 const searchUsers = async () => {
   const keyword = userSearchKeyword.value.trim()
-
-  // Clear selection if user modified the search keyword
-  if (selectedUser.value && keyword !== selectedUser.value.email) {
-    selectedUser.value = null
-    assignForm.user_id = null
-  }
 
   if (!keyword) {
     userSearchResults.value = []

--- a/frontend/src/views/admin/__tests__/SubscriptionsView.userUsageLink.spec.ts
+++ b/frontend/src/views/admin/__tests__/SubscriptionsView.userUsageLink.spec.ts
@@ -4,8 +4,10 @@ import { defineComponent } from 'vue'
 
 import SubscriptionsView from '../SubscriptionsView.vue'
 
-const { listSubscriptions, getAllGroups, listUsers, searchUsageUsers } = vi.hoisted(() => ({
+const { listSubscriptions, assignSubscription, getAllGroups, listUsers, searchUsageUsers, showError } = vi.hoisted(() => ({
   listSubscriptions: vi.fn(),
+  assignSubscription: vi.fn(),
+  showError: vi.fn(),
   getAllGroups: vi.fn(),
   listUsers: vi.fn(),
   searchUsageUsers: vi.fn()
@@ -13,7 +15,7 @@ const { listSubscriptions, getAllGroups, listUsers, searchUsageUsers } = vi.hois
 
 vi.mock('@/api/admin', () => ({
   adminAPI: {
-    subscriptions: { list: listSubscriptions },
+    subscriptions: { list: listSubscriptions, assign: assignSubscription },
     groups: { getAll: getAllGroups },
     users: { list: listUsers },
     usage: { searchUsers: searchUsageUsers }
@@ -22,7 +24,7 @@ vi.mock('@/api/admin', () => ({
 
 vi.mock('@/stores/app', () => ({
   useAppStore: () => ({
-    showError: vi.fn(),
+    showError,
     showSuccess: vi.fn()
   })
 }))
@@ -80,6 +82,7 @@ describe('admin subscription users', () => {
       total: 1,
       pages: 1
     })
+    assignSubscription.mockResolvedValue({})
     getAllGroups.mockResolvedValue([])
     listUsers.mockResolvedValue({
       items: [{ id: 42, email: 'reader@example.com' }],
@@ -137,6 +140,50 @@ describe('admin subscription users', () => {
       expect(picker.text()).not.toContain('deleted@example.com')
       await picker.get('button').trigger('click')
       expect((search.element as HTMLInputElement).value).toBe('reader@example.com')
+    } finally {
+      wrapper.unmount()
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(['another', ''])('clears the assignment user immediately when input changes to %j', async (keyword) => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const wrapper = mountView()
+    try {
+      await flushPromises()
+      await wrapper.findAll('button')
+        .find((button) => button.text() === 'admin.subscriptions.assignSubscription')!
+        .trigger('click')
+      const form = wrapper.get('#assign-subscription-form')
+      form.getComponent({ name: 'Select' }).vm.$emit('update:modelValue', 3)
+      const search = wrapper.get('[data-assign-user-search] input')
+      await search.trigger('focus')
+      await search.setValue('reader')
+      await vi.advanceTimersByTimeAsync(300)
+      await flushPromises()
+      await wrapper.get('[data-assign-user-search] button').trigger('click')
+
+      await search.setValue(keyword)
+      await form.trigger('submit')
+      await flushPromises()
+
+      expect(assignSubscription).not.toHaveBeenCalled()
+      expect(showError).toHaveBeenCalledWith('admin.subscriptions.pleaseSelectUser')
+      expect(listUsers).toHaveBeenCalledTimes(1)
+
+      listUsers.mockResolvedValue({ items: [{ id: 84, email: 'another@example.com' }] })
+      await search.trigger('focus')
+      await search.setValue('another')
+      await vi.advanceTimersByTimeAsync(300)
+      await flushPromises()
+      await wrapper.get('[data-assign-user-search] button').trigger('click')
+      await form.trigger('submit')
+      await flushPromises()
+
+      expect(assignSubscription).toHaveBeenCalledTimes(1)
+      expect(assignSubscription).toHaveBeenCalledWith({
+        user_id: 84, group_id: 3, validity_days: 30
+      })
     } finally {
       wrapper.unmount()
       vi.useRealTimers()


### PR DESCRIPTION
After selecting a user for a subscription, changing or clearing the search input left that user selected until the 300 ms debounce elapsed. Submitting during that interval could assign the subscription to the previous user.

Move the existing selection invalidation into the input callback so it takes effect immediately. The search request remains debounced. Regression tests reproduce both input changes and verify that selecting the next user still assigns correctly.

Validation: 188 frontend tests passed (14 critical suites plus the subscription suite), along with full typecheck, ESLint, and `git diff --check`.

CI also passed: Go unit and integration tests, Go lint, frontend, shell, security, and CLA checks.