### PR TITLE
fix(proxies): refresh the list after partial imports

### DIFF
--- a/frontend/src/__tests__/integration/proxy-data-import.spec.ts
+++ b/frontend/src/__tests__/integration/proxy-data-import.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
+import { adminAPI } from '@/api/admin'
+import type { AdminDataImportResult } from '@/types'
 import ImportDataModal from '@/components/admin/proxy/ImportDataModal.vue'
 
 const showError = vi.fn()
@@ -27,9 +29,105 @@ vi.mock('vue-i18n', () => ({
 }))
 
 describe('Proxy ImportDataModal', () => {
+  const partialResult: AdminDataImportResult = {
+    proxy_created: 1,
+    proxy_reused: 0,
+    proxy_failed: 1,
+    account_created: 0,
+    account_failed: 0,
+    errors: [{ kind: 'proxy', name: 'invalid proxy', message: 'invalid port' }]
+  }
+
+  const mountWithFile = async () => {
+    const wrapper = mount(ImportDataModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          BaseDialog: { template: '<div><slot /><footer><slot name="footer" /></footer></div>' }
+        }
+      }
+    })
+    const input = wrapper.find('input[type="file"]')
+    const file = new File(['{}'], 'data.json', { type: 'application/json' })
+    Object.defineProperty(file, 'text', { value: () => Promise.resolve('{}') })
+    Object.defineProperty(input.element, 'files', { value: [file] })
+    await input.trigger('change')
+    return wrapper
+  }
+
+  it.each([
+    { name: 'created', proxy_created: 1, proxy_reused: 0 },
+    { name: 'reused', proxy_created: 0, proxy_reused: 1 }
+  ])('refreshes $name proxies when closing a partial import result', async (counts) => {
+    vi.mocked(adminAPI.proxies.importData).mockResolvedValue({ ...partialResult, ...counts })
+    const wrapper = await mountWithFile()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(showError).toHaveBeenCalledWith('admin.proxies.dataImportCompletedWithErrors')
+    expect(wrapper.text()).toContain('invalid port')
+    expect(wrapper.emitted('imported')).toBeUndefined()
+    expect(wrapper.emitted('close')).toBeUndefined()
+
+    await wrapper.get('footer button[type="button"]').trigger('click')
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    await wrapper.setProps({ show: false })
+    await wrapper.setProps({ show: true })
+    await wrapper.get('footer button[type="button"]').trigger('click')
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+  })
+
+  it('keeps a pending refresh when a later import entirely fails', async () => {
+    vi.mocked(adminAPI.proxies.importData)
+      .mockResolvedValueOnce(partialResult)
+      .mockResolvedValueOnce({ ...partialResult, proxy_created: 0 })
+    const wrapper = await mountWithFile()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.get('footer button[type="button"]').trigger('click')
+
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+  })
+
+  it('does not refresh when all imported proxies fail', async () => {
+    vi.mocked(adminAPI.proxies.importData).mockResolvedValue({ ...partialResult, proxy_created: 0 })
+    const wrapper = await mountWithFile()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.get('footer button[type="button"]').trigger('click')
+
+    expect(wrapper.emitted('imported')).toBeUndefined()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('refreshes immediately after a successful retry without refreshing twice on close', async () => {
+    vi.mocked(adminAPI.proxies.importData)
+      .mockResolvedValueOnce(partialResult)
+      .mockResolvedValueOnce({ ...partialResult, proxy_failed: 0, errors: [] })
+    const wrapper = await mountWithFile()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(showSuccess).toHaveBeenCalledWith('admin.proxies.dataImportSuccess')
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+
+    await wrapper.get('footer button[type="button"]').trigger('click')
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+  })
+
   beforeEach(() => {
     showError.mockReset()
     showSuccess.mockReset()
+    vi.mocked(adminAPI.proxies.importData).mockReset()
   })
 
   it('未选择文件时提示错误', async () => {

--- a/frontend/src/components/admin/proxy/ImportDataModal.vue
+++ b/frontend/src/components/admin/proxy/ImportDataModal.vue
@@ -108,6 +108,7 @@ const { t } = useI18n()
 const appStore = useAppStore()
 
 const importing = ref(false)
+const hasImportedData = ref(false)
 const file = ref<File | null>(null)
 const result = ref<AdminDataImportResult | null>(null)
 
@@ -121,6 +122,7 @@ watch(
   (open) => {
     if (open) {
       file.value = null
+      hasImportedData.value = false
       result.value = null
       if (fileInput.value) {
         fileInput.value.value = ''
@@ -140,6 +142,10 @@ const handleFileChange = (event: Event) => {
 
 const handleClose = () => {
   if (importing.value) return
+  if (hasImportedData.value) {
+    hasImportedData.value = false
+    emit('imported')
+  }
   emit('close')
 }
 
@@ -183,8 +189,10 @@ const handleImport = async () => {
     }
 
     if (res.proxy_failed > 0) {
+      hasImportedData.value ||= res.proxy_created > 0 || res.proxy_reused > 0
       appStore.showError(t('admin.proxies.dataImportCompletedWithErrors', msgParams))
     } else {
+      hasImportedData.value = false
       appStore.showSuccess(t('admin.proxies.dataImportSuccess', msgParams))
       emit('imported')
     }


### PR DESCRIPTION
When a proxy import created or reused entries but also reported failures, closing the result dialog left the proxy list stale. Remember successful work during a partial import and emit `imported` when closing, following the account import dialog's existing pattern.

Keep partial-import details visible and preserve immediate refresh for a fully successful import. Tests cover partial creation/reuse, retries, complete failure, and avoiding duplicate refresh events.

Validation: 189 frontend tests passed (14 critical suites plus the proxy import suite), along with full typecheck, ESLint, and `git diff --check`.

CI also passed: Go unit and integration tests, Go lint, frontend, shell, security, and CLA checks.