### PR TITLE
[codex] Fix OpenAI account-pool sticky scheduling

### DIFF
--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -448,7 +448,7 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 
-	if !req.StickyWeighted {
+	if !req.StickyWeighted || openAIStickyRequestRequiresBoundedWait(req) {
 		selection, escapedSticky, err := s.selectBySessionHash(ctx, req)
 		if err != nil {
 			return nil, decision, err
@@ -558,20 +558,23 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		return nil, false, nil
 	}
 	escapeCfg := s.service.openAIStickyEscapeConfig()
-	if reason, errorRate, ttft, shouldEscape := s.shouldEscapeStickyAccount(accountID, escapeCfg); shouldEscape && !req.DisableStickyEscape {
-		slog.Info("sticky_escape_triggered",
-			"account_id", accountID,
-			"reason", reason,
-			"error_rate", errorRate,
-			"ttft", ttft,
-		)
-		return nil, true, nil
+	stickyRequiresBoundedWait := openAIStickyRequestRequiresBoundedWait(req)
+	if !stickyRequiresBoundedWait {
+		if reason, errorRate, ttft, shouldEscape := s.shouldEscapeStickyAccount(accountID, escapeCfg); shouldEscape && !req.DisableStickyEscape {
+			slog.Info("sticky_escape_triggered",
+				"account_id", accountID,
+				"reason", reason,
+				"error_rate", errorRate,
+				"ttft", ttft,
+			)
+			return nil, true, nil
+		}
 	}
 	result, acquireErr := s.service.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
+
 	if acquireErr != nil && req.DisableStickyEscape {
 		return nil, false, acquireErr
-	}
-	if acquireErr == nil && result != nil && result.Acquired {
+	}	if acquireErr == nil && result != nil && result.Acquired {
 		if !req.PreserveStickyBinding {
 			_ = s.service.refreshStickySessionTTL(ctx, req.GroupID, sessionHash, s.service.openAIWSSessionStickyTTL())
 		}
@@ -585,6 +588,17 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 	cfg := s.service.schedulingConfig()
 	// WaitPlan.MaxConcurrency 使用 Concurrency（非 EffectiveLoadFactor），因为 WaitPlan 控制的是 Redis 实际并发槽位等待。
 	if s.service.concurrencyService != nil {
+		if stickyRequiresBoundedWait {
+			return attachSelectionProfitGate(ctx, &AccountSelectionResult{
+				Account: account,
+				WaitPlan: &AccountWaitPlan{
+					AccountID:      accountID,
+					MaxConcurrency: account.Concurrency,
+					Timeout:        cfg.StickySessionWaitTimeout,
+					MaxWaiting:     cfg.StickySessionMaxWaiting,
+				},
+			}), false, nil
+		}
 		if escapeCfg.enabled && !req.DisableStickyEscape && acquireErr == nil && result != nil && !result.Acquired {
 			errorRate, ttft, _ := s.stats.snapshot(accountID)
 			slog.Info("sticky_escape_triggered",
@@ -595,17 +609,23 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 			)
 			return nil, true, nil
 		}
-		return attachSelectionProfitGate(ctx, &AccountSelectionResult{
-			Account: account,
-			WaitPlan: &AccountWaitPlan{
-				AccountID:      accountID,
-				MaxConcurrency: account.Concurrency,
-				Timeout:        cfg.StickySessionWaitTimeout,
-				MaxWaiting:     cfg.StickySessionMaxWaiting,
-			},
-		}), false, nil
+		return nil, true, nil
 	}
 	return nil, false, nil
+}
+
+func openAIStickyRequestRequiresBoundedWait(req OpenAIAccountScheduleRequest) bool {
+	if req.PreserveStickyBinding {
+		return true
+	}
+	switch req.RequiredTransport {
+	case OpenAIUpstreamTransportResponsesWebsocket,
+		OpenAIUpstreamTransportResponsesWebsocketV2,
+		OpenAIUpstreamTransportResponsesWebsocketV2Ingress:
+		return true
+	default:
+		return false
+	}
 }
 
 func openAIStickyAccountMatchesGroup(account *Account, groupID *int64) bool {
@@ -1056,6 +1076,9 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 			return nil
 		}
 		groupTopK := plan.topK
+		if req.PreserveStickyBinding {
+			groupTopK = len(pool)
+		}
 		if groupTopK > len(pool) {
 			groupTopK = len(pool)
 		}
@@ -1475,7 +1498,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		filtered = append(filtered, account)
 		loadReq = append(loadReq, AccountWithConcurrency{
 			ID:             account.ID,
-			MaxConcurrency: account.EffectiveLoadFactor(),
+			MaxConcurrency: openAIAccountLoadCapacity(account),
 		})
 	}
 	if len(filtered) == 0 {
@@ -1655,7 +1678,7 @@ func buildOpenAIAccountLoadRequest(accounts []*Account) []AccountWithConcurrency
 		}
 		loadReq = append(loadReq, AccountWithConcurrency{
 			ID:             account.ID,
-			MaxConcurrency: account.EffectiveLoadFactor(),
+			MaxConcurrency: openAIAccountLoadCapacity(account),
 		})
 	}
 	return loadReq

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -571,10 +571,10 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		}
 	}
 	result, acquireErr := s.service.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
-
 	if acquireErr != nil && req.DisableStickyEscape {
 		return nil, false, acquireErr
-	}	if acquireErr == nil && result != nil && result.Acquired {
+	}
+	if acquireErr == nil && result != nil && result.Acquired {
 		if !req.PreserveStickyBinding {
 			_ = s.service.refreshStickySessionTTL(ctx, req.GroupID, sessionHash, s.service.openAIWSSessionStickyTTL())
 		}

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -2287,7 +2287,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionSticky(t *testin
 	}
 }
 
-func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyKeepsSticky(t *testing.T) {
+func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyFallsBackToIdleAccount(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(10100)
 	accounts := []Account{
@@ -2327,6 +2327,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyKeepsS
 	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.OAuthEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.LBTopK = 1
 
 	concurrencyCache := schedulerTestConcurrencyCache{
 		acquireResults: map[int64]bool{
@@ -2363,10 +2364,85 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyKeepsS
 	require.NoError(t, err)
 	require.NotNil(t, selection)
 	require.NotNil(t, selection.Account)
-	require.Equal(t, int64(21001), selection.Account.ID, "busy sticky account should remain selected")
+	require.Equal(t, int64(21002), selection.Account.ID, "busy sticky account should fall back to an idle account")
+	require.True(t, selection.Acquired)
+	require.Nil(t, selection.WaitPlan)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.False(t, decision.StickySessionHit)
+	require.Equal(t, int64(21001), cache.sessionBindings["openai:session_hash_sticky_busy"], "temporary spillover must preserve the sticky binding")
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_WebSocketStickyBusyWaitsOnBoundAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(10105)
+	accounts := []Account{
+		{
+			ID:          21501,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    0,
+			GroupIDs:    []int64{groupID},
+			Extra: map[string]any{
+				"openai_apikey_responses_websockets_v2_enabled": true,
+			},
+		},
+		{
+			ID:          21502,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    1,
+			GroupIDs:    []int64{groupID},
+			Extra: map[string]any{
+				"openai_apikey_responses_websockets_v2_enabled": true,
+			},
+		},
+	}
+	cache := &schedulerTestGatewayCache{
+		sessionBindings: map[string]int64{
+			"openai:session_hash_ws_sticky_busy": 21501,
+		},
+	}
+	cfg := newSchedulerTestOpenAIWSV2Config()
+	cfg.Gateway.Scheduling.StickySessionMaxWaiting = 2
+	cfg.Gateway.Scheduling.StickySessionWaitTimeout = 45 * time.Second
+	concurrencyCache := schedulerTestConcurrencyCache{
+		acquireResults: map[int64]bool{21501: false, 21502: true},
+		waitCounts:     map[int64]int{21501: 0},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              cache,
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true", "true"),
+		concurrencyService: NewConcurrencyService(concurrencyCache),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(
+		ctx,
+		&groupID,
+		"",
+		"session_hash_ws_sticky_busy",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportResponsesWebsocketV2,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(21501), selection.Account.ID)
 	require.False(t, selection.Acquired)
 	require.NotNil(t, selection.WaitPlan)
-	require.Equal(t, int64(21001), selection.WaitPlan.AccountID)
+	require.Equal(t, int64(21501), selection.WaitPlan.AccountID)
 	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
 	require.True(t, decision.StickySessionHit)
 }
@@ -2537,7 +2613,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyEscape
 	}
 }
 
-func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyEscapeDisabledKeepsLegacyBehavior(t *testing.T) {
+func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyFallsBackWhenEscapeDisabled(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(10104)
 	accounts := []Account{
@@ -2573,11 +2649,15 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyEscapeDisa
 	require.NoError(t, err)
 	require.NotNil(t, selection)
 	require.NotNil(t, selection.Account)
-	require.Equal(t, int64(21401), selection.Account.ID)
-	require.NotNil(t, selection.WaitPlan)
-	require.Equal(t, int64(21401), selection.WaitPlan.AccountID)
-	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
-	require.True(t, decision.StickySessionHit)
+	require.Equal(t, int64(21402), selection.Account.ID)
+	require.True(t, selection.Acquired)
+	require.Nil(t, selection.WaitPlan)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.False(t, decision.StickySessionHit)
+	require.Equal(t, int64(21401), cache.sessionBindings["openai:session_hash_sticky_disabled"], "temporary spillover must preserve the sticky binding")
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
 }
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_SubscriptionPriorityChoosesSubscriptionPoolFirst(t *testing.T) {
@@ -3670,6 +3750,21 @@ func TestDefaultOpenAIAccountScheduler_IsAccountTransportCompatible_Branches(t *
 
 	account.Extra["openai_apikey_responses_websockets_v2_mode"] = OpenAIWSIngressModeOff
 	require.False(t, scheduler.isAccountTransportCompatible(account, OpenAIUpstreamTransportResponsesWebsocketV2Ingress))
+}
+
+func TestBuildOpenAIAccountLoadRequest_PreservesUnlimitedConcurrency(t *testing.T) {
+	loadFactor := 4
+	loads := buildOpenAIAccountLoadRequest([]*Account{
+		{ID: 8801, Platform: PlatformOpenAI, Concurrency: 0},
+		{ID: 8802, Platform: PlatformOpenAI, Concurrency: 3},
+		{ID: 8803, Platform: PlatformOpenAI, Concurrency: 0, LoadFactor: &loadFactor},
+	})
+
+	require.Equal(t, []AccountWithConcurrency{
+		{ID: 8801, MaxConcurrency: 0},
+		{ID: 8802, MaxConcurrency: 3},
+		{ID: 8803, MaxConcurrency: 4},
+	}, loads)
 }
 
 func int64PtrForTest(v int64) *int64 {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -1130,31 +1130,62 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		}
 	}
 	if s.concurrencyService == nil || !cfg.LoadBatchEnabled {
-		account, err := s.selectAccountForModelWithExclusions(ctx, groupID, platform, sessionHash, requestedModel, excludedIDs, requireCompact, stickyAccountID, requiredCapability, preferLowUpstreamRate)
-		if err != nil {
-			return nil, err
-		}
-		result, err := s.tryAcquireAccountSlot(ctx, account.ID, account.Concurrency)
-		if err == nil && result != nil && result.Acquired {
-			return s.newAcquiredSelectionResult(ctx, account, result.ReleaseFunc)
-		}
-		if stickyAccountID > 0 && stickyAccountID == account.ID && s.concurrencyService != nil {
-			waitingCount, _ := s.concurrencyService.GetAccountWaitingCount(ctx, account.ID)
-			if waitingCount < cfg.StickySessionMaxWaiting {
+		localExcluded := cloneExcludedAccountIDs(excludedIDs)
+		selectionSessionHash := sessionHash
+		var stickyWaitAccount *Account
+		var fallbackWaitAccount *Account
+		for {
+			account, err := s.selectAccountForModelWithExclusions(ctx, groupID, platform, selectionSessionHash, requestedModel, localExcluded, requireCompact, stickyAccountID, requiredCapability, preferLowUpstreamRate)
+			if err != nil {
+				if stickyWaitAccount != nil {
+					return s.newSelectionResult(ctx, stickyWaitAccount, false, nil, &AccountWaitPlan{
+						AccountID:      stickyWaitAccount.ID,
+						MaxConcurrency: stickyWaitAccount.Concurrency,
+						Timeout:        cfg.StickySessionWaitTimeout,
+						MaxWaiting:     cfg.StickySessionMaxWaiting,
+					})
+				}
+				if fallbackWaitAccount != nil {
+					return s.newSelectionResult(ctx, fallbackWaitAccount, false, nil, &AccountWaitPlan{
+						AccountID:      fallbackWaitAccount.ID,
+						MaxConcurrency: fallbackWaitAccount.Concurrency,
+						Timeout:        cfg.FallbackWaitTimeout,
+						MaxWaiting:     cfg.FallbackMaxWaiting,
+					})
+				}
+				return nil, err
+			}
+
+			result, acquireErr := s.tryAcquireAccountSlot(ctx, account.ID, account.Concurrency)
+			if acquireErr == nil && result != nil && result.Acquired {
+				return s.newAcquiredSelectionResult(ctx, account, result.ReleaseFunc)
+			}
+			if s.concurrencyService == nil {
 				return s.newSelectionResult(ctx, account, false, nil, &AccountWaitPlan{
 					AccountID:      account.ID,
 					MaxConcurrency: account.Concurrency,
-					Timeout:        cfg.StickySessionWaitTimeout,
-					MaxWaiting:     cfg.StickySessionMaxWaiting,
+					Timeout:        cfg.FallbackWaitTimeout,
+					MaxWaiting:     cfg.FallbackMaxWaiting,
 				})
 			}
+
+			if account.ID == stickyAccountID && stickyAccountID > 0 {
+				waitingCount, _ := s.concurrencyService.GetAccountWaitingCount(ctx, account.ID)
+				if waitingCount < cfg.StickySessionMaxWaiting && stickyWaitAccount == nil {
+					stickyWaitAccount = account
+				}
+				// A failed sticky admission must not cause the next fallback
+				// selection to eagerly replace the durable session binding.
+				selectionSessionHash = ""
+			} else if fallbackWaitAccount == nil {
+				fallbackWaitAccount = account
+			}
+
+			if localExcluded == nil {
+				localExcluded = make(map[int64]struct{})
+			}
+			localExcluded[account.ID] = struct{}{}
 		}
-		return s.newSelectionResult(ctx, account, false, nil, &AccountWaitPlan{
-			AccountID:      account.ID,
-			MaxConcurrency: account.Concurrency,
-			Timeout:        cfg.FallbackWaitTimeout,
-			MaxWaiting:     cfg.FallbackMaxWaiting,
-		})
 	}
 
 	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
@@ -1174,10 +1205,10 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	}
 
 	// ============ Layer 1: Sticky session ============
-	// A healthy sticky account whose bounded wait queue is full may be used as a
-	// one-request capacity spillover in Layer 2. Keep that spillover temporary:
-	// rewriting the durable binding here would make a short burst migrate the
-	// whole conversation to a cache-cold account.
+	// A healthy sticky account whose immediate slot acquisition fails may be used
+	// as a one-request capacity spillover in Layer 2. Keep that spillover
+	// temporary: rewriting the durable binding here would make a short burst
+	// migrate the whole conversation to a cache-cold account.
 	stickySpillover := false
 	if sessionHash != "" {
 		accountID := stickyAccountID
@@ -1211,15 +1242,6 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 							return selection, nil
 						}
 
-						waitingCount, _ := s.concurrencyService.GetAccountWaitingCount(ctx, accountID)
-						if waitingCount < cfg.StickySessionMaxWaiting {
-							return s.newSelectionResult(ctx, account, false, nil, &AccountWaitPlan{
-								AccountID:      accountID,
-								MaxConcurrency: account.Concurrency,
-								Timeout:        cfg.StickySessionWaitTimeout,
-								MaxWaiting:     cfg.StickySessionMaxWaiting,
-							})
-						}
 						stickySpillover = true
 					}
 				}
@@ -1286,7 +1308,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	for _, acc := range candidates {
 		accountLoads = append(accountLoads, AccountWithConcurrency{
 			ID:             acc.ID,
-			MaxConcurrency: acc.EffectiveLoadFactor(),
+			MaxConcurrency: openAIAccountLoadCapacity(acc),
 		})
 	}
 
@@ -1506,6 +1528,19 @@ func (s *OpenAIGatewayService) tryAcquireAccountSlot(ctx context.Context, accoun
 		return &AcquireResult{Acquired: true, ReleaseFunc: func() {}}, nil
 	}
 	return s.concurrencyService.AcquireAccountSlot(ctx, accountID, maxConcurrency)
+}
+
+func openAIAccountLoadCapacity(account *Account) int {
+	if account == nil {
+		return 0
+	}
+	if account.LoadFactor != nil && *account.LoadFactor > 0 {
+		return *account.LoadFactor
+	}
+	if account.Concurrency > 0 {
+		return account.Concurrency
+	}
+	return 0
 }
 
 func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1207,6 +1207,53 @@ func TestOpenAISelectAccountWithLoadAwareness_StickyWaitPlan(t *testing.T) {
 	}
 }
 
+func TestOpenAISelectAccountWithLoadAwareness_StickyBusyFallsBackToIdleAccount(t *testing.T) {
+	for _, loadBatchEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("load_batch_%t", loadBatchEnabled), func(t *testing.T) {
+			sessionHash := "sticky-fallback"
+			groupID := int64(1)
+			repo := stubOpenAIAccountRepo{
+				accounts: []Account{
+					{ID: 101, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, GroupIDs: []int64{groupID}},
+					{ID: 102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 1, GroupIDs: []int64{groupID}},
+				},
+			}
+			cache := &stubGatewayCache{
+				sessionBindings: map[string]int64{"openai:" + sessionHash: 101},
+			}
+			concurrencyCache := stubConcurrencyCache{
+				acquireResults: map[int64]bool{101: false, 102: true},
+				waitCounts:     map[int64]int{101: 0},
+				loadMap: map[int64]*AccountLoadInfo{
+					101: {AccountID: 101, LoadRate: 0},
+					102: {AccountID: 102, LoadRate: 1},
+				},
+			}
+			cfg := &config.Config{}
+			cfg.Gateway.Scheduling.LoadBatchEnabled = loadBatchEnabled
+
+			svc := &OpenAIGatewayService{
+				accountRepo:        repo,
+				cache:              cache,
+				cfg:                cfg,
+				concurrencyService: NewConcurrencyService(concurrencyCache),
+			}
+
+			selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, sessionHash, "gpt-4", nil)
+			require.NoError(t, err)
+			require.NotNil(t, selection)
+			require.NotNil(t, selection.Account)
+			require.Equal(t, int64(102), selection.Account.ID, "an idle API Key account must bypass a busy sticky OAuth account")
+			require.True(t, selection.Acquired)
+			require.Nil(t, selection.WaitPlan)
+			require.Equal(t, int64(101), cache.sessionBindings["openai:"+sessionHash], "temporary spillover must preserve the sticky binding")
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+		})
+	}
+}
+
 func TestOpenAISelectAccountWithLoadAwareness_StickyCapacitySpilloverKeepsBinding(t *testing.T) {
 	sessionHash := "sticky-spillover"
 	groupID := int64(1)


### PR DESCRIPTION
Fixes #6992



This fixes OpenAI account-pool scheduling when a durable sticky account is busy.



Changes:

- Ordinary HTTP requests retry eligible accounts after sticky slot acquisition fails, without rewriting the durable sticky binding.

- WebSocket, guardian, and non-movable continuation paths keep bounded waiting on the bound account.

- Preserve-binding selection is no longer limited to LBTopK, and unlimited account concurrency remains 0 for load calculations.

- Adds regression coverage for load-batch and non-load-batch paths, sticky binding preservation, WebSocket waiting, and unlimited capacity.



Validation:

- go test -count=1 ./internal/service

- git diff --check