### PR TITLE
fix(deploy): make sub2api healthcheck ignore proxy env vars

### DIFF
--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -210,7 +210,7 @@ services:
     networks:
       - sub2api-network
     healthcheck:
-      test: ["CMD", "wget", "-q", "-T", "5", "-O", "/dev/null", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-Y", "off", "-q", "-T", "5", "-O", "/dev/null", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What changed

`deploy/docker-compose.local.yml`: the `sub2api` service healthcheck now runs `wget -Y off ...` instead of `wget ...`.

## Why

The healthcheck probes `http://localhost:8080/health` with busybox `wget`. If `HTTP_PROXY` / `http_proxy` is set in the container environment (a common setup when the gateway itself needs an outbound proxy to reach upstream providers), busybox `wget` honours the proxy for the localhost probe too. The probe then goes through the proxy, fails, and Docker marks a perfectly working container as `unhealthy`, which also breaks `depends_on: condition: service_healthy` chains.

`-Y off` tells busybox `wget` to bypass any proxy for that request, so the probe always hits the local process directly. No behaviour change when no proxy variables are set.

## Notes for reviewers

- One-line change, healthcheck only; no application code touched.
- Verified on a local deployment (Docker Desktop, macOS) that the container reports `healthy` with the new command.
- `docker-compose.yml` (named-volume variant) uses the same probe and could take the same flag if you want consistency; kept this PR minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)