### PR TITLE
feat: add self-heal-watch.sh for automated Sub2API health monitoring

### DIFF
--- a/deploy/self-heal-watch/README.md
+++ b/deploy/self-heal-watch/README.md
@@ -1,0 +1,114 @@
+# Sub2API Self-Heal Watch
+
+自动巡检 Sub2API 容器状态、HTTP endpoints 和日志错误模式，发现异常时自动重启服务。
+
+## 功能
+
+- 检查 Docker 容器状态（running / exited / unhealthy）
+- 检查 HTTP endpoints（`/`, `/health`, `/v1/models`）
+- 扫描最近 100 行日志中的错误模式（账号耗尽、代理连接失败、OAuth 超时等）
+- 检查容器内 `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`UPDATE_PROXY_URL` 环境变量是否指向正确的 NAS 代理地址
+- 发现异常时自动重启 `docker compose restart`
+- 重启后再次验证 `/health` 是否恢复 200
+
+## 错误模式列表
+
+检测以下日志关键字，任一出现即触发自愈：
+
+| 模式 | 含义 |
+|---|---|
+| `no available accounts` | 无可用账号 |
+| `unsupported_country_region_territory` | 账号地区不支持 |
+| `account_select_failed` | 账号选择失败 |
+| `token_refresh.retry_attempt_failed` | Token 刷新重试失败 |
+| `OAuth refresh attempt timed out` | OAuth 刷新超时 |
+| `account OAuth credentials permanently rejected` | OAuth 凭证永久拒绝 |
+| `proxyconnect tcp: dial tcp 127.0.0.1:7890` | 代理地址错误（指向了容器内 localhost 而非 NAS IP） |
+
+## 快速开始
+
+### 前置要求
+
+- 已部署 Sub2API（Docker Compose）
+- 可通过 SSH 访问运行 Sub2API 的 NAS/服务器
+- SSH key 已配置好免密码登录
+
+### 参数说明
+
+| 参数 | 环境变量 | 默认值 | 说明 |
+|---|---|---|---|
+| `-h HOST` | `SELF_HEAL_HOST` | `192.168.10.20` | NAS SSH 地址 |
+| `-u USER` | `SELF_HEAL_USER` | `l890852` | SSH 用户名 |
+| `-k KEY` | `SELF_HEAL_KEY` | `~/.ssh/id_ed25519_nas` | SSH 私钥路径 |
+| `-d DIR` | `SELF_HEAL_COMPOSE_DIR` | `/volume1/docker/sub2api` | docker-compose.yml 所在目录 |
+| `-p PORT` | `SELF_HEAL_PORT` | `3014` | Sub2API Web 端口 |
+| `-P URL` | `SELF_HEAL_PROXY_URL` | *(空)* | HTTP 代理地址（curl -x 参数） |
+| `-i SEC` | `SELF_HEAL_INTERVAL` | `3600` | 巡检间隔（秒），仅循环模式生效 |
+| `--no-restart` | — | false | 仅告警，不自动重启 |
+| `--dry-run` | — | false | 打印操作但不执行 |
+
+### 示例
+
+```bash
+# 单次检查（适用于 cron）
+SELF_HEAL_ONCE=true SELF_HEAL_HOST=192.168.10.20 \
+  SELF_HEAL_COMPOSE_DIR=/volume1/docker/sub2api \
+  SELF_HEAL_PROXY_URL=http://192.168.10.20:7890 \
+  ./self-heal-watch.sh
+
+# 持续循环（适用于 systemd service 或 screen）
+./self-heal-watch.sh -h 192.168.10.20 -u l890852 \
+  -d /volume1/docker/sub2api -P http://192.168.10.20:7890 -i 3600
+
+# 仅告警，不重启（集成到自己的告警系统时）
+./self-heal-watch.sh --no-restart
+```
+
+### 配合 Cron 使用（推荐）
+
+```crontab
+# 每小时巡检一次，发现问题自动修复
+0 * * * * SELF_HEAL_ONCE=true SELF_HEAL_HOST=192.168.10.20 SELF_HEAL_COMPOSE_DIR=/volume1/docker/sub2api SELF_HEAL_PROXY_URL=http://192.168.10.20:7890 /path/to/self-heal-watch.sh >> /var/log/sub2api-self-heal.log 2>&1
+```
+
+### 配合 Systemd 使用
+
+```ini
+# /etc/systemd/system/sub2api-self-heal.service
+[Unit]
+Description=Sub2API Self-Heal Watch
+After=network-online.target
+
+[Service]
+Type=simple
+User=youruser
+Environment="SELF_HEAL_HOST=192.168.10.20"
+Environment="SELF_HEAL_COMPOSE_DIR=/volume1/docker/sub2api"
+Environment="SELF_HEAL_PROXY_URL=http://192.168.10.20:7890"
+ExecStart=/opt/sub2api/self-heal-watch.sh
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## 关键注意事项
+
+### 代理地址必须用 NAS IP，不能用容器内 localhost
+
+Docker Compose 中如果写了 `HTTP_PROXY=127.0.0.1:7890`，容器内 localhost 指向容器自己而非宿主 NAS，会导致代理完全失效。正确写法：
+
+```yaml
+environment:
+  HTTP_PROXY: "http://192.168.10.20:7890"
+  HTTPS_PROXY: "http://192.168.10.20:7890"
+  ALL_PROXY: "http://192.168.10.20:7890"
+  UPDATE_PROXY_URL: "http://192.168.10.20:7890"
+```
+
+本脚本会检测容器 env 中是否仍残留 `127.0.0.1:7890`，发现后告警。
+
+## License
+
+MIT — 与 Sub2API 主仓库保持一致。

--- a/deploy/self-heal-watch/self-heal-watch.sh
+++ b/deploy/self-heal-watch/self-heal-watch.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# self-heal-watch.sh — Sub2API self-healing monitor for Docker + NAS environments
+# Usage: ./self-heal-watch.sh [OPTIONS]
+#   -h HOST        NAS SSH host (default: 192.168.10.20)
+#   -u USER        SSH user (default: l890852)
+#   -k KEY         SSH private key (default: ~/.ssh/id_ed25519_nas)
+#   -d COMPOSE_DIR Docker compose directory on remote (default: /volume1/docker/sub2api)
+#   -p PORT        Web UI port (default: 3014)
+#   -P PROXY_URL   Proxy URL for API calls (e.g. http://192.168.10.20:7890)
+#   -i INTERVAL    Check interval in seconds (default: 3600)
+#   --no-restart   Only alert, do not restart containers
+#   --dry-run      Print actions without executing
+
+set -euo pipefail
+
+HOST="${SELF_HEAL_HOST:-192.168.10.20}"
+USER="${SELF_HEAL_USER:-l890852}"
+KEY="${SELF_HEAL_KEY:-$HOME/.ssh/id_ed25519_nas}"
+COMPOSE_DIR="${SELF_HEAL_COMPOSE_DIR:-/volume1/docker/sub2api}"
+PORT="${SELF_HEAL_PORT:-3014}"
+PROXY_URL="${SELF_HEAL_PROXY_URL:-}"
+INTERVAL="${SELF_HEAL_INTERVAL:-3600}"
+DRY_RUN=false
+NO_RESTART=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h) HOST="$2"; shift 2 ;;
+    -u) USER="$2"; shift 2 ;;
+    -k) KEY="$2"; shift 2 ;;
+    -d) COMPOSE_DIR="$2"; shift 2 ;;
+    -p) PORT="$2"; shift 2 ;;
+    -P) PROXY_URL="$2"; shift 2 ;;
+    -i) INTERVAL="$2"; shift 2 ;;
+    --no-restart) NO_RESTART=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+SSH="ssh -i "$KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=10"
+SSH_CMD="$USER@$HOST"
+WEB_URL="http://${HOST}:${PORT}"
+
+ERROR_PATTERNS=(
+  "no available accounts"
+  "unsupported_country_region_territory"
+  "account_select_failed"
+  "token_refresh.retry_attempt_failed"
+  "OAuth refresh attempt timed out"
+  "account OAuth credentials permanently rejected"
+  "proxyconnect tcp: dial tcp 127.0.0.1:7890"
+)
+
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+
+check_http() {
+  local url=$1
+  local proxy_arg=()
+  [[ -n "$PROXY_URL" ]] && proxy_arg=(-x "$PROXY_URL")
+  curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${proxy_arg[@]}" "$url" 2>/dev/null || echo "000"
+}
+
+restart_containers() {
+  log "Restarting sub2api containers..."
+  if $DRY_RUN; then
+    log "[DRY-RUN] Would run: cd $COMPOSE_DIR && sudo docker compose restart"
+    return 0
+  fi
+  $SSH "$SSH_CMD" "cd $COMPOSE_DIR && sudo docker compose restart" 2>/dev/null
+  sleep 5
+}
+
+heal() {
+  log "Attempting self-heal..."
+  restart_containers
+  sleep 10
+  local http_code; http_code=$(check_http "${WEB_URL}/health")
+  if [[ "$http_code" == "200" ]]; then
+    log "Heal successful — /health returned 200"
+    return 0
+  else
+    log "Heal failed — /health still returning $http_code"
+    return 1
+  fi
+}
+
+run_check() {
+  log "=== Starting sub2api health check ==="
+
+  # 1. Container status
+  local container_status; container_status=$($SSH "$SSH_CMD" \
+    "cd $COMPOSE_DIR && sudo docker compose ps --format json 2>/dev/null" 2>/dev/null || echo "")
+
+  if [[ -z "$container_status" ]]; then
+    log "WARN: Could not get container status from $COMPOSE_DIR"
+  else
+    local unhealthy; unhealthy=$(echo "$container_status" | \
+      jq -r 'select(.State != "running" and .State != "Up") | .Name' 2>/dev/null || echo "")
+    if [[ -n "$unhealthy" ]]; then
+      log "WARN: Unhealthy containers: $unhealthy"
+    else
+      log "Containers: OK"
+    fi
+  fi
+
+  # 2. HTTP health checks
+  local base_code; base_code=$(check_http "$WEB_URL/")
+  local health_code; health_code=$(check_http "${WEB_URL}/health")
+  local models_code; models_code=$(check_http "${WEB_URL}/v1/models")
+
+  log "/ -> $base_code | /health -> $health_code | /v1/models -> $models_code"
+
+  # 3. Log scan for error patterns
+  local log_errors=""
+  for pattern in "${ERROR_PATTERNS[@]}"; do
+    local found; found=$($SSH "$SSH_CMD" \
+      "cd $COMPOSE_DIR && sudo docker compose logs --tail=100 2>/dev/null | grep -i '$pattern' | tail -3" 2>/dev/null || true)
+    if [[ -n "$found" ]]; then
+      log_errors+="  [$pattern] found in logs: $(echo "$found" | tr '\n' '|')\n"
+    fi
+  done
+
+  if [[ -n "$log_errors" ]]; then
+    log "ERROR patterns detected:\n$log_errors"
+  else
+    log "Logs: clean, no error patterns"
+  fi
+
+  # 4. Proxy env check
+  if [[ -n "$PROXY_URL" ]]; then
+    local proxy_check; proxy_check=$($SSH "$SSH_CMD" \
+      "cd $COMPOSE_DIR && sudo docker compose exec -T sub2api env | grep -E '^(HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|UPDATE_PROXY_URL)=' 2>/dev/null" || true)
+    if echo "$proxy_check" | grep -qv "$HOST"; then
+      log "WARN: Proxy env may still point to localhost instead of $HOST"
+    else
+      log "Proxy env: OK ($PROXY_URL)"
+    fi
+  fi
+
+  # 5. Decide heal
+  local needs_heal=false
+  if [[ "$health_code" != "200" ]]; then
+    needs_heal=true
+    log "Reason to heal: /health returned $health_code"
+  fi
+  if [[ -n "$log_errors" ]]; then
+    needs_heal=true
+    log "Reason to heal: error patterns in logs"
+  fi
+
+  if $needs_heal; then
+    if $NO_RESTART; then
+      log "Alert: sub2api needs attention (no-restart mode, not healing)"
+      return 1
+    fi
+    heal && return 0 || return 1
+  fi
+
+  log "Result: HEALTHY"
+  return 0
+}
+
+# Run once or loop
+if [[ "${SELF_HEAL_ONCE:-false}" == "true" ]]; then
+  run_check
+else
+  while true; do
+    run_check || true
+    log "Sleeping ${INTERVAL}s before next check..."
+    sleep "$INTERVAL"
+  done
+fi


### PR DESCRIPTION
## Summary

Adds `deploy/self-heal-watch/` — a self-healing health monitor for Sub2API Docker deployments. Based on the proven automation that has been running in production checking sub2api every hour on a NAS.

## What this does

- **Container status check** — verifies all `docker compose` containers are `running`
- **HTTP health checks** — validates `/`, `/health`, `/v1/models` endpoints
- **Error pattern scan** — scans last 100 log lines for 7 known failure modes (account exhaustion, OAuth timeout, proxy misconfigs, etc.)
- **Proxy env validation** — checks container env vars match the NAS proxy IP, not container localhost
- **Auto-restart on failure** — `docker compose restart` then re-verify `/health` returns 200

## Key detection patterns

| Pattern | Indicates |
|---|---|
| `no available accounts` | All upstream accounts exhausted |
| `unsupported_country_region_territory` | Account geo restriction |
| `token_refresh.retry_attempt_failed` | Token refresh storm |
| `OAuth refresh attempt timed out` | Auth channel down |
| `proxyconnect tcp: dial tcp 127.0.0.1:7890` | Proxy still pointing to container localhost instead of NAS IP |

## Usage

Single check (cron-friendly):
```
SELF_HEAL_ONCE=true SELF_HEAL_HOST=192.168.10.20 \
  SELF_HEAL_COMPOSE_DIR=/volume1/docker/sub2api \
  SELF_HEAL_PROXY_URL=http://192.168.10.20:7890 \
  ./deploy/self-heal-watch/self-heal-watch.sh
```

Continuous loop with systemd — see `deploy/self-heal-watch/README.md`.

## Testing

- Dry-run mode: `--dry-run` prints actions without executing
- No-restart mode: `--no-restart` alerts but does not restart
