### PR TITLE
fix(openai-ws): ctx_pool 每账号连接上限系数默认值改为 5.0

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1276,9 +1276,11 @@ type GatewayOpenAIWSConfig struct {
 	MaxIdlePerAccount  int `mapstructure:"max_idle_per_account"`
 	// DynamicMaxConnsByAccountConcurrencyEnabled: 是否按账号并发动态计算连接池上限
 	DynamicMaxConnsByAccountConcurrencyEnabled bool `mapstructure:"dynamic_max_conns_by_account_concurrency_enabled"`
-	// OAuthMaxConnsFactor: OAuth 账号连接池系数（effective=ceil(concurrency*factor)）
+	// OAuthMaxConnsFactor: OAuth 账号连接池系数（effective=ceil(concurrency*factor)，再受 max_conns_per_account 封顶）。
+	// ctx_pool 接入下每个客户端会话在整个生命周期（含轮次之间）持有一条上游连接，此上限限制的是同时持有连接的会话数，
+	// 在飞请求数另由账号并发槽限制；系数 1.0 会让存活会话数一到并发数就返回 1013 busy，默认 5.0。
 	OAuthMaxConnsFactor float64 `mapstructure:"oauth_max_conns_factor"`
-	// APIKeyMaxConnsFactor: API Key 账号连接池系数（effective=ceil(concurrency*factor)）
+	// APIKeyMaxConnsFactor: API Key 账号连接池系数，含义与 OAuthMaxConnsFactor 相同，默认 5.0。
 	APIKeyMaxConnsFactor  float64 `mapstructure:"apikey_max_conns_factor"`
 	DialTimeoutSeconds    int     `mapstructure:"dial_timeout_seconds"`
 	ReadTimeoutSeconds    int     `mapstructure:"read_timeout_seconds"`
@@ -2402,8 +2404,8 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.min_idle_per_account", 4)
 	viper.SetDefault("gateway.openai_ws.max_idle_per_account", 12)
 	viper.SetDefault("gateway.openai_ws.dynamic_max_conns_by_account_concurrency_enabled", true)
-	viper.SetDefault("gateway.openai_ws.oauth_max_conns_factor", 1.0)
-	viper.SetDefault("gateway.openai_ws.apikey_max_conns_factor", 1.0)
+	viper.SetDefault("gateway.openai_ws.oauth_max_conns_factor", 5.0)
+	viper.SetDefault("gateway.openai_ws.apikey_max_conns_factor", 5.0)
 	viper.SetDefault("gateway.openai_ws.dial_timeout_seconds", 10)
 	viper.SetDefault("gateway.openai_ws.read_timeout_seconds", 900)
 	viper.SetDefault("gateway.openai_ws.write_timeout_seconds", 120)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -452,11 +452,11 @@ func TestLoadDefaultOpenAIWSConfig(t *testing.T) {
 	if !cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled {
 		t.Fatalf("Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = false, want true")
 	}
-	if cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor != 1.0 {
-		t.Fatalf("Gateway.OpenAIWS.OAuthMaxConnsFactor = %v, want 1.0", cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor)
+	if cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor != 5.0 {
+		t.Fatalf("Gateway.OpenAIWS.OAuthMaxConnsFactor = %v, want 5.0", cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor)
 	}
-	if cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor != 1.0 {
-		t.Fatalf("Gateway.OpenAIWS.APIKeyMaxConnsFactor = %v, want 1.0", cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor)
+	if cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor != 5.0 {
+		t.Fatalf("Gateway.OpenAIWS.APIKeyMaxConnsFactor = %v, want 5.0", cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor)
 	}
 	if cfg.Gateway.OpenAIWS.StickySessionTTLSeconds != 3600 {
 		t.Fatalf("Gateway.OpenAIWS.StickySessionTTLSeconds = %d, want 3600", cfg.Gateway.OpenAIWS.StickySessionTTLSeconds)

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -358,9 +358,13 @@ gateway:
     # 是否按账号并发动态计算连接池上限：
     # effective_max_conns = min(max_conns_per_account, ceil(account.concurrency * factor))
     dynamic_max_conns_by_account_concurrency_enabled: true
-    # 按账号类型分别设置系数（OAuth / API Key）
-    oauth_max_conns_factor: 1.0
-    apikey_max_conns_factor: 1.0
+    # 按账号类型分别设置系数（OAuth / API Key）。
+    # ctx_pool 接入下每个客户端会话在整个生命周期（轮次之间也不释放）持有一条上游连接，
+    # 该上限限制的是同时持有连接的会话数，在飞请求数另由账号并发限制；
+    # 系数 1.0 会让存活会话数一到并发数，新会话就收到 1013 upstream websocket is busy。
+    # 空闲连接数另受 max_idle_per_account 裁剪。
+    oauth_max_conns_factor: 5.0
+    apikey_max_conns_factor: 5.0
     dial_timeout_seconds: 10
     read_timeout_seconds: 900
     write_timeout_seconds: 120


### PR DESCRIPTION
## 背景

ctx_pool 接入模式下，每个客户端（Codex）会话在整个生命周期持有一条上游 Responses WebSocket 连接，轮次之间也不释放，直到 `ingress_inter_turn_idle_timeout_seconds`（默认 300 秒）空闲超时（#4163 引入的会话生命周期语义）。而每账号连接池上限按 `ceil(account.concurrency × factor)` 计算，`oauth_max_conns_factor` / `apikey_max_conns_factor` 默认都是 1.0，即上限 = 账号并发数。

这两个数限制的不是同一件事：账号并发限制的是在飞请求数，连接上限限制的是同时持有连接的会话数。一个 Codex 用户开几个窗口，再加上子智能体、记忆整理、guardian 预热等附属会话，同时存活的会话数很容易远超在飞请求数。会话数一到上限，新会话 acquire 等满 `dial_timeout + 2s` 后收到 `1013 upstream websocket is busy, please retry later`；这条路径不是拨号错误，不走换号，Codex 重试 5 次全落回同一账号，然后退回 HTTP。客户端表现为 `Reconnecting... n/5` 与 `websocket closed by server before response.completed`，即 #1769 / #3349 / #1807 里 1013 busy 的那部分。

## 改动

- `oauth_max_conns_factor` 与 `apikey_max_conns_factor` 默认值 1.0 → 5.0，仍受 `max_conns_per_account`（默认 128）封顶。两者走同一公式、同一个池，会话持有连接的语义相同，按机制一致处理。
- `config.go` 与 `config.example.yaml` 注释补充：该上限限制的是同时持有连接的会话数，在飞请求数另由账号并发限制；空闲连接另受 `max_idle_per_account`（默认 12）裁剪。
- 默认值测试同步。

不改账号并发，不改上限公式；显式配置过系数的部署不受影响。

## 为什么改默认值，而不是只靠配置

- 默认 1.0 不是"偏小"，而是语义上不成立：它让"同时持有连接的会话数"等于"在飞请求数"，而 ctx_pool 下会话在轮次之间也持有连接，一个 Codex 用户的窗口、子智能体、记忆整理、guardian 预热各占一个会话，会话数天然远大于在飞请求数。这是构造问题，不是调优问题。
- 症状对用户不可解释：客户端只看到 `Reconnecting... n/5`，网关日志是 `1013 upstream websocket is busy`。#1769、#3349、#1807 里多位用户遇到后都归为"WS 不稳定"，没有人把它和 `oauth_max_conns_factor` 联系起来；配置项的名字和原注释也看不出它限制的是会话数。可配置只对知道该调什么的人有用，默认值才决定开箱即用的体验。
- 改默认值对已显式配置的部署无影响，没配置的部署直接受益，这正是默认值该起的作用。
- 代价可控：连接只在有会话时被持有，空闲连接另受 `max_idle_per_account`（默认 12）裁剪，`max_conns_per_account`（默认 128）硬上限不变，平时不会多占。

## 为什么是 5.0

- 上限 = ceil(concurrency × factor)。测试环境账号并发 5，此前两天观测到每账号同时存活会话峰值 17–21（单个 key 一次多智能体批次就有 12 个会话，粘性会话把它们落到同一账号）。要盖住 21，系数至少 4.2；取 4 得 20，正好卡在峰值之下；取 5 得 25，留约 20% 余量。
- 对默认并发 3 的账号，5.0 对应上限 15，仍盖得住单个批次的 12。
- 这是经验值，不是最优值：会话数与在飞数的比值由客户端行为决定，不同客户端组合会不同；实验窗口内每账号实际持有峰值只到 10，25 这条线没有被真正压到过；上游是否限制单账号 20 余条 WebSocket 没有数据，只有一个旁证——旧上限下预热路径曾越过上限到 13 条同时持有，上游无异常。所以配置项保留，环境不同可自行调整。

## 数据

测试环境：4 个 OAuth 账号（并发 5）、Codex Desktop 0.153.4 与 CLI 多会话加多智能体批次。2026-09-11 17:07 只把 `oauth_max_conns_factor` 从默认 1.0 改为 5，其他不动，与同机前一段时间对照：

| 指标 | 因子 1.0（09-11 07:19–17:07） | 因子 5（09-11 17:07–09-12 11:11） |
|---|---|---|
| 轮次请求 `ingress_ws_turn_request_sent` | 4542 | 4450 |
| `ingress_ws_upstream_acquire_fail reason=acquire_timeout` | 518（按账号 61 / 204 / 144 / 109） | 0 |
| 客户端收到 `1013 upstream websocket is busy` | 518 | 0 |
| 账号并发槽 `account is busy` | 80 | 1 |
| `reason=dial_fail`（代理侧，已走换号） | 12 | 4 |
| 单个巡检周期内每账号空闲连接峰值 | 5 / 5 / 6 / 5 | 10 / 9 / 7 / 11 |

流量相当，acquire 超时与 1013 busy 从 518 次归零；空闲连接峰值超过原上限 5，没到 `max_idle_per_account` 的 12。

## 测试

- `go test ./internal/config/`、`go test -run 'OpenAIWS.*(Pool|MaxConns|Conns|Prewarm)' ./internal/service/` 通过
- `golangci-lint run ./internal/config/` 0 issues
- 测试机按上述配置运行 18 小时（截至提 PR），无回归

## 关联

- #1769、#3349、#1807：其中 `1013 upstream websocket is busy` / `Reconnecting... n/5` 的容量成因由本 PR 消除；这几个 issue 还混有其他成因（1011 上游中途断开、续接恢复等），不在本 PR 范围
- #4163：引入了会话生命周期持有连接与轮次间空闲超时，是"该上限限制的是会话数"的前提
- #6960、#6965：同一测试环境此前合并的 WS 抢占与读循环修复，本 PR 数据在它们之上采集
- #7049：池满排队的等待者只挂在单条连接上、别处腾出容量不唤醒，已在 #7049 处理（本 PR 处理容量，#7049 优化容量之外的排队等待，无代码依赖）
- 后续另提：拨号阶段超时被归为 acquire 超时而不走换号

