### PR TITLE
fix(timezone): embed IANA timezone data

### DIFF
--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 	"log"
 	"time"
+
+	// Embed the IANA timezone database so standalone binaries can resolve
+	// configured locations on platforms such as Windows without system tzdata.
+	_ "time/tzdata"
 )
 
 var (


### PR DESCRIPTION
## Summary

On some devices, configured IANA time zones could not be recognized because Windows release binaries cannot rely on the host system to provide IANA time zone data. This caused configurations such as `Asia/Shanghai` to fail during startup.

- Embed Go's official `time/tzdata` package so standalone binaries and test environments carry the IANA database.
- Preserve existing time zone configuration semantics.

## Testing

- `CGO_ENABLED=0 go build -trimpath -o NUL ./cmd/server`
- `go test ./internal/pkg/timezone`