### PR TITLE
feat(usage): snapshot API reference costs for Codex

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1658,6 +1658,8 @@ var (
 		{Name: "cache_read_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
 		{Name: "total_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
 		{Name: "actual_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
+		{Name: "api_reference_cost", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
+		{Name: "api_reference_pricing", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "rate_multiplier", Type: field.TypeFloat64, Default: 1, SchemaType: map[string]string{"postgres": "decimal(10,4)"}},
 		{Name: "long_context_billing_applied", Type: field.TypeBool, Default: false},
 		{Name: "account_rate_multiplier", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(10,4)"}},
@@ -1692,31 +1694,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "usage_logs_api_keys_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[43]},
+				Columns:    []*schema.Column{UsageLogsColumns[45]},
 				RefColumns: []*schema.Column{APIKeysColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_accounts_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[44]},
+				Columns:    []*schema.Column{UsageLogsColumns[46]},
 				RefColumns: []*schema.Column{AccountsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_groups_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[45]},
+				Columns:    []*schema.Column{UsageLogsColumns[47]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "usage_logs_users_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[46]},
+				Columns:    []*schema.Column{UsageLogsColumns[48]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_user_subscriptions_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[47]},
+				Columns:    []*schema.Column{UsageLogsColumns[49]},
 				RefColumns: []*schema.Column{UserSubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1725,32 +1727,32 @@ var (
 			{
 				Name:    "usagelog_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[46]},
+				Columns: []*schema.Column{UsageLogsColumns[48]},
 			},
 			{
 				Name:    "usagelog_api_key_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[43]},
+				Columns: []*schema.Column{UsageLogsColumns[45]},
 			},
 			{
 				Name:    "usagelog_account_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[44]},
+				Columns: []*schema.Column{UsageLogsColumns[46]},
 			},
 			{
 				Name:    "usagelog_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[45]},
+				Columns: []*schema.Column{UsageLogsColumns[47]},
 			},
 			{
 				Name:    "usagelog_subscription_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[47]},
+				Columns: []*schema.Column{UsageLogsColumns[49]},
 			},
 			{
 				Name:    "usagelog_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[42]},
+				Columns: []*schema.Column{UsageLogsColumns[44]},
 			},
 			{
 				Name:    "usagelog_model",
@@ -1770,17 +1772,17 @@ var (
 			{
 				Name:    "usagelog_user_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[46], UsageLogsColumns[42]},
+				Columns: []*schema.Column{UsageLogsColumns[48], UsageLogsColumns[44]},
 			},
 			{
 				Name:    "usagelog_api_key_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[43], UsageLogsColumns[42]},
+				Columns: []*schema.Column{UsageLogsColumns[45], UsageLogsColumns[44]},
 			},
 			{
 				Name:    "usagelog_group_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[45], UsageLogsColumns[42]},
+				Columns: []*schema.Column{UsageLogsColumns[47], UsageLogsColumns[44]},
 			},
 		},
 	}

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -44565,6 +44565,9 @@ type UsageLogMutation struct {
 	addtotal_cost                *float64
 	actual_cost                  *float64
 	addactual_cost               *float64
+	api_reference_cost           *float64
+	addapi_reference_cost        *float64
+	api_reference_pricing        *map[string]interface{}
 	rate_multiplier              *float64
 	addrate_multiplier           *float64
 	long_context_billing_applied *bool
@@ -46070,6 +46073,125 @@ func (m *UsageLogMutation) ResetActualCost() {
 	m.addactual_cost = nil
 }
 
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (m *UsageLogMutation) SetAPIReferenceCost(f float64) {
+	m.api_reference_cost = &f
+	m.addapi_reference_cost = nil
+}
+
+// APIReferenceCost returns the value of the "api_reference_cost" field in the mutation.
+func (m *UsageLogMutation) APIReferenceCost() (r float64, exists bool) {
+	v := m.api_reference_cost
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAPIReferenceCost returns the old "api_reference_cost" field's value of the UsageLog entity.
+// If the UsageLog object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageLogMutation) OldAPIReferenceCost(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAPIReferenceCost is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAPIReferenceCost requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAPIReferenceCost: %w", err)
+	}
+	return oldValue.APIReferenceCost, nil
+}
+
+// AddAPIReferenceCost adds f to the "api_reference_cost" field.
+func (m *UsageLogMutation) AddAPIReferenceCost(f float64) {
+	if m.addapi_reference_cost != nil {
+		*m.addapi_reference_cost += f
+	} else {
+		m.addapi_reference_cost = &f
+	}
+}
+
+// AddedAPIReferenceCost returns the value that was added to the "api_reference_cost" field in this mutation.
+func (m *UsageLogMutation) AddedAPIReferenceCost() (r float64, exists bool) {
+	v := m.addapi_reference_cost
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (m *UsageLogMutation) ClearAPIReferenceCost() {
+	m.api_reference_cost = nil
+	m.addapi_reference_cost = nil
+	m.clearedFields[usagelog.FieldAPIReferenceCost] = struct{}{}
+}
+
+// APIReferenceCostCleared returns if the "api_reference_cost" field was cleared in this mutation.
+func (m *UsageLogMutation) APIReferenceCostCleared() bool {
+	_, ok := m.clearedFields[usagelog.FieldAPIReferenceCost]
+	return ok
+}
+
+// ResetAPIReferenceCost resets all changes to the "api_reference_cost" field.
+func (m *UsageLogMutation) ResetAPIReferenceCost() {
+	m.api_reference_cost = nil
+	m.addapi_reference_cost = nil
+	delete(m.clearedFields, usagelog.FieldAPIReferenceCost)
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (m *UsageLogMutation) SetAPIReferencePricing(value map[string]interface{}) {
+	m.api_reference_pricing = &value
+}
+
+// APIReferencePricing returns the value of the "api_reference_pricing" field in the mutation.
+func (m *UsageLogMutation) APIReferencePricing() (r map[string]interface{}, exists bool) {
+	v := m.api_reference_pricing
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAPIReferencePricing returns the old "api_reference_pricing" field's value of the UsageLog entity.
+// If the UsageLog object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageLogMutation) OldAPIReferencePricing(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAPIReferencePricing is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAPIReferencePricing requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAPIReferencePricing: %w", err)
+	}
+	return oldValue.APIReferencePricing, nil
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (m *UsageLogMutation) ClearAPIReferencePricing() {
+	m.api_reference_pricing = nil
+	m.clearedFields[usagelog.FieldAPIReferencePricing] = struct{}{}
+}
+
+// APIReferencePricingCleared returns if the "api_reference_pricing" field was cleared in this mutation.
+func (m *UsageLogMutation) APIReferencePricingCleared() bool {
+	_, ok := m.clearedFields[usagelog.FieldAPIReferencePricing]
+	return ok
+}
+
+// ResetAPIReferencePricing resets all changes to the "api_reference_pricing" field.
+func (m *UsageLogMutation) ResetAPIReferencePricing() {
+	m.api_reference_pricing = nil
+	delete(m.clearedFields, usagelog.FieldAPIReferencePricing)
+}
+
 // SetRateMultiplier sets the "rate_multiplier" field.
 func (m *UsageLogMutation) SetRateMultiplier(f float64) {
 	m.rate_multiplier = &f
@@ -47279,7 +47401,7 @@ func (m *UsageLogMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UsageLogMutation) Fields() []string {
-	fields := make([]string, 0, 47)
+	fields := make([]string, 0, 49)
 	if m.user != nil {
 		fields = append(fields, usagelog.FieldUserID)
 	}
@@ -47360,6 +47482,12 @@ func (m *UsageLogMutation) Fields() []string {
 	}
 	if m.actual_cost != nil {
 		fields = append(fields, usagelog.FieldActualCost)
+	}
+	if m.api_reference_cost != nil {
+		fields = append(fields, usagelog.FieldAPIReferenceCost)
+	}
+	if m.api_reference_pricing != nil {
+		fields = append(fields, usagelog.FieldAPIReferencePricing)
 	}
 	if m.rate_multiplier != nil {
 		fields = append(fields, usagelog.FieldRateMultiplier)
@@ -47483,6 +47611,10 @@ func (m *UsageLogMutation) Field(name string) (ent.Value, bool) {
 		return m.TotalCost()
 	case usagelog.FieldActualCost:
 		return m.ActualCost()
+	case usagelog.FieldAPIReferenceCost:
+		return m.APIReferenceCost()
+	case usagelog.FieldAPIReferencePricing:
+		return m.APIReferencePricing()
 	case usagelog.FieldRateMultiplier:
 		return m.RateMultiplier()
 	case usagelog.FieldLongContextBillingApplied:
@@ -47586,6 +47718,10 @@ func (m *UsageLogMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldTotalCost(ctx)
 	case usagelog.FieldActualCost:
 		return m.OldActualCost(ctx)
+	case usagelog.FieldAPIReferenceCost:
+		return m.OldAPIReferenceCost(ctx)
+	case usagelog.FieldAPIReferencePricing:
+		return m.OldAPIReferencePricing(ctx)
 	case usagelog.FieldRateMultiplier:
 		return m.OldRateMultiplier(ctx)
 	case usagelog.FieldLongContextBillingApplied:
@@ -47824,6 +47960,20 @@ func (m *UsageLogMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetActualCost(v)
 		return nil
+	case usagelog.FieldAPIReferenceCost:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAPIReferenceCost(v)
+		return nil
+	case usagelog.FieldAPIReferencePricing:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAPIReferencePricing(v)
+		return nil
 	case usagelog.FieldRateMultiplier:
 		v, ok := value.(float64)
 		if !ok {
@@ -48011,6 +48161,9 @@ func (m *UsageLogMutation) AddedFields() []string {
 	if m.addactual_cost != nil {
 		fields = append(fields, usagelog.FieldActualCost)
 	}
+	if m.addapi_reference_cost != nil {
+		fields = append(fields, usagelog.FieldAPIReferenceCost)
+	}
 	if m.addrate_multiplier != nil {
 		fields = append(fields, usagelog.FieldRateMultiplier)
 	}
@@ -48069,6 +48222,8 @@ func (m *UsageLogMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedTotalCost()
 	case usagelog.FieldActualCost:
 		return m.AddedActualCost()
+	case usagelog.FieldAPIReferenceCost:
+		return m.AddedAPIReferenceCost()
 	case usagelog.FieldRateMultiplier:
 		return m.AddedRateMultiplier()
 	case usagelog.FieldAccountRateMultiplier:
@@ -48185,6 +48340,13 @@ func (m *UsageLogMutation) AddField(name string, value ent.Value) error {
 		}
 		m.AddActualCost(v)
 		return nil
+	case usagelog.FieldAPIReferenceCost:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddAPIReferenceCost(v)
+		return nil
 	case usagelog.FieldRateMultiplier:
 		v, ok := value.(float64)
 		if !ok {
@@ -48279,6 +48441,12 @@ func (m *UsageLogMutation) ClearedFields() []string {
 	if m.FieldCleared(usagelog.FieldSubscriptionID) {
 		fields = append(fields, usagelog.FieldSubscriptionID)
 	}
+	if m.FieldCleared(usagelog.FieldAPIReferenceCost) {
+		fields = append(fields, usagelog.FieldAPIReferenceCost)
+	}
+	if m.FieldCleared(usagelog.FieldAPIReferencePricing) {
+		fields = append(fields, usagelog.FieldAPIReferencePricing)
+	}
 	if m.FieldCleared(usagelog.FieldAccountRateMultiplier) {
 		fields = append(fields, usagelog.FieldAccountRateMultiplier)
 	}
@@ -48358,6 +48526,12 @@ func (m *UsageLogMutation) ClearField(name string) error {
 		return nil
 	case usagelog.FieldSubscriptionID:
 		m.ClearSubscriptionID()
+		return nil
+	case usagelog.FieldAPIReferenceCost:
+		m.ClearAPIReferenceCost()
+		return nil
+	case usagelog.FieldAPIReferencePricing:
+		m.ClearAPIReferencePricing()
 		return nil
 	case usagelog.FieldAccountRateMultiplier:
 		m.ClearAccountRateMultiplier()
@@ -48483,6 +48657,12 @@ func (m *UsageLogMutation) ResetField(name string) error {
 		return nil
 	case usagelog.FieldActualCost:
 		m.ResetActualCost()
+		return nil
+	case usagelog.FieldAPIReferenceCost:
+		m.ResetAPIReferenceCost()
+		return nil
+	case usagelog.FieldAPIReferencePricing:
+		m.ResetAPIReferencePricing()
 		return nil
 	case usagelog.FieldRateMultiplier:
 		m.ResetRateMultiplier()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -2077,63 +2077,63 @@ func init() {
 	// usagelog.DefaultActualCost holds the default value on creation for the actual_cost field.
 	usagelog.DefaultActualCost = usagelogDescActualCost.Default.(float64)
 	// usagelogDescRateMultiplier is the schema descriptor for rate_multiplier field.
-	usagelogDescRateMultiplier := usagelogFields[27].Descriptor()
+	usagelogDescRateMultiplier := usagelogFields[29].Descriptor()
 	// usagelog.DefaultRateMultiplier holds the default value on creation for the rate_multiplier field.
 	usagelog.DefaultRateMultiplier = usagelogDescRateMultiplier.Default.(float64)
 	// usagelogDescLongContextBillingApplied is the schema descriptor for long_context_billing_applied field.
-	usagelogDescLongContextBillingApplied := usagelogFields[28].Descriptor()
+	usagelogDescLongContextBillingApplied := usagelogFields[30].Descriptor()
 	// usagelog.DefaultLongContextBillingApplied holds the default value on creation for the long_context_billing_applied field.
 	usagelog.DefaultLongContextBillingApplied = usagelogDescLongContextBillingApplied.Default.(bool)
 	// usagelogDescBillingType is the schema descriptor for billing_type field.
-	usagelogDescBillingType := usagelogFields[30].Descriptor()
+	usagelogDescBillingType := usagelogFields[32].Descriptor()
 	// usagelog.DefaultBillingType holds the default value on creation for the billing_type field.
 	usagelog.DefaultBillingType = usagelogDescBillingType.Default.(int8)
 	// usagelogDescStream is the schema descriptor for stream field.
-	usagelogDescStream := usagelogFields[31].Descriptor()
+	usagelogDescStream := usagelogFields[33].Descriptor()
 	// usagelog.DefaultStream holds the default value on creation for the stream field.
 	usagelog.DefaultStream = usagelogDescStream.Default.(bool)
 	// usagelogDescUserAgent is the schema descriptor for user_agent field.
-	usagelogDescUserAgent := usagelogFields[34].Descriptor()
+	usagelogDescUserAgent := usagelogFields[36].Descriptor()
 	// usagelog.UserAgentValidator is a validator for the "user_agent" field. It is called by the builders before save.
 	usagelog.UserAgentValidator = usagelogDescUserAgent.Validators[0].(func(string) error)
 	// usagelogDescIPAddress is the schema descriptor for ip_address field.
-	usagelogDescIPAddress := usagelogFields[35].Descriptor()
+	usagelogDescIPAddress := usagelogFields[37].Descriptor()
 	// usagelog.IPAddressValidator is a validator for the "ip_address" field. It is called by the builders before save.
 	usagelog.IPAddressValidator = usagelogDescIPAddress.Validators[0].(func(string) error)
 	// usagelogDescImageCount is the schema descriptor for image_count field.
-	usagelogDescImageCount := usagelogFields[36].Descriptor()
+	usagelogDescImageCount := usagelogFields[38].Descriptor()
 	// usagelog.DefaultImageCount holds the default value on creation for the image_count field.
 	usagelog.DefaultImageCount = usagelogDescImageCount.Default.(int)
 	// usagelogDescImageSize is the schema descriptor for image_size field.
-	usagelogDescImageSize := usagelogFields[37].Descriptor()
+	usagelogDescImageSize := usagelogFields[39].Descriptor()
 	// usagelog.ImageSizeValidator is a validator for the "image_size" field. It is called by the builders before save.
 	usagelog.ImageSizeValidator = usagelogDescImageSize.Validators[0].(func(string) error)
 	// usagelogDescImageInputSize is the schema descriptor for image_input_size field.
-	usagelogDescImageInputSize := usagelogFields[38].Descriptor()
+	usagelogDescImageInputSize := usagelogFields[40].Descriptor()
 	// usagelog.ImageInputSizeValidator is a validator for the "image_input_size" field. It is called by the builders before save.
 	usagelog.ImageInputSizeValidator = usagelogDescImageInputSize.Validators[0].(func(string) error)
 	// usagelogDescImageOutputSize is the schema descriptor for image_output_size field.
-	usagelogDescImageOutputSize := usagelogFields[39].Descriptor()
+	usagelogDescImageOutputSize := usagelogFields[41].Descriptor()
 	// usagelog.ImageOutputSizeValidator is a validator for the "image_output_size" field. It is called by the builders before save.
 	usagelog.ImageOutputSizeValidator = usagelogDescImageOutputSize.Validators[0].(func(string) error)
 	// usagelogDescImageSizeSource is the schema descriptor for image_size_source field.
-	usagelogDescImageSizeSource := usagelogFields[40].Descriptor()
+	usagelogDescImageSizeSource := usagelogFields[42].Descriptor()
 	// usagelog.ImageSizeSourceValidator is a validator for the "image_size_source" field. It is called by the builders before save.
 	usagelog.ImageSizeSourceValidator = usagelogDescImageSizeSource.Validators[0].(func(string) error)
 	// usagelogDescVideoCount is the schema descriptor for video_count field.
-	usagelogDescVideoCount := usagelogFields[42].Descriptor()
+	usagelogDescVideoCount := usagelogFields[44].Descriptor()
 	// usagelog.DefaultVideoCount holds the default value on creation for the video_count field.
 	usagelog.DefaultVideoCount = usagelogDescVideoCount.Default.(int)
 	// usagelogDescVideoResolution is the schema descriptor for video_resolution field.
-	usagelogDescVideoResolution := usagelogFields[43].Descriptor()
+	usagelogDescVideoResolution := usagelogFields[45].Descriptor()
 	// usagelog.VideoResolutionValidator is a validator for the "video_resolution" field. It is called by the builders before save.
 	usagelog.VideoResolutionValidator = usagelogDescVideoResolution.Validators[0].(func(string) error)
 	// usagelogDescCacheTTLOverridden is the schema descriptor for cache_ttl_overridden field.
-	usagelogDescCacheTTLOverridden := usagelogFields[45].Descriptor()
+	usagelogDescCacheTTLOverridden := usagelogFields[47].Descriptor()
 	// usagelog.DefaultCacheTTLOverridden holds the default value on creation for the cache_ttl_overridden field.
 	usagelog.DefaultCacheTTLOverridden = usagelogDescCacheTTLOverridden.Default.(bool)
 	// usagelogDescCreatedAt is the schema descriptor for created_at field.
-	usagelogDescCreatedAt := usagelogFields[46].Descriptor()
+	usagelogDescCreatedAt := usagelogFields[48].Descriptor()
 	// usagelog.DefaultCreatedAt holds the default value on creation for the created_at field.
 	usagelog.DefaultCreatedAt = usagelogDescCreatedAt.Default.(func() time.Time)
 	userMixin := schema.User{}.Mixin()

--- a/backend/ent/schema/usage_log.go
+++ b/backend/ent/schema/usage_log.go
@@ -108,6 +108,13 @@ func (UsageLog) Fields() []ent.Field {
 		field.Float("actual_cost").
 			Default(0).
 			SchemaType(map[string]string{dialect.Postgres: "decimal(20,10)"}),
+		// No default/backfill: historical or unpriced requests are unknown.
+		field.Float("api_reference_cost").
+			Optional().Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "decimal(20,10)"}),
+		field.JSON("api_reference_pricing", map[string]any{}).
+			Optional().
+			SchemaType(map[string]string{dialect.Postgres: "jsonb"}),
 		field.Float("rate_multiplier").
 			Default(1).
 			SchemaType(map[string]string{dialect.Postgres: "decimal(10,4)"}),

--- a/backend/ent/usagelog.go
+++ b/backend/ent/usagelog.go
@@ -77,6 +77,10 @@ type UsageLog struct {
 	TotalCost float64 `json:"total_cost,omitempty"`
 	// ActualCost holds the value of the "actual_cost" field.
 	ActualCost float64 `json:"actual_cost,omitempty"`
+	// APIReferenceCost holds the value of the "api_reference_cost" field.
+	APIReferenceCost *float64 `json:"api_reference_cost,omitempty"`
+	// APIReferencePricing holds the value of the "api_reference_pricing" field.
+	APIReferencePricing map[string]interface{} `json:"api_reference_pricing,omitempty"`
 	// RateMultiplier holds the value of the "rate_multiplier" field.
 	RateMultiplier float64 `json:"rate_multiplier,omitempty"`
 	// Whether long-context pricing changed token prices for this request
@@ -200,11 +204,11 @@ func (*UsageLog) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case usagelog.FieldImageSizeBreakdown:
+		case usagelog.FieldAPIReferencePricing, usagelog.FieldImageSizeBreakdown:
 			values[i] = new([]byte)
 		case usagelog.FieldUpstreamModelMismatch, usagelog.FieldLongContextBillingApplied, usagelog.FieldStream, usagelog.FieldCacheTTLOverridden:
 			values[i] = new(sql.NullBool)
-		case usagelog.FieldInputCost, usagelog.FieldOutputCost, usagelog.FieldCacheCreationCost, usagelog.FieldCacheReadCost, usagelog.FieldTotalCost, usagelog.FieldActualCost, usagelog.FieldRateMultiplier, usagelog.FieldAccountRateMultiplier:
+		case usagelog.FieldInputCost, usagelog.FieldOutputCost, usagelog.FieldCacheCreationCost, usagelog.FieldCacheReadCost, usagelog.FieldTotalCost, usagelog.FieldActualCost, usagelog.FieldAPIReferenceCost, usagelog.FieldRateMultiplier, usagelog.FieldAccountRateMultiplier:
 			values[i] = new(sql.NullFloat64)
 		case usagelog.FieldID, usagelog.FieldUserID, usagelog.FieldAPIKeyID, usagelog.FieldAccountID, usagelog.FieldChannelID, usagelog.FieldGroupID, usagelog.FieldSubscriptionID, usagelog.FieldInputTokens, usagelog.FieldOutputTokens, usagelog.FieldCacheCreationTokens, usagelog.FieldCacheReadTokens, usagelog.FieldCacheCreation5mTokens, usagelog.FieldCacheCreation1hTokens, usagelog.FieldBillingType, usagelog.FieldDurationMs, usagelog.FieldFirstTokenMs, usagelog.FieldImageCount, usagelog.FieldVideoCount, usagelog.FieldVideoDurationSeconds:
 			values[i] = new(sql.NullInt64)
@@ -404,6 +408,21 @@ func (_m *UsageLog) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field actual_cost", values[i])
 			} else if value.Valid {
 				_m.ActualCost = value.Float64
+			}
+		case usagelog.FieldAPIReferenceCost:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field api_reference_cost", values[i])
+			} else if value.Valid {
+				_m.APIReferenceCost = new(float64)
+				*_m.APIReferenceCost = value.Float64
+			}
+		case usagelog.FieldAPIReferencePricing:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field api_reference_pricing", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.APIReferencePricing); err != nil {
+					return fmt.Errorf("unmarshal field api_reference_pricing: %w", err)
+				}
 			}
 		case usagelog.FieldRateMultiplier:
 			if value, ok := values[i].(*sql.NullFloat64); !ok {
@@ -699,6 +718,14 @@ func (_m *UsageLog) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("actual_cost=")
 	builder.WriteString(fmt.Sprintf("%v", _m.ActualCost))
+	builder.WriteString(", ")
+	if v := _m.APIReferenceCost; v != nil {
+		builder.WriteString("api_reference_cost=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	builder.WriteString("api_reference_pricing=")
+	builder.WriteString(fmt.Sprintf("%v", _m.APIReferencePricing))
 	builder.WriteString(", ")
 	builder.WriteString("rate_multiplier=")
 	builder.WriteString(fmt.Sprintf("%v", _m.RateMultiplier))

--- a/backend/ent/usagelog/usagelog.go
+++ b/backend/ent/usagelog/usagelog.go
@@ -68,6 +68,10 @@ const (
 	FieldTotalCost = "total_cost"
 	// FieldActualCost holds the string denoting the actual_cost field in the database.
 	FieldActualCost = "actual_cost"
+	// FieldAPIReferenceCost holds the string denoting the api_reference_cost field in the database.
+	FieldAPIReferenceCost = "api_reference_cost"
+	// FieldAPIReferencePricing holds the string denoting the api_reference_pricing field in the database.
+	FieldAPIReferencePricing = "api_reference_pricing"
 	// FieldRateMultiplier holds the string denoting the rate_multiplier field in the database.
 	FieldRateMultiplier = "rate_multiplier"
 	// FieldLongContextBillingApplied holds the string denoting the long_context_billing_applied field in the database.
@@ -187,6 +191,8 @@ var Columns = []string{
 	FieldCacheReadCost,
 	FieldTotalCost,
 	FieldActualCost,
+	FieldAPIReferenceCost,
+	FieldAPIReferencePricing,
 	FieldRateMultiplier,
 	FieldLongContextBillingApplied,
 	FieldAccountRateMultiplier,
@@ -433,6 +439,11 @@ func ByTotalCost(opts ...sql.OrderTermOption) OrderOption {
 // ByActualCost orders the results by the actual_cost field.
 func ByActualCost(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActualCost, opts...).ToFunc()
+}
+
+// ByAPIReferenceCost orders the results by the api_reference_cost field.
+func ByAPIReferenceCost(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAPIReferenceCost, opts...).ToFunc()
 }
 
 // ByRateMultiplier orders the results by the rate_multiplier field.

--- a/backend/ent/usagelog/where.go
+++ b/backend/ent/usagelog/where.go
@@ -190,6 +190,11 @@ func ActualCost(v float64) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldActualCost, v))
 }
 
+// APIReferenceCost applies equality check predicate on the "api_reference_cost" field. It's identical to APIReferenceCostEQ.
+func APIReferenceCost(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldAPIReferenceCost, v))
+}
+
 // RateMultiplier applies equality check predicate on the "rate_multiplier" field. It's identical to RateMultiplierEQ.
 func RateMultiplier(v float64) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldRateMultiplier, v))
@@ -1533,6 +1538,66 @@ func ActualCostLT(v float64) predicate.UsageLog {
 // ActualCostLTE applies the LTE predicate on the "actual_cost" field.
 func ActualCostLTE(v float64) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldLTE(FieldActualCost, v))
+}
+
+// APIReferenceCostEQ applies the EQ predicate on the "api_reference_cost" field.
+func APIReferenceCostEQ(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostNEQ applies the NEQ predicate on the "api_reference_cost" field.
+func APIReferenceCostNEQ(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNEQ(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostIn applies the In predicate on the "api_reference_cost" field.
+func APIReferenceCostIn(vs ...float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIn(FieldAPIReferenceCost, vs...))
+}
+
+// APIReferenceCostNotIn applies the NotIn predicate on the "api_reference_cost" field.
+func APIReferenceCostNotIn(vs ...float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotIn(FieldAPIReferenceCost, vs...))
+}
+
+// APIReferenceCostGT applies the GT predicate on the "api_reference_cost" field.
+func APIReferenceCostGT(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGT(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostGTE applies the GTE predicate on the "api_reference_cost" field.
+func APIReferenceCostGTE(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGTE(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostLT applies the LT predicate on the "api_reference_cost" field.
+func APIReferenceCostLT(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLT(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostLTE applies the LTE predicate on the "api_reference_cost" field.
+func APIReferenceCostLTE(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLTE(FieldAPIReferenceCost, v))
+}
+
+// APIReferenceCostIsNil applies the IsNil predicate on the "api_reference_cost" field.
+func APIReferenceCostIsNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIsNull(FieldAPIReferenceCost))
+}
+
+// APIReferenceCostNotNil applies the NotNil predicate on the "api_reference_cost" field.
+func APIReferenceCostNotNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotNull(FieldAPIReferenceCost))
+}
+
+// APIReferencePricingIsNil applies the IsNil predicate on the "api_reference_pricing" field.
+func APIReferencePricingIsNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIsNull(FieldAPIReferencePricing))
+}
+
+// APIReferencePricingNotNil applies the NotNil predicate on the "api_reference_pricing" field.
+func APIReferencePricingNotNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotNull(FieldAPIReferencePricing))
 }
 
 // RateMultiplierEQ applies the EQ predicate on the "rate_multiplier" field.

--- a/backend/ent/usagelog_create.go
+++ b/backend/ent/usagelog_create.go
@@ -365,6 +365,26 @@ func (_c *UsageLogCreate) SetNillableActualCost(v *float64) *UsageLogCreate {
 	return _c
 }
 
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (_c *UsageLogCreate) SetAPIReferenceCost(v float64) *UsageLogCreate {
+	_c.mutation.SetAPIReferenceCost(v)
+	return _c
+}
+
+// SetNillableAPIReferenceCost sets the "api_reference_cost" field if the given value is not nil.
+func (_c *UsageLogCreate) SetNillableAPIReferenceCost(v *float64) *UsageLogCreate {
+	if v != nil {
+		_c.SetAPIReferenceCost(*v)
+	}
+	return _c
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (_c *UsageLogCreate) SetAPIReferencePricing(v map[string]interface{}) *UsageLogCreate {
+	_c.mutation.SetAPIReferencePricing(v)
+	return _c
+}
+
 // SetRateMultiplier sets the "rate_multiplier" field.
 func (_c *UsageLogCreate) SetRateMultiplier(v float64) *UsageLogCreate {
 	_c.mutation.SetRateMultiplier(v)
@@ -1055,6 +1075,14 @@ func (_c *UsageLogCreate) createSpec() (*UsageLog, *sqlgraph.CreateSpec) {
 		_spec.SetField(usagelog.FieldActualCost, field.TypeFloat64, value)
 		_node.ActualCost = value
 	}
+	if value, ok := _c.mutation.APIReferenceCost(); ok {
+		_spec.SetField(usagelog.FieldAPIReferenceCost, field.TypeFloat64, value)
+		_node.APIReferenceCost = &value
+	}
+	if value, ok := _c.mutation.APIReferencePricing(); ok {
+		_spec.SetField(usagelog.FieldAPIReferencePricing, field.TypeJSON, value)
+		_node.APIReferencePricing = value
+	}
 	if value, ok := _c.mutation.RateMultiplier(); ok {
 		_spec.SetField(usagelog.FieldRateMultiplier, field.TypeFloat64, value)
 		_node.RateMultiplier = value
@@ -1731,6 +1759,48 @@ func (u *UsageLogUpsert) UpdateActualCost() *UsageLogUpsert {
 // AddActualCost adds v to the "actual_cost" field.
 func (u *UsageLogUpsert) AddActualCost(v float64) *UsageLogUpsert {
 	u.Add(usagelog.FieldActualCost, v)
+	return u
+}
+
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (u *UsageLogUpsert) SetAPIReferenceCost(v float64) *UsageLogUpsert {
+	u.Set(usagelog.FieldAPIReferenceCost, v)
+	return u
+}
+
+// UpdateAPIReferenceCost sets the "api_reference_cost" field to the value that was provided on create.
+func (u *UsageLogUpsert) UpdateAPIReferenceCost() *UsageLogUpsert {
+	u.SetExcluded(usagelog.FieldAPIReferenceCost)
+	return u
+}
+
+// AddAPIReferenceCost adds v to the "api_reference_cost" field.
+func (u *UsageLogUpsert) AddAPIReferenceCost(v float64) *UsageLogUpsert {
+	u.Add(usagelog.FieldAPIReferenceCost, v)
+	return u
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (u *UsageLogUpsert) ClearAPIReferenceCost() *UsageLogUpsert {
+	u.SetNull(usagelog.FieldAPIReferenceCost)
+	return u
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (u *UsageLogUpsert) SetAPIReferencePricing(v map[string]interface{}) *UsageLogUpsert {
+	u.Set(usagelog.FieldAPIReferencePricing, v)
+	return u
+}
+
+// UpdateAPIReferencePricing sets the "api_reference_pricing" field to the value that was provided on create.
+func (u *UsageLogUpsert) UpdateAPIReferencePricing() *UsageLogUpsert {
+	u.SetExcluded(usagelog.FieldAPIReferencePricing)
+	return u
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (u *UsageLogUpsert) ClearAPIReferencePricing() *UsageLogUpsert {
+	u.SetNull(usagelog.FieldAPIReferencePricing)
 	return u
 }
 
@@ -2663,6 +2733,55 @@ func (u *UsageLogUpsertOne) AddActualCost(v float64) *UsageLogUpsertOne {
 func (u *UsageLogUpsertOne) UpdateActualCost() *UsageLogUpsertOne {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.UpdateActualCost()
+	})
+}
+
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (u *UsageLogUpsertOne) SetAPIReferenceCost(v float64) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetAPIReferenceCost(v)
+	})
+}
+
+// AddAPIReferenceCost adds v to the "api_reference_cost" field.
+func (u *UsageLogUpsertOne) AddAPIReferenceCost(v float64) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddAPIReferenceCost(v)
+	})
+}
+
+// UpdateAPIReferenceCost sets the "api_reference_cost" field to the value that was provided on create.
+func (u *UsageLogUpsertOne) UpdateAPIReferenceCost() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateAPIReferenceCost()
+	})
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (u *UsageLogUpsertOne) ClearAPIReferenceCost() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearAPIReferenceCost()
+	})
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (u *UsageLogUpsertOne) SetAPIReferencePricing(v map[string]interface{}) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetAPIReferencePricing(v)
+	})
+}
+
+// UpdateAPIReferencePricing sets the "api_reference_pricing" field to the value that was provided on create.
+func (u *UsageLogUpsertOne) UpdateAPIReferencePricing() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateAPIReferencePricing()
+	})
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (u *UsageLogUpsertOne) ClearAPIReferencePricing() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearAPIReferencePricing()
 	})
 }
 
@@ -3819,6 +3938,55 @@ func (u *UsageLogUpsertBulk) AddActualCost(v float64) *UsageLogUpsertBulk {
 func (u *UsageLogUpsertBulk) UpdateActualCost() *UsageLogUpsertBulk {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.UpdateActualCost()
+	})
+}
+
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (u *UsageLogUpsertBulk) SetAPIReferenceCost(v float64) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetAPIReferenceCost(v)
+	})
+}
+
+// AddAPIReferenceCost adds v to the "api_reference_cost" field.
+func (u *UsageLogUpsertBulk) AddAPIReferenceCost(v float64) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddAPIReferenceCost(v)
+	})
+}
+
+// UpdateAPIReferenceCost sets the "api_reference_cost" field to the value that was provided on create.
+func (u *UsageLogUpsertBulk) UpdateAPIReferenceCost() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateAPIReferenceCost()
+	})
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (u *UsageLogUpsertBulk) ClearAPIReferenceCost() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearAPIReferenceCost()
+	})
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (u *UsageLogUpsertBulk) SetAPIReferencePricing(v map[string]interface{}) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetAPIReferencePricing(v)
+	})
+}
+
+// UpdateAPIReferencePricing sets the "api_reference_pricing" field to the value that was provided on create.
+func (u *UsageLogUpsertBulk) UpdateAPIReferencePricing() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateAPIReferencePricing()
+	})
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (u *UsageLogUpsertBulk) ClearAPIReferencePricing() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearAPIReferencePricing()
 	})
 }
 

--- a/backend/ent/usagelog_update.go
+++ b/backend/ent/usagelog_update.go
@@ -561,6 +561,45 @@ func (_u *UsageLogUpdate) AddActualCost(v float64) *UsageLogUpdate {
 	return _u
 }
 
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (_u *UsageLogUpdate) SetAPIReferenceCost(v float64) *UsageLogUpdate {
+	_u.mutation.ResetAPIReferenceCost()
+	_u.mutation.SetAPIReferenceCost(v)
+	return _u
+}
+
+// SetNillableAPIReferenceCost sets the "api_reference_cost" field if the given value is not nil.
+func (_u *UsageLogUpdate) SetNillableAPIReferenceCost(v *float64) *UsageLogUpdate {
+	if v != nil {
+		_u.SetAPIReferenceCost(*v)
+	}
+	return _u
+}
+
+// AddAPIReferenceCost adds value to the "api_reference_cost" field.
+func (_u *UsageLogUpdate) AddAPIReferenceCost(v float64) *UsageLogUpdate {
+	_u.mutation.AddAPIReferenceCost(v)
+	return _u
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (_u *UsageLogUpdate) ClearAPIReferenceCost() *UsageLogUpdate {
+	_u.mutation.ClearAPIReferenceCost()
+	return _u
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (_u *UsageLogUpdate) SetAPIReferencePricing(v map[string]interface{}) *UsageLogUpdate {
+	_u.mutation.SetAPIReferencePricing(v)
+	return _u
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (_u *UsageLogUpdate) ClearAPIReferencePricing() *UsageLogUpdate {
+	_u.mutation.ClearAPIReferencePricing()
+	return _u
+}
+
 // SetRateMultiplier sets the "rate_multiplier" field.
 func (_u *UsageLogUpdate) SetRateMultiplier(v float64) *UsageLogUpdate {
 	_u.mutation.ResetRateMultiplier()
@@ -1263,6 +1302,21 @@ func (_u *UsageLogUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedActualCost(); ok {
 		_spec.AddField(usagelog.FieldActualCost, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.APIReferenceCost(); ok {
+		_spec.SetField(usagelog.FieldAPIReferenceCost, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedAPIReferenceCost(); ok {
+		_spec.AddField(usagelog.FieldAPIReferenceCost, field.TypeFloat64, value)
+	}
+	if _u.mutation.APIReferenceCostCleared() {
+		_spec.ClearField(usagelog.FieldAPIReferenceCost, field.TypeFloat64)
+	}
+	if value, ok := _u.mutation.APIReferencePricing(); ok {
+		_spec.SetField(usagelog.FieldAPIReferencePricing, field.TypeJSON, value)
+	}
+	if _u.mutation.APIReferencePricingCleared() {
+		_spec.ClearField(usagelog.FieldAPIReferencePricing, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.RateMultiplier(); ok {
 		_spec.SetField(usagelog.FieldRateMultiplier, field.TypeFloat64, value)
@@ -2075,6 +2129,45 @@ func (_u *UsageLogUpdateOne) AddActualCost(v float64) *UsageLogUpdateOne {
 	return _u
 }
 
+// SetAPIReferenceCost sets the "api_reference_cost" field.
+func (_u *UsageLogUpdateOne) SetAPIReferenceCost(v float64) *UsageLogUpdateOne {
+	_u.mutation.ResetAPIReferenceCost()
+	_u.mutation.SetAPIReferenceCost(v)
+	return _u
+}
+
+// SetNillableAPIReferenceCost sets the "api_reference_cost" field if the given value is not nil.
+func (_u *UsageLogUpdateOne) SetNillableAPIReferenceCost(v *float64) *UsageLogUpdateOne {
+	if v != nil {
+		_u.SetAPIReferenceCost(*v)
+	}
+	return _u
+}
+
+// AddAPIReferenceCost adds value to the "api_reference_cost" field.
+func (_u *UsageLogUpdateOne) AddAPIReferenceCost(v float64) *UsageLogUpdateOne {
+	_u.mutation.AddAPIReferenceCost(v)
+	return _u
+}
+
+// ClearAPIReferenceCost clears the value of the "api_reference_cost" field.
+func (_u *UsageLogUpdateOne) ClearAPIReferenceCost() *UsageLogUpdateOne {
+	_u.mutation.ClearAPIReferenceCost()
+	return _u
+}
+
+// SetAPIReferencePricing sets the "api_reference_pricing" field.
+func (_u *UsageLogUpdateOne) SetAPIReferencePricing(v map[string]interface{}) *UsageLogUpdateOne {
+	_u.mutation.SetAPIReferencePricing(v)
+	return _u
+}
+
+// ClearAPIReferencePricing clears the value of the "api_reference_pricing" field.
+func (_u *UsageLogUpdateOne) ClearAPIReferencePricing() *UsageLogUpdateOne {
+	_u.mutation.ClearAPIReferencePricing()
+	return _u
+}
+
 // SetRateMultiplier sets the "rate_multiplier" field.
 func (_u *UsageLogUpdateOne) SetRateMultiplier(v float64) *UsageLogUpdateOne {
 	_u.mutation.ResetRateMultiplier()
@@ -2807,6 +2900,21 @@ func (_u *UsageLogUpdateOne) sqlSave(ctx context.Context) (_node *UsageLog, err 
 	}
 	if value, ok := _u.mutation.AddedActualCost(); ok {
 		_spec.AddField(usagelog.FieldActualCost, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.APIReferenceCost(); ok {
+		_spec.SetField(usagelog.FieldAPIReferenceCost, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedAPIReferenceCost(); ok {
+		_spec.AddField(usagelog.FieldAPIReferenceCost, field.TypeFloat64, value)
+	}
+	if _u.mutation.APIReferenceCostCleared() {
+		_spec.ClearField(usagelog.FieldAPIReferenceCost, field.TypeFloat64)
+	}
+	if value, ok := _u.mutation.APIReferencePricing(); ok {
+		_spec.SetField(usagelog.FieldAPIReferencePricing, field.TypeJSON, value)
+	}
+	if _u.mutation.APIReferencePricingCleared() {
+		_spec.ClearField(usagelog.FieldAPIReferencePricing, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.RateMultiplier(); ok {
 		_spec.SetField(usagelog.FieldRateMultiplier, field.TypeFloat64, value)

--- a/backend/internal/repository/usage_log_api_reference_cost_integration_test.go
+++ b/backend/internal/repository/usage_log_api_reference_cost_integration_test.go
@@ -14,8 +14,11 @@ import (
 
 func TestUsageLogAPIReferenceCostPersistence(t *testing.T) {
 	ctx := context.Background()
-	client := testEntClient(t)
-	repo := newUsageLogRepositoryWithSQL(client, integrationDB)
+	// Dashboard integration tests aggregate across the shared database. Keep
+	// these request fixtures inside a transaction that the harness rolls back.
+	tx := testEntTx(t)
+	client := tx.Client()
+	repo := newUsageLogRepositoryWithSQL(client, tx)
 	user := mustCreateUser(t, client, &service.User{Email: "reference-" + uuid.NewString() + "@example.com"})
 	key := mustCreateApiKey(t, client, &service.APIKey{UserID: user.ID, Key: "sk-reference-" + uuid.NewString(), Name: "reference"})
 	account := mustCreateAccount(t, client, &service.Account{Name: "reference-" + uuid.NewString()})

--- a/backend/internal/repository/usage_log_api_reference_cost_integration_test.go
+++ b/backend/internal/repository/usage_log_api_reference_cost_integration_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageLogAPIReferenceCostPersistence(t *testing.T) {
+	ctx := context.Background()
+	client := testEntClient(t)
+	repo := newUsageLogRepositoryWithSQL(client, integrationDB)
+	user := mustCreateUser(t, client, &service.User{Email: "reference-" + uuid.NewString() + "@example.com"})
+	key := mustCreateApiKey(t, client, &service.APIKey{UserID: user.ID, Key: "sk-reference-" + uuid.NewString(), Name: "reference"})
+	account := mustCreateAccount(t, client, &service.Account{Name: "reference-" + uuid.NewString()})
+	at := time.Now().UTC().Truncate(time.Second)
+	amount := 1.2345678901
+	log := &service.UsageLog{
+		UserID: user.ID, APIKeyID: key.ID, AccountID: account.ID, RequestID: uuid.NewString(), Model: "gpt-5.6-terra", CreatedAt: at,
+		APIReferenceCost: &amount, APIReferencePricing: &service.APIReferencePricingSnapshot{SchemaVersion: 1, Model: "gpt-5.6-terra", Source: "model_catalog", PricingAt: at},
+	}
+	inserted, err := repo.Create(ctx, log)
+	require.NoError(t, err)
+	require.True(t, inserted)
+	got, err := repo.GetByID(ctx, log.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.APIReferenceCost)
+	require.InDelta(t, amount, *got.APIReferenceCost, 1e-10)
+	require.Equal(t, log.APIReferencePricing, got.APIReferencePricing)
+
+	// Duplicate delivery cannot replace the original immutable price snapshot.
+	changed := 100.0
+	log.APIReferenceCost = &changed
+	log.APIReferencePricing.Source = "changed"
+	inserted, err = repo.Create(ctx, log)
+	require.NoError(t, err)
+	require.False(t, inserted)
+	got, err = repo.GetByID(ctx, log.ID)
+	require.NoError(t, err)
+	require.InDelta(t, amount, *got.APIReferenceCost, 1e-10)
+	require.Equal(t, "model_catalog", got.APIReferencePricing.Source)
+
+	log.RequestID = uuid.NewString()
+	log.APIReferenceCost, log.APIReferencePricing = nil, nil
+	_, err = repo.Create(ctx, log)
+	require.NoError(t, err)
+	got, err = repo.GetByID(ctx, log.ID)
+	require.NoError(t, err)
+	require.Nil(t, got.APIReferenceCost)
+	require.Nil(t, got.APIReferencePricing)
+}

--- a/backend/internal/repository/usage_log_api_reference_cost_test.go
+++ b/backend/internal/repository/usage_log_api_reference_cost_test.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"context"
+	"database/sql/driver"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageLogAPIReferenceCostRoundTrip(t *testing.T) {
+	for _, hasReference := range []bool{false, true} {
+		t.Run(map[bool]string{false: "historical NULL", true: "known zero with pricing evidence"}[hasReference], func(t *testing.T) {
+			db, mock := newSQLMock(t)
+			repo := &usageLogRepository{sql: db}
+			at := time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC)
+			log := &service.UsageLog{UserID: 1, APIKeyID: 2, AccountID: 3, RequestID: "reference-round-trip", Model: "gpt-5.6-terra", CreatedAt: at}
+			if hasReference {
+				zero := 0.0
+				log.APIReferenceCost = &zero
+				log.APIReferencePricing = &service.APIReferencePricingSnapshot{SchemaVersion: 1, Model: log.Model, Source: "model_catalog", PricingAt: at}
+			}
+			prepared := prepareUsageLogInsert(log)
+			require.Len(t, prepared.args, len(usageLogInsertArgTypes))
+			mock.ExpectQuery("INSERT INTO usage_logs").WithArgs(anySliceToDriverValues(prepared.args)...).
+				WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(4), at))
+			inserted, err := repo.Create(context.Background(), log)
+			require.NoError(t, err)
+			require.True(t, inserted)
+			values := []driver.Value{int64(4)}
+			for _, arg := range prepared.args {
+				value, err := driver.DefaultParameterConverter.ConvertValue(arg)
+				require.NoError(t, err)
+				values = append(values, value)
+			}
+			mock.ExpectQuery("SELECT .* FROM usage_logs WHERE id").WithArgs(int64(4)).
+				WillReturnRows(sqlmock.NewRows(strings.Split(usageLogSelectColumns, ", ")).AddRow(values...))
+			got, err := repo.GetByID(context.Background(), 4)
+			require.NoError(t, err)
+			require.Equal(t, log.APIReferenceCost, got.APIReferenceCost)
+			require.Equal(t, log.APIReferencePricing, got.APIReferencePricing)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -81,6 +81,8 @@ var usageLogInsertArgTypes = [...]string{
 	"text",        // model_mapping_chain
 	"text",        // billing_tier
 	"text",        // billing_mode
+	"numeric",     // api_reference_cost
+	"jsonb",       // api_reference_pricing
 	"numeric",     // account_stats_cost
 	"text",        // upstream_request_id
 	"text",        // session_id
@@ -282,6 +284,8 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -293,7 +297,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -742,6 +746,8 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -749,9 +755,8 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			created_at
 		) AS (VALUES `)
 
-	// Each batch row prepends the synthetic input_index before the 60
-	// usage-log column values.
-	args := make([]any, 0, len(keys)*61)
+	// Each batch row prepends input_index to the usage-log column values.
+	args := make([]any, 0, len(keys)*(len(usageLogInsertArgTypes)+1))
 	argPos := 1
 	for idx, key := range keys {
 		if idx > 0 {
@@ -837,6 +842,8 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				model_mapping_chain,
 				billing_tier,
 				billing_mode,
+				api_reference_cost,
+				api_reference_pricing,
 				account_stats_cost,
 				upstream_request_id,
 				session_id,
@@ -901,6 +908,8 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				model_mapping_chain,
 				billing_tier,
 				billing_mode,
+				api_reference_cost,
+				api_reference_pricing,
 				account_stats_cost,
 				upstream_request_id,
 				session_id,
@@ -1005,6 +1014,8 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -1095,6 +1106,8 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -1159,6 +1172,8 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -1231,6 +1246,8 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			model_mapping_chain,
 			billing_tier,
 			billing_mode,
+			api_reference_cost,
+			api_reference_pricing,
 			account_stats_cost,
 			upstream_request_id,
 			session_id,
@@ -1242,7 +1259,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$12, $13, $14, $15,
 			$16, $17, $18, $19,
 			$20, $21, $22, $23, $24, $25,
-			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62
+			$26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 	`, prepared.args...)
@@ -1362,6 +1379,8 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			modelMappingChain,
 			billingTier,
 			billingMode,
+			log.APIReferenceCost, // api_reference_cost
+			nullAPIReferencePricingJSON(log.APIReferencePricing), // api_reference_pricing
 			log.AccountStatsCost, // account_stats_cost
 			upstreamRequestID,    // upstream_request_id
 			sessionID,            // session_id
@@ -1391,4 +1410,16 @@ func (r *usageLogRepository) bestEffortRecentKey(requestID string, apiKeyID int6
 		return "", false
 	}
 	return usageLogBatchKey(requestID, apiKeyID), true
+}
+
+// nullAPIReferencePricingJSON retains SQL NULL for old/unpriced requests.
+func nullAPIReferencePricingJSON(snapshot *service.APIReferencePricingSnapshot) sql.NullString {
+	if snapshot == nil {
+		return sql.NullString{}
+	}
+	payload, err := json.Marshal(snapshot)
+	if err != nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: string(payload), Valid: true}
 }

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, requested_reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, upstream_request_id, session_id, native_compaction_v2, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, requested_reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, api_reference_cost, api_reference_pricing, account_stats_cost, upstream_request_id, session_id, native_compaction_v2, created_at"
 
 func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *service.UsageLog, err error) {
 	query := "SELECT " + usageLogSelectColumns + " FROM usage_logs WHERE id = $1"
@@ -498,6 +498,8 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		modelMappingChain         sql.NullString
 		billingTier               sql.NullString
 		billingMode               sql.NullString
+		apiReferenceCost          sql.NullFloat64
+		apiReferencePricing       sql.NullString
 		accountStatsCost          sql.NullFloat64
 		upstreamRequestID         sql.NullString
 		sessionID                 sql.NullString
@@ -564,6 +566,8 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&modelMappingChain,
 		&billingTier,
 		&billingMode,
+		&apiReferenceCost,
+		&apiReferencePricing,
 		&accountStatsCost,
 		&upstreamRequestID,
 		&sessionID,
@@ -695,6 +699,16 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	}
 	if billingMode.Valid {
 		log.BillingMode = &billingMode.String
+	}
+	if apiReferenceCost.Valid {
+		log.APIReferenceCost = &apiReferenceCost.Float64
+	}
+	if apiReferencePricing.Valid {
+		var snapshot service.APIReferencePricingSnapshot
+		if err := json.Unmarshal([]byte(apiReferencePricing.String), &snapshot); err != nil {
+			return nil, fmt.Errorf("decode API reference pricing: %w", err)
+		}
+		log.APIReferencePricing = &snapshot
 	}
 	if accountStatsCost.Valid {
 		log.AccountStatsCost = &accountStatsCost.Float64

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -98,6 +98,8 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			sqlmock.AnyArg(), // model_mapping_chain
 			sqlmock.AnyArg(), // billing_tier
 			sqlmock.AnyArg(), // billing_mode
+			sqlmock.AnyArg(), // api_reference_cost
+			sqlmock.AnyArg(), // api_reference_pricing
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // upstream_request_id
 			sqlmock.AnyArg(), // session_id
@@ -193,6 +195,8 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			sqlmock.AnyArg(), // model_mapping_chain
 			sqlmock.AnyArg(), // billing_tier
 			sqlmock.AnyArg(), // billing_mode
+			sqlmock.AnyArg(), // api_reference_cost
+			sqlmock.AnyArg(), // api_reference_pricing
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // upstream_request_id
 			sqlmock.AnyArg(), // session_id
@@ -956,8 +960,10 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			sql.NullString{},
-			sql.NullFloat64{},
-			sql.NullString{}, // upstream_request_id
+			sql.NullFloat64{}, // api_reference_cost
+			sql.NullString{},  // api_reference_pricing
+			sql.NullFloat64{}, // account_stats_cost
+			sql.NullString{},  // upstream_request_id
 			sql.NullString{},
 			false, // native_compaction_v2
 			now,
@@ -1036,6 +1042,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // model_mapping_chain
 			sql.NullString{},  // billing_tier
 			sql.NullString{},  // billing_mode
+			sql.NullFloat64{}, // api_reference_cost
+			sql.NullString{},  // api_reference_pricing
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // upstream_request_id
 			sql.NullString{},  // session_id
@@ -1099,6 +1107,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // model_mapping_chain
 			sql.NullString{},  // billing_tier
 			sql.NullString{},  // billing_mode
+			sql.NullFloat64{}, // api_reference_cost
+			sql.NullString{},  // api_reference_pricing
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // upstream_request_id
 			sql.NullString{},  // session_id
@@ -1163,6 +1173,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // model_mapping_chain
 			sql.NullString{},  // billing_tier
 			sql.NullString{},  // billing_mode
+			sql.NullFloat64{}, // api_reference_cost
+			sql.NullString{},  // api_reference_pricing
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // upstream_request_id
 			sql.NullString{},  // session_id

--- a/backend/internal/service/api_reference_cost.go
+++ b/backend/internal/service/api_reference_cost.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
+	"time"
+)
+
+// APIReferencePricingSnapshot records the inputs and price card used for an
+// immutable API-price comparison. It is not a provider-issued dollar quota.
+// Source deliberately says model_catalog: GetModelPricing can use either the
+// downloaded catalog or built-in prices, including model-specific policies.
+type APIReferencePricingSnapshot struct {
+	SchemaVersion       int           `json:"schema_version"`
+	Model               string        `json:"model"`
+	PricingModel        string        `json:"pricing_model"`
+	Source              string        `json:"source"`
+	PricingAt           time.Time     `json:"pricing_at"`
+	ServiceTier         string        `json:"service_tier"`
+	ObservedServiceTier string        `json:"observed_service_tier,omitempty"`
+	PriceCard           ModelPricing  `json:"price_card"`
+	Tokens              UsageTokens   `json:"tokens"`
+	Costs               CostBreakdown `json:"costs"`
+}
+
+// applyOpenAIAPIReferenceCost is deliberately independent of customer billing:
+// no group/channel resolver or account/user multiplier enters this calculation.
+// Unknown prices and unsupported media/tool billing remain NULL, not zero.
+func (s *OpenAIGatewayService) applyOpenAIAPIReferenceCost(ctx context.Context, log *UsageLog, account *Account, result *OpenAIForwardResult, tokens UsageTokens, serviceTier string, pricingAt time.Time) {
+	if s == nil || s.billingService == nil || log == nil || account == nil || result == nil ||
+		!account.IsOpenAIOAuth() || account.IsShadow() || account.IsOpenAIAgentIdentity() || account.IsOpenAIPersonalAccessToken() {
+		return
+	}
+	// These modes require separate catalog units. Do not record a token-only
+	// subtotal as if it represented the entire request's reference cost.
+	if result.ImageCount > 0 || result.VideoCount > 0 || result.AudioUsage != nil || result.WebSearchCalls > 0 || result.SearchCount > 0 {
+		return
+	}
+	model := strings.TrimSpace(upstreamSentModel(result.Model, result.UpstreamModel))
+	pricingModel := model
+	if !s.billingService.HasIdentifiedTokenPricing(pricingModel) {
+		if normalized := normalizeKnownOpenAICodexModel(model); normalized != "" {
+			pricingModel = normalized
+		}
+	}
+	if !s.billingService.HasIdentifiedTokenPricing(pricingModel) {
+		return
+	}
+	resolver := NewModelPricingResolver(nil, s.billingService)
+	resolved := resolver.Resolve(ctx, PricingInput{Model: pricingModel})
+	if resolved == nil || resolved.BasePricing == nil {
+		return
+	}
+	serviceTier = normalizeBillingServiceTier(serviceTier)
+	if pricingAt.IsZero() {
+		pricingAt = time.Now()
+	}
+	cost, err := s.billingService.CalculateCostUnified(CostInput{
+		Ctx: ctx, Model: pricingModel, Tokens: tokens, RateMultiplier: 1,
+		ServiceTier: serviceTier, PricingAt: pricingAt, Resolver: resolver, Resolved: resolved,
+	})
+	if err != nil || cost == nil || cost.TotalCost < 0 || math.IsNaN(cost.TotalCost) || math.IsInf(cost.TotalCost, 0) {
+		return
+	}
+	snapshot := &APIReferencePricingSnapshot{
+		SchemaVersion: 1, Model: model, PricingModel: pricingModel,
+		Source: "model_catalog", PricingAt: pricingAt.UTC(), ServiceTier: serviceTier,
+		ObservedServiceTier: normalizeBillingServiceTier(result.UpstreamResponseServiceTier),
+		PriceCard:           *resolved.BasePricing, Tokens: tokens, Costs: *cost,
+	}
+	// A corrupt/non-finite catalog entry must not break usage persistence or
+	// create an amount without its corresponding pricing evidence.
+	if _, err := json.Marshal(snapshot); err != nil {
+		return
+	}
+	log.APIReferenceCost = &cost.TotalCost
+	log.APIReferencePricing = snapshot
+}

--- a/backend/internal/service/api_reference_cost_test.go
+++ b/backend/internal/service/api_reference_cost_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIReferenceCostUsesUpstreamModelAndPreservesPrice(t *testing.T) {
+	svc := &OpenAIGatewayService{billingService: NewBillingService(&config.Config{}, nil)}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	at := time.Date(2026, 9, 12, 3, 0, 0, 0, time.UTC)
+	tokens := UsageTokens{InputTokens: 1000, OutputTokens: 500, CacheReadTokens: 200}
+	log := &UsageLog{TotalCost: 99, ActualCost: 199}
+	result := &OpenAIForwardResult{Model: "customer-alias", UpstreamModel: "gpt-5.6-terra"}
+	svc.applyOpenAIAPIReferenceCost(context.Background(), log, account, result, tokens, "priority", at)
+	require.NotNil(t, log.APIReferenceCost)
+	// Terra priority: input $4/M, output $24/M, cache reads $0.4/M.
+	require.InDelta(t, 0.01608, *log.APIReferenceCost, 1e-10)
+	require.Equal(t, "gpt-5.6-terra", log.APIReferencePricing.Model)
+	require.Equal(t, "model_catalog", log.APIReferencePricing.Source)
+	require.Equal(t, at, log.APIReferencePricing.PricingAt)
+	require.Equal(t, 99.0, log.TotalCost)
+	require.Equal(t, 199.0, log.ActualCost)
+	before, err := json.Marshal(log.APIReferencePricing)
+	require.NoError(t, err)
+	// Catalog replacement/mutation must not change already-recorded evidence.
+	svc.billingService.fallbackPrices["gpt-5.6-terra"].InputPricePerToken = 123
+	after, err := json.Marshal(log.APIReferencePricing)
+	require.NoError(t, err)
+	require.Equal(t, string(before), string(after))
+}
+
+func TestAPIReferenceCostUnknownIsDifferentFromZero(t *testing.T) {
+	svc := &OpenAIGatewayService{billingService: NewBillingService(&config.Config{}, nil)}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	for _, tc := range []struct {
+		name    string
+		model   string
+		tokens  UsageTokens
+		missing bool
+	}{
+		{"known zero usage", "gpt-5.6-terra", UsageTokens{}, false},
+		{"unknown model with usage", "unknown-model", UsageTokens{InputTokens: 10}, true},
+		{"unknown model without usage", "unknown-model", UsageTokens{}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log := &UsageLog{}
+			svc.applyOpenAIAPIReferenceCost(context.Background(), log, account, &OpenAIForwardResult{Model: tc.model}, tc.tokens, "", time.Now())
+			if tc.missing {
+				require.Nil(t, log.APIReferenceCost)
+				require.Nil(t, log.APIReferencePricing)
+			} else {
+				require.NotNil(t, log.APIReferenceCost)
+				require.Zero(t, *log.APIReferenceCost)
+			}
+		})
+	}
+	// A known free catalog card also records zero, rather than missing pricing.
+	svc.billingService.fallbackPrices["gpt-5.6-terra"] = &ModelPricing{}
+	free := &UsageLog{}
+	svc.applyOpenAIAPIReferenceCost(context.Background(), free, account, &OpenAIForwardResult{Model: "gpt-5.6-terra"}, UsageTokens{InputTokens: 10}, "", time.Now())
+	require.NotNil(t, free.APIReferenceCost)
+	require.Zero(t, *free.APIReferenceCost)
+}
+
+func TestAPIReferenceCostRejectsUnsupportedScopeAndInvalidPrices(t *testing.T) {
+	svc := &OpenAIGatewayService{billingService: NewBillingService(&config.Config{}, nil)}
+	parent := int64(1)
+	for _, account := range []*Account{
+		nil,
+		{Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+		{Platform: PlatformAnthropic, Type: AccountTypeOAuth},
+		{Platform: PlatformOpenAI, Type: AccountTypeOAuth, ParentAccountID: &parent},
+		{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Credentials: map[string]any{"auth_mode": OpenAIAuthModePersonalAccessToken}},
+	} {
+		log := &UsageLog{}
+		svc.applyOpenAIAPIReferenceCost(context.Background(), log, account, &OpenAIForwardResult{Model: "gpt-5.6-terra"}, UsageTokens{InputTokens: 10}, "", time.Now())
+		require.Nil(t, log.APIReferenceCost)
+	}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	tool := &UsageLog{}
+	svc.applyOpenAIAPIReferenceCost(context.Background(), tool, account, &OpenAIForwardResult{Model: "gpt-5.6-terra", WebSearchCalls: 1}, UsageTokens{InputTokens: 10}, "", time.Now())
+	require.Nil(t, tool.APIReferenceCost, "token-only subtotal must not claim a complete tool request")
+	svc.billingService.fallbackPrices["gpt-5.6-terra"] = &ModelPricing{InputPricePerToken: math.NaN()}
+	invalid := &UsageLog{}
+	svc.applyOpenAIAPIReferenceCost(context.Background(), invalid, account, &OpenAIForwardResult{Model: "gpt-5.6-terra"}, UsageTokens{InputTokens: 10}, "", time.Now())
+	require.Nil(t, invalid.APIReferenceCost)
+}
+
+func TestRecordUsageAPIReferenceCostIgnoresCustomerPricesAndMultipliers(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+	svc.resolver = NewModelPricingResolver(nil, svc.billingService)
+	groupID := int64(2)
+	customPrice, accountMultiplier := 100.0, 9.0
+	requestAt := time.Date(2026, 9, 12, 1, 2, 3, 0, time.UTC)
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{RequestID: "reference-custom-prices", Model: "customer-alias", UpstreamModel: "gpt-5.6-terra", Usage: OpenAIUsage{InputTokens: 1200, CacheReadInputTokens: 200, OutputTokens: 500}},
+		APIKey: &APIKey{ID: 1, GroupID: &groupID, Group: &Group{ID: groupID, RateMultiplier: 7, ModelPricing: []ChannelModelPricing{{Models: []string{"gpt-5.6-terra"}, InputPrice: &customPrice, OutputPrice: &customPrice}}}},
+		User:   &User{ID: 2}, Account: &Account{ID: 3, Platform: PlatformOpenAI, Type: AccountTypeOAuth, RateMultiplier: &accountMultiplier}, PricingAt: requestAt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.NotNil(t, usageRepo.lastLog.APIReferenceCost)
+	require.InDelta(t, 0.00804, *usageRepo.lastLog.APIReferenceCost, 1e-10)
+	require.Greater(t, usageRepo.lastLog.TotalCost, *usageRepo.lastLog.APIReferenceCost)
+	require.Equal(t, requestAt, usageRepo.lastLog.APIReferencePricing.PricingAt)
+	require.Equal(t, 1000, usageRepo.lastLog.APIReferencePricing.Tokens.InputTokens, "cache input is not double charged")
+}
+
+func TestRecordUsageAPIReferenceCostPreservesCodexFastTier(t *testing.T) {
+	for _, tc := range []struct {
+		requested string
+		observed  string
+		priced    string
+		want      float64
+	}{
+		{"priority", "default", "priority", 0.01608},
+		{"priority", "priority", "priority", 0.01608},
+		{"default", "default", "default", 0.00804},
+	} {
+		t.Run(tc.requested+"/"+tc.observed, func(t *testing.T) {
+			usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+			svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+			tier := tc.requested
+			err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+				Result: &OpenAIForwardResult{
+					RequestID: "reference-tier-" + tc.observed, Model: "gpt-5.6-terra",
+					ServiceTier: &tier, UpstreamResponseServiceTier: tc.observed,
+					Usage: OpenAIUsage{InputTokens: 1200, CacheReadInputTokens: 200, OutputTokens: 500},
+				},
+				APIKey: &APIKey{ID: 1, Group: &Group{ID: 4, Platform: PlatformOpenAI, FreeOpenAIFast: true, RateMultiplier: 0.5}},
+				User:   &User{ID: 2}, Account: &Account{ID: 3, Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, usageRepo.lastLog.APIReferenceCost)
+			require.InDelta(t, tc.want, *usageRepo.lastLog.APIReferenceCost, 1e-10)
+			require.Equal(t, tc.priced, usageRepo.lastLog.APIReferencePricing.ServiceTier)
+			require.Equal(t, tc.observed, usageRepo.lastLog.APIReferencePricing.ObservedServiceTier)
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -174,7 +174,12 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	if !isGrokVideoUsageResult(result, nil) {
 		ApplyOpenAIImageBillingResolution(result)
 	}
-	logServiceTierBillingDowngrade("service.openai_gateway", account, result.RequestID, ApplyOpenAIServiceTierBillingResolution(billingAccount, result))
+	tierResolution := ApplyOpenAIServiceTierBillingResolution(billingAccount, result)
+	logServiceTierBillingDowngrade("service.openai_gateway", account, result.RequestID, tierResolution)
+	// Use the protocol's effective tier, independently of customer discounts.
+	// Codex can report "default" for Fast turns; its outbound tier remains the
+	// authoritative reference in that case (see ResolveOpenAIServiceTierBilling).
+	referenceServiceTier := tierResolution.Billing
 
 	// OpenAI input_tokens 是总输入，包含缓存读取和缓存写入明细。
 	// 将三类 token 拆成互斥桶，避免缓存写入同时按普通输入和 cache_write 重复计费。
@@ -484,6 +489,8 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 			tokens, cost.TotalCost, pricingAt,
 		)
 	}
+
+	s.applyOpenAIAPIReferenceCost(ctx, usageLog, account, result, tokens, referenceServiceTier, pricingAt)
 
 	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
 		writeUsageLogBestEffort(ctx, s.usageLogRepo, usageLog, "service.openai_gateway")

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -172,6 +172,10 @@ type UsageLog struct {
 	AccountRateMultiplier *float64
 	// AccountStatsCost 账号统计定价预计算费用（nil = 使用默认公式 total_cost × account_rate_multiplier）
 	AccountStatsCost *float64
+	// APIReferenceCost is the immutable model-catalog USD comparison amount.
+	// Nil means not recorded/unsupported/missing pricing, distinct from zero.
+	APIReferenceCost    *float64
+	APIReferencePricing *APIReferencePricingSnapshot
 
 	BillingType        int8
 	RequestType        RequestType

--- a/backend/migrations/239_add_usage_log_api_reference_cost.sql
+++ b/backend/migrations/239_add_usage_log_api_reference_cost.sql
@@ -1,0 +1,10 @@
+-- Preserve the reference amount at recording time, independently of customer
+-- pricing and multipliers. NULL means unknown; existing rows are not repriced.
+ALTER TABLE usage_logs
+    ADD COLUMN IF NOT EXISTS api_reference_cost NUMERIC(20,10),
+    ADD COLUMN IF NOT EXISTS api_reference_pricing JSONB;
+
+COMMENT ON COLUMN usage_logs.api_reference_cost IS
+    'Model-catalog API reference USD at request recording; NULL when unavailable';
+COMMENT ON COLUMN usage_logs.api_reference_pricing IS
+    'Versioned reference pricing inputs, price card, and component costs';


### PR DESCRIPTION
OpenAI/Codex usage currently has billing amounts that can reflect custom channel prices and account or group multipliers. Comparing subscription usage across quota cycles needs a separate, reproducible API-price reference.

This adds nullable `api_reference_cost` and `api_reference_pricing` fields to usage logs for ordinary OpenAI OAuth accounts. The reference calculation uses the actual forwarded model, token/cache buckets, effective service tier and the existing model price catalog, without customer/account multipliers or channel selling prices. The saved snapshot preserves the pricing inputs and price card. Existing billing amounts and charges are unchanged.

Unknown prices and unsupported media/search billing remain NULL; a known zero-cost request remains zero. Shadow, AgentIdentity and personal-access-token accounts are excluded. Historical logs are not backfilled with today's prices. The source is identified as `model_catalog`, which can include built-in fallback prices; this is an API-equivalent comparison, not a provider-issued monetary quota.

This is the independent pricing prerequisite for the 5h/7d quota-cycle estimates in #7047 (related to #5878 and #5551).

Review/merge order: #7045 → #7047 → #7058 → #7059. All four PRs currently target `main`; each successor includes its prerequisite commits.

Local validation on Go 1.27.0:

- `make test-unit` passed.
- `make test-integration` passed with PostgreSQL and Redis testcontainers, including nullable fields and pricing-snapshot persistence.
- `golangci-lint` v2.13.0: 0 issues.
- `git diff --check` passed.

Pricing tests cover custom-price/multiplier independence, forwarded model selection, cache tokens, Codex Fast service-tier semantics, missing prices, zero usage, unsupported billing modes and retained price snapshots.
