### PR TITLE
perf(openai): WS 连接池排队等待者按账号池变更重选连接

### DIFF
--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -40,6 +40,7 @@ var (
 	errOpenAIWSConnClosed               = errors.New("openai ws connection closed")
 	errOpenAIWSConnQueueFull            = errors.New("openai ws connection queue full")
 	errOpenAIWSPreferredConnUnavailable = errors.New("openai ws preferred connection unavailable")
+	errOpenAIWSPoolChanged              = errors.New("openai ws account pool changed")
 )
 
 type openAIWSDialError struct {
@@ -494,6 +495,32 @@ func (c *openAIWSConn) acquire(ctx context.Context) error {
 			}
 			return nil
 		}
+	}
+}
+
+// acquireOrPoolChanged 与 acquire 相同，但同时监听账号池的变更信号：
+// 别的连接释放、连接被剔除或新拨号完成都会触发它，此时返回 errOpenAIWSPoolChanged，
+// 调用方应放弃只等这一条连接，回到选择逻辑重新挑选。
+func (c *openAIWSConn) acquireOrPoolChanged(ctx context.Context, poolChanged <-chan struct{}) error {
+	if c == nil {
+		return errOpenAIWSConnClosed
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closedCh:
+		return errOpenAIWSConnClosed
+	case <-poolChanged:
+		return errOpenAIWSPoolChanged
+	case <-c.leaseCh:
+		if err := ctx.Err(); err != nil {
+			c.release()
+			return err
+		}
+		if !c.leaseTokenUsable() {
+			return errOpenAIWSConnClosed
+		}
+		return nil
 	}
 }
 
@@ -1071,11 +1098,32 @@ func (p *openAIWSConnPool) runBackgroundCleanupSweep(now time.Time) {
 	}
 }
 
+// openAIWSAcquireQueueWait 跨广播重选与递归重试累计一次获取的排队耗时，
+// 由 Acquire 在统一出口写入租约与指标，任何成功路径都不会漏记。
+type openAIWSAcquireQueueWait struct {
+	queued  bool
+	rewoken bool
+	total   time.Duration
+}
+
 func (p *openAIWSConnPool) Acquire(ctx context.Context, req openAIWSAcquireRequest) (*openAIWSConnLease, error) {
 	if p != nil {
 		p.metrics.acquireTotal.Add(1)
 	}
-	lease, err := p.acquire(ctx, cloneOpenAIWSAcquireRequest(req), 0)
+	queueWait := &openAIWSAcquireQueueWait{}
+	lease, err := p.acquire(ctx, cloneOpenAIWSAcquireRequest(req), 0, queueWait)
+	if lease != nil && queueWait.rewoken {
+		// 广播重选经 tryAcquire 拿令牌，不像排队分支那样在取得令牌后检查取消，
+		// 这里补上复查：上下文已取消就归还令牌并按取消返回。
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			lease.Release()
+			return nil, ctxErr
+		}
+	}
+	if lease != nil && queueWait.total > 0 {
+		lease.queueWait = queueWait.total
+		p.metrics.acquireQueueWaitMs.Add(queueWait.total.Milliseconds())
+	}
 	if lease != nil && lease.conn != nil {
 		now := time.Now()
 		lease.idleBefore = lease.conn.idleDuration(now)
@@ -1084,12 +1132,15 @@ func (p *openAIWSConnPool) Acquire(ctx context.Context, req openAIWSAcquireReque
 	return lease, err
 }
 
-func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireRequest, retry int) (*openAIWSConnLease, error) {
+func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireRequest, retry int, queueWait *openAIWSAcquireQueueWait) (*openAIWSConnLease, error) {
 	if p == nil || req.Account == nil || req.Account.ID <= 0 {
 		return nil, errors.New("invalid ws acquire request")
 	}
 	if stringsTrim(req.WSURL) == "" {
 		return nil, errors.New("ws url is empty")
+	}
+	if queueWait == nil {
+		queueWait = &openAIWSAcquireQueueWait{}
 	}
 
 retryAcquire:
@@ -1139,7 +1190,7 @@ retryAcquire:
 						preferredConn.close()
 						p.evictConn(accountID, preferredConn.id)
 						if retry < 1 {
-							return p.acquire(ctx, req, retry+1)
+							return p.acquire(ctx, req, retry+1, queueWait)
 						}
 						return nil, err
 					}
@@ -1181,7 +1232,7 @@ retryAcquire:
 				if errors.Is(err, errOpenAIWSConnClosed) {
 					p.evictConn(accountID, preferredConn.id)
 					if retry < 1 {
-						return p.acquire(ctx, req, retry+1)
+						return p.acquire(ctx, req, retry+1, queueWait)
 					}
 				}
 				return nil, err
@@ -1192,7 +1243,7 @@ retryAcquire:
 					preferredConn.close()
 					p.evictConn(accountID, preferredConn.id)
 					if retry < 1 {
-						return p.acquire(ctx, req, retry+1)
+						return p.acquire(ctx, req, retry+1, queueWait)
 					}
 					return nil, err
 				}
@@ -1225,7 +1276,7 @@ retryAcquire:
 						conn.close()
 						p.evictConn(accountID, conn.id)
 						if retry < 1 {
-							return p.acquire(ctx, req, retry+1)
+							return p.acquire(ctx, req, retry+1, queueWait)
 						}
 						return nil, err
 					}
@@ -1254,7 +1305,7 @@ retryAcquire:
 					best.close()
 					p.evictConn(accountID, best.id)
 					if retry < 1 {
-						return p.acquire(ctx, req, retry+1)
+						return p.acquire(ctx, req, retry+1, queueWait)
 					}
 					return nil, err
 				}
@@ -1282,7 +1333,7 @@ retryAcquire:
 							conn.close()
 							p.evictConn(accountID, conn.id)
 							if retry < 1 {
-								return p.acquire(ctx, req, retry+1)
+								return p.acquire(ctx, req, retry+1, queueWait)
 							}
 							return nil, err
 						}
@@ -1362,7 +1413,7 @@ retryAcquire:
 				conn.close()
 			}
 			if retry < 1 {
-				return p.acquire(ctx, req, retry+1)
+				return p.acquire(ctx, req, retry+1, queueWait)
 			}
 			return nil, errOpenAIWSConnClosed
 		}
@@ -1419,20 +1470,36 @@ acquireAtCapacity:
 		return nil, errOpenAIWSConnQueueFull
 	}
 	target.waiters.Add(1)
+	// 排队时不只等这一条连接的令牌：账号池任何容量变化（别的连接释放、被剔除、
+	// 新拨号完成）都会唤醒等待者回到 retryAcquire 重新选择。变更通道必须在锁内取，
+	// 否则会漏掉解锁到开始等待之间的信号。
+	changedCh := ap.changeChannelLocked()
 	ap.mu.Unlock()
 	closeOpenAIWSConns(evicted)
-	defer target.waiters.Add(-1)
 	waitStart := time.Now()
-	p.metrics.acquireQueueWaitTotal.Add(1)
+	if !queueWait.queued {
+		queueWait.queued = true
+		p.metrics.acquireQueueWaitTotal.Add(1)
+	}
 
-	if err := target.acquire(ctx); err != nil {
-		if errors.Is(err, errOpenAIWSConnClosed) {
+	waitErr := target.acquireOrPoolChanged(ctx, changedCh)
+	target.waiters.Add(-1)
+	queueWait.total += time.Since(waitStart)
+	if waitErr != nil {
+		if errors.Is(waitErr, errOpenAIWSPoolChanged) {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			queueWait.rewoken = true
+			goto retryAcquire
+		}
+		if errors.Is(waitErr, errOpenAIWSConnClosed) {
 			p.evictConn(accountID, target.id)
 			if retry < 1 {
-				return p.acquire(ctx, req, retry+1)
+				return p.acquire(ctx, req, retry+1, queueWait)
 			}
 		}
-		return nil, err
+		return nil, waitErr
 	}
 	if p.shouldHealthCheckConn(target) {
 		if err := target.pingWithTimeout(openAIWSConnHealthCheckTO); err != nil {
@@ -1440,15 +1507,13 @@ acquireAtCapacity:
 			target.close()
 			p.evictConn(accountID, target.id)
 			if retry < 1 {
-				return p.acquire(ctx, req, retry+1)
+				return p.acquire(ctx, req, retry+1, queueWait)
 			}
 			return nil, err
 		}
 	}
 
-	queueWait := time.Since(waitStart)
-	p.metrics.acquireQueueWaitMs.Add(queueWait.Milliseconds())
-	lease := &openAIWSConnLease{pool: p, accountID: accountID, conn: target, queueWait: queueWait, connPick: connPick, reused: true}
+	lease := &openAIWSConnLease{pool: p, accountID: accountID, conn: target, connPick: connPick, reused: true}
 	p.metrics.acquireReuseTotal.Add(1)
 	p.recordLastSuccessfulAcquire(accountID, acquireGeneration, req)
 	p.ensureTargetIdleAsync(accountID)

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -322,6 +322,180 @@ func TestOpenAIWSConnPool_AcquireQueueWaitMetrics(t *testing.T) {
 	require.GreaterOrEqual(t, metrics.ConnPickTotal, int64(1))
 }
 
+func TestOpenAIWSConnPool_AcquireAtCapacityWakesWhenAnotherConnReleases(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 4
+
+	pool := newOpenAIWSConnPool(cfg)
+	accountID := int64(993)
+	account := &Account{ID: accountID, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	req := openAIWSAcquireRequest{Account: account, WSURL: "wss://example.com/v1/responses"}
+	target := newOpenAIWSConn("target", accountID, &openAIWSFakeConn{}, nil)
+	other := newOpenAIWSConn("other", accountID, &openAIWSFakeConn{}, nil)
+	require.True(t, target.tryAcquire())
+	require.True(t, other.tryAcquire())
+	// other 上已有一个等待者，新来的等待者会挂到 target 上。
+	other.waiters.Add(1)
+
+	ap := pool.ensureAccountPoolLocked(accountID)
+	ap.mu.Lock()
+	ap.conns[target.id] = target
+	ap.conns[other.id] = other
+	ap.lastAcquire = &req
+	ap.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	type result struct {
+		lease *openAIWSConnLease
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		lease, err := pool.Acquire(ctx, req)
+		resultCh <- result{lease: lease, err: err}
+	}()
+	require.Eventually(t, func() bool { return target.waiters.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	time.Sleep(40 * time.Millisecond)
+	otherLease := &openAIWSConnLease{pool: pool, accountID: accountID, conn: other}
+	otherLease.Release()
+
+	select {
+	case got := <-resultCh:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.lease)
+		require.Equal(t, other.id, got.lease.ConnID())
+		require.True(t, got.lease.Reused())
+		require.GreaterOrEqual(t, got.lease.QueueWaitDuration(), 30*time.Millisecond, "queue wait accumulated before the wake-up must be carried into the lease")
+		got.lease.Release()
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waiter queued on a busy connection must be woken when another connection is released")
+	}
+	require.Equal(t, int32(0), target.waiters.Load())
+	metrics := pool.SnapshotMetrics()
+	require.Equal(t, int64(1), metrics.AcquireQueueWaitTotal)
+	require.GreaterOrEqual(t, metrics.AcquireQueueWaitMsTotal, int64(30))
+}
+
+func TestOpenAIWSConnPool_AcquireAtCapacityWakesWhenCapacityFreedByEviction(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 4
+
+	pool := newOpenAIWSConnPool(cfg)
+	dialer := &openAIWSCountingDialer{}
+	pool.setClientDialerForTest(dialer)
+	accountID := int64(994)
+	account := &Account{ID: accountID, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	req := openAIWSAcquireRequest{Account: account, WSURL: "wss://example.com/v1/responses"}
+	target := newOpenAIWSConn("target", accountID, &openAIWSFakeConn{}, nil)
+	other := newOpenAIWSConn("other", accountID, &openAIWSFakeConn{}, nil)
+	require.True(t, target.tryAcquire())
+	require.True(t, other.tryAcquire())
+	other.waiters.Add(1)
+
+	ap := pool.ensureAccountPoolLocked(accountID)
+	ap.mu.Lock()
+	ap.conns[target.id] = target
+	ap.conns[other.id] = other
+	ap.lastAcquire = &req
+	ap.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	type result struct {
+		lease *openAIWSConnLease
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		lease, err := pool.Acquire(ctx, req)
+		resultCh <- result{lease: lease, err: err}
+	}()
+	require.Eventually(t, func() bool { return target.waiters.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// 剔除另一条连接腾出名额，等待者应重新选择并新拨号，而不是继续等 target。
+	time.Sleep(40 * time.Millisecond)
+	pool.evictConn(accountID, other.id)
+
+	select {
+	case got := <-resultCh:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.lease)
+		require.False(t, got.lease.Reused())
+		require.NotEqual(t, target.id, got.lease.ConnID())
+		require.GreaterOrEqual(t, got.lease.QueueWaitDuration(), 30*time.Millisecond, "queue wait must be carried into a lease obtained by dialing after the wake-up")
+		got.lease.Release()
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("waiter queued on a busy connection must be woken when pool capacity is freed")
+	}
+	require.Equal(t, 1, dialer.DialCount())
+	require.Equal(t, int32(0), target.waiters.Load())
+	metrics := pool.SnapshotMetrics()
+	require.Equal(t, int64(1), metrics.AcquireQueueWaitTotal)
+	require.GreaterOrEqual(t, metrics.AcquireQueueWaitMsTotal, int64(30))
+}
+
+func TestOpenAIWSConnPool_AcquireAtCapacityCanceledWaiterDoesNotTakeReleasedConn(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 4
+
+	accountID := int64(995)
+	account := &Account{ID: accountID, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	req := openAIWSAcquireRequest{Account: account, WSURL: "wss://example.com/v1/responses"}
+	pool := newOpenAIWSConnPool(cfg)
+	target := newOpenAIWSConn("target", accountID, &openAIWSFakeConn{}, nil)
+	other := newOpenAIWSConn("other", accountID, &openAIWSFakeConn{}, nil)
+	require.True(t, target.tryAcquire())
+	require.True(t, other.tryAcquire())
+	other.waiters.Add(1)
+
+	ap := pool.ensureAccountPoolLocked(accountID)
+	ap.mu.Lock()
+	ap.conns[target.id] = target
+	ap.conns[other.id] = other
+	ap.lastAcquire = &req
+	ap.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type result struct {
+		lease *openAIWSConnLease
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		lease, err := pool.Acquire(ctx, req)
+		resultCh <- result{lease: lease, err: err}
+	}()
+	require.Eventually(t, func() bool { return target.waiters.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// 持锁广播：等待者被唤醒后卡在重新取锁上，此时取消请求并归还 other 的令牌，
+	// 解锁后重选会看到一条空闲连接，但请求已经取消，不能带着租约返回。
+	ap.mu.Lock()
+	ap.signalChangedLocked()
+	cancel()
+	other.release()
+	ap.mu.Unlock()
+
+	select {
+	case got := <-resultCh:
+		require.ErrorIs(t, got.err, context.Canceled)
+		require.Nil(t, got.lease, "a canceled waiter must not come back with a lease after a pool change wake-up")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("canceled waiter must return promptly")
+	}
+	require.True(t, other.tryAcquire(), "the released token must stay available to other acquirers")
+	other.release()
+	require.Equal(t, int32(0), target.waiters.Load())
+}
+
 func TestOpenAIWSConnPool_DialSuccessWakesTopologyWaiterAndCanceledWaiterDoesNotLoseLease(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1


### PR DESCRIPTION
## 目的

账号连接池满时，排队的会话在 7 秒后收到 1013 `upstream websocket is busy`，客户端只能断线重连。但这 7 秒里同账号常常已经有连接空出来了，排队的会话却不知道，白等到超时。本 PR 让排队中的会话在账号池任何容量变化时立即重新选择连接，消掉“本可拿到连接却等到超时”这一类失败。

## 解决的问题

ctx_pool 模式下池满时，现有排队方式是挑一条“等待者最少”的连接，只在这一条连接的令牌上阻塞，直到拨号超时加 2 秒（默认 7 秒）。同账号其他连接释放、连接被剔除、新拨号完成，都不会唤醒它。

真实流量里的代价（测试机，默认系数，Codex Desktop 每轮开新连接并抢占旧会话）有 4 个时序完全一致的案例：

| 时刻 | 事件 |
|---|---|
| 0 秒 | 新连接开始等上游连接，池已满 |
| 5.0 秒 | 被抢占的旧会话释放它的连接，等待者没被唤醒 |
| 7.0 秒 | 等待者超时，客户端收到 1013 |
| 7.4 秒 | 客户端重连，拿到的正是 5 秒时释放的那条连接 |

用户看到的是这一轮多等 7 秒，外加一次 “websocket closed by server” 重连。#7043 调高默认上限后池满变少，但高并发账号和显式配置小系数的部署仍会池满，池满时这段等待照样白等。

## 效果（实测）

压测：一个 key 绑定 4 个 OAuth 账号，每账号并发 5、系数 1，模型 gpt-5.6-luna（reasoning low）。24 个会话各跑一轮后保持空闲把池占满，再放入等待者，2.5 秒后随机关掉若干占位会话释放连接。同一台测试机换回改前二进制跑同样场景作对照。统计口径：某账号上“本可拿到连接的等待者” = min(该账号等待者数, 该账号在等待窗内释放的连接数)。

| 版本 | 本可拿到连接的等待者 | 实际拿到 | 白等 7 秒后收 1013 |
|---|---|---|---|
| 改前 | 7 | 3 | 4 |
| 本 PR | 6 | 6 | 0 |

- 本 PR：全部在释放的同一瞬间拿到连接，日志里 `queue_wait_ms` 为 2463–2475 毫秒，正好等于 2.5 秒的释放延迟。
- 改前：唯一成功的一组是 5 个等待者恰好铺满该账号全部 5 条连接、释放哪条都有人在等的特例；只要等待者少于连接数，改前一次都没唤醒。
- 两边都没有 queue_full，没有错误日志。

<details>
<summary>按账号明细</summary>

| 版本 | 轮次 | 账号 | 等待者 | 窗口内释放 | 本可拿到 | 实际拿到 |
|---|---|---|---|---|---|---|
| 本 PR | 4 等 / 4 放 | A | 1 | 1 | 1 | 1 |
| 本 PR | 4 等 / 4 放 | B | 3 | 1 | 1 | 1 |
| 本 PR | 8 等 / 8 放 | A | 5 | 3 | 3 | 3 |
| 本 PR | 8 等 / 8 放 | B | 3 | 1 | 1 | 1 |
| 改前 | 4 等 / 4 放 | A | 1 | 1 | 1 | 0 |
| 改前 | 4 等 / 4 放 | B | 3 | 2 | 2 | 0 |
| 改前 | 8 等 / 8 放 | A | 5 | 3 | 3 | 3 |
| 改前 | 8 等 / 8 放 | B | 3 | 1 | 1 | 0 |

</details>

## 改动

- `openai_ws_pool.go`：池满排队进入等待前在锁内取账号池变更通道，等待改为四路 select（ctx、目标连接关闭、目标连接令牌、账号池变更）；变更信号触发即回到 `retryAcquire` 重跑一遍完整选择。释放、剔除、拨号完成三处已有的 `signalChangedLocked` 广播不变。
- 排队耗时改为跨重选与递归重试的累计器，由 `Acquire` 在统一出口写入租约与指标；广播重选拿到的租约在出口复查上下文，已取消则归还令牌并按取消返回。
- 重选只在同一账号的池内进行：候选是该账号已有的连接，或在该账号上限之内新拨一条，不会切换账号。
- 等待者计数显式加减，不再用 defer。强制亲和（`ForcePreferredConn`）路径不变。不加配置项，不改默认值。

## 测试

- 新增 `TestOpenAIWSConnPool_AcquireAtCapacityWakesWhenAnotherConnReleases`：容量占满、等待者挂在 A 上，释放 B 后等待者在 500 毫秒内拿到 B，租约与指标带累计排队耗时。
- 新增 `TestOpenAIWSConnPool_AcquireAtCapacityWakesWhenCapacityFreedByEviction`：剔除另一条连接腾出名额后等待者重选并新拨号成功。
- 新增 `TestOpenAIWSConnPool_AcquireAtCapacityCanceledWaiterDoesNotTakeReleasedConn`：持锁广播让等待者卡在重新取锁上，此时取消请求并归还令牌，等待者必须按取消返回且不消耗令牌。
- 连接池全部用例含 `-race`、service 包全量单测、golangci-lint 全绿。

## 关联

- 父 PR：#7043（ctx_pool 每账号连接上限系数默认值）。本 PR 是其正文里预告的后续：#7043 处理容量，本 PR 优化容量之外的排队等待行为。两者无代码依赖，合并顺序无关。
- 不关联具体 issue：1013 busy 相关的 issue 都混有多种成因。

## 代价与保留项

- 广播会让该账号所有等待者一起重选，每次重选在账号锁内 O(连接数)；等待者数量受 `queue_limit_per_conn` 约束。
- 重选后有可能立即撞上单连接排队上限返回 queue_full，而不是继续等原连接。
- 被抢占的空闲旧会话释放连接有约 5 秒延迟（coder 关闭握手超时），本 PR 不处理，另行跟进。
