### PR TITLE
fix(profile): remove verified notification emails by identity

### DIFF
--- a/frontend/src/components/user/profile/ProfileBalanceNotifyCard.vue
+++ b/frontend/src/components/user/profile/ProfileBalanceNotifyCard.vue
@@ -305,7 +305,7 @@ async function verifyPending(idx: number) {
   try {
     await userAPI.verifyNotifyEmail(pe.email, pe.code)
     if (pe.timer) clearInterval(pe.timer)
-    pendingEmails.value.splice(idx, 1)
+    pendingEmails.value = pendingEmails.value.filter(entry => entry !== pe)
     appStore.showSuccess(t('profile.balanceNotify.verifySuccess'))
     const updated = await userAPI.getProfile()
     authStore.user = updated

--- a/frontend/src/components/user/profile/__tests__/ProfileBalanceNotifyCard.spec.ts
+++ b/frontend/src/components/user/profile/__tests__/ProfileBalanceNotifyCard.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { enableAutoUnmount, flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import ProfileBalanceNotifyCard from '../ProfileBalanceNotifyCard.vue'
+
+const { sendNotifyEmailCode, verifyNotifyEmail, getProfile } = vi.hoisted(() => ({
+  sendNotifyEmailCode: vi.fn(),
+  verifyNotifyEmail: vi.fn(),
+  getProfile: vi.fn()
+}))
+
+vi.mock('@/api', () => ({
+  userAPI: { sendNotifyEmailCode, verifyNotifyEmail, getProfile }
+}))
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ user: null }) }))
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showSuccess: vi.fn(), showError: vi.fn() })
+}))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+enableAutoUnmount(afterEach)
+
+const deferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
+const pendingRows = (wrapper: VueWrapper) => wrapper.findAll('.bg-yellow-50')
+const pendingEmails = (wrapper: VueWrapper) => pendingRows(wrapper).map(row => row.get('span').text())
+
+const button = (wrapper: VueWrapper, text: string) =>
+  wrapper.findAll('button').find(item => item.text() === text)!
+
+describe('ProfileBalanceNotifyCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetAllMocks()
+    sendNotifyEmailCode.mockResolvedValue({})
+    getProfile.mockResolvedValue({ balance_notify_extra_emails: [] })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it.each([0, 1])('removes only verified emails when request %i finishes first', async (first) => {
+    const emails = ['first@example.com', 'second@example.com', 'third@example.com']
+    const requests = [deferred(), deferred()]
+    verifyNotifyEmail.mockImplementation((email: string) => requests[emails.indexOf(email)]!.promise)
+    const wrapper = mount(ProfileBalanceNotifyCard, {
+      props: { enabled: true, threshold: null, extraEmails: [], systemDefaultThreshold: 5, userEmail: '' }
+    })
+
+    for (const email of emails) {
+      await wrapper.get('input[type="email"]').setValue(email)
+      await button(wrapper, 'common.add').trigger('click')
+    }
+    for (const row of pendingRows(wrapper)) {
+      await row.findAll('button').find(item => item.text() === 'profile.balanceNotify.sendCode')!.trigger('click')
+    }
+    await flushPromises()
+    for (const row of pendingRows(wrapper)) {
+      await row.get('input').setValue('123456')
+    }
+    for (const row of pendingRows(wrapper).slice(0, 2)) {
+      await row.findAll('button').find(item => item.text() === 'profile.balanceNotify.verify')!.trigger('click')
+    }
+    expect(verifyNotifyEmail.mock.calls).toEqual(emails.slice(0, 2).map(email => [email, '123456']))
+
+    requests[first]!.resolve()
+    await flushPromises()
+    expect(pendingEmails(wrapper)).toEqual(emails.filter((_, index) => index !== first))
+
+    requests[1 - first]!.resolve()
+    await flushPromises()
+    expect(pendingEmails(wrapper)).toEqual([emails[2]])
+    expect((pendingRows(wrapper)[0]!.get('input').element as HTMLInputElement).value).toBe('123456')
+    expect(getProfile).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Verifying multiple notification emails at the same time could remove the wrong pending email. Once the first request removed its row, a later response still used its original array index.

Remove the captured pending entry by identity instead. Regression tests complete two requests in both orders and verify that the third pending email and its code stay intact.

Validation: 184 frontend tests passed (14 critical suites plus the new component suite), full typecheck, ESLint, and `git diff --check` passed.

CI passed: Go unit and integration tests, Go lint, frontend, shell, security, and CLA checks.