### PR TITLE
feat(scheduler): balance accounts by load-factor bands

### DIFF
--- a/backend/internal/service/account_load_band_test.go
+++ b/backend/internal/service/account_load_band_test.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func loadBandTestAccount(id int64, weight, current, waiting int) accountWithLoad {
+	return accountWithLoad{
+		account: &Account{
+			ID: id, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true,
+			Concurrency: 100, LoadFactor: &weight,
+		},
+		loadInfo: &AccountLoadInfo{
+			AccountID: id, CurrentConcurrency: current, WaitingCount: waiting,
+			LoadRate: (current + waiting) * 100 / weight,
+		},
+	}
+}
+
+func TestAccountLoadBandWeightedDistribution(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b int
+	}{
+		{"idle", 0, 0},
+		{"within first band", 4, 0},
+		{"within second band", 9, 1},
+		{"within third band", 14, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(42))
+			const samples = 12000
+			selectedA := 0
+			lastUsed := time.Now()
+			for range samples {
+				accounts := []accountWithLoad{
+					loadBandTestAccount(1, 5, tc.a, 0),
+					loadBandTestAccount(2, 1, tc.b, 0),
+				}
+				// A recently used account still receives its share even if B
+				// has never been used. LRU must not override weighted sampling.
+				accounts[0].account.LastUsedAt = &lastUsed
+				orderAccountsByLoadBand(accounts, false, rng.Float64)
+				if accounts[0].account.ID == 1 {
+					selectedA++
+				}
+			}
+			require.InDelta(t, 5.0/6, float64(selectedA)/samples, 0.02)
+		})
+	}
+}
+
+func TestAccountLoadBandPriorityAndMultipleAccounts(t *testing.T) {
+	accounts := []accountWithLoad{
+		loadBandTestAccount(1, 5, 0, 0),
+		loadBandTestAccount(2, 1, 1, 0),
+		loadBandTestAccount(3, 2, 0, 0),
+		loadBandTestAccount(4, 1, 3, 0),
+	}
+	accounts[3].account.Priority = -1
+	rng := rand.New(rand.NewSource(42))
+	counts := map[int64]int{}
+	for range 12000 {
+		order := append([]accountWithLoad(nil), accounts...)
+		orderAccountsByLoadBand(order, false, rng.Float64)
+		require.Equal(t, int64(4), order[0].account.ID, "priority precedes load bands")
+		require.Equal(t, int64(2), order[3].account.ID, "higher band follows both idle accounts")
+		counts[order[1].account.ID]++
+	}
+	require.InDelta(t, 5.0/7, float64(counts[1])/12000, 0.02)
+	require.InDelta(t, 2.0/7, float64(counts[3])/12000, 0.02)
+}
+
+func TestAccountLoadBandEffectiveFactorAndWidth(t *testing.T) {
+	a := loadBandTestAccount(1, 100, 5, 0)
+	b := loadBandTestAccount(2, 20, 0, 0)
+	// 100:20 has the same weights as 5:1 but wider bands. Both remain
+	// in band zero at 5:0; a draw may still select A.
+	order := []accountWithLoad{a, b}
+	orderAccountsByLoadBand(order, false, func() float64 { return 0.5 })
+	require.Equal(t, int64(1), order[0].account.ID)
+	// An unset factor uses Concurrency as both band width and weight.
+	a.account.LoadFactor = nil
+	a.account.Concurrency = 5
+	b.account.LoadFactor = nil
+	b.account.Concurrency = 1
+	order = []accountWithLoad{a, b}
+	orderAccountsByLoadBand(order, false, func() float64 { return 0.5 })
+	require.Equal(t, int64(2), order[0].account.ID)
+}
+
+func TestOpenAILoadBandSelectionIntegration(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		a, b     int
+		limitA   int
+		denyA    bool
+		sticky   int64
+		waitingA int
+		want     int64
+	}{
+		{"force B at first boundary", 5, 0, 100, false, 0, 0, 2},
+		{"continue beyond 100 percent", 9, 2, 100, false, 0, 0, 1},
+		{"force B at second boundary", 10, 1, 100, false, 0, 0, 2},
+		{"actual concurrency limit", 4, 1, 4, false, 0, 0, 2},
+		{"unlimited concurrency", 9, 2, 0, false, 0, 0, 1},
+		{"slot race falls through", 4, 1, 100, true, 0, 0, 2},
+		{"sticky precedes load bands", 5, 0, 100, false, 1, 0, 1},
+		{"waiting contributes to band", 4, 0, 100, false, 0, 1, 2},
+		{"released slot lowers band", 4, 1, 100, false, 0, 0, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := loadBandTestAccount(1, 5, tc.a, tc.waitingA)
+			b := loadBandTestAccount(2, 1, tc.b, 0)
+			a.account.Concurrency = tc.limitA
+			cache := &stubGatewayCache{sessionBindings: map[string]int64{}}
+			if tc.sticky != 0 {
+				cache.sessionBindings["openai:test-band-session"] = tc.sticky
+			}
+			concurrencyCache := stubConcurrencyCache{
+				loadMap:        map[int64]*AccountLoadInfo{1: a.loadInfo, 2: b.loadInfo},
+				acquireResults: map[int64]bool{1: !tc.denyA, 2: true},
+			}
+			svc := &OpenAIGatewayService{
+				accountRepo:        stubOpenAIAccountRepo{accounts: []Account{*a.account, *b.account}},
+				cache:              cache,
+				concurrencyService: NewConcurrencyService(concurrencyCache),
+			}
+			selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), nil, "test-band-session", "gpt-4", nil)
+			require.NoError(t, err)
+			require.NotNil(t, selection)
+			require.True(t, selection.Acquired)
+			t.Cleanup(selection.ReleaseFunc)
+			require.Equal(t, tc.want, selection.Account.ID)
+			require.Equal(t, tc.want, cache.sessionBindings["openai:test-band-session"])
+		})
+	}
+}
+
+func TestAccountLoadBandOAuthPreference(t *testing.T) {
+	a := loadBandTestAccount(1, 5, 0, 0)
+	b := loadBandTestAccount(2, 1, 0, 0)
+	b.account.Type = AccountTypeOAuth
+	order := []accountWithLoad{a, b}
+	orderAccountsByLoadBand(order, true, func() float64 { return 0.5 })
+	require.Equal(t, int64(2), order[0].account.ID)
+	// OAuth preference does not override a lower load band.
+	b.loadInfo.CurrentConcurrency = 1
+	orderAccountsByLoadBand(order, true, func() float64 { return 0.5 })
+	require.Equal(t, int64(1), order[0].account.ID)
+}

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -2829,8 +2829,8 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 
 		repo := &mockAccountRepoForPlatform{
 			accounts: []Account{
-				{ID: 1, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5},
-				{ID: 2, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5},
+				{ID: 1, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5, LoadFactor: new(1)},
+				{ID: 2, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5, LoadFactor: new(1)},
 			},
 			accountsByID: map[int64]*Account{},
 		}
@@ -2860,8 +2860,8 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 
 		concurrencyCache := &mockConcurrencyCache{
 			loadMap: map[int64]*AccountLoadInfo{
-				1: {AccountID: 1, LoadRate: 80},
-				2: {AccountID: 2, LoadRate: 20},
+				1: {AccountID: 1, CurrentConcurrency: 4, LoadRate: 400},
+				2: {AccountID: 2, CurrentConcurrency: 1, LoadRate: 100},
 			},
 		}
 
@@ -2886,8 +2886,8 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 
 		repo := &mockAccountRepoForPlatform{
 			accounts: []Account{
-				{ID: 1, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5},
-				{ID: 2, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5},
+				{ID: 1, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5, LoadFactor: new(1)},
+				{ID: 2, Platform: PlatformAnthropic, Priority: 1, Status: StatusActive, Schedulable: true, Concurrency: 5, LoadFactor: new(1)},
 			},
 			accountsByID: map[int64]*Account{},
 		}
@@ -2918,8 +2918,8 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 		concurrencyCache := &mockConcurrencyCache{
 			acquireResults: map[int64]bool{1: false, 2: false},
 			loadMap: map[int64]*AccountLoadInfo{
-				1: {AccountID: 1, LoadRate: 10},
-				2: {AccountID: 2, LoadRate: 20},
+				1: {AccountID: 1, CurrentConcurrency: 1, LoadRate: 100},
+				2: {AccountID: 2, CurrentConcurrency: 2, LoadRate: 200},
 			},
 		}
 
@@ -2975,8 +2975,8 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 
 		concurrencyCache := &mockConcurrencyCache{
 			loadMap: map[int64]*AccountLoadInfo{
-				1: {AccountID: 1, LoadRate: 100},
-				2: {AccountID: 2, LoadRate: 100},
+				1: {AccountID: 1, CurrentConcurrency: 5, LoadRate: 100},
+				2: {AccountID: 2, CurrentConcurrency: 5, LoadRate: 100},
 				3: {AccountID: 3, LoadRate: 0},
 			},
 		}
@@ -3307,7 +3307,7 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 
 		concurrencyCache := &mockConcurrencyCache{
 			loadMap: map[int64]*AccountLoadInfo{
-				1: {AccountID: 1, LoadRate: 50},
+				1: {AccountID: 1, CurrentConcurrency: 5, LoadRate: 100},
 			},
 			skipDefaultLoad: true,
 		}
@@ -3585,4 +3585,50 @@ func TestGatewayService_SelectAccountForModelWithPlatform_RoutedOpenAIGroup(t *t
 	require.NoError(t, err)
 	require.NotNil(t, acc)
 	require.Equal(t, int64(2), acc.ID, "routed account must win over the higher-priority unrouted one")
+}
+
+// The shared gateway must use the same bands for each platform, including when
+// an account has passed its load factor but still has actual concurrency slots.
+func TestGatewayLoadBandAcrossPlatforms(t *testing.T) {
+	for _, platform := range []string{PlatformAnthropic, PlatformGemini, PlatformAntigravity} {
+		for _, tc := range []struct {
+			name string
+			a, b int
+			want int64
+		}{
+			{"first boundary", 5, 0, 2},
+			{"second band", 9, 2, 1},
+		} {
+			t.Run(platform+"/"+tc.name, func(t *testing.T) {
+				a := loadBandTestAccount(1, 5, tc.a, 0)
+				b := loadBandTestAccount(2, 1, tc.b, 0)
+				for _, item := range []accountWithLoad{a, b} {
+					item.account.Platform = platform
+					item.account.Type = AccountTypeAPIKey
+				}
+				repo := &mockAccountRepoForPlatform{
+					accounts:     []Account{*a.account, *b.account},
+					accountsByID: map[int64]*Account{1: a.account, 2: b.account},
+				}
+				groupID := int64(1)
+				group := &Group{ID: groupID, Platform: platform, Status: StatusActive, Hydrated: true}
+				cfg := testConfig()
+				cfg.Gateway.Scheduling.LoadBatchEnabled = true
+				svc := &GatewayService{
+					accountRepo: repo,
+					groupRepo:   &mockGroupRepoForGateway{groups: map[int64]*Group{groupID: group}},
+					cache:       &mockGatewayCacheForPlatform{}, cfg: cfg,
+					concurrencyService: NewConcurrencyService(&mockConcurrencyCache{
+						loadMap: map[int64]*AccountLoadInfo{1: a.loadInfo, 2: b.loadInfo},
+					}),
+				}
+				selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "", nil, "", 0)
+				require.NoError(t, err)
+				require.NotNil(t, selection)
+				require.True(t, selection.Acquired)
+				t.Cleanup(selection.ReleaseFunc)
+				require.Equal(t, tc.want, selection.Account.ID)
+			})
+		}
+	}
 }

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -1613,26 +1613,6 @@ func filterByMinPriority(accounts []accountWithLoad) []accountWithLoad {
 	return result
 }
 
-// filterByMinLoadRate 过滤出负载率最低的账号集合
-func filterByMinLoadRate(accounts []accountWithLoad) []accountWithLoad {
-	if len(accounts) == 0 {
-		return accounts
-	}
-	minLoadRate := accounts[0].loadInfo.LoadRate
-	for _, acc := range accounts[1:] {
-		if acc.loadInfo.LoadRate < minLoadRate {
-			minLoadRate = acc.loadInfo.LoadRate
-		}
-	}
-	result := make([]accountWithLoad, 0, len(accounts))
-	for _, acc := range accounts {
-		if acc.loadInfo.LoadRate == minLoadRate {
-			result = append(result, acc)
-		}
-	}
-	return result
-}
-
 // filterBySoonestReset 过滤出「会话窗口最早重置」的账号集合（use-it-or-lose-it）。
 // 仅保留拥有未来重置时间（SessionWindowEnd 在当前时间之后）且最早的账号；
 // 窗口为空或已过期的账号视为无活跃窗口、优先级最低。
@@ -1666,66 +1646,6 @@ func filterBySoonestReset(accounts []accountWithLoad) []accountWithLoad {
 	return result
 }
 
-// selectByLRU 从集合中选择最久未用的账号
-// 如果有多个账号具有相同的最小 LastUsedAt，则随机选择一个
-func selectByLRU(accounts []accountWithLoad, preferOAuth bool) *accountWithLoad {
-	if len(accounts) == 0 {
-		return nil
-	}
-	if len(accounts) == 1 {
-		return &accounts[0]
-	}
-
-	// 1. 找到最小的 LastUsedAt（nil 被视为最小）
-	var minTime *time.Time
-	hasNil := false
-	for _, acc := range accounts {
-		if acc.account.LastUsedAt == nil {
-			hasNil = true
-			break
-		}
-		if minTime == nil || acc.account.LastUsedAt.Before(*minTime) {
-			minTime = acc.account.LastUsedAt
-		}
-	}
-
-	// 2. 收集所有具有最小 LastUsedAt 的账号索引
-	var candidateIdxs []int
-	for i, acc := range accounts {
-		if hasNil {
-			if acc.account.LastUsedAt == nil {
-				candidateIdxs = append(candidateIdxs, i)
-			}
-		} else {
-			if acc.account.LastUsedAt != nil && acc.account.LastUsedAt.Equal(*minTime) {
-				candidateIdxs = append(candidateIdxs, i)
-			}
-		}
-	}
-
-	// 3. 如果只有一个候选，直接返回
-	if len(candidateIdxs) == 1 {
-		return &accounts[candidateIdxs[0]]
-	}
-
-	// 4. 如果有多个候选且 preferOAuth，优先选择 OAuth 类型
-	if preferOAuth {
-		var oauthIdxs []int
-		for _, idx := range candidateIdxs {
-			if accounts[idx].account.Type == AccountTypeOAuth {
-				oauthIdxs = append(oauthIdxs, idx)
-			}
-		}
-		if len(oauthIdxs) > 0 {
-			candidateIdxs = oauthIdxs
-		}
-	}
-
-	// 5. 随机选择一个
-	selectedIdx := candidateIdxs[mathrand.Intn(len(candidateIdxs))]
-	return &accounts[selectedIdx]
-}
-
 func sortAccountsByPriorityAndLastUsed(accounts []*Account, preferOAuth bool) {
 	sort.SliceStable(accounts, func(i, j int) bool {
 		a, b := accounts[i], accounts[j]
@@ -1747,38 +1667,6 @@ func sortAccountsByPriorityAndLastUsed(accounts []*Account, preferOAuth bool) {
 		}
 	})
 	shuffleWithinPriorityAndLastUsed(accounts, preferOAuth)
-}
-
-// shuffleWithinSortGroups 对排序后的 accountWithLoad 切片，按 (Priority, LoadRate, LastUsedAt) 分组后组内随机打乱。
-// 防止并发请求读取同一快照时，确定性排序导致所有请求命中相同账号。
-func shuffleWithinSortGroups(accounts []accountWithLoad) {
-	if len(accounts) <= 1 {
-		return
-	}
-	i := 0
-	for i < len(accounts) {
-		j := i + 1
-		for j < len(accounts) && sameAccountWithLoadGroup(accounts[i], accounts[j]) {
-			j++
-		}
-		if j-i > 1 {
-			mathrand.Shuffle(j-i, func(a, b int) {
-				accounts[i+a], accounts[i+b] = accounts[i+b], accounts[i+a]
-			})
-		}
-		i = j
-	}
-}
-
-// sameAccountWithLoadGroup 判断两个 accountWithLoad 是否属于同一排序组
-func sameAccountWithLoadGroup(a, b accountWithLoad) bool {
-	if a.account.Priority != b.account.Priority {
-		return false
-	}
-	if a.loadInfo.LoadRate != b.loadInfo.LoadRate {
-		return false
-	}
-	return sameLastUsedAt(a.account.LastUsedAt, b.account.LastUsedAt)
 }
 
 // shuffleWithinPriorityAndLastUsed 对排序后的 []*Account 切片，按 (Priority, LastUsedAt) 分组后组内随机打乱。

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -1614,7 +1614,7 @@ func filterByMinPriority(accounts []accountWithLoad) []accountWithLoad {
 }
 
 // filterByMinLoadRate 过滤出负载率最低的账号集合
-func filterByMinLoadRate(accounts []accountWithLoad) []accountWithLoad {
+func filterByMinLoadRate(accounts []accountWithLoad) []accountWithLoad { //nolint:unused // Used by legacy scheduler tests.
 	if len(accounts) == 0 {
 		return accounts
 	}
@@ -1668,7 +1668,7 @@ func filterBySoonestReset(accounts []accountWithLoad) []accountWithLoad {
 
 // selectByLRU 从集合中选择最久未用的账号
 // 如果有多个账号具有相同的最小 LastUsedAt，则随机选择一个
-func selectByLRU(accounts []accountWithLoad, preferOAuth bool) *accountWithLoad {
+func selectByLRU(accounts []accountWithLoad, preferOAuth bool) *accountWithLoad { //nolint:unused // Used by legacy scheduler tests.
 	if len(accounts) == 0 {
 		return nil
 	}
@@ -1751,7 +1751,7 @@ func sortAccountsByPriorityAndLastUsed(accounts []*Account, preferOAuth bool) {
 
 // shuffleWithinSortGroups 对排序后的 accountWithLoad 切片，按 (Priority, LoadRate, LastUsedAt) 分组后组内随机打乱。
 // 防止并发请求读取同一快照时，确定性排序导致所有请求命中相同账号。
-func shuffleWithinSortGroups(accounts []accountWithLoad) {
+func shuffleWithinSortGroups(accounts []accountWithLoad) { //nolint:unused // Used by legacy scheduler tests.
 	if len(accounts) <= 1 {
 		return
 	}
@@ -1771,7 +1771,7 @@ func shuffleWithinSortGroups(accounts []accountWithLoad) {
 }
 
 // sameAccountWithLoadGroup 判断两个 accountWithLoad 是否属于同一排序组
-func sameAccountWithLoadGroup(a, b accountWithLoad) bool {
+func sameAccountWithLoadGroup(a, b accountWithLoad) bool { //nolint:unused // Used by legacy scheduler tests.
 	if a.account.Priority != b.account.Priority {
 		return false
 	}

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -1613,6 +1613,26 @@ func filterByMinPriority(accounts []accountWithLoad) []accountWithLoad {
 	return result
 }
 
+// filterByMinLoadRate 过滤出负载率最低的账号集合
+func filterByMinLoadRate(accounts []accountWithLoad) []accountWithLoad {
+	if len(accounts) == 0 {
+		return accounts
+	}
+	minLoadRate := accounts[0].loadInfo.LoadRate
+	for _, acc := range accounts[1:] {
+		if acc.loadInfo.LoadRate < minLoadRate {
+			minLoadRate = acc.loadInfo.LoadRate
+		}
+	}
+	result := make([]accountWithLoad, 0, len(accounts))
+	for _, acc := range accounts {
+		if acc.loadInfo.LoadRate == minLoadRate {
+			result = append(result, acc)
+		}
+	}
+	return result
+}
+
 // filterBySoonestReset 过滤出「会话窗口最早重置」的账号集合（use-it-or-lose-it）。
 // 仅保留拥有未来重置时间（SessionWindowEnd 在当前时间之后）且最早的账号；
 // 窗口为空或已过期的账号视为无活跃窗口、优先级最低。
@@ -1646,6 +1666,66 @@ func filterBySoonestReset(accounts []accountWithLoad) []accountWithLoad {
 	return result
 }
 
+// selectByLRU 从集合中选择最久未用的账号
+// 如果有多个账号具有相同的最小 LastUsedAt，则随机选择一个
+func selectByLRU(accounts []accountWithLoad, preferOAuth bool) *accountWithLoad {
+	if len(accounts) == 0 {
+		return nil
+	}
+	if len(accounts) == 1 {
+		return &accounts[0]
+	}
+
+	// 1. 找到最小的 LastUsedAt（nil 被视为最小）
+	var minTime *time.Time
+	hasNil := false
+	for _, acc := range accounts {
+		if acc.account.LastUsedAt == nil {
+			hasNil = true
+			break
+		}
+		if minTime == nil || acc.account.LastUsedAt.Before(*minTime) {
+			minTime = acc.account.LastUsedAt
+		}
+	}
+
+	// 2. 收集所有具有最小 LastUsedAt 的账号索引
+	var candidateIdxs []int
+	for i, acc := range accounts {
+		if hasNil {
+			if acc.account.LastUsedAt == nil {
+				candidateIdxs = append(candidateIdxs, i)
+			}
+		} else {
+			if acc.account.LastUsedAt != nil && acc.account.LastUsedAt.Equal(*minTime) {
+				candidateIdxs = append(candidateIdxs, i)
+			}
+		}
+	}
+
+	// 3. 如果只有一个候选，直接返回
+	if len(candidateIdxs) == 1 {
+		return &accounts[candidateIdxs[0]]
+	}
+
+	// 4. 如果有多个候选且 preferOAuth，优先选择 OAuth 类型
+	if preferOAuth {
+		var oauthIdxs []int
+		for _, idx := range candidateIdxs {
+			if accounts[idx].account.Type == AccountTypeOAuth {
+				oauthIdxs = append(oauthIdxs, idx)
+			}
+		}
+		if len(oauthIdxs) > 0 {
+			candidateIdxs = oauthIdxs
+		}
+	}
+
+	// 5. 随机选择一个
+	selectedIdx := candidateIdxs[mathrand.Intn(len(candidateIdxs))]
+	return &accounts[selectedIdx]
+}
+
 func sortAccountsByPriorityAndLastUsed(accounts []*Account, preferOAuth bool) {
 	sort.SliceStable(accounts, func(i, j int) bool {
 		a, b := accounts[i], accounts[j]
@@ -1667,6 +1747,38 @@ func sortAccountsByPriorityAndLastUsed(accounts []*Account, preferOAuth bool) {
 		}
 	})
 	shuffleWithinPriorityAndLastUsed(accounts, preferOAuth)
+}
+
+// shuffleWithinSortGroups 对排序后的 accountWithLoad 切片，按 (Priority, LoadRate, LastUsedAt) 分组后组内随机打乱。
+// 防止并发请求读取同一快照时，确定性排序导致所有请求命中相同账号。
+func shuffleWithinSortGroups(accounts []accountWithLoad) {
+	if len(accounts) <= 1 {
+		return
+	}
+	i := 0
+	for i < len(accounts) {
+		j := i + 1
+		for j < len(accounts) && sameAccountWithLoadGroup(accounts[i], accounts[j]) {
+			j++
+		}
+		if j-i > 1 {
+			mathrand.Shuffle(j-i, func(a, b int) {
+				accounts[i+a], accounts[i+b] = accounts[i+b], accounts[i+a]
+			})
+		}
+		i = j
+	}
+}
+
+// sameAccountWithLoadGroup 判断两个 accountWithLoad 是否属于同一排序组
+func sameAccountWithLoadGroup(a, b accountWithLoad) bool {
+	if a.account.Priority != b.account.Priority {
+		return false
+	}
+	if a.loadInfo.LoadRate != b.loadInfo.LoadRate {
+		return false
+	}
+	return sameLastUsedAt(a.account.LastUsedAt, b.account.LastUsedAt)
 }
 
 // shuffleWithinPriorityAndLastUsed 对排序后的 []*Account 切片，按 (Priority, LastUsedAt) 分组后组内随机打乱。

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	mathrand "math/rand"
 	"sort"
 	"strings"
@@ -450,33 +451,14 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 				if loadInfo == nil {
 					loadInfo = &AccountLoadInfo{AccountID: acc.ID}
 				}
-				if loadInfo.LoadRate < 100 {
+				if acc.Concurrency <= 0 || loadInfo.CurrentConcurrency < acc.Concurrency {
 					routingAvailable = append(routingAvailable, accountWithLoad{account: acc, loadInfo: loadInfo})
 				}
 			}
 
 			if len(routingAvailable) > 0 {
-				// 排序：优先级 > 负载率 > 最后使用时间
-				sort.SliceStable(routingAvailable, func(i, j int) bool {
-					a, b := routingAvailable[i], routingAvailable[j]
-					if a.account.Priority != b.account.Priority {
-						return a.account.Priority < b.account.Priority
-					}
-					if a.loadInfo.LoadRate != b.loadInfo.LoadRate {
-						return a.loadInfo.LoadRate < b.loadInfo.LoadRate
-					}
-					switch {
-					case a.account.LastUsedAt == nil && b.account.LastUsedAt != nil:
-						return true
-					case a.account.LastUsedAt != nil && b.account.LastUsedAt == nil:
-						return false
-					case a.account.LastUsedAt == nil && b.account.LastUsedAt == nil:
-						return false
-					default:
-						return a.account.LastUsedAt.Before(*b.account.LastUsedAt)
-					}
-				})
-				shuffleWithinSortGroups(routingAvailable)
+				// 优先级 > 负载档位 > 同档位按负载因子加权随机
+				orderAccountsByLoadBand(routingAvailable, false, nil)
 
 				// 4. 尝试获取槽位
 				for _, item := range routingAvailable {
@@ -497,7 +479,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 					}
 				}
 
-				// 5. 所有路由账号槽位满，尝试返回等待计划（选择负载最低的）
+				// 5. 所有路由账号槽位满，尝试返回等待计划（按负载档位和权重顺序）
 				// 遍历找到第一个满足会话限制的账号
 				for _, item := range routingAvailable {
 					if !s.checkAndRegisterSession(ctx, item.account, sessionHash) {
@@ -515,7 +497,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 				}
 				// 所有路由账号会话限制都已满，继续到 Layer 2 回退
 			}
-			// 路由列表中的账号都不可用（负载率 >= 100），继续到 Layer 2 回退
+			// 路由列表中的账号都不可用（并发槽位已满等），继续到 Layer 2 回退
 			logger.LegacyPrintf("service.gateway", "[ModelRouting] All routed accounts unavailable for model=%s, falling back to normal selection", requestedModel)
 		}
 	}
@@ -727,7 +709,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			if loadInfo == nil {
 				loadInfo = &AccountLoadInfo{AccountID: acc.ID}
 			}
-			if loadInfo.LoadRate < 100 {
+			if acc.Concurrency <= 0 || loadInfo.CurrentConcurrency < acc.Concurrency {
 				available = append(available, accountWithLoad{
 					account:  acc,
 					loadInfo: loadInfo,
@@ -735,7 +717,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			}
 		}
 
-		// 分层过滤选择：优先级 →（可选）最早重置 → 负载率 → LRU
+		// 分层过滤选择：优先级 →（可选）最早重置 → 负载档位 → 加权随机
 		for len(available) > 0 {
 			// 1. 取优先级最小的集合
 			candidates := filterByMinPriority(available)
@@ -743,13 +725,12 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			if cfg.PreferSoonestReset {
 				candidates = filterBySoonestReset(candidates)
 			}
-			// 3. 取负载率最低的集合
-			candidates = filterByMinLoadRate(candidates)
-			// 4. LRU 选择最久未用的账号
-			selected := selectByLRU(candidates, preferOAuth)
-			if selected == nil {
+			// 3. 选择最低负载档位，同档位按负载因子加权随机
+			orderAccountsByLoadBand(candidates, preferOAuth, nil)
+			if len(candidates) == 0 {
 				break
 			}
+			selected := &candidates[0]
 
 			result, err := s.tryAcquireAccountSlot(ctx, selected.account.ID, selected.account.Concurrency)
 			if err == nil && result.Acquired {
@@ -1585,6 +1566,33 @@ func (s *GatewayService) newSelectionResult(ctx context.Context, account *Accoun
 	}), nil
 }
 
+// orderAccountsByLoadBand 按优先级、floor(负载 / 负载因子)、加权随机排序。
+// 随机键只生成一次；-log(1-U)/权重使同档位账号按权重概率排在首位。
+func orderAccountsByLoadBand(accounts []accountWithLoad, preferOAuth bool, randomFloat func() float64) {
+	if randomFloat == nil {
+		randomFloat = mathrand.Float64
+	}
+	keys := make(map[int64]float64, len(accounts))
+	for _, item := range accounts {
+		keys[item.account.ID] = -math.Log1p(-randomFloat()) / float64(item.account.EffectiveLoadFactor())
+	}
+	sort.SliceStable(accounts, func(i, j int) bool {
+		a, b := accounts[i], accounts[j]
+		if a.account.Priority != b.account.Priority {
+			return a.account.Priority < b.account.Priority
+		}
+		aBand := (a.loadInfo.CurrentConcurrency + a.loadInfo.WaitingCount) / a.account.EffectiveLoadFactor()
+		bBand := (b.loadInfo.CurrentConcurrency + b.loadInfo.WaitingCount) / b.account.EffectiveLoadFactor()
+		if aBand != bBand {
+			return aBand < bBand
+		}
+		if preferOAuth && (a.account.Type == AccountTypeOAuth) != (b.account.Type == AccountTypeOAuth) {
+			return a.account.Type == AccountTypeOAuth
+		}
+		return keys[a.account.ID] < keys[b.account.ID]
+	})
+}
+
 // filterByMinPriority 过滤出优先级最小的账号集合
 func filterByMinPriority(accounts []accountWithLoad) []accountWithLoad {
 	if len(accounts) == 0 {
@@ -1628,7 +1636,7 @@ func filterByMinLoadRate(accounts []accountWithLoad) []accountWithLoad {
 // filterBySoonestReset 过滤出「会话窗口最早重置」的账号集合（use-it-or-lose-it）。
 // 仅保留拥有未来重置时间（SessionWindowEnd 在当前时间之后）且最早的账号；
 // 窗口为空或已过期的账号视为无活跃窗口、优先级最低。
-// 当所有账号都没有活跃窗口时，返回原集合（不改变后续 LRU 选择）。
+// 当所有账号都没有活跃窗口时，返回原集合（保留后续选择顺序）。
 func filterBySoonestReset(accounts []accountWithLoad) []accountWithLoad {
 	if len(accounts) <= 1 {
 		return accounts

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -1297,7 +1297,8 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			if loadInfo == nil {
 				loadInfo = &AccountLoadInfo{AccountID: acc.ID}
 			}
-			if loadInfo.LoadRate < 100 {
+			// LoadFactor defines scheduling bands; Concurrency is the slot limit.
+			if acc.Concurrency <= 0 || loadInfo.CurrentConcurrency < acc.Concurrency {
 				available = append(available, accountWithLoad{
 					account:  acc,
 					loadInfo: loadInfo,
@@ -1309,26 +1310,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			return nil, false, nil
 		}
 
-		sort.SliceStable(available, func(i, j int) bool {
-			a, b := available[i], available[j]
-			if a.account.Priority != b.account.Priority {
-				return a.account.Priority < b.account.Priority
-			}
-			if a.loadInfo.LoadRate != b.loadInfo.LoadRate {
-				return a.loadInfo.LoadRate < b.loadInfo.LoadRate
-			}
-			switch {
-			case a.account.LastUsedAt == nil && b.account.LastUsedAt != nil:
-				return true
-			case a.account.LastUsedAt != nil && b.account.LastUsedAt == nil:
-				return false
-			case a.account.LastUsedAt == nil && b.account.LastUsedAt == nil:
-				return false
-			default:
-				return a.account.LastUsedAt.Before(*b.account.LastUsedAt)
-			}
-		})
-		shuffleWithinSortGroups(available)
+		orderAccountsByLoadBand(available, false, nil)
 		if rateOrder.enabled {
 			sort.SliceStable(available, func(i, j int) bool {
 				return rateOrder.compare(available[i].account, available[j].account) < 0

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1250,19 +1250,19 @@ func TestOpenAISelectAccountWithLoadAwareness_StickyCapacitySpilloverKeepsBindin
 	}
 }
 
-func TestOpenAISelectAccountWithLoadAwareness_PrefersLowerLoad(t *testing.T) {
+func TestOpenAISelectAccountWithLoadAwareness_PrefersLowerLoadBand(t *testing.T) {
 	groupID := int64(1)
 	repo := stubOpenAIAccountRepo{
 		accounts: []Account{
-			{ID: 1, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 1},
-			{ID: 2, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 1},
+			{ID: 1, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 10, LoadFactor: new(1), Priority: 1},
+			{ID: 2, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 10, LoadFactor: new(1), Priority: 1},
 		},
 	}
 	cache := &stubGatewayCache{}
 	concurrencyCache := stubConcurrencyCache{
 		loadMap: map[int64]*AccountLoadInfo{
-			1: {AccountID: 1, LoadRate: 80},
-			2: {AccountID: 2, LoadRate: 10},
+			1: {AccountID: 1, CurrentConcurrency: 8, LoadRate: 800},
+			2: {AccountID: 2, CurrentConcurrency: 1, LoadRate: 100},
 		},
 	}
 
@@ -1394,7 +1394,7 @@ func TestOpenAISelectAccountWithLoadAwareness_AllFullWaitPlan(t *testing.T) {
 	cache := &stubGatewayCache{}
 	concurrencyCache := stubConcurrencyCache{
 		loadMap: map[int64]*AccountLoadInfo{
-			1: {AccountID: 1, LoadRate: 100},
+			1: {AccountID: 1, CurrentConcurrency: 1, LoadRate: 100},
 		},
 	}
 
@@ -1452,7 +1452,7 @@ func TestOpenAISelectAccountWithLoadAwareness_MissingLoadInfo(t *testing.T) {
 	cache := &stubGatewayCache{}
 	concurrencyCache := stubConcurrencyCache{
 		loadMap: map[int64]*AccountLoadInfo{
-			1: {AccountID: 1, LoadRate: 50},
+			1: {AccountID: 1, CurrentConcurrency: 1, LoadRate: 100},
 		},
 		skipDefaultLoad: true,
 	}
@@ -1497,7 +1497,7 @@ func TestOpenAISelectAccountForModelWithExclusions_LeastRecentlyUsed(t *testing.
 	}
 }
 
-func TestOpenAISelectAccountWithLoadAwareness_PreferNeverUsed(t *testing.T) {
+func TestOpenAISelectAccountWithLoadAwareness_SamplesUsedAndNeverUsed(t *testing.T) {
 	groupID := int64(1)
 	lastUsed := time.Now().Add(-1 * time.Hour)
 	repo := stubOpenAIAccountRepo{
@@ -1520,13 +1520,18 @@ func TestOpenAISelectAccountWithLoadAwareness_PreferNeverUsed(t *testing.T) {
 		concurrencyService: NewConcurrencyService(concurrencyCache),
 	}
 
-	selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-4", nil)
-	if err != nil {
-		t.Fatalf("SelectAccountWithLoadAwareness error: %v", err)
+	seen := map[int64]bool{}
+	for range 100 {
+		selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-4", nil)
+		if err != nil {
+			t.Fatalf("SelectAccountWithLoadAwareness error: %v", err)
+		}
+		require.NotNil(t, selection)
+		require.NotNil(t, selection.Account)
+		seen[selection.Account.ID] = true
+		selection.ReleaseFunc()
 	}
-	if selection == nil || selection.Account == nil || selection.Account.ID != 2 {
-		t.Fatalf("expected account 2")
-	}
+	require.Len(t, seen, 2, "last-used time must not override weighted selection")
 }
 
 func TestOpenAIStreamingTimeout(t *testing.T) {


### PR DESCRIPTION
账号池中通常同时存在不同额度的账号。以 Codex 为例，Plus、Pro 5x、Pro 20x 的额度比例大致为：

> Plus : Pro 5x : Pro 20x = 1 : 5 : 20

如果系统中三类账号数量都比较多，我们希望单个账号承担的请求量也大致体现这个比例：Pro 20x 承担的请求最多，Pro 5x 次之，Plus 最少。这样可以避免额度较少的 Plus 账号过早用完，而额度较高的账号还剩下大量余量。

因此，我们把三类账号的负载因子也设置为：

| 账号类型 | 负载因子 |
|---|---:|
| Plus | 1 |
| Pro 5x | 5 |
| Pro 20x | 20 |

但是，在账号数量多、整体比较空闲时，现有普通调度很难实现这个预期。实际情况往往是负载因子小的账号承担了过多请求，因此更快用完额度。

下面用三个账号作为例子，说明现有方案和改进方案分别会遇到什么问题。假设三个账号的优先级相同，请求需要重新选择账号，也没有命中已有会话的粘性绑定。

### 方案一：比较当前负载率

方案一先计算账号当前已经承载的负载：

> 当前负载 = 正在处理的请求数 + 等待中的请求数

“正在处理的请求数”是已经占用并发槽位的请求；“等待中的请求数”是已经分配给该账号、但暂时没有并发槽位而排队等待的请求。

然后计算当前负载率：

> 当前负载率 = 当前负载 ÷ 负载因子

调度器优先选择当前负载率较低的账号。

假设三个账号一开始都空闲：

| 账号 | 负载因子 | 当前负载 | 当前负载率 |
|---|---:|---:|---:|
| Plus | 1 | 0 | 0% |
| Pro 5x | 5 | 0 | 0% |
| Pro 20x | 20 | 0 | 0% |

虽然三个账号的承载能力不同，但当前负载率都是 `0%`，因此负载因子无法影响这次选择，只能继续依据最后使用时间等其他规则。

假设第一个请求被分配给 Pro 20x，而且还没有完成。此时第二个请求到达：

| 账号 | 当前负载 | 当前负载率 |
|---|---:|---:|
| Plus | 0 | 0% |
| Pro 5x | 0 | 0% |
| Pro 20x | 1 | 5% |

由于 Plus 和 Pro 5x 仍然是空闲的 `0%`，它们都会排在已经有一个请求的 Pro 20x 前面。第二个请求就可能被分配给 Plus 或 Pro 5x。

如果第二个请求分配给 Pro 5x，第三个请求到达时，Plus、Pro 5x、Pro 20x 的负载率分别为 `0%`、`20%`、`5%`。此时 Plus 的 `0%` 最低，第三个请求又可能分配给 Plus。

于是，三个请求可能分别落到三个账号上：

| 账号类型 | 请求数 |
|---|---:|
| Plus | 1 |
| Pro 5x | 1 |
| Pro 20x | 1 |

这与期望的 `1∶5∶20` 相差很大。即使把负载因子设置成更大的数值，只要还有空闲账号，它们的 `0%` 仍然低于已经接单账号的非零负载率。

因此，方案一在账号池较空闲时容易让分配趋于平均。对于额度只有 Pro 20x 二十分之一的 Plus 来说，这种“平均接单”实际上代表它承担了远高于预期的请求份额，因而更容易先用完额度。

### 方案二：比较接下一个请求后的负载率

为了解决方案一无法区分空闲账号的问题，方案二把即将分配的请求也算进去：分别假设把请求交给每个账号，计算它接单后的负载率，然后选择结果最低的账号。

> 接单后的负载率 =（当前负载 + 1）÷ 负载因子

三个账号都空闲时：

| 候选账号 | 接单后的计算 | 接单后的负载率 |
|---|---|---:|
| Plus | `(0 + 1) ÷ 1` | 100% |
| Pro 5x | `(0 + 1) ÷ 5` | 20% |
| Pro 20x | `(0 + 1) ÷ 20` | 5% |

Pro 20x 的接单后负载率最低，所以第一个请求交给 Pro 20x。

假设请求持续到达，而且前面的请求还没有完成，关键分配节点如下。结果相同时都可以选择；为了让后续负载衔接，下面展示其中一条可能的分配路径：

| 新请求 | 分配前负载：Plus / Pro 5x / Pro 20x | 接单后的负载率 | 分配给 |
|---|---|---|---|
| 第 1 个 | 0 / 0 / 0 | 100% / 20% / 5% | Pro 20x |
| 第 4 个 | 0 / 0 / 3 | 100% / 20% / 20% | 两者皆可，本例选择 Pro 20x |
| 第 5 个 | 0 / 0 / 4 | 100% / 20% / 25% | Pro 5x |
| 第 6 个 | 0 / 1 / 4 | 100% / 40% / 25% | Pro 20x |

第 4 个请求时，Pro 5x 和 Pro 20x 的接单后负载率都是 `20%`，单靠这个指标无法区分两者，因此两者都可以选择。第 5 个请求时，Pro 5x 的 `20%` 低于 Pro 20x 的 `25%`，所以选择 Pro 5x。

随着请求继续积累，Plus 接一个请求后就达到 `100%`，所以只要另外两个账号接单后的负载率仍低于 `100%`，Plus 就不会参与。关键边界如下：

| 新请求 | 分配前负载：Plus / Pro 5x / Pro 20x | 接单后的负载率 | 分配给 |
|---|---|---|---|
| 第 24 个 | 0 / 4 / 19 | 100% / 100% / 100% | 三者皆可，本例选择 Pro 20x |
| 第 25 个 | 0 / 4 / 20 | 100% / 100% / 105% | Plus、Pro 5x 皆可，本例选择 Pro 5x |
| 第 26 个 | 0 / 5 / 20 | 100% / 120% / 105% | Plus |

在这个持续积累的场景中，前三类账号最终大致形成 `Plus:1、Pro 5x:5、Pro 20x:20` 的分配。

但是，这个结果依赖于请求能够持续积累。如果整体并发较低，只要下一次请求到达时仍有空闲的 Pro 20x，它接单后的负载率就通常低于空闲的 Pro 5x 和 Plus。例如，Pro 20x 当前有 1 个请求时，接下一个请求后的负载率为 `2/20=10%`；空闲 Pro 5x 为 `1/5=20%`，空闲 Plus 为 `1/1=100%`，所以仍然选择 Pro 20x。

即使 Pro 20x 当前有 3 个请求，接下一个请求后的负载率也只有 `4/20=20%`。只要池中经常能找到空闲的 Pro 20x，方案二就可能持续选择它，Plus 和 Pro 5x 长期没有机会接单，无法形成预期的 `1∶5∶20` 分配。

### 方案三：最低负载档位优先，同档位按权重随机

前两种方案的问题分别是：

- 方案一在系统空闲时容易趋于平均，Plus 等小额度账号承担了过多请求。
- 方案二在系统空闲时容易持续选择 Pro 20x，Plus 和 Pro 5x 长期没有机会接单。

因此，我们希望同时满足两个条件：账号都比较空闲时，按照负载因子体现接单比例；某个账号的当前负载明显高于其他账号时，优先选择负载较低的账号进行纠偏。

方案三先计算每个账号的当前负载：

> 当前负载 = 正在处理的请求数 + 等待中的请求数

再计算负载档位：

> 负载档位 = floor(当前负载 ÷ 负载因子)

以 Plus、Pro 5x、Pro 20x 为例：

| 账号类型 | 负载因子 | 第 0 档 | 第 1 档 | 第 2 档 |
|---|---:|---:|---:|---:|
| Plus | 1 | 0 | 1 | 2 |
| Pro 5x | 5 | 0～4 | 5～9 | 10～14 |
| Pro 20x | 20 | 0～19 | 20～39 | 40～59 |

调度时遵循两步：

1. 只在最低负载档位的账号中选择。
2. 如果最低档位中有多个账号，就按它们的负载因子加权随机。

三个账号都处于第 0 档时，按负载因子 `1、5、20` 加权随机。总权重为 `1 + 5 + 20 = 26`，所以三个账号的选择概率分别为：

- Plus： 1 ÷ 26，约 3.8%
- Pro 5x： 5 ÷ 26，约 19.2%
- Pro 20x：20 ÷ 26，约 76.9%

这样，低负载时 Pro 20x 的机会最多，但 Plus 和 Pro 5x 也会持续获得请求，不会因为账号都空闲就失去负载因子的区别。

如果请求发生重叠，关键状态如下：

| 当前负载：Plus / Pro 5x / Pro 20x | 对应档位 | 下一步 |
|---|---|---|
| 0 / 0 / 1 | 0 / 0 / 0 | 三个账号同档，按 `1∶5∶20` 随机 |
| 1 / 0 / 1 | 1 / 0 / 0 | Plus 已进入第 1 档，只在 Pro 5x 和 Pro 20x 中按 `5∶20` 随机 |
| 1 / 4 / 19 | 1 / 0 / 0 | 仍只在 Pro 5x 和 Pro 20x 中按 `5∶20` 随机 |
| 1 / 5 / 19 | 1 / 1 / 0 | Pro 5x 也进入第 1 档，优先选择 Pro 20x |
| 1 / 5 / 20 | 1 / 1 / 1 | 三个账号重新同档，按 `1∶5∶20` 随机 |

例如，在 `1 / 4 / 19` 的状态下，如果随机选择了 Pro 20x，负载变成 `1 / 4 / 20`。这时 Pro 5x 仍在第 0 档，而 Plus 和 Pro 20x 在第 1 档，所以下一个请求会优先给 Pro 5x。

如果随机选择了 Pro 5x，负载变成 `1 / 5 / 19`。此时 Plus 和 Pro 5x 在第 1 档，Pro 20x 在第 0 档，所以下一个请求会优先给 Pro 20x。

请求完成后，当前负载下降，档位也会重新计算。例如当前负载为 `1 / 5 / 20` 时，三个账号都在第 1 档；如果 Plus 的请求完成，负载变为 `0 / 5 / 20`，档位变为 `0 / 1 / 1`，下一次请求就会重新考虑第 0 档的 Plus。

本方案让账号在低负载时按负载因子获得不同的接单概率，在负载出现差异时优先选择负载较低的账号。这样可以减少小额度账号承担过多请求的情况，同时避免流量长期集中在大额度账号上，使整体分配更接近各类账号的额度比例。

相关调度单元测试已通过，覆盖档位边界、等待数计入、加权概率、多账号、多平台普通入口、模型路由、粘性会话、并发上限和抢槽失败回退。


