### PR TITLE
fix(channel-monitor): add missing minimax to provider allowlists

### DIFF
--- a/backend/internal/service/channel_monitor_validate.go
+++ b/backend/internal/service/channel_monitor_validate.go
@@ -22,6 +22,7 @@ var monitorProviders = map[string]struct{}{
 	MonitorProviderKimi:        {},
 	MonitorProviderZhipu:       {},
 	MonitorProviderDeepseek:    {},
+	MonitorProviderMiniMax:     {},
 }
 
 // probeCapableProviders 支持探活（probe / quota_probe）的 provider。
@@ -36,6 +37,7 @@ var probeCapableProviders = map[string]struct{}{
 	MonitorProviderKimi:      {},
 	MonitorProviderZhipu:     {},
 	MonitorProviderDeepseek:  {},
+	MonitorProviderMiniMax:   {},
 }
 
 // validateProvider 校验 provider 字符串。


### PR DESCRIPTION
Fixes #7061

## 问题

在「新增渠道监控」中选择 **MiniMax** 平台提交时，后端返回：

```
provider must be one of openai/anthropic/gemini/grok/antigravity/kimi/zhipu/deepseek/minimax
```

报错信息里**列出了 minimax**，但提交仍被拒绝。

## 根因

`backend/internal/service/channel_monitor_validate.go` 的两个 provider 白名单漏了 `MonitorProviderMiniMax`：

- `monitorProviders`
- `probeCapableProviders`

而 minimax 的其他支持均已就位：常量 `MonitorProviderMiniMax`、`providerMiniMaxChatAdapter`、ent schema enum、错误提示字符串、前端平台选项。**仅校验白名单未同步**。

## 修复

两处白名单补上 `MonitorProviderMiniMax: {},`。由于 minimax adapter 已注册探活能力（复用 openai 兼容路径 `/v1/chat/completions`），故同时加入 `probeCapableProviders`。

## 验证

- `go build ./...` 通过
- 本地实测：启用渠道监控后创建 `provider=minimax` 监控成功（不再被 `validateProvider` 拒绝）