### PR TITLE
fix(openai-ws): 对齐新版 ctx_pool 连接容量计算

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1274,7 +1274,9 @@ type GatewayOpenAIWSConfig struct {
 	MaxConnsPerAccount int `mapstructure:"max_conns_per_account"`
 	MinIdlePerAccount  int `mapstructure:"min_idle_per_account"`
 	MaxIdlePerAccount  int `mapstructure:"max_idle_per_account"`
-	// DynamicMaxConnsByAccountConcurrencyEnabled: 是否按账号并发动态计算连接池上限
+	// DynamicMaxConnsByAccountConcurrencyEnabled: 是否按账号并发动态计算连接池上限。
+	// 旧版及 mode_router_v2 的 ctx_pool 共用此开关和类型系数；关闭后使用 max_conns_per_account。
+	// mode_router_v2 下并发数 <= 0 的账号仍不可调度。
 	DynamicMaxConnsByAccountConcurrencyEnabled bool `mapstructure:"dynamic_max_conns_by_account_concurrency_enabled"`
 	// OAuthMaxConnsFactor: OAuth 账号连接池系数（effective=ceil(concurrency*factor)）
 	OAuthMaxConnsFactor float64 `mapstructure:"oauth_max_conns_factor"`

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -2156,14 +2156,8 @@ func (p *openAIWSConnPool) effectiveMaxConnsByAccount(account *Account) int {
 	if hardCap <= 0 {
 		return 0
 	}
-	if p.modeRouterV2Enabled() {
-		if account == nil {
-			return hardCap
-		}
-		if account.Concurrency <= 0 {
-			return 0
-		}
-		return min(account.Concurrency, hardCap)
+	if p.modeRouterV2Enabled() && account != nil && account.Concurrency <= 0 {
+		return 0
 	}
 	if account == nil || !p.dynamicMaxConnsEnabled() {
 		return hardCap

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -1164,21 +1164,95 @@ func TestOpenAIWSConnPool_EffectiveMaxConnsDisabledFallbackHardCap(t *testing.T)
 	require.Equal(t, 8, pool.effectiveMaxConnsByAccount(account), "关闭动态模式后应保持旧行为")
 }
 
-func TestOpenAIWSConnPool_EffectiveMaxConnsByAccount_ModeRouterV2RespectsHardCap(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
-	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 8
-	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
-	cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 0.3
-	cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor = 0.6
+func TestOpenAIWSConnPool_EffectiveMaxConnsByAccount_ModeRouterV2(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType string
+		concurrency int
+		factor      float64
+		dynamic     bool
+		want        int
+	}{
+		{name: "oauth expansion", accountType: AccountTypeOAuth, concurrency: 1, factor: 5, dynamic: true, want: 5},
+		{name: "apikey expansion", accountType: AccountTypeAPIKey, concurrency: 1, factor: 5, dynamic: true, want: 5},
+		{name: "oauth fraction", accountType: AccountTypeOAuth, concurrency: 20, factor: 0.3, dynamic: true, want: 6},
+		{name: "apikey rounding", accountType: AccountTypeAPIKey, concurrency: 3, factor: 0.6, dynamic: true, want: 2},
+		{name: "minimum one", accountType: AccountTypeOAuth, concurrency: 1, factor: 0.3, dynamic: true, want: 1},
+		{name: "hard cap", accountType: AccountTypeOAuth, concurrency: 3, factor: 5, dynamic: true, want: 8},
+		{name: "dynamic disabled", accountType: AccountTypeAPIKey, concurrency: 2, factor: 0.6, want: 8},
+		{name: "zero concurrency", accountType: AccountTypeOAuth, factor: 5, dynamic: true, want: 0},
+		{name: "negative concurrency", accountType: AccountTypeAPIKey, concurrency: -1, factor: 5, dynamic: true, want: 0},
+		{name: "zero concurrency dynamic disabled", accountType: AccountTypeOAuth, factor: 5, want: 0},
+		{name: "negative concurrency dynamic disabled", accountType: AccountTypeAPIKey, concurrency: -1, factor: 5, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+			cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 8
+			cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = tt.dynamic
+			cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 1
+			cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor = 1
+			if tt.accountType == AccountTypeOAuth {
+				cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = tt.factor
+			} else {
+				cfg.Gateway.OpenAIWS.APIKeyMaxConnsFactor = tt.factor
+			}
+			pool := newOpenAIWSConnPool(cfg)
+			t.Cleanup(pool.Close)
+			account := &Account{Platform: PlatformOpenAI, Type: tt.accountType, Concurrency: tt.concurrency}
+			require.Equal(t, tt.want, pool.effectiveMaxConnsByAccount(account))
+			require.Equal(t, 8, pool.effectiveMaxConnsByAccount(nil))
+		})
+	}
+}
 
-	pool := newOpenAIWSConnPool(cfg)
+func TestOpenAIWSConnPool_AcquireRetainedSessionsUsesScaledCapacity(t *testing.T) {
+	for _, mode := range []struct {
+		name string
+		v2   bool
+	}{
+		{name: "legacy"},
+		{name: "mode router v2", v2: true},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = mode.v2
+			cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 3
+			cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 3
+			cfg.Gateway.OpenAIWS.PoolTargetUtilization = 1
+			cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+			cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 2
+			pool := newOpenAIWSConnPool(cfg)
+			pool.setClientDialerForTest(&openAIWSFakeDialer{})
+			t.Cleanup(pool.Close)
+			req := openAIWSAcquireRequest{
+				Account: &Account{ID: 902, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 2},
+				WSURL:   "wss://example.com/v1/responses",
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			leases := make([]*openAIWSConnLease, 0, 3)
+			for range 3 {
+				lease, err := pool.Acquire(ctx, req)
+				require.NoError(t, err, "轮次之间仍持有连接的会话应可使用系数扩出的容量")
+				t.Cleanup(lease.Release)
+				leases = append(leases, lease)
+			}
 
-	high := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 20}
-	require.Equal(t, 8, pool.effectiveMaxConnsByAccount(high), "v2 路径也必须受连接池硬上限约束")
+			fullCtx, fullCancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer fullCancel()
+			_, err := pool.Acquire(fullCtx, req)
+			require.ErrorIs(t, err, context.DeadlineExceeded, "扩容后仍必须受全局硬上限约束")
 
-	nonPositive := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 0}
-	require.Equal(t, 0, pool.effectiveMaxConnsByAccount(nonPositive), "并发数<=0 时应不可调度")
+			leases[0].Release()
+			reused, err := pool.Acquire(ctx, req)
+			require.NoError(t, err)
+			defer reused.Release()
+			require.Equal(t, leases[0].ConnID(), reused.ConnID())
+			require.True(t, reused.Reused())
+		})
+	}
 }
 
 func TestOpenAIWSConnPool_AcquireRejectsWhenEffectiveMaxConnsIsZero(t *testing.T) {

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -357,6 +357,8 @@ gateway:
     max_idle_per_account: 12
     # 是否按账号并发动态计算连接池上限：
     # effective_max_conns = min(max_conns_per_account, ceil(account.concurrency * factor))
+    # 旧版及 mode_router_v2 的 ctx_pool 共用此开关和下方类型系数；关闭后使用 max_conns_per_account。
+    # mode_router_v2 下并发数 <= 0 的账号仍不可调度。
     dynamic_max_conns_by_account_concurrency_enabled: true
     # 按账号类型分别设置系数（OAuth / API Key）
     oauth_max_conns_factor: 1.0

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -873,11 +873,7 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
-          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
-          </p>
           <p v-if="openAIWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t('admin.accounts.openai.wsModeHintPrefix') }}
             {{ t(openAIWSModeHintKey) }}
           </p>
           <Select
@@ -1155,11 +1151,7 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
-          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
-          </p>
           <p v-if="openAIAPIKeyWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t('admin.accounts.openai.wsModeHintPrefix') }}
             {{ t(openAIAPIKeyWSModeHintKey) }}
           </p>
           <Select

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -873,7 +873,11 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
+          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
+          </p>
           <p v-if="openAIWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.wsModeHintPrefix') }}
             {{ t(openAIWSModeHintKey) }}
           </p>
           <Select
@@ -1151,7 +1155,11 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
+          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
+          </p>
           <p v-if="openAIAPIKeyWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.wsModeHintPrefix') }}
             {{ t(openAIAPIKeyWSModeHintKey) }}
           </p>
           <Select

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -873,8 +873,8 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
-          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t(openAIWSModeConcurrencyHintKey) }}
+          <p v-if="openAIWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t(openAIWSModeHintKey) }}
           </p>
           <Select
             v-model="openaiOAuthResponsesWebSocketV2Mode"
@@ -1151,8 +1151,8 @@
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
             {{ t('admin.accounts.openai.wsModeDesc') }}
           </p>
-          <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {{ t(openAIAPIKeyWSModeConcurrencyHintKey) }}
+          <p v-if="openAIAPIKeyWSModeHintKey" class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            {{ t(openAIAPIKeyWSModeHintKey) }}
           </p>
           <Select
             v-model="openaiAPIKeyResponsesWebSocketV2Mode"
@@ -1513,7 +1513,7 @@ import {
   OPENAI_WS_MODE_PASSTHROUGH,
   OPENAI_WS_MODE_HTTP_BRIDGE,
   isOpenAIWSModeEnabled,
-  resolveOpenAIWSModeConcurrencyHintKey
+  resolveOpenAIWSModeHintKey
 } from '@/utils/openaiWsMode'
 import type { OpenAIWSMode } from '@/utils/openaiWsMode'
 interface Props {
@@ -1824,11 +1824,11 @@ const toggleOpenAIEndpointCapability = (
     capability
   ])
 }
-const openAIWSModeConcurrencyHintKey = computed(() =>
-  resolveOpenAIWSModeConcurrencyHintKey(openaiOAuthResponsesWebSocketV2Mode.value)
+const openAIWSModeHintKey = computed(() =>
+  resolveOpenAIWSModeHintKey(openaiOAuthResponsesWebSocketV2Mode.value)
 )
-const openAIAPIKeyWSModeConcurrencyHintKey = computed(() =>
-  resolveOpenAIWSModeConcurrencyHintKey(openaiAPIKeyResponsesWebSocketV2Mode.value)
+const openAIAPIKeyWSModeHintKey = computed(() =>
+  resolveOpenAIWSModeHintKey(openaiAPIKeyResponsesWebSocketV2Mode.value)
 )
 
 // Model mapping helpers

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3132,8 +3132,8 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t(openAIWSModeConcurrencyHintKey) }}
+            <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t(openAIWSModeHintKey) }}
             </p>
           </div>
           <div class="w-52">
@@ -3975,7 +3975,7 @@ import {
   OPENAI_WS_MODE_PASSTHROUGH,
   OPENAI_WS_MODE_HTTP_BRIDGE,
   isOpenAIWSModeEnabled,
-  resolveOpenAIWSModeConcurrencyHintKey,
+  resolveOpenAIWSModeHintKey,
   type OpenAIWSMode
 } from '@/utils/openaiWsMode'
 import OAuthAuthorizationFlow from './OAuthAuthorizationFlow.vue'
@@ -4653,8 +4653,8 @@ const openaiResponsesWebSocketV2Mode = computed({
   }
 })
 
-const openAIWSModeConcurrencyHintKey = computed(() =>
-  resolveOpenAIWSModeConcurrencyHintKey(openaiResponsesWebSocketV2Mode.value)
+const openAIWSModeHintKey = computed(() =>
+  resolveOpenAIWSModeHintKey(openaiResponsesWebSocketV2Mode.value)
 )
 
 const isOpenAIModelRestrictionDisabled = computed(() =>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3132,11 +3132,7 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
-            </p>
             <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.wsModeHintPrefix') }}
               {{ t(openAIWSModeHintKey) }}
             </p>
           </div>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3132,7 +3132,11 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
+            </p>
             <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.wsModeHintPrefix') }}
               {{ t(openAIWSModeHintKey) }}
             </p>
           </div>

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1871,11 +1871,7 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
-            </p>
             <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('admin.accounts.openai.wsModeHintPrefix') }}
               {{ t(openAIWSModeHintKey) }}
             </p>
           </div>

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1871,8 +1871,8 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t(openAIWSModeConcurrencyHintKey) }}
+            <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t(openAIWSModeHintKey) }}
             </p>
           </div>
           <div class="w-52">
@@ -3101,7 +3101,7 @@ import {
   OPENAI_WS_MODE_PASSTHROUGH,
   OPENAI_WS_MODE_HTTP_BRIDGE,
   isOpenAIWSModeEnabled,
-  resolveOpenAIWSModeConcurrencyHintKey,
+  resolveOpenAIWSModeHintKey,
   type OpenAIWSMode,
   resolveOpenAIWSModeFromExtra
 } from '@/utils/openaiWsMode'
@@ -3588,8 +3588,8 @@ const openaiResponsesWebSocketV2Mode = computed({
     openaiOAuthResponsesWebSocketV2Mode.value = mode
   }
 })
-const openAIWSModeConcurrencyHintKey = computed(() =>
-  resolveOpenAIWSModeConcurrencyHintKey(openaiResponsesWebSocketV2Mode.value)
+const openAIWSModeHintKey = computed(() =>
+  resolveOpenAIWSModeHintKey(openaiResponsesWebSocketV2Mode.value)
 )
 const codexImageToolOptions = computed<Array<{
   value: CodexImageToolMode

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1871,7 +1871,11 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.openai.wsModeDesc') }}
             </p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.wsModeRoutingDesc') }}
+            </p>
             <p v-if="openAIWSModeHintKey" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.wsModeHintPrefix') }}
               {{ t(openAIWSModeHintKey) }}
             </p>
           </div>

--- a/frontend/src/i18n/__tests__/wsModeLocaleDesc.spec.ts
+++ b/frontend/src/i18n/__tests__/wsModeLocaleDesc.spec.ts
@@ -5,9 +5,7 @@ import zh from '../locales/zh/admin/accounts'
 
 describe('OpenAI WS mode locale descriptions', () => {
   it('documents the global v2 router requirement for account WS modes', () => {
-    expect(zh.accounts.openai.wsModeRoutingDesc).toContain('mode_router_v2_enabled')
-    expect(zh.accounts.openai.wsModeRoutingDesc).toContain('http_bridge')
-    expect(en.accounts.openai.wsModeRoutingDesc).toContain('mode_router_v2_enabled')
-    expect(en.accounts.openai.wsModeRoutingDesc).toContain('http_bridge')
+    expect(zh.accounts.openai.wsModeDesc).toContain('mode_router_v2_enabled=true')
+    expect(en.accounts.openai.wsModeDesc).toContain('mode_router_v2_enabled=true')
   })
 })

--- a/frontend/src/i18n/__tests__/wsModeLocaleDesc.spec.ts
+++ b/frontend/src/i18n/__tests__/wsModeLocaleDesc.spec.ts
@@ -5,9 +5,9 @@ import zh from '../locales/zh/admin/accounts'
 
 describe('OpenAI WS mode locale descriptions', () => {
   it('documents the global v2 router requirement for account WS modes', () => {
-    expect(zh.accounts.openai.wsModeDesc).toContain('mode_router_v2_enabled')
-    expect(zh.accounts.openai.wsModeDesc).toContain('http_bridge')
-    expect(en.accounts.openai.wsModeDesc).toContain('mode_router_v2_enabled')
-    expect(en.accounts.openai.wsModeDesc).toContain('http_bridge')
+    expect(zh.accounts.openai.wsModeRoutingDesc).toContain('mode_router_v2_enabled')
+    expect(zh.accounts.openai.wsModeRoutingDesc).toContain('http_bridge')
+    expect(en.accounts.openai.wsModeRoutingDesc).toContain('mode_router_v2_enabled')
+    expect(en.accounts.openai.wsModeRoutingDesc).toContain('http_bridge')
   })
 })

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -605,10 +605,7 @@ export default {
           'Disabled by default. Enable to allow responses_websockets_v2 capability (still gated by global and account-type switches).',
         wsMode: 'WS mode',
         wsModeDesc:
-          'Account WS switch: select Off to disable WS for this account, or another option to enable it. Availability still depends on the other gateway WS switches.',
-        wsModeRoutingDesc:
-          'Connection mode: when gateway.openai_ws.mode_router_v2_enabled=true, the selected mode applies, including http_bridge. When false (the default), all three modes use the legacy context pool whenever WS is allowed.',
-        wsModeHintPrefix: 'Connection behavior when the selected mode takes effect:',
+          'Applies only to the current OpenAI account type. Select Off to disable WS. Other modes use the selected connection method only when gateway.openai_ws.mode_router_v2_enabled=true; otherwise, they use the context pool.',
         wsModeOff: 'Off (off)',
         wsModeCtxPool: 'Context Pool (ctx_pool)',
         wsModePassthrough: 'Passthrough (passthrough)',
@@ -616,11 +613,11 @@ export default {
         wsModeShared: 'Shared (shared)',
         wsModeDedicated: 'Dedicated (dedicated)',
         wsModeCtxPoolHint:
-          'The gateway gets upstream WebSocket connections from a pool, reusing existing connections when possible. Gateway configuration sets the maximum number of connections in the pool.',
+          'The gateway gets and reuses upstream WS connections from a pool, with the pool limit determined by gateway configuration.',
         wsModePassthroughHint:
-          'The gateway opens a separate upstream WebSocket connection for each client session and relays messages in both directions, without using a connection pool.',
+          'The gateway opens a separate upstream WS connection for each client session, without using a connection pool.',
         wsModeHttpBridgeHint:
-          'The client connects to the gateway over WebSocket. The gateway converts requests to upstream HTTP requests, then converts SSE streaming responses back into WebSocket messages for the client.',
+          'The gateway converts client WS requests to upstream HTTP requests, then converts SSE streaming responses back into WS messages.',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           'Only applies to OpenAI OAuth. This account can use OpenAI WebSocket Mode only when enabled.',

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -605,7 +605,10 @@ export default {
           'Disabled by default. Enable to allow responses_websockets_v2 capability (still gated by global and account-type switches).',
         wsMode: 'WS mode',
         wsModeDesc:
-          'Only applies to the current OpenAI account type; account WS modes, including http_bridge, take effect only when the global gateway.openai_ws.mode_router_v2_enabled=true.',
+          'Account WS switch: select Off to disable WS for this account, or another option to enable it. Availability still depends on the other gateway WS switches.',
+        wsModeRoutingDesc:
+          'Connection mode: when gateway.openai_ws.mode_router_v2_enabled=true, the selected mode applies, including http_bridge. When false (the default), all three modes use the legacy context pool whenever WS is allowed.',
+        wsModeHintPrefix: 'Connection behavior when the selected mode takes effect:',
         wsModeOff: 'Off (off)',
         wsModeCtxPool: 'Context Pool (ctx_pool)',
         wsModePassthrough: 'Passthrough (passthrough)',

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -613,7 +613,7 @@ export default {
         wsModeShared: 'Shared (shared)',
         wsModeDedicated: 'Dedicated (dedicated)',
         wsModeConcurrencyHint:
-          'When WS mode is enabled, account concurrency becomes the WS connection pool limit for this account.',
+          'Account concurrency limits requests in flight; the context pool connection limit is controlled by the gateway connection pool settings.',
         wsModePassthroughHint: 'Passthrough mode does not use the WS connection pool.',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -612,9 +612,10 @@ export default {
         wsModeHttpBridge: 'HTTP Bridge (http_bridge)',
         wsModeShared: 'Shared (shared)',
         wsModeDedicated: 'Dedicated (dedicated)',
-        wsModeConcurrencyHint:
-          'Account concurrency limits requests in flight; the context pool connection limit is controlled by the gateway connection pool settings.',
-        wsModePassthroughHint: 'Passthrough mode does not use the WS connection pool.',
+        wsModeCtxPoolHint:
+          'Gateway → acquire upstream WS connections from the pool; capacity is determined by configuration.',
+        wsModePassthroughHint: 'Gateway → upstream WS, without a connection pool.',
+        wsModeHttpBridgeHint: 'Gateway conversion → upstream HTTP/SSE.',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           'Only applies to OpenAI OAuth. This account can use OpenAI WebSocket Mode only when enabled.',

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -613,9 +613,11 @@ export default {
         wsModeShared: 'Shared (shared)',
         wsModeDedicated: 'Dedicated (dedicated)',
         wsModeCtxPoolHint:
-          'Gateway → acquire upstream WS connections from the pool; capacity is determined by configuration.',
-        wsModePassthroughHint: 'Gateway → upstream WS, without a connection pool.',
-        wsModeHttpBridgeHint: 'Gateway conversion → upstream HTTP/SSE.',
+          'The gateway gets upstream WebSocket connections from a pool, reusing existing connections when possible. Gateway configuration sets the maximum number of connections in the pool.',
+        wsModePassthroughHint:
+          'The gateway opens a separate upstream WebSocket connection for each client session and relays messages in both directions, without using a connection pool.',
+        wsModeHttpBridgeHint:
+          'The client connects to the gateway over WebSocket. The gateway converts requests to upstream HTTP requests, then converts SSE streaming responses back into WebSocket messages for the client.',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           'Only applies to OpenAI OAuth. This account can use OpenAI WebSocket Mode only when enabled.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -698,9 +698,9 @@ export default {
         wsModeHttpBridge: 'HTTP 桥接（http_bridge）',
         wsModeShared: '共享（shared）',
         wsModeDedicated: '独享（dedicated）',
-        wsModeCtxPoolHint: '网关 → 从连接池获取上游 WS 连接，数量由配置决定。',
-        wsModePassthroughHint: '网关 → 上游 WS，不使用连接池。',
-        wsModeHttpBridgeHint: '网关转换 → 上游 HTTP/SSE。',
+        wsModeCtxPoolHint: '网关从连接池中获取上游 WebSocket 连接，优先复用已有连接。连接池最多能建立多少条连接，由网关配置决定。',
+        wsModePassthroughHint: '网关为每个客户端会话单独建立上游 WebSocket 连接，转发双方的消息，不使用连接池。',
+        wsModeHttpBridgeHint: '客户端通过 WebSocket 连接网关，网关将请求转换为上游 HTTP 请求，再把上游的 SSE 流式响应转换成 WebSocket 消息返回给客户端。',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           '仅对 OpenAI OAuth 生效。开启后该账号才允许使用 OpenAI WebSocket Mode 协议。',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -691,7 +691,10 @@ export default {
           '默认关闭。开启后可启用 responses_websockets_v2 协议能力（受网关全局开关与账号类型开关约束）。',
         wsMode: 'WS mode',
         wsModeDesc:
-          '仅对当前 OpenAI 账号类型生效；包括 http_bridge 在内的账号 WS mode 仅在全局 gateway.openai_ws.mode_router_v2_enabled=true 时生效。',
+          '账号 WS 开关：选择“关闭”可禁用本账号的 WS；选择其他选项则启用，实际是否可用仍受网关其他 WS 开关限制。',
+        wsModeRoutingDesc:
+          '连接方式：全局 gateway.openai_ws.mode_router_v2_enabled=true 时，按所选模式（包括 http_bridge）连接；为 false（默认）时，不区分这三种模式，允许 WS 时统一使用旧版上下文池。',
+        wsModeHintPrefix: '所选模式生效后的连接方式：',
         wsModeOff: '关闭（off）',
         wsModeCtxPool: '上下文池（ctx_pool）',
         wsModePassthrough: '透传（passthrough）',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -691,19 +691,16 @@ export default {
           '默认关闭。开启后可启用 responses_websockets_v2 协议能力（受网关全局开关与账号类型开关约束）。',
         wsMode: 'WS mode',
         wsModeDesc:
-          '账号 WS 开关：选择“关闭”可禁用本账号的 WS；选择其他选项则启用，实际是否可用仍受网关其他 WS 开关限制。',
-        wsModeRoutingDesc:
-          '连接方式：全局 gateway.openai_ws.mode_router_v2_enabled=true 时，按所选模式（包括 http_bridge）连接；为 false（默认）时，不区分这三种模式，允许 WS 时统一使用旧版上下文池。',
-        wsModeHintPrefix: '所选模式生效后的连接方式：',
+          '仅对当前 OpenAI 账号类型生效。选择“关闭”可禁用 WS；其余模式需全局 gateway.openai_ws.mode_router_v2_enabled=true 才按所选方式连接，未开启时统一使用上下文池。',
         wsModeOff: '关闭（off）',
         wsModeCtxPool: '上下文池（ctx_pool）',
         wsModePassthrough: '透传（passthrough）',
         wsModeHttpBridge: 'HTTP 桥接（http_bridge）',
         wsModeShared: '共享（shared）',
         wsModeDedicated: '独享（dedicated）',
-        wsModeCtxPoolHint: '网关从连接池中获取上游 WebSocket 连接，优先复用已有连接。连接池最多能建立多少条连接，由网关配置决定。',
-        wsModePassthroughHint: '网关为每个客户端会话单独建立上游 WebSocket 连接，转发双方的消息，不使用连接池。',
-        wsModeHttpBridgeHint: '客户端通过 WebSocket 连接网关，网关将请求转换为上游 HTTP 请求，再把上游的 SSE 流式响应转换成 WebSocket 消息返回给客户端。',
+        wsModeCtxPoolHint: '网关从连接池获取并复用上游 WS 连接，连接池上限由网关配置决定。',
+        wsModePassthroughHint: '网关为每个客户端会话单独建立上游 WS 连接，不使用连接池。',
+        wsModeHttpBridgeHint: '网关将客户端 WS 请求转换为上游 HTTP 请求，再将 SSE 流式响应转换为 WS 消息返回。',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           '仅对 OpenAI OAuth 生效。开启后该账号才允许使用 OpenAI WebSocket Mode 协议。',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -698,7 +698,7 @@ export default {
         wsModeHttpBridge: 'HTTP 桥接（http_bridge）',
         wsModeShared: '共享（shared）',
         wsModeDedicated: '独享（dedicated）',
-        wsModeConcurrencyHint: '启用 WS mode 后，该账号并发数将作为该账号 WS 连接池上限。',
+        wsModeConcurrencyHint: '账号并发数限制同时执行的请求数；上下文池的连接上限由网关连接池配置决定。',
         wsModePassthroughHint: 'passthrough 模式不使用 WS 连接池。',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -698,8 +698,9 @@ export default {
         wsModeHttpBridge: 'HTTP 桥接（http_bridge）',
         wsModeShared: '共享（shared）',
         wsModeDedicated: '独享（dedicated）',
-        wsModeConcurrencyHint: '账号并发数限制同时执行的请求数；上下文池的连接上限由网关连接池配置决定。',
-        wsModePassthroughHint: 'passthrough 模式不使用 WS 连接池。',
+        wsModeCtxPoolHint: '网关 → 从连接池获取上游 WS 连接，数量由配置决定。',
+        wsModePassthroughHint: '网关 → 上游 WS，不使用连接池。',
+        wsModeHttpBridgeHint: '网关转换 → 上游 HTTP/SSE。',
         oauthResponsesWebsocketsV2: 'OAuth WebSocket Mode',
         oauthResponsesWebsocketsV2Desc:
           '仅对 OpenAI OAuth 生效。开启后该账号才允许使用 OpenAI WebSocket Mode 协议。',

--- a/frontend/src/utils/__tests__/openaiWsMode.spec.ts
+++ b/frontend/src/utils/__tests__/openaiWsMode.spec.ts
@@ -7,7 +7,7 @@ import {
   isOpenAIWSModeEnabled,
   normalizeOpenAIWSMode,
   openAIWSModeFromEnabled,
-  resolveOpenAIWSModeConcurrencyHintKey,
+  resolveOpenAIWSModeHintKey,
   resolveOpenAIWSModeFromExtra
 } from '@/utils/openaiWsMode'
 
@@ -59,18 +59,16 @@ describe('openaiWsMode utils', () => {
     expect(isOpenAIWSModeEnabled(OPENAI_WS_MODE_HTTP_BRIDGE)).toBe(true)
   })
 
-  it('resolves concurrency hint key by mode', () => {
-    expect(resolveOpenAIWSModeConcurrencyHintKey(OPENAI_WS_MODE_OFF)).toBe(
-      'admin.accounts.openai.wsModeConcurrencyHint'
+  it('hides the off hint and resolves each active mode separately', () => {
+    expect(resolveOpenAIWSModeHintKey(OPENAI_WS_MODE_OFF)).toBeNull()
+    expect(resolveOpenAIWSModeHintKey(OPENAI_WS_MODE_CTX_POOL)).toBe(
+      'admin.accounts.openai.wsModeCtxPoolHint'
     )
-    expect(resolveOpenAIWSModeConcurrencyHintKey(OPENAI_WS_MODE_CTX_POOL)).toBe(
-      'admin.accounts.openai.wsModeConcurrencyHint'
-    )
-    expect(resolveOpenAIWSModeConcurrencyHintKey(OPENAI_WS_MODE_PASSTHROUGH)).toBe(
+    expect(resolveOpenAIWSModeHintKey(OPENAI_WS_MODE_PASSTHROUGH)).toBe(
       'admin.accounts.openai.wsModePassthroughHint'
     )
-    expect(resolveOpenAIWSModeConcurrencyHintKey(OPENAI_WS_MODE_HTTP_BRIDGE)).toBe(
-      'admin.accounts.openai.wsModePassthroughHint'
+    expect(resolveOpenAIWSModeHintKey(OPENAI_WS_MODE_HTTP_BRIDGE)).toBe(
+      'admin.accounts.openai.wsModeHttpBridgeHint'
     )
   })
 })

--- a/frontend/src/utils/openaiWsMode.ts
+++ b/frontend/src/utils/openaiWsMode.ts
@@ -44,13 +44,23 @@ export const isOpenAIWSModeEnabled = (mode: OpenAIWSMode): boolean => {
   return mode !== OPENAI_WS_MODE_OFF
 }
 
-export const resolveOpenAIWSModeConcurrencyHintKey = (
+export const resolveOpenAIWSModeHintKey = (
   mode: OpenAIWSMode
-): 'admin.accounts.openai.wsModeConcurrencyHint' | 'admin.accounts.openai.wsModePassthroughHint' => {
-  if (mode === OPENAI_WS_MODE_PASSTHROUGH || mode === OPENAI_WS_MODE_HTTP_BRIDGE) {
-    return 'admin.accounts.openai.wsModePassthroughHint'
+):
+  | 'admin.accounts.openai.wsModeCtxPoolHint'
+  | 'admin.accounts.openai.wsModePassthroughHint'
+  | 'admin.accounts.openai.wsModeHttpBridgeHint'
+  | null => {
+  switch (mode) {
+    case OPENAI_WS_MODE_CTX_POOL:
+      return 'admin.accounts.openai.wsModeCtxPoolHint'
+    case OPENAI_WS_MODE_PASSTHROUGH:
+      return 'admin.accounts.openai.wsModePassthroughHint'
+    case OPENAI_WS_MODE_HTTP_BRIDGE:
+      return 'admin.accounts.openai.wsModeHttpBridgeHint'
+    default:
+      return null
   }
-  return 'admin.accounts.openai.wsModeConcurrencyHint'
 }
 
 export const resolveOpenAIWSModeFromExtra = (


### PR DESCRIPTION
## 问题与改动

开启 `gateway.openai_ws.mode_router_v2_enabled=true` 并选择 `ctx_pool` 时，每账号池容量原来直接取 `min(account.concurrency, max_conns_per_account)`，绕过现有动态容量开关和 OAuth / API Key 类型系数。客户端会话在轮次之间仍持有上游连接，而请求并发槽已经释放，因此请求数不高时也可能耗尽连接池，导致 acquire 超时和 `1013 upstream websocket is busy`。

本 PR 让新版 ctx_pool 与旧版共用现有容量计算，不新增配置：

- 动态容量开启：`min(max_conns_per_account, max(1, ceil(account.concurrency * factor)))`，factor 按账号类型取现有配置。
- 动态容量关闭：使用 `max_conns_per_account`。
- 保留新版对 `account.concurrency <= 0` 返回零容量的规则，以及全局连接硬上限。
- 请求并发槽、会话租约生命周期、模式路由、passthrough 和 HTTP bridge 行为保持原样。
- 同步配置注释、示例配置和中英文界面提示。创建、编辑与批量编辑账号时，沿用上游的“公共说明 + 模式提示”结构：公共说明区分关闭账号 WS 和选择上游连接方式，并说明后者依赖全局 mode router 开关。按所选模式显示以下提示：
  - `off`：不显示模式链路提示。
  - `ctx_pool`：网关从连接池获取并复用上游 WS 连接，连接池上限由网关配置决定。
  - `passthrough`：网关为每个客户端会话单独建立上游 WS 连接，不使用连接池。
  - `http_bridge`：网关将客户端 WS 请求转换为上游 HTTP 请求，再将 SSE 流式响应转换为 WS 消息返回。

例如账号并发 5、类型系数 5、硬上限 128 时，新旧 ctx_pool 均允许最多 25 条池连接；请求并发仍为 5。容量提高不保证消除所有 1013，也不处理池满后的等待唤醒或拨号换号问题。

## 全局开关、账号模式与实际链路

下表按当前账号 UI 保存行为说明常规 OpenAI WS 接入；请求仍需满足协议开关、账号类型开关和能力校验等准入条件。

| `mode_router_v2_enabled` | 账号 WS mode | 实际连接方式 |
| --- | --- | --- |
| `false`（默认） | `off` | UI 同时将旧 WS enabled 字段设为 false，关闭账号 WS |
| `false`（默认） | `ctx_pool` / `passthrough` / `http_bridge` | UI 同时将旧 WS enabled 字段设为 true；不区分这三种连接方式，允许 WS 时统一走旧版 `ctx_pool` |
| `true` | `ctx_pool` | 客户端 WS → 网关 → 从连接池获取上游 WS 连接；连接数量由网关连接池配置决定 |
| `true` | `passthrough` | 客户端 WS → 网关 → 上游 WS，不使用连接池 |
| `true` | `http_bridge` | 客户端 WS → 网关转换 → 上游 HTTP/SSE |
| `true` | `off` | 该账号不参与 WS 接入 |

这里有两层含义：账号是否启用 WS，以及启用后采用什么连接方式。全局开关为 `false` 时，后端忽略 mode 字符串，读取旧 enabled 字段；当前 UI 保存时会同时写入两者，因此选择 `off` 仍会关闭账号 WS，不能笼统称为“WS mode 配置完全无效”。如果仅通过 API 修改 mode 而未更新 enabled，旧版行为由原 enabled 值决定。

全局开关为 `false` 时，在账号界面选择 `passthrough` 并不会切换到新版透传路径。本 PR 对齐两条 `ctx_pool` 路径的容量计算，并澄清界面说明；现有控件、保存逻辑和模式分流规则保持原样。

## 历史调查：为什么此前没有对齐

| 阶段 | 可核对记录 | 对容量规则的影响 |
| --- | --- | --- |
| #682，初始全量同步 | [bb664d9](https://github.com/Wei-Shaw/sub2api/commit/bb664d9bbfe8fe004fdc47c55653c5c904a6bed1) 中，新版直接返回账号并发数；测试 `ModeRouterV2UsesAccountConcurrency` 设置并发 20、硬上限 8、OAuth 系数 0.3，却明确期待 20，断言“v2 路径应直接使用账号并发数作为池上限”；同期 UI 使用同样说明 | 这是代码、测试、UI 一致表达的历史规则，不能简单归因为漏同步 |
| #772，新增透传并整理模式 | [1d0872e](https://github.com/Wei-Shaw/sub2api/commit/1d0872e7cace0c0386131443ac5e3e4046e96f3b) 将 shared / dedicated 归并为 ctx_pool，并增加 passthrough 路由 | 沿用新版容量规则，没有接入动态系数 |
| #4163，会话生命周期约束 | [c8cfc93](https://github.com/Wei-Shaw/sub2api/commit/c8cfc936326fd98da046cfc74123fb1bb8985385) 将直接返回并发数改为 `min(concurrency, hardCap)`；测试改为 `ModeRouterV2RespectsHardCap`，同一组 20 / 8 / 0.3 的期望从 20 改成 8 | 补了全局硬上限，继续忽略系数，没有改成按系数应得的 6 |
| #7043，默认系数调整 | 默认类型系数 1.0 → 5.0，PR 明确“不改账号并发，不改上限公式” | 对沿用旧公式的路径有效；新版提前返回，改默认值不会进入新版容量计算 |
| 本 PR | 保留新版非法并发检查后进入共用公式，并更新原有测试及提示 | 明确调整旧规则，使同一组配置对两条池路径生效 |

已查阅上述 PR 正文、评论、review 及相关提交。记录能确认历史行为是有意写入契约的，但没有找到作者进一步解释“为什么必须忽略类型系数”的设计理由；不推测作者动机。

**补充校正 #7043 的历史归因：** 跨轮次保留上游连接并非由 #4163 首次引入。#682 的 `openai_ws_forwarder.go` 已有 `defer releaseSessionLease()`，同期 handler 的 `AfterTurn` 已调用 `releaseTurnSlots()`，后续轮次重新抢槽。#4163 是为已经存在的长会话补充默认 300 秒轮次间空闲回收、每 API key 活连接限制和健康检查保护。这也说明“存活连接数与在飞请求数不相等”的容量问题在新版路径同样存在。

## 与 #7043 及其他 PR 的链路关系

- #7043 调整**默认系数**；本 PR 调整**新版是否使用既有系数及开关**。二者互补，提交互相独立。
- 创建本 PR 时 #7043 尚未合并，本 PR 基于上游 main，只包含本次算法、测试和说明增量，保留上游现有默认系数 1.0。显式设置系数即可使用本次修复；默认扩容到 5.0 由 #7043 提供。
- #7049 处理池满等待者在其他连接释放或后台建连完成后重新选择的问题，属于另一条链路。容量计算与等待唤醒可以分别合入；仅修正容量后，默认预热场景仍可能遇到 #7049 的排队问题。本次池行为测试将目标利用率设为 1，避免预热提前建连，使测试单独验证容量边界。
- passthrough 不使用此连接池；UI 选择 passthrough 也须全局 mode router 开关生效才会进入新版分流。既有测试部署全局开关未配置，采用默认 false，因此此前观测走的是旧版池路径。

## 既有观测与本次验证的边界

#7043 记录了同机 4 个 OAuth 账号、每账号并发 5、Codex 多会话场景的配置对照：系数 1.0 窗口有 4542 轮请求、518 次 acquire timeout / 1013 busy；系数 5 窗口有 4450 轮、0 次这类错误，后者观测约 18 小时。这些是**旧版路径的历史数据**，用于说明连接容量成因，不作为本 PR 新版路径的线上实测，也不证明 5.0 是所有部署的最佳值。

本次先加入回归测试并确认旧实现失败：新版扩容用例期待 5、实际 1；关闭动态开关期待硬上限 8、实际 2；保持前两条租约时旧版可取得第三条连接，新版超时。修改后同一组测试通过。

## 兼容性与配置

本次是已开启 mode router v2 的部署的行为调整：
- 现有显式 OAuth / API Key 系数将开始生效；大于 1 可增加容量，小于 1 可缩小容量，仍受硬上限约束。
- 现有动态容量开关设为 false 时，新版将使用硬上限，不再以账号并发数限制连接池。
- 动态开关开启、系数为 1 时，正并发账号的容量保持原结果；新版零/负并发账号继续拒绝获取连接。
- 若希望保留此前新版的正并发容量，可开启动态容量并将对应类型系数设为 1。连接可能增加的部署应结合上游允许连接数设置硬上限。

## 验证

- 在上游基线上完成红绿验证：恢复旧公式时仅新版的第三条连接获取超时；应用本 PR 后通过。覆盖 OAuth / API Key 系数、向上取整、全局硬上限、动态开关、nil 账号、零/负并发、保留租约时扩容以及释放后的连接复用。
- **独立 PR 分支**：`go test -vet=off -p 1 -tags=unit ./...` 全部通过；`golangci-lint run --concurrency 2 --timeout 10m ./...` 为 0 issues。
- Windows 首轮全量单测发现缺少 `sh` 和代理影响本地连接测试的环境问题。仅在测试子进程的 PATH 加入现有 Git `usr/bin` 并清除代理环境变量后，上述全量单测通过；没有修改宿主全局配置或相关业务代码。
- **当前 main 工作区**：连接池定向回归通过；`go test -vet=off -p 1 -tags=integration ./...` 退出 0。需要 Docker 的数据库集成测试因 Docker 不可用被测试框架跳过，不能视为已完成数据库集成验证。
- **前端**：容量说明调整时 Makefile 关键测试及 WS 模式测试共 16 个文件、189 项测试通过；最终精简文案修改后，创建/编辑/批量编辑组件、模式映射和 i18n 共 6 个文件、160 项测试通过，目标文件 lint、完整类型检查及前端构建通过。
- `git diff --check` 通过；PR 仅包含本次容量计算及直接相关的测试、配置说明和界面文案增量，已核对与 main 上对应改动一致。
- 已将包含容量修复和最终中英文模式提示的测试构建部署验证。旧程序已备份，配置内容未更改；运行程序与本地构建校验一致，首页与健康检查返回 200，中英文说明及账号管理页面资源与本地构建逐字节一致，检查窗口内无服务错误日志。
- 以上为部署与页面资源冒烟验证，没有新增真实上游 E2E 测试数据。

