### PR TITLE
fix: 修复视频计费展示与智谱渠道监控探测路径问题

### DIFF
--- a/backend/internal/handler/model_plaza_handler.go
+++ b/backend/internal/handler/model_plaza_handler.go
@@ -92,6 +92,10 @@ type modelPlazaGroup struct {
 	// 不取分组/用户专属倍率。
 	ImageRateIndependent bool    `json:"image_rate_independent"`
 	ImageRateMultiplier  float64 `json:"image_rate_multiplier"`
+	// 生视频独立倍率：为 true 时视频计费模型的实付倍率取 VideoRateMultiplier，
+	// 不取分组/用户专属倍率。
+	VideoRateIndependent bool    `json:"video_rate_independent"`
+	VideoRateMultiplier  float64 `json:"video_rate_multiplier"`
 	// 分组是否启用长上下文阶梯计费；关闭时模型实付列只展示最低档/基础价。
 	LongContextPricingEnabled bool              `json:"long_context_pricing_enabled"`
 	Models                    []modelPlazaModel `json:"models"`
@@ -211,6 +215,8 @@ func toModelPlazaGroupDTO(g *service.PlazaGroup, userRates map[int64]float64) mo
 		IsExclusive:               g.IsExclusive,
 		ImageRateIndependent:      g.ImageRateIndependent,
 		ImageRateMultiplier:       g.ImageRateMultiplier,
+		VideoRateIndependent:      g.VideoRateIndependent,
+		VideoRateMultiplier:       g.VideoRateMultiplier,
 		LongContextPricingEnabled: g.LongContextPricingEnabled,
 		Models:                    models,
 	}

--- a/backend/internal/service/channel_monitor_checker.go
+++ b/backend/internal/service/channel_monitor_checker.go
@@ -224,6 +224,13 @@ var providerKimiChatAdapter = newOpenAICompatibleChatAdapter(providerOpenAIPath)
 //nolint:gochecknoglobals // 适配器表是只读静态数据，初始化后不变更。
 var providerZhipuChatAdapter = newOpenAICompatibleChatAdapter(providerZhipuPath)
 
+// providerZhipuCompatibleChatAdapter 供非官方域名的 zhipu 监控使用：第三方 OpenAI
+// 兼容中转站通常只实现通用的 /v1/chat/completions，不支持智谱官方原生路径
+// （/api/paas/v4/chat/completions）。见 isZhipuOfficialEndpoint。
+//
+//nolint:gochecknoglobals // 适配器表是只读静态数据，初始化后不变更。
+var providerZhipuCompatibleChatAdapter = newOpenAICompatibleChatAdapter(providerOpenAIPath)
+
 //nolint:gochecknoglobals // 适配器表是只读静态数据，初始化后不变更。
 var providerDeepseekChatAdapter = newOpenAICompatibleChatAdapter(providerOpenAIPath)
 
@@ -266,10 +273,30 @@ var providerOpenAIResponsesAdapter = providerAdapter{
 	textPath: "output.0.content.0.text",
 }
 
-// providerAdapterFor 按 provider + api_mode 选择具体 adapter。
-func providerAdapterFor(provider, apiMode string) (providerAdapter, string, bool) {
+// zhipuOfficialHost 智谱官方 API 域名。官方原生路径
+// （/api/paas/v4/chat/completions，即 providerZhipuPath）只有这个域名才实现；
+// 任何其它域名都是第三方中转站，只保证支持通用的 /v1/chat/completions。
+const zhipuOfficialHost = "open.bigmodel.cn"
+
+// isZhipuOfficialEndpoint 判断 endpoint 是否指向智谱官方域名。
+// 解析失败时保守地当作官方域名，保留一直以来的默认行为——真正畸形的
+// endpoint 会在 validateEndpoint 阶段被拦下，走不到这里。
+func isZhipuOfficialEndpoint(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return true
+	}
+	return strings.EqualFold(u.Hostname(), zhipuOfficialHost)
+}
+
+// providerAdapterFor 按 provider + api_mode 选择具体 adapter；zhipu 额外按 endpoint
+// 是否为官方域名在原生路径 / 通用兼容路径间切换（见 isZhipuOfficialEndpoint）。
+func providerAdapterFor(provider, apiMode, endpoint string) (providerAdapter, string, bool) {
 	if provider == MonitorProviderOpenAI && defaultAPIMode(apiMode) == MonitorAPIModeResponses {
 		return providerOpenAIResponsesAdapter, MonitorAPIModeResponses, true
+	}
+	if provider == MonitorProviderZhipu && !isZhipuOfficialEndpoint(endpoint) {
+		return providerZhipuCompatibleChatAdapter, MonitorAPIModeChatCompletions, true
 	}
 	adapter, ok := providerAdapters[provider]
 	return adapter, MonitorAPIModeChatCompletions, ok
@@ -288,7 +315,7 @@ func callProvider(ctx context.Context, provider, endpoint, apiKey, model, prompt
 	if err := validateAPIMode(provider, requestedAPIMode); err != nil {
 		return "", "", 0, err
 	}
-	adapter, apiMode, ok := providerAdapterFor(provider, requestedAPIMode)
+	adapter, apiMode, ok := providerAdapterFor(provider, requestedAPIMode, endpoint)
 	if !ok {
 		return "", "", 0, fmt.Errorf("unsupported provider %q", provider)
 	}

--- a/backend/internal/service/channel_monitor_endpoint_test.go
+++ b/backend/internal/service/channel_monitor_endpoint_test.go
@@ -57,6 +57,47 @@ func TestNormalizeMonitorEndpoint_PreservesBasePath(t *testing.T) {
 		normalizeEndpoint("https://relay.example/tenant%2Fone/anthropic/v1/"))
 }
 
+func TestIsZhipuOfficialEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		endpoint string
+		want     bool
+	}{
+		{"https://open.bigmodel.cn", true},
+		{"https://open.bigmodel.cn/api/paas/v4", true},
+		{"https://OPEN.BIGMODEL.CN/api/coding/paas/v4", true},
+		{"https://relay.example.com", false},
+		{"https://not-open.bigmodel.cn", false},
+		{"https://open.bigmodel.cn.evil.com", false},
+		{"://bad", true}, // url.Parse 失败时保守当作官方域名，保留旧行为
+	} {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			require.Equal(t, tc.want, isZhipuOfficialEndpoint(tc.endpoint))
+		})
+	}
+}
+
+func TestProviderAdapterFor_ZhipuPathSelection(t *testing.T) {
+	// 官方域名（含 Coding 计划的 base path）：走官方原生路径，行为不变。
+	for _, endpoint := range []string{"https://open.bigmodel.cn", "https://open.bigmodel.cn/api/paas/v4", "https://open.bigmodel.cn/api/coding/paas/v4"} {
+		t.Run("official/"+endpoint, func(t *testing.T) {
+			adapter, apiMode, ok := providerAdapterFor(MonitorProviderZhipu, "", endpoint)
+			require.True(t, ok)
+			require.Equal(t, MonitorAPIModeChatCompletions, apiMode)
+			require.Equal(t, providerZhipuPath, adapter.buildPath("glm-5.3-flash"))
+		})
+	}
+
+	// 第三方中转站：回退到通用兼容路径，修复 404。
+	for _, endpoint := range []string{"https://relay.example.com", "https://api.opkaa.com"} {
+		t.Run("third-party/"+endpoint, func(t *testing.T) {
+			adapter, apiMode, ok := providerAdapterFor(MonitorProviderZhipu, "", endpoint)
+			require.True(t, ok)
+			require.Equal(t, MonitorAPIModeChatCompletions, apiMode)
+			require.Equal(t, providerOpenAIPath, adapter.buildPath("glm-5.3-flash"))
+		})
+	}
+}
+
 func TestCallProvider_BasePath(t *testing.T) {
 	swapMonitorHTTPClient(t)
 	requests := make(chan string, 1)
@@ -83,7 +124,9 @@ func TestCallProvider_BasePath(t *testing.T) {
 		{"openai chat version", MonitorProviderOpenAI, "", "/relay/v1/", "/relay/v1/chat/completions"},
 		{"openai responses version", MonitorProviderOpenAI, MonitorAPIModeResponses, "/relay/v1", "/relay/v1/responses"},
 		{"gemini version", MonitorProviderGemini, "", "/relay/v1beta", "/relay/v1beta/models/test-model:generateContent"},
-		{"zhipu version", MonitorProviderZhipu, "", "/api/paas/v4", "/api/paas/v4/chat/completions"},
+		// httptest server 的地址不是官方域名 open.bigmodel.cn，所以按当前行为
+		// （见 isZhipuOfficialEndpoint）应该回退到通用兼容路径，而不是官方原生路径。
+		{"zhipu third-party relay", MonitorProviderZhipu, "", "", "/v1/chat/completions"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, status, err := callProvider(context.Background(), tc.provider,

--- a/backend/internal/service/model_plaza_service.go
+++ b/backend/internal/service/model_plaza_service.go
@@ -52,6 +52,10 @@ type PlazaGroup struct {
 	// = 档位价 × ImageRateMultiplier，不乘分组/用户专属倍率（与计费口径一致）。
 	ImageRateIndependent bool
 	ImageRateMultiplier  float64
+	// 视频按次实付倍率：VideoRateIndependent 为 true 时，视频计费模型的实付
+	// = 档位价 × VideoRateMultiplier，不乘分组/用户专属倍率（与计费口径一致）。
+	VideoRateIndependent bool
+	VideoRateMultiplier  float64
 	// LongContextPricingEnabled 分组是否按上下文长度应用阶梯价；关闭时模型展示的是最低档。
 	LongContextPricingEnabled bool
 	Models                    []PlazaModel
@@ -132,6 +136,8 @@ func (s *ModelPlazaService) ListGroups(ctx context.Context) ([]PlazaGroup, error
 			IsExclusive:               g.IsExclusive,
 			ImageRateIndependent:      g.ImageRateIndependent,
 			ImageRateMultiplier:       g.ImageRateMultiplier,
+			VideoRateIndependent:      g.VideoRateIndependent,
+			VideoRateMultiplier:       g.VideoRateMultiplier,
 			LongContextPricingEnabled: g.LongContextPricingEnabled,
 		}
 		groupEnt[g.ID] = g

--- a/backend/internal/service/model_plaza_service_test.go
+++ b/backend/internal/service/model_plaza_service_test.go
@@ -324,6 +324,42 @@ func TestListPlazaGroups_GroupImagePriceIgnoredForNonImageModes(t *testing.T) {
 	require.Nil(t, p.PerRequestPrice)
 }
 
+func TestListPlazaGroups_VideoRateIndependentPassthrough(t *testing.T) {
+	// 分组开启视频独立倍率时，PlazaGroup 应透传 VideoRateIndependent/VideoRateMultiplier，
+	// 与图片独立倍率字段的透传方式一致（对应 model_plaza_service.go 曾遗漏的字段）。
+	perSecond := 0.1
+	channels := []Channel{{
+		ID: 1, Name: "video-ch", Status: StatusActive, GroupIDs: []int64{10, 20},
+		ModelPricing: []ChannelModelPricing{{
+			Platform:        "grok",
+			Models:          []string{"grok-video"},
+			BillingMode:     BillingModeVideo,
+			PerRequestPrice: &perSecond,
+		}},
+	}}
+	groups := []Group{
+		{ID: 10, Name: "g-video", Platform: "grok", RateMultiplier: 0.15,
+			VideoRateIndependent: true, VideoRateMultiplier: 1},
+		{ID: 20, Name: "g-plain", Platform: "grok", RateMultiplier: 0.1},
+	}
+	svc := newPlazaService(channels, groups, nil)
+	out, err := svc.ListGroups(context.Background())
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	byName := map[string]PlazaGroup{}
+	for _, g := range out {
+		byName[g.Name] = g
+	}
+
+	video := byName["g-video"]
+	require.True(t, video.VideoRateIndependent)
+	require.InDelta(t, 1.0, video.VideoRateMultiplier, 1e-9)
+
+	plain := byName["g-plain"]
+	require.False(t, plain.VideoRateIndependent)
+	require.InDelta(t, 0.0, plain.VideoRateMultiplier, 1e-9)
+}
+
 func TestListPlazaGroups_RepoErrorsPropagate(t *testing.T) {
 	sentinel := errors.New("boom")
 	repo := &mockChannelRepository{

--- a/frontend/src/api/modelPlaza.ts
+++ b/frontend/src/api/modelPlaza.ts
@@ -73,6 +73,9 @@ export interface ModelPlazaGroup {
   /** 生图独立倍率：true 时图片计费模型的实付倍率取 image_rate_multiplier，不取分组/专属倍率。 */
   image_rate_independent: boolean
   image_rate_multiplier: number
+  /** 生视频独立倍率：true 时视频计费模型的实付倍率取 video_rate_multiplier，不取分组/专属倍率。 */
+  video_rate_independent: boolean
+  video_rate_multiplier: number
   /** 分组是否启用长上下文阶梯计费；false 时实付列只展示最低档，官方阶梯仅供参考。 */
   long_context_pricing_enabled: boolean
   models: PlazaModel[]

--- a/frontend/src/components/channels/SupportedModelChip.vue
+++ b/frontend/src/components/channels/SupportedModelChip.vue
@@ -135,6 +135,17 @@
               :scale="1"
             />
 
+            <PricingRow
+              v-if="
+                model.pricing.billing_mode === BILLING_MODE_VIDEO &&
+                model.pricing.per_request_price != null
+              "
+              :label="t(prefixKey('videoPrice'))"
+              :value="model.pricing.per_request_price"
+              :unit="t(prefixKey('unitPerSecond'))"
+              :scale="1"
+            />
+
             <div
               v-if="model.pricing.intervals && model.pricing.intervals.length > 0"
               class="mt-2 border-t pt-2"
@@ -172,7 +183,8 @@ import { formatScaled, resolveIntervalPrices } from '@/utils/pricing'
 import {
   BILLING_MODE_TOKEN,
   BILLING_MODE_PER_REQUEST,
-  BILLING_MODE_IMAGE
+  BILLING_MODE_IMAGE,
+  BILLING_MODE_VIDEO
 } from '@/constants/channel'
 // 复用 api/channels.ts 的用户侧最小形态 DTO。
 // admin 侧 ChannelModelPricing 字段更多，但结构上是用户 DTO 的超集，admin 视图传入可直接通过结构化子类型检查。
@@ -235,6 +247,8 @@ const billingModeLabel = computed(() => {
       return t(prefixKey('billingModePerRequest'))
     case BILLING_MODE_IMAGE:
       return t(prefixKey('billingModeImage'))
+    case BILLING_MODE_VIDEO:
+      return t(prefixKey('billingModeVideo'))
     default:
       return '-'
   }
@@ -246,7 +260,11 @@ function formatRange(min: number, max: number | null): string {
 }
 
 function formatInterval(iv: UserPricingInterval, pricing: UserSupportedModelPricing): string {
-  if (pricing.billing_mode === BILLING_MODE_PER_REQUEST || pricing.billing_mode === BILLING_MODE_IMAGE) {
+  if (
+    pricing.billing_mode === BILLING_MODE_PER_REQUEST ||
+    pricing.billing_mode === BILLING_MODE_IMAGE ||
+    pricing.billing_mode === BILLING_MODE_VIDEO
+  ) {
     return formatScaled(iv.per_request_price, 1)
   }
   const resolved = resolveIntervalPrices(iv, pricing)

--- a/frontend/src/components/channels/__tests__/SupportedModelChip.spec.ts
+++ b/frontend/src/components/channels/__tests__/SupportedModelChip.spec.ts
@@ -51,4 +51,107 @@ describe('SupportedModelChip', () => {
     expect(document.body.textContent).toContain('$20 / $75')
     wrapper.unmount()
   })
+
+  it('按视频计费模式展示计费模式标签、按秒单价与分辨率档位定价', async () => {
+    const wrapper = mount(SupportedModelChip, {
+      attachTo: document.body,
+      props: {
+        model: {
+          name: 'grok-video',
+          platform: '',
+          pricing: {
+            billing_mode: 'video',
+            input_price: null,
+            output_price: null,
+            cache_write_price: null,
+            cache_read_price: null,
+            image_input_price: null,
+            image_output_price: null,
+            per_request_price: 0.1,
+            intervals: [
+              {
+                min_tokens: 0,
+                max_tokens: null,
+                tier_label: '480p',
+                input_price: null,
+                output_price: null,
+                cache_write_price: null,
+                cache_read_price: null,
+                per_request_price: 0.1
+              },
+              {
+                min_tokens: 0,
+                max_tokens: null,
+                tier_label: '720p',
+                input_price: null,
+                output_price: null,
+                cache_write_price: null,
+                cache_read_price: null,
+                per_request_price: 0.2
+              },
+              {
+                min_tokens: 0,
+                max_tokens: null,
+                tier_label: '1080p',
+                input_price: null,
+                output_price: null,
+                cache_write_price: null,
+                cache_read_price: null,
+                per_request_price: 0.3
+              }
+            ]
+          }
+        },
+        showPlatform: false
+      }
+    })
+
+    await wrapper.find('[tabindex="0"]').trigger('mouseenter')
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    // 计费模式标签走 VIDEO 分支,不再落到空的 default 分支
+    expect(text).toContain('availableChannels.pricing.billingModeVideo')
+    // 分辨率档位标签与各自单价(旧 bug 下 formatInterval 不识别 video,全部显示为 -)
+    expect(text).toContain('480p')
+    expect(text).toContain('$0.1')
+    expect(text).toContain('720p')
+    expect(text).toContain('$0.2')
+    expect(text).toContain('1080p')
+    expect(text).toContain('$0.3')
+    wrapper.unmount()
+  })
+
+  it('按视频计费模式无阶梯定价时展示默认每秒单价', async () => {
+    const wrapper = mount(SupportedModelChip, {
+      attachTo: document.body,
+      props: {
+        model: {
+          name: 'grok-video-flat',
+          platform: '',
+          pricing: {
+            billing_mode: 'video',
+            input_price: null,
+            output_price: null,
+            cache_write_price: null,
+            cache_read_price: null,
+            image_input_price: null,
+            image_output_price: null,
+            per_request_price: 0.15,
+            intervals: []
+          }
+        },
+        showPlatform: false
+      }
+    })
+
+    await wrapper.find('[tabindex="0"]').trigger('mouseenter')
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('availableChannels.pricing.videoPrice')
+    expect(text).toContain('$0.15')
+    expect(text).toContain('availableChannels.pricing.unitPerSecond')
+    wrapper.unmount()
+  })
 })

--- a/frontend/src/components/modelPlaza/PlazaGroupSection.vue
+++ b/frontend/src/components/modelPlaza/PlazaGroupSection.vue
@@ -61,6 +61,8 @@
         :user-rate-multiplier="group.user_rate_multiplier ?? null"
         :image-rate-independent="group.image_rate_independent"
         :image-rate-multiplier="group.image_rate_multiplier"
+        :video-rate-independent="group.video_rate_independent"
+        :video-rate-multiplier="group.video_rate_multiplier"
         :peak-window="peakWindow"
         :peak-rate-multiplier="group.peak_rate_multiplier"
       />

--- a/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
+++ b/frontend/src/components/modelPlaza/PlazaModelPricingTable.vue
@@ -287,7 +287,7 @@
               >{{ periodRate(period) }}x</span
             >
             <span
-              v-else-if="usesIndependentImageRate(m)"
+              v-else-if="usesIndependentRequestRate(m)"
               class="font-bold text-gray-700 dark:text-gray-300"
               >{{ requestRate(m) }}x</span
             >
@@ -311,6 +311,7 @@ import { platformAccentColor, platformBadgeLightClass, platformLabel } from '@/u
 import {
   BILLING_MODE_TOKEN,
   BILLING_MODE_IMAGE,
+  BILLING_MODE_VIDEO,
   type BillingMode
 } from '@/constants/channel'
 import type { PlazaModel, PlazaTimePricingPeriod } from '@/api/modelPlaza'
@@ -327,6 +328,9 @@ const props = defineProps<{
   /** 生图独立倍率:true 时图片计费模型的实付倍率取 imageRateMultiplier,不取分组/专属倍率。 */
   imageRateIndependent?: boolean
   imageRateMultiplier?: number | null
+  /** 生视频独立倍率:true 时视频计费模型的实付倍率取 videoRateMultiplier,不取分组/专属倍率。 */
+  videoRateIndependent?: boolean
+  videoRateMultiplier?: number | null
   /**
    * 高峰窗口描述(含倍率与服务器时区标注),空串/缺省 = 分组未启用高峰。
    * 表格所有价格均为不含高峰因子的口径,该窗口仅用于分时时段行的 tooltip 披露:
@@ -412,14 +416,18 @@ function paidPerMillion(value: number | null | undefined, period: PlazaTimePrici
   return formatScaled(value * rate, PER_MILLION, MIN_DECIMALS)
 }
 
-/** 图片计费模型且分组开启生图独立倍率:实付倍率取独立倍率,与计费口径一致。 */
-function usesIndependentImageRate(m: PlazaModel): boolean {
-  return billingMode(m) === BILLING_MODE_IMAGE && props.imageRateIndependent === true
+/** 图片/视频计费模型且分组开启对应独立倍率:实付倍率取独立倍率,与计费口径一致。 */
+function usesIndependentRequestRate(m: PlazaModel): boolean {
+  const mode = billingMode(m)
+  if (mode === BILLING_MODE_IMAGE) return props.imageRateIndependent === true
+  if (mode === BILLING_MODE_VIDEO) return props.videoRateIndependent === true
+  return false
 }
 
-/** 按次/按图片行的生效倍率。 */
+/** 按次/按图片/按视频行的生效倍率。 */
 function requestRate(m: PlazaModel): number {
-  return usesIndependentImageRate(m) ? (props.imageRateMultiplier ?? 1) : effectiveRate.value
+  if (!usesIndependentRequestRate(m)) return effectiveRate.value
+  return billingMode(m) === BILLING_MODE_VIDEO ? (props.videoRateMultiplier ?? 1) : (props.imageRateMultiplier ?? 1)
 }
 
 /** 按次 / 按图片单价(乘该行生效倍率,不换算 1M)。 */

--- a/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
+++ b/frontend/src/components/modelPlaza/__tests__/PlazaModelPricingTable.spec.ts
@@ -46,6 +46,8 @@ function mountTable(
   extraProps?: {
     imageRateIndependent?: boolean
     imageRateMultiplier?: number | null
+    videoRateIndependent?: boolean
+    videoRateMultiplier?: number | null
     peakWindow?: string
     peakRateMultiplier?: number | null
   }
@@ -402,6 +404,69 @@ describe('PlazaModelPricingTable', () => {
     expect(text).toContain('$0.02')
     const rateCell = wrapper.findAll('tbody tr td').at(-1)!
     expect(rateCell.text()).toBe('0.1x')
+  })
+
+  it('视频独立倍率开启时,按视频价格 × 独立倍率,不乘分组倍率;倍率列展示独立倍率', () => {
+    const model = tokenModel({
+      name: 'grok-video',
+      pricing: {
+        billing_mode: 'video',
+        input_price: null,
+        output_price: null,
+        cache_write_price: null,
+        cache_read_price: null,
+        image_input_price: null,
+        image_output_price: null,
+        per_request_price: null,
+        intervals: [
+          {
+            min_tokens: 0,
+            max_tokens: null,
+            tier_label: '480p',
+            input_price: null,
+            output_price: null,
+            cache_write_price: null,
+            cache_read_price: null,
+            per_request_price: 0.1
+          }
+        ]
+      },
+      official_pricing: null
+    })
+    const wrapper = mountTable([model], 0.15, null, {
+      videoRateIndependent: true,
+      videoRateMultiplier: 1
+    })
+    const text = wrapper.text()
+    // 0.1 × 1(独立倍率),而非 0.1 × 0.15
+    expect(text).toContain('$0.1')
+    expect(text).not.toContain('$0.015')
+    // 倍率列展示独立倍率 1x,而非分组倍率 0.15x
+    const rateCell = wrapper.findAll('tbody tr td').at(-1)!
+    expect(rateCell.text()).toBe('1x')
+  })
+
+  it('视频独立倍率关闭时,按视频价格仍乘分组/专属生效倍率', () => {
+    const model = tokenModel({
+      name: 'grok-video',
+      pricing: {
+        billing_mode: 'video',
+        input_price: null,
+        output_price: null,
+        cache_write_price: null,
+        cache_read_price: null,
+        image_input_price: null,
+        image_output_price: null,
+        per_request_price: 0.2,
+        intervals: []
+      },
+      official_pricing: null
+    })
+    const wrapper = mountTable([model], 0.15, null, { videoRateIndependent: false })
+    const text = wrapper.text()
+    expect(text).toContain('$0.03')
+    const rateCell = wrapper.findAll('tbody tr td').at(-1)!
+    expect(rateCell.text()).toBe('0.15x')
   })
 
   it('按图模型主行展示阶梯芯片,不把 image_output_price(每 token)当按次价', () => {

--- a/frontend/src/i18n/locales/en/admin/channels.ts
+++ b/frontend/src/i18n/locales/en/admin/channels.ts
@@ -35,9 +35,11 @@ export default {
         cacheReadPrice: 'Cache Read',
         imageOutputPrice: 'Image Output',
         perRequestPrice: 'Per Request',
+        videoPrice: 'Video Price',
         intervals: 'Tiered Pricing',
         unitPerMillion: '/ 1M tokens',
-        unitPerRequest: '/ request'
+        unitPerRequest: '/ request',
+        unitPerSecond: '/ sec'
       }
     },
 

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -601,9 +601,11 @@ export default {
       imageInputPrice: 'Image Input',
       imageOutputPrice: 'Image Output',
       perRequestPrice: 'Per Request',
+      videoPrice: 'Video Price',
       intervals: 'Tiered Pricing',
       unitPerMillion: '/ 1M tokens',
-      unitPerRequest: '/ request'
+      unitPerRequest: '/ request',
+      unitPerSecond: '/ sec'
     }
   },
 

--- a/frontend/src/i18n/locales/zh/admin/channels.ts
+++ b/frontend/src/i18n/locales/zh/admin/channels.ts
@@ -35,9 +35,11 @@ export default {
         cacheReadPrice: '缓存读取',
         imageOutputPrice: '图片输出',
         perRequestPrice: '每次请求',
+        videoPrice: '视频价格',
         intervals: '阶梯定价',
         unitPerMillion: '/ 1M token',
-        unitPerRequest: '/ 次'
+        unitPerRequest: '/ 次',
+        unitPerSecond: '/ 秒'
       }
     },
 

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -606,9 +606,11 @@ export default {
       imageInputPrice: '图片输入',
       imageOutputPrice: '图片输出',
       perRequestPrice: '每次请求',
+      videoPrice: '视频价格',
       intervals: '阶梯定价',
       unitPerMillion: '/ 1M token',
-      unitPerRequest: '/ 次'
+      unitPerRequest: '/ 次',
+      unitPerSecond: '/ 秒'
     }
   },
 


### PR DESCRIPTION
Fixes #7068
Fixes #7067

这个 PR 修了两个 issue 里记录的三个问题：视频计费展示（#7068，两处）和智谱渠道监控探测路径硬编码（#7067）。

## 问题一：视频计费（#7068）

跟 `billing_mode=video` 展示相关的两处问题：

1. **可用渠道定价弹窗**（`SupportedModelChip.vue`）：组件完全没处理 `BILLING_MODE_VIDEO`——计费模式显示为 `-`，配置了固定按秒单价时整行不展示，配置了分辨率阶梯价（480p/720p/1080p）时因为 `formatInterval` 不识别 video 模式，每一档都显示 `-`。
2. **模型广场**（`model_plaza_service.go` / `model_plaza_handler.go`）：`PlazaGroup`/`modelPlazaGroup` 只透传了 `ImageRateIndependent`/`ImageRateMultiplier`，没有透传 `Group` 上已经存在的 `VideoRateIndependent`/`VideoRateMultiplier`。导致分组即使配置了视频独立倍率（如 1x），模型广场的"折扣倍率"列上视频模型仍然展示分组通用倍率（如 0.15x）。

这两个都只是展示问题：实际计费的 `calculateOpenAIVideoCost`/`resolveVideoRateMultiplier` 逻辑本身是对的（已逐行确认），不影响真实扣费，只是管理员/用户在这两个预览页面看到的价格和倍率是错的。

### 改动

- `SupportedModelChip.vue`：引入 `BILLING_MODE_VIDEO`，补上 `billingModeLabel` 分支，为按秒固定价新增一行 `PricingRow`（读 `per_request_price`，新增 `videoPrice`/`unitPerSecond` i18n key），并让 `formatInterval` 把 video 档位当作按次/按图片档位处理。
- `model_plaza_service.go`：给 `PlazaGroup` 补上 `VideoRateIndependent`/`VideoRateMultiplier` 两个字段，`ListGroups` 里从 `Group` 透传。
- `model_plaza_handler.go`：`modelPlazaGroup` 这个 JSON DTO 和 `toModelPlazaGroupDTO` 同步补上。
- `frontend/src/api/modelPlaza.ts`、`PlazaGroupSection.vue`、`PlazaModelPricingTable.vue`：把新字段一路传到表格组件，并把原本图片专用的 `usesIndependentImageRate`/`requestRate` 泛化成 `usesIndependentRequestRate`/`requestRate`，让图片和视频复用同一套独立倍率判断逻辑。
- i18n：`videoPrice`/`unitPerSecond` 两个 key 在 zh/en 两个语言、`dashboard.ts`（用户侧）和 `admin/channels.ts`（管理端）两个前缀里都补齐了（这个组件在两处共用）。

## 问题二：渠道监控 zhipu 探测路径硬编码（#7067）

`channel_monitor_checker.go` 里 zhipu 的探活 adapter 固定用智谱官方原生路径 `/api/paas/v4/chat/completions`，跟 kimi/deepseek/minimax 共用的通用路径 `/v1/chat/completions` 不一样。这条原生路径只有官方域名 `open.bigmodel.cn` 才实现，配置成第三方 OpenAI 兼容中转站的 zhipu 监控必定 404——kimi/deepseek 监控指向同一个中转站却能正常探活，纯粹是因为它们自己的官方原生路径恰好等于通用路径，运气好而已。

由于 `/api/paas/v4/chat/completions` 只在 `open.bigmodel.cn` 这一个域名上存在，不存在"某个第三方域名也需要这条路径"的场景，所以这里不是需要暴露新配置项给用户选的问题，而是可以让代码自己判断：`providerAdapterFor` 现在按 endpoint 的 host 是否是 `open.bigmodel.cn`（`isZhipuOfficialEndpoint`）来选择原生路径还是通用兼容路径，跟 kimi/deepseek/minimax 的行为对齐。没有改数据库 schema，没有新增用户可见配置项；配置了官方域名的现有监控行为完全不变。

### 改动

- `channel_monitor_checker.go`：新增 `isZhipuOfficialEndpoint` 按 host 判定；`providerAdapterFor` 增加 endpoint 参数，zhipu 命中非官方域名时改用新增的 `providerZhipuCompatibleChatAdapter`（复用通用路径）。
- `channel_monitor_endpoint_test.go`：原来 `TestCallProvider_BasePath` 里 zhipu 那个用例其实是拿 httptest 的非官方地址断言走原生路径，等于把旧 bug 写进了测试——改成断言第三方中转站场景应该拿到通用路径；新增 `TestIsZhipuOfficialEndpoint`（host 判定的纯函数用例）和 `TestProviderAdapterFor_ZhipuPathSelection`（官方域名 vs 第三方域名两组 adapter 选择）。

## 测试

- `go build ./...` 通过
- `go vet ./internal/service/... ./internal/handler/...` 无告警
- `go test -tags=unit ./internal/service/... ./internal/handler/...` 通过（含新增的 `TestListPlazaGroups_VideoRateIndependentPassthrough`、`TestIsZhipuOfficialEndpoint`、`TestProviderAdapterFor_ZhipuPathSelection`，以及更新过的 `TestCallProvider_BasePath`）
- `pnpm run lint:check` 通过
- `pnpm run typecheck` 通过
- 跑了根 `Makefile` 里 `FRONTEND_CRITICAL_VITEST` 全量列表，外加 `SupportedModelChip.spec.ts`、`PlazaModelPricingTable.spec.ts`、`PlazaGroupSection.spec.ts`、`localeKeyCompleteness.spec.ts`，全部通过，其中新增用例覆盖：
  - 可用渠道弹窗里视频计费模式的标签、按秒固定价、分辨率阶梯价三处展示
  - 模型广场表格里视频独立倍率正确覆盖分组通用倍率（对照图片独立倍率的既有用例写的）
