### PR TITLE
fix(scheduler): 修复选号耗时返回值和粘性命中率重复计数

### DIFF
--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -131,6 +131,7 @@ type openAIAccountSchedulerMetrics struct {
 	selectTotal            atomic.Int64
 	stickyPreviousHitTotal atomic.Int64
 	stickySessionHitTotal  atomic.Int64
+	stickyHitTotal         atomic.Int64
 	loadBalanceSelectTotal atomic.Int64
 	accountSwitchTotal     atomic.Int64
 	latencyMsTotal         atomic.Int64
@@ -171,6 +172,9 @@ func (m *openAIAccountSchedulerMetrics) recordSelect(decision OpenAIAccountSched
 	}
 	if decision.StickySessionHit {
 		m.stickySessionHitTotal.Add(1)
+	}
+	if decision.StickyPreviousHit || decision.StickySessionHit {
+		m.stickyHitTotal.Add(1)
 	}
 	if decision.Layer == openAIAccountScheduleLayerLoadBalance {
 		m.loadBalanceSelectTotal.Add(1)
@@ -378,12 +382,12 @@ func newDefaultOpenAIAccountScheduler(service *OpenAIGatewayService, stats *open
 func (s *defaultOpenAIAccountScheduler) Select(
 	ctx context.Context,
 	req OpenAIAccountScheduleRequest,
-) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+) (selection *AccountSelectionResult, decision OpenAIAccountScheduleDecision, err error) {
 	if s != nil && s.service != nil && s.service.openAIGroupRequiresPrivacySet(ctx, req.GroupID) {
 		req.RequirePrivacySet = true
 	}
-	decision := OpenAIAccountScheduleDecision{}
 	start := time.Now()
+	// 命名返回值保证 defer 写入的耗时同时返回给调用方。
 	defer func() {
 		decision.LatencyMs = time.Since(start).Milliseconds()
 		s.metrics.recordSelect(decision)
@@ -1844,6 +1848,7 @@ func (s *defaultOpenAIAccountScheduler) SnapshotMetrics() OpenAIAccountScheduler
 	selectTotal := s.metrics.selectTotal.Load()
 	prevHit := s.metrics.stickyPreviousHitTotal.Load()
 	sessionHit := s.metrics.stickySessionHitTotal.Load()
+	stickyHit := s.metrics.stickyHitTotal.Load()
 	switchTotal := s.metrics.accountSwitchTotal.Load()
 	latencyTotal := s.metrics.latencyMsTotal.Load()
 	loadSkewTotal := s.metrics.loadSkewMilliTotal.Load()
@@ -1859,7 +1864,7 @@ func (s *defaultOpenAIAccountScheduler) SnapshotMetrics() OpenAIAccountScheduler
 	}
 	if selectTotal > 0 {
 		snapshot.SchedulerLatencyMsAvg = float64(latencyTotal) / float64(selectTotal)
-		snapshot.StickyHitRatio = float64(prevHit+sessionHit) / float64(selectTotal)
+		snapshot.StickyHitRatio = float64(stickyHit) / float64(selectTotal)
 		snapshot.AccountSwitchRate = float64(switchTotal) / float64(selectTotal)
 		snapshot.LoadSkewAvg = float64(loadSkewTotal) / 1000 / float64(selectTotal)
 	}

--- a/backend/internal/service/openai_account_scheduler_metrics_test.go
+++ b/backend/internal/service/openai_account_scheduler_metrics_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type schedulerLatencyAccountRepo struct{ schedulerTestOpenAIAccountRepo }
+
+func (r schedulerLatencyAccountRepo) ListSchedulableByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	time.Sleep(20 * time.Millisecond)
+	return r.schedulerTestOpenAIAccountRepo.ListSchedulableByPlatform(ctx, platform)
+}
+
+func (r schedulerLatencyAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	return r.ListSchedulableByPlatform(ctx, platform)
+}
+
+func TestOpenAISchedulerSelectReturnsRealLatency(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	t.Cleanup(resetOpenAIAdvancedSchedulerSettingCacheForTest)
+	for _, withAccount := range []bool{false, true} {
+		name := "no_available_account"
+		var accounts []Account
+		if withAccount {
+			name = "selected_account"
+			accounts = []Account{{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 5}}
+		}
+		t.Run(name, func(t *testing.T) {
+			scheduler := &defaultOpenAIAccountScheduler{
+				service: &OpenAIGatewayService{accountRepo: schedulerLatencyAccountRepo{schedulerTestOpenAIAccountRepo{accounts: accounts}}},
+				stats:   newOpenAIAccountRuntimeStats(),
+			}
+			selection, decision, err := scheduler.Select(context.Background(), OpenAIAccountScheduleRequest{Platform: PlatformOpenAI})
+			if withAccount {
+				require.NoError(t, err)
+				require.NotNil(t, selection)
+				require.Equal(t, int64(1), decision.SelectedAccountID)
+				if selection.ReleaseFunc != nil {
+					t.Cleanup(selection.ReleaseFunc)
+				}
+			} else {
+				require.Error(t, err)
+			}
+			require.GreaterOrEqual(t, decision.LatencyMs, int64(20))
+			metrics := scheduler.SnapshotMetrics()
+			require.Equal(t, decision.LatencyMs, metrics.SchedulerLatencyMsTotal)
+			require.Equal(t, float64(decision.LatencyMs), metrics.SchedulerLatencyMsAvg)
+		})
+	}
+}
+
+func TestOpenAISchedulerStickyHitRatioCountsSelectionOnce(t *testing.T) {
+	scheduler := &defaultOpenAIAccountScheduler{stats: newOpenAIAccountRuntimeStats()}
+	scheduler.metrics.recordSelect(OpenAIAccountScheduleDecision{StickyPreviousHit: true, StickySessionHit: true})
+	snapshot := scheduler.SnapshotMetrics()
+	require.Equal(t, int64(1), snapshot.SelectTotal)
+	require.Equal(t, int64(1), snapshot.StickyPreviousHitTotal)
+	require.Equal(t, int64(1), snapshot.StickySessionHitTotal)
+	require.Equal(t, 1.0, snapshot.StickyHitRatio)
+
+	scheduler.metrics.recordSelect(OpenAIAccountScheduleDecision{StickyPreviousHit: true})
+	scheduler.metrics.recordSelect(OpenAIAccountScheduleDecision{StickySessionHit: true})
+	scheduler.metrics.recordSelect(OpenAIAccountScheduleDecision{})
+	snapshot = scheduler.SnapshotMetrics()
+	require.Equal(t, int64(4), snapshot.SelectTotal)
+	require.Equal(t, int64(2), snapshot.StickyPreviousHitTotal)
+	require.Equal(t, int64(2), snapshot.StickySessionHitTotal)
+	require.Equal(t, 0.75, snapshot.StickyHitRatio)
+}


### PR DESCRIPTION
## 问题

在上游 `main`（`bdb42e22f81fcb633ff0a060961211dd2bcb515b`）上可复现两处调度指标错误：

1. `Select` 在 `defer` 中更新局部 `decision.LatencyMs`，但函数按值返回。返回值已经复制，调用方拿到的耗时仍为 0，内部累计指标却已经记录真实耗时。
2. 加权粘性允许一次选号同时命中 `previous_response` 和 `session_hash`。将两个命中计数直接相加作为总命中率分子，会把同一次选号计算两遍；单次双命中可显示为 200%。

## 修改

- 将 `decision` 改为命名返回值，确保成功与失败返回都能获得 `defer` 写入的耗时。
- 单独累计“命中任意粘性绑定的选号次数”，一次双命中只累计一次；两个分类计数保留原有含义。
- 不改变选号、排序、粘性绑定、重试及计费逻辑，不新增配置、数据库字段或对外指标字段。

## 回归验证

新增测试先在未修改的上游基线上运行，复现成功与失败选号的耗时均为 0，以及双粘性命中率为 2；应用修复后通过。

- 延迟 20ms 的内存仓储：成功/失败两条路径返回耗时与内部累计值、平均值一致。
- 双命中、仅 previous 命中、仅 session 命中和无命中四种情况：分类计数保持独立，汇总按请求去重。

本地验证命令（`backend/`，Go 1.27.1）：

```sh
go test -p 4 ./internal/service -run 'TestOpenAIScheduler(SelectReturnsRealLatency|StickyHitRatioCountsSelectionOnce)$|TestOpenAIGatewayService_OpenAIAccountSchedulerMetrics' -count=1 -timeout=90s
go test -p 4 -tags=unit ./internal/service ./internal/handler -count=1 -timeout=8m
golangci-lint run ./internal/service/... ./internal/handler/... --timeout=10m
```

所有测试均使用合成数据，不依赖生产配置或真实上游。
