### PR TITLE
fix(batch-image): 修正批量生图账号优先级排序方向

### DIFF
--- a/backend/internal/service/batch_image_public.go
+++ b/backend/internal/service/batch_image_public.go
@@ -944,9 +944,10 @@ func (s *BatchImagePublicService) selectProviderAndAccount(ctx context.Context, 
 		if err != nil {
 			return nil, nil, err
 		}
+		// 与普通账号调度一致：priority 数值越小越优先，同优先级按 ID 排序。
 		sort.SliceStable(accounts, func(i, j int) bool {
 			if accounts[i].Priority != accounts[j].Priority {
-				return accounts[i].Priority > accounts[j].Priority
+				return accounts[i].Priority < accounts[j].Priority
 			}
 			return accounts[i].ID < accounts[j].ID
 		})

--- a/backend/internal/service/batch_image_public_test.go
+++ b/backend/internal/service/batch_image_public_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBatchImagePublicService_SelectAccountPriority(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		priorities   [2]int
+		firstBlocked bool
+		wantID       int64
+	}{
+		{name: "lower priority value wins even with higher ID", priorities: [2]int{1, 9}, wantID: 202},
+		{name: "lower priority value wins regardless of repository order", priorities: [2]int{9, 1}, wantID: 101},
+		{name: "equal priorities keep lower ID first", priorities: [2]int{5, 5}, wantID: 101},
+		{name: "preferred but unschedulable account is skipped", priorities: [2]int{1, 9}, firstBlocked: true, wantID: 101},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, _, _, _ := newTestBatchImagePublicService(true)
+			accounts := []Account{testBatchImageAccount(202, AccountTypeAPIKey), testBatchImageAccount(101, AccountTypeAPIKey)}
+			accounts[0].Priority = tt.priorities[0]
+			accounts[1].Priority = tt.priorities[1]
+			accounts[0].Schedulable = !tt.firstBlocked
+			svc.AccountRepo = &publicBatchImageAccountRepo{accounts: accounts}
+
+			provider, account, err := svc.selectProviderAndAccount(context.Background(), testBatchImageOwner(), BatchImageProviderGeminiAPI, "gemini-2.5-flash-image")
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+			require.NotNil(t, account)
+			require.Equal(t, tt.wantID, account.ID)
+		})
+	}
+}
+
 func TestBatchImagePublicService_Submit(t *testing.T) {
 	ctx := context.Background()
 
@@ -54,7 +83,7 @@ func TestBatchImagePublicService_Submit(t *testing.T) {
 		require.Equal(t, "files/gemini_api/input", batchImageDerefString(job.ProviderInputRef))
 		require.Equal(t, "files/gemini_api/output", batchImageDerefString(job.ProviderOutputRef))
 		require.NotNil(t, job.AccountID)
-		require.Equal(t, int64(202), *job.AccountID)
+		require.Equal(t, int64(101), *job.AccountID)
 		require.Equal(t, 1, job.PricingSnapshotVersion)
 		require.InDelta(t, 0.25, job.BaseUnitPrice, 1e-12)
 		require.InDelta(t, 1.0, job.GroupRateMultiplier, 1e-12)
@@ -71,7 +100,7 @@ func TestBatchImagePublicService_Submit(t *testing.T) {
 		groupID := int64(7)
 		accountMultiplier := 1.25
 		accountRepo := svc.AccountRepo.(*publicBatchImageAccountRepo)
-		accountRepo.accounts[1].RateMultiplier = &accountMultiplier
+		accountRepo.accounts[0].RateMultiplier = &accountMultiplier
 		svc.GroupRepo = &publicBatchImageGroupRepo{groups: map[int64]*Group{
 			groupID: {
 				ID:                           groupID,


### PR DESCRIPTION
## 问题

批量生图的 `selectProviderAndAccount` 对候选账号按 `Priority` 降序排序，与普通账号调度“数值越小越优先”的约定相反。同一组账号用于批量任务时，会优先使用管理员设置为更低优先级的账号。

在上游 `main`（`bdb42e22f81fcb633ff0a060961211dd2bcb515b`）上，用优先级分别为 1、9 的两个合成账号即可复现；交换仓储返回顺序后仍会错误地选择 9。

## 修改

- 将账号优先级比较改为升序。
- 同优先级继续按账号 ID 升序，保留原有确定性排序。
- 保留平台、模型能力、可调度状态与 provider 兼容性过滤，以及 provider 自身的选择顺序。
- 更新提交任务用例的账号断言，并将倍率夹具配置到按新规则选中的账号上；不修改价格计算、冻结款项或结算公式。

## 回归验证

新增选号用例先在未修改的上游基线上失败，应用修复后通过，覆盖：

- 优先级与账号 ID 顺序相反时，仍按优先级选择。
- 仓储返回顺序不影响不同优先级的选择。
- 同优先级保留较小 ID 优先。
- 优先级更高但不可调度的账号仍被跳过。
- 提交任务、价格快照、倍率与余额冻结相关原有用例。

本地验证命令（`backend/`，Go 1.27.1）：

```sh
go test -p 4 -tags=unit ./internal/service -run 'TestBatchImagePublicService_' -count=1 -timeout=90s
go test -p 4 -tags=unit ./internal/service ./internal/handler -count=1 -timeout=8m
golangci-lint run ./internal/service/... ./internal/handler/... --timeout=10m
```

不新增配置或数据库迁移。已配置不同优先级的批量生图账号，其选择结果会按管理员设置的正常优先级方向变化。
