### PR TITLE
fix(admin): surface partial Antigravity refresh warnings

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -1545,6 +1545,7 @@ func (h *AccountHandler) Refresh(c *gin.Context) {
 
 	if warning == "missing_project_id_temporary" {
 		response.Success(c, gin.H{
+			"account": h.buildAccountResponseWithRuntime(c.Request.Context(), updatedAccount),
 			"message": "Token refreshed successfully, but project_id could not be retrieved (will retry automatically)",
 			"warning": "missing_project_id_temporary",
 		})

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -311,9 +311,13 @@ export async function testAccount(id: number): Promise<{
  * @param id - Account ID
  * @returns Updated account
  */
-export async function refreshCredentials(id: number): Promise<Account> {
-  const { data } = await apiClient.post<Account>(`/admin/accounts/${id}/refresh`)
-  return data
+export type RefreshCredentialsResult =
+  | { account: Account; message: string; warning: 'missing_project_id_temporary' }
+  | { account: Account; message?: never; warning?: never }
+
+export async function refreshCredentials(id: number): Promise<RefreshCredentialsResult> {
+  const { data } = await apiClient.post<Account | RefreshCredentialsResult>(`/admin/accounts/${id}/refresh`)
+  return 'account' in data ? data : { account: data }
 }
 
 /**

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -2352,9 +2352,10 @@ const handleDuplicateAccount = async (a: Account) => {
 }
 const handleRefresh = async (a: Account) => {
   try {
-    const updated = await adminAPI.accounts.refreshCredentials(a.id)
-    patchAccountInList(updated)
+    const result = await adminAPI.accounts.refreshCredentials(a.id)
+    patchAccountInList(result.account)
     enterAutoRefreshSilentWindow()
+    if (result.warning) appStore.showWarning(result.message)
   } catch (error) {
     console.error('Failed to refresh credentials:', error)
   }

--- a/frontend/src/views/admin/__tests__/AccountsView.lite.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.lite.spec.ts
@@ -13,7 +13,9 @@ const {
   getUpstreamBillingProbeSettings,
   getAllProxies,
   getAllGroups,
-  showError
+  refreshCredentials,
+  showError,
+  showWarning
 } = vi.hoisted(() => ({
   listAccounts: vi.fn(),
   listWithEtag: vi.fn(),
@@ -22,7 +24,9 @@ const {
   getUpstreamBillingProbeSettings: vi.fn(),
   getAllProxies: vi.fn(),
   getAllGroups: vi.fn(),
-  showError: vi.fn()
+  refreshCredentials: vi.fn(),
+  showError: vi.fn(),
+  showWarning: vi.fn()
 }))
 
 vi.mock('@/api/admin', () => ({
@@ -36,7 +40,8 @@ vi.mock('@/api/admin', () => ({
       delete: vi.fn(),
       batchClearError: vi.fn(),
       batchRefresh: vi.fn(),
-      toggleSchedulable: vi.fn()
+      toggleSchedulable: vi.fn(),
+      refreshCredentials
     },
     proxies: { getAll: getAllProxies },
     groups: { getAll: getAllGroups }
@@ -44,7 +49,7 @@ vi.mock('@/api/admin', () => ({
 }))
 
 vi.mock('@/stores/app', () => ({
-  useAppStore: () => ({ showError, showSuccess: vi.fn(), showInfo: vi.fn() })
+  useAppStore: () => ({ showError, showWarning, showSuccess: vi.fn(), showInfo: vi.fn() })
 }))
 
 vi.mock('@/stores/auth', () => ({
@@ -60,7 +65,7 @@ const DataTableStub = defineComponent({
   props: { data: { type: Array, default: () => [] } },
   template: `
     <div>
-      <div v-for="row in data" :key="row.id">
+      <div v-for="row in data" :key="row.id" :data-account-name="row.name">
         <slot name="cell-groups" :row="row" />
         <slot name="cell-actions" :row="row" />
       </div>
@@ -161,7 +166,9 @@ describe('admin AccountsView lite account list', () => {
     getUpstreamBillingProbeSettings.mockReset().mockResolvedValue({ enabled: true })
     getAllProxies.mockReset().mockResolvedValue([])
     getAllGroups.mockReset().mockResolvedValue([{ id: 7, name: 'codex', platform: 'openai' }])
+    refreshCredentials.mockReset()
     showError.mockReset()
+    showWarning.mockReset()
   })
 
   afterEach(() => {
@@ -251,6 +258,24 @@ describe('admin AccountsView lite account list', () => {
     await flushPromises()
     expect(getById).toHaveBeenCalledTimes(3)
     expect(wrapper.get('[data-test="stats-account"]').text()).toBe('compact row')
+    wrapper.unmount()
+  })
+
+  it('shows the warning and patches the account after a partial Antigravity refresh', async () => {
+    refreshCredentials.mockResolvedValue({
+      account: { ...fullAccount, name: 'refreshed account' },
+      message: 'Token refreshed, but project_id is temporarily unavailable',
+      warning: 'missing_project_id_temporary'
+    })
+    const wrapper = mountView(false)
+    await flushPromises()
+
+    wrapper.findComponent(AccountActionMenu).vm.$emit('refresh-token', listRow)
+    await flushPromises()
+
+    expect(refreshCredentials).toHaveBeenCalledWith(42)
+    expect(wrapper.get('[data-account-name]').attributes('data-account-name')).toBe('refreshed account')
+    expect(showWarning).toHaveBeenCalledWith('Token refreshed, but project_id is temporarily unavailable')
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
- return the updated account when an Antigravity credential refresh succeeds but `project_id` retrieval is temporarily unavailable
- model both refresh response shapes in the admin API and keep the account list current
- surface the partial-success warning to administrators

## Test plan
- `cd frontend && ./node_modules/.bin/vitest --config vitest.config.ts run src/views/admin/__tests__/AccountsView.lite.spec.ts`
- `frontend/node_modules/.bin/vue-tsc.CMD --noEmit -p frontend/tsconfig.json`
- ESLint on the three changed frontend files
- `git diff --check origin/main...HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)