### PR TITLE
fix(antigravity): isolate OAuth token cache key by account ID to prevent 429 collision

### DIFF
--- a/backend/internal/service/antigravity_token_provider.go
+++ b/backend/internal/service/antigravity_token_provider.go
@@ -231,9 +231,5 @@ func (p *AntigravityTokenProvider) markBackfillAttempted(accountID int64) {
 }
 
 func AntigravityTokenCacheKey(account *Account) string {
-	projectID := strings.TrimSpace(account.GetCredential("project_id"))
-	if projectID != "" {
-		return "ag:" + projectID
-	}
 	return "ag:account:" + strconv.FormatInt(account.ID, 10)
 }

--- a/backend/internal/service/token_cache_invalidator.go
+++ b/backend/internal/service/token_cache_invalidator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strconv"
+	"strings"
 )
 
 type TokenCacheInvalidator interface {
@@ -39,9 +40,12 @@ func (c *CompositeTokenCacheInvalidator) InvalidateToken(ctx context.Context, ac
 		keysToDelete = append(keysToDelete, GeminiTokenCacheKey(account))
 		keysToDelete = append(keysToDelete, "gemini:"+accountIDKey)
 	case PlatformAntigravity:
-		// Antigravity 同样可能有两种缓存键
+		// Antigravity 可能有两种缓存键：旧版基于 project_id，新版基于 account_id
+		// 显式清理旧版可能残留的 project 缓存键，同时清理当前基于 account 的缓存键
+		if projectID := strings.TrimSpace(account.GetCredential("project_id")); projectID != "" {
+			keysToDelete = append(keysToDelete, "ag:"+projectID)
+		}
 		keysToDelete = append(keysToDelete, AntigravityTokenCacheKey(account))
-		keysToDelete = append(keysToDelete, "ag:"+accountIDKey)
 	case PlatformOpenAI:
 		keysToDelete = append(keysToDelete, OpenAITokenCacheKey(account))
 	case PlatformGrok:

--- a/backend/internal/service/token_cache_key_test.go
+++ b/backend/internal/service/token_cache_key_test.go
@@ -87,60 +87,45 @@ func TestAntigravityTokenCacheKey(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "with_project_id",
+			name: "basic_account",
 			account: &Account{
 				ID: 200,
-				Credentials: map[string]any{
-					"project_id": "ag-project-456",
-				},
 			},
-			expected: "ag:ag-project-456",
+			expected: "ag:account:200",
 		},
 		{
-			name: "project_id_with_whitespace",
+			name: "account_with_project_id_still_uses_account_id",
 			account: &Account{
 				ID: 201,
 				Credentials: map[string]any{
-					"project_id": "  ag-project-spaces  ",
+					"project_id": "aicode-consumers",
 				},
 			},
-			expected: "ag:ag-project-spaces",
+			expected: "ag:account:201",
 		},
 		{
-			name: "empty_project_id_fallback_to_account_id",
+			name: "account_with_credentials",
 			account: &Account{
 				ID: 202,
 				Credentials: map[string]any{
-					"project_id": "",
+					"access_token": "test-token",
 				},
 			},
 			expected: "ag:account:202",
 		},
 		{
-			name: "whitespace_only_project_id_fallback_to_account_id",
+			name: "account_id_zero",
 			account: &Account{
-				ID: 203,
-				Credentials: map[string]any{
-					"project_id": "   ",
-				},
+				ID: 0,
 			},
-			expected: "ag:account:203",
+			expected: "ag:account:0",
 		},
 		{
-			name: "no_project_id_key_fallback_to_account_id",
+			name: "large_account_id",
 			account: &Account{
-				ID:          204,
-				Credentials: map[string]any{},
+				ID: 9999999999,
 			},
-			expected: "ag:account:204",
-		},
-		{
-			name: "nil_credentials_fallback_to_account_id",
-			account: &Account{
-				ID:          205,
-				Credentials: nil,
-			},
-			expected: "ag:account:205",
+			expected: "ag:account:9999999999",
 		},
 	}
 


### PR DESCRIPTION
### Summary
Isolate Antigravity OAuth Access Token cache keys by `account.ID` (aligned with OpenAI, Claude, and Grok) instead of `project_id`.

### Problem
For personal Antigravity (Google Gemini) accounts, the upstream OAuth flow returns a common, fixed project ID: `"aicode-consumers"`.

Previously, `AntigravityTokenCacheKey` used `project_id` when present:
```go
func AntigravityTokenCacheKey(account *Account) string {
    projectID := strings.TrimSpace(account.GetCredential("project_id"))
    if projectID != "" {
        return "ag:" + projectID
    }
    return "ag:account:" + strconv.FormatInt(account.ID, 10)
}
```
This causes all personal accounts to share the exact same Redis cache key: `oauth:token:ag:aicode-consumers`.

**Consequence:**
When Account A exhausts its 5-hour quota or triggers an upstream 429 rate limit, the Sub2API scheduler flags Account A and switches to Account B. However, Account B reads Account A's cached token from Redis and sends it upstream. Google immediately rejects it with another 429, causing the scheduler to cascade-mark all healthy Antigravity accounts in the pool as rate-limited, resulting in a false-positive `503 No available accounts` outage.

### Solution
- Change `AntigravityTokenCacheKey` to always use `"ag:account:" + strconv.FormatInt(account.ID, 10)`, consistent with OpenAI and Claude.
- Update unit test cases in `token_cache_key_test.go`.

### Verification
- Unit tests (`TestAntigravityTokenCacheKey`) pass.
- Verified in live environment with multiple personal Antigravity accounts: independent Redis cache keys (`oauth:token:ag:account:<id>`) are properly generated and account failover operates without token collision.