### PR TITLE
fix(monitor): honor the selected auto-refresh interval

### DIFF
--- a/frontend/src/composables/useAutoRefresh.ts
+++ b/frontend/src/composables/useAutoRefresh.ts
@@ -50,7 +50,7 @@ export function useAutoRefresh(options: UseAutoRefreshOptions) {
     if (shouldPause?.()) return
     if (fetching.value) return
 
-    if (countdown.value <= 0) {
+    if (countdown.value <= 1) {
       countdown.value = intervalSeconds.value
       fetching.value = true
       try { await onRefresh() } finally { fetching.value = false }

--- a/frontend/src/views/user/ChannelStatusV1View.vue
+++ b/frontend/src/views/user/ChannelStatusV1View.vue
@@ -102,7 +102,7 @@ async function reload(silent = false) {
   } finally {
     if (abortController === ctrl) {
       if (!silent) loading.value = false
-      countdown.value = DEFAULT_INTERVAL_SECONDS
+      autoRefresh.resetCountdown()
       abortController = null
     }
   }

--- a/frontend/src/views/user/__tests__/ChannelStatusV1View.refresh.spec.ts
+++ b/frontend/src/views/user/__tests__/ChannelStatusV1View.refresh.spec.ts
@@ -1,0 +1,62 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ChannelStatusV1View from '../ChannelStatusV1View.vue'
+
+const { list } = vi.hoisted(() => ({ list: vi.fn() }))
+vi.mock('@/api/channelMonitor', () => ({ list, status: vi.fn() }))
+vi.mock('@/stores/app', () => ({ useAppStore: () => ({ cachedPublicSettings: { channel_monitor_enabled: true }, showError: vi.fn() }) }))
+vi.mock('vue-i18n', async () => ({
+  ...await vi.importActual<typeof import('vue-i18n')>('vue-i18n'),
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+const mountView = () => shallowMount(ChannelStatusV1View, {
+  global: { stubs: {
+    AppLayout: { template: '<div><slot /></div>' },
+    MonitorHero: { props: ['autoRefresh'], emits: ['refresh'], template: `<div>
+      <button class="interval" @click="autoRefresh.setInterval(120)">120 seconds</button>
+      <button class="refresh" @click="$emit('refresh')">Refresh</button>
+      <button class="disable" @click="autoRefresh.setEnabled(false)">Disable</button>
+    </div>` },
+  } },
+})
+let wrapper: ReturnType<typeof mountView>
+beforeEach(() => { vi.useFakeTimers(); localStorage.clear(); list.mockReset().mockResolvedValue({ items: [] }) })
+afterEach(() => { wrapper?.unmount(); vi.useRealTimers(); localStorage.clear() })
+
+describe('channel monitor refresh interval', () => {
+  it('refreshes at the selected interval on successive automatic refreshes', async () => {
+    wrapper = mountView(); await flushPromises()
+    await wrapper.get('.interval').trigger('click')
+    await vi.advanceTimersByTimeAsync(119000)
+    expect(list).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(list).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(119000)
+    expect(list).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(list).toHaveBeenCalledTimes(3)
+  })
+
+  it('preserves the selected interval after a manual refresh', async () => {
+    wrapper = mountView(); await flushPromises()
+    await wrapper.get('.interval').trigger('click')
+    await wrapper.get('.refresh').trigger('click'); await flushPromises()
+    expect(list).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(119000)
+    expect(list).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(list).toHaveBeenCalledTimes(3)
+  })
+
+  it('honors a persisted interval after the initial load', async () => {
+    localStorage.setItem('channel-status-auto-refresh', JSON.stringify({ enabled: true, interval_seconds: 120 }))
+    wrapper = mountView(); await flushPromises()
+    await vi.advanceTimersByTimeAsync(119000)
+    expect(list).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(list).toHaveBeenCalledTimes(2)
+    await wrapper.get('.disable').trigger('click')
+    await vi.advanceTimersByTimeAsync(120000)
+    expect(list).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
The V1 channel monitor resets its countdown to the default after every response, overriding the selected or persisted refresh interval. Reset through the existing auto-refresh helper and trigger the refresh when the last countdown second elapses, rather than waiting one extra tick.

Validation: three regressions cover successive automatic refreshes, manual refresh and a persisted interval; all fail on the unchanged base. They and all 14 frontend critical suites pass: 192 tests total. `vue-tsc --noEmit`, full ESLint and `git diff --check` pass. Repository CI passed: Go unit and integration tests, Go lint, frontend, shell, security and CLA checks.